### PR TITLE
Fix a tutorial example

### DIFF
--- a/doc/tutorial/code/exercises/ex1a-safe-read-write.fst
+++ b/doc/tutorial/code/exercises/ex1a-safe-read-write.fst
@@ -35,6 +35,7 @@ module UntrustedClientCode
 // END: UntrustedClientCode
 
 // BEGIN: StaticChecking
+  val staticChecking : unit -> unit
   let staticChecking () =
     let v1 = read tmp in
     let v2 = read readme in

--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -560,7 +560,7 @@ in ML-like languages.)
 If we provide explicit annotations we can give these functions more
 precise types:
 
-    val hello_incr i : int -> IO int
+    val hello_incr : int -> ML int
     let hello_incr i = IO.print_string "hello"; i + 1
 
     val loop : int -> Dv int


### PR DESCRIPTION
Without this fix, uncommenting the supposedly ill-typed code did *not* 
produce any error, maybe inferring something crazy like:

  val staticChecking : 
    x:unit{ACLs.canWrite passwd && ACLs.canRead passwd} -> unit

This also fixes another example that didn't compile.