### PR TITLE
Fix a number of OpenSSL build issues

### DIFF
--- a/examples/low-level/Makefile
+++ b/examples/low-level/Makefile
@@ -213,6 +213,12 @@ krml-test.exe: spartan_aes/aes.o crypto/*.fst
                 crypto/spartan/Crypto.Config.fst crypto/real/Flag.fst crypto/Crypto.KrmlTest.fst
 	./krml-test.exe
 
+ifeq ($(OS),Windows_NT)
+  WINSOCK=,-lws2_32
+else
+  WINSOCK=
+endif
+
 test-perf.exe: crypto/test_perf.c krml-test.exe
 	# Add this argument once someone writes a proper API for the Crypto
 	# subsystem
@@ -226,7 +232,7 @@ test-perf.exe: crypto/test_perf.c krml-test.exe
                   -ldopt -flto \
                   -ccopts -Ofast,-m64,-march=native,-mtune=native,-funroll-loops,-fomit-frame-pointer,-Wno-int-conversion \
                   -I $(KREMLIN_HOME)/kremlib -I $(KREMLIN_HOME)/test \
-                  -I $(OPENSSL_HOME)/include -ldopts -L,$(OPENSSL_HOME)/lib,-L,$(OPENSSL_HOME),-lcrypto $(CFLAGS)
+                  -I $(OPENSSL_HOME)/include -ldopts -L,$(OPENSSL_HOME)/lib,-L,$(OPENSSL_HOME),-lcrypto$(WINSOCK) $(CFLAGS)
 	PATH=$(OPENSSL_HOME):"$(PATH)" \
 	  LD_LIBRARY_PATH=$(OPENSSL_HOME):"$(LD_LIBRARY_PATH)" \
 	  DYLD_LIBRARY_PATH=$(OPENSSL_HOME):"$(DYLD_LIBRARY_PATH)" ./test-perf.exe

--- a/ucontrib/CoreCrypto/ml/Makefile
+++ b/ucontrib/CoreCrypto/ml/Makefile
@@ -78,7 +78,6 @@ openssl/libcrypto.a: openssl/Configure
 
 libcrypto.a: openssl/libcrypto.a
 	cp openssl/libcrypto.a .
-	cp openssl/crypto/opensslconf.h openssl/include/openssl
 
 DLL_OBJ = $(PLATFORM)/platform.cmx CoreCrypto.cmx openssl_stub.o $(DB)/DB.cmx DHDB.cmx
 CoreCrypto.cmxa: #explicitly sequentialize

--- a/ucontrib/CoreCrypto/ml/Makefile
+++ b/ucontrib/CoreCrypto/ml/Makefile
@@ -23,9 +23,9 @@ ifeq ($(OS),Windows_NT)
     EXTRA_OPTS =
     EXTRA_LIBS = -L.
     ifeq ($(MARCH),x86_64)
-      OPENSSL_CONF = CC=x86_64-w64-mingw32-gcc ./Configure mingw64
+      OPENSSL_CONF = CROSS_COMPILE=x86_64-w64-mingw32- ./Configure mingw64 no-shared no-engine
     else
-      OPENSSL_CONF = CC=i686-w64-mingw32-gcc ./Configure mingw
+      OPENSSL_CONF = CROSS_COMPILE=i686-w64-mingw32- ./Configure mingw no-shared no-engine
     endif
 else
     # On Unix-like systems, the library search path is LD_LIBRARY_PATH, which is
@@ -78,6 +78,7 @@ openssl/libcrypto.a: openssl/Configure
 
 libcrypto.a: openssl/libcrypto.a
 	cp openssl/libcrypto.a .
+	cp openssl/crypto/opensslconf.h openssl/include/openssl
 
 DLL_OBJ = $(PLATFORM)/platform.cmx CoreCrypto.cmx openssl_stub.o $(DB)/DB.cmx DHDB.cmx
 CoreCrypto.cmxa: #explicitly sequentialize


### PR DESCRIPTION
These changes fix a number of OpenSSL build issues:

 * windres fails when not finding gcc. Solution: don't build DLLs. Use proper cross compilation settings.
 * Linking against libcrypto.a fails, missing symbols like CertOpenStore. Solution: don't build engines.
