### PR TITLE
downgrade.fst: build-config prelude

### DIFF
--- a/examples/algorithms/downgrade.fst
+++ b/examples/algorithms/downgrade.fst
@@ -1,4 +1,4 @@
-(*--build-options
+(*--build-config
   options:--z3timeout 20;
   variables:LIB=../../lib;
   other-files:$LIB/classical.fst $LIB/ext.fst $LIB/set.fsi $LIB/set.fst $LIB/heap.fst


### PR DESCRIPTION
Not sure if build-options has ever been useful, but I suppose it should
be build-config.