### PR TITLE
Fix link to exercise 7c answer

### DIFF
--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -2914,7 +2914,7 @@ type exp =
 ~~
 Add cases for `ELet` to all definitions and proofs.
 
-[Load answer in editor](code/exercises/ex7c-stlc-let.fst)
+[Load answer in editor](code/solutions/ex7c-stlc-let.fst)
 ~~ CH
 Make the prev kind of link a macro of some sorts. It doesn't have a
 proper body so it's not an environment, but what is it? Entity?


### PR DESCRIPTION
Trivial change to link to the solutions directory for the answer rather than the exercises directory.
The link text "Load answer in editor" could also be improved but based on the comment below I assume it is "TODO".