### PR TITLE
Added commandline option to pass options down to Z3.

### DIFF
--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -155,7 +155,8 @@ let init () =
         ("z3refresh"                    , Bool false);
         ("z3rlimit"                     , Int 5);
         ("z3seed"                       , Int 0);
-        ("z3timeout"                    , Int 5)] in
+        ("z3timeout"                    , Int 5);
+        ("z3cliopt"                     , List [])] in
    let o = peek () in
    Util.smap_clear o;
    vals |> List.iter set_option'                          //initialize it with the default values
@@ -236,6 +237,7 @@ let get_verify_module           ()      = lookup_opt "verify_module"            
 let get___temp_no_proj          ()      = lookup_opt "__temp_no_proj"           (as_list as_string)
 let get_version                 ()      = lookup_opt "version"                  as_bool
 let get_warn_top_level_effects  ()      = lookup_opt "no_warn_top_level_effects"   as_bool
+let get_z3cliopt                ()      = lookup_opt "z3cliopt"                 (as_list as_string)
 let get_z3refresh               ()      = lookup_opt "z3refresh"                as_bool
 let get_z3rlimit                ()      = lookup_opt "z3rlimit"                 as_int
 let get_z3seed                  ()      = lookup_opt "z3seed"                   as_int
@@ -659,6 +661,11 @@ let rec specs () : list<Getopt.opt> =
         "Top-level effects are checked by default; turn this flag on to prevent warning when this happens");
 
        ( noshort,
+         "z3cliopt",
+         OneArg ((fun s -> List (get_z3cliopt() @ [s] |> List.map String)), "[option]"),
+         "Z3 command line options");
+
+       ( noshort,
         "z3refresh",
         ZeroArgs (fun () -> Bool false),
         "Restart Z3 after each query; useful for ensuring proof robustness");
@@ -919,6 +926,7 @@ let warn_top_level_effects       () = get_warn_top_level_effects      ()
 let z3_exe                       () = match get_smt () with
                                     | None -> Platform.exe "z3"
                                     | Some s -> s
+let z3_cliopt                    () = get_z3cliopt                    ()
 let z3_refresh                   () = get_z3refresh                   ()
 let z3_rlimit                    () = get_z3rlimit                    ()
 let z3_seed                      () = get_z3seed                      ()

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -126,6 +126,7 @@ val verify_module               : unit    -> list<string>
 val warn_cardinality            : unit    -> bool
 val warn_top_level_effects      : unit    -> bool
 val z3_exe                      : unit    -> string
+val z3_cliopt                   : unit    -> list<string>
 val z3_refresh                  : unit    -> bool
 val z3_rlimit                   : unit    -> int
 val z3_seed                     : unit    -> int

--- a/src/smtencoding/FStar.SMTEncoding.Z3.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fs
@@ -75,11 +75,11 @@ let ini_params () =
   then raise <| BU.Failure (BU.format1 "Z3 4.5.0 recommended; at least Z3 v4.4.1 required; got %s\n" (z3version_as_string z3_v))
   else ()
   end;
-  BU.format1 "-smt2 -in \
-    AUTO_CONFIG=false \
-    MODEL=true \
-    SMT.RELEVANCY=2 \
-    SMT.RANDOM_SEED=%s" (string_of_int (Options.z3_seed()))
+  (String.concat " "
+                (List.append
+                 [ "-smt2 -in auto_config=false model=true smt.relevancy=2";
+                   (Util.format1 "smt.random_seed=%s" (string_of_int (Options.z3_seed()))) ]
+                 (Options.z3_cliopt())))
 
 type label = string
 type unsat_core = option<list<string>>
@@ -254,11 +254,10 @@ let doZ3Exe =
         res
 
 let z3_options () =
-    BU.format1 "(set-option :global-decls false)\
+    "(set-option :global-decls false)\
      (set-option :smt.mbqi false)\
      (set-option :auto_config false)\
-     (set-option :produce-unsat-cores true)\
-     (set-option :smt.random_seed %s)\n" (string_of_int (Options.z3_seed()))
+     (set-option :produce-unsat-cores true)"
 
 type job<'a> = {
     job:unit -> 'a;


### PR DESCRIPTION
Also cleaned up default Z3 options. The smt.random_seed option is best not written to the smt2 file because it can't easily be changed without copying/modifying files. The other options are non-negotiable anyways.

Feel free to send this back to me for revision if there's anything unusual/undesirable in my changes!