### PR TITLE
Add #ifdef to set a custom stack size for managed F*

### DIFF
--- a/src/fstar/FStar.Top.fs
+++ b/src/fstar/FStar.Top.fs
@@ -1,7 +1,12 @@
 #light "off"
 module FStar.Top
 open FStar.All
-let _ = 
+let _ =
+#if CUSTOM_STACK_SIZE
+    let t = (new System.Threading.Thread(FStar.Main.main, 1048576 * 32)) in
+    t.Start() ; t.Join() ;
+#else
     let _ = FStar.Main.main () in
+#endif
     printfn "done"
 

--- a/src/fstar/FStar.Top.fs
+++ b/src/fstar/FStar.Top.fs
@@ -2,11 +2,6 @@
 module FStar.Top
 open FStar.All
 let _ =
-#if CUSTOM_STACK_SIZE
-    let t = (new System.Threading.Thread(FStar.Main.main, 1048576 * 32)) in
+    let t = (new System.Threading.Thread(FStar.Main.main, 1024 * 1024 * 32)) in
     t.Start() ; t.Join() ;
-#else
-    let _ = FStar.Main.main () in
-#endif
     printfn "done"
-


### PR DESCRIPTION
Here's a simple way of getting around the small stack size in F#/.NET/Windows. Not necessarily meant to be merged into master, I just wanted to save it somewhere. 