### PR TITLE
Adjust the path for the emacs docker

### DIFF
--- a/.docker/emacs/Dockerfile
+++ b/.docker/emacs/Dockerfile
@@ -1,4 +1,4 @@
-FROM fstar-base
+FROM fstarlang/fstar
 
 MAINTAINER Daniel Fabian <daniel.fabian@integral-it.ch>; Benjamin Beurdouche <benjamin.beurdouche@inria.fr>
 


### PR DESCRIPTION
Based on the docker CI, the official path should be fstarlang/fstar, I believe.