### PR TITLE
Improve consistency of Util.{split,splitLines} between OCaml and F#

### DIFF
--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -359,8 +359,8 @@ let replace_chars (s:string) (c:char) (by:string) =
   BatString.replace_chars (function c -> by | x -> BatString.of_char x) s
 let hashcode s = Z.of_int (BatHashtbl.hash s)
 let compare s1 s2 = Z.of_int (BatString.compare s1 s2)
-let splitlines s = BatString.nsplit s "\n"
-let split s sep = BatString.nsplit s sep
+let split s sep = if s = "" then [""] else BatString.nsplit s sep
+let splitlines s = split s "\n"
 
 let iof = int_of_float
 let foi = float_of_int


### PR DESCRIPTION
`Batstring,nsplit` returns `[]` when splitting an empty string in OCaml, whereas `String.Split` returns `[""]` in F#.

There's another inconsistency (splitLines takes `Environment.NewLine` into account on the F# side, but not on the OCaml side), but I'm not sure what the fix is.

References : http://ocaml-batteries-team.github.io/batteries-included/hdoc2/BatString.html , https://msdn.microsoft.com/en-us/library/b873y76a(v=vs.110).aspx