### PR TITLE
Completion support in interactive mode, plus improved #info queries

### DIFF
--- a/src/basic/FStar.Ident.fs
+++ b/src/basic/FStar.Ident.fs
@@ -25,13 +25,15 @@ let path_of_text text = String.split ['.'] text
 let path_of_ns ns = List.map text_of_id ns
 let path_of_lid lid = List.map text_of_id (lid.ns@[lid.ident])
 let ids_of_lid lid = lid.ns@[lid.ident]
-let lid_of_ids ids =
-    let ns, id = Util.prefix ids in
+let lid_of_ns_and_id ns id =
     let nsstr = List.map text_of_id ns |> text_of_path in
     {ns=ns;
      ident=id;
      nsstr=nsstr;
      str=(if nsstr="" then id.idText else nsstr ^ "." ^ id.idText)}
+let lid_of_ids ids =
+    let ns, id = Util.prefix ids in
+    lid_of_ns_and_id ns id
 let lid_of_path path pos =
     let ids = List.map (fun s -> mk_ident(s, pos)) path in
     lid_of_ids ids

--- a/src/fstar/FStar.Interactive.fs
+++ b/src/fstar/FStar.Interactive.fs
@@ -438,20 +438,20 @@ let rec go (line_col:(int*int))
           (fun (prefix, matched, match_len) ->
            let naked_match = match matched with [_] -> true | _ -> false in
            let stripped_ns, shortened = ToSyntax.Env.shorten_module_path (fst env) prefix naked_match in
-           (str_of_ids stripped_ns,
-            str_of_ids shortened,
+           (str_of_ids shortened,
             str_of_ids matched,
+            str_of_ids stripped_ns,
             match_len)) in
     let needle = Util.split search_term "." in
     let lidents = FStar.TypeChecker.Env.lidents (snd env) in
     let matches = List.filter_map (match_lident_against needle) lidents in
-    List.iter (fun (stripped_ns, prefix, matched, match_len) ->
+    List.iter (fun (prefix, matched, stripped_ns, match_len) ->
                let candidate, match_len =
                  if prefix = "" then (matched, match_len)
                  else (prefix ^ "." ^ matched, String.length prefix + match_len + 1) in
                Util.print3 "%s %s %s\n"
                  (string match_len) stripped_ns candidate)
-              matches;
+              (List.sort matches);
     Util.print_string "#done-ok\n";
     go line_col filename stack curmod env ts
   | Pop msg ->

--- a/src/fstar/FStar.Interactive.fs
+++ b/src/fstar/FStar.Interactive.fs
@@ -444,7 +444,8 @@ let rec go (line_col:(int*int))
                                        |> Util.map_option prepare_candidate)
                                   lidents in
     List.iter (fun (candidate, ns, match_len) ->
-               Util.print3 "%s %s %s\n" (string match_len) ns candidate)
+               Util.print3 "%s %s %s\n"
+               (Util.string_of_int match_len) ns candidate)
               (Util.sort_with (fun (cd1, ns1, _) (cd2, ns2, _) ->
                                match String.compare cd1 cd2 with
                                | 0 -> String.compare ns1 ns2

--- a/src/tosyntax/FStar.ToSyntax.Env.fs
+++ b/src/tosyntax/FStar.ToSyntax.Env.fs
@@ -323,7 +323,9 @@ let lookup_default_id
     find_in_module env lid k_global_def k_not_found
 
 let module_is_defined env lid =
-    lid_equals lid (current_module env) ||
+    (match env.curmodule with
+     | None -> false
+     | Some m -> lid_equals lid (current_module env)) ||
     List.existsb (fun x -> lid_equals lid (fst x)) env.modules
 
 let resolve_module_name env lid (honor_ns: bool) : option<lident> =

--- a/src/tosyntax/FStar.ToSyntax.Env.fs
+++ b/src/tosyntax/FStar.ToSyntax.Env.fs
@@ -370,8 +370,8 @@ let shorten_module_path env ids is_full_path =
          | [] -> None
          | ns_last_id :: rev_ns_prefix ->
            aux rev_ns_prefix ns_last_id |>
-             Option.map (fun (stripped_ids, rev_kept_ids) ->
-                         (stripped_ids, id :: rev_kept_ids)) in
+             BU.map_option (fun (stripped_ids, rev_kept_ids) ->
+                            (stripped_ids, id :: rev_kept_ids)) in
   if is_full_path && module_is_defined env (FStar.Ident.lid_of_ids ids)
   then (ids, []) // FIXME is that right? If m is defined then all names in m are accessible?
   else match List.rev ids with

--- a/src/tosyntax/FStar.ToSyntax.Env.fsi
+++ b/src/tosyntax/FStar.ToSyntax.Env.fsi
@@ -105,6 +105,7 @@ val qualify: env -> ident -> lident
 val empty_env: unit -> env
 val current_module: env -> lident
 val try_lookup_id: env -> ident -> option<(term*bool)>
+val shorten_module_path: env -> list<ident> -> bool -> list<ident>
 val try_lookup_lid: env -> lident -> option<(term*bool)>
 val try_lookup_lid_no_resolve: env -> lident -> option<(term*bool)>
 val try_lookup_effect_name: env -> lident -> option<lident>

--- a/src/tosyntax/FStar.ToSyntax.Env.fsi
+++ b/src/tosyntax/FStar.ToSyntax.Env.fsi
@@ -105,7 +105,7 @@ val qualify: env -> ident -> lident
 val empty_env: unit -> env
 val current_module: env -> lident
 val try_lookup_id: env -> ident -> option<(term*bool)>
-val shorten_module_path: env -> list<ident> -> bool -> list<ident>
+val shorten_module_path: env -> list<ident> -> bool -> (list<ident> * list<ident>)
 val try_lookup_lid: env -> lident -> option<(term*bool)>
 val try_lookup_lid_no_resolve: env -> lident -> option<(term*bool)>
 val try_lookup_effect_name: env -> lident -> option<lident>

--- a/src/typechecker/FStar.TypeChecker.Err.fs
+++ b/src/typechecker/FStar.TypeChecker.Err.fs
@@ -31,14 +31,17 @@ module N = FStar.TypeChecker.Normalize
 module BU = FStar.Util //basic util
 open FStar.TypeChecker.Common
 
+let format_info env name typ range =
+    BU.format3 "(defined at %s) %s : %s"
+        (Range.string_of_range range)
+        name
+        (Normalize.term_to_string env typ)
+
 let info_as_string env info = 
     let id_string, range = match info.identifier with 
         | Inl bv -> Print.nm_to_string bv, FStar.Syntax.Syntax.range_of_bv bv
         | Inr fv -> Print.lid_to_string (FStar.Syntax.Syntax.lid_of_fv fv), FStar.Syntax.Syntax.range_of_fv fv in
-    BU.format3 "(defined at %s) %s : %s"
-        (Range.string_of_range range) 
-        id_string 
-        (Normalize.term_to_string env info.identifier_ty)
+    format_info env id_string info.identifier_ty range
 
 let info_at_pos env file row col = 
     match FStar.TypeChecker.Common.info_at_pos file row col with


### PR DESCRIPTION
There are a few FIXME left, but things seem to work OK.  Context: https://github.com/FStarLang/fstar-mode.el/issues/53

Bumping the F* version number after merging this will allow me to enable it by default in fstar-mode.