### PR TITLE
Deal with Makefile error reporting doing singular/plural case properly.

### DIFF
--- a/examples/unit-tests/Makefile
+++ b/examples/unit-tests/Makefile
@@ -33,7 +33,7 @@ basictests: $(SVERFILES)
 
 sall-neg: $(NEGFILES)
 	-$(SFSTAR) --explicit_deps $(STDLIB) --split_cases 1 $^ 2>&1 | tee fstar_log
-	@FAILC=`egrep "^[0-9]* errors were reported" -o fstar_log | egrep -o "[0-9]+"`; if [ "$$FAILC" != "$(NEGTESTS)" ]; then echo "Wrong failure count: $$FAILC (expected $(NEGTESTS))" && false; else echo "Success: $$FAILC failures were expected"; fi
+	@FAILC=`egrep "^[0-9]* error.* reported" -o fstar_log | egrep -o "[0-9]+"`; if [ "$$FAILC" != "$(NEGTESTS)" ]; then echo "Wrong failure count: $$FAILC (expected $(NEGTESTS))" && false; else echo "Success: $$FAILC failures were expected"; fi
 
 mac: mac.fst
 	$(FSTAR)  mac.fst


### PR DESCRIPTION
A Makefile error says either:
```1 error was reported ```
or 
```36 errors were reported```
(the first in lax mode). To catch both, the Makefile should grep for ""^[0-9]* error.* reported". 