### PR TITLE
Stabilized topological sort of file dependencies.

### DIFF
--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -669,7 +669,7 @@ let collect (verify_mode: verify_mode) (filenames: list<string>): _ =
       (* List stored in the "right" order. *)
       f, deps_as_filenames
     ) as_list
-  ) (List.sort (smap_keys graph)) in
+  ) (FStar.List.sortWith (fun x y -> String.compare x y) (smap_keys graph)) in
   let topologically_sorted = List.collect must_find_r !topologically_sorted in
 
   List.iter (fun (m, r) ->

--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -669,7 +669,7 @@ let collect (verify_mode: verify_mode) (filenames: list<string>): _ =
       (* List stored in the "right" order. *)
       f, deps_as_filenames
     ) as_list
-  ) (smap_keys graph) in
+  ) (List.sort (smap_keys graph)) in
   let topologically_sorted = List.collect must_find_r !topologically_sorted in
 
   List.iter (fun (m, r) ->


### PR DESCRIPTION
An attempt to stabilize the order of input files. This stabilizes everything in my current pet test case, but I'm not sure this change makes it stable under all circumstances. 

Without this, the order of input files is essentially random. Consequently, all Z3 queries get mixed up too, which makes debugging very hard and has potential performance implications as well.

Relates to #746.