### PR TITLE
Bugfix for FStar_Util.replace_string

### DIFF
--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -342,7 +342,7 @@ let substring s i j= BatString.sub s (Z.to_int i) (Z.to_int j)
 let replace_char (s:string) (c1:char) (c2:char) =
   BatString.map (fun c -> if c = c1 then c2 else c) s
 let replace_string (s:string) (s1:string) (s2:string) =
-  BatString.rev (BatString.nreplace ~str:(BatString.rev s) ~sub:s1 ~by:s2)
+  BatString.rev (BatString.nreplace ~str:(BatString.rev s) ~sub:(BatString.rev s1) ~by:(BatString.rev s2))
 let hashcode s = Z.of_int (BatHashtbl.hash s)
 let compare s1 s2 = Z.of_int (BatString.compare s1 s2)
 let splitlines s = BatString.nsplit s "\n"

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -341,8 +341,8 @@ let substring_from s index = BatString.tail s (Z.to_int index)
 let substring s i j= BatString.sub s (Z.to_int i) (Z.to_int j)
 let replace_char (s:string) (c1:char) (c2:char) =
   BatString.map (fun c -> if c = c1 then c2 else c) s
-let replace_string (s:string) (s1:string) (s2:string) =
-  BatString.rev (BatString.nreplace ~str:(BatString.rev s) ~sub:(BatString.rev s1) ~by:(BatString.rev s2))
+let replace_chars (s:string) (c:char) (by:string) =
+  BatString.replace_chars (function c -> by | x -> BatString.of_char x) s
 let hashcode s = Z.of_int (BatHashtbl.hash s)
 let compare s1 s2 = Z.of_int (BatString.compare s1 s2)
 let splitlines s = BatString.nsplit s "\n"

--- a/src/basic/util.fs
+++ b/src/basic/util.fs
@@ -326,7 +326,7 @@ let is_upper (c:char) = 'A' <= c && c <= 'Z'
 let substring_from (s:string) i = s.Substring(i)
 let substring (s:string) i j = s.Substring(i, j)
 let replace_char (s:string) (c1:char) (c2:char) = s.Replace(c1,c2)
-let replace_string (s:string) (s1:string) (s2:string) = s.Replace(s1, s2)
+let replace_chars (s:string) (c:char) (by:string) = s.Replace(String.of_char c,by)
 let hashcode (s:string) = s.GetHashCode()
 let compare (s1:string) (s2:string) = s1.CompareTo(s2)
 let splitlines (s:string) = Array.toList (s.Split([|Environment.NewLine;"\n"|], StringSplitOptions.None))

--- a/src/basic/util.fsi
+++ b/src/basic/util.fsi
@@ -193,7 +193,7 @@ val substring_from: string -> int -> string
 (* Second argument is a length, not an index. *)
 val substring: string -> int -> int -> string
 val replace_char: string -> char -> char -> Tot<string>
-val replace_string: string -> string -> string -> Tot<string>
+val replace_chars: string -> char -> string -> Tot<string>
 val hashcode: string -> Tot<int>
 val compare: string -> string -> Tot<int>
 val splitlines: string -> Tot<list<string>>

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -814,7 +814,7 @@ let print_make :
          | (f,deps) ->
              let deps =
                FStar_List.map
-                 (fun s  -> FStar_Util.replace_string s " " "\\ ") deps
+                 (fun s  -> FStar_Util.replace_chars s ' ' "\\ ") deps
                 in
              FStar_Util.print2 "%s: %s\n" f (FStar_String.concat " " deps))
       deps

--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -694,7 +694,7 @@ let collect (verify_mode: verify_mode) (filenames: list<string>): _ =
     format. *)
 let print_make (deps: list<(string * list<string>)>): unit =
   List.iter (fun (f, deps) ->
-    let deps = List.map (fun s -> replace_string s " " "\\ ") deps in
+    let deps = List.map (fun s -> replace_chars s ' ' "\\ ") deps in
     Util.print2 "%s: %s\n" f (String.concat " " deps)
   ) deps
 


### PR DESCRIPTION
This one kept me busy for quite a while after triggering random segfaults in native OCaml land! Two parts of the code tried to write to the same file after one of the string replacements had failed. 

The two `BatString.rev` calls in the `nreplace` call are probably there because `nreplace` replaces string matches right-to-left; but it doesn't reverse any strings, it just replaces the last occurrence first. However, `FStar_Util.replace_string` is only used in one other place with `s1` being a single character. May be better to remove it altogether to avoid confusion and/or debug time? 