### PR TITLE
Better names for cmd_line_res and local variables

### DIFF
--- a/src/basic/getoptsimple.fs
+++ b/src/basic/getoptsimple.fs
@@ -26,12 +26,12 @@ type opt'<'a> = char * string * opt_variant<'a> * string
 type opt = opt'<unit>
 type parse_cmdline_res =
   | Help
-  | Die of string
-  | GoOn
+  | Error of string
+  | Success
 
 (* remark: doesn't work with files starting with -- *)
 let rec parse (opts:list<opt>) def ar ix max i =
-  if ix > max then GoOn
+  if ix > max then Success
   else
     let arg = ar.(ix) in
     let go_on () = let _ = def arg in parse opts def ar (ix + 1) max (i + 1) in
@@ -46,14 +46,14 @@ let rec parse (opts:list<opt>) def ar ix max i =
                     (match p with
                        | ZeroArgs f -> f (); parse opts def ar (ix + 1) max (i + 1)
                        | OneArg (f, _) ->
-                           if ix + 1 > max then Die ("last option '" + argtrim + "' takes an argument but has none\n")
+                           if ix + 1 > max then Error ("last option '" + argtrim + "' takes an argument but has none\n")
                            else
                              try
                                f (ar.(ix + 1));
                                parse opts def ar (ix + 2) max (i + 1)
                              with _ ->
-                                  Die ("wrong argument given to option '" + argtrim + "'\n"))
-                | None -> Die ("unrecognized option '" + arg + "'\n")
+                                  Error ("wrong argument given to option '" + argtrim + "'\n"))
+                | None -> Error ("unrecognized option '" + arg + "'\n")
           else go_on ()
 
 let parse_cmdline specs others =

--- a/src/basic/getoptsimple.fsi
+++ b/src/basic/getoptsimple.fsi
@@ -28,8 +28,8 @@ type opt = opt'<unit>
 
 type parse_cmdline_res =
   | Help
-  | Die of string
-  | GoOn
+  | Error of string
+  | Success
 
 val parse_cmdline: list<opt> -> (string -> 'a) -> parse_cmdline_res
 val parse_string: list<opt> -> (string -> 'a) -> string -> parse_cmdline_res

--- a/src/basic/ml/FStar_Getopt.ml
+++ b/src/basic/ml/FStar_Getopt.ml
@@ -6,12 +6,12 @@ type 'a opt' = char * string * 'a opt_variant * string
 type opt = unit opt'
 type parse_cmdline_res =
   | Help
-  | Die of string
-  | GoOn
+  | Error of string
+  | Success
 
 (* remark: doesn't work with files starting with -- *)
 let rec parse (opts:opt list) def ar ix max i =
-  if ix > max then GoOn
+  if ix > max then Success
   else
     let arg = ar.(ix) in
     let go_on () = let _ = def arg in parse opts def ar (ix + 1) max (i + 1) in
@@ -27,11 +27,11 @@ let rec parse (opts:opt list) def ar ix max i =
             | ZeroArgs f -> f (); parse opts def ar (ix + 1) max (i + 1)
             | OneArg (f, _) ->
                if ix + 1 > max
-               then Die ("last option '" ^ argtrim ^ "' takes an argument but has none\n")
+               then Error ("last option '" ^ argtrim ^ "' takes an argument but has none\n")
                else
                  (f (ar.(ix + 1));
                   parse opts def ar (ix + 2) max (i + 1)))
-        | None -> Die ("unrecognized option '" ^ arg ^ "'\n")
+        | None -> Error ("unrecognized option '" ^ arg ^ "'\n")
       else go_on ()
 
 let parse_cmdline specs others =

--- a/src/basic/options.fs
+++ b/src/basic/options.fs
@@ -756,12 +756,12 @@ let find_file filename =
 let prims () =
   match get_prims() with
   | None ->
-    let filen = "prims.fst" in
-    begin match find_file filen with
+    let filename = "prims.fst" in
+    begin match find_file filename with
           | Some result ->
             result
           | None ->
-            raise (Util.Failure (Util.format1 "unable to find required file \"%s\" in the module search path.\n" filen))
+            raise (Util.Failure (Util.format1 "unable to find required file \"%s\" in the module search path.\n" filename))
     end
   | Some x -> x
 

--- a/src/fstar/fstar.fs
+++ b/src/fstar/fstar.fs
@@ -83,9 +83,9 @@ let go _ =
   match res with
     | Help ->
         Options.display_usage(); exit 0
-    | Die msg ->
+    | Error msg ->
         Util.print_string msg
-    | GoOn ->
+    | Success ->
         if Options.dep() <> None  //--dep: Just compute and print the transitive dependency graph; don't verify anything
         then Parser.Dep.print (Parser.Dep.collect Parser.Dep.VerifyAll filenames)
         else if (Options.interactive()) then //--in

--- a/src/fstar/universal.fs
+++ b/src/fstar/universal.fs
@@ -69,8 +69,8 @@ let tc_prims () : Syntax.modul
   let solver = if Options.lax() then SMT.dummy else SMT.solver in
   let env = TcEnv.initial_env Tc.type_of solver Const.prims_lid in
   env.solver.init env;
-  let p = Options.prims () in
-  let dsenv, prims_mod = parse (DsEnv.empty_env ()) None p in
+  let prims_filename = Options.prims () in
+  let dsenv, prims_mod = parse (DsEnv.empty_env ()) None prims_filename in
   let prims_mod, env = Tc.check_module env (List.hd prims_mod) in
   prims_mod, dsenv, env
 

--- a/src/tc/tc.fs
+++ b/src/tc/tc.fs
@@ -1506,9 +1506,9 @@ let rec tc_eff_decl env (m:Syntax.eff_decl)  =
 and tc_decl env se deserialized = match se with
     | Sig_pragma(p, r) ->
         let set_options t s = match Options.set_options t s with
-            | Getopt.GoOn -> ()
+            | Getopt.Success -> ()
             | Getopt.Help  -> raise (Error ("Failed to process pragma: use 'fstar --help' to see which options are available", r))
-            | Getopt.Die s -> raise (Error ("Failed to process pragma: " ^s, r)) in
+            | Getopt.Error s -> raise (Error ("Failed to process pragma: " ^s, r)) in
         begin match p with
             | SetOptions o ->
                 set_options Options.Set o;

--- a/src/typechecker/tc.fs
+++ b/src/typechecker/tc.fs
@@ -2679,9 +2679,9 @@ let rec tc_decl env se = match se with
 
     | Sig_pragma(p, r) ->
        let set_options t s = match Options.set_options t s with
-            | Getopt.GoOn -> ()
+            | Getopt.Success -> ()
             | Getopt.Help  -> raise (Error ("Failed to process pragma: use 'fstar --help' to see which options are available", r))
-            | Getopt.Die s -> raise (Error ("Failed to process pragma: " ^s, r)) in
+            | Getopt.Error s -> raise (Error ("Failed to process pragma: " ^s, r)) in
         begin match p with
             | SetOptions o ->
                 set_options Options.Set o;


### PR DESCRIPTION
I was debugging F* and noticed that some names were different from ones that are usually used or just not intuitive (like `p` meaning prims filename).

I'm not sure whether such PRs are welcome because they change (at least this one) names that were intentionally chosen at some point in the past. Please let me know if it's OK, so I could do some more cleanup while working on other issues.