### PR TITLE
Transitive Dependency Support 

### DIFF
--- a/examples/unit-tests/Makefile
+++ b/examples/unit-tests/Makefile
@@ -3,7 +3,9 @@ include ../Makefile.include
 NEGFILES=negative-tests.fst
 NEGTESTS=36
 
-all: basictests testint32.vv testmref.vv testTwoLevelHeap.vv mac2.vv all-neg testghost inverse testghost
+all: all-pos all-neg
+
+all-pos: basictests testint32.vv testmref.vv testTwoLevelHeap.vv mac2.vv testghost inverse testghost
 
 basictests: $(VERFILES)
 		$(FSTAR) --admit_fsi FStar.Set $(STDLIB) int32.fst $^

--- a/lib/ml/FStar_List.ml
+++ b/lib/ml/FStar_List.ml
@@ -54,4 +54,5 @@ let rec unzip3 l =
   match l with
   | [] -> [],[],[]
   | (x,y,z)::t -> let u,v,w = unzip3 t in x::u,y::v,z::w
+let unique = BatList.unique
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ FSLEX   := $(RUNTIME) $(FSLYDIR)/build/fslex.exe
 
 # --------------------------------------------------------------------
 .PHONY: all z3_x86 z3_x64 wc clean tidy boot ocaml
-.PHONY: msbuild msbuild-clean
+.PHONY: msbuild msbuild-clean nuget-restore nuget-clean
 
 # --------------------------------------------------------------------
 all: $(BIN)/fstar.exe
@@ -83,7 +83,17 @@ z3-x64:
 	cp $(BIN)/z3.x64.dll $(BIN)/z3.dll
 
 # --------------------------------------------------------------------
-msbuild:
+
+nuget-restore:
+	VS/.nuget/NuGet.exe restore VS/FStar.sln
+
+nuget-clean:
+	rm -r VS/packages
+
+$(FSYACC) $(FSLEX): nuget-restore
+
+# --------------------------------------------------------------------
+msbuild: nuget-restore
 	$(MAKE) -C VS install-packages
 	$(MSBUILD) VS/FStar.sln
 
@@ -91,11 +101,11 @@ msbuild-clean:
 	$(MSBUILD) /t:clean VS/FStar.sln
 
 # --------------------------------------------------------------------
-parser/parse.fs: parser/parse.fsy
+parser/parse.fs: parser/parse.fsy $(FSYACC)
 	$(MAKE) -C VS install-packages
 	$(FSYACC) --module FStar.Parser.Parse $<
 
-parser/lex.fs: parser/lex.fsl
+parser/lex.fs: parser/lex.fsl $(FSLEX)
 	$(MAKE) -C VS install-packages
 	$(FSLEX) --unicode $<
 

--- a/src/basic/basic.fsproj
+++ b/src/basic/basic.fsproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>basic</Name>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\VS\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,20 +37,29 @@
     <DocumentationFile>bin\Release\basic.XML</DocumentationFile>
     <OtherFlags>--mlcompatibility</OtherFlags>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="FSharp.PowerPack">
-      <HintPath>..\..\bin\FSharp.PowerPack.dll</HintPath>
-    </Reference>
-    <Reference Include="FSharp.PowerPack.Compatibility">
-      <HintPath>..\..\bin\FSharp.PowerPack.Compatibility.dll</HintPath>
-    </Reference>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <ItemGroup>
     <Compile Include="prims-fake.fs" />
     <Compile Include="char.fsi" />
@@ -73,23 +84,22 @@
     <Compile Include="options.fs" />
     <Compile Include="unionfind.fsi" />
     <Compile Include="unionfind.fs" />
+    <Content Include="packages.config" />
   </ItemGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <ItemGroup>
+    <Reference Include="FSharp.PowerPack">
+      <HintPath>..\..\bin\FSharp.PowerPack.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.PowerPack.Compatibility">
+      <HintPath>..\..\bin\FSharp.PowerPack.Compatibility.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 	     Other similar extension points exist, see Microsoft.Common.targets.
 	<Target Name="BeforeBuild">

--- a/src/basic/list.fs
+++ b/src/basic/list.fs
@@ -260,6 +260,14 @@ let sortWith f l = List.sortWith f l
 
 let bool_of_compare = (fun ( f  :  'a  ->  'a  ->  Prims.int ) ( x  :  'a ) ( y  :  'a ) -> ((f x y) >= 0))
 
-
+let rec unique l =
+  // this matches the semantics of BatList.unique.
+  match l with
+  | [] -> []
+  | h::t -> 
+    if mem h t then
+      unique t
+    else 
+      h::(unique t)
 
 

--- a/src/basic/list.fsi
+++ b/src/basic/list.fsi
@@ -59,4 +59,5 @@ val rev_append : (list<'_5110>) -> (list<'_5110>) -> Tot<(list<'_5110>)>
 val concat : (list<(list<'_6116>)>) -> Tot<(list<'_6116>)>
 val contains<'_17778 when '_17778 : equality>  : '_17778 -> (list<'_17778>) -> Tot<bool>
 val unzip : (list<('_36948 * '_36947)>) -> Tot<((list<'_36948>) * (list<'_36947>))>
+val unique<'a when 'a:equality> : list<'a> -> list<'a>
 

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -103,6 +103,29 @@ let run_proc (name:string) (args:string) (stdin:string) : bool * string * string
   (true, res, "")
 
 let get_file_extension (fn:string) : string = snd (BatString.rsplit fn ".")
+let is_path_absolute path_str = 
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let path_str' = of_string path_str in
+  is_absolute path_str'
+let join_paths path_str0 path_str1 = 
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let open BatPathGen.OfString.Operators in
+  to_string ((of_string path_str0) //@ (of_string path_str1))
+
+let normalize_file_path (path_str:string) =
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let open BatPathGen.OfString.Operators in
+  to_string 
+    (normalize_in_tree
+       (let path = of_string path_str in
+         if is_absolute path then
+           path
+         else
+           let pwd = of_string (BatSys.getcwd ()) in
+           pwd //@ path))
 
 type stream_reader = BatIO.input
 let open_stdin () = BatIO.stdin

--- a/src/basic/packages.config
+++ b/src/basic/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NDepend.Path" version="1.0.0" targetFramework="net45" />
+</packages>

--- a/src/basic/util.fs
+++ b/src/basic/util.fs
@@ -148,6 +148,9 @@ let run_proc (name:string) (args:string) (stdin:string) : bool * string * string
   result, stdout, stderr
 
 let get_file_extension (fn: string) :string = Path.GetExtension fn
+let is_path_absolute p = System.IO.Path.IsPathRooted(p)
+let join_paths p0 p1 = System.IO.Path.Combine(p0, p1)
+let normalize_file_path (path:string) = System.IO.Path.GetFullPath(path)
 
 type stream_reader = System.IO.StreamReader (* not relying on representation *)
 let open_stdin () = new System.IO.StreamReader(System.Console.OpenStandardInput())

--- a/src/basic/util.fsi
+++ b/src/basic/util.fsi
@@ -110,6 +110,10 @@ val kill_all: unit -> unit
 val run_proc : string -> string -> string -> (bool * string * string)
 
 val get_file_extension: string -> string
+val is_path_absolute: string -> bool
+val join_paths: string -> string -> string
+val normalize_file_path: string -> string
+
 open Prims
 val int_of_string: string -> int
 val int_of_char:   char -> Tot<int>

--- a/src/extraction/app.config
+++ b/src/extraction/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/extraction/extraction.fsproj
+++ b/src/extraction/extraction.fsproj
@@ -33,6 +33,33 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\extraction.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Compile Include="ml-syntax.fs" />
+    <Compile Include="env.fs" />
+    <Compile Include="util.fs" />
+    <Compile Include="codegen.fsi" />
+    <Compile Include="codegen.fs" />
+    <Compile Include="extracttyp.fs" />
+    <Compile Include="extractexp.fs" />
+    <Compile Include="extractmod.fs" />
+    <Content Include="app.config" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.PowerPack, Version=4.0.0.1, Culture=neutral, PublicKeyToken=f536804aa0eb945b" />
     <Reference Include="FSharp.PowerPack.Compatibility, Version=4.0.0.1, Culture=neutral, PublicKeyToken=f536804aa0eb945b" />
@@ -43,18 +70,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ml-syntax.fs" />
-    <Compile Include="env.fs" />
-    <Compile Include="util.fs" />
-    <Compile Include="codegen.fsi" />
-    <Compile Include="codegen.fs" />
-    <Compile Include="extracttyp.fs" />
-    <Compile Include="extractexp.fs" />
-    <Compile Include="extractmod.fs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\absyn\absyn.fsproj">
       <Name>absyn</Name>
       <Project>{13e8984e-188d-447b-b7b7-9f7441050565}</Project>
@@ -76,22 +91,6 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/fstar/fstar.fs
+++ b/src/fstar/fstar.fs
@@ -217,22 +217,22 @@ let interactive_mode dsenv env =
                     Util.fprint1 "%s\n" fail;
                     let dsenv, env = reset_mark dsenv_mark env_mark in
                     go stack curmod dsenv env in
-	            
+              
                 let dsenv, env =
-		            if !should_read_build_config then
-		              if Util.starts_with text (Parser.ParseIt.get_bc_start_string ()) then
-		                begin
-		                  let filenames = Parser.ParseIt.read_build_config_from_string "" false text in
-		                  let _, dsenv, env = batch_mode_tc_no_prims dsenv env filenames in
-		                  should_read_build_config := false;
-		                  dsenv, env
-		                end
-		              else begin
-		                should_read_build_config := false;
-		                dsenv, env
-		              end
-		            else
-		              dsenv, env in
+                if !should_read_build_config then
+                  if Util.starts_with text (Parser.ParseIt.get_bc_start_string ()) then
+                    begin
+                      let filenames = Parser.ParseIt.read_build_config_from_string "" false text true in
+                      let _, dsenv, env = batch_mode_tc_no_prims dsenv env filenames in
+                      should_read_build_config := false;
+                      dsenv, env
+                    end
+                  else begin
+                    should_read_build_config := false;
+                    dsenv, env
+                  end
+                else
+                  dsenv, env in
 
               let dsenv_mark, env_mark = mark dsenv env in
               let res = tc_one_fragment curmod dsenv_mark env_mark text in
@@ -282,14 +282,17 @@ let go _ =
                                     | [f] -> Parser.Driver.read_build_config f //then, try to read a build config from the header of the file
                                     | _ -> Util.print_string "--use_build_config expects just a single file on the command line and no other arguments"; exit 1
                              else filenames in
-             let fmods, dsenv, env = batch_mode_tc filenames  in
-             report_errors None;
-             if !Options.interactive
-             then interactive_mode dsenv env
-             else begin
+             if !Options.find_deps then
+               Util.print_string (Util.format1 "%s\n" (Util.concat_l "\n" filenames))
+             else
+               (let fmods, dsenv, env = batch_mode_tc filenames in
+               report_errors None;
+               if !Options.interactive
+               then interactive_mode dsenv env
+               else begin
                 codegen fmods env;
                 finished_message fmods
-             end
+               end)
 
 
 let main () =

--- a/src/ocaml-output/FStar_FStar.ml
+++ b/src/ocaml-output/FStar_FStar.ml
@@ -341,7 +341,7 @@ end))))))
 in (let _64_256 = if (FStar_ST.read should_read_build_config) then begin
 if (let _129_135 = (FStar_Parser_ParseIt.get_bc_start_string ())
 in (FStar_Util.starts_with text _129_135)) then begin
-(let filenames = (FStar_Parser_ParseIt.read_build_config_from_string "" false text)
+(let filenames = (FStar_Parser_ParseIt.read_build_config_from_string "" false text true)
 in (let _64_249 = (batch_mode_tc_no_prims dsenv env filenames)
 in (match (_64_249) with
 | (_64_246, dsenv, env) -> begin
@@ -429,7 +429,12 @@ end)
 end else begin
 filenames
 end
-in (let _64_303 = (batch_mode_tc filenames)
+in if (FStar_ST.read FStar_Options.find_deps) then begin
+(let _129_147 = (let _129_146 = (FStar_Util.concat_l "\n" filenames)
+in (FStar_Util.format1 "%s\n" _129_146))
+in (FStar_Util.print_string _129_147))
+end else begin
+(let _64_303 = (batch_mode_tc filenames)
 in (match (_64_303) with
 | (fmods, dsenv, env) -> begin
 (let _64_304 = (report_errors None)
@@ -439,7 +444,8 @@ end else begin
 (let _64_306 = (codegen fmods env)
 in (finished_message fmods))
 end)
-end)))
+end))
+end)
 end)
 end)))
 
@@ -458,13 +464,13 @@ end else begin
 ()
 end
 in (let _64_315 = if (FStar_ST.read FStar_Options.trace_error) then begin
-(let _129_150 = (FStar_Util.message_of_exn e)
-in (let _129_149 = (FStar_Util.trace_of_exn e)
-in (FStar_Util.fprint2 "\nUnexpected error\n%s\n%s\n" _129_150 _129_149)))
+(let _129_152 = (FStar_Util.message_of_exn e)
+in (let _129_151 = (FStar_Util.trace_of_exn e)
+in (FStar_Util.fprint2 "\nUnexpected error\n%s\n%s\n" _129_152 _129_151)))
 end else begin
 if (not ((FStar_Absyn_Util.handleable e))) then begin
-(let _129_151 = (FStar_Util.message_of_exn e)
-in (FStar_Util.fprint1 "\nUnexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n" _129_151))
+(let _129_153 = (FStar_Util.message_of_exn e)
+in (FStar_Util.fprint1 "\nUnexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n" _129_153))
 end else begin
 ()
 end

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -219,6 +219,10 @@ false
 end)
 end))
 
+let auto_deps = (FStar_Util.mk_ref false)
+
+let find_deps = (FStar_Util.mk_ref false)
+
 let init_options = (fun _21_34 -> (match (()) with
 | () -> begin
 (let _21_35 = (FStar_ST.op_Colon_Equals show_signatures [])
@@ -268,31 +272,33 @@ in (let _21_119 = (FStar_ST.op_Colon_Equals verify_module [])
 in (let _21_121 = (FStar_ST.op_Colon_Equals __temp_no_proj [])
 in (let _21_123 = (FStar_ST.op_Colon_Equals _include_path [])
 in (let _21_125 = (FStar_ST.op_Colon_Equals print_fuels false)
-in (FStar_ST.op_Colon_Equals use_native_int false)))))))))))))))))))))))))))))))))))))))))))))))
+in (let _21_127 = (FStar_ST.op_Colon_Equals use_native_int false)
+in (let _21_129 = (FStar_ST.op_Colon_Equals auto_deps false)
+in (FStar_ST.op_Colon_Equals find_deps false)))))))))))))))))))))))))))))))))))))))))))))))))
 end))
 
-let set_fstar_home = (fun _21_127 -> (match (()) with
+let set_fstar_home = (fun _21_131 -> (match (()) with
 | () -> begin
 (let fh = (match ((FStar_ST.read fstar_home_opt)) with
 | None -> begin
 (let x = (FStar_Util.get_exec_dir ())
 in (let x = (Prims.strcat x "/..")
-in (let _21_131 = (FStar_ST.op_Colon_Equals _fstar_home x)
-in (let _21_133 = (FStar_ST.op_Colon_Equals fstar_home_opt (Some (x)))
+in (let _21_135 = (FStar_ST.op_Colon_Equals _fstar_home x)
+in (let _21_137 = (FStar_ST.op_Colon_Equals fstar_home_opt (Some (x)))
 in x))))
 end
 | Some (x) -> begin
-(let _21_137 = (FStar_ST.op_Colon_Equals _fstar_home x)
+(let _21_141 = (FStar_ST.op_Colon_Equals _fstar_home x)
 in x)
 end)
 in fh)
 end))
 
-let get_fstar_home = (fun _21_140 -> (match (()) with
+let get_fstar_home = (fun _21_144 -> (match (()) with
 | () -> begin
 (match ((FStar_ST.read fstar_home_opt)) with
 | None -> begin
-(let _21_142 = (let _86_43 = (set_fstar_home ())
+(let _21_146 = (let _86_43 = (set_fstar_home ())
 in (FStar_All.pipe_left Prims.ignore _86_43))
 in (FStar_ST.read _fstar_home))
 end
@@ -301,18 +307,21 @@ x
 end)
 end))
 
-let get_include_path = (fun _21_146 -> (match (()) with
-| () -> begin
-(let h = (get_fstar_home ())
-in (let _86_46 = (FStar_ST.read _include_path)
-in (FStar_List.append _86_46 ((".")::((Prims.strcat h "/lib"))::((Prims.strcat h "/lib/fstar"))::[]))))
-end))
+let get_include_path = (fun dirname -> (let _86_48 = (let h = (get_fstar_home ())
+in (let _86_47 = (FStar_ST.read _include_path)
+in (FStar_List.append _86_47 ((".")::((Prims.strcat h "/lib"))::((Prims.strcat h "/lib/fstar"))::[]))))
+in (FStar_List.map (fun p -> if (FStar_Util.is_path_absolute p) then begin
+(FStar_Util.normalize_file_path p)
+end else begin
+(FStar_Util.join_paths dirname p)
+end) _86_48)))
 
-let prims = (fun _21_148 -> (match (()) with
+let prims = (fun _21_153 -> (match (()) with
 | () -> begin
 (match ((FStar_ST.read prims_ref)) with
 | None -> begin
-"prims.fst"
+(let _86_51 = (get_fstar_home ())
+in (FStar_Util.format1 "%s/lib/prims.fst" _86_51))
 end
 | Some (x) -> begin
 x
@@ -329,41 +338,41 @@ end))
 
 let cache_dir = "cache"
 
-let display_version = (fun _21_156 -> (match (()) with
+let display_version = (fun _21_161 -> (match (()) with
 | () -> begin
-(let _86_53 = (FStar_Util.format5 "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" FStar_Version.version FStar_Version.platform FStar_Version.compiler FStar_Version.date FStar_Version.commit)
-in (FStar_Util.print_string _86_53))
+(let _86_56 = (FStar_Util.format5 "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" FStar_Version.version FStar_Version.platform FStar_Version.compiler FStar_Version.date FStar_Version.commit)
+in (FStar_Util.print_string _86_56))
 end))
 
-let display_usage = (fun specs -> (let _21_158 = (FStar_Util.print_string "fstar [option] infile...")
-in (FStar_List.iter (fun _21_165 -> (match (_21_165) with
-| (_21_161, flag, p, doc) -> begin
+let display_usage = (fun specs -> (let _21_163 = (FStar_Util.print_string "fstar [option] infile...")
+in (FStar_List.iter (fun _21_170 -> (match (_21_170) with
+| (_21_166, flag, p, doc) -> begin
 (match (p) with
 | FStar_Getopt.ZeroArgs (ig) -> begin
 if (doc = "") then begin
-(let _86_57 = (FStar_Util.format1 "  --%s\n" flag)
-in (FStar_Util.print_string _86_57))
-end else begin
-(let _86_58 = (FStar_Util.format2 "  --%s  %s\n" flag doc)
-in (FStar_Util.print_string _86_58))
-end
-end
-| FStar_Getopt.OneArg (_21_169, argname) -> begin
-if (doc = "") then begin
-(let _86_60 = (FStar_Util.format2 "  --%s %s\n" flag argname)
+(let _86_60 = (FStar_Util.format1 "  --%s\n" flag)
 in (FStar_Util.print_string _86_60))
 end else begin
-(let _86_61 = (FStar_Util.format3 "  --%s %s  %s\n" flag argname doc)
+(let _86_61 = (FStar_Util.format2 "  --%s  %s\n" flag doc)
 in (FStar_Util.print_string _86_61))
+end
+end
+| FStar_Getopt.OneArg (_21_174, argname) -> begin
+if (doc = "") then begin
+(let _86_63 = (FStar_Util.format2 "  --%s %s\n" flag argname)
+in (FStar_Util.print_string _86_63))
+end else begin
+(let _86_64 = (FStar_Util.format3 "  --%s %s  %s\n" flag argname doc)
+in (FStar_Util.print_string _86_64))
 end
 end)
 end)) specs)))
 
-let rec specs = (fun _21_173 -> (match (()) with
+let rec specs = (fun _21_178 -> (match (()) with
 | () -> begin
-(let specs = ((FStar_Getopt.noshort, "admit_fsi", FStar_Getopt.OneArg (((fun x -> (let _86_71 = (let _86_70 = (FStar_ST.read admit_fsi)
-in (x)::_86_70)
-in (FStar_ST.op_Colon_Equals admit_fsi _86_71))), "module name")), "Treat .fsi as a .fst"))::((FStar_Getopt.noshort, "admit_smt_queries", FStar_Getopt.OneArg (((fun s -> (let _86_75 = if (s = "true") then begin
+(let specs = ((FStar_Getopt.noshort, "admit_fsi", FStar_Getopt.OneArg (((fun x -> (let _86_74 = (let _86_73 = (FStar_ST.read admit_fsi)
+in (x)::_86_73)
+in (FStar_ST.op_Colon_Equals admit_fsi _86_74))), "module name")), "Treat .fsi as a .fst"))::((FStar_Getopt.noshort, "admit_smt_queries", FStar_Getopt.OneArg (((fun s -> (let _86_78 = if (s = "true") then begin
 true
 end else begin
 if (s = "false") then begin
@@ -372,140 +381,147 @@ end else begin
 (FStar_All.failwith "Invalid argument to --admit_smt_queries")
 end
 end
-in (FStar_ST.op_Colon_Equals admit_smt_queries _86_75))), "true|false")), "Admit SMT queries (UNSAFE! But, useful during development); default: \'false\'"))::((FStar_Getopt.noshort, "cardinality", FStar_Getopt.OneArg (((fun x -> (let _86_79 = (validate_cardinality x)
-in (FStar_ST.op_Colon_Equals cardinality _86_79))), "off|warn|check")), "Check cardinality constraints on inductive data types(default \'off\')"))::((FStar_Getopt.noshort, "codegen", FStar_Getopt.OneArg (((fun s -> (let _86_83 = (parse_codegen s)
-in (FStar_ST.op_Colon_Equals codegen _86_83))), "OCaml|FSharp")), "Generate code for execution"))::((FStar_Getopt.noshort, "codegen-lib", FStar_Getopt.OneArg (((fun s -> (let _86_88 = (let _86_87 = (FStar_ST.read codegen_libs)
-in ((FStar_Util.split s "."))::_86_87)
-in (FStar_ST.op_Colon_Equals codegen_libs _86_88))), "namespace")), "External runtime library library"))::((FStar_Getopt.noshort, "debug", FStar_Getopt.OneArg (((fun x -> (let _86_93 = (let _86_92 = (FStar_ST.read debug)
-in (x)::_86_92)
-in (FStar_ST.op_Colon_Equals debug _86_93))), "module name")), "Print LOTS of debugging information while checking module [arg]"))::((FStar_Getopt.noshort, "debug_level", FStar_Getopt.OneArg (((fun x -> (let _86_98 = (let _86_97 = (FStar_ST.read debug_level)
-in ((dlevel x))::_86_97)
-in (FStar_ST.op_Colon_Equals debug_level _86_98))), "Low|Medium|High|Extreme")), "Control the verbosity of debugging info"))::((FStar_Getopt.noshort, "dump_module", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals dump_module (Some (x)))), "module name")), ""))::((FStar_Getopt.noshort, "eager_inference", FStar_Getopt.ZeroArgs ((fun _21_182 -> (match (()) with
+in (FStar_ST.op_Colon_Equals admit_smt_queries _86_78))), "true|false")), "Admit SMT queries (UNSAFE! But, useful during development); default: \'false\'"))::((FStar_Getopt.noshort, "cardinality", FStar_Getopt.OneArg (((fun x -> (let _86_82 = (validate_cardinality x)
+in (FStar_ST.op_Colon_Equals cardinality _86_82))), "off|warn|check")), "Check cardinality constraints on inductive data types(default \'off\')"))::((FStar_Getopt.noshort, "codegen", FStar_Getopt.OneArg (((fun s -> (let _86_86 = (parse_codegen s)
+in (FStar_ST.op_Colon_Equals codegen _86_86))), "OCaml|FSharp")), "Generate code for execution"))::((FStar_Getopt.noshort, "codegen-lib", FStar_Getopt.OneArg (((fun s -> (let _86_91 = (let _86_90 = (FStar_ST.read codegen_libs)
+in ((FStar_Util.split s "."))::_86_90)
+in (FStar_ST.op_Colon_Equals codegen_libs _86_91))), "namespace")), "External runtime library library"))::((FStar_Getopt.noshort, "debug", FStar_Getopt.OneArg (((fun x -> (let _86_96 = (let _86_95 = (FStar_ST.read debug)
+in (x)::_86_95)
+in (FStar_ST.op_Colon_Equals debug _86_96))), "module name")), "Print LOTS of debugging information while checking module [arg]"))::((FStar_Getopt.noshort, "debug_level", FStar_Getopt.OneArg (((fun x -> (let _86_101 = (let _86_100 = (FStar_ST.read debug_level)
+in ((dlevel x))::_86_100)
+in (FStar_ST.op_Colon_Equals debug_level _86_101))), "Low|Medium|High|Extreme")), "Control the verbosity of debugging info"))::((FStar_Getopt.noshort, "dump_module", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals dump_module (Some (x)))), "module name")), ""))::((FStar_Getopt.noshort, "eager_inference", FStar_Getopt.ZeroArgs ((fun _21_187 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals eager_inference true)
-end))), "Solve all type-inference constraints eagerly; more efficient but at the cost of generality"))::((FStar_Getopt.noshort, "fs_typ_app", FStar_Getopt.ZeroArgs ((fun _21_183 -> (match (()) with
+end))), "Solve all type-inference constraints eagerly; more efficient but at the cost of generality"))::((FStar_Getopt.noshort, "fs_typ_app", FStar_Getopt.ZeroArgs ((fun _21_188 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals fs_typ_app true)
-end))), "Allow the use of t<t1,...,tn> syntax for type applications; brittle since it clashes with the integer less-than operator"))::((FStar_Getopt.noshort, "fsi", FStar_Getopt.ZeroArgs ((fun _21_184 -> (match (()) with
+end))), "Allow the use of t<t1,...,tn> syntax for type applications; brittle since it clashes with the integer less-than operator"))::((FStar_Getopt.noshort, "fsi", FStar_Getopt.ZeroArgs ((fun _21_189 -> (match (()) with
 | () -> begin
 (set_interactive_fsi ())
-end))), "fsi flag; A flag to indicate if type checking a fsi in the interactive mode"))::((FStar_Getopt.noshort, "fstar_home", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals fstar_home_opt (Some (x)))), "dir")), "Set the FSTAR_HOME variable to dir"))::((FStar_Getopt.noshort, "full_context_dependency", FStar_Getopt.ZeroArgs ((fun _21_186 -> (match (()) with
+end))), "fsi flag; A flag to indicate if type checking a fsi in the interactive mode"))::((FStar_Getopt.noshort, "fstar_home", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals fstar_home_opt (Some (x)))), "dir")), "Set the FSTAR_HOME variable to dir"))::((FStar_Getopt.noshort, "full_context_dependency", FStar_Getopt.ZeroArgs ((fun _21_191 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals full_context_dependency true)
-end))), "Introduce unification variables that are dependent on the entire context (possibly expensive, but better for type inference (on, by default)"))::((FStar_Getopt.noshort, "hide_genident_nums", FStar_Getopt.ZeroArgs ((fun _21_187 -> (match (()) with
+end))), "Introduce unification variables that are dependent on the entire context (possibly expensive, but better for type inference (on, by default)"))::((FStar_Getopt.noshort, "hide_genident_nums", FStar_Getopt.ZeroArgs ((fun _21_192 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals hide_genident_nums true)
-end))), "Don\'t print generated identifier numbers"))::((FStar_Getopt.noshort, "hide_uvar_nums", FStar_Getopt.ZeroArgs ((fun _21_188 -> (match (()) with
+end))), "Don\'t print generated identifier numbers"))::((FStar_Getopt.noshort, "hide_uvar_nums", FStar_Getopt.ZeroArgs ((fun _21_193 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals hide_uvar_nums true)
-end))), "Don\'t print unification variable numbers"))::((FStar_Getopt.noshort, "in", FStar_Getopt.ZeroArgs ((fun _21_189 -> (match (()) with
+end))), "Don\'t print unification variable numbers"))::((FStar_Getopt.noshort, "in", FStar_Getopt.ZeroArgs ((fun _21_194 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals interactive true)
-end))), "Interactive mode; reads input from stdin"))::((FStar_Getopt.noshort, "include", FStar_Getopt.OneArg (((fun s -> (let _86_116 = (let _86_115 = (FStar_ST.read _include_path)
-in (FStar_List.append _86_115 ((s)::[])))
-in (FStar_ST.op_Colon_Equals _include_path _86_116))), "path")), "A directory in which to search for files included on the command line"))::((FStar_Getopt.noshort, "initial_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_120 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals initial_fuel _86_120))), "non-negative integer")), "Number of unrolling of recursive functions to try initially (default 2)"))::((FStar_Getopt.noshort, "initial_ifuel", FStar_Getopt.OneArg (((fun x -> (let _86_124 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals initial_ifuel _86_124))), "non-negative integer")), "Number of unrolling of inductive datatypes to try at first (default 1)"))::((FStar_Getopt.noshort, "lax", FStar_Getopt.ZeroArgs ((fun _21_193 -> (match (()) with
+end))), "Interactive mode; reads input from stdin"))::((FStar_Getopt.noshort, "include", FStar_Getopt.OneArg (((fun s -> (let _86_119 = (let _86_118 = (FStar_ST.read _include_path)
+in (FStar_List.append _86_118 ((s)::[])))
+in (FStar_ST.op_Colon_Equals _include_path _86_119))), "path")), "A directory in which to search for files included on the command line"))::((FStar_Getopt.noshort, "initial_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_123 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals initial_fuel _86_123))), "non-negative integer")), "Number of unrolling of recursive functions to try initially (default 2)"))::((FStar_Getopt.noshort, "initial_ifuel", FStar_Getopt.OneArg (((fun x -> (let _86_127 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals initial_ifuel _86_127))), "non-negative integer")), "Number of unrolling of inductive datatypes to try at first (default 1)"))::((FStar_Getopt.noshort, "lax", FStar_Getopt.ZeroArgs ((fun _21_198 -> (match (()) with
 | () -> begin
-(let _21_194 = (FStar_ST.op_Colon_Equals pretype true)
+(let _21_199 = (FStar_ST.op_Colon_Equals pretype true)
 in (FStar_ST.op_Colon_Equals verify false))
-end))), "Run the lax-type checker only (admit all verification conditions)"))::((FStar_Getopt.noshort, "log_types", FStar_Getopt.ZeroArgs ((fun _21_196 -> (match (()) with
+end))), "Run the lax-type checker only (admit all verification conditions)"))::((FStar_Getopt.noshort, "log_types", FStar_Getopt.ZeroArgs ((fun _21_201 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals log_types true)
-end))), "Print types computed for data/val/let-bindings"))::((FStar_Getopt.noshort, "logQueries", FStar_Getopt.ZeroArgs ((fun _21_197 -> (match (()) with
+end))), "Print types computed for data/val/let-bindings"))::((FStar_Getopt.noshort, "logQueries", FStar_Getopt.ZeroArgs ((fun _21_202 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals logQueries true)
-end))), "Log the Z3 queries in queries.smt2"))::((FStar_Getopt.noshort, "max_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_131 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals max_fuel _86_131))), "non-negative integer")), "Number of unrolling of recursive functions to try at most (default 8)"))::((FStar_Getopt.noshort, "max_ifuel", FStar_Getopt.OneArg (((fun x -> (let _86_135 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals max_ifuel _86_135))), "non-negative integer")), "Number of unrolling of inductive datatypes to try at most (default 2)"))::((FStar_Getopt.noshort, "min_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_139 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals min_fuel _86_139))), "non-negative integer")), "Minimum number of unrolling of recursive functions to try (default 1)"))::((FStar_Getopt.noshort, "MLish", FStar_Getopt.ZeroArgs ((fun _21_201 -> (match (()) with
+end))), "Log the Z3 queries in queries.smt2"))::((FStar_Getopt.noshort, "max_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_134 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals max_fuel _86_134))), "non-negative integer")), "Number of unrolling of recursive functions to try at most (default 8)"))::((FStar_Getopt.noshort, "max_ifuel", FStar_Getopt.OneArg (((fun x -> (let _86_138 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals max_ifuel _86_138))), "non-negative integer")), "Number of unrolling of inductive datatypes to try at most (default 2)"))::((FStar_Getopt.noshort, "min_fuel", FStar_Getopt.OneArg (((fun x -> (let _86_142 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals min_fuel _86_142))), "non-negative integer")), "Minimum number of unrolling of recursive functions to try (default 1)"))::((FStar_Getopt.noshort, "MLish", FStar_Getopt.ZeroArgs ((fun _21_206 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals full_context_dependency false)
-end))), "Introduce unification variables that are only dependent on the type variables in the context"))::((FStar_Getopt.noshort, "n_cores", FStar_Getopt.OneArg (((fun x -> (let _86_144 = (FStar_Util.int_of_string x)
-in (FStar_ST.op_Colon_Equals n_cores _86_144))), "positive integer")), "Maximum number of cores to use for the solver (default 1)"))::((FStar_Getopt.noshort, "no_fs_typ_app", FStar_Getopt.ZeroArgs ((fun _21_203 -> (match (()) with
+end))), "Introduce unification variables that are only dependent on the type variables in the context"))::((FStar_Getopt.noshort, "n_cores", FStar_Getopt.OneArg (((fun x -> (let _86_147 = (FStar_Util.int_of_string x)
+in (FStar_ST.op_Colon_Equals n_cores _86_147))), "positive integer")), "Maximum number of cores to use for the solver (default 1)"))::((FStar_Getopt.noshort, "no_fs_typ_app", FStar_Getopt.ZeroArgs ((fun _21_208 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals fs_typ_app false)
-end))), "Do not allow the use of t<t1,...,tn> syntax for type applications"))::((FStar_Getopt.noshort, "no_slack", FStar_Getopt.ZeroArgs ((fun _21_204 -> (match (()) with
+end))), "Do not allow the use of t<t1,...,tn> syntax for type applications"))::((FStar_Getopt.noshort, "no_slack", FStar_Getopt.ZeroArgs ((fun _21_209 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals no_slack true)
-end))), "Use the partially flow-insensitive variant of --rel2 (experimental)"))::((FStar_Getopt.noshort, "odir", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals outputDir (Some (x)))), "dir")), "Place output in directory dir"))::((FStar_Getopt.noshort, "prims", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals prims_ref (Some (x)))), "file")), ""))::((FStar_Getopt.noshort, "print_before_norm", FStar_Getopt.ZeroArgs ((fun _21_207 -> (match (()) with
+end))), "Use the partially flow-insensitive variant of --rel2 (experimental)"))::((FStar_Getopt.noshort, "odir", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals outputDir (Some (x)))), "dir")), "Place output in directory dir"))::((FStar_Getopt.noshort, "prims", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals prims_ref (Some (x)))), "file")), ""))::((FStar_Getopt.noshort, "print_before_norm", FStar_Getopt.ZeroArgs ((fun _21_212 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals norm_then_print false)
-end))), "Do not normalize types before printing (for debugging)"))::((FStar_Getopt.noshort, "print_effect_args", FStar_Getopt.ZeroArgs ((fun _21_208 -> (match (()) with
+end))), "Do not normalize types before printing (for debugging)"))::((FStar_Getopt.noshort, "print_effect_args", FStar_Getopt.ZeroArgs ((fun _21_213 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals print_effect_args true)
-end))), "Print inferred predicate transformers for all computation types"))::((FStar_Getopt.noshort, "print_fuels", FStar_Getopt.ZeroArgs ((fun _21_209 -> (match (()) with
+end))), "Print inferred predicate transformers for all computation types"))::((FStar_Getopt.noshort, "print_fuels", FStar_Getopt.ZeroArgs ((fun _21_214 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals print_fuels true)
-end))), "Print the fuel amounts used for each successful query"))::((FStar_Getopt.noshort, "print_implicits", FStar_Getopt.ZeroArgs ((fun _21_210 -> (match (()) with
+end))), "Print the fuel amounts used for each successful query"))::((FStar_Getopt.noshort, "print_implicits", FStar_Getopt.ZeroArgs ((fun _21_215 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals print_implicits true)
-end))), "Print implicit arguments"))::((FStar_Getopt.noshort, "prn", FStar_Getopt.ZeroArgs ((fun _21_211 -> (match (()) with
+end))), "Print implicit arguments"))::((FStar_Getopt.noshort, "prn", FStar_Getopt.ZeroArgs ((fun _21_216 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals print_real_names true)
-end))), "Print real names---you may want to use this in conjunction with logQueries"))::((FStar_Getopt.noshort, "serialize_mods", FStar_Getopt.ZeroArgs ((fun _21_212 -> (match (()) with
+end))), "Print real names---you may want to use this in conjunction with logQueries"))::((FStar_Getopt.noshort, "serialize_mods", FStar_Getopt.ZeroArgs ((fun _21_217 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals serialize_mods true)
-end))), "Serialize compiled modules"))::((FStar_Getopt.noshort, "show_signatures", FStar_Getopt.OneArg (((fun x -> (let _86_163 = (let _86_162 = (FStar_ST.read show_signatures)
-in (x)::_86_162)
-in (FStar_ST.op_Colon_Equals show_signatures _86_163))), "module name")), "Show the checked signatures for all top-level symbols in the module"))::((FStar_Getopt.noshort, "silent", FStar_Getopt.ZeroArgs ((fun _21_214 -> (match (()) with
+end))), "Serialize compiled modules"))::((FStar_Getopt.noshort, "show_signatures", FStar_Getopt.OneArg (((fun x -> (let _86_166 = (let _86_165 = (FStar_ST.read show_signatures)
+in (x)::_86_165)
+in (FStar_ST.op_Colon_Equals show_signatures _86_166))), "module name")), "Show the checked signatures for all top-level symbols in the module"))::((FStar_Getopt.noshort, "silent", FStar_Getopt.ZeroArgs ((fun _21_219 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals silent true)
-end))), ""))::((FStar_Getopt.noshort, "smt", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals z3_exe x)), "path")), "Path to the SMT solver (usually Z3, but could be any SMT2-compatible solver)"))::((FStar_Getopt.noshort, "split_cases", FStar_Getopt.OneArg (((fun n -> (let _86_171 = (FStar_Util.int_of_string n)
-in (FStar_ST.op_Colon_Equals split_cases _86_171))), "t")), "Partition VC of a match into groups of n cases"))::((FStar_Getopt.noshort, "trace_error", FStar_Getopt.ZeroArgs ((fun _21_217 -> (match (()) with
+end))), ""))::((FStar_Getopt.noshort, "smt", FStar_Getopt.OneArg (((fun x -> (FStar_ST.op_Colon_Equals z3_exe x)), "path")), "Path to the SMT solver (usually Z3, but could be any SMT2-compatible solver)"))::((FStar_Getopt.noshort, "split_cases", FStar_Getopt.OneArg (((fun n -> (let _86_174 = (FStar_Util.int_of_string n)
+in (FStar_ST.op_Colon_Equals split_cases _86_174))), "t")), "Partition VC of a match into groups of n cases"))::((FStar_Getopt.noshort, "trace_error", FStar_Getopt.ZeroArgs ((fun _21_222 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals trace_error true)
-end))), "Don\'t print an error message; show an exception trace instead"))::((FStar_Getopt.noshort, "unthrottle_inductives", FStar_Getopt.ZeroArgs ((fun _21_218 -> (match (()) with
+end))), "Don\'t print an error message; show an exception trace instead"))::((FStar_Getopt.noshort, "unthrottle_inductives", FStar_Getopt.ZeroArgs ((fun _21_223 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals unthrottle_inductives true)
-end))), "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)"))::((FStar_Getopt.noshort, "use_build_config", FStar_Getopt.ZeroArgs ((fun _21_219 -> (match (()) with
+end))), "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)"))::((FStar_Getopt.noshort, "use_build_config", FStar_Getopt.ZeroArgs ((fun _21_224 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals use_build_config true)
-end))), "Expect just a single file on the command line and no options; will read the \'build-config\' prelude from the file"))::((FStar_Getopt.noshort, "use_eq_at_higher_order", FStar_Getopt.ZeroArgs ((fun _21_220 -> (match (()) with
+end))), "Expect just a single file on the command line and no options; will read the \'build-config\' prelude from the file"))::((FStar_Getopt.noshort, "use_eq_at_higher_order", FStar_Getopt.ZeroArgs ((fun _21_225 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals use_eq_at_higher_order true)
-end))), "Use equality constraints when comparing higher-order types; temporary"))::((FStar_Getopt.noshort, "use_native_int", FStar_Getopt.ZeroArgs ((fun _21_221 -> (match (()) with
+end))), "Use equality constraints when comparing higher-order types; temporary"))::((FStar_Getopt.noshort, "use_native_int", FStar_Getopt.ZeroArgs ((fun _21_226 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals use_native_int true)
-end))), "Extract the \'int\' type to platform-specific native int; you will need to link the generated code with the appropriate version of the prims library"))::((FStar_Getopt.noshort, "verify_module", FStar_Getopt.OneArg (((fun x -> (let _86_181 = (let _86_180 = (FStar_ST.read verify_module)
-in (x)::_86_180)
-in (FStar_ST.op_Colon_Equals verify_module _86_181))), "string")), "Name of the module to verify"))::((FStar_Getopt.noshort, "__temp_no_proj", FStar_Getopt.OneArg (((fun x -> (let _86_186 = (let _86_185 = (FStar_ST.read __temp_no_proj)
-in (x)::_86_185)
-in (FStar_ST.op_Colon_Equals __temp_no_proj _86_186))), "string")), "Don\'t generate projectors for this module"))::(('v', "version", FStar_Getopt.ZeroArgs ((fun _21_224 -> (let _21_226 = (display_version ())
-in (FStar_All.exit 0)))), "Display version number"))::((FStar_Getopt.noshort, "warn_top_level_effects", FStar_Getopt.ZeroArgs ((fun _21_228 -> (match (()) with
+end))), "Extract the \'int\' type to platform-specific native int; you will need to link the generated code with the appropriate version of the prims library"))::((FStar_Getopt.noshort, "verify_module", FStar_Getopt.OneArg (((fun x -> (let _86_184 = (let _86_183 = (FStar_ST.read verify_module)
+in (x)::_86_183)
+in (FStar_ST.op_Colon_Equals verify_module _86_184))), "string")), "Name of the module to verify"))::((FStar_Getopt.noshort, "__temp_no_proj", FStar_Getopt.OneArg (((fun x -> (let _86_189 = (let _86_188 = (FStar_ST.read __temp_no_proj)
+in (x)::_86_188)
+in (FStar_ST.op_Colon_Equals __temp_no_proj _86_189))), "string")), "Don\'t generate projectors for this module"))::(('v', "version", FStar_Getopt.ZeroArgs ((fun _21_229 -> (let _21_231 = (display_version ())
+in (FStar_All.exit 0)))), "Display version number"))::((FStar_Getopt.noshort, "warn_top_level_effects", FStar_Getopt.ZeroArgs ((fun _21_233 -> (match (()) with
 | () -> begin
 (FStar_ST.op_Colon_Equals warn_top_level_effects true)
-end))), "Top-level effects are ignored, by default; turn this flag on to be warned when this happens"))::((FStar_Getopt.noshort, "z3timeout", FStar_Getopt.OneArg (((fun s -> (let _86_192 = (FStar_Util.int_of_string s)
-in (FStar_ST.op_Colon_Equals z3timeout _86_192))), "t")), "Set the Z3 per-query (soft) timeout to t seconds (default 5)"))::[]
-in (('h', "help", FStar_Getopt.ZeroArgs ((fun x -> (let _21_232 = (display_usage specs)
+end))), "Top-level effects are ignored, by default; turn this flag on to be warned when this happens"))::((FStar_Getopt.noshort, "z3timeout", FStar_Getopt.OneArg (((fun s -> (let _86_195 = (FStar_Util.int_of_string s)
+in (FStar_ST.op_Colon_Equals z3timeout _86_195))), "t")), "Set the Z3 per-query (soft) timeout to t seconds (default 5)"))::((FStar_Getopt.noshort, "auto_deps", FStar_Getopt.ZeroArgs ((fun _21_235 -> (match (()) with
+| () -> begin
+(FStar_ST.op_Colon_Equals auto_deps true)
+end))), "automatically treat files discovered by --find_deps as dependencies."))::((FStar_Getopt.noshort, "find_deps", FStar_Getopt.ZeroArgs ((fun _21_236 -> (match (()) with
+| () -> begin
+(let _21_237 = (FStar_ST.op_Colon_Equals find_deps true)
+in (FStar_ST.op_Colon_Equals auto_deps true))
+end))), "find transitive dependencies given build-config other-files specifications."))::[]
+in (('h', "help", FStar_Getopt.ZeroArgs ((fun x -> (let _21_241 = (display_usage specs)
 in (FStar_All.exit 0)))), "Display this information"))::specs)
 end))
 and parse_codegen = (fun s -> (match (s) with
 | ("OCaml") | ("FSharp") -> begin
 Some (s)
 end
-| _21_238 -> begin
-(let _21_239 = (FStar_Util.print_string "Wrong argument to codegen flag\n")
-in (let _21_241 = (let _86_195 = (specs ())
-in (display_usage _86_195))
+| _21_247 -> begin
+(let _21_248 = (FStar_Util.print_string "Wrong argument to codegen flag\n")
+in (let _21_250 = (let _86_200 = (specs ())
+in (display_usage _86_200))
 in (FStar_All.exit 1)))
 end))
 and validate_cardinality = (fun x -> (match (x) with
 | ("warn") | ("check") | ("off") -> begin
 x
 end
-| _21_248 -> begin
-(let _21_249 = (FStar_Util.print_string "Wrong argument to cardinality flag\n")
-in (let _21_251 = (let _86_197 = (specs ())
-in (display_usage _86_197))
+| _21_257 -> begin
+(let _21_258 = (FStar_Util.print_string "Wrong argument to cardinality flag\n")
+in (let _21_260 = (let _86_202 = (specs ())
+in (display_usage _86_202))
 in (FStar_All.exit 1)))
 end))
-and set_interactive_fsi = (fun _21_253 -> if (FStar_ST.read interactive) then begin
+and set_interactive_fsi = (fun _21_262 -> if (FStar_ST.read interactive) then begin
 (FStar_ST.op_Colon_Equals interactive_fsi true)
 end else begin
-(let _21_255 = (FStar_Util.print_string "Set interactive flag first before setting interactive fsi flag\n")
-in (let _21_257 = (let _86_199 = (specs ())
-in (display_usage _86_199))
+(let _21_264 = (FStar_Util.print_string "Set interactive flag first before setting interactive fsi flag\n")
+in (let _21_266 = (let _86_204 = (specs ())
+in (display_usage _86_204))
 in (FStar_All.exit 1)))
 end)
 
@@ -517,31 +533,31 @@ end
 (FStar_List.contains m l)
 end)))
 
-let dont_gen_projectors = (fun m -> (let _86_204 = (FStar_ST.read __temp_no_proj)
-in (FStar_List.contains m _86_204)))
+let dont_gen_projectors = (fun m -> (let _86_209 = (FStar_ST.read __temp_no_proj)
+in (FStar_List.contains m _86_209)))
 
-let should_print_message = (fun m -> (((should_verify m) && (not ((let _86_207 = (FStar_ST.read admit_fsi)
-in (FStar_List.contains m _86_207))))) && (m <> "Prims")))
+let should_print_message = (fun m -> (((should_verify m) && (not ((let _86_212 = (FStar_ST.read admit_fsi)
+in (FStar_List.contains m _86_212))))) && (m <> "Prims")))
 
-let set_options = (let no_smt_specs = (let _86_210 = (specs ())
-in (FStar_All.pipe_right _86_210 (FStar_List.filter (fun _21_271 -> (match (_21_271) with
-| (_21_265, name, _21_268, _21_270) -> begin
+let set_options = (let no_smt_specs = (let _86_215 = (specs ())
+in (FStar_All.pipe_right _86_215 (FStar_List.filter (fun _21_280 -> (match (_21_280) with
+| (_21_274, name, _21_277, _21_279) -> begin
 (name <> "smt")
 end)))))
-in (fun s -> (FStar_Getopt.parse_string no_smt_specs (fun _21_274 -> ()) s)))
+in (fun s -> (FStar_Getopt.parse_string no_smt_specs (fun _21_283 -> ()) s)))
 
 let reset_options_string = (FStar_ST.alloc None)
 
-let reset_options = (fun _21_276 -> (match (()) with
+let reset_options = (fun _21_285 -> (match (()) with
 | () -> begin
-(let _21_277 = (init_options ())
-in (let res = (let _86_216 = (specs ())
-in (FStar_Getopt.parse_cmdline _86_216 (fun x -> ())))
+(let _21_286 = (init_options ())
+in (let res = (let _86_221 = (specs ())
+in (FStar_Getopt.parse_cmdline _86_221 (fun x -> ())))
 in (match ((FStar_ST.read reset_options_string)) with
 | Some (x) -> begin
 (set_options x)
 end
-| _21_284 -> begin
+| _21_293 -> begin
 res
 end)))
 end))

--- a/src/ocaml-output/FStar_Parser_Driver.ml
+++ b/src/ocaml-output/FStar_Parser_Driver.ml
@@ -93,7 +93,7 @@ in (FStar_All.exit 1))
 end)
 end)
 
-let read_build_config = (fun file -> (FStar_Parser_ParseIt.read_build_config file))
+let read_build_config = (fun file -> (FStar_Parser_ParseIt.read_build_config file true))
 
 
 

--- a/src/parser/driver.fs
+++ b/src/parser/driver.fs
@@ -71,5 +71,6 @@ let parse_file env fn =
       Util.print_string <| Print.format_error r msg;
       exit 1
 
-let read_build_config file = ParseIt.read_build_config file
-
+let read_build_config file = 
+  ParseIt.read_build_config file true
+  

--- a/src/parser/parseit.fsi
+++ b/src/parser/parseit.fsi
@@ -20,6 +20,6 @@ open FStar.Util
 open FStar
 
 val parse: either<string,string> -> either<AST.inputFragment, (string * Range.range)>
-val read_build_config_from_string:string -> bool -> string -> list<string>
-val read_build_config:string -> list<string>
+val read_build_config_from_string:string -> bool -> string -> bool -> list<string>
+val read_build_config:string -> bool -> list<string>
 val get_bc_start_string: unit -> string

--- a/src/parser/parser.fsproj
+++ b/src/parser/parser.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/tests/App.config
+++ b/src/tests/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
## Description
This is the first version of transitive dependencies for F*, implemented by recursive parsing of `build-config` headers. 

## Usage
Passing `--find_deps` as an argument to F* will cause it to recurse `build-config` headers, collecting the names of dependencies.

## Testing
- Results of `--find_deps` usage tested against files from a third-party project written in F*.
- Regression tested against unit test suite:
  - F# build on Win64 with Visual Studio 2013
  - OCaml build on Win64 with OPAM version of `batteries`.
  - F# build on Debian Jessie i386
  - OCaml build on Debian Jessie i386

## Known Issues
- I anticipate that `--admit_fsi` not being transitive will become an annoyance, if not problematic to maintain. I would like to suggest a top-level directive to address this (e.g. `admit module FStar.Seq`).

## Additional Changes
- added `FStar_List.unique` (mirrors `BatList.unique`).
- added `all-pos` unit test target (`all-neg` tests cannot be used with the `--lax` compile flag).
- added `Makefile` logic that restores the NuGet package cache.