### PR TITLE
Fix trusty-based Dockerfile

### DIFF
--- a/.docker/ubuntu_trusty/Dockerfile
+++ b/.docker/ubuntu_trusty/Dockerfile
@@ -22,7 +22,7 @@ RUN add-apt-repository --yes ppa:0k53d-karl-f830m/openssl
 RUN apt-get -qq update
 
 # Install required packages and set versions
-RUN apt-get install --yes libssl-dev libsqlite3-dev g++-5 gcc-5 m4 make opam pkg-config python
+RUN apt-get install --yes libssl-dev libsqlite3-dev g++-5 gcc-5 m4 make opam pkg-config python libgmp3-dev
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 200
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 200
 
@@ -32,7 +32,7 @@ RUN opam init
 RUN eval $(opam config env)
 RUN opam switch ${opamv}
 RUN eval $(opam config env)
-RUN opam install ocamlfind batteries sqlite3 fileutils stdint
+RUN opam install ocamlfind batteries sqlite3 fileutils stdint zarith
 RUN eval $(opam config env)
 
 # Prepare Z3


### PR DESCRIPTION
This PR fixes the Dockerfile so we can build trusty-base docker image.
These images weren't "buildable" since Apr 13 => https://github.com/FStarLang/FStar/commit/57fbfe8bde320b065508e445280ff2ebed396f63