### PR TITLE
Refactor sigelt -> sigelt' (inductive) + sigelt (record w/ range and docs)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -130,7 +130,7 @@ boot_fstis/FStar.unionfind.fsti: basic/unionfind.fsi
 boot_fstis/FStar.Parser.Parse.fsti: parser/parse.fsi
 	echo "#light \"off\"" > $@
 	$(HEAD) -n -12 $^ >> $@
-	$(SED) -i 's/module FStar.Parser.Parse/module FStar.Parser.Parse\nopen FStar.All\nopen FStar.BaseTypes\ntype bytes = array<byte>/' $@
+	$(SED) -i 's/module FStar.Parser.Parse/module FStar.Parser.Parse\nopen FStar.All\nopen FStar.BaseTypes\ntype bytes = array<byte>\nopen FStar.Syntax.Syntax/' $@
 
 rename_as_fst:
 	./tools/rename_all_boot_fsts

--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -115,10 +115,10 @@ let print_ifamily i =
 
 let bundle_as_inductive_families env ses quals : list<inductive_family> =
     ses |> List.collect
-        (fun se -> match se.elt with
+        (fun se -> match se.sigel with
             | Sig_inductive_typ(l, _us, bs, t, _mut_i, datas, quals) ->
                 let bs, t = SS.open_term bs t in
-                let datas = ses |> List.collect (fun se -> match se.elt with
+                let datas = ses |> List.collect (fun se -> match se.sigel with
                     | Sig_datacon(d, _, t, l', nparams, _, _) when Ident.lid_equals l l' ->
                         let bs', body = U.arrow_formals t in
                         let bs_params, rest = BU.first_N (List.length bs) bs' in
@@ -160,8 +160,8 @@ let extract_bundle env se =
         env,  (false, lident_as_mlsymbol ind.iname, None, ml_params, Some tbody) in
 
 
-    match se.elt with
-        | Sig_bundle([{elt = Sig_datacon(l, _, t, _, _, _, _)}], [ExceptionConstructor], _) ->
+    match se.sigel with
+        | Sig_bundle([{sigel = Sig_datacon(l, _, t, _, _, _, _)}], [ExceptionConstructor], _) ->
           let env, ctor = extract_ctor [] env ({dname=l; dtyp=t}) in
           env, [MLM_Exn ctor]
 
@@ -201,7 +201,7 @@ let extract_bundle env se =
 
 let rec extract_sig (g:env_t) (se:sigelt) : env_t * list<mlmodule1> =
      debug g (fun u -> BU.print1 ">>>> extract_sig %s \n" (Print.sigelt_to_string se));
-     match se.elt with
+     match se.sigel with
         | Sig_bundle _
         | Sig_inductive_typ _
         | Sig_datacon _ ->
@@ -300,11 +300,11 @@ let rec extract_sig (g:env_t) (se:sigelt) : env_t * list<mlmodule1> =
                   let imp = match U.arrow_formals t with
                     | [], t -> fail_exp lid t
                     | bs, t -> U.abs bs (fail_exp lid t) None in
-                  { se with elt = Sig_let((false, [{lbname=Inr (S.lid_as_fv lid Delta_constant None);
-                                                    lbunivs=[];
-                                                    lbtyp=t;
-                                                    lbeff=FStar.Syntax.Const.effect_ML_lid;
-                                                    lbdef=imp}]), [], quals, []) } in
+                  { se with sigel = Sig_let((false, [{lbname=Inr (S.lid_as_fv lid Delta_constant None);
+                                                      lbunivs=[];
+                                                      lbtyp=t;
+                                                      lbeff=FStar.Syntax.Const.effect_ML_lid;
+                                                      lbdef=imp}]), [], quals, []) } in
               let g, mlm = extract_sig g always_fail in //extend the scope with the new name
               match BU.find_map quals (function Discriminator l -> Some l |  _ -> None) with
                   | Some l -> //if it's a discriminator, generate real code for it, rather than mlm

--- a/src/fsdoc/FStar.Fsdoc.Generator.fs
+++ b/src/fsdoc/FStar.Fsdoc.Generator.fs
@@ -77,7 +77,7 @@ let string_of_optiont f y xo =
     | Some x -> f x
     | None -> y
 
-let string_of_fsdoco d = string_of_optiont (fun x -> "(*" ^ string_of_fsdoc x ^ "*)") "" d
+let string_of_fsdoco d = string_of_optiont (fun x -> "(*" ^ S.string_of_fsdoc x ^ "*)") "" d
 let string_of_termo t = string_of_optiont term_to_string "" t
 
 // wrap-up s in MD code block.
@@ -142,7 +142,7 @@ let string_of_decl' d =
 // - it's got a fsdoc attached to it (either at top-level or in it's subtree); or
 // - it itself is a Fsdoc
 let decl_documented (d:decl) =
-    let tycon_documented (tt:list<(tycon * option<fsdoc>)>) =
+    let tycon_documented (tt:list<(tycon * option<S.fsdoc>)>) =
         let tyconvars_documented tycon =
             match tycon with
             | TyconAbstract _ | TyconAbbrev _ -> false

--- a/src/ocaml-output/FStar_Common.ml
+++ b/src/ocaml-output/FStar_Common.ml
@@ -1,16 +1,37 @@
+
 open Prims
-let has_cygpath: Prims.bool =
-  try
-    let uu____2 = FStar_Util.run_proc "which" "cygpath" "" in
-    match uu____2 with
-    | (uu____6,t_out,uu____8) ->
-        (FStar_Util.trim_string t_out) = "/usr/bin/cygpath"
-  with | uu____10 -> false
-let try_convert_file_name_to_mixed: Prims.string -> Prims.string =
-  fun s  ->
-    if has_cygpath
-    then
-      let uu____14 = FStar_Util.run_proc "cygpath" (Prims.strcat "-m " s) "" in
-      match uu____14 with
-      | (uu____18,t_out,uu____20) -> FStar_Util.trim_string t_out
-    else s
+
+let has_cygpath : Prims.bool = try
+(match (()) with
+| () -> begin
+(
+
+let uu____2 = (FStar_Util.run_proc "which" "cygpath" "")
+in (match (uu____2) with
+| (uu____6, t_out, uu____8) -> begin
+((FStar_Util.trim_string t_out) = "/usr/bin/cygpath")
+end))
+end)
+with
+| uu____10 -> begin
+false
+end
+
+
+let try_convert_file_name_to_mixed : Prims.string  ->  Prims.string = (fun s -> (match (has_cygpath) with
+| true -> begin
+(
+
+let uu____14 = (FStar_Util.run_proc "cygpath" (Prims.strcat "-m " s) "")
+in (match (uu____14) with
+| (uu____18, t_out, uu____20) -> begin
+(FStar_Util.trim_string t_out)
+end))
+end
+| uu____21 -> begin
+s
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Const.ml
+++ b/src/ocaml-output/FStar_Const.ml
@@ -1,98 +1,250 @@
+
 open Prims
 type signedness =
-  | Unsigned
-  | Signed
-let uu___is_Unsigned: signedness -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unsigned  -> true | uu____4 -> false
-let uu___is_Signed: signedness -> Prims.bool =
-  fun projectee  -> match projectee with | Signed  -> true | uu____8 -> false
+| Unsigned
+| Signed
+
+
+let uu___is_Unsigned : signedness  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unsigned -> begin
+true
+end
+| uu____4 -> begin
+false
+end))
+
+
+let uu___is_Signed : signedness  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Signed -> begin
+true
+end
+| uu____8 -> begin
+false
+end))
+
 type width =
-  | Int8
-  | Int16
-  | Int32
-  | Int64
-let uu___is_Int8: width -> Prims.bool =
-  fun projectee  -> match projectee with | Int8  -> true | uu____12 -> false
-let uu___is_Int16: width -> Prims.bool =
-  fun projectee  -> match projectee with | Int16  -> true | uu____16 -> false
-let uu___is_Int32: width -> Prims.bool =
-  fun projectee  -> match projectee with | Int32  -> true | uu____20 -> false
-let uu___is_Int64: width -> Prims.bool =
-  fun projectee  -> match projectee with | Int64  -> true | uu____24 -> false
+| Int8
+| Int16
+| Int32
+| Int64
+
+
+let uu___is_Int8 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int8 -> begin
+true
+end
+| uu____12 -> begin
+false
+end))
+
+
+let uu___is_Int16 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int16 -> begin
+true
+end
+| uu____16 -> begin
+false
+end))
+
+
+let uu___is_Int32 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int32 -> begin
+true
+end
+| uu____20 -> begin
+false
+end))
+
+
+let uu___is_Int64 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int64 -> begin
+true
+end
+| uu____24 -> begin
+false
+end))
+
 type sconst =
-  | Const_effect
-  | Const_unit
-  | Const_bool of Prims.bool
-  | Const_int of (Prims.string* (signedness* width) Prims.option)
-  | Const_char of FStar_BaseTypes.char
-  | Const_float of FStar_BaseTypes.double
-  | Const_bytearray of (FStar_BaseTypes.byte Prims.array* FStar_Range.range)
-  | Const_string of (FStar_BaseTypes.byte Prims.array* FStar_Range.range)
-  | Const_range of FStar_Range.range
-  | Const_reify
-  | Const_reflect of FStar_Ident.lid
-let uu___is_Const_effect: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_effect  -> true | uu____63 -> false
-let uu___is_Const_unit: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_unit  -> true | uu____67 -> false
-let uu___is_Const_bool: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_bool _0 -> true | uu____72 -> false
-let __proj__Const_bool__item___0: sconst -> Prims.bool =
-  fun projectee  -> match projectee with | Const_bool _0 -> _0
-let uu___is_Const_int: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_int _0 -> true | uu____89 -> false
-let __proj__Const_int__item___0:
-  sconst -> (Prims.string* (signedness* width) Prims.option) =
-  fun projectee  -> match projectee with | Const_int _0 -> _0
-let uu___is_Const_char: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_char _0 -> true | uu____116 -> false
-let __proj__Const_char__item___0: sconst -> FStar_BaseTypes.char =
-  fun projectee  -> match projectee with | Const_char _0 -> _0
-let uu___is_Const_float: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_float _0 -> true | uu____128 -> false
-let __proj__Const_float__item___0: sconst -> FStar_BaseTypes.double =
-  fun projectee  -> match projectee with | Const_float _0 -> _0
-let uu___is_Const_bytearray: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_bytearray _0 -> true | uu____143 -> false
-let __proj__Const_bytearray__item___0:
-  sconst -> (FStar_BaseTypes.byte Prims.array* FStar_Range.range) =
-  fun projectee  -> match projectee with | Const_bytearray _0 -> _0
-let uu___is_Const_string: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_string _0 -> true | uu____167 -> false
-let __proj__Const_string__item___0:
-  sconst -> (FStar_BaseTypes.byte Prims.array* FStar_Range.range) =
-  fun projectee  -> match projectee with | Const_string _0 -> _0
-let uu___is_Const_range: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_range _0 -> true | uu____188 -> false
-let __proj__Const_range__item___0: sconst -> FStar_Range.range =
-  fun projectee  -> match projectee with | Const_range _0 -> _0
-let uu___is_Const_reify: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_reify  -> true | uu____199 -> false
-let uu___is_Const_reflect: sconst -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const_reflect _0 -> true | uu____204 -> false
-let __proj__Const_reflect__item___0: sconst -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Const_reflect _0 -> _0
-let eq_const: sconst -> sconst -> Prims.bool =
-  fun c1  ->
-    fun c2  ->
-      match (c1, c2) with
-      | (Const_int (s1,o1),Const_int (s2,o2)) ->
-          (let uu____234 = FStar_Util.ensure_decimal s1 in
-           let uu____235 = FStar_Util.ensure_decimal s2 in
-           uu____234 = uu____235) && (o1 = o2)
-      | (Const_bytearray (a,_),Const_bytearray (b,_))
-        |(Const_string (a,_),Const_string (b,_)) -> a = b
-      | (Const_reflect l1,Const_reflect l2) -> FStar_Ident.lid_equals l1 l2
-      | uu____256 -> c1 = c2
+| Const_effect
+| Const_unit
+| Const_bool of Prims.bool
+| Const_int of (Prims.string * (signedness * width) Prims.option)
+| Const_char of FStar_BaseTypes.char
+| Const_float of FStar_BaseTypes.double
+| Const_bytearray of (FStar_BaseTypes.byte Prims.array * FStar_Range.range)
+| Const_string of (FStar_BaseTypes.byte Prims.array * FStar_Range.range)
+| Const_range of FStar_Range.range
+| Const_reify
+| Const_reflect of FStar_Ident.lid
+
+
+let uu___is_Const_effect : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_effect -> begin
+true
+end
+| uu____63 -> begin
+false
+end))
+
+
+let uu___is_Const_unit : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_unit -> begin
+true
+end
+| uu____67 -> begin
+false
+end))
+
+
+let uu___is_Const_bool : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_bool (_0) -> begin
+true
+end
+| uu____72 -> begin
+false
+end))
+
+
+let __proj__Const_bool__item___0 : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_bool (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_int : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_int (_0) -> begin
+true
+end
+| uu____89 -> begin
+false
+end))
+
+
+let __proj__Const_int__item___0 : sconst  ->  (Prims.string * (signedness * width) Prims.option) = (fun projectee -> (match (projectee) with
+| Const_int (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_char : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_char (_0) -> begin
+true
+end
+| uu____116 -> begin
+false
+end))
+
+
+let __proj__Const_char__item___0 : sconst  ->  FStar_BaseTypes.char = (fun projectee -> (match (projectee) with
+| Const_char (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_float : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_float (_0) -> begin
+true
+end
+| uu____128 -> begin
+false
+end))
+
+
+let __proj__Const_float__item___0 : sconst  ->  FStar_BaseTypes.double = (fun projectee -> (match (projectee) with
+| Const_float (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_bytearray : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_bytearray (_0) -> begin
+true
+end
+| uu____143 -> begin
+false
+end))
+
+
+let __proj__Const_bytearray__item___0 : sconst  ->  (FStar_BaseTypes.byte Prims.array * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Const_bytearray (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_string : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_string (_0) -> begin
+true
+end
+| uu____167 -> begin
+false
+end))
+
+
+let __proj__Const_string__item___0 : sconst  ->  (FStar_BaseTypes.byte Prims.array * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Const_string (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_range : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_range (_0) -> begin
+true
+end
+| uu____188 -> begin
+false
+end))
+
+
+let __proj__Const_range__item___0 : sconst  ->  FStar_Range.range = (fun projectee -> (match (projectee) with
+| Const_range (_0) -> begin
+_0
+end))
+
+
+let uu___is_Const_reify : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_reify -> begin
+true
+end
+| uu____199 -> begin
+false
+end))
+
+
+let uu___is_Const_reflect : sconst  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const_reflect (_0) -> begin
+true
+end
+| uu____204 -> begin
+false
+end))
+
+
+let __proj__Const_reflect__item___0 : sconst  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Const_reflect (_0) -> begin
+_0
+end))
+
+
+let eq_const : sconst  ->  sconst  ->  Prims.bool = (fun c1 c2 -> (match (((c1), (c2))) with
+| (Const_int (s1, o1), Const_int (s2, o2)) -> begin
+((
+
+let uu____234 = (FStar_Util.ensure_decimal s1)
+in (
+
+let uu____235 = (FStar_Util.ensure_decimal s2)
+in (uu____234 = uu____235))) && (o1 = o2))
+end
+| ((Const_bytearray (a, _), Const_bytearray (b, _))) | ((Const_string (a, _), Const_string (b, _))) -> begin
+(a = b)
+end
+| (Const_reflect (l1), Const_reflect (l2)) -> begin
+(FStar_Ident.lid_equals l1 l2)
+end
+| uu____256 -> begin
+(c1 = c2)
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Dependencies.ml
+++ b/src/ocaml-output/FStar_Dependencies.ml
@@ -1,34 +1,54 @@
+
 open Prims
-let find_deps_if_needed:
-  FStar_Parser_Dep.verify_mode ->
-    Prims.string Prims.list -> Prims.string Prims.list
-  =
-  fun verify_mode  ->
-    fun files  ->
-      let uu____10 = FStar_Options.explicit_deps () in
-      if uu____10
-      then files
-      else
-        (let uu____13 = FStar_Parser_Dep.collect verify_mode files in
-         match uu____13 with
-         | (uu____27,deps,uu____29) ->
-             (match deps with
-              | [] ->
-                  (FStar_Util.print_error
-                     "Dependency analysis failed; reverting to using only the files provided";
-                   files)
-              | uu____50 ->
-                  let deps1 = FStar_List.rev deps in
-                  let deps2 =
-                    let uu____56 =
-                      let uu____57 =
-                        let uu____58 = FStar_List.hd deps1 in
-                        FStar_Util.basename uu____58 in
-                      uu____57 = "prims.fst" in
-                    if uu____56
-                    then FStar_List.tl deps1
-                    else
-                      (FStar_Util.print_error
-                         "dependency analysis did not find prims.fst?!";
-                       FStar_All.exit (Prims.parse_int "1")) in
-                  deps2))
+
+let find_deps_if_needed : FStar_Parser_Dep.verify_mode  ->  Prims.string Prims.list  ->  Prims.string Prims.list = (fun verify_mode files -> (
+
+let uu____10 = (FStar_Options.explicit_deps ())
+in (match (uu____10) with
+| true -> begin
+files
+end
+| uu____12 -> begin
+(
+
+let uu____13 = (FStar_Parser_Dep.collect verify_mode files)
+in (match (uu____13) with
+| (uu____27, deps, uu____29) -> begin
+(match (deps) with
+| [] -> begin
+((FStar_Util.print_error "Dependency analysis failed; reverting to using only the files provided");
+files;
+)
+end
+| uu____50 -> begin
+(
+
+let deps1 = (FStar_List.rev deps)
+in (
+
+let deps2 = (
+
+let uu____56 = (
+
+let uu____57 = (
+
+let uu____58 = (FStar_List.hd deps1)
+in (FStar_Util.basename uu____58))
+in (uu____57 = "prims.fst"))
+in (match (uu____56) with
+| true -> begin
+(FStar_List.tl deps1)
+end
+| uu____60 -> begin
+((FStar_Util.print_error "dependency analysis did not find prims.fst?!");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end))
+in deps2))
+end)
+end))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -1,140 +1,241 @@
+
 open Prims
-exception Err of Prims.string
-let uu___is_Err: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Err uu____6 -> true | uu____7 -> false
-let __proj__Err__item__uu___: Prims.exn -> Prims.string =
-  fun projectee  -> match projectee with | Err uu____14 -> uu____14
-exception Error of (Prims.string* FStar_Range.range)
-let uu___is_Error: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Error uu____22 -> true | uu____25 -> false
-let __proj__Error__item__uu___:
-  Prims.exn -> (Prims.string* FStar_Range.range) =
-  fun projectee  -> match projectee with | Error uu____36 -> uu____36
-exception Warning of (Prims.string* FStar_Range.range)
-let uu___is_Warning: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Warning uu____46 -> true | uu____49 -> false
-let __proj__Warning__item__uu___:
-  Prims.exn -> (Prims.string* FStar_Range.range) =
-  fun projectee  -> match projectee with | Warning uu____60 -> uu____60
-let diag: FStar_Range.range -> Prims.string -> Prims.unit =
-  fun r  ->
-    fun msg  ->
-      let uu____69 = FStar_Options.debug_any () in
-      if uu____69
-      then
-        let uu____70 =
-          let uu____71 = FStar_Range.string_of_range r in
-          FStar_Util.format2 "%s : (Diagnostic) %s\n" uu____71 msg in
-        FStar_Util.print_string uu____70
-      else ()
-let warn: FStar_Range.range -> Prims.string -> Prims.unit =
-  fun r  ->
-    fun msg  ->
-      let uu____79 = FStar_Range.string_of_range r in
-      FStar_Util.print2_error "%s: (Warning) %s\n" uu____79 msg
-let num_errs: Prims.int FStar_ST.ref =
-  FStar_Util.mk_ref (Prims.parse_int "0")
-let verification_errs:
-  (FStar_Range.range* Prims.string) Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref []
+exception Err of (Prims.string)
+
+
+let uu___is_Err : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Err (uu____6) -> begin
+true
+end
+| uu____7 -> begin
+false
+end))
+
+
+let __proj__Err__item__uu___ : Prims.exn  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Err (uu____14) -> begin
+uu____14
+end))
+
+exception Error of ((Prims.string * FStar_Range.range))
+
+
+let uu___is_Error : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Error (uu____22) -> begin
+true
+end
+| uu____25 -> begin
+false
+end))
+
+
+let __proj__Error__item__uu___ : Prims.exn  ->  (Prims.string * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Error (uu____36) -> begin
+uu____36
+end))
+
+exception Warning of ((Prims.string * FStar_Range.range))
+
+
+let uu___is_Warning : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Warning (uu____46) -> begin
+true
+end
+| uu____49 -> begin
+false
+end))
+
+
+let __proj__Warning__item__uu___ : Prims.exn  ->  (Prims.string * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Warning (uu____60) -> begin
+uu____60
+end))
+
+
+let diag : FStar_Range.range  ->  Prims.string  ->  Prims.unit = (fun r msg -> (
+
+let uu____69 = (FStar_Options.debug_any ())
+in (match (uu____69) with
+| true -> begin
+(
+
+let uu____70 = (
+
+let uu____71 = (FStar_Range.string_of_range r)
+in (FStar_Util.format2 "%s : (Diagnostic) %s\n" uu____71 msg))
+in (FStar_Util.print_string uu____70))
+end
+| uu____72 -> begin
+()
+end)))
+
+
+let warn : FStar_Range.range  ->  Prims.string  ->  Prims.unit = (fun r msg -> (
+
+let uu____79 = (FStar_Range.string_of_range r)
+in (FStar_Util.print2_error "%s: (Warning) %s\n" uu____79 msg)))
+
+
+let num_errs : Prims.int FStar_ST.ref = (FStar_Util.mk_ref (Prims.parse_int "0"))
+
+
+let verification_errs : (FStar_Range.range * Prims.string) Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
 type error_message_prefix =
-  {
-  set_prefix: Prims.string -> Prims.unit;
-  append_prefix: Prims.string -> Prims.string;
-  clear_prefix: Prims.unit -> Prims.unit;}
-let message_prefix: error_message_prefix =
-  let pfx = FStar_Util.mk_ref None in
-  let set_prefix s = FStar_ST.write pfx (Some s) in
-  let clear_prefix uu____151 = FStar_ST.write pfx None in
-  let append_prefix s =
-    let uu____159 = FStar_ST.read pfx in
-    match uu____159 with
-    | None  -> s
-    | Some p -> Prims.strcat p (Prims.strcat ": " s) in
-  { set_prefix; append_prefix; clear_prefix }
-let add_errors: (Prims.string* FStar_Range.range) Prims.list -> Prims.unit =
-  fun errs  ->
-    let errs1 =
-      FStar_All.pipe_right errs
-        (FStar_List.map
-           (fun uu____188  ->
-              match uu____188 with
-              | (msg,r) ->
-                  let uu____195 = message_prefix.append_prefix msg in
-                  (r, uu____195))) in
-    let n_errs = FStar_List.length errs1 in
-    FStar_Util.atomically
-      (fun uu____200  ->
-         (let uu____202 =
-            let uu____206 = FStar_ST.read verification_errs in
-            FStar_List.append errs1 uu____206 in
-          FStar_ST.write verification_errs uu____202);
-         (let uu____222 =
-            let uu____223 = FStar_ST.read num_errs in uu____223 + n_errs in
-          FStar_ST.write num_errs uu____222))
-let mk_error: Prims.string -> FStar_Range.range -> Prims.string =
-  fun msg  ->
-    fun r  ->
-      if r.FStar_Range.use_range <> r.FStar_Range.def_range
-      then
-        let uu____236 = FStar_Range.string_of_use_range r in
-        let uu____237 = FStar_Range.string_of_range r in
-        FStar_Util.format3 "%s: (Error) %s (see %s)\n" uu____236 msg
-          uu____237
-      else
-        (let uu____239 = FStar_Range.string_of_range r in
-         FStar_Util.format2 "%s: (Error) %s\n" uu____239 msg)
-let report_all: Prims.unit -> Prims.nat =
-  fun uu____243  ->
-    let all_errs =
-      FStar_Util.atomically
-        (fun uu____251  ->
-           let x = FStar_ST.read verification_errs in
-           FStar_ST.write verification_errs []; x) in
-    let all_errs1 =
-      FStar_List.sortWith
-        (fun uu____275  ->
-           fun uu____276  ->
-             match (uu____275, uu____276) with
-             | ((r1,uu____286),(r2,uu____288)) ->
-                 FStar_Range.compare_use_range r1 r2) all_errs in
-    FStar_All.pipe_right all_errs1
-      (FStar_List.iter
-         (fun uu____299  ->
-            match uu____299 with
-            | (r,msg) ->
-                let uu____304 = mk_error msg r in
-                FStar_Util.print_error uu____304));
-    FStar_List.length all_errs1
-let handle_err: Prims.bool -> Prims.exn -> Prims.unit =
-  fun warning  ->
-    fun e  ->
-      match e with
-      | Error (msg,r) ->
-          let msg1 = message_prefix.append_prefix msg in
-          let uu____317 = FStar_Range.string_of_range r in
-          FStar_Util.print3_error "%s : %s %s\n" uu____317
-            (if warning then "(Warning)" else "(Error)") msg1
-      | FStar_Util.NYI msg ->
-          let msg1 = message_prefix.append_prefix msg in
-          FStar_Util.print1_error "Feature not yet implemented: %s" msg1
-      | Err msg ->
-          let msg1 = message_prefix.append_prefix msg in
-          FStar_Util.print1_error "Error: %s" msg1
-      | uu____323 -> Prims.raise e
-let handleable: Prims.exn -> Prims.bool =
-  fun uu___54_326  ->
-    match uu___54_326 with
-    | Error _|FStar_Util.NYI _|Err _ -> true
-    | uu____330 -> false
-let report: FStar_Range.range -> Prims.string -> Prims.unit =
-  fun r  ->
-    fun msg  ->
-      FStar_Util.incr num_errs;
-      (let msg1 = message_prefix.append_prefix msg in
-       let uu____342 = mk_error msg1 r in FStar_Util.print_error uu____342)
-let get_err_count: Prims.unit -> Prims.int =
-  fun uu____345  -> FStar_ST.read num_errs
+{set_prefix : Prims.string  ->  Prims.unit; append_prefix : Prims.string  ->  Prims.string; clear_prefix : Prims.unit  ->  Prims.unit}
+
+
+let message_prefix : error_message_prefix = (
+
+let pfx = (FStar_Util.mk_ref None)
+in (
+
+let set_prefix = (fun s -> (FStar_ST.write pfx (Some (s))))
+in (
+
+let clear_prefix = (fun uu____151 -> (FStar_ST.write pfx None))
+in (
+
+let append_prefix = (fun s -> (
+
+let uu____159 = (FStar_ST.read pfx)
+in (match (uu____159) with
+| None -> begin
+s
+end
+| Some (p) -> begin
+(Prims.strcat p (Prims.strcat ": " s))
+end)))
+in {set_prefix = set_prefix; append_prefix = append_prefix; clear_prefix = clear_prefix}))))
+
+
+let add_errors : (Prims.string * FStar_Range.range) Prims.list  ->  Prims.unit = (fun errs -> (
+
+let errs1 = (FStar_All.pipe_right errs (FStar_List.map (fun uu____188 -> (match (uu____188) with
+| (msg, r) -> begin
+(
+
+let uu____195 = (message_prefix.append_prefix msg)
+in ((r), (uu____195)))
+end))))
+in (
+
+let n_errs = (FStar_List.length errs1)
+in (FStar_Util.atomically (fun uu____200 -> ((
+
+let uu____202 = (
+
+let uu____206 = (FStar_ST.read verification_errs)
+in (FStar_List.append errs1 uu____206))
+in (FStar_ST.write verification_errs uu____202));
+(
+
+let uu____222 = (
+
+let uu____223 = (FStar_ST.read num_errs)
+in (uu____223 + n_errs))
+in (FStar_ST.write num_errs uu____222));
+))))))
+
+
+let mk_error : Prims.string  ->  FStar_Range.range  ->  Prims.string = (fun msg r -> (match ((r.FStar_Range.use_range <> r.FStar_Range.def_range)) with
+| true -> begin
+(
+
+let uu____236 = (FStar_Range.string_of_use_range r)
+in (
+
+let uu____237 = (FStar_Range.string_of_range r)
+in (FStar_Util.format3 "%s: (Error) %s (see %s)\n" uu____236 msg uu____237)))
+end
+| uu____238 -> begin
+(
+
+let uu____239 = (FStar_Range.string_of_range r)
+in (FStar_Util.format2 "%s: (Error) %s\n" uu____239 msg))
+end))
+
+
+let report_all : Prims.unit  ->  Prims.nat = (fun uu____243 -> (
+
+let all_errs = (FStar_Util.atomically (fun uu____251 -> (
+
+let x = (FStar_ST.read verification_errs)
+in ((FStar_ST.write verification_errs []);
+x;
+))))
+in (
+
+let all_errs1 = (FStar_List.sortWith (fun uu____275 uu____276 -> (match (((uu____275), (uu____276))) with
+| ((r1, uu____286), (r2, uu____288)) -> begin
+(FStar_Range.compare_use_range r1 r2)
+end)) all_errs)
+in ((FStar_All.pipe_right all_errs1 (FStar_List.iter (fun uu____299 -> (match (uu____299) with
+| (r, msg) -> begin
+(
+
+let uu____304 = (mk_error msg r)
+in (FStar_Util.print_error uu____304))
+end))));
+(FStar_List.length all_errs1);
+))))
+
+
+let handle_err : Prims.bool  ->  Prims.exn  ->  Prims.unit = (fun warning e -> (match (e) with
+| Error (msg, r) -> begin
+(
+
+let msg1 = (message_prefix.append_prefix msg)
+in (
+
+let uu____317 = (FStar_Range.string_of_range r)
+in (FStar_Util.print3_error "%s : %s %s\n" uu____317 (match (warning) with
+| true -> begin
+"(Warning)"
+end
+| uu____318 -> begin
+"(Error)"
+end) msg1)))
+end
+| FStar_Util.NYI (msg) -> begin
+(
+
+let msg1 = (message_prefix.append_prefix msg)
+in (FStar_Util.print1_error "Feature not yet implemented: %s" msg1))
+end
+| Err (msg) -> begin
+(
+
+let msg1 = (message_prefix.append_prefix msg)
+in (FStar_Util.print1_error "Error: %s" msg1))
+end
+| uu____323 -> begin
+(Prims.raise e)
+end))
+
+
+let handleable : Prims.exn  ->  Prims.bool = (fun uu___54_326 -> (match (uu___54_326) with
+| (Error (_)) | (FStar_Util.NYI (_)) | (Err (_)) -> begin
+true
+end
+| uu____330 -> begin
+false
+end))
+
+
+let report : FStar_Range.range  ->  Prims.string  ->  Prims.unit = (fun r msg -> ((FStar_Util.incr num_errs);
+(
+
+let msg1 = (message_prefix.append_prefix msg)
+in (
+
+let uu____342 = (mk_error msg1 r)
+in (FStar_Util.print_error uu____342)));
+))
+
+
+let get_err_count : Prims.unit  ->  Prims.int = (fun uu____345 -> (FStar_ST.read num_errs))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -1,1692 +1,2775 @@
+
 open Prims
 type decl =
-  | DGlobal of (flag Prims.list* (Prims.string Prims.list* Prims.string)*
-  typ* expr)
-  | DFunction of (cc Prims.option* flag Prims.list* Prims.int* typ*
-  (Prims.string Prims.list* Prims.string)* binder Prims.list* expr)
-  | DTypeAlias of ((Prims.string Prims.list* Prims.string)* Prims.int* typ)
-  | DTypeFlat of ((Prims.string Prims.list* Prims.string)* Prims.int*
-  (Prims.string* (typ* Prims.bool)) Prims.list)
-  | DExternal of (cc Prims.option* (Prims.string Prims.list* Prims.string)*
-  typ)
-  | DTypeVariant of ((Prims.string Prims.list* Prims.string)* Prims.int*
-  (Prims.string* (Prims.string* (typ* Prims.bool)) Prims.list) Prims.list)
-and cc =
-  | StdCall
-  | CDecl
-  | FastCall
-and flag =
-  | Private
-  | NoExtract
-  | CInline
-  | Substitute
-and lifetime =
-  | Eternal
-  | Stack
-and expr =
-  | EBound of Prims.int
-  | EQualified of (Prims.string Prims.list* Prims.string)
-  | EConstant of (width* Prims.string)
-  | EUnit
-  | EApp of (expr* expr Prims.list)
-  | ELet of (binder* expr* expr)
-  | EIfThenElse of (expr* expr* expr)
-  | ESequence of expr Prims.list
-  | EAssign of (expr* expr)
-  | EBufCreate of (lifetime* expr* expr)
-  | EBufRead of (expr* expr)
-  | EBufWrite of (expr* expr* expr)
-  | EBufSub of (expr* expr)
-  | EBufBlit of (expr* expr* expr* expr* expr)
-  | EMatch of (expr* (pattern* expr) Prims.list)
-  | EOp of (op* width)
-  | ECast of (expr* typ)
-  | EPushFrame
-  | EPopFrame
-  | EBool of Prims.bool
-  | EAny
-  | EAbort
-  | EReturn of expr
-  | EFlat of (typ* (Prims.string* expr) Prims.list)
-  | EField of (typ* expr* Prims.string)
-  | EWhile of (expr* expr)
-  | EBufCreateL of (lifetime* expr Prims.list)
-  | ETuple of expr Prims.list
-  | ECons of (typ* Prims.string* expr Prims.list)
-  | EBufFill of (expr* expr* expr)
-  | EString of Prims.string
-  | EFun of (binder Prims.list* expr)
-and op =
-  | Add
-  | AddW
-  | Sub
-  | SubW
-  | Div
-  | DivW
-  | Mult
-  | MultW
-  | Mod
-  | BOr
-  | BAnd
-  | BXor
-  | BShiftL
-  | BShiftR
-  | BNot
-  | Eq
-  | Neq
-  | Lt
-  | Lte
-  | Gt
-  | Gte
-  | And
-  | Or
-  | Xor
-  | Not
-and pattern =
-  | PUnit
-  | PBool of Prims.bool
-  | PVar of binder
-  | PCons of (Prims.string* pattern Prims.list)
-  | PTuple of pattern Prims.list
-  | PRecord of (Prims.string* pattern) Prims.list
-and width =
-  | UInt8
-  | UInt16
-  | UInt32
-  | UInt64
-  | Int8
-  | Int16
-  | Int32
-  | Int64
-  | Bool
-  | Int
-  | UInt
-and binder = {
-  name: Prims.string;
-  typ: typ;
-  mut: Prims.bool;}
-and typ =
-  | TInt of width
-  | TBuf of typ
-  | TUnit
-  | TQualified of (Prims.string Prims.list* Prims.string)
-  | TBool
-  | TAny
-  | TArrow of (typ* typ)
-  | TZ
-  | TBound of Prims.int
-  | TApp of ((Prims.string Prims.list* Prims.string)* typ Prims.list)
-  | TTuple of typ Prims.list
-let uu___is_DGlobal: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DGlobal _0 -> true | uu____300 -> false
-let __proj__DGlobal__item___0:
-  decl ->
-    (flag Prims.list* (Prims.string Prims.list* Prims.string)* typ* expr)
-  = fun projectee  -> match projectee with | DGlobal _0 -> _0
-let uu___is_DFunction: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DFunction _0 -> true | uu____349 -> false
-let __proj__DFunction__item___0:
-  decl ->
-    (cc Prims.option* flag Prims.list* Prims.int* typ* (Prims.string
-      Prims.list* Prims.string)* binder Prims.list* expr)
-  = fun projectee  -> match projectee with | DFunction _0 -> _0
-let uu___is_DTypeAlias: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DTypeAlias _0 -> true | uu____406 -> false
-let __proj__DTypeAlias__item___0:
-  decl -> ((Prims.string Prims.list* Prims.string)* Prims.int* typ) =
-  fun projectee  -> match projectee with | DTypeAlias _0 -> _0
-let uu___is_DTypeFlat: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DTypeFlat _0 -> true | uu____447 -> false
-let __proj__DTypeFlat__item___0:
-  decl ->
-    ((Prims.string Prims.list* Prims.string)* Prims.int* (Prims.string* (typ*
-      Prims.bool)) Prims.list)
-  = fun projectee  -> match projectee with | DTypeFlat _0 -> _0
-let uu___is_DExternal: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DExternal _0 -> true | uu____499 -> false
-let __proj__DExternal__item___0:
-  decl -> (cc Prims.option* (Prims.string Prims.list* Prims.string)* typ) =
-  fun projectee  -> match projectee with | DExternal _0 -> _0
-let uu___is_DTypeVariant: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DTypeVariant _0 -> true | uu____546 -> false
-let __proj__DTypeVariant__item___0:
-  decl ->
-    ((Prims.string Prims.list* Prims.string)* Prims.int* (Prims.string*
-      (Prims.string* (typ* Prims.bool)) Prims.list) Prims.list)
-  = fun projectee  -> match projectee with | DTypeVariant _0 -> _0
-let uu___is_StdCall: cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | StdCall  -> true | uu____599 -> false
-let uu___is_CDecl: cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CDecl  -> true | uu____603 -> false
-let uu___is_FastCall: cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FastCall  -> true | uu____607 -> false
-let uu___is_Private: flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Private  -> true | uu____611 -> false
-let uu___is_NoExtract: flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____615 -> false
-let uu___is_CInline: flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CInline  -> true | uu____619 -> false
-let uu___is_Substitute: flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Substitute  -> true | uu____623 -> false
-let uu___is_Eternal: lifetime -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eternal  -> true | uu____627 -> false
-let uu___is_Stack: lifetime -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Stack  -> true | uu____631 -> false
-let uu___is_EBound: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBound _0 -> true | uu____636 -> false
-let __proj__EBound__item___0: expr -> Prims.int =
-  fun projectee  -> match projectee with | EBound _0 -> _0
-let uu___is_EQualified: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EQualified _0 -> true | uu____651 -> false
-let __proj__EQualified__item___0:
-  expr -> (Prims.string Prims.list* Prims.string) =
-  fun projectee  -> match projectee with | EQualified _0 -> _0
-let uu___is_EConstant: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EConstant _0 -> true | uu____674 -> false
-let __proj__EConstant__item___0: expr -> (width* Prims.string) =
-  fun projectee  -> match projectee with | EConstant _0 -> _0
-let uu___is_EUnit: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EUnit  -> true | uu____691 -> false
-let uu___is_EApp: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EApp _0 -> true | uu____699 -> false
-let __proj__EApp__item___0: expr -> (expr* expr Prims.list) =
-  fun projectee  -> match projectee with | EApp _0 -> _0
-let uu___is_ELet: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ELet _0 -> true | uu____723 -> false
-let __proj__ELet__item___0: expr -> (binder* expr* expr) =
-  fun projectee  -> match projectee with | ELet _0 -> _0
-let uu___is_EIfThenElse: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EIfThenElse _0 -> true | uu____747 -> false
-let __proj__EIfThenElse__item___0: expr -> (expr* expr* expr) =
-  fun projectee  -> match projectee with | EIfThenElse _0 -> _0
-let uu___is_ESequence: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ESequence _0 -> true | uu____769 -> false
-let __proj__ESequence__item___0: expr -> expr Prims.list =
-  fun projectee  -> match projectee with | ESequence _0 -> _0
-let uu___is_EAssign: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAssign _0 -> true | uu____786 -> false
-let __proj__EAssign__item___0: expr -> (expr* expr) =
-  fun projectee  -> match projectee with | EAssign _0 -> _0
-let uu___is_EBufCreate: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufCreate _0 -> true | uu____807 -> false
-let __proj__EBufCreate__item___0: expr -> (lifetime* expr* expr) =
-  fun projectee  -> match projectee with | EBufCreate _0 -> _0
-let uu___is_EBufRead: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufRead _0 -> true | uu____830 -> false
-let __proj__EBufRead__item___0: expr -> (expr* expr) =
-  fun projectee  -> match projectee with | EBufRead _0 -> _0
-let uu___is_EBufWrite: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufWrite _0 -> true | uu____851 -> false
-let __proj__EBufWrite__item___0: expr -> (expr* expr* expr) =
-  fun projectee  -> match projectee with | EBufWrite _0 -> _0
-let uu___is_EBufSub: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufSub _0 -> true | uu____874 -> false
-let __proj__EBufSub__item___0: expr -> (expr* expr) =
-  fun projectee  -> match projectee with | EBufSub _0 -> _0
-let uu___is_EBufBlit: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufBlit _0 -> true | uu____897 -> false
-let __proj__EBufBlit__item___0: expr -> (expr* expr* expr* expr* expr) =
-  fun projectee  -> match projectee with | EBufBlit _0 -> _0
-let uu___is_EMatch: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EMatch _0 -> true | uu____929 -> false
-let __proj__EMatch__item___0: expr -> (expr* (pattern* expr) Prims.list) =
-  fun projectee  -> match projectee with | EMatch _0 -> _0
-let uu___is_EOp: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EOp _0 -> true | uu____958 -> false
-let __proj__EOp__item___0: expr -> (op* width) =
-  fun projectee  -> match projectee with | EOp _0 -> _0
-let uu___is_ECast: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ECast _0 -> true | uu____978 -> false
-let __proj__ECast__item___0: expr -> (expr* typ) =
-  fun projectee  -> match projectee with | ECast _0 -> _0
-let uu___is_EPushFrame: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EPushFrame  -> true | uu____995 -> false
-let uu___is_EPopFrame: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EPopFrame  -> true | uu____999 -> false
-let uu___is_EBool: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBool _0 -> true | uu____1004 -> false
-let __proj__EBool__item___0: expr -> Prims.bool =
-  fun projectee  -> match projectee with | EBool _0 -> _0
-let uu___is_EAny: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAny  -> true | uu____1015 -> false
-let uu___is_EAbort: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAbort  -> true | uu____1019 -> false
-let uu___is_EReturn: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EReturn _0 -> true | uu____1024 -> false
-let __proj__EReturn__item___0: expr -> expr =
-  fun projectee  -> match projectee with | EReturn _0 -> _0
-let uu___is_EFlat: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EFlat _0 -> true | uu____1041 -> false
-let __proj__EFlat__item___0: expr -> (typ* (Prims.string* expr) Prims.list) =
-  fun projectee  -> match projectee with | EFlat _0 -> _0
-let uu___is_EField: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EField _0 -> true | uu____1071 -> false
-let __proj__EField__item___0: expr -> (typ* expr* Prims.string) =
-  fun projectee  -> match projectee with | EField _0 -> _0
-let uu___is_EWhile: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EWhile _0 -> true | uu____1094 -> false
-let __proj__EWhile__item___0: expr -> (expr* expr) =
-  fun projectee  -> match projectee with | EWhile _0 -> _0
-let uu___is_EBufCreateL: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufCreateL _0 -> true | uu____1115 -> false
-let __proj__EBufCreateL__item___0: expr -> (lifetime* expr Prims.list) =
-  fun projectee  -> match projectee with | EBufCreateL _0 -> _0
-let uu___is_ETuple: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ETuple _0 -> true | uu____1137 -> false
-let __proj__ETuple__item___0: expr -> expr Prims.list =
-  fun projectee  -> match projectee with | ETuple _0 -> _0
-let uu___is_ECons: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ECons _0 -> true | uu____1156 -> false
-let __proj__ECons__item___0: expr -> (typ* Prims.string* expr Prims.list) =
-  fun projectee  -> match projectee with | ECons _0 -> _0
-let uu___is_EBufFill: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBufFill _0 -> true | uu____1183 -> false
-let __proj__EBufFill__item___0: expr -> (expr* expr* expr) =
-  fun projectee  -> match projectee with | EBufFill _0 -> _0
-let uu___is_EString: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EString _0 -> true | uu____1204 -> false
-let __proj__EString__item___0: expr -> Prims.string =
-  fun projectee  -> match projectee with | EString _0 -> _0
-let uu___is_EFun: expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EFun _0 -> true | uu____1219 -> false
-let __proj__EFun__item___0: expr -> (binder Prims.list* expr) =
-  fun projectee  -> match projectee with | EFun _0 -> _0
-let uu___is_Add: op -> Prims.bool =
-  fun projectee  -> match projectee with | Add  -> true | uu____1239 -> false
-let uu___is_AddW: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | AddW  -> true | uu____1243 -> false
-let uu___is_Sub: op -> Prims.bool =
-  fun projectee  -> match projectee with | Sub  -> true | uu____1247 -> false
-let uu___is_SubW: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SubW  -> true | uu____1251 -> false
-let uu___is_Div: op -> Prims.bool =
-  fun projectee  -> match projectee with | Div  -> true | uu____1255 -> false
-let uu___is_DivW: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DivW  -> true | uu____1259 -> false
-let uu___is_Mult: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mult  -> true | uu____1263 -> false
-let uu___is_MultW: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MultW  -> true | uu____1267 -> false
-let uu___is_Mod: op -> Prims.bool =
-  fun projectee  -> match projectee with | Mod  -> true | uu____1271 -> false
-let uu___is_BOr: op -> Prims.bool =
-  fun projectee  -> match projectee with | BOr  -> true | uu____1275 -> false
-let uu___is_BAnd: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BAnd  -> true | uu____1279 -> false
-let uu___is_BXor: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BXor  -> true | uu____1283 -> false
-let uu___is_BShiftL: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BShiftL  -> true | uu____1287 -> false
-let uu___is_BShiftR: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BShiftR  -> true | uu____1291 -> false
-let uu___is_BNot: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BNot  -> true | uu____1295 -> false
-let uu___is_Eq: op -> Prims.bool =
-  fun projectee  -> match projectee with | Eq  -> true | uu____1299 -> false
-let uu___is_Neq: op -> Prims.bool =
-  fun projectee  -> match projectee with | Neq  -> true | uu____1303 -> false
-let uu___is_Lt: op -> Prims.bool =
-  fun projectee  -> match projectee with | Lt  -> true | uu____1307 -> false
-let uu___is_Lte: op -> Prims.bool =
-  fun projectee  -> match projectee with | Lte  -> true | uu____1311 -> false
-let uu___is_Gt: op -> Prims.bool =
-  fun projectee  -> match projectee with | Gt  -> true | uu____1315 -> false
-let uu___is_Gte: op -> Prims.bool =
-  fun projectee  -> match projectee with | Gte  -> true | uu____1319 -> false
-let uu___is_And: op -> Prims.bool =
-  fun projectee  -> match projectee with | And  -> true | uu____1323 -> false
-let uu___is_Or: op -> Prims.bool =
-  fun projectee  -> match projectee with | Or  -> true | uu____1327 -> false
-let uu___is_Xor: op -> Prims.bool =
-  fun projectee  -> match projectee with | Xor  -> true | uu____1331 -> false
-let uu___is_Not: op -> Prims.bool =
-  fun projectee  -> match projectee with | Not  -> true | uu____1335 -> false
-let uu___is_PUnit: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PUnit  -> true | uu____1339 -> false
-let uu___is_PBool: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PBool _0 -> true | uu____1344 -> false
-let __proj__PBool__item___0: pattern -> Prims.bool =
-  fun projectee  -> match projectee with | PBool _0 -> _0
-let uu___is_PVar: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PVar _0 -> true | uu____1356 -> false
-let __proj__PVar__item___0: pattern -> binder =
-  fun projectee  -> match projectee with | PVar _0 -> _0
-let uu___is_PCons: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PCons _0 -> true | uu____1371 -> false
-let __proj__PCons__item___0: pattern -> (Prims.string* pattern Prims.list) =
-  fun projectee  -> match projectee with | PCons _0 -> _0
-let uu___is_PTuple: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PTuple _0 -> true | uu____1393 -> false
-let __proj__PTuple__item___0: pattern -> pattern Prims.list =
-  fun projectee  -> match projectee with | PTuple _0 -> _0
-let uu___is_PRecord: pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PRecord _0 -> true | uu____1411 -> false
-let __proj__PRecord__item___0: pattern -> (Prims.string* pattern) Prims.list
-  = fun projectee  -> match projectee with | PRecord _0 -> _0
-let uu___is_UInt8: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt8  -> true | uu____1431 -> false
-let uu___is_UInt16: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt16  -> true | uu____1435 -> false
-let uu___is_UInt32: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt32  -> true | uu____1439 -> false
-let uu___is_UInt64: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt64  -> true | uu____1443 -> false
-let uu___is_Int8: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int8  -> true | uu____1447 -> false
-let uu___is_Int16: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int16  -> true | uu____1451 -> false
-let uu___is_Int32: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int32  -> true | uu____1455 -> false
-let uu___is_Int64: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int64  -> true | uu____1459 -> false
-let uu___is_Bool: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Bool  -> true | uu____1463 -> false
-let uu___is_Int: width -> Prims.bool =
-  fun projectee  -> match projectee with | Int  -> true | uu____1467 -> false
-let uu___is_UInt: width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt  -> true | uu____1471 -> false
-let uu___is_TInt: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TInt _0 -> true | uu____1488 -> false
-let __proj__TInt__item___0: typ -> width =
-  fun projectee  -> match projectee with | TInt _0 -> _0
-let uu___is_TBuf: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBuf _0 -> true | uu____1500 -> false
-let __proj__TBuf__item___0: typ -> typ =
-  fun projectee  -> match projectee with | TBuf _0 -> _0
-let uu___is_TUnit: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TUnit  -> true | uu____1511 -> false
-let uu___is_TQualified: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TQualified _0 -> true | uu____1519 -> false
-let __proj__TQualified__item___0:
-  typ -> (Prims.string Prims.list* Prims.string) =
-  fun projectee  -> match projectee with | TQualified _0 -> _0
-let uu___is_TBool: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBool  -> true | uu____1539 -> false
-let uu___is_TAny: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TAny  -> true | uu____1543 -> false
-let uu___is_TArrow: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TArrow _0 -> true | uu____1550 -> false
-let __proj__TArrow__item___0: typ -> (typ* typ) =
-  fun projectee  -> match projectee with | TArrow _0 -> _0
-let uu___is_TZ: typ -> Prims.bool =
-  fun projectee  -> match projectee with | TZ  -> true | uu____1567 -> false
-let uu___is_TBound: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBound _0 -> true | uu____1572 -> false
-let __proj__TBound__item___0: typ -> Prims.int =
-  fun projectee  -> match projectee with | TBound _0 -> _0
-let uu___is_TApp: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TApp _0 -> true | uu____1590 -> false
-let __proj__TApp__item___0:
-  typ -> ((Prims.string Prims.list* Prims.string)* typ Prims.list) =
-  fun projectee  -> match projectee with | TApp _0 -> _0
-let uu___is_TTuple: typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TTuple _0 -> true | uu____1621 -> false
-let __proj__TTuple__item___0: typ -> typ Prims.list =
-  fun projectee  -> match projectee with | TTuple _0 -> _0
-type program = decl Prims.list
-type ident = Prims.string
-type fields_t = (Prims.string* (typ* Prims.bool)) Prims.list
+| DGlobal of (flag Prims.list * (Prims.string Prims.list * Prims.string) * typ * expr)
+| DFunction of (cc Prims.option * flag Prims.list * Prims.int * typ * (Prims.string Prims.list * Prims.string) * binder Prims.list * expr)
+| DTypeAlias of ((Prims.string Prims.list * Prims.string) * Prims.int * typ)
+| DTypeFlat of ((Prims.string Prims.list * Prims.string) * Prims.int * (Prims.string * (typ * Prims.bool)) Prims.list)
+| DExternal of (cc Prims.option * (Prims.string Prims.list * Prims.string) * typ)
+| DTypeVariant of ((Prims.string Prims.list * Prims.string) * Prims.int * (Prims.string * (Prims.string * (typ * Prims.bool)) Prims.list) Prims.list) 
+ and cc =
+| StdCall
+| CDecl
+| FastCall 
+ and flag =
+| Private
+| NoExtract
+| CInline
+| Substitute 
+ and lifetime =
+| Eternal
+| Stack 
+ and expr =
+| EBound of Prims.int
+| EQualified of (Prims.string Prims.list * Prims.string)
+| EConstant of (width * Prims.string)
+| EUnit
+| EApp of (expr * expr Prims.list)
+| ELet of (binder * expr * expr)
+| EIfThenElse of (expr * expr * expr)
+| ESequence of expr Prims.list
+| EAssign of (expr * expr)
+| EBufCreate of (lifetime * expr * expr)
+| EBufRead of (expr * expr)
+| EBufWrite of (expr * expr * expr)
+| EBufSub of (expr * expr)
+| EBufBlit of (expr * expr * expr * expr * expr)
+| EMatch of (expr * (pattern * expr) Prims.list)
+| EOp of (op * width)
+| ECast of (expr * typ)
+| EPushFrame
+| EPopFrame
+| EBool of Prims.bool
+| EAny
+| EAbort
+| EReturn of expr
+| EFlat of (typ * (Prims.string * expr) Prims.list)
+| EField of (typ * expr * Prims.string)
+| EWhile of (expr * expr)
+| EBufCreateL of (lifetime * expr Prims.list)
+| ETuple of expr Prims.list
+| ECons of (typ * Prims.string * expr Prims.list)
+| EBufFill of (expr * expr * expr)
+| EString of Prims.string
+| EFun of (binder Prims.list * expr) 
+ and op =
+| Add
+| AddW
+| Sub
+| SubW
+| Div
+| DivW
+| Mult
+| MultW
+| Mod
+| BOr
+| BAnd
+| BXor
+| BShiftL
+| BShiftR
+| BNot
+| Eq
+| Neq
+| Lt
+| Lte
+| Gt
+| Gte
+| And
+| Or
+| Xor
+| Not 
+ and pattern =
+| PUnit
+| PBool of Prims.bool
+| PVar of binder
+| PCons of (Prims.string * pattern Prims.list)
+| PTuple of pattern Prims.list
+| PRecord of (Prims.string * pattern) Prims.list 
+ and width =
+| UInt8
+| UInt16
+| UInt32
+| UInt64
+| Int8
+| Int16
+| Int32
+| Int64
+| Bool
+| Int
+| UInt 
+ and binder =
+{name : Prims.string; typ : typ; mut : Prims.bool} 
+ and typ =
+| TInt of width
+| TBuf of typ
+| TUnit
+| TQualified of (Prims.string Prims.list * Prims.string)
+| TBool
+| TAny
+| TArrow of (typ * typ)
+| TZ
+| TBound of Prims.int
+| TApp of ((Prims.string Prims.list * Prims.string) * typ Prims.list)
+| TTuple of typ Prims.list
+
+
+let uu___is_DGlobal : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DGlobal (_0) -> begin
+true
+end
+| uu____300 -> begin
+false
+end))
+
+
+let __proj__DGlobal__item___0 : decl  ->  (flag Prims.list * (Prims.string Prims.list * Prims.string) * typ * expr) = (fun projectee -> (match (projectee) with
+| DGlobal (_0) -> begin
+_0
+end))
+
+
+let uu___is_DFunction : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DFunction (_0) -> begin
+true
+end
+| uu____349 -> begin
+false
+end))
+
+
+let __proj__DFunction__item___0 : decl  ->  (cc Prims.option * flag Prims.list * Prims.int * typ * (Prims.string Prims.list * Prims.string) * binder Prims.list * expr) = (fun projectee -> (match (projectee) with
+| DFunction (_0) -> begin
+_0
+end))
+
+
+let uu___is_DTypeAlias : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DTypeAlias (_0) -> begin
+true
+end
+| uu____406 -> begin
+false
+end))
+
+
+let __proj__DTypeAlias__item___0 : decl  ->  ((Prims.string Prims.list * Prims.string) * Prims.int * typ) = (fun projectee -> (match (projectee) with
+| DTypeAlias (_0) -> begin
+_0
+end))
+
+
+let uu___is_DTypeFlat : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DTypeFlat (_0) -> begin
+true
+end
+| uu____447 -> begin
+false
+end))
+
+
+let __proj__DTypeFlat__item___0 : decl  ->  ((Prims.string Prims.list * Prims.string) * Prims.int * (Prims.string * (typ * Prims.bool)) Prims.list) = (fun projectee -> (match (projectee) with
+| DTypeFlat (_0) -> begin
+_0
+end))
+
+
+let uu___is_DExternal : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DExternal (_0) -> begin
+true
+end
+| uu____499 -> begin
+false
+end))
+
+
+let __proj__DExternal__item___0 : decl  ->  (cc Prims.option * (Prims.string Prims.list * Prims.string) * typ) = (fun projectee -> (match (projectee) with
+| DExternal (_0) -> begin
+_0
+end))
+
+
+let uu___is_DTypeVariant : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DTypeVariant (_0) -> begin
+true
+end
+| uu____546 -> begin
+false
+end))
+
+
+let __proj__DTypeVariant__item___0 : decl  ->  ((Prims.string Prims.list * Prims.string) * Prims.int * (Prims.string * (Prims.string * (typ * Prims.bool)) Prims.list) Prims.list) = (fun projectee -> (match (projectee) with
+| DTypeVariant (_0) -> begin
+_0
+end))
+
+
+let uu___is_StdCall : cc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| StdCall -> begin
+true
+end
+| uu____599 -> begin
+false
+end))
+
+
+let uu___is_CDecl : cc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CDecl -> begin
+true
+end
+| uu____603 -> begin
+false
+end))
+
+
+let uu___is_FastCall : cc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FastCall -> begin
+true
+end
+| uu____607 -> begin
+false
+end))
+
+
+let uu___is_Private : flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Private -> begin
+true
+end
+| uu____611 -> begin
+false
+end))
+
+
+let uu___is_NoExtract : flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoExtract -> begin
+true
+end
+| uu____615 -> begin
+false
+end))
+
+
+let uu___is_CInline : flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CInline -> begin
+true
+end
+| uu____619 -> begin
+false
+end))
+
+
+let uu___is_Substitute : flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Substitute -> begin
+true
+end
+| uu____623 -> begin
+false
+end))
+
+
+let uu___is_Eternal : lifetime  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eternal -> begin
+true
+end
+| uu____627 -> begin
+false
+end))
+
+
+let uu___is_Stack : lifetime  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Stack -> begin
+true
+end
+| uu____631 -> begin
+false
+end))
+
+
+let uu___is_EBound : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBound (_0) -> begin
+true
+end
+| uu____636 -> begin
+false
+end))
+
+
+let __proj__EBound__item___0 : expr  ->  Prims.int = (fun projectee -> (match (projectee) with
+| EBound (_0) -> begin
+_0
+end))
+
+
+let uu___is_EQualified : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EQualified (_0) -> begin
+true
+end
+| uu____651 -> begin
+false
+end))
+
+
+let __proj__EQualified__item___0 : expr  ->  (Prims.string Prims.list * Prims.string) = (fun projectee -> (match (projectee) with
+| EQualified (_0) -> begin
+_0
+end))
+
+
+let uu___is_EConstant : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EConstant (_0) -> begin
+true
+end
+| uu____674 -> begin
+false
+end))
+
+
+let __proj__EConstant__item___0 : expr  ->  (width * Prims.string) = (fun projectee -> (match (projectee) with
+| EConstant (_0) -> begin
+_0
+end))
+
+
+let uu___is_EUnit : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EUnit -> begin
+true
+end
+| uu____691 -> begin
+false
+end))
+
+
+let uu___is_EApp : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EApp (_0) -> begin
+true
+end
+| uu____699 -> begin
+false
+end))
+
+
+let __proj__EApp__item___0 : expr  ->  (expr * expr Prims.list) = (fun projectee -> (match (projectee) with
+| EApp (_0) -> begin
+_0
+end))
+
+
+let uu___is_ELet : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ELet (_0) -> begin
+true
+end
+| uu____723 -> begin
+false
+end))
+
+
+let __proj__ELet__item___0 : expr  ->  (binder * expr * expr) = (fun projectee -> (match (projectee) with
+| ELet (_0) -> begin
+_0
+end))
+
+
+let uu___is_EIfThenElse : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EIfThenElse (_0) -> begin
+true
+end
+| uu____747 -> begin
+false
+end))
+
+
+let __proj__EIfThenElse__item___0 : expr  ->  (expr * expr * expr) = (fun projectee -> (match (projectee) with
+| EIfThenElse (_0) -> begin
+_0
+end))
+
+
+let uu___is_ESequence : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ESequence (_0) -> begin
+true
+end
+| uu____769 -> begin
+false
+end))
+
+
+let __proj__ESequence__item___0 : expr  ->  expr Prims.list = (fun projectee -> (match (projectee) with
+| ESequence (_0) -> begin
+_0
+end))
+
+
+let uu___is_EAssign : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EAssign (_0) -> begin
+true
+end
+| uu____786 -> begin
+false
+end))
+
+
+let __proj__EAssign__item___0 : expr  ->  (expr * expr) = (fun projectee -> (match (projectee) with
+| EAssign (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufCreate : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufCreate (_0) -> begin
+true
+end
+| uu____807 -> begin
+false
+end))
+
+
+let __proj__EBufCreate__item___0 : expr  ->  (lifetime * expr * expr) = (fun projectee -> (match (projectee) with
+| EBufCreate (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufRead : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufRead (_0) -> begin
+true
+end
+| uu____830 -> begin
+false
+end))
+
+
+let __proj__EBufRead__item___0 : expr  ->  (expr * expr) = (fun projectee -> (match (projectee) with
+| EBufRead (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufWrite : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufWrite (_0) -> begin
+true
+end
+| uu____851 -> begin
+false
+end))
+
+
+let __proj__EBufWrite__item___0 : expr  ->  (expr * expr * expr) = (fun projectee -> (match (projectee) with
+| EBufWrite (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufSub : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufSub (_0) -> begin
+true
+end
+| uu____874 -> begin
+false
+end))
+
+
+let __proj__EBufSub__item___0 : expr  ->  (expr * expr) = (fun projectee -> (match (projectee) with
+| EBufSub (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufBlit : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufBlit (_0) -> begin
+true
+end
+| uu____897 -> begin
+false
+end))
+
+
+let __proj__EBufBlit__item___0 : expr  ->  (expr * expr * expr * expr * expr) = (fun projectee -> (match (projectee) with
+| EBufBlit (_0) -> begin
+_0
+end))
+
+
+let uu___is_EMatch : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EMatch (_0) -> begin
+true
+end
+| uu____929 -> begin
+false
+end))
+
+
+let __proj__EMatch__item___0 : expr  ->  (expr * (pattern * expr) Prims.list) = (fun projectee -> (match (projectee) with
+| EMatch (_0) -> begin
+_0
+end))
+
+
+let uu___is_EOp : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EOp (_0) -> begin
+true
+end
+| uu____958 -> begin
+false
+end))
+
+
+let __proj__EOp__item___0 : expr  ->  (op * width) = (fun projectee -> (match (projectee) with
+| EOp (_0) -> begin
+_0
+end))
+
+
+let uu___is_ECast : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ECast (_0) -> begin
+true
+end
+| uu____978 -> begin
+false
+end))
+
+
+let __proj__ECast__item___0 : expr  ->  (expr * typ) = (fun projectee -> (match (projectee) with
+| ECast (_0) -> begin
+_0
+end))
+
+
+let uu___is_EPushFrame : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EPushFrame -> begin
+true
+end
+| uu____995 -> begin
+false
+end))
+
+
+let uu___is_EPopFrame : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EPopFrame -> begin
+true
+end
+| uu____999 -> begin
+false
+end))
+
+
+let uu___is_EBool : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBool (_0) -> begin
+true
+end
+| uu____1004 -> begin
+false
+end))
+
+
+let __proj__EBool__item___0 : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBool (_0) -> begin
+_0
+end))
+
+
+let uu___is_EAny : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EAny -> begin
+true
+end
+| uu____1015 -> begin
+false
+end))
+
+
+let uu___is_EAbort : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EAbort -> begin
+true
+end
+| uu____1019 -> begin
+false
+end))
+
+
+let uu___is_EReturn : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EReturn (_0) -> begin
+true
+end
+| uu____1024 -> begin
+false
+end))
+
+
+let __proj__EReturn__item___0 : expr  ->  expr = (fun projectee -> (match (projectee) with
+| EReturn (_0) -> begin
+_0
+end))
+
+
+let uu___is_EFlat : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EFlat (_0) -> begin
+true
+end
+| uu____1041 -> begin
+false
+end))
+
+
+let __proj__EFlat__item___0 : expr  ->  (typ * (Prims.string * expr) Prims.list) = (fun projectee -> (match (projectee) with
+| EFlat (_0) -> begin
+_0
+end))
+
+
+let uu___is_EField : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EField (_0) -> begin
+true
+end
+| uu____1071 -> begin
+false
+end))
+
+
+let __proj__EField__item___0 : expr  ->  (typ * expr * Prims.string) = (fun projectee -> (match (projectee) with
+| EField (_0) -> begin
+_0
+end))
+
+
+let uu___is_EWhile : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EWhile (_0) -> begin
+true
+end
+| uu____1094 -> begin
+false
+end))
+
+
+let __proj__EWhile__item___0 : expr  ->  (expr * expr) = (fun projectee -> (match (projectee) with
+| EWhile (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufCreateL : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufCreateL (_0) -> begin
+true
+end
+| uu____1115 -> begin
+false
+end))
+
+
+let __proj__EBufCreateL__item___0 : expr  ->  (lifetime * expr Prims.list) = (fun projectee -> (match (projectee) with
+| EBufCreateL (_0) -> begin
+_0
+end))
+
+
+let uu___is_ETuple : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ETuple (_0) -> begin
+true
+end
+| uu____1137 -> begin
+false
+end))
+
+
+let __proj__ETuple__item___0 : expr  ->  expr Prims.list = (fun projectee -> (match (projectee) with
+| ETuple (_0) -> begin
+_0
+end))
+
+
+let uu___is_ECons : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ECons (_0) -> begin
+true
+end
+| uu____1156 -> begin
+false
+end))
+
+
+let __proj__ECons__item___0 : expr  ->  (typ * Prims.string * expr Prims.list) = (fun projectee -> (match (projectee) with
+| ECons (_0) -> begin
+_0
+end))
+
+
+let uu___is_EBufFill : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EBufFill (_0) -> begin
+true
+end
+| uu____1183 -> begin
+false
+end))
+
+
+let __proj__EBufFill__item___0 : expr  ->  (expr * expr * expr) = (fun projectee -> (match (projectee) with
+| EBufFill (_0) -> begin
+_0
+end))
+
+
+let uu___is_EString : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EString (_0) -> begin
+true
+end
+| uu____1204 -> begin
+false
+end))
+
+
+let __proj__EString__item___0 : expr  ->  Prims.string = (fun projectee -> (match (projectee) with
+| EString (_0) -> begin
+_0
+end))
+
+
+let uu___is_EFun : expr  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EFun (_0) -> begin
+true
+end
+| uu____1219 -> begin
+false
+end))
+
+
+let __proj__EFun__item___0 : expr  ->  (binder Prims.list * expr) = (fun projectee -> (match (projectee) with
+| EFun (_0) -> begin
+_0
+end))
+
+
+let uu___is_Add : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Add -> begin
+true
+end
+| uu____1239 -> begin
+false
+end))
+
+
+let uu___is_AddW : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| AddW -> begin
+true
+end
+| uu____1243 -> begin
+false
+end))
+
+
+let uu___is_Sub : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sub -> begin
+true
+end
+| uu____1247 -> begin
+false
+end))
+
+
+let uu___is_SubW : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SubW -> begin
+true
+end
+| uu____1251 -> begin
+false
+end))
+
+
+let uu___is_Div : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Div -> begin
+true
+end
+| uu____1255 -> begin
+false
+end))
+
+
+let uu___is_DivW : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DivW -> begin
+true
+end
+| uu____1259 -> begin
+false
+end))
+
+
+let uu___is_Mult : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mult -> begin
+true
+end
+| uu____1263 -> begin
+false
+end))
+
+
+let uu___is_MultW : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MultW -> begin
+true
+end
+| uu____1267 -> begin
+false
+end))
+
+
+let uu___is_Mod : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mod -> begin
+true
+end
+| uu____1271 -> begin
+false
+end))
+
+
+let uu___is_BOr : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BOr -> begin
+true
+end
+| uu____1275 -> begin
+false
+end))
+
+
+let uu___is_BAnd : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BAnd -> begin
+true
+end
+| uu____1279 -> begin
+false
+end))
+
+
+let uu___is_BXor : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BXor -> begin
+true
+end
+| uu____1283 -> begin
+false
+end))
+
+
+let uu___is_BShiftL : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BShiftL -> begin
+true
+end
+| uu____1287 -> begin
+false
+end))
+
+
+let uu___is_BShiftR : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BShiftR -> begin
+true
+end
+| uu____1291 -> begin
+false
+end))
+
+
+let uu___is_BNot : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BNot -> begin
+true
+end
+| uu____1295 -> begin
+false
+end))
+
+
+let uu___is_Eq : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eq -> begin
+true
+end
+| uu____1299 -> begin
+false
+end))
+
+
+let uu___is_Neq : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Neq -> begin
+true
+end
+| uu____1303 -> begin
+false
+end))
+
+
+let uu___is_Lt : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Lt -> begin
+true
+end
+| uu____1307 -> begin
+false
+end))
+
+
+let uu___is_Lte : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Lte -> begin
+true
+end
+| uu____1311 -> begin
+false
+end))
+
+
+let uu___is_Gt : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Gt -> begin
+true
+end
+| uu____1315 -> begin
+false
+end))
+
+
+let uu___is_Gte : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Gte -> begin
+true
+end
+| uu____1319 -> begin
+false
+end))
+
+
+let uu___is_And : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| And -> begin
+true
+end
+| uu____1323 -> begin
+false
+end))
+
+
+let uu___is_Or : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Or -> begin
+true
+end
+| uu____1327 -> begin
+false
+end))
+
+
+let uu___is_Xor : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Xor -> begin
+true
+end
+| uu____1331 -> begin
+false
+end))
+
+
+let uu___is_Not : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Not -> begin
+true
+end
+| uu____1335 -> begin
+false
+end))
+
+
+let uu___is_PUnit : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PUnit -> begin
+true
+end
+| uu____1339 -> begin
+false
+end))
+
+
+let uu___is_PBool : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PBool (_0) -> begin
+true
+end
+| uu____1344 -> begin
+false
+end))
+
+
+let __proj__PBool__item___0 : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PBool (_0) -> begin
+_0
+end))
+
+
+let uu___is_PVar : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PVar (_0) -> begin
+true
+end
+| uu____1356 -> begin
+false
+end))
+
+
+let __proj__PVar__item___0 : pattern  ->  binder = (fun projectee -> (match (projectee) with
+| PVar (_0) -> begin
+_0
+end))
+
+
+let uu___is_PCons : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PCons (_0) -> begin
+true
+end
+| uu____1371 -> begin
+false
+end))
+
+
+let __proj__PCons__item___0 : pattern  ->  (Prims.string * pattern Prims.list) = (fun projectee -> (match (projectee) with
+| PCons (_0) -> begin
+_0
+end))
+
+
+let uu___is_PTuple : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PTuple (_0) -> begin
+true
+end
+| uu____1393 -> begin
+false
+end))
+
+
+let __proj__PTuple__item___0 : pattern  ->  pattern Prims.list = (fun projectee -> (match (projectee) with
+| PTuple (_0) -> begin
+_0
+end))
+
+
+let uu___is_PRecord : pattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PRecord (_0) -> begin
+true
+end
+| uu____1411 -> begin
+false
+end))
+
+
+let __proj__PRecord__item___0 : pattern  ->  (Prims.string * pattern) Prims.list = (fun projectee -> (match (projectee) with
+| PRecord (_0) -> begin
+_0
+end))
+
+
+let uu___is_UInt8 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UInt8 -> begin
+true
+end
+| uu____1431 -> begin
+false
+end))
+
+
+let uu___is_UInt16 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UInt16 -> begin
+true
+end
+| uu____1435 -> begin
+false
+end))
+
+
+let uu___is_UInt32 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UInt32 -> begin
+true
+end
+| uu____1439 -> begin
+false
+end))
+
+
+let uu___is_UInt64 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UInt64 -> begin
+true
+end
+| uu____1443 -> begin
+false
+end))
+
+
+let uu___is_Int8 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int8 -> begin
+true
+end
+| uu____1447 -> begin
+false
+end))
+
+
+let uu___is_Int16 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int16 -> begin
+true
+end
+| uu____1451 -> begin
+false
+end))
+
+
+let uu___is_Int32 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int32 -> begin
+true
+end
+| uu____1455 -> begin
+false
+end))
+
+
+let uu___is_Int64 : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int64 -> begin
+true
+end
+| uu____1459 -> begin
+false
+end))
+
+
+let uu___is_Bool : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Bool -> begin
+true
+end
+| uu____1463 -> begin
+false
+end))
+
+
+let uu___is_Int : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int -> begin
+true
+end
+| uu____1467 -> begin
+false
+end))
+
+
+let uu___is_UInt : width  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UInt -> begin
+true
+end
+| uu____1471 -> begin
+false
+end))
+
+
+let uu___is_TInt : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TInt (_0) -> begin
+true
+end
+| uu____1488 -> begin
+false
+end))
+
+
+let __proj__TInt__item___0 : typ  ->  width = (fun projectee -> (match (projectee) with
+| TInt (_0) -> begin
+_0
+end))
+
+
+let uu___is_TBuf : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TBuf (_0) -> begin
+true
+end
+| uu____1500 -> begin
+false
+end))
+
+
+let __proj__TBuf__item___0 : typ  ->  typ = (fun projectee -> (match (projectee) with
+| TBuf (_0) -> begin
+_0
+end))
+
+
+let uu___is_TUnit : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TUnit -> begin
+true
+end
+| uu____1511 -> begin
+false
+end))
+
+
+let uu___is_TQualified : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TQualified (_0) -> begin
+true
+end
+| uu____1519 -> begin
+false
+end))
+
+
+let __proj__TQualified__item___0 : typ  ->  (Prims.string Prims.list * Prims.string) = (fun projectee -> (match (projectee) with
+| TQualified (_0) -> begin
+_0
+end))
+
+
+let uu___is_TBool : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TBool -> begin
+true
+end
+| uu____1539 -> begin
+false
+end))
+
+
+let uu___is_TAny : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TAny -> begin
+true
+end
+| uu____1543 -> begin
+false
+end))
+
+
+let uu___is_TArrow : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TArrow (_0) -> begin
+true
+end
+| uu____1550 -> begin
+false
+end))
+
+
+let __proj__TArrow__item___0 : typ  ->  (typ * typ) = (fun projectee -> (match (projectee) with
+| TArrow (_0) -> begin
+_0
+end))
+
+
+let uu___is_TZ : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TZ -> begin
+true
+end
+| uu____1567 -> begin
+false
+end))
+
+
+let uu___is_TBound : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TBound (_0) -> begin
+true
+end
+| uu____1572 -> begin
+false
+end))
+
+
+let __proj__TBound__item___0 : typ  ->  Prims.int = (fun projectee -> (match (projectee) with
+| TBound (_0) -> begin
+_0
+end))
+
+
+let uu___is_TApp : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TApp (_0) -> begin
+true
+end
+| uu____1590 -> begin
+false
+end))
+
+
+let __proj__TApp__item___0 : typ  ->  ((Prims.string Prims.list * Prims.string) * typ Prims.list) = (fun projectee -> (match (projectee) with
+| TApp (_0) -> begin
+_0
+end))
+
+
+let uu___is_TTuple : typ  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TTuple (_0) -> begin
+true
+end
+| uu____1621 -> begin
+false
+end))
+
+
+let __proj__TTuple__item___0 : typ  ->  typ Prims.list = (fun projectee -> (match (projectee) with
+| TTuple (_0) -> begin
+_0
+end))
+
+
+type program =
+decl Prims.list
+
+
+type ident =
+Prims.string
+
+
+type fields_t =
+(Prims.string * (typ * Prims.bool)) Prims.list
+
+
 type branches_t =
-  (Prims.string* (Prims.string* (typ* Prims.bool)) Prims.list) Prims.list
-type branch = (pattern* expr)
-type branches = (pattern* expr) Prims.list
-type constant = (width* Prims.string)
-type var = Prims.int
-type lident = (Prims.string Prims.list* Prims.string)
-type version = Prims.int
-let current_version: Prims.int = Prims.parse_int "20"
-type file = (Prims.string* program)
-type binary_format = (version* file Prims.list)
-let fst3 uu____1674 = match uu____1674 with | (x,uu____1679,uu____1680) -> x
-let snd3 uu____1694 = match uu____1694 with | (uu____1698,x,uu____1700) -> x
-let thd3 uu____1714 = match uu____1714 with | (uu____1718,uu____1719,x) -> x
-let mk_width: Prims.string -> width Prims.option =
-  fun uu___119_1724  ->
-    match uu___119_1724 with
-    | "UInt8" -> Some UInt8
-    | "UInt16" -> Some UInt16
-    | "UInt32" -> Some UInt32
-    | "UInt64" -> Some UInt64
-    | "Int8" -> Some Int8
-    | "Int16" -> Some Int16
-    | "Int32" -> Some Int32
-    | "Int64" -> Some Int64
-    | uu____1726 -> None
-let mk_bool_op: Prims.string -> op Prims.option =
-  fun uu___120_1730  ->
-    match uu___120_1730 with
-    | "op_Negation" -> Some Not
-    | "op_AmpAmp" -> Some And
-    | "op_BarBar" -> Some Or
-    | "op_Equality" -> Some Eq
-    | "op_disEquality" -> Some Neq
-    | uu____1732 -> None
-let is_bool_op: Prims.string -> Prims.bool =
-  fun op  -> (mk_bool_op op) <> None
-let mk_op: Prims.string -> op Prims.option =
-  fun uu___121_1740  ->
-    match uu___121_1740 with
-    | "add"|"op_Plus_Hat" -> Some Add
-    | "add_mod"|"op_Plus_Percent_Hat" -> Some AddW
-    | "sub"|"op_Subtraction_Hat" -> Some Sub
-    | "sub_mod"|"op_Subtraction_Percent_Hat" -> Some SubW
-    | "mul"|"op_Star_Hat" -> Some Mult
-    | "mul_mod"|"op_Star_Percent_Hat" -> Some MultW
-    | "div"|"op_Slash_Hat" -> Some Div
-    | "div_mod"|"op_Slash_Percent_Hat" -> Some DivW
-    | "rem"|"op_Percent_Hat" -> Some Mod
-    | "logor"|"op_Bar_Hat" -> Some BOr
-    | "logxor"|"op_Hat_Hat" -> Some BXor
-    | "logand"|"op_Amp_Hat" -> Some BAnd
-    | "lognot" -> Some BNot
-    | "shift_right"|"op_Greater_Greater_Hat" -> Some BShiftR
-    | "shift_left"|"op_Less_Less_Hat" -> Some BShiftL
-    | "eq"|"op_Equals_Hat" -> Some Eq
-    | "op_Greater_Hat"|"gt" -> Some Gt
-    | "op_Greater_Equals_Hat"|"gte" -> Some Gte
-    | "op_Less_Hat"|"lt" -> Some Lt
-    | "op_Less_Equals_Hat"|"lte" -> Some Lte
-    | uu____1742 -> None
-let is_op: Prims.string -> Prims.bool = fun op  -> (mk_op op) <> None
-let is_machine_int: Prims.string -> Prims.bool =
-  fun m  -> (mk_width m) <> None
+(Prims.string * (Prims.string * (typ * Prims.bool)) Prims.list) Prims.list
+
+
+type branch =
+(pattern * expr)
+
+
+type branches =
+(pattern * expr) Prims.list
+
+
+type constant =
+(width * Prims.string)
+
+
+type var =
+Prims.int
+
+
+type lident =
+(Prims.string Prims.list * Prims.string)
+
+
+type version =
+Prims.int
+
+
+let current_version : version = (Prims.parse_int "20")
+
+
+type file =
+(Prims.string * program)
+
+
+type binary_format =
+(version * file Prims.list)
+
+
+let fst3 = (fun uu____1674 -> (match (uu____1674) with
+| (x, uu____1679, uu____1680) -> begin
+x
+end))
+
+
+let snd3 = (fun uu____1694 -> (match (uu____1694) with
+| (uu____1698, x, uu____1700) -> begin
+x
+end))
+
+
+let thd3 = (fun uu____1714 -> (match (uu____1714) with
+| (uu____1718, uu____1719, x) -> begin
+x
+end))
+
+
+let mk_width : Prims.string  ->  width Prims.option = (fun uu___117_1724 -> (match (uu___117_1724) with
+| "UInt8" -> begin
+Some (UInt8)
+end
+| "UInt16" -> begin
+Some (UInt16)
+end
+| "UInt32" -> begin
+Some (UInt32)
+end
+| "UInt64" -> begin
+Some (UInt64)
+end
+| "Int8" -> begin
+Some (Int8)
+end
+| "Int16" -> begin
+Some (Int16)
+end
+| "Int32" -> begin
+Some (Int32)
+end
+| "Int64" -> begin
+Some (Int64)
+end
+| uu____1726 -> begin
+None
+end))
+
+
+let mk_bool_op : Prims.string  ->  op Prims.option = (fun uu___118_1730 -> (match (uu___118_1730) with
+| "op_Negation" -> begin
+Some (Not)
+end
+| "op_AmpAmp" -> begin
+Some (And)
+end
+| "op_BarBar" -> begin
+Some (Or)
+end
+| "op_Equality" -> begin
+Some (Eq)
+end
+| "op_disEquality" -> begin
+Some (Neq)
+end
+| uu____1732 -> begin
+None
+end))
+
+
+let is_bool_op : Prims.string  ->  Prims.bool = (fun op -> ((mk_bool_op op) <> None))
+
+
+let mk_op : Prims.string  ->  op Prims.option = (fun uu___119_1740 -> (match (uu___119_1740) with
+| ("add") | ("op_Plus_Hat") -> begin
+Some (Add)
+end
+| ("add_mod") | ("op_Plus_Percent_Hat") -> begin
+Some (AddW)
+end
+| ("sub") | ("op_Subtraction_Hat") -> begin
+Some (Sub)
+end
+| ("sub_mod") | ("op_Subtraction_Percent_Hat") -> begin
+Some (SubW)
+end
+| ("mul") | ("op_Star_Hat") -> begin
+Some (Mult)
+end
+| ("mul_mod") | ("op_Star_Percent_Hat") -> begin
+Some (MultW)
+end
+| ("div") | ("op_Slash_Hat") -> begin
+Some (Div)
+end
+| ("div_mod") | ("op_Slash_Percent_Hat") -> begin
+Some (DivW)
+end
+| ("rem") | ("op_Percent_Hat") -> begin
+Some (Mod)
+end
+| ("logor") | ("op_Bar_Hat") -> begin
+Some (BOr)
+end
+| ("logxor") | ("op_Hat_Hat") -> begin
+Some (BXor)
+end
+| ("logand") | ("op_Amp_Hat") -> begin
+Some (BAnd)
+end
+| "lognot" -> begin
+Some (BNot)
+end
+| ("shift_right") | ("op_Greater_Greater_Hat") -> begin
+Some (BShiftR)
+end
+| ("shift_left") | ("op_Less_Less_Hat") -> begin
+Some (BShiftL)
+end
+| ("eq") | ("op_Equals_Hat") -> begin
+Some (Eq)
+end
+| ("op_Greater_Hat") | ("gt") -> begin
+Some (Gt)
+end
+| ("op_Greater_Equals_Hat") | ("gte") -> begin
+Some (Gte)
+end
+| ("op_Less_Hat") | ("lt") -> begin
+Some (Lt)
+end
+| ("op_Less_Equals_Hat") | ("lte") -> begin
+Some (Lte)
+end
+| uu____1742 -> begin
+None
+end))
+
+
+let is_op : Prims.string  ->  Prims.bool = (fun op -> ((mk_op op) <> None))
+
+
+let is_machine_int : Prims.string  ->  Prims.bool = (fun m -> ((mk_width m) <> None))
+
 type env =
-  {
-  names: name Prims.list;
-  names_t: Prims.string Prims.list;
-  module_name: Prims.string Prims.list;}
-and name = {
-  pretty: Prims.string;
-  mut: Prims.bool;}
-let empty: Prims.string Prims.list -> env =
-  fun module_name  -> { names = []; names_t = []; module_name }
-let extend: env -> Prims.string -> Prims.bool -> env =
-  fun env  ->
-    fun x  ->
-      fun is_mut  ->
-        let uu___126_1809 = env in
-        {
-          names = ({ pretty = x; mut = is_mut } :: (env.names));
-          names_t = (uu___126_1809.names_t);
-          module_name = (uu___126_1809.module_name)
-        }
-let extend_t: env -> Prims.string -> env =
-  fun env  ->
-    fun x  ->
-      let uu___127_1816 = env in
-      {
-        names = (uu___127_1816.names);
-        names_t = (x :: (env.names_t));
-        module_name = (uu___127_1816.module_name)
-      }
-let find_name: env -> Prims.string -> name =
-  fun env  ->
-    fun x  ->
-      let uu____1823 =
-        FStar_List.tryFind (fun name  -> name.pretty = x) env.names in
-      match uu____1823 with
-      | Some name -> name
-      | None  -> failwith "internal error: name not found"
-let is_mutable: env -> Prims.string -> Prims.bool =
-  fun env  -> fun x  -> let uu____1833 = find_name env x in uu____1833.mut
-let find: env -> Prims.string -> Prims.int =
-  fun env  ->
-    fun x  ->
-      try FStar_List.index (fun name  -> name.pretty = x) env.names
-      with
-      | uu____1843 ->
-          let uu____1844 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____1844
-let find_t: env -> Prims.string -> Prims.int =
-  fun env  ->
-    fun x  ->
-      try FStar_List.index (fun name  -> name = x) env.names_t
-      with
-      | uu____1854 ->
-          let uu____1855 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____1855
-let add_binders env binders =
-  FStar_List.fold_left
-    (fun env1  ->
-       fun uu____1885  ->
-         match uu____1885 with
-         | ((name,uu____1891),uu____1892) -> extend env1 name false) env
-    binders
-let rec translate: FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
-  fun uu____1983  ->
-    match uu____1983 with
-    | FStar_Extraction_ML_Syntax.MLLib modules1 ->
-        FStar_List.filter_map
-          (fun m  ->
-             let m_name =
-               let uu____2014 = m in
-               match uu____2014 with
-               | ((prefix1,final),uu____2026,uu____2027) ->
-                   FStar_String.concat "."
-                     (FStar_List.append prefix1 [final]) in
-             try
-               FStar_Util.print1 "Attempting to translate module %s\n" m_name;
-               (let uu____2043 = translate_module m in Some uu____2043)
-             with
-             | e ->
-                 ((let uu____2048 = FStar_Util.print_exn e in
-                   FStar_Util.print2
-                     "Unable to translate module: %s because:\n  %s\n" m_name
-                     uu____2048);
-                  None)) modules1
-and translate_module:
-  ((Prims.string Prims.list* Prims.string)*
-    (FStar_Extraction_ML_Syntax.mlsig* FStar_Extraction_ML_Syntax.mlmodule)
-    Prims.option* FStar_Extraction_ML_Syntax.mllib) -> file
-  =
-  fun uu____2049  ->
-    match uu____2049 with
-    | (module_name,modul,uu____2061) ->
-        let module_name1 =
-          FStar_List.append (Prims.fst module_name) [Prims.snd module_name] in
-        let program =
-          match modul with
-          | Some (_signature,decls) ->
-              FStar_List.filter_map (translate_decl (empty module_name1))
-                decls
-          | uu____2085 ->
-              failwith "Unexpected standalone interface or nested modules" in
-        ((FStar_String.concat "_" module_name1), program)
-and translate_flags:
-  FStar_Extraction_ML_Syntax.c_flag Prims.list -> flag Prims.list =
-  fun flags  ->
-    FStar_List.choose
-      (fun uu___122_2093  ->
-         match uu___122_2093 with
-         | FStar_Extraction_ML_Syntax.Private  -> Some Private
-         | FStar_Extraction_ML_Syntax.NoExtract  -> Some NoExtract
-         | FStar_Extraction_ML_Syntax.Attribute "c_inline" -> Some CInline
-         | FStar_Extraction_ML_Syntax.Attribute "substitute" ->
-             Some Substitute
-         | FStar_Extraction_ML_Syntax.Attribute a ->
-             (FStar_Util.print1_warning "Warning: unrecognized attribute %s"
-                a;
-              None)
-         | uu____2097 -> None) flags
-and translate_decl:
-  env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.option =
-  fun env  ->
-    fun d  ->
-      match d with
-      | FStar_Extraction_ML_Syntax.MLM_Let
-        (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = (name,_);
-                        FStar_Extraction_ML_Syntax.mllb_tysc = Some
-                          (tvars,t0);
-                        FStar_Extraction_ML_Syntax.mllb_add_unit = _;
-                        FStar_Extraction_ML_Syntax.mllb_def =
-                          {
-                            FStar_Extraction_ML_Syntax.expr =
-                              FStar_Extraction_ML_Syntax.MLE_Fun (args,body);
-                            FStar_Extraction_ML_Syntax.mlty = _;
-                            FStar_Extraction_ML_Syntax.loc = _;_};
-                        FStar_Extraction_ML_Syntax.print_typ = _;_}::[])
-        |FStar_Extraction_ML_Syntax.MLM_Let
-        (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = (name,_);
-                        FStar_Extraction_ML_Syntax.mllb_tysc = Some
-                          (tvars,t0);
-                        FStar_Extraction_ML_Syntax.mllb_add_unit = _;
-                        FStar_Extraction_ML_Syntax.mllb_def =
-                          {
-                            FStar_Extraction_ML_Syntax.expr =
-                              FStar_Extraction_ML_Syntax.MLE_Coerce
-                              ({
-                                 FStar_Extraction_ML_Syntax.expr =
-                                   FStar_Extraction_ML_Syntax.MLE_Fun
-                                   (args,body);
-                                 FStar_Extraction_ML_Syntax.mlty = _;
-                                 FStar_Extraction_ML_Syntax.loc = _;_},_,_);
-                            FStar_Extraction_ML_Syntax.mlty = _;
-                            FStar_Extraction_ML_Syntax.loc = _;_};
-                        FStar_Extraction_ML_Syntax.print_typ = _;_}::[])
-          ->
-          let assumed =
-            FStar_Util.for_some
-              (fun uu___123_2142  ->
-                 match uu___123_2142 with
-                 | FStar_Extraction_ML_Syntax.Assumed  -> true
-                 | uu____2143 -> false) flags in
-          let env1 =
-            if flavor = FStar_Extraction_ML_Syntax.Rec
-            then extend env name false
-            else env in
-          let env2 =
-            FStar_List.fold_left
-              (fun env2  ->
-                 fun uu____2150  ->
-                   match uu____2150 with
-                   | (name1,uu____2154) -> extend_t env2 name1) env1 tvars in
-          let rec find_return_type uu___124_2158 =
-            match uu___124_2158 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____2159,uu____2160,t)
-                -> find_return_type t
-            | t -> t in
-          let t =
-            let uu____2164 = find_return_type t0 in
-            translate_type env2 uu____2164 in
-          let binders = translate_binders env2 args in
-          let env3 = add_binders env2 args in
-          let name1 = ((env3.module_name), name) in
-          let flags1 = translate_flags flags in
-          if assumed
-          then
-            (if (FStar_List.length tvars) = (Prims.parse_int "0")
-             then
-               let uu____2179 =
-                 let uu____2180 =
-                   let uu____2188 = translate_type env3 t0 in
-                   (None, name1, uu____2188) in
-                 DExternal uu____2180 in
-               Some uu____2179
-             else None)
-          else
-            (try
-               let body1 = translate_expr env3 body in
-               Some
-                 (DFunction
-                    (None, flags1, (FStar_List.length tvars), t, name1,
-                      binders, body1))
-             with
-             | e ->
-                 ((let uu____2211 = FStar_Util.print_exn e in
-                   FStar_Util.print2 "Warning: writing a stub for %s (%s)\n"
-                     (Prims.snd name1) uu____2211);
-                  Some
-                    (DFunction
-                       (None, flags1, (FStar_List.length tvars), t, name1,
-                         binders, EAbort))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-          (flavor,flags,{
-                          FStar_Extraction_ML_Syntax.mllb_name =
-                            (name,uu____2224);
-                          FStar_Extraction_ML_Syntax.mllb_tysc = Some ([],t);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____2226;
-                          FStar_Extraction_ML_Syntax.mllb_def = expr;
-                          FStar_Extraction_ML_Syntax.print_typ = uu____2228;_}::[])
-          ->
-          let flags1 = translate_flags flags in
-          let t1 = translate_type env t in
-          let name1 = ((env.module_name), name) in
-          (try
-             let expr1 = translate_expr env expr in
-             Some (DGlobal (flags1, name1, t1, expr1))
-           with
-           | e ->
-               ((let uu____2254 = FStar_Util.print_exn e in
-                 FStar_Util.print2
-                   "Warning: not translating definition for %s (%s)\n"
-                   (Prims.snd name1) uu____2254);
-                Some (DGlobal (flags1, name1, t1, EAny))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-          (uu____2260,uu____2261,{
-                                   FStar_Extraction_ML_Syntax.mllb_name =
-                                     (name,uu____2263);
-                                   FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-                                   FStar_Extraction_ML_Syntax.mllb_add_unit =
-                                     uu____2265;
-                                   FStar_Extraction_ML_Syntax.mllb_def =
-                                     uu____2266;
-                                   FStar_Extraction_ML_Syntax.print_typ =
-                                     uu____2267;_}::uu____2268)
-          ->
-          (FStar_Util.print1
-             "Warning: not translating definition for %s (and possibly others)\n"
-             name;
-           (match ts with
-            | Some (idents,t) ->
-                let uu____2278 =
-                  let uu____2279 = FStar_List.map Prims.fst idents in
-                  FStar_String.concat ", " uu____2279 in
-                let uu____2283 =
-                  FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
-                FStar_Util.print2 "Type scheme is: forall %s. %s\n"
-                  uu____2278 uu____2283
-            | None  -> ());
-           None)
-      | FStar_Extraction_ML_Syntax.MLM_Let uu____2285 ->
-          failwith "impossible"
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu____2287 -> None
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((assumed,name,_mangled_name,args,Some
-            (FStar_Extraction_ML_Syntax.MLTD_Abbrev t))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____2319  ->
-                   match uu____2319 with
-                   | (name2,uu____2323) -> extend_t env1 name2) env args in
-          if assumed
-          then None
-          else
-            (let uu____2326 =
-               let uu____2327 =
-                 let uu____2334 = translate_type env1 t in
-                 (name1, (FStar_List.length args), uu____2334) in
-               DTypeAlias uu____2327 in
-             Some uu____2326)
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____2340,name,_mangled_name,args,Some
-            (FStar_Extraction_ML_Syntax.MLTD_Record fields))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____2374  ->
-                   match uu____2374 with
-                   | (name2,uu____2378) -> extend_t env1 name2) env args in
-          let uu____2379 =
-            let uu____2380 =
-              let uu____2392 =
-                FStar_List.map
-                  (fun uu____2404  ->
-                     match uu____2404 with
-                     | (f,t) ->
-                         let uu____2413 =
-                           let uu____2416 = translate_type env1 t in
-                           (uu____2416, false) in
-                         (f, uu____2413)) fields in
-              (name1, (FStar_List.length args), uu____2392) in
-            DTypeFlat uu____2380 in
-          Some uu____2379
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____2429,name,_mangled_name,args,Some
-            (FStar_Extraction_ML_Syntax.MLTD_DType branches))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____2464  ->
-                   match uu____2464 with
-                   | (name2,uu____2468) -> extend_t env1 name2) env args in
-          let uu____2469 =
-            let uu____2470 =
-              let uu____2485 =
-                FStar_List.mapi
-                  (fun i  ->
-                     fun uu____2505  ->
-                       match uu____2505 with
-                       | (cons1,ts) ->
-                           let uu____2520 =
-                             FStar_List.mapi
-                               (fun j  ->
-                                  fun t  ->
-                                    let uu____2532 =
-                                      let uu____2533 =
-                                        FStar_Util.string_of_int i in
-                                      let uu____2534 =
-                                        FStar_Util.string_of_int j in
-                                      FStar_Util.format2 "x%s%s" uu____2533
-                                        uu____2534 in
-                                    let uu____2535 =
-                                      let uu____2538 = translate_type env1 t in
-                                      (uu____2538, false) in
-                                    (uu____2532, uu____2535)) ts in
-                           (cons1, uu____2520)) branches in
-              (name1, (FStar_List.length args), uu____2485) in
-            DTypeVariant uu____2470 in
-          Some uu____2469
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____2559,name,_mangled_name,uu____2562,uu____2563)::uu____2564)
-          ->
-          (FStar_Util.print1
-             "Warning: not translating definition for %s (and possibly others)\n"
-             name;
-           None)
-      | FStar_Extraction_ML_Syntax.MLM_Ty [] ->
-          (FStar_Util.print_string
-             "Impossible!! Empty block of mutually recursive type declarations";
-           None)
-      | FStar_Extraction_ML_Syntax.MLM_Top uu____2586 ->
-          failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn uu____2588 ->
-          failwith "todo: translate_decl [MLM_Exn]"
-and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
-  fun env  ->
-    fun t  ->
-      match t with
-      | FStar_Extraction_ML_Syntax.MLTY_Tuple []
-        |FStar_Extraction_ML_Syntax.MLTY_Top  -> TAny
-      | FStar_Extraction_ML_Syntax.MLTY_Var (name,uu____2596) ->
-          let uu____2597 = find_t env name in TBound uu____2597
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____2599,t2) ->
-          let uu____2601 =
-            let uu____2604 = translate_type env t1 in
-            let uu____2605 = translate_type env t2 in
-            (uu____2604, uu____2605) in
-          TArrow uu____2601
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____2608 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2608 = "Prims.unit" -> TUnit
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____2611 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2611 = "Prims.bool" -> TBool
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
-          is_machine_int m ->
-          let uu____2618 = FStar_Util.must (mk_width m) in TInt uu____2618
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
-          is_machine_int m ->
-          let uu____2625 = FStar_Util.must (mk_width m) in TInt uu____2625
-      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____2629 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2629 = "FStar.Buffer.buffer" ->
-          let uu____2630 = translate_type env arg in TBuf uu____2630
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____2631::[],p) when
-          let uu____2634 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2634 = "FStar.Ghost.erased" -> TAny
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],(path,type_name)) ->
-          TQualified (path, type_name)
-      | FStar_Extraction_ML_Syntax.MLTY_Named (args,("Prims"::[],t1)) when
-          FStar_Util.starts_with t1 "tuple" ->
-          let uu____2652 = FStar_List.map (translate_type env) args in
-          TTuple uu____2652
-      | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
-          if (FStar_List.length args) > (Prims.parse_int "0")
-          then
-            let uu____2661 =
-              let uu____2668 = FStar_List.map (translate_type env) args in
-              (lid, uu____2668) in
-            TApp uu____2661
-          else TQualified lid
-      | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____2674 = FStar_List.map (translate_type env) ts in
-          TTuple uu____2674
-and translate_binders:
-  env ->
-    (FStar_Extraction_ML_Syntax.mlident* FStar_Extraction_ML_Syntax.mlty)
-      Prims.list -> binder Prims.list
-  = fun env  -> fun args  -> FStar_List.map (translate_binder env) args
-and translate_binder:
-  env ->
-    (FStar_Extraction_ML_Syntax.mlident* FStar_Extraction_ML_Syntax.mlty) ->
-      binder
-  =
-  fun env  ->
-    fun uu____2684  ->
-      match uu____2684 with
-      | ((name,uu____2688),typ) ->
-          let uu____2692 = translate_type env typ in
-          { name; typ = uu____2692; mut = false }
-and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
-  fun env  ->
-    fun e  ->
-      match e.FStar_Extraction_ML_Syntax.expr with
-      | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
-      | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
-      | FStar_Extraction_ML_Syntax.MLE_Var (name,uu____2697) ->
-          let uu____2698 = find env name in EBound uu____2698
-      | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
-          (is_machine_int m) && (is_op op) ->
-          let uu____2702 =
-            let uu____2705 = FStar_Util.must (mk_op op) in
-            let uu____2706 = FStar_Util.must (mk_width m) in
-            (uu____2705, uu____2706) in
-          EOp uu____2702
-      | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
-          is_bool_op op ->
-          let uu____2709 =
-            let uu____2712 = FStar_Util.must (mk_bool_op op) in
-            (uu____2712, Bool) in
-          EOp uu____2709
-      | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
-      | FStar_Extraction_ML_Syntax.MLE_Let
-          ((flavor,flags,{
-                           FStar_Extraction_ML_Syntax.mllb_name =
-                             (name,uu____2717);
-                           FStar_Extraction_ML_Syntax.mllb_tysc = Some
-                             ([],typ);
-                           FStar_Extraction_ML_Syntax.mllb_add_unit =
-                             add_unit;
-                           FStar_Extraction_ML_Syntax.mllb_def = body;
-                           FStar_Extraction_ML_Syntax.print_typ = print7;_}::[]),continuation)
-          ->
-          let is_mut =
-            FStar_Util.for_some
-              (fun uu___125_2733  ->
-                 match uu___125_2733 with
-                 | FStar_Extraction_ML_Syntax.Mutable  -> true
-                 | uu____2734 -> false) flags in
-          let uu____2735 =
-            if is_mut
-            then
-              let uu____2740 =
-                match typ with
-                | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
-                    let uu____2744 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                    uu____2744 = "FStar.ST.stackref" -> t
-                | uu____2745 ->
-                    let uu____2746 =
-                      let uu____2747 =
-                        FStar_Extraction_ML_Code.string_of_mlty ([], "") typ in
-                      FStar_Util.format1
-                        "unexpected: bad desugaring of Mutable (typ is %s)"
-                        uu____2747 in
-                    failwith uu____2746 in
-              let uu____2749 =
-                match body with
-                | {
-                    FStar_Extraction_ML_Syntax.expr =
-                      FStar_Extraction_ML_Syntax.MLE_App
-                      (uu____2750,body1::[]);
-                    FStar_Extraction_ML_Syntax.mlty = uu____2752;
-                    FStar_Extraction_ML_Syntax.loc = uu____2753;_} -> body1
-                | uu____2755 ->
-                    failwith "unexpected: bad desugaring of Mutable" in
-              (uu____2740, uu____2749)
-            else (typ, body) in
-          (match uu____2735 with
-           | (typ1,body1) ->
-               let binder =
-                 let uu____2760 = translate_type env typ1 in
-                 { name; typ = uu____2760; mut = is_mut } in
-               let body2 = translate_expr env body1 in
-               let env1 = extend env name is_mut in
-               let continuation1 = translate_expr env1 continuation in
-               ELet (binder, body2, continuation1))
-      | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
-          let uu____2776 =
-            let uu____2782 = translate_expr env expr in
-            let uu____2783 = translate_branches env branches in
-            (uu____2782, uu____2783) in
-          EMatch uu____2776
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2791;
-             FStar_Extraction_ML_Syntax.loc = uu____2792;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                =
-                                                                FStar_Extraction_ML_Syntax.MLE_Var
-                                                                (v1,uu____2794);
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____2795;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____2796;_}::[])
-          when
-          (let uu____2798 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____2798 = "FStar.ST.op_Bang") && (is_mutable env v1)
-          -> let uu____2799 = find env v1 in EBound uu____2799
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2801;
-             FStar_Extraction_ML_Syntax.loc = uu____2802;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                =
-                                                                FStar_Extraction_ML_Syntax.MLE_Var
-                                                                (v1,uu____2804);
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____2805;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____2806;_}::e1::[])
-          when
-          (let uu____2809 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____2809 = "FStar.ST.op_Colon_Equals") && (is_mutable env v1)
-          ->
-          let uu____2810 =
-            let uu____2813 =
-              let uu____2814 = find env v1 in EBound uu____2814 in
-            let uu____2815 = translate_expr env e1 in
-            (uu____2813, uu____2815) in
-          EAssign uu____2810
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2817;
-             FStar_Extraction_ML_Syntax.loc = uu____2818;_},e1::e2::[])
-          when
-          (let uu____2822 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____2822 = "FStar.Buffer.index") ||
-            (let uu____2823 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____2823 = "FStar.Buffer.op_Array_Access")
-          ->
-          let uu____2824 =
-            let uu____2827 = translate_expr env e1 in
-            let uu____2828 = translate_expr env e2 in
-            (uu____2827, uu____2828) in
-          EBufRead uu____2824
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2830;
-             FStar_Extraction_ML_Syntax.loc = uu____2831;_},e1::e2::[])
-          when
-          let uu____2835 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2835 = "FStar.Buffer.create" ->
-          let uu____2836 =
-            let uu____2840 = translate_expr env e1 in
-            let uu____2841 = translate_expr env e2 in
-            (Stack, uu____2840, uu____2841) in
-          EBufCreate uu____2836
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2843;
-             FStar_Extraction_ML_Syntax.loc = uu____2844;_},_e0::e1::e2::[])
-          when
-          let uu____2849 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2849 = "FStar.Buffer.rcreate" ->
-          let uu____2850 =
-            let uu____2854 = translate_expr env e1 in
-            let uu____2855 = translate_expr env e2 in
-            (Eternal, uu____2854, uu____2855) in
-          EBufCreate uu____2850
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2857;
-             FStar_Extraction_ML_Syntax.loc = uu____2858;_},e2::[])
-          when
-          let uu____2861 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2861 = "FStar.Buffer.createL" ->
-          let rec list_elements1 acc e21 =
-            match e21.FStar_Extraction_ML_Syntax.expr with
-            | FStar_Extraction_ML_Syntax.MLE_CTor
-                (("Prims"::[],"Cons"),hd1::tl1::[]) ->
-                list_elements1 (hd1 :: acc) tl1
-            | FStar_Extraction_ML_Syntax.MLE_CTor (("Prims"::[],"Nil"),[]) ->
-                FStar_List.rev acc
-            | uu____2885 ->
-                failwith
-                  "Argument of FStar.Buffer.createL is not a string literal!" in
-          let list_elements2 = list_elements1 [] in
-          let uu____2891 =
-            let uu____2895 =
-              let uu____2897 = list_elements2 e2 in
-              FStar_List.map (translate_expr env) uu____2897 in
-            (Stack, uu____2895) in
-          EBufCreateL uu____2891
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2901;
-             FStar_Extraction_ML_Syntax.loc = uu____2902;_},e1::e2::_e3::[])
-          when
-          let uu____2907 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2907 = "FStar.Buffer.sub" ->
-          let uu____2908 =
-            let uu____2911 = translate_expr env e1 in
-            let uu____2912 = translate_expr env e2 in
-            (uu____2911, uu____2912) in
-          EBufSub uu____2908
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2914;
-             FStar_Extraction_ML_Syntax.loc = uu____2915;_},e1::e2::[])
-          when
-          let uu____2919 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2919 = "FStar.Buffer.join" -> translate_expr env e1
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2921;
-             FStar_Extraction_ML_Syntax.loc = uu____2922;_},e1::e2::[])
-          when
-          let uu____2926 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2926 = "FStar.Buffer.offset" ->
-          let uu____2927 =
-            let uu____2930 = translate_expr env e1 in
-            let uu____2931 = translate_expr env e2 in
-            (uu____2930, uu____2931) in
-          EBufSub uu____2927
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2933;
-             FStar_Extraction_ML_Syntax.loc = uu____2934;_},e1::e2::e3::[])
-          when
-          (let uu____2939 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____2939 = "FStar.Buffer.upd") ||
-            (let uu____2940 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____2940 = "FStar.Buffer.op_Array_Assignment")
-          ->
-          let uu____2941 =
-            let uu____2945 = translate_expr env e1 in
-            let uu____2946 = translate_expr env e2 in
-            let uu____2947 = translate_expr env e3 in
-            (uu____2945, uu____2946, uu____2947) in
-          EBufWrite uu____2941
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2949;
-             FStar_Extraction_ML_Syntax.loc = uu____2950;_},uu____2951::[])
-          when
-          let uu____2953 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2953 = "FStar.ST.push_frame" -> EPushFrame
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2955;
-             FStar_Extraction_ML_Syntax.loc = uu____2956;_},uu____2957::[])
-          when
-          let uu____2959 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2959 = "FStar.ST.pop_frame" -> EPopFrame
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2961;
-             FStar_Extraction_ML_Syntax.loc = uu____2962;_},e1::e2::e3::e4::e5::[])
-          when
-          let uu____2969 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2969 = "FStar.Buffer.blit" ->
-          let uu____2970 =
-            let uu____2976 = translate_expr env e1 in
-            let uu____2977 = translate_expr env e2 in
-            let uu____2978 = translate_expr env e3 in
-            let uu____2979 = translate_expr env e4 in
-            let uu____2980 = translate_expr env e5 in
-            (uu____2976, uu____2977, uu____2978, uu____2979, uu____2980) in
-          EBufBlit uu____2970
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2982;
-             FStar_Extraction_ML_Syntax.loc = uu____2983;_},e1::e2::e3::[])
-          when
-          let uu____2988 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____2988 = "FStar.Buffer.fill" ->
-          let uu____2989 =
-            let uu____2993 = translate_expr env e1 in
-            let uu____2994 = translate_expr env e2 in
-            let uu____2995 = translate_expr env e3 in
-            (uu____2993, uu____2994, uu____2995) in
-          EBufFill uu____2989
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____2997;
-             FStar_Extraction_ML_Syntax.loc = uu____2998;_},uu____2999::[])
-          when
-          let uu____3001 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____3001 = "FStar.ST.get" -> EUnit
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____3003;
-             FStar_Extraction_ML_Syntax.loc = uu____3004;_},e1::[])
-          when
-          let uu____3007 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____3007 = "Obj.repr" ->
-          let uu____3008 =
-            let uu____3011 = translate_expr env e1 in (uu____3011, TAny) in
-          ECast uu____3008
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op);
-             FStar_Extraction_ML_Syntax.mlty = uu____3014;
-             FStar_Extraction_ML_Syntax.loc = uu____3015;_},args)
-          when (is_machine_int m) && (is_op op) ->
-          let uu____3020 = FStar_Util.must (mk_width m) in
-          let uu____3021 = FStar_Util.must (mk_op op) in
-          mk_op_app env uu____3020 uu____3021 args
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op);
-             FStar_Extraction_ML_Syntax.mlty = uu____3023;
-             FStar_Extraction_ML_Syntax.loc = uu____3024;_},args)
-          when is_bool_op op ->
-          let uu____3029 = FStar_Util.must (mk_bool_op op) in
-          mk_op_app env Bool uu____3029 args
-      | FStar_Extraction_ML_Syntax.MLE_App
-        ({
-           FStar_Extraction_ML_Syntax.expr =
-             FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],"int_to_t");
-           FStar_Extraction_ML_Syntax.mlty = _;
-           FStar_Extraction_ML_Syntax.loc = _;_},{
-                                                   FStar_Extraction_ML_Syntax.expr
-                                                     =
-                                                     FStar_Extraction_ML_Syntax.MLE_Const
-                                                     (FStar_Extraction_ML_Syntax.MLC_Int
-                                                     (c,None ));
-                                                   FStar_Extraction_ML_Syntax.mlty
-                                                     = _;
-                                                   FStar_Extraction_ML_Syntax.loc
-                                                     = _;_}::[])
-        |FStar_Extraction_ML_Syntax.MLE_App
-        ({
-           FStar_Extraction_ML_Syntax.expr =
-             FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],"uint_to_t");
-           FStar_Extraction_ML_Syntax.mlty = _;
-           FStar_Extraction_ML_Syntax.loc = _;_},{
-                                                   FStar_Extraction_ML_Syntax.expr
-                                                     =
-                                                     FStar_Extraction_ML_Syntax.MLE_Const
-                                                     (FStar_Extraction_ML_Syntax.MLC_Int
-                                                     (c,None ));
-                                                   FStar_Extraction_ML_Syntax.mlty
-                                                     = _;
-                                                   FStar_Extraction_ML_Syntax.loc
-                                                     = _;_}::[])
-          when is_machine_int m ->
-          let uu____3054 =
-            let uu____3057 = FStar_Util.must (mk_width m) in (uu____3057, c) in
-          EConstant uu____3054
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name
-               ("C"::[],"string_of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____3058;
-             FStar_Extraction_ML_Syntax.loc = uu____3059;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                = e1;
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____3061;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____3062;_}::[])
-          ->
-          (match e1 with
-           | FStar_Extraction_ML_Syntax.MLE_Const
-               (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____3066 ->
-               failwith
-                 "Cannot extract string_of_literal applied to a non-literal")
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name
-               ("FStar"::"Int"::"Cast"::[],c);
-             FStar_Extraction_ML_Syntax.mlty = uu____3068;
-             FStar_Extraction_ML_Syntax.loc = uu____3069;_},arg::[])
-          ->
-          let is_known_type =
-            (((((((FStar_Util.starts_with c "uint8") ||
-                    (FStar_Util.starts_with c "uint16"))
-                   || (FStar_Util.starts_with c "uint32"))
-                  || (FStar_Util.starts_with c "uint64"))
-                 || (FStar_Util.starts_with c "int8"))
-                || (FStar_Util.starts_with c "int16"))
-               || (FStar_Util.starts_with c "int32"))
-              || (FStar_Util.starts_with c "int64") in
-          if (FStar_Util.ends_with c "uint64") && is_known_type
-          then
-            let uu____3074 =
-              let uu____3077 = translate_expr env arg in
-              (uu____3077, (TInt UInt64)) in
-            ECast uu____3074
-          else
-            if (FStar_Util.ends_with c "uint32") && is_known_type
-            then
-              (let uu____3079 =
-                 let uu____3082 = translate_expr env arg in
-                 (uu____3082, (TInt UInt32)) in
-               ECast uu____3079)
-            else
-              if (FStar_Util.ends_with c "uint16") && is_known_type
-              then
-                (let uu____3084 =
-                   let uu____3087 = translate_expr env arg in
-                   (uu____3087, (TInt UInt16)) in
-                 ECast uu____3084)
-              else
-                if (FStar_Util.ends_with c "uint8") && is_known_type
-                then
-                  (let uu____3089 =
-                     let uu____3092 = translate_expr env arg in
-                     (uu____3092, (TInt UInt8)) in
-                   ECast uu____3089)
-                else
-                  if (FStar_Util.ends_with c "int64") && is_known_type
-                  then
-                    (let uu____3094 =
-                       let uu____3097 = translate_expr env arg in
-                       (uu____3097, (TInt Int64)) in
-                     ECast uu____3094)
-                  else
-                    if (FStar_Util.ends_with c "int32") && is_known_type
-                    then
-                      (let uu____3099 =
-                         let uu____3102 = translate_expr env arg in
-                         (uu____3102, (TInt Int32)) in
-                       ECast uu____3099)
-                    else
-                      if (FStar_Util.ends_with c "int16") && is_known_type
-                      then
-                        (let uu____3104 =
-                           let uu____3107 = translate_expr env arg in
-                           (uu____3107, (TInt Int16)) in
-                         ECast uu____3104)
-                      else
-                        if (FStar_Util.ends_with c "int8") && is_known_type
-                        then
-                          (let uu____3109 =
-                             let uu____3112 = translate_expr env arg in
-                             (uu____3112, (TInt Int8)) in
-                           ECast uu____3109)
-                        else
-                          (let uu____3114 =
-                             let uu____3118 =
-                               let uu____3120 = translate_expr env arg in
-                               [uu____3120] in
-                             ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____3118) in
-                           EApp uu____3114)
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name (path,function_name);
-             FStar_Extraction_ML_Syntax.mlty = uu____3125;
-             FStar_Extraction_ML_Syntax.loc = uu____3126;_},args)
-          ->
-          let uu____3132 =
-            let uu____3136 = FStar_List.map (translate_expr env) args in
-            ((EQualified (path, function_name)), uu____3136) in
-          EApp uu____3132
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Var (name,uu____3141);
-             FStar_Extraction_ML_Syntax.mlty = uu____3142;
-             FStar_Extraction_ML_Syntax.loc = uu____3143;_},args)
-          ->
-          let uu____3147 =
-            let uu____3151 =
-              let uu____3152 = find env name in EBound uu____3152 in
-            let uu____3153 = FStar_List.map (translate_expr env) args in
-            (uu____3151, uu____3153) in
-          EApp uu____3147
-      | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
-          let uu____3159 =
-            let uu____3162 = translate_expr env e1 in
-            let uu____3163 = translate_type env t_to in
-            (uu____3162, uu____3163) in
-          ECast uu____3159
-      | FStar_Extraction_ML_Syntax.MLE_Record (uu____3164,fields) ->
-          let uu____3174 =
-            let uu____3180 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____3181 =
-              FStar_List.map
-                (fun uu____3189  ->
-                   match uu____3189 with
-                   | (field,expr) ->
-                       let uu____3196 = translate_expr env expr in
-                       (field, uu____3196)) fields in
-            (uu____3180, uu____3181) in
-          EFlat uu____3174
-      | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
-          let uu____3202 =
-            let uu____3206 =
-              assert_lid env e1.FStar_Extraction_ML_Syntax.mlty in
-            let uu____3207 = translate_expr env e1 in
-            (uu____3206, uu____3207, (Prims.snd path)) in
-          EField uu____3202
-      | FStar_Extraction_ML_Syntax.MLE_Let uu____3209 ->
-          failwith "todo: translate_expr [MLE_Let]"
-      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____3217) ->
-          let uu____3220 =
-            let uu____3221 =
-              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1 in
-            FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____3221 in
-          failwith uu____3220
-      | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____3225 = FStar_List.map (translate_expr env) seqs in
-          ESequence uu____3225
-      | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____3229 = FStar_List.map (translate_expr env) es in
-          ETuple uu____3229
-      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____3231,cons1),es) ->
-          let uu____3241 =
-            let uu____3246 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____3247 = FStar_List.map (translate_expr env) es in
-            (uu____3246, cons1, uu____3247) in
-          ECons uu____3241
-      | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
-          let binders = translate_binders env args in
-          let env1 = add_binders env args in
-          let uu____3261 =
-            let uu____3265 = translate_expr env1 body in
-            (binders, uu____3265) in
-          EFun uu____3261
-      | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
-          let uu____3272 =
-            let uu____3276 = translate_expr env e1 in
-            let uu____3277 = translate_expr env e2 in
-            let uu____3278 =
-              match e3 with
-              | None  -> EUnit
-              | Some e31 -> translate_expr env e31 in
-            (uu____3276, uu____3277, uu____3278) in
-          EIfThenElse uu____3272
-      | FStar_Extraction_ML_Syntax.MLE_Raise uu____3280 ->
-          failwith "todo: translate_expr [MLE_Raise]"
-      | FStar_Extraction_ML_Syntax.MLE_Try uu____3284 ->
-          failwith "todo: translate_expr [MLE_Try]"
-      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____3292 ->
-          failwith "todo: translate_expr [MLE_Coerce]"
-and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
-  fun env  ->
-    fun t  ->
-      match t with
-      | FStar_Extraction_ML_Syntax.MLTY_Named (ts,lid) ->
-          if (FStar_List.length ts) > (Prims.parse_int "0")
-          then
-            let uu____3305 =
-              let uu____3312 = FStar_List.map (translate_type env) ts in
-              (lid, uu____3312) in
-            TApp uu____3305
-          else TQualified lid
-      | uu____3316 -> failwith "invalid argument: assert_lid"
-and translate_branches:
-  env ->
-    (FStar_Extraction_ML_Syntax.mlpattern* FStar_Extraction_ML_Syntax.mlexpr
-      Prims.option* FStar_Extraction_ML_Syntax.mlexpr) Prims.list ->
-      (pattern* expr) Prims.list
-  =
-  fun env  -> fun branches  -> FStar_List.map (translate_branch env) branches
-and translate_branch:
-  env ->
-    (FStar_Extraction_ML_Syntax.mlpattern* FStar_Extraction_ML_Syntax.mlexpr
-      Prims.option* FStar_Extraction_ML_Syntax.mlexpr) -> (pattern* expr)
-  =
-  fun env  ->
-    fun uu____3331  ->
-      match uu____3331 with
-      | (pat,guard,expr) ->
-          if guard = None
-          then
-            let uu____3346 = translate_pat env pat in
-            (match uu____3346 with
-             | (env1,pat1) ->
-                 let uu____3353 = translate_expr env1 expr in
-                 (pat1, uu____3353))
-          else failwith "todo: translate_branch"
-and translate_pat:
-  env -> FStar_Extraction_ML_Syntax.mlpattern -> (env* pattern) =
-  fun env  ->
-    fun p  ->
-      match p with
-      | FStar_Extraction_ML_Syntax.MLP_Const
-          (FStar_Extraction_ML_Syntax.MLC_Unit ) -> (env, PUnit)
-      | FStar_Extraction_ML_Syntax.MLP_Const
-          (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env, (PBool b))
-      | FStar_Extraction_ML_Syntax.MLP_Var (name,uu____3363) ->
-          let env1 = extend env name false in
-          (env1, (PVar { name; typ = TAny; mut = false }))
-      | FStar_Extraction_ML_Syntax.MLP_Wild  ->
-          let env1 = extend env "_" false in
-          (env1, (PVar { name = "_"; typ = TAny; mut = false }))
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____3366,cons1),ps) ->
-          let uu____3376 =
-            FStar_List.fold_left
-              (fun uu____3383  ->
-                 fun p1  ->
-                   match uu____3383 with
-                   | (env1,acc) ->
-                       let uu____3395 = translate_pat env1 p1 in
-                       (match uu____3395 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
-          (match uu____3376 with
-           | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____3412,ps) ->
-          let uu____3422 =
-            FStar_List.fold_left
-              (fun uu____3435  ->
-                 fun uu____3436  ->
-                   match (uu____3435, uu____3436) with
-                   | ((env1,acc),(field,p1)) ->
-                       let uu____3473 = translate_pat env1 p1 in
-                       (match uu____3473 with
-                        | (env2,p2) -> (env2, ((field, p2) :: acc))))
-              (env, []) ps in
-          (match uu____3422 with
-           | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____3507 =
-            FStar_List.fold_left
-              (fun uu____3514  ->
-                 fun p1  ->
-                   match uu____3514 with
-                   | (env1,acc) ->
-                       let uu____3526 = translate_pat env1 p1 in
-                       (match uu____3526 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
-          (match uu____3507 with
-           | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____3542 ->
-          failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____3545 ->
-          failwith "todo: translate_pat [MLP_Branch]"
-and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
-  fun c  ->
-    match c with
-    | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
-    | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
-    | FStar_Extraction_ML_Syntax.MLC_Int (s,Some uu____3552) ->
-        failwith
-          "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____3560 ->
-        failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Char uu____3561 ->
-        failwith "todo: translate_expr [MLC_Char]"
-    | FStar_Extraction_ML_Syntax.MLC_String uu____3562 ->
-        failwith "todo: translate_expr [MLC_String]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____3563 ->
-        failwith "todo: translate_expr [MLC_Bytes]"
-    | FStar_Extraction_ML_Syntax.MLC_Int (uu____3565,None ) ->
-        failwith "todo: translate_expr [MLC_Int]"
-and mk_op_app:
-  env -> width -> op -> FStar_Extraction_ML_Syntax.mlexpr Prims.list -> expr
-  =
-  fun env  ->
-    fun w  ->
-      fun op  ->
-        fun args  ->
-          let uu____3576 =
-            let uu____3580 = FStar_List.map (translate_expr env) args in
-            ((EOp (op, w)), uu____3580) in
-          EApp uu____3576
+{names : name Prims.list; names_t : Prims.string Prims.list; module_name : Prims.string Prims.list} 
+ and name =
+{pretty : Prims.string; mut : Prims.bool}
+
+
+let empty : Prims.string Prims.list  ->  env = (fun module_name -> {names = []; names_t = []; module_name = module_name})
+
+
+let extend : env  ->  Prims.string  ->  Prims.bool  ->  env = (fun env x is_mut -> (
+
+let uu___124_1809 = env
+in {names = ({pretty = x; mut = is_mut})::env.names; names_t = uu___124_1809.names_t; module_name = uu___124_1809.module_name}))
+
+
+let extend_t : env  ->  Prims.string  ->  env = (fun env x -> (
+
+let uu___125_1816 = env
+in {names = uu___125_1816.names; names_t = (x)::env.names_t; module_name = uu___125_1816.module_name}))
+
+
+let find_name : env  ->  Prims.string  ->  name = (fun env x -> (
+
+let uu____1823 = (FStar_List.tryFind (fun name -> (name.pretty = x)) env.names)
+in (match (uu____1823) with
+| Some (name) -> begin
+name
+end
+| None -> begin
+(failwith "internal error: name not found")
+end)))
+
+
+let is_mutable : env  ->  Prims.string  ->  Prims.bool = (fun env x -> (
+
+let uu____1833 = (find_name env x)
+in uu____1833.mut))
+
+
+let find : env  ->  Prims.string  ->  Prims.int = (fun env x -> try
+(match (()) with
+| () -> begin
+(FStar_List.index (fun name -> (name.pretty = x)) env.names)
+end)
+with
+| uu____1843 -> begin
+(
+
+let uu____1844 = (FStar_Util.format1 "Internal error: name not found %s\n" x)
+in (failwith uu____1844))
+end)
+
+
+let find_t : env  ->  Prims.string  ->  Prims.int = (fun env x -> try
+(match (()) with
+| () -> begin
+(FStar_List.index (fun name -> (name = x)) env.names_t)
+end)
+with
+| uu____1854 -> begin
+(
+
+let uu____1855 = (FStar_Util.format1 "Internal error: name not found %s\n" x)
+in (failwith uu____1855))
+end)
+
+
+let add_binders = (fun env binders -> (FStar_List.fold_left (fun env1 uu____1885 -> (match (uu____1885) with
+| ((name, uu____1891), uu____1892) -> begin
+(extend env1 name false)
+end)) env binders))
+
+
+let rec translate : FStar_Extraction_ML_Syntax.mllib  ->  file Prims.list = (fun uu____1983 -> (match (uu____1983) with
+| FStar_Extraction_ML_Syntax.MLLib (modules1) -> begin
+(FStar_List.filter_map (fun m -> (
+
+let m_name = (
+
+let uu____2014 = m
+in (match (uu____2014) with
+| ((prefix1, final), uu____2026, uu____2027) -> begin
+(FStar_String.concat "." (FStar_List.append prefix1 ((final)::[])))
+end))
+in try
+(match (()) with
+| () -> begin
+((FStar_Util.print1 "Attempting to translate module %s\n" m_name);
+(
+
+let uu____2043 = (translate_module m)
+in Some (uu____2043));
+)
+end)
+with
+| e -> begin
+((
+
+let uu____2048 = (FStar_Util.print_exn e)
+in (FStar_Util.print2 "Unable to translate module: %s because:\n  %s\n" m_name uu____2048));
+None;
+)
+end)) modules1)
+end))
+and translate_module : ((Prims.string Prims.list * Prims.string) * (FStar_Extraction_ML_Syntax.mlsig * FStar_Extraction_ML_Syntax.mlmodule) Prims.option * FStar_Extraction_ML_Syntax.mllib)  ->  file = (fun uu____2049 -> (match (uu____2049) with
+| (module_name, modul, uu____2061) -> begin
+(
+
+let module_name1 = (FStar_List.append (Prims.fst module_name) (((Prims.snd module_name))::[]))
+in (
+
+let program = (match (modul) with
+| Some (_signature, decls) -> begin
+(FStar_List.filter_map (translate_decl (empty module_name1)) decls)
+end
+| uu____2085 -> begin
+(failwith "Unexpected standalone interface or nested modules")
+end)
+in (((FStar_String.concat "_" module_name1)), (program))))
+end))
+and translate_flags : FStar_Extraction_ML_Syntax.c_flag Prims.list  ->  flag Prims.list = (fun flags -> (FStar_List.choose (fun uu___120_2093 -> (match (uu___120_2093) with
+| FStar_Extraction_ML_Syntax.Private -> begin
+Some (Private)
+end
+| FStar_Extraction_ML_Syntax.NoExtract -> begin
+Some (NoExtract)
+end
+| FStar_Extraction_ML_Syntax.Attribute ("c_inline") -> begin
+Some (CInline)
+end
+| FStar_Extraction_ML_Syntax.Attribute ("substitute") -> begin
+Some (Substitute)
+end
+| FStar_Extraction_ML_Syntax.Attribute (a) -> begin
+((FStar_Util.print1_warning "Warning: unrecognized attribute %s" a);
+None;
+)
+end
+| uu____2097 -> begin
+None
+end)) flags))
+and translate_decl : env  ->  FStar_Extraction_ML_Syntax.mlmodule1  ->  decl Prims.option = (fun env d -> (match (d) with
+| (FStar_Extraction_ML_Syntax.MLM_Let (flavor, flags, ({FStar_Extraction_ML_Syntax.mllb_name = (name, _); FStar_Extraction_ML_Syntax.mllb_tysc = Some (tvars, t0); FStar_Extraction_ML_Syntax.mllb_add_unit = _; FStar_Extraction_ML_Syntax.mllb_def = {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Fun (args, body); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}; FStar_Extraction_ML_Syntax.print_typ = _})::[])) | (FStar_Extraction_ML_Syntax.MLM_Let (flavor, flags, ({FStar_Extraction_ML_Syntax.mllb_name = (name, _); FStar_Extraction_ML_Syntax.mllb_tysc = Some (tvars, t0); FStar_Extraction_ML_Syntax.mllb_add_unit = _; FStar_Extraction_ML_Syntax.mllb_def = {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Coerce ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Fun (args, body); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}, _, _); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}; FStar_Extraction_ML_Syntax.print_typ = _})::[])) -> begin
+(
+
+let assumed = (FStar_Util.for_some (fun uu___121_2142 -> (match (uu___121_2142) with
+| FStar_Extraction_ML_Syntax.Assumed -> begin
+true
+end
+| uu____2143 -> begin
+false
+end)) flags)
+in (
+
+let env1 = (match ((flavor = FStar_Extraction_ML_Syntax.Rec)) with
+| true -> begin
+(extend env name false)
+end
+| uu____2145 -> begin
+env
+end)
+in (
+
+let env2 = (FStar_List.fold_left (fun env2 uu____2150 -> (match (uu____2150) with
+| (name1, uu____2154) -> begin
+(extend_t env2 name1)
+end)) env1 tvars)
+in (
+
+let rec find_return_type = (fun uu___122_2158 -> (match (uu___122_2158) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (uu____2159, uu____2160, t) -> begin
+(find_return_type t)
+end
+| t -> begin
+t
+end))
+in (
+
+let t = (
+
+let uu____2164 = (find_return_type t0)
+in (translate_type env2 uu____2164))
+in (
+
+let binders = (translate_binders env2 args)
+in (
+
+let env3 = (add_binders env2 args)
+in (
+
+let name1 = ((env3.module_name), (name))
+in (
+
+let flags1 = (translate_flags flags)
+in (match (assumed) with
+| true -> begin
+(match (((FStar_List.length tvars) = (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____2179 = (
+
+let uu____2180 = (
+
+let uu____2188 = (translate_type env3 t0)
+in ((None), (name1), (uu____2188)))
+in DExternal (uu____2180))
+in Some (uu____2179))
+end
+| uu____2193 -> begin
+None
+end)
+end
+| uu____2194 -> begin
+try
+(match (()) with
+| () -> begin
+(
+
+let body1 = (translate_expr env3 body)
+in Some (DFunction (((None), (flags1), ((FStar_List.length tvars)), (t), (name1), (binders), (body1)))))
+end)
+with
+| e -> begin
+((
+
+let uu____2211 = (FStar_Util.print_exn e)
+in (FStar_Util.print2 "Warning: writing a stub for %s (%s)\n" (Prims.snd name1) uu____2211));
+Some (DFunction (((None), (flags1), ((FStar_List.length tvars)), (t), (name1), (binders), (EAbort))));
+)
+end
+end))))))))))
+end
+| FStar_Extraction_ML_Syntax.MLM_Let (flavor, flags, ({FStar_Extraction_ML_Syntax.mllb_name = (name, uu____2224); FStar_Extraction_ML_Syntax.mllb_tysc = Some ([], t); FStar_Extraction_ML_Syntax.mllb_add_unit = uu____2226; FStar_Extraction_ML_Syntax.mllb_def = expr; FStar_Extraction_ML_Syntax.print_typ = uu____2228})::[]) -> begin
+(
+
+let flags1 = (translate_flags flags)
+in (
+
+let t1 = (translate_type env t)
+in (
+
+let name1 = ((env.module_name), (name))
+in try
+(match (()) with
+| () -> begin
+(
+
+let expr1 = (translate_expr env expr)
+in Some (DGlobal (((flags1), (name1), (t1), (expr1)))))
+end)
+with
+| e -> begin
+((
+
+let uu____2254 = (FStar_Util.print_exn e)
+in (FStar_Util.print2 "Warning: not translating definition for %s (%s)\n" (Prims.snd name1) uu____2254));
+Some (DGlobal (((flags1), (name1), (t1), (EAny))));
+)
+end)))
+end
+| FStar_Extraction_ML_Syntax.MLM_Let (uu____2260, uu____2261, ({FStar_Extraction_ML_Syntax.mllb_name = (name, uu____2263); FStar_Extraction_ML_Syntax.mllb_tysc = ts; FStar_Extraction_ML_Syntax.mllb_add_unit = uu____2265; FStar_Extraction_ML_Syntax.mllb_def = uu____2266; FStar_Extraction_ML_Syntax.print_typ = uu____2267})::uu____2268) -> begin
+((FStar_Util.print1 "Warning: not translating definition for %s (and possibly others)\n" name);
+(match (ts) with
+| Some (idents, t) -> begin
+(
+
+let uu____2278 = (
+
+let uu____2279 = (FStar_List.map Prims.fst idents)
+in (FStar_String.concat ", " uu____2279))
+in (
+
+let uu____2283 = (FStar_Extraction_ML_Code.string_of_mlty (([]), ("")) t)
+in (FStar_Util.print2 "Type scheme is: forall %s. %s\n" uu____2278 uu____2283)))
+end
+| None -> begin
+()
+end);
+None;
+)
+end
+| FStar_Extraction_ML_Syntax.MLM_Let (uu____2285) -> begin
+(failwith "impossible")
+end
+| FStar_Extraction_ML_Syntax.MLM_Loc (uu____2287) -> begin
+None
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty (((assumed, name, _mangled_name, args, Some (FStar_Extraction_ML_Syntax.MLTD_Abbrev (t))))::[]) -> begin
+(
+
+let name1 = ((env.module_name), (name))
+in (
+
+let env1 = (FStar_List.fold_left (fun env1 uu____2319 -> (match (uu____2319) with
+| (name2, uu____2323) -> begin
+(extend_t env1 name2)
+end)) env args)
+in (match (assumed) with
+| true -> begin
+None
+end
+| uu____2325 -> begin
+(
+
+let uu____2326 = (
+
+let uu____2327 = (
+
+let uu____2334 = (translate_type env1 t)
+in ((name1), ((FStar_List.length args)), (uu____2334)))
+in DTypeAlias (uu____2327))
+in Some (uu____2326))
+end)))
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty (((uu____2340, name, _mangled_name, args, Some (FStar_Extraction_ML_Syntax.MLTD_Record (fields))))::[]) -> begin
+(
+
+let name1 = ((env.module_name), (name))
+in (
+
+let env1 = (FStar_List.fold_left (fun env1 uu____2374 -> (match (uu____2374) with
+| (name2, uu____2378) -> begin
+(extend_t env1 name2)
+end)) env args)
+in (
+
+let uu____2379 = (
+
+let uu____2380 = (
+
+let uu____2392 = (FStar_List.map (fun uu____2404 -> (match (uu____2404) with
+| (f, t) -> begin
+(
+
+let uu____2413 = (
+
+let uu____2416 = (translate_type env1 t)
+in ((uu____2416), (false)))
+in ((f), (uu____2413)))
+end)) fields)
+in ((name1), ((FStar_List.length args)), (uu____2392)))
+in DTypeFlat (uu____2380))
+in Some (uu____2379))))
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty (((uu____2429, name, _mangled_name, args, Some (FStar_Extraction_ML_Syntax.MLTD_DType (branches))))::[]) -> begin
+(
+
+let name1 = ((env.module_name), (name))
+in (
+
+let env1 = (FStar_List.fold_left (fun env1 uu____2464 -> (match (uu____2464) with
+| (name2, uu____2468) -> begin
+(extend_t env1 name2)
+end)) env args)
+in (
+
+let uu____2469 = (
+
+let uu____2470 = (
+
+let uu____2485 = (FStar_List.mapi (fun i uu____2505 -> (match (uu____2505) with
+| (cons1, ts) -> begin
+(
+
+let uu____2520 = (FStar_List.mapi (fun j t -> (
+
+let uu____2532 = (
+
+let uu____2533 = (FStar_Util.string_of_int i)
+in (
+
+let uu____2534 = (FStar_Util.string_of_int j)
+in (FStar_Util.format2 "x%s%s" uu____2533 uu____2534)))
+in (
+
+let uu____2535 = (
+
+let uu____2538 = (translate_type env1 t)
+in ((uu____2538), (false)))
+in ((uu____2532), (uu____2535))))) ts)
+in ((cons1), (uu____2520)))
+end)) branches)
+in ((name1), ((FStar_List.length args)), (uu____2485)))
+in DTypeVariant (uu____2470))
+in Some (uu____2469))))
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty (((uu____2559, name, _mangled_name, uu____2562, uu____2563))::uu____2564) -> begin
+((FStar_Util.print1 "Warning: not translating definition for %s (and possibly others)\n" name);
+None;
+)
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty ([]) -> begin
+((FStar_Util.print_string "Impossible!! Empty block of mutually recursive type declarations");
+None;
+)
+end
+| FStar_Extraction_ML_Syntax.MLM_Top (uu____2586) -> begin
+(failwith "todo: translate_decl [MLM_Top]")
+end
+| FStar_Extraction_ML_Syntax.MLM_Exn (uu____2588) -> begin
+(failwith "todo: translate_decl [MLM_Exn]")
+end))
+and translate_type : env  ->  FStar_Extraction_ML_Syntax.mlty  ->  typ = (fun env t -> (match (t) with
+| (FStar_Extraction_ML_Syntax.MLTY_Tuple ([])) | (FStar_Extraction_ML_Syntax.MLTY_Top) -> begin
+TAny
+end
+| FStar_Extraction_ML_Syntax.MLTY_Var (name, uu____2596) -> begin
+(
+
+let uu____2597 = (find_t env name)
+in TBound (uu____2597))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu____2599, t2) -> begin
+(
+
+let uu____2601 = (
+
+let uu____2604 = (translate_type env t1)
+in (
+
+let uu____2605 = (translate_type env t2)
+in ((uu____2604), (uu____2605))))
+in TArrow (uu____2601))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ([], p) when (
+
+let uu____2608 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2608 = "Prims.unit")) -> begin
+TUnit
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ([], p) when (
+
+let uu____2611 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2611 = "Prims.bool")) -> begin
+TBool
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ([], (("FStar")::(m)::[], "t")) when (is_machine_int m) -> begin
+(
+
+let uu____2618 = (FStar_Util.must (mk_width m))
+in TInt (uu____2618))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ([], (("FStar")::(m)::[], "t\'")) when (is_machine_int m) -> begin
+(
+
+let uu____2625 = (FStar_Util.must (mk_width m))
+in TInt (uu____2625))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ((arg)::[], p) when (
+
+let uu____2629 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2629 = "FStar.Buffer.buffer")) -> begin
+(
+
+let uu____2630 = (translate_type env arg)
+in TBuf (uu____2630))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ((uu____2631)::[], p) when (
+
+let uu____2634 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2634 = "FStar.Ghost.erased")) -> begin
+TAny
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named ([], (path, type_name)) -> begin
+TQualified (((path), (type_name)))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, (("Prims")::[], t1)) when (FStar_Util.starts_with t1 "tuple") -> begin
+(
+
+let uu____2652 = (FStar_List.map (translate_type env) args)
+in TTuple (uu____2652))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, lid) -> begin
+(match (((FStar_List.length args) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____2661 = (
+
+let uu____2668 = (FStar_List.map (translate_type env) args)
+in ((lid), (uu____2668)))
+in TApp (uu____2661))
+end
+| uu____2671 -> begin
+TQualified (lid)
+end)
+end
+| FStar_Extraction_ML_Syntax.MLTY_Tuple (ts) -> begin
+(
+
+let uu____2674 = (FStar_List.map (translate_type env) ts)
+in TTuple (uu____2674))
+end))
+and translate_binders : env  ->  (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty) Prims.list  ->  binder Prims.list = (fun env args -> (FStar_List.map (translate_binder env) args))
+and translate_binder : env  ->  (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty)  ->  binder = (fun env uu____2684 -> (match (uu____2684) with
+| ((name, uu____2688), typ) -> begin
+(
+
+let uu____2692 = (translate_type env typ)
+in {name = name; typ = uu____2692; mut = false})
+end))
+and translate_expr : env  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  expr = (fun env e -> (match (e.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_Tuple ([]) -> begin
+EUnit
+end
+| FStar_Extraction_ML_Syntax.MLE_Const (c) -> begin
+(translate_constant c)
+end
+| FStar_Extraction_ML_Syntax.MLE_Var (name, uu____2697) -> begin
+(
+
+let uu____2698 = (find env name)
+in EBound (uu____2698))
+end
+| FStar_Extraction_ML_Syntax.MLE_Name (("FStar")::(m)::[], op) when ((is_machine_int m) && (is_op op)) -> begin
+(
+
+let uu____2702 = (
+
+let uu____2705 = (FStar_Util.must (mk_op op))
+in (
+
+let uu____2706 = (FStar_Util.must (mk_width m))
+in ((uu____2705), (uu____2706))))
+in EOp (uu____2702))
+end
+| FStar_Extraction_ML_Syntax.MLE_Name (("Prims")::[], op) when (is_bool_op op) -> begin
+(
+
+let uu____2709 = (
+
+let uu____2712 = (FStar_Util.must (mk_bool_op op))
+in ((uu____2712), (Bool)))
+in EOp (uu____2709))
+end
+| FStar_Extraction_ML_Syntax.MLE_Name (n1) -> begin
+EQualified (n1)
+end
+| FStar_Extraction_ML_Syntax.MLE_Let ((flavor, flags, ({FStar_Extraction_ML_Syntax.mllb_name = (name, uu____2717); FStar_Extraction_ML_Syntax.mllb_tysc = Some ([], typ); FStar_Extraction_ML_Syntax.mllb_add_unit = add_unit; FStar_Extraction_ML_Syntax.mllb_def = body; FStar_Extraction_ML_Syntax.print_typ = print7})::[]), continuation) -> begin
+(
+
+let is_mut = (FStar_Util.for_some (fun uu___123_2733 -> (match (uu___123_2733) with
+| FStar_Extraction_ML_Syntax.Mutable -> begin
+true
+end
+| uu____2734 -> begin
+false
+end)) flags)
+in (
+
+let uu____2735 = (match (is_mut) with
+| true -> begin
+(
+
+let uu____2740 = (match (typ) with
+| FStar_Extraction_ML_Syntax.MLTY_Named ((t)::[], p) when (
+
+let uu____2744 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2744 = "FStar.ST.stackref")) -> begin
+t
+end
+| uu____2745 -> begin
+(
+
+let uu____2746 = (
+
+let uu____2747 = (FStar_Extraction_ML_Code.string_of_mlty (([]), ("")) typ)
+in (FStar_Util.format1 "unexpected: bad desugaring of Mutable (typ is %s)" uu____2747))
+in (failwith uu____2746))
+end)
+in (
+
+let uu____2749 = (match (body) with
+| {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_App (uu____2750, (body1)::[]); FStar_Extraction_ML_Syntax.mlty = uu____2752; FStar_Extraction_ML_Syntax.loc = uu____2753} -> begin
+body1
+end
+| uu____2755 -> begin
+(failwith "unexpected: bad desugaring of Mutable")
+end)
+in ((uu____2740), (uu____2749))))
+end
+| uu____2756 -> begin
+((typ), (body))
+end)
+in (match (uu____2735) with
+| (typ1, body1) -> begin
+(
+
+let binder = (
+
+let uu____2760 = (translate_type env typ1)
+in {name = name; typ = uu____2760; mut = is_mut})
+in (
+
+let body2 = (translate_expr env body1)
+in (
+
+let env1 = (extend env name is_mut)
+in (
+
+let continuation1 = (translate_expr env1 continuation)
+in ELet (((binder), (body2), (continuation1)))))))
+end)))
+end
+| FStar_Extraction_ML_Syntax.MLE_Match (expr, branches) -> begin
+(
+
+let uu____2776 = (
+
+let uu____2782 = (translate_expr env expr)
+in (
+
+let uu____2783 = (translate_branches env branches)
+in ((uu____2782), (uu____2783))))
+in EMatch (uu____2776))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2791; FStar_Extraction_ML_Syntax.loc = uu____2792}, ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Var (v1, uu____2794); FStar_Extraction_ML_Syntax.mlty = uu____2795; FStar_Extraction_ML_Syntax.loc = uu____2796})::[]) when ((
+
+let uu____2798 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2798 = "FStar.ST.op_Bang")) && (is_mutable env v1)) -> begin
+(
+
+let uu____2799 = (find env v1)
+in EBound (uu____2799))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2801; FStar_Extraction_ML_Syntax.loc = uu____2802}, ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Var (v1, uu____2804); FStar_Extraction_ML_Syntax.mlty = uu____2805; FStar_Extraction_ML_Syntax.loc = uu____2806})::(e1)::[]) when ((
+
+let uu____2809 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2809 = "FStar.ST.op_Colon_Equals")) && (is_mutable env v1)) -> begin
+(
+
+let uu____2810 = (
+
+let uu____2813 = (
+
+let uu____2814 = (find env v1)
+in EBound (uu____2814))
+in (
+
+let uu____2815 = (translate_expr env e1)
+in ((uu____2813), (uu____2815))))
+in EAssign (uu____2810))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2817; FStar_Extraction_ML_Syntax.loc = uu____2818}, (e1)::(e2)::[]) when ((
+
+let uu____2822 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2822 = "FStar.Buffer.index")) || (
+
+let uu____2823 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2823 = "FStar.Buffer.op_Array_Access"))) -> begin
+(
+
+let uu____2824 = (
+
+let uu____2827 = (translate_expr env e1)
+in (
+
+let uu____2828 = (translate_expr env e2)
+in ((uu____2827), (uu____2828))))
+in EBufRead (uu____2824))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2830; FStar_Extraction_ML_Syntax.loc = uu____2831}, (e1)::(e2)::[]) when (
+
+let uu____2835 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2835 = "FStar.Buffer.create")) -> begin
+(
+
+let uu____2836 = (
+
+let uu____2840 = (translate_expr env e1)
+in (
+
+let uu____2841 = (translate_expr env e2)
+in ((Stack), (uu____2840), (uu____2841))))
+in EBufCreate (uu____2836))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2843; FStar_Extraction_ML_Syntax.loc = uu____2844}, (_e0)::(e1)::(e2)::[]) when (
+
+let uu____2849 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2849 = "FStar.Buffer.rcreate")) -> begin
+(
+
+let uu____2850 = (
+
+let uu____2854 = (translate_expr env e1)
+in (
+
+let uu____2855 = (translate_expr env e2)
+in ((Eternal), (uu____2854), (uu____2855))))
+in EBufCreate (uu____2850))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2857; FStar_Extraction_ML_Syntax.loc = uu____2858}, (e2)::[]) when (
+
+let uu____2861 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2861 = "FStar.Buffer.createL")) -> begin
+(
+
+let rec list_elements1 = (fun acc e21 -> (match (e21.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_CTor ((("Prims")::[], "Cons"), (hd1)::(tl1)::[]) -> begin
+(list_elements1 ((hd1)::acc) tl1)
+end
+| FStar_Extraction_ML_Syntax.MLE_CTor ((("Prims")::[], "Nil"), []) -> begin
+(FStar_List.rev acc)
+end
+| uu____2885 -> begin
+(failwith "Argument of FStar.Buffer.createL is not a string literal!")
+end))
+in (
+
+let list_elements2 = (list_elements1 [])
+in (
+
+let uu____2891 = (
+
+let uu____2895 = (
+
+let uu____2897 = (list_elements2 e2)
+in (FStar_List.map (translate_expr env) uu____2897))
+in ((Stack), (uu____2895)))
+in EBufCreateL (uu____2891))))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2901; FStar_Extraction_ML_Syntax.loc = uu____2902}, (e1)::(e2)::(_e3)::[]) when (
+
+let uu____2907 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2907 = "FStar.Buffer.sub")) -> begin
+(
+
+let uu____2908 = (
+
+let uu____2911 = (translate_expr env e1)
+in (
+
+let uu____2912 = (translate_expr env e2)
+in ((uu____2911), (uu____2912))))
+in EBufSub (uu____2908))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2914; FStar_Extraction_ML_Syntax.loc = uu____2915}, (e1)::(e2)::[]) when (
+
+let uu____2919 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2919 = "FStar.Buffer.join")) -> begin
+(translate_expr env e1)
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2921; FStar_Extraction_ML_Syntax.loc = uu____2922}, (e1)::(e2)::[]) when (
+
+let uu____2926 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2926 = "FStar.Buffer.offset")) -> begin
+(
+
+let uu____2927 = (
+
+let uu____2930 = (translate_expr env e1)
+in (
+
+let uu____2931 = (translate_expr env e2)
+in ((uu____2930), (uu____2931))))
+in EBufSub (uu____2927))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2933; FStar_Extraction_ML_Syntax.loc = uu____2934}, (e1)::(e2)::(e3)::[]) when ((
+
+let uu____2939 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2939 = "FStar.Buffer.upd")) || (
+
+let uu____2940 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2940 = "FStar.Buffer.op_Array_Assignment"))) -> begin
+(
+
+let uu____2941 = (
+
+let uu____2945 = (translate_expr env e1)
+in (
+
+let uu____2946 = (translate_expr env e2)
+in (
+
+let uu____2947 = (translate_expr env e3)
+in ((uu____2945), (uu____2946), (uu____2947)))))
+in EBufWrite (uu____2941))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2949; FStar_Extraction_ML_Syntax.loc = uu____2950}, (uu____2951)::[]) when (
+
+let uu____2953 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2953 = "FStar.ST.push_frame")) -> begin
+EPushFrame
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2955; FStar_Extraction_ML_Syntax.loc = uu____2956}, (uu____2957)::[]) when (
+
+let uu____2959 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2959 = "FStar.ST.pop_frame")) -> begin
+EPopFrame
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2961; FStar_Extraction_ML_Syntax.loc = uu____2962}, (e1)::(e2)::(e3)::(e4)::(e5)::[]) when (
+
+let uu____2969 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2969 = "FStar.Buffer.blit")) -> begin
+(
+
+let uu____2970 = (
+
+let uu____2976 = (translate_expr env e1)
+in (
+
+let uu____2977 = (translate_expr env e2)
+in (
+
+let uu____2978 = (translate_expr env e3)
+in (
+
+let uu____2979 = (translate_expr env e4)
+in (
+
+let uu____2980 = (translate_expr env e5)
+in ((uu____2976), (uu____2977), (uu____2978), (uu____2979), (uu____2980)))))))
+in EBufBlit (uu____2970))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2982; FStar_Extraction_ML_Syntax.loc = uu____2983}, (e1)::(e2)::(e3)::[]) when (
+
+let uu____2988 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____2988 = "FStar.Buffer.fill")) -> begin
+(
+
+let uu____2989 = (
+
+let uu____2993 = (translate_expr env e1)
+in (
+
+let uu____2994 = (translate_expr env e2)
+in (
+
+let uu____2995 = (translate_expr env e3)
+in ((uu____2993), (uu____2994), (uu____2995)))))
+in EBufFill (uu____2989))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____2997; FStar_Extraction_ML_Syntax.loc = uu____2998}, (uu____2999)::[]) when (
+
+let uu____3001 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____3001 = "FStar.ST.get")) -> begin
+EUnit
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____3003; FStar_Extraction_ML_Syntax.loc = uu____3004}, (e1)::[]) when (
+
+let uu____3007 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____3007 = "Obj.repr")) -> begin
+(
+
+let uu____3008 = (
+
+let uu____3011 = (translate_expr env e1)
+in ((uu____3011), (TAny)))
+in ECast (uu____3008))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("FStar")::(m)::[], op); FStar_Extraction_ML_Syntax.mlty = uu____3014; FStar_Extraction_ML_Syntax.loc = uu____3015}, args) when ((is_machine_int m) && (is_op op)) -> begin
+(
+
+let uu____3020 = (FStar_Util.must (mk_width m))
+in (
+
+let uu____3021 = (FStar_Util.must (mk_op op))
+in (mk_op_app env uu____3020 uu____3021 args)))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("Prims")::[], op); FStar_Extraction_ML_Syntax.mlty = uu____3023; FStar_Extraction_ML_Syntax.loc = uu____3024}, args) when (is_bool_op op) -> begin
+(
+
+let uu____3029 = (FStar_Util.must (mk_bool_op op))
+in (mk_op_app env Bool uu____3029 args))
+end
+| (FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("FStar")::(m)::[], "int_to_t"); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}, ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_Int (c, None)); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _})::[])) | (FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("FStar")::(m)::[], "uint_to_t"); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}, ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_Int (c, None)); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _})::[])) when (is_machine_int m) -> begin
+(
+
+let uu____3054 = (
+
+let uu____3057 = (FStar_Util.must (mk_width m))
+in ((uu____3057), (c)))
+in EConstant (uu____3054))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("C")::[], "string_of_literal"); FStar_Extraction_ML_Syntax.mlty = uu____3058; FStar_Extraction_ML_Syntax.loc = uu____3059}, ({FStar_Extraction_ML_Syntax.expr = e1; FStar_Extraction_ML_Syntax.mlty = uu____3061; FStar_Extraction_ML_Syntax.loc = uu____3062})::[]) -> begin
+(match (e1) with
+| FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_String (s)) -> begin
+EString (s)
+end
+| uu____3066 -> begin
+(failwith "Cannot extract string_of_literal applied to a non-literal")
+end)
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (("FStar")::("Int")::("Cast")::[], c); FStar_Extraction_ML_Syntax.mlty = uu____3068; FStar_Extraction_ML_Syntax.loc = uu____3069}, (arg)::[]) -> begin
+(
+
+let is_known_type = ((((((((FStar_Util.starts_with c "uint8") || (FStar_Util.starts_with c "uint16")) || (FStar_Util.starts_with c "uint32")) || (FStar_Util.starts_with c "uint64")) || (FStar_Util.starts_with c "int8")) || (FStar_Util.starts_with c "int16")) || (FStar_Util.starts_with c "int32")) || (FStar_Util.starts_with c "int64"))
+in (match (((FStar_Util.ends_with c "uint64") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3074 = (
+
+let uu____3077 = (translate_expr env arg)
+in ((uu____3077), (TInt (UInt64))))
+in ECast (uu____3074))
+end
+| uu____3078 -> begin
+(match (((FStar_Util.ends_with c "uint32") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3079 = (
+
+let uu____3082 = (translate_expr env arg)
+in ((uu____3082), (TInt (UInt32))))
+in ECast (uu____3079))
+end
+| uu____3083 -> begin
+(match (((FStar_Util.ends_with c "uint16") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3084 = (
+
+let uu____3087 = (translate_expr env arg)
+in ((uu____3087), (TInt (UInt16))))
+in ECast (uu____3084))
+end
+| uu____3088 -> begin
+(match (((FStar_Util.ends_with c "uint8") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3089 = (
+
+let uu____3092 = (translate_expr env arg)
+in ((uu____3092), (TInt (UInt8))))
+in ECast (uu____3089))
+end
+| uu____3093 -> begin
+(match (((FStar_Util.ends_with c "int64") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3094 = (
+
+let uu____3097 = (translate_expr env arg)
+in ((uu____3097), (TInt (Int64))))
+in ECast (uu____3094))
+end
+| uu____3098 -> begin
+(match (((FStar_Util.ends_with c "int32") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3099 = (
+
+let uu____3102 = (translate_expr env arg)
+in ((uu____3102), (TInt (Int32))))
+in ECast (uu____3099))
+end
+| uu____3103 -> begin
+(match (((FStar_Util.ends_with c "int16") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3104 = (
+
+let uu____3107 = (translate_expr env arg)
+in ((uu____3107), (TInt (Int16))))
+in ECast (uu____3104))
+end
+| uu____3108 -> begin
+(match (((FStar_Util.ends_with c "int8") && is_known_type)) with
+| true -> begin
+(
+
+let uu____3109 = (
+
+let uu____3112 = (translate_expr env arg)
+in ((uu____3112), (TInt (Int8))))
+in ECast (uu____3109))
+end
+| uu____3113 -> begin
+(
+
+let uu____3114 = (
+
+let uu____3118 = (
+
+let uu____3120 = (translate_expr env arg)
+in (uu____3120)::[])
+in ((EQualified (((("FStar")::("Int")::("Cast")::[]), (c)))), (uu____3118)))
+in EApp (uu____3114))
+end)
+end)
+end)
+end)
+end)
+end)
+end)
+end))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (path, function_name); FStar_Extraction_ML_Syntax.mlty = uu____3125; FStar_Extraction_ML_Syntax.loc = uu____3126}, args) -> begin
+(
+
+let uu____3132 = (
+
+let uu____3136 = (FStar_List.map (translate_expr env) args)
+in ((EQualified (((path), (function_name)))), (uu____3136)))
+in EApp (uu____3132))
+end
+| FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Var (name, uu____3141); FStar_Extraction_ML_Syntax.mlty = uu____3142; FStar_Extraction_ML_Syntax.loc = uu____3143}, args) -> begin
+(
+
+let uu____3147 = (
+
+let uu____3151 = (
+
+let uu____3152 = (find env name)
+in EBound (uu____3152))
+in (
+
+let uu____3153 = (FStar_List.map (translate_expr env) args)
+in ((uu____3151), (uu____3153))))
+in EApp (uu____3147))
+end
+| FStar_Extraction_ML_Syntax.MLE_Coerce (e1, t_from, t_to) -> begin
+(
+
+let uu____3159 = (
+
+let uu____3162 = (translate_expr env e1)
+in (
+
+let uu____3163 = (translate_type env t_to)
+in ((uu____3162), (uu____3163))))
+in ECast (uu____3159))
+end
+| FStar_Extraction_ML_Syntax.MLE_Record (uu____3164, fields) -> begin
+(
+
+let uu____3174 = (
+
+let uu____3180 = (assert_lid env e.FStar_Extraction_ML_Syntax.mlty)
+in (
+
+let uu____3181 = (FStar_List.map (fun uu____3189 -> (match (uu____3189) with
+| (field, expr) -> begin
+(
+
+let uu____3196 = (translate_expr env expr)
+in ((field), (uu____3196)))
+end)) fields)
+in ((uu____3180), (uu____3181))))
+in EFlat (uu____3174))
+end
+| FStar_Extraction_ML_Syntax.MLE_Proj (e1, path) -> begin
+(
+
+let uu____3202 = (
+
+let uu____3206 = (assert_lid env e1.FStar_Extraction_ML_Syntax.mlty)
+in (
+
+let uu____3207 = (translate_expr env e1)
+in ((uu____3206), (uu____3207), ((Prims.snd path)))))
+in EField (uu____3202))
+end
+| FStar_Extraction_ML_Syntax.MLE_Let (uu____3209) -> begin
+(failwith "todo: translate_expr [MLE_Let]")
+end
+| FStar_Extraction_ML_Syntax.MLE_App (head1, uu____3217) -> begin
+(
+
+let uu____3220 = (
+
+let uu____3221 = (FStar_Extraction_ML_Code.string_of_mlexpr (([]), ("")) head1)
+in (FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)" uu____3221))
+in (failwith uu____3220))
+end
+| FStar_Extraction_ML_Syntax.MLE_Seq (seqs) -> begin
+(
+
+let uu____3225 = (FStar_List.map (translate_expr env) seqs)
+in ESequence (uu____3225))
+end
+| FStar_Extraction_ML_Syntax.MLE_Tuple (es) -> begin
+(
+
+let uu____3229 = (FStar_List.map (translate_expr env) es)
+in ETuple (uu____3229))
+end
+| FStar_Extraction_ML_Syntax.MLE_CTor ((uu____3231, cons1), es) -> begin
+(
+
+let uu____3241 = (
+
+let uu____3246 = (assert_lid env e.FStar_Extraction_ML_Syntax.mlty)
+in (
+
+let uu____3247 = (FStar_List.map (translate_expr env) es)
+in ((uu____3246), (cons1), (uu____3247))))
+in ECons (uu____3241))
+end
+| FStar_Extraction_ML_Syntax.MLE_Fun (args, body) -> begin
+(
+
+let binders = (translate_binders env args)
+in (
+
+let env1 = (add_binders env args)
+in (
+
+let uu____3261 = (
+
+let uu____3265 = (translate_expr env1 body)
+in ((binders), (uu____3265)))
+in EFun (uu____3261))))
+end
+| FStar_Extraction_ML_Syntax.MLE_If (e1, e2, e3) -> begin
+(
+
+let uu____3272 = (
+
+let uu____3276 = (translate_expr env e1)
+in (
+
+let uu____3277 = (translate_expr env e2)
+in (
+
+let uu____3278 = (match (e3) with
+| None -> begin
+EUnit
+end
+| Some (e31) -> begin
+(translate_expr env e31)
+end)
+in ((uu____3276), (uu____3277), (uu____3278)))))
+in EIfThenElse (uu____3272))
+end
+| FStar_Extraction_ML_Syntax.MLE_Raise (uu____3280) -> begin
+(failwith "todo: translate_expr [MLE_Raise]")
+end
+| FStar_Extraction_ML_Syntax.MLE_Try (uu____3284) -> begin
+(failwith "todo: translate_expr [MLE_Try]")
+end
+| FStar_Extraction_ML_Syntax.MLE_Coerce (uu____3292) -> begin
+(failwith "todo: translate_expr [MLE_Coerce]")
+end))
+and assert_lid : env  ->  FStar_Extraction_ML_Syntax.mlty  ->  typ = (fun env t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Named (ts, lid) -> begin
+(match (((FStar_List.length ts) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____3305 = (
+
+let uu____3312 = (FStar_List.map (translate_type env) ts)
+in ((lid), (uu____3312)))
+in TApp (uu____3305))
+end
+| uu____3315 -> begin
+TQualified (lid)
+end)
+end
+| uu____3316 -> begin
+(failwith "invalid argument: assert_lid")
+end))
+and translate_branches : env  ->  (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr Prims.option * FStar_Extraction_ML_Syntax.mlexpr) Prims.list  ->  (pattern * expr) Prims.list = (fun env branches -> (FStar_List.map (translate_branch env) branches))
+and translate_branch : env  ->  (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr Prims.option * FStar_Extraction_ML_Syntax.mlexpr)  ->  (pattern * expr) = (fun env uu____3331 -> (match (uu____3331) with
+| (pat, guard, expr) -> begin
+(match ((guard = None)) with
+| true -> begin
+(
+
+let uu____3346 = (translate_pat env pat)
+in (match (uu____3346) with
+| (env1, pat1) -> begin
+(
+
+let uu____3353 = (translate_expr env1 expr)
+in ((pat1), (uu____3353)))
+end))
+end
+| uu____3354 -> begin
+(failwith "todo: translate_branch")
+end)
+end))
+and translate_pat : env  ->  FStar_Extraction_ML_Syntax.mlpattern  ->  (env * pattern) = (fun env p -> (match (p) with
+| FStar_Extraction_ML_Syntax.MLP_Const (FStar_Extraction_ML_Syntax.MLC_Unit) -> begin
+((env), (PUnit))
+end
+| FStar_Extraction_ML_Syntax.MLP_Const (FStar_Extraction_ML_Syntax.MLC_Bool (b)) -> begin
+((env), (PBool (b)))
+end
+| FStar_Extraction_ML_Syntax.MLP_Var (name, uu____3363) -> begin
+(
+
+let env1 = (extend env name false)
+in ((env1), (PVar ({name = name; typ = TAny; mut = false}))))
+end
+| FStar_Extraction_ML_Syntax.MLP_Wild -> begin
+(
+
+let env1 = (extend env "_" false)
+in ((env1), (PVar ({name = "_"; typ = TAny; mut = false}))))
+end
+| FStar_Extraction_ML_Syntax.MLP_CTor ((uu____3366, cons1), ps) -> begin
+(
+
+let uu____3376 = (FStar_List.fold_left (fun uu____3383 p1 -> (match (uu____3383) with
+| (env1, acc) -> begin
+(
+
+let uu____3395 = (translate_pat env1 p1)
+in (match (uu____3395) with
+| (env2, p2) -> begin
+((env2), ((p2)::acc))
+end))
+end)) ((env), ([])) ps)
+in (match (uu____3376) with
+| (env1, ps1) -> begin
+((env1), (PCons (((cons1), ((FStar_List.rev ps1))))))
+end))
+end
+| FStar_Extraction_ML_Syntax.MLP_Record (uu____3412, ps) -> begin
+(
+
+let uu____3422 = (FStar_List.fold_left (fun uu____3435 uu____3436 -> (match (((uu____3435), (uu____3436))) with
+| ((env1, acc), (field, p1)) -> begin
+(
+
+let uu____3473 = (translate_pat env1 p1)
+in (match (uu____3473) with
+| (env2, p2) -> begin
+((env2), ((((field), (p2)))::acc))
+end))
+end)) ((env), ([])) ps)
+in (match (uu____3422) with
+| (env1, ps1) -> begin
+((env1), (PRecord ((FStar_List.rev ps1))))
+end))
+end
+| FStar_Extraction_ML_Syntax.MLP_Tuple (ps) -> begin
+(
+
+let uu____3507 = (FStar_List.fold_left (fun uu____3514 p1 -> (match (uu____3514) with
+| (env1, acc) -> begin
+(
+
+let uu____3526 = (translate_pat env1 p1)
+in (match (uu____3526) with
+| (env2, p2) -> begin
+((env2), ((p2)::acc))
+end))
+end)) ((env), ([])) ps)
+in (match (uu____3507) with
+| (env1, ps1) -> begin
+((env1), (PTuple ((FStar_List.rev ps1))))
+end))
+end
+| FStar_Extraction_ML_Syntax.MLP_Const (uu____3542) -> begin
+(failwith "todo: translate_pat [MLP_Const]")
+end
+| FStar_Extraction_ML_Syntax.MLP_Branch (uu____3545) -> begin
+(failwith "todo: translate_pat [MLP_Branch]")
+end))
+and translate_constant : FStar_Extraction_ML_Syntax.mlconstant  ->  expr = (fun c -> (match (c) with
+| FStar_Extraction_ML_Syntax.MLC_Unit -> begin
+EUnit
+end
+| FStar_Extraction_ML_Syntax.MLC_Bool (b) -> begin
+EBool (b)
+end
+| FStar_Extraction_ML_Syntax.MLC_Int (s, Some (uu____3552)) -> begin
+(failwith "impossible: machine integer not desugared to a function call")
+end
+| FStar_Extraction_ML_Syntax.MLC_Float (uu____3560) -> begin
+(failwith "todo: translate_expr [MLC_Float]")
+end
+| FStar_Extraction_ML_Syntax.MLC_Char (uu____3561) -> begin
+(failwith "todo: translate_expr [MLC_Char]")
+end
+| FStar_Extraction_ML_Syntax.MLC_String (uu____3562) -> begin
+(failwith "todo: translate_expr [MLC_String]")
+end
+| FStar_Extraction_ML_Syntax.MLC_Bytes (uu____3563) -> begin
+(failwith "todo: translate_expr [MLC_Bytes]")
+end
+| FStar_Extraction_ML_Syntax.MLC_Int (uu____3565, None) -> begin
+(failwith "todo: translate_expr [MLC_Int]")
+end))
+and mk_op_app : env  ->  width  ->  op  ->  FStar_Extraction_ML_Syntax.mlexpr Prims.list  ->  expr = (fun env w op args -> (
+
+let uu____3576 = (
+
+let uu____3580 = (FStar_List.map (translate_expr env) args)
+in ((EOp (((op), (w)))), (uu____3580)))
+in EApp (uu____3576)))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_Code.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Code.ml
@@ -1,1399 +1,1936 @@
+
 open Prims
 type assoc =
-  | ILeft
-  | IRight
-  | Left
-  | Right
-  | NonAssoc
-let uu___is_ILeft: assoc -> Prims.bool =
-  fun projectee  -> match projectee with | ILeft  -> true | uu____4 -> false
-let uu___is_IRight: assoc -> Prims.bool =
-  fun projectee  -> match projectee with | IRight  -> true | uu____8 -> false
-let uu___is_Left: assoc -> Prims.bool =
-  fun projectee  -> match projectee with | Left  -> true | uu____12 -> false
-let uu___is_Right: assoc -> Prims.bool =
-  fun projectee  -> match projectee with | Right  -> true | uu____16 -> false
-let uu___is_NonAssoc: assoc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NonAssoc  -> true | uu____20 -> false
+| ILeft
+| IRight
+| Left
+| Right
+| NonAssoc
+
+
+let uu___is_ILeft : assoc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ILeft -> begin
+true
+end
+| uu____4 -> begin
+false
+end))
+
+
+let uu___is_IRight : assoc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| IRight -> begin
+true
+end
+| uu____8 -> begin
+false
+end))
+
+
+let uu___is_Left : assoc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Left -> begin
+true
+end
+| uu____12 -> begin
+false
+end))
+
+
+let uu___is_Right : assoc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Right -> begin
+true
+end
+| uu____16 -> begin
+false
+end))
+
+
+let uu___is_NonAssoc : assoc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NonAssoc -> begin
+true
+end
+| uu____20 -> begin
+false
+end))
+
 type fixity =
-  | Prefix
-  | Postfix
-  | Infix of assoc
-let uu___is_Prefix: fixity -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Prefix  -> true | uu____27 -> false
-let uu___is_Postfix: fixity -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Postfix  -> true | uu____31 -> false
-let uu___is_Infix: fixity -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Infix _0 -> true | uu____36 -> false
-let __proj__Infix__item___0: fixity -> assoc =
-  fun projectee  -> match projectee with | Infix _0 -> _0
-type opprec = (Prims.int* fixity)
-type level = (opprec* assoc)
-let t_prio_fun: (Prims.int* fixity) = ((Prims.parse_int "10"), (Infix Right))
-let t_prio_tpl: (Prims.int* fixity) =
-  ((Prims.parse_int "20"), (Infix NonAssoc))
-let t_prio_name: (Prims.int* fixity) = ((Prims.parse_int "30"), Postfix)
-let e_bin_prio_lambda: (Prims.int* fixity) = ((Prims.parse_int "5"), Prefix)
-let e_bin_prio_if: (Prims.int* fixity) = ((Prims.parse_int "15"), Prefix)
-let e_bin_prio_letin: (Prims.int* fixity) = ((Prims.parse_int "19"), Prefix)
-let e_bin_prio_or: (Prims.int* fixity) =
-  ((Prims.parse_int "20"), (Infix Left))
-let e_bin_prio_and: (Prims.int* fixity) =
-  ((Prims.parse_int "25"), (Infix Left))
-let e_bin_prio_eq: (Prims.int* fixity) =
-  ((Prims.parse_int "27"), (Infix NonAssoc))
-let e_bin_prio_order: (Prims.int* fixity) =
-  ((Prims.parse_int "29"), (Infix NonAssoc))
-let e_bin_prio_op1: (Prims.int* fixity) =
-  ((Prims.parse_int "30"), (Infix Left))
-let e_bin_prio_op2: (Prims.int* fixity) =
-  ((Prims.parse_int "40"), (Infix Left))
-let e_bin_prio_op3: (Prims.int* fixity) =
-  ((Prims.parse_int "50"), (Infix Left))
-let e_bin_prio_op4: (Prims.int* fixity) =
-  ((Prims.parse_int "60"), (Infix Left))
-let e_bin_prio_comb: (Prims.int* fixity) =
-  ((Prims.parse_int "70"), (Infix Left))
-let e_bin_prio_seq: (Prims.int* fixity) =
-  ((Prims.parse_int "100"), (Infix Left))
-let e_app_prio: (Prims.int* fixity) =
-  ((Prims.parse_int "10000"), (Infix Left))
-let min_op_prec: (Prims.int* fixity) =
-  ((- (Prims.parse_int "1")), (Infix NonAssoc))
-let max_op_prec: (Prims.int* fixity) = (FStar_Util.max_int, (Infix NonAssoc))
-let rec in_ns x =
-  match x with
-  | ([],uu____101) -> true
-  | (x1::t1,x2::t2) when x1 = x2 -> in_ns (t1, t2)
-  | (uu____115,uu____116) -> false
-let path_of_ns:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    Prims.string Prims.list -> Prims.string Prims.list
-  =
-  fun currentModule  ->
-    fun ns  ->
-      let ns' = FStar_Extraction_ML_Util.flatten_ns ns in
-      if ns' = currentModule
-      then []
-      else
-        (let cg_libs = FStar_Options.codegen_libs () in
-         let ns_len = FStar_List.length ns in
-         let found =
-           FStar_Util.find_map cg_libs
-             (fun cg_path  ->
-                let cg_len = FStar_List.length cg_path in
-                if (FStar_List.length cg_path) < ns_len
-                then
-                  let uu____154 = FStar_Util.first_N cg_len ns in
-                  match uu____154 with
-                  | (pfx,sfx) ->
-                      (if pfx = cg_path
-                       then
-                         let uu____172 =
-                           let uu____174 =
-                             let uu____176 =
-                               FStar_Extraction_ML_Util.flatten_ns sfx in
-                             [uu____176] in
-                           FStar_List.append pfx uu____174 in
-                         Some uu____172
-                       else None)
-                else None) in
-         match found with | None  -> [ns'] | Some x -> x)
-let mlpath_of_mlpath:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlpath
-  =
-  fun currentModule  ->
-    fun x  ->
-      let uu____193 = FStar_Extraction_ML_Syntax.string_of_mlpath x in
-      match uu____193 with
-      | "Prims.Some" -> ([], "Some")
-      | "Prims.None" -> ([], "None")
-      | uu____196 ->
-          let uu____197 = x in
-          (match uu____197 with
-           | (ns,x1) ->
-               let uu____202 = path_of_ns currentModule ns in (uu____202, x1))
-let ptsym_of_symbol:
-  FStar_Extraction_ML_Syntax.mlsymbol -> FStar_Extraction_ML_Syntax.mlsymbol
-  =
-  fun s  ->
-    let uu____208 =
-      let uu____209 =
-        let uu____210 = FStar_String.get s (Prims.parse_int "0") in
-        FStar_Char.lowercase uu____210 in
-      let uu____211 = FStar_String.get s (Prims.parse_int "0") in
-      uu____209 <> uu____211 in
-    if uu____208 then Prims.strcat "l__" s else s
-let ptsym:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol
-  =
-  fun currentModule  ->
-    fun mlp  ->
-      if FStar_List.isEmpty (Prims.fst mlp)
-      then ptsym_of_symbol (Prims.snd mlp)
-      else
-        (let uu____222 = mlpath_of_mlpath currentModule mlp in
-         match uu____222 with
-         | (p,s) ->
-             let uu____227 =
-               let uu____229 =
-                 let uu____231 = ptsym_of_symbol s in [uu____231] in
-               FStar_List.append p uu____229 in
-             FStar_String.concat "." uu____227)
-let ptctor:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol
-  =
-  fun currentModule  ->
-    fun mlp  ->
-      let uu____238 = mlpath_of_mlpath currentModule mlp in
-      match uu____238 with
-      | (p,s) ->
-          let s1 =
-            let uu____244 =
-              let uu____245 =
-                let uu____246 = FStar_String.get s (Prims.parse_int "0") in
-                FStar_Char.uppercase uu____246 in
-              let uu____247 = FStar_String.get s (Prims.parse_int "0") in
-              uu____245 <> uu____247 in
-            if uu____244 then Prims.strcat "U__" s else s in
-          FStar_String.concat "." (FStar_List.append p [s1])
-let infix_prim_ops:
-  (Prims.string* (Prims.int* fixity)* Prims.string) Prims.list =
-  [("op_Addition", e_bin_prio_op1, "+");
-  ("op_Subtraction", e_bin_prio_op1, "-");
-  ("op_Multiply", e_bin_prio_op1, "*");
-  ("op_Division", e_bin_prio_op1, "/");
-  ("op_Equality", e_bin_prio_eq, "=");
-  ("op_Colon_Equals", e_bin_prio_eq, ":=");
-  ("op_disEquality", e_bin_prio_eq, "<>");
-  ("op_AmpAmp", e_bin_prio_and, "&&");
-  ("op_BarBar", e_bin_prio_or, "||");
-  ("op_LessThanOrEqual", e_bin_prio_order, "<=");
-  ("op_GreaterThanOrEqual", e_bin_prio_order, ">=");
-  ("op_LessThan", e_bin_prio_order, "<");
-  ("op_GreaterThan", e_bin_prio_order, ">");
-  ("op_Modulus", e_bin_prio_order, "mod")]
-let prim_uni_ops: (Prims.string* Prims.string) Prims.list =
-  [("op_Negation", "not");
-  ("op_Minus", "~-");
-  ("op_Bang", "Support.ST.read")]
-let prim_types uu____372 = []
-let prim_constructors: (Prims.string* Prims.string) Prims.list =
-  [("Some", "Some"); ("None", "None"); ("Nil", "[]"); ("Cons", "::")]
-let is_prims_ns: FStar_Extraction_ML_Syntax.mlsymbol Prims.list -> Prims.bool
-  = fun ns  -> ns = ["Prims"]
-let as_bin_op:
-  FStar_Extraction_ML_Syntax.mlpath ->
-    (FStar_Extraction_ML_Syntax.mlsymbol* (Prims.int* fixity)* Prims.string)
-      Prims.option
-  =
-  fun uu____400  ->
-    match uu____400 with
-    | (ns,x) ->
-        if is_prims_ns ns
-        then
-          FStar_List.tryFind
-            (fun uu____422  ->
-               match uu____422 with | (y,uu____429,uu____430) -> x = y)
-            infix_prim_ops
-        else None
-let is_bin_op: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
-  fun p  -> let uu____444 = as_bin_op p in uu____444 <> None
-let as_uni_op:
-  FStar_Extraction_ML_Syntax.mlpath ->
-    (FStar_Extraction_ML_Syntax.mlsymbol* Prims.string) Prims.option
-  =
-  fun uu____467  ->
-    match uu____467 with
-    | (ns,x) ->
-        if is_prims_ns ns
-        then
-          FStar_List.tryFind
-            (fun uu____480  -> match uu____480 with | (y,uu____484) -> x = y)
-            prim_uni_ops
-        else None
-let is_uni_op: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
-  fun p  -> let uu____491 = as_uni_op p in uu____491 <> None
-let is_standard_type: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
-  fun p  -> false
-let as_standard_constructor:
-  FStar_Extraction_ML_Syntax.mlpath ->
-    (FStar_Extraction_ML_Syntax.mlsymbol* Prims.string) Prims.option
-  =
-  fun uu____508  ->
-    match uu____508 with
-    | (ns,x) ->
-        if is_prims_ns ns
-        then
-          FStar_List.tryFind
-            (fun uu____521  -> match uu____521 with | (y,uu____525) -> x = y)
-            prim_constructors
-        else None
-let is_standard_constructor: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool
-  = fun p  -> let uu____532 = as_standard_constructor p in uu____532 <> None
-let maybe_paren:
-  ((Prims.int* fixity)* assoc) ->
-    (Prims.int* fixity) -> FStar_Format.doc -> FStar_Format.doc
-  =
-  fun uu____553  ->
-    fun inner  ->
-      fun doc1  ->
-        match uu____553 with
-        | (outer,side) ->
-            let noparens _inner _outer side1 =
-              let uu____586 = _inner in
-              match uu____586 with
-              | (pi,fi) ->
-                  let uu____591 = _outer in
-                  (match uu____591 with
-                   | (po,fo) ->
-                       (pi > po) ||
-                         ((match (fi, side1) with
-                           | (Postfix ,Left ) -> true
-                           | (Prefix ,Right ) -> true
-                           | (Infix (Left ),Left ) ->
-                               (pi = po) && (fo = (Infix Left))
-                           | (Infix (Right ),Right ) ->
-                               (pi = po) && (fo = (Infix Right))
-                           | (Infix (Left ),ILeft ) ->
-                               (pi = po) && (fo = (Infix Left))
-                           | (Infix (Right ),IRight ) ->
-                               (pi = po) && (fo = (Infix Right))
-                           | (uu____596,NonAssoc ) -> (pi = po) && (fi = fo)
-                           | (uu____597,uu____598) -> false))) in
-            if noparens inner outer side
-            then doc1
-            else FStar_Format.parens doc1
-let escape_byte_hex: FStar_BaseTypes.byte -> Prims.string =
-  fun x  -> Prims.strcat "\\x" (FStar_Util.hex_string_of_byte x)
-let escape_char_hex: FStar_BaseTypes.char -> Prims.string =
-  fun x  -> escape_byte_hex (FStar_Util.byte_of_char x)
-let escape_or:
-  (FStar_Char.char -> Prims.string) -> FStar_Char.char -> Prims.string =
-  fun fallback  ->
-    fun uu___118_614  ->
-      match uu___118_614 with
-      | c when c = '\\' -> "\\\\"
-      | c when c = ' ' -> " "
-      | c when c = '\b' -> "\\b"
-      | c when c = '\t' -> "\\t"
-      | c when c = '\r' -> "\\r"
-      | c when c = '\n' -> "\\n"
-      | c when c = '\'' -> "\\'"
-      | c when c = '"' -> "\\\""
-      | c when FStar_Util.is_letter_or_digit c -> FStar_Util.string_of_char c
-      | c when FStar_Util.is_punctuation c -> FStar_Util.string_of_char c
-      | c when FStar_Util.is_symbol c -> FStar_Util.string_of_char c
-      | c -> fallback c
-let string_of_mlconstant:
-  FStar_Extraction_ML_Syntax.mlconstant -> Prims.string =
-  fun sctt  ->
-    match sctt with
-    | FStar_Extraction_ML_Syntax.MLC_Unit  -> "()"
-    | FStar_Extraction_ML_Syntax.MLC_Bool (true ) -> "true"
-    | FStar_Extraction_ML_Syntax.MLC_Bool (false ) -> "false"
-    | FStar_Extraction_ML_Syntax.MLC_Char c ->
-        let uu____633 =
-          let uu____634 = escape_or escape_char_hex c in
-          Prims.strcat uu____634 "'" in
-        Prims.strcat "'" uu____633
-    | FStar_Extraction_ML_Syntax.MLC_Int
-        (s,Some (FStar_Const.Signed ,FStar_Const.Int32 )) ->
-        Prims.strcat s "l"
-    | FStar_Extraction_ML_Syntax.MLC_Int
-        (s,Some (FStar_Const.Signed ,FStar_Const.Int64 )) ->
-        Prims.strcat s "L"
-    | FStar_Extraction_ML_Syntax.MLC_Int (s,Some (_,FStar_Const.Int8 ))
-      |FStar_Extraction_ML_Syntax.MLC_Int (s,Some (_,FStar_Const.Int16 )) ->
-        s
-    | FStar_Extraction_ML_Syntax.MLC_Int (s,None ) ->
-        Prims.strcat "(Prims.parse_int \"" (Prims.strcat s "\")")
-    | FStar_Extraction_ML_Syntax.MLC_Float d -> FStar_Util.string_of_float d
-    | FStar_Extraction_ML_Syntax.MLC_Bytes bytes ->
-        let uu____669 =
-          let uu____670 = FStar_Bytes.f_encode escape_byte_hex bytes in
-          Prims.strcat uu____670 "\"" in
-        Prims.strcat "\"" uu____669
-    | FStar_Extraction_ML_Syntax.MLC_String chars ->
-        let uu____672 =
-          let uu____673 =
-            FStar_String.collect (escape_or FStar_Util.string_of_char) chars in
-          Prims.strcat uu____673 "\"" in
-        Prims.strcat "\"" uu____672
-    | uu____674 ->
-        failwith "TODO: extract integer constants properly into OCaml"
-let rec doc_of_mltype':
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun outer  ->
-      fun ty  ->
-        match ty with
-        | FStar_Extraction_ML_Syntax.MLTY_Var x ->
-            let escape_tyvar s =
-              if FStar_Util.starts_with s "'_"
-              then FStar_Util.replace_char s '_' 'u'
-              else s in
-            let uu____696 =
-              let uu____697 = FStar_Extraction_ML_Syntax.idsym x in
-              FStar_All.pipe_left escape_tyvar uu____697 in
-            FStar_Format.text uu____696
-        | FStar_Extraction_ML_Syntax.MLTY_Tuple tys ->
-            let doc1 =
-              FStar_List.map (doc_of_mltype currentModule (t_prio_tpl, Left))
-                tys in
-            let doc2 =
-              let uu____705 =
-                let uu____706 =
-                  FStar_Format.combine (FStar_Format.text " * ") doc1 in
-                FStar_Format.hbox uu____706 in
-              FStar_Format.parens uu____705 in
-            doc2
-        | FStar_Extraction_ML_Syntax.MLTY_Named (args,name) ->
-            let args1 =
-              match args with
-              | [] -> FStar_Format.empty
-              | arg::[] ->
-                  doc_of_mltype currentModule (t_prio_name, Left) arg
-              | uu____715 ->
-                  let args1 =
-                    FStar_List.map
-                      (doc_of_mltype currentModule (min_op_prec, NonAssoc))
-                      args in
-                  let uu____721 =
-                    let uu____722 =
-                      FStar_Format.combine (FStar_Format.text ", ") args1 in
-                    FStar_Format.hbox uu____722 in
-                  FStar_Format.parens uu____721 in
-            let name1 = ptsym currentModule name in
-            let uu____724 =
-              FStar_Format.reduce1 [args1; FStar_Format.text name1] in
-            FStar_Format.hbox uu____724
-        | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____726,t2) ->
-            let d1 = doc_of_mltype currentModule (t_prio_fun, Left) t1 in
-            let d2 = doc_of_mltype currentModule (t_prio_fun, Right) t2 in
-            let uu____734 =
-              let uu____735 =
-                FStar_Format.reduce1 [d1; FStar_Format.text " -> "; d2] in
-              FStar_Format.hbox uu____735 in
-            maybe_paren outer t_prio_fun uu____734
-        | FStar_Extraction_ML_Syntax.MLTY_Top  ->
-            let uu____736 = FStar_Extraction_ML_Util.codegen_fsharp () in
-            if uu____736
-            then FStar_Format.text "obj"
-            else FStar_Format.text "Obj.t"
-and doc_of_mltype:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun outer  ->
-      fun ty  ->
-        doc_of_mltype' currentModule outer
-          (FStar_Extraction_ML_Util.resugar_mlty ty)
-let rec doc_of_expr:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun outer  ->
-      fun e  ->
-        match e.FStar_Extraction_ML_Syntax.expr with
-        | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t,t') ->
-            let doc1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-            let uu____788 = FStar_Extraction_ML_Util.codegen_fsharp () in
-            if uu____788
-            then
-              let uu____789 =
-                FStar_Format.reduce
-                  [FStar_Format.text "Prims.checked_cast"; doc1] in
-              FStar_Format.parens uu____789
-            else
-              (let uu____791 =
-                 FStar_Format.reduce
-                   [FStar_Format.text "Obj.magic "; FStar_Format.parens doc1] in
-               FStar_Format.parens uu____791)
-        | FStar_Extraction_ML_Syntax.MLE_Seq es ->
-            let docs =
-              FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) es in
-            let docs1 =
-              FStar_List.map
-                (fun d  ->
-                   FStar_Format.reduce
-                     [d; FStar_Format.text ";"; FStar_Format.hardline]) docs in
-            let uu____801 = FStar_Format.reduce docs1 in
-            FStar_Format.parens uu____801
-        | FStar_Extraction_ML_Syntax.MLE_Const c ->
-            let uu____803 = string_of_mlconstant c in
-            FStar_Format.text uu____803
-        | FStar_Extraction_ML_Syntax.MLE_Var (x,uu____805) ->
-            FStar_Format.text x
-        | FStar_Extraction_ML_Syntax.MLE_Name path ->
-            let uu____807 = ptsym currentModule path in
-            FStar_Format.text uu____807
-        | FStar_Extraction_ML_Syntax.MLE_Record (path,fields) ->
-            let for1 uu____823 =
-              match uu____823 with
-              | (name,e1) ->
-                  let doc1 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  let uu____831 =
-                    let uu____833 =
-                      let uu____834 = ptsym currentModule (path, name) in
-                      FStar_Format.text uu____834 in
-                    [uu____833; FStar_Format.text "="; doc1] in
-                  FStar_Format.reduce1 uu____831 in
-            let uu____836 =
-              let uu____837 = FStar_List.map for1 fields in
-              FStar_Format.combine (FStar_Format.text "; ") uu____837 in
-            FStar_Format.cbrackets uu____836
-        | FStar_Extraction_ML_Syntax.MLE_CTor (ctor,[]) ->
-            let name =
-              let uu____844 = is_standard_constructor ctor in
-              if uu____844
-              then
-                let uu____845 =
-                  let uu____848 = as_standard_constructor ctor in
-                  FStar_Option.get uu____848 in
-                Prims.snd uu____845
-              else ptctor currentModule ctor in
-            FStar_Format.text name
-        | FStar_Extraction_ML_Syntax.MLE_CTor (ctor,args) ->
-            let name =
-              let uu____860 = is_standard_constructor ctor in
-              if uu____860
-              then
-                let uu____861 =
-                  let uu____864 = as_standard_constructor ctor in
-                  FStar_Option.get uu____864 in
-                Prims.snd uu____861
-              else ptctor currentModule ctor in
-            let args1 =
-              FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args in
-            let doc1 =
-              match (name, args1) with
-              | ("::",x::xs::[]) ->
-                  FStar_Format.reduce
-                    [FStar_Format.parens x; FStar_Format.text "::"; xs]
-              | (uu____880,uu____881) ->
-                  let uu____884 =
-                    let uu____886 =
-                      let uu____888 =
-                        let uu____889 =
-                          FStar_Format.combine (FStar_Format.text ", ") args1 in
-                        FStar_Format.parens uu____889 in
-                      [uu____888] in
-                    (FStar_Format.text name) :: uu____886 in
-                  FStar_Format.reduce1 uu____884 in
-            maybe_paren outer e_app_prio doc1
-        | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-            let docs =
-              FStar_List.map
-                (fun x  ->
-                   let uu____895 =
-                     doc_of_expr currentModule (min_op_prec, NonAssoc) x in
-                   FStar_Format.parens uu____895) es in
-            let docs1 =
-              let uu____899 =
-                FStar_Format.combine (FStar_Format.text ", ") docs in
-              FStar_Format.parens uu____899 in
-            docs1
-        | FStar_Extraction_ML_Syntax.MLE_Let ((rec_,uu____901,lets),body) ->
-            let pre =
-              if
-                e.FStar_Extraction_ML_Syntax.loc <>
-                  FStar_Extraction_ML_Syntax.dummy_loc
-              then
-                let uu____911 =
-                  let uu____913 =
-                    let uu____915 =
-                      doc_of_loc e.FStar_Extraction_ML_Syntax.loc in
-                    [uu____915] in
-                  FStar_Format.hardline :: uu____913 in
-                FStar_Format.reduce uu____911
-              else FStar_Format.empty in
-            let doc1 = doc_of_lets currentModule (rec_, false, lets) in
-            let body1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) body in
-            let uu____922 =
-              let uu____923 =
-                let uu____925 =
-                  let uu____927 =
-                    let uu____929 =
-                      FStar_Format.reduce1 [FStar_Format.text "in"; body1] in
-                    [uu____929] in
-                  doc1 :: uu____927 in
-                pre :: uu____925 in
-              FStar_Format.combine FStar_Format.hardline uu____923 in
-            FStar_Format.parens uu____922
-        | FStar_Extraction_ML_Syntax.MLE_App (e1,args) ->
-            (match ((e1.FStar_Extraction_ML_Syntax.expr), args) with
-             | (FStar_Extraction_ML_Syntax.MLE_Name
-                p,{
-                    FStar_Extraction_ML_Syntax.expr =
-                      FStar_Extraction_ML_Syntax.MLE_Fun
-                      (uu____936::[],scrutinee);
-                    FStar_Extraction_ML_Syntax.mlty = uu____938;
-                    FStar_Extraction_ML_Syntax.loc = uu____939;_}::{
-                                                                    FStar_Extraction_ML_Syntax.expr
-                                                                    =
-                                                                    FStar_Extraction_ML_Syntax.MLE_Fun
-                                                                    ((arg,uu____941)::[],possible_match);
-                                                                    FStar_Extraction_ML_Syntax.mlty
-                                                                    =
-                                                                    uu____943;
-                                                                    FStar_Extraction_ML_Syntax.loc
-                                                                    =
-                                                                    uu____944;_}::[])
-                 when
-                 let uu____962 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu____962 = "FStar.All.try_with" ->
-                 let branches =
-                   match possible_match with
-                   | {
-                       FStar_Extraction_ML_Syntax.expr =
-                         FStar_Extraction_ML_Syntax.MLE_Match
-                         ({
-                            FStar_Extraction_ML_Syntax.expr =
-                              FStar_Extraction_ML_Syntax.MLE_Var arg';
-                            FStar_Extraction_ML_Syntax.mlty = uu____975;
-                            FStar_Extraction_ML_Syntax.loc = uu____976;_},branches);
-                       FStar_Extraction_ML_Syntax.mlty = uu____978;
-                       FStar_Extraction_ML_Syntax.loc = uu____979;_} when
-                       let uu____990 = FStar_Extraction_ML_Syntax.idsym arg in
-                       let uu____991 = FStar_Extraction_ML_Syntax.idsym arg' in
-                       uu____990 = uu____991 -> branches
-                   | e2 -> [(FStar_Extraction_ML_Syntax.MLP_Wild, None, e2)] in
-                 doc_of_expr currentModule outer
-                   {
-                     FStar_Extraction_ML_Syntax.expr =
-                       (FStar_Extraction_ML_Syntax.MLE_Try
-                          (scrutinee, branches));
-                     FStar_Extraction_ML_Syntax.mlty =
-                       (possible_match.FStar_Extraction_ML_Syntax.mlty);
-                     FStar_Extraction_ML_Syntax.loc =
-                       (possible_match.FStar_Extraction_ML_Syntax.loc)
-                   }
-             | (FStar_Extraction_ML_Syntax.MLE_Name p,e11::e2::[]) when
-                 is_bin_op p -> doc_of_binop currentModule p e11 e2
-             | (FStar_Extraction_ML_Syntax.MLE_App
-                ({
-                   FStar_Extraction_ML_Syntax.expr =
-                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                   FStar_Extraction_ML_Syntax.mlty = uu____1012;
-                   FStar_Extraction_ML_Syntax.loc = uu____1013;_},unitVal::[]),e11::e2::[])
-                 when
-                 (is_bin_op p) &&
-                   (unitVal = FStar_Extraction_ML_Syntax.ml_unit)
-                 -> doc_of_binop currentModule p e11 e2
-             | (FStar_Extraction_ML_Syntax.MLE_Name p,e11::[]) when
-                 is_uni_op p -> doc_of_uniop currentModule p e11
-             | (FStar_Extraction_ML_Syntax.MLE_App
-                ({
-                   FStar_Extraction_ML_Syntax.expr =
-                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                   FStar_Extraction_ML_Syntax.mlty = uu____1023;
-                   FStar_Extraction_ML_Syntax.loc = uu____1024;_},unitVal::[]),e11::[])
-                 when
-                 (is_uni_op p) &&
-                   (unitVal = FStar_Extraction_ML_Syntax.ml_unit)
-                 -> doc_of_uniop currentModule p e11
-             | uu____1029 ->
-                 let e2 = doc_of_expr currentModule (e_app_prio, ILeft) e1 in
-                 let args1 =
-                   FStar_List.map
-                     (doc_of_expr currentModule (e_app_prio, IRight)) args in
-                 let uu____1040 = FStar_Format.reduce1 (e2 :: args1) in
-                 FStar_Format.parens uu____1040)
-        | FStar_Extraction_ML_Syntax.MLE_Proj (e1,f) ->
-            let e2 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-            let doc1 =
-              let uu____1047 = FStar_Extraction_ML_Util.codegen_fsharp () in
-              if uu____1047
-              then
-                FStar_Format.reduce
-                  [e2;
-                  FStar_Format.text ".";
-                  FStar_Format.text (Prims.snd f)]
-              else
-                (let uu____1050 =
-                   let uu____1052 =
-                     let uu____1054 =
-                       let uu____1056 =
-                         let uu____1057 = ptsym currentModule f in
-                         FStar_Format.text uu____1057 in
-                       [uu____1056] in
-                     (FStar_Format.text ".") :: uu____1054 in
-                   e2 :: uu____1052 in
-                 FStar_Format.reduce uu____1050) in
-            doc1
-        | FStar_Extraction_ML_Syntax.MLE_Fun (ids,body) ->
-            let bvar_annot x xt =
-              let uu____1075 = FStar_Extraction_ML_Util.codegen_fsharp () in
-              if uu____1075
-              then
-                let uu____1076 =
-                  let uu____1078 =
-                    let uu____1080 =
-                      let uu____1082 =
-                        match xt with
-                        | Some xxt ->
-                            let uu____1084 =
-                              let uu____1086 =
-                                let uu____1088 =
-                                  doc_of_mltype currentModule outer xxt in
-                                [uu____1088] in
-                              (FStar_Format.text " : ") :: uu____1086 in
-                            FStar_Format.reduce1 uu____1084
-                        | uu____1089 -> FStar_Format.text "" in
-                      [uu____1082; FStar_Format.text ")"] in
-                    (FStar_Format.text x) :: uu____1080 in
-                  (FStar_Format.text "(") :: uu____1078 in
-                FStar_Format.reduce1 uu____1076
-              else FStar_Format.text x in
-            let ids1 =
-              FStar_List.map
-                (fun uu____1098  ->
-                   match uu____1098 with
-                   | ((x,uu____1104),xt) -> bvar_annot x (Some xt)) ids in
-            let body1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) body in
-            let doc1 =
-              let uu____1112 =
-                let uu____1114 =
-                  let uu____1116 = FStar_Format.reduce1 ids1 in
-                  [uu____1116; FStar_Format.text "->"; body1] in
-                (FStar_Format.text "fun") :: uu____1114 in
-              FStar_Format.reduce1 uu____1112 in
-            FStar_Format.parens doc1
-        | FStar_Extraction_ML_Syntax.MLE_If (cond,e1,None ) ->
-            let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
-            let doc1 =
-              let uu____1124 =
-                let uu____1126 =
-                  FStar_Format.reduce1
-                    [FStar_Format.text "if";
-                    cond1;
-                    FStar_Format.text "then";
-                    FStar_Format.text "begin"] in
-                let uu____1127 =
-                  let uu____1129 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  [uu____1129; FStar_Format.text "end"] in
-                uu____1126 :: uu____1127 in
-              FStar_Format.combine FStar_Format.hardline uu____1124 in
-            maybe_paren outer e_bin_prio_if doc1
-        | FStar_Extraction_ML_Syntax.MLE_If (cond,e1,Some e2) ->
-            let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
-            let doc1 =
-              let uu____1140 =
-                let uu____1142 =
-                  FStar_Format.reduce1
-                    [FStar_Format.text "if";
-                    cond1;
-                    FStar_Format.text "then";
-                    FStar_Format.text "begin"] in
-                let uu____1143 =
-                  let uu____1145 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  let uu____1148 =
-                    let uu____1150 =
-                      FStar_Format.reduce1
-                        [FStar_Format.text "end";
-                        FStar_Format.text "else";
-                        FStar_Format.text "begin"] in
-                    let uu____1151 =
-                      let uu____1153 =
-                        doc_of_expr currentModule (min_op_prec, NonAssoc) e2 in
-                      [uu____1153; FStar_Format.text "end"] in
-                    uu____1150 :: uu____1151 in
-                  uu____1145 :: uu____1148 in
-                uu____1142 :: uu____1143 in
-              FStar_Format.combine FStar_Format.hardline uu____1140 in
-            maybe_paren outer e_bin_prio_if doc1
-        | FStar_Extraction_ML_Syntax.MLE_Match (cond,pats) ->
-            let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
-            let pats1 = FStar_List.map (doc_of_branch currentModule) pats in
-            let doc1 =
-              let uu____1175 =
-                FStar_Format.reduce1
-                  [FStar_Format.text "match";
-                  FStar_Format.parens cond1;
-                  FStar_Format.text "with"] in
-              uu____1175 :: pats1 in
-            let doc2 = FStar_Format.combine FStar_Format.hardline doc1 in
-            FStar_Format.parens doc2
-        | FStar_Extraction_ML_Syntax.MLE_Raise (exn,[]) ->
-            let uu____1179 =
-              let uu____1181 =
-                let uu____1183 =
-                  let uu____1184 = ptctor currentModule exn in
-                  FStar_Format.text uu____1184 in
-                [uu____1183] in
-              (FStar_Format.text "raise") :: uu____1181 in
-            FStar_Format.reduce1 uu____1179
-        | FStar_Extraction_ML_Syntax.MLE_Raise (exn,args) ->
-            let args1 =
-              FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args in
-            let uu____1193 =
-              let uu____1195 =
-                let uu____1197 =
-                  let uu____1198 = ptctor currentModule exn in
-                  FStar_Format.text uu____1198 in
-                let uu____1199 =
-                  let uu____1201 =
-                    let uu____1202 =
-                      FStar_Format.combine (FStar_Format.text ", ") args1 in
-                    FStar_Format.parens uu____1202 in
-                  [uu____1201] in
-                uu____1197 :: uu____1199 in
-              (FStar_Format.text "raise") :: uu____1195 in
-            FStar_Format.reduce1 uu____1193
-        | FStar_Extraction_ML_Syntax.MLE_Try (e1,pats) ->
-            let uu____1215 =
-              let uu____1217 =
-                let uu____1219 =
-                  doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                let uu____1222 =
-                  let uu____1224 =
-                    let uu____1226 =
-                      let uu____1227 =
-                        FStar_List.map (doc_of_branch currentModule) pats in
-                      FStar_Format.combine FStar_Format.hardline uu____1227 in
-                    [uu____1226] in
-                  (FStar_Format.text "with") :: uu____1224 in
-                uu____1219 :: uu____1222 in
-              (FStar_Format.text "try") :: uu____1217 in
-            FStar_Format.combine FStar_Format.hardline uu____1215
-and doc_of_binop:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath ->
-      FStar_Extraction_ML_Syntax.mlexpr ->
-        FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun p  ->
-      fun e1  ->
-        fun e2  ->
-          let uu____1233 =
-            let uu____1239 = as_bin_op p in FStar_Option.get uu____1239 in
-          match uu____1233 with
-          | (uu____1251,prio,txt) ->
-              let e11 = doc_of_expr currentModule (prio, Left) e1 in
-              let e21 = doc_of_expr currentModule (prio, Right) e2 in
-              let doc1 =
-                FStar_Format.reduce1 [e11; FStar_Format.text txt; e21] in
-              FStar_Format.parens doc1
-and doc_of_uniop:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath ->
-      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun p  ->
-      fun e1  ->
-        let uu____1268 =
-          let uu____1271 = as_uni_op p in FStar_Option.get uu____1271 in
-        match uu____1268 with
-        | (uu____1277,txt) ->
-            let e11 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-            let doc1 =
-              FStar_Format.reduce1
-                [FStar_Format.text txt; FStar_Format.parens e11] in
-            FStar_Format.parens doc1
-and doc_of_pattern:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpattern -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun pattern  ->
-      match pattern with
-      | FStar_Extraction_ML_Syntax.MLP_Wild  -> FStar_Format.text "_"
-      | FStar_Extraction_ML_Syntax.MLP_Const c ->
-          let uu____1286 = string_of_mlconstant c in
-          FStar_Format.text uu____1286
-      | FStar_Extraction_ML_Syntax.MLP_Var x ->
-          FStar_Format.text (Prims.fst x)
-      | FStar_Extraction_ML_Syntax.MLP_Record (path,fields) ->
-          let for1 uu____1303 =
-            match uu____1303 with
-            | (name,p) ->
-                let uu____1308 =
-                  let uu____1310 =
-                    let uu____1311 = ptsym currentModule (path, name) in
-                    FStar_Format.text uu____1311 in
-                  let uu____1313 =
-                    let uu____1315 =
-                      let uu____1317 = doc_of_pattern currentModule p in
-                      [uu____1317] in
-                    (FStar_Format.text "=") :: uu____1315 in
-                  uu____1310 :: uu____1313 in
-                FStar_Format.reduce1 uu____1308 in
-          let uu____1318 =
-            let uu____1319 = FStar_List.map for1 fields in
-            FStar_Format.combine (FStar_Format.text "; ") uu____1319 in
-          FStar_Format.cbrackets uu____1318
-      | FStar_Extraction_ML_Syntax.MLP_CTor (ctor,[]) ->
-          let name =
-            let uu____1326 = is_standard_constructor ctor in
-            if uu____1326
-            then
-              let uu____1327 =
-                let uu____1330 = as_standard_constructor ctor in
-                FStar_Option.get uu____1330 in
-              Prims.snd uu____1327
-            else ptctor currentModule ctor in
-          FStar_Format.text name
-      | FStar_Extraction_ML_Syntax.MLP_CTor (ctor,pats) ->
-          let name =
-            let uu____1342 = is_standard_constructor ctor in
-            if uu____1342
-            then
-              let uu____1343 =
-                let uu____1346 = as_standard_constructor ctor in
-                FStar_Option.get uu____1346 in
-              Prims.snd uu____1343
-            else ptctor currentModule ctor in
-          let doc1 =
-            match (name, pats) with
-            | ("::",x::xs::[]) ->
-                let uu____1358 =
-                  let uu____1360 =
-                    let uu____1361 = doc_of_pattern currentModule x in
-                    FStar_Format.parens uu____1361 in
-                  let uu____1362 =
-                    let uu____1364 =
-                      let uu____1366 = doc_of_pattern currentModule xs in
-                      [uu____1366] in
-                    (FStar_Format.text "::") :: uu____1364 in
-                  uu____1360 :: uu____1362 in
-                FStar_Format.reduce uu____1358
-            | (uu____1367,(FStar_Extraction_ML_Syntax.MLP_Tuple
-               uu____1368)::[]) ->
-                let uu____1371 =
-                  let uu____1373 =
-                    let uu____1375 =
-                      let uu____1376 = FStar_List.hd pats in
-                      doc_of_pattern currentModule uu____1376 in
-                    [uu____1375] in
-                  (FStar_Format.text name) :: uu____1373 in
-                FStar_Format.reduce1 uu____1371
-            | uu____1377 ->
-                let uu____1381 =
-                  let uu____1383 =
-                    let uu____1385 =
-                      let uu____1386 =
-                        let uu____1387 =
-                          FStar_List.map (doc_of_pattern currentModule) pats in
-                        FStar_Format.combine (FStar_Format.text ", ")
-                          uu____1387 in
-                      FStar_Format.parens uu____1386 in
-                    [uu____1385] in
-                  (FStar_Format.text name) :: uu____1383 in
-                FStar_Format.reduce1 uu____1381 in
-          maybe_paren (min_op_prec, NonAssoc) e_app_prio doc1
-      | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
-          let uu____1395 = FStar_Format.combine (FStar_Format.text ", ") ps1 in
-          FStar_Format.parens uu____1395
-      | FStar_Extraction_ML_Syntax.MLP_Branch ps ->
-          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
-          let ps2 = FStar_List.map FStar_Format.parens ps1 in
-          FStar_Format.combine (FStar_Format.text " | ") ps2
-and doc_of_branch:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlbranch -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun uu____1403  ->
-      match uu____1403 with
-      | (p,cond,e) ->
-          let case =
-            match cond with
-            | None  ->
-                let uu____1410 =
-                  let uu____1412 =
-                    let uu____1414 = doc_of_pattern currentModule p in
-                    [uu____1414] in
-                  (FStar_Format.text "|") :: uu____1412 in
-                FStar_Format.reduce1 uu____1410
-            | Some c ->
-                let c1 = doc_of_expr currentModule (min_op_prec, NonAssoc) c in
-                let uu____1419 =
-                  let uu____1421 =
-                    let uu____1423 = doc_of_pattern currentModule p in
-                    [uu____1423; FStar_Format.text "when"; c1] in
-                  (FStar_Format.text "|") :: uu____1421 in
-                FStar_Format.reduce1 uu____1419 in
-          let uu____1424 =
-            let uu____1426 =
-              FStar_Format.reduce1
-                [case; FStar_Format.text "->"; FStar_Format.text "begin"] in
-            let uu____1427 =
-              let uu____1429 =
-                doc_of_expr currentModule (min_op_prec, NonAssoc) e in
-              [uu____1429; FStar_Format.text "end"] in
-            uu____1426 :: uu____1427 in
-          FStar_Format.combine FStar_Format.hardline uu____1424
-and doc_of_lets:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    (FStar_Extraction_ML_Syntax.mlletflavor* Prims.bool*
-      FStar_Extraction_ML_Syntax.mllb Prims.list) -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun uu____1433  ->
-      match uu____1433 with
-      | (rec_,top_level,lets) ->
-          let for1 uu____1446 =
-            match uu____1446 with
-            | { FStar_Extraction_ML_Syntax.mllb_name = name;
-                FStar_Extraction_ML_Syntax.mllb_tysc = tys;
-                FStar_Extraction_ML_Syntax.mllb_add_unit = uu____1449;
-                FStar_Extraction_ML_Syntax.mllb_def = e;
-                FStar_Extraction_ML_Syntax.print_typ = pt;_} ->
-                let e1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e in
-                let ids = [] in
-                let ids1 =
-                  FStar_List.map
-                    (fun uu____1466  ->
-                       match uu____1466 with
-                       | (x,uu____1470) -> FStar_Format.text x) ids in
-                let ty_annot =
-                  if Prims.op_Negation pt
-                  then FStar_Format.text ""
-                  else
-                    (let uu____1473 =
-                       (FStar_Extraction_ML_Util.codegen_fsharp ()) &&
-                         ((rec_ = FStar_Extraction_ML_Syntax.Rec) ||
-                            top_level) in
-                     if uu____1473
-                     then
-                       match tys with
-                       | Some (_::_,_)|None  -> FStar_Format.text ""
-                       | Some ([],ty) ->
-                           let ty1 =
-                             doc_of_mltype currentModule
-                               (min_op_prec, NonAssoc) ty in
-                           FStar_Format.reduce1 [FStar_Format.text ":"; ty1]
-                     else
-                       if top_level
-                       then
-                         (match tys with
-                          | None |Some (_::_,_) -> FStar_Format.text ""
-                          | Some ([],ty) ->
-                              let ty1 =
-                                doc_of_mltype currentModule
-                                  (min_op_prec, NonAssoc) ty in
-                              FStar_Format.reduce1
-                                [FStar_Format.text ":"; ty1])
-                       else FStar_Format.text "") in
-                let uu____1506 =
-                  let uu____1508 =
-                    let uu____1509 = FStar_Extraction_ML_Syntax.idsym name in
-                    FStar_Format.text uu____1509 in
-                  let uu____1510 =
-                    let uu____1512 = FStar_Format.reduce1 ids1 in
-                    [uu____1512; ty_annot; FStar_Format.text "="; e1] in
-                  uu____1508 :: uu____1510 in
-                FStar_Format.reduce1 uu____1506 in
-          let letdoc =
-            if rec_ = FStar_Extraction_ML_Syntax.Rec
-            then
-              FStar_Format.reduce1
-                [FStar_Format.text "let"; FStar_Format.text "rec"]
-            else FStar_Format.text "let" in
-          let lets1 = FStar_List.map for1 lets in
-          let lets2 =
-            FStar_List.mapi
-              (fun i  ->
-                 fun doc1  ->
-                   FStar_Format.reduce1
-                     [if i = (Prims.parse_int "0")
-                      then letdoc
-                      else FStar_Format.text "and";
-                     doc1]) lets1 in
-          FStar_Format.combine FStar_Format.hardline lets2
-and doc_of_loc: FStar_Extraction_ML_Syntax.mlloc -> FStar_Format.doc =
-  fun uu____1522  ->
-    match uu____1522 with
-    | (lineno,file) ->
-        let uu____1525 =
-          (FStar_Options.no_location_info ()) ||
-            (FStar_Extraction_ML_Util.codegen_fsharp ()) in
-        if uu____1525
-        then FStar_Format.empty
-        else
-          (let file1 = FStar_Util.basename file in
-           FStar_Format.reduce1
-             [FStar_Format.text "#";
-             FStar_Format.num lineno;
-             FStar_Format.text (Prims.strcat "\"" (Prims.strcat file1 "\""))])
-let doc_of_mltydecl:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mltydecl -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun decls  ->
-      let for1 uu____1545 =
-        match uu____1545 with
-        | (uu____1554,x,mangle_opt,tparams,body) ->
-            let x1 = match mangle_opt with | None  -> x | Some y -> y in
-            let tparams1 =
-              match tparams with
-              | [] -> FStar_Format.empty
-              | x2::[] ->
-                  let uu____1569 = FStar_Extraction_ML_Syntax.idsym x2 in
-                  FStar_Format.text uu____1569
-              | uu____1570 ->
-                  let doc1 =
-                    FStar_List.map
-                      (fun x2  ->
-                         let uu____1575 = FStar_Extraction_ML_Syntax.idsym x2 in
-                         FStar_Format.text uu____1575) tparams in
-                  let uu____1576 =
-                    FStar_Format.combine (FStar_Format.text ", ") doc1 in
-                  FStar_Format.parens uu____1576 in
-            let forbody body1 =
-              match body1 with
-              | FStar_Extraction_ML_Syntax.MLTD_Abbrev ty ->
-                  doc_of_mltype currentModule (min_op_prec, NonAssoc) ty
-              | FStar_Extraction_ML_Syntax.MLTD_Record fields ->
-                  let forfield uu____1593 =
-                    match uu____1593 with
-                    | (name,ty) ->
-                        let name1 = FStar_Format.text name in
-                        let ty1 =
-                          doc_of_mltype currentModule (min_op_prec, NonAssoc)
-                            ty in
-                        FStar_Format.reduce1
-                          [name1; FStar_Format.text ":"; ty1] in
-                  let uu____1602 =
-                    let uu____1603 = FStar_List.map forfield fields in
-                    FStar_Format.combine (FStar_Format.text "; ") uu____1603 in
-                  FStar_Format.cbrackets uu____1602
-              | FStar_Extraction_ML_Syntax.MLTD_DType ctors ->
-                  let forctor uu____1618 =
-                    match uu____1618 with
-                    | (name,tys) ->
-                        (match tys with
-                         | [] -> FStar_Format.text name
-                         | uu____1626 ->
-                             let tys1 =
-                               FStar_List.map
-                                 (doc_of_mltype currentModule
-                                    (t_prio_tpl, Left)) tys in
-                             let tys2 =
-                               FStar_Format.combine (FStar_Format.text " * ")
-                                 tys1 in
-                             FStar_Format.reduce1
-                               [FStar_Format.text name;
-                               FStar_Format.text "of";
-                               tys2]) in
-                  let ctors1 = FStar_List.map forctor ctors in
-                  let ctors2 =
-                    FStar_List.map
-                      (fun d  ->
-                         FStar_Format.reduce1 [FStar_Format.text "|"; d])
-                      ctors1 in
-                  FStar_Format.combine FStar_Format.hardline ctors2 in
-            let doc1 =
-              let uu____1642 =
-                let uu____1644 =
-                  let uu____1646 =
-                    let uu____1647 = ptsym currentModule ([], x1) in
-                    FStar_Format.text uu____1647 in
-                  [uu____1646] in
-                tparams1 :: uu____1644 in
-              FStar_Format.reduce1 uu____1642 in
-            (match body with
-             | None  -> doc1
-             | Some body1 ->
-                 let body2 = forbody body1 in
-                 let uu____1651 =
-                   let uu____1653 =
-                     FStar_Format.reduce1 [doc1; FStar_Format.text "="] in
-                   [uu____1653; body2] in
-                 FStar_Format.combine FStar_Format.hardline uu____1651) in
-      let doc1 = FStar_List.map for1 decls in
-      let doc2 =
-        if (FStar_List.length doc1) > (Prims.parse_int "0")
-        then
-          let uu____1668 =
-            let uu____1670 =
-              let uu____1672 =
-                FStar_Format.combine (FStar_Format.text " \n and ") doc1 in
-              [uu____1672] in
-            (FStar_Format.text "type") :: uu____1670 in
-          FStar_Format.reduce1 uu____1668
-        else FStar_Format.text "" in
-      doc2
-let rec doc_of_sig1:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlsig1 -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun s  ->
-      match s with
-      | FStar_Extraction_ML_Syntax.MLS_Mod (x,subsig) ->
-          let uu____1688 =
-            let uu____1690 =
-              FStar_Format.reduce1
-                [FStar_Format.text "module";
-                FStar_Format.text x;
-                FStar_Format.text "="] in
-            let uu____1691 =
-              let uu____1693 = doc_of_sig currentModule subsig in
-              let uu____1694 =
-                let uu____1696 =
-                  FStar_Format.reduce1 [FStar_Format.text "end"] in
-                [uu____1696] in
-              uu____1693 :: uu____1694 in
-            uu____1690 :: uu____1691 in
-          FStar_Format.combine FStar_Format.hardline uu____1688
-      | FStar_Extraction_ML_Syntax.MLS_Exn (x,[]) ->
-          FStar_Format.reduce1
-            [FStar_Format.text "exception"; FStar_Format.text x]
-      | FStar_Extraction_ML_Syntax.MLS_Exn (x,args) ->
-          let args1 =
-            FStar_List.map
-              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args in
-          let args2 =
-            let uu____1708 =
-              FStar_Format.combine (FStar_Format.text " * ") args1 in
-            FStar_Format.parens uu____1708 in
-          FStar_Format.reduce1
-            [FStar_Format.text "exception";
-            FStar_Format.text x;
-            FStar_Format.text "of";
-            args2]
-      | FStar_Extraction_ML_Syntax.MLS_Val (x,(uu____1710,ty)) ->
-          let ty1 = doc_of_mltype currentModule (min_op_prec, NonAssoc) ty in
-          FStar_Format.reduce1
-            [FStar_Format.text "val";
-            FStar_Format.text x;
-            FStar_Format.text ": ";
-            ty1]
-      | FStar_Extraction_ML_Syntax.MLS_Ty decls ->
-          doc_of_mltydecl currentModule decls
-and doc_of_sig:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlsig -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun s  ->
-      let docs = FStar_List.map (doc_of_sig1 currentModule) s in
-      let docs1 =
-        FStar_List.map
-          (fun x  ->
-             FStar_Format.reduce
-               [x; FStar_Format.hardline; FStar_Format.hardline]) docs in
-      FStar_Format.reduce docs1
-let doc_of_mod1:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlmodule1 -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun m  ->
-      match m with
-      | FStar_Extraction_ML_Syntax.MLM_Exn (x,[]) ->
-          FStar_Format.reduce1
-            [FStar_Format.text "exception"; FStar_Format.text x]
-      | FStar_Extraction_ML_Syntax.MLM_Exn (x,args) ->
-          let args1 =
-            FStar_List.map
-              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args in
-          let args2 =
-            let uu____1742 =
-              FStar_Format.combine (FStar_Format.text " * ") args1 in
-            FStar_Format.parens uu____1742 in
-          FStar_Format.reduce1
-            [FStar_Format.text "exception";
-            FStar_Format.text x;
-            FStar_Format.text "of";
-            args2]
-      | FStar_Extraction_ML_Syntax.MLM_Ty decls ->
-          doc_of_mltydecl currentModule decls
-      | FStar_Extraction_ML_Syntax.MLM_Let (rec_,uu____1745,lets) ->
-          doc_of_lets currentModule (rec_, true, lets)
-      | FStar_Extraction_ML_Syntax.MLM_Top e ->
-          let uu____1751 =
-            let uu____1753 =
-              let uu____1755 =
-                let uu____1757 =
-                  let uu____1759 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e in
-                  [uu____1759] in
-                (FStar_Format.text "=") :: uu____1757 in
-              (FStar_Format.text "_") :: uu____1755 in
-            (FStar_Format.text "let") :: uu____1753 in
-          FStar_Format.reduce1 uu____1751
-      | FStar_Extraction_ML_Syntax.MLM_Loc loc -> doc_of_loc loc
-let doc_of_mod:
-  FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlmodule -> FStar_Format.doc
-  =
-  fun currentModule  ->
-    fun m  ->
-      let docs =
-        FStar_List.map
-          (fun x  ->
-             let doc1 = doc_of_mod1 currentModule x in
-             [doc1;
-             (match x with
-              | FStar_Extraction_ML_Syntax.MLM_Loc uu____1775 ->
-                  FStar_Format.empty
-              | uu____1776 -> FStar_Format.hardline);
-             FStar_Format.hardline]) m in
-      FStar_Format.reduce (FStar_List.flatten docs)
-let rec doc_of_mllib_r:
-  FStar_Extraction_ML_Syntax.mllib ->
-    (Prims.string* FStar_Format.doc) Prims.list
-  =
-  fun uu____1782  ->
-    match uu____1782 with
-    | FStar_Extraction_ML_Syntax.MLLib mllib ->
-        let rec for1_sig uu____1820 =
-          match uu____1820 with
-          | (x,sigmod,FStar_Extraction_ML_Syntax.MLLib sub1) ->
-              let x1 = FStar_Extraction_ML_Util.flatten_mlpath x in
-              let head1 =
-                FStar_Format.reduce1
-                  [FStar_Format.text "module";
-                  FStar_Format.text x1;
-                  FStar_Format.text ":";
-                  FStar_Format.text "sig"] in
-              let tail1 = FStar_Format.reduce1 [FStar_Format.text "end"] in
-              let doc1 =
-                FStar_Option.map
-                  (fun uu____1859  ->
-                     match uu____1859 with
-                     | (s,uu____1863) -> doc_of_sig x1 s) sigmod in
-              let sub2 = FStar_List.map for1_sig sub1 in
-              let sub3 =
-                FStar_List.map
-                  (fun x2  ->
-                     FStar_Format.reduce
-                       [x2; FStar_Format.hardline; FStar_Format.hardline])
-                  sub2 in
-              let uu____1878 =
-                let uu____1880 =
-                  let uu____1882 =
-                    let uu____1884 = FStar_Format.reduce sub3 in
-                    [uu____1884;
-                    FStar_Format.cat tail1 FStar_Format.hardline] in
-                  (match doc1 with
-                   | None  -> FStar_Format.empty
-                   | Some s -> FStar_Format.cat s FStar_Format.hardline) ::
-                    uu____1882 in
-                (FStar_Format.cat head1 FStar_Format.hardline) :: uu____1880 in
-              FStar_Format.reduce uu____1878
-        and for1_mod istop uu____1887 =
-          match uu____1887 with
-          | (x,sigmod,FStar_Extraction_ML_Syntax.MLLib sub1) ->
-              let x1 = FStar_Extraction_ML_Util.flatten_mlpath x in
-              let head1 =
-                let uu____1921 =
-                  let uu____1923 = FStar_Extraction_ML_Util.codegen_fsharp () in
-                  if uu____1923
-                  then [FStar_Format.text "module"; FStar_Format.text x1]
-                  else
-                    if Prims.op_Negation istop
-                    then
-                      [FStar_Format.text "module";
-                      FStar_Format.text x1;
-                      FStar_Format.text "=";
-                      FStar_Format.text "struct"]
-                    else [] in
-                FStar_Format.reduce1 uu____1921 in
-              let tail1 =
-                if Prims.op_Negation istop
-                then FStar_Format.reduce1 [FStar_Format.text "end"]
-                else FStar_Format.reduce1 [] in
-              let doc1 =
-                FStar_Option.map
-                  (fun uu____1934  ->
-                     match uu____1934 with
-                     | (uu____1937,m) -> doc_of_mod x1 m) sigmod in
-              let sub2 = FStar_List.map (for1_mod false) sub1 in
-              let sub3 =
-                FStar_List.map
-                  (fun x2  ->
-                     FStar_Format.reduce
-                       [x2; FStar_Format.hardline; FStar_Format.hardline])
-                  sub2 in
-              let prefix1 =
-                let uu____1955 = FStar_Extraction_ML_Util.codegen_fsharp () in
-                if uu____1955
-                then
-                  [FStar_Format.cat (FStar_Format.text "#light \"off\"")
-                     FStar_Format.hardline]
-                else [] in
-              let uu____1958 =
-                let uu____1960 =
-                  let uu____1962 =
-                    let uu____1964 =
-                      let uu____1966 =
-                        let uu____1968 =
-                          let uu____1970 =
-                            let uu____1972 = FStar_Format.reduce sub3 in
-                            [uu____1972;
-                            FStar_Format.cat tail1 FStar_Format.hardline] in
-                          (match doc1 with
-                           | None  -> FStar_Format.empty
-                           | Some s ->
-                               FStar_Format.cat s FStar_Format.hardline)
-                            :: uu____1970 in
-                        FStar_Format.hardline :: uu____1968 in
-                      (FStar_Format.text "open Prims") :: uu____1966 in
-                    FStar_Format.hardline :: uu____1964 in
-                  head1 :: uu____1962 in
-                FStar_List.append prefix1 uu____1960 in
-              FStar_All.pipe_left FStar_Format.reduce uu____1958 in
-        let docs =
-          FStar_List.map
-            (fun uu____1990  ->
-               match uu____1990 with
-               | (x,s,m) ->
-                   let uu____2017 = FStar_Extraction_ML_Util.flatten_mlpath x in
-                   let uu____2018 = for1_mod true (x, s, m) in
-                   (uu____2017, uu____2018)) mllib in
-        docs
-let doc_of_mllib:
-  FStar_Extraction_ML_Syntax.mllib ->
-    (Prims.string* FStar_Format.doc) Prims.list
-  = fun mllib  -> doc_of_mllib_r mllib
-let string_of_mlexpr:
-  FStar_Extraction_ML_Syntax.mlpath ->
-    FStar_Extraction_ML_Syntax.mlexpr -> Prims.string
-  =
-  fun cmod  ->
-    fun e  ->
-      let doc1 =
-        let uu____2038 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
-        doc_of_expr uu____2038 (min_op_prec, NonAssoc) e in
-      FStar_Format.pretty (Prims.parse_int "0") doc1
-let string_of_mlty:
-  FStar_Extraction_ML_Syntax.mlpath ->
-    FStar_Extraction_ML_Syntax.mlty -> Prims.string
-  =
-  fun cmod  ->
-    fun e  ->
-      let doc1 =
-        let uu____2048 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
-        doc_of_mltype uu____2048 (min_op_prec, NonAssoc) e in
-      FStar_Format.pretty (Prims.parse_int "0") doc1
+| Prefix
+| Postfix
+| Infix of assoc
+
+
+let uu___is_Prefix : fixity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Prefix -> begin
+true
+end
+| uu____27 -> begin
+false
+end))
+
+
+let uu___is_Postfix : fixity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Postfix -> begin
+true
+end
+| uu____31 -> begin
+false
+end))
+
+
+let uu___is_Infix : fixity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Infix (_0) -> begin
+true
+end
+| uu____36 -> begin
+false
+end))
+
+
+let __proj__Infix__item___0 : fixity  ->  assoc = (fun projectee -> (match (projectee) with
+| Infix (_0) -> begin
+_0
+end))
+
+
+type opprec =
+(Prims.int * fixity)
+
+
+type level =
+(opprec * assoc)
+
+
+let t_prio_fun : (Prims.int * fixity) = (((Prims.parse_int "10")), (Infix (Right)))
+
+
+let t_prio_tpl : (Prims.int * fixity) = (((Prims.parse_int "20")), (Infix (NonAssoc)))
+
+
+let t_prio_name : (Prims.int * fixity) = (((Prims.parse_int "30")), (Postfix))
+
+
+let e_bin_prio_lambda : (Prims.int * fixity) = (((Prims.parse_int "5")), (Prefix))
+
+
+let e_bin_prio_if : (Prims.int * fixity) = (((Prims.parse_int "15")), (Prefix))
+
+
+let e_bin_prio_letin : (Prims.int * fixity) = (((Prims.parse_int "19")), (Prefix))
+
+
+let e_bin_prio_or : (Prims.int * fixity) = (((Prims.parse_int "20")), (Infix (Left)))
+
+
+let e_bin_prio_and : (Prims.int * fixity) = (((Prims.parse_int "25")), (Infix (Left)))
+
+
+let e_bin_prio_eq : (Prims.int * fixity) = (((Prims.parse_int "27")), (Infix (NonAssoc)))
+
+
+let e_bin_prio_order : (Prims.int * fixity) = (((Prims.parse_int "29")), (Infix (NonAssoc)))
+
+
+let e_bin_prio_op1 : (Prims.int * fixity) = (((Prims.parse_int "30")), (Infix (Left)))
+
+
+let e_bin_prio_op2 : (Prims.int * fixity) = (((Prims.parse_int "40")), (Infix (Left)))
+
+
+let e_bin_prio_op3 : (Prims.int * fixity) = (((Prims.parse_int "50")), (Infix (Left)))
+
+
+let e_bin_prio_op4 : (Prims.int * fixity) = (((Prims.parse_int "60")), (Infix (Left)))
+
+
+let e_bin_prio_comb : (Prims.int * fixity) = (((Prims.parse_int "70")), (Infix (Left)))
+
+
+let e_bin_prio_seq : (Prims.int * fixity) = (((Prims.parse_int "100")), (Infix (Left)))
+
+
+let e_app_prio : (Prims.int * fixity) = (((Prims.parse_int "10000")), (Infix (Left)))
+
+
+let min_op_prec : (Prims.int * fixity) = (((~- ((Prims.parse_int "1")))), (Infix (NonAssoc)))
+
+
+let max_op_prec : (Prims.int * fixity) = ((FStar_Util.max_int), (Infix (NonAssoc)))
+
+
+let rec in_ns = (fun x -> (match (x) with
+| ([], uu____101) -> begin
+true
+end
+| ((x1)::t1, (x2)::t2) when (x1 = x2) -> begin
+(in_ns ((t1), (t2)))
+end
+| (uu____115, uu____116) -> begin
+false
+end))
+
+
+let path_of_ns : FStar_Extraction_ML_Syntax.mlsymbol  ->  Prims.string Prims.list  ->  Prims.string Prims.list = (fun currentModule ns -> (
+
+let ns' = (FStar_Extraction_ML_Util.flatten_ns ns)
+in (match ((ns' = currentModule)) with
+| true -> begin
+[]
+end
+| uu____132 -> begin
+(
+
+let cg_libs = (FStar_Options.codegen_libs ())
+in (
+
+let ns_len = (FStar_List.length ns)
+in (
+
+let found = (FStar_Util.find_map cg_libs (fun cg_path -> (
+
+let cg_len = (FStar_List.length cg_path)
+in (match (((FStar_List.length cg_path) < ns_len)) with
+| true -> begin
+(
+
+let uu____154 = (FStar_Util.first_N cg_len ns)
+in (match (uu____154) with
+| (pfx, sfx) -> begin
+(match ((pfx = cg_path)) with
+| true -> begin
+(
+
+let uu____172 = (
+
+let uu____174 = (
+
+let uu____176 = (FStar_Extraction_ML_Util.flatten_ns sfx)
+in (uu____176)::[])
+in (FStar_List.append pfx uu____174))
+in Some (uu____172))
+end
+| uu____178 -> begin
+None
+end)
+end))
+end
+| uu____180 -> begin
+None
+end))))
+in (match (found) with
+| None -> begin
+(ns')::[]
+end
+| Some (x) -> begin
+x
+end))))
+end)))
+
+
+let mlpath_of_mlpath : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlpath = (fun currentModule x -> (
+
+let uu____193 = (FStar_Extraction_ML_Syntax.string_of_mlpath x)
+in (match (uu____193) with
+| "Prims.Some" -> begin
+(([]), ("Some"))
+end
+| "Prims.None" -> begin
+(([]), ("None"))
+end
+| uu____196 -> begin
+(
+
+let uu____197 = x
+in (match (uu____197) with
+| (ns, x1) -> begin
+(
+
+let uu____202 = (path_of_ns currentModule ns)
+in ((uu____202), (x1)))
+end))
+end)))
+
+
+let ptsym_of_symbol : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlsymbol = (fun s -> (
+
+let uu____208 = (
+
+let uu____209 = (
+
+let uu____210 = (FStar_String.get s (Prims.parse_int "0"))
+in (FStar_Char.lowercase uu____210))
+in (
+
+let uu____211 = (FStar_String.get s (Prims.parse_int "0"))
+in (uu____209 <> uu____211)))
+in (match (uu____208) with
+| true -> begin
+(Prims.strcat "l__" s)
+end
+| uu____212 -> begin
+s
+end)))
+
+
+let ptsym : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlsymbol = (fun currentModule mlp -> (match ((FStar_List.isEmpty (Prims.fst mlp))) with
+| true -> begin
+(ptsym_of_symbol (Prims.snd mlp))
+end
+| uu____221 -> begin
+(
+
+let uu____222 = (mlpath_of_mlpath currentModule mlp)
+in (match (uu____222) with
+| (p, s) -> begin
+(
+
+let uu____227 = (
+
+let uu____229 = (
+
+let uu____231 = (ptsym_of_symbol s)
+in (uu____231)::[])
+in (FStar_List.append p uu____229))
+in (FStar_String.concat "." uu____227))
+end))
+end))
+
+
+let ptctor : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlsymbol = (fun currentModule mlp -> (
+
+let uu____238 = (mlpath_of_mlpath currentModule mlp)
+in (match (uu____238) with
+| (p, s) -> begin
+(
+
+let s1 = (
+
+let uu____244 = (
+
+let uu____245 = (
+
+let uu____246 = (FStar_String.get s (Prims.parse_int "0"))
+in (FStar_Char.uppercase uu____246))
+in (
+
+let uu____247 = (FStar_String.get s (Prims.parse_int "0"))
+in (uu____245 <> uu____247)))
+in (match (uu____244) with
+| true -> begin
+(Prims.strcat "U__" s)
+end
+| uu____248 -> begin
+s
+end))
+in (FStar_String.concat "." (FStar_List.append p ((s1)::[]))))
+end)))
+
+
+let infix_prim_ops : (Prims.string * (Prims.int * fixity) * Prims.string) Prims.list = ((("op_Addition"), (e_bin_prio_op1), ("+")))::((("op_Subtraction"), (e_bin_prio_op1), ("-")))::((("op_Multiply"), (e_bin_prio_op1), ("*")))::((("op_Division"), (e_bin_prio_op1), ("/")))::((("op_Equality"), (e_bin_prio_eq), ("=")))::((("op_Colon_Equals"), (e_bin_prio_eq), (":=")))::((("op_disEquality"), (e_bin_prio_eq), ("<>")))::((("op_AmpAmp"), (e_bin_prio_and), ("&&")))::((("op_BarBar"), (e_bin_prio_or), ("||")))::((("op_LessThanOrEqual"), (e_bin_prio_order), ("<=")))::((("op_GreaterThanOrEqual"), (e_bin_prio_order), (">=")))::((("op_LessThan"), (e_bin_prio_order), ("<")))::((("op_GreaterThan"), (e_bin_prio_order), (">")))::((("op_Modulus"), (e_bin_prio_order), ("mod")))::[]
+
+
+let prim_uni_ops : (Prims.string * Prims.string) Prims.list = ((("op_Negation"), ("not")))::((("op_Minus"), ("~-")))::((("op_Bang"), ("Support.ST.read")))::[]
+
+
+let prim_types = (fun uu____372 -> [])
+
+
+let prim_constructors : (Prims.string * Prims.string) Prims.list = ((("Some"), ("Some")))::((("None"), ("None")))::((("Nil"), ("[]")))::((("Cons"), ("::")))::[]
+
+
+let is_prims_ns : FStar_Extraction_ML_Syntax.mlsymbol Prims.list  ->  Prims.bool = (fun ns -> (ns = ("Prims")::[]))
+
+
+let as_bin_op : FStar_Extraction_ML_Syntax.mlpath  ->  (FStar_Extraction_ML_Syntax.mlsymbol * (Prims.int * fixity) * Prims.string) Prims.option = (fun uu____400 -> (match (uu____400) with
+| (ns, x) -> begin
+(match ((is_prims_ns ns)) with
+| true -> begin
+(FStar_List.tryFind (fun uu____422 -> (match (uu____422) with
+| (y, uu____429, uu____430) -> begin
+(x = y)
+end)) infix_prim_ops)
+end
+| uu____435 -> begin
+None
+end)
+end))
+
+
+let is_bin_op : FStar_Extraction_ML_Syntax.mlpath  ->  Prims.bool = (fun p -> (
+
+let uu____444 = (as_bin_op p)
+in (uu____444 <> None)))
+
+
+let as_uni_op : FStar_Extraction_ML_Syntax.mlpath  ->  (FStar_Extraction_ML_Syntax.mlsymbol * Prims.string) Prims.option = (fun uu____467 -> (match (uu____467) with
+| (ns, x) -> begin
+(match ((is_prims_ns ns)) with
+| true -> begin
+(FStar_List.tryFind (fun uu____480 -> (match (uu____480) with
+| (y, uu____484) -> begin
+(x = y)
+end)) prim_uni_ops)
+end
+| uu____485 -> begin
+None
+end)
+end))
+
+
+let is_uni_op : FStar_Extraction_ML_Syntax.mlpath  ->  Prims.bool = (fun p -> (
+
+let uu____491 = (as_uni_op p)
+in (uu____491 <> None)))
+
+
+let is_standard_type : FStar_Extraction_ML_Syntax.mlpath  ->  Prims.bool = (fun p -> false)
+
+
+let as_standard_constructor : FStar_Extraction_ML_Syntax.mlpath  ->  (FStar_Extraction_ML_Syntax.mlsymbol * Prims.string) Prims.option = (fun uu____508 -> (match (uu____508) with
+| (ns, x) -> begin
+(match ((is_prims_ns ns)) with
+| true -> begin
+(FStar_List.tryFind (fun uu____521 -> (match (uu____521) with
+| (y, uu____525) -> begin
+(x = y)
+end)) prim_constructors)
+end
+| uu____526 -> begin
+None
+end)
+end))
+
+
+let is_standard_constructor : FStar_Extraction_ML_Syntax.mlpath  ->  Prims.bool = (fun p -> (
+
+let uu____532 = (as_standard_constructor p)
+in (uu____532 <> None)))
+
+
+let maybe_paren : ((Prims.int * fixity) * assoc)  ->  (Prims.int * fixity)  ->  FStar_Format.doc  ->  FStar_Format.doc = (fun uu____553 inner doc1 -> (match (uu____553) with
+| (outer, side) -> begin
+(
+
+let noparens = (fun _inner _outer side1 -> (
+
+let uu____586 = _inner
+in (match (uu____586) with
+| (pi, fi) -> begin
+(
+
+let uu____591 = _outer
+in (match (uu____591) with
+| (po, fo) -> begin
+((pi > po) || (match (((fi), (side1))) with
+| (Postfix, Left) -> begin
+true
+end
+| (Prefix, Right) -> begin
+true
+end
+| (Infix (Left), Left) -> begin
+((pi = po) && (fo = Infix (Left)))
+end
+| (Infix (Right), Right) -> begin
+((pi = po) && (fo = Infix (Right)))
+end
+| (Infix (Left), ILeft) -> begin
+((pi = po) && (fo = Infix (Left)))
+end
+| (Infix (Right), IRight) -> begin
+((pi = po) && (fo = Infix (Right)))
+end
+| (uu____596, NonAssoc) -> begin
+((pi = po) && (fi = fo))
+end
+| (uu____597, uu____598) -> begin
+false
+end))
+end))
+end)))
+in (match ((noparens inner outer side)) with
+| true -> begin
+doc1
+end
+| uu____599 -> begin
+(FStar_Format.parens doc1)
+end))
+end))
+
+
+let escape_byte_hex : FStar_BaseTypes.byte  ->  Prims.string = (fun x -> (Prims.strcat "\\x" (FStar_Util.hex_string_of_byte x)))
+
+
+let escape_char_hex : FStar_BaseTypes.char  ->  Prims.string = (fun x -> (escape_byte_hex (FStar_Util.byte_of_char x)))
+
+
+let escape_or : (FStar_Char.char  ->  Prims.string)  ->  FStar_Char.char  ->  Prims.string = (fun fallback uu___116_614 -> (match (uu___116_614) with
+| c when (c = '\\') -> begin
+"\\\\"
+end
+| c when (c = ' ') -> begin
+" "
+end
+| c when (c = '\b') -> begin
+"\\b"
+end
+| c when (c = '\t') -> begin
+"\\t"
+end
+| c when (c = '\r') -> begin
+"\\r"
+end
+| c when (c = '\n') -> begin
+"\\n"
+end
+| c when (c = '\'') -> begin
+"\\\'"
+end
+| c when (c = '\"') -> begin
+"\\\""
+end
+| c when (FStar_Util.is_letter_or_digit c) -> begin
+(FStar_Util.string_of_char c)
+end
+| c when (FStar_Util.is_punctuation c) -> begin
+(FStar_Util.string_of_char c)
+end
+| c when (FStar_Util.is_symbol c) -> begin
+(FStar_Util.string_of_char c)
+end
+| c -> begin
+(fallback c)
+end))
+
+
+let string_of_mlconstant : FStar_Extraction_ML_Syntax.mlconstant  ->  Prims.string = (fun sctt -> (match (sctt) with
+| FStar_Extraction_ML_Syntax.MLC_Unit -> begin
+"()"
+end
+| FStar_Extraction_ML_Syntax.MLC_Bool (true) -> begin
+"true"
+end
+| FStar_Extraction_ML_Syntax.MLC_Bool (false) -> begin
+"false"
+end
+| FStar_Extraction_ML_Syntax.MLC_Char (c) -> begin
+(
+
+let uu____633 = (
+
+let uu____634 = (escape_or escape_char_hex c)
+in (Prims.strcat uu____634 "\'"))
+in (Prims.strcat "\'" uu____633))
+end
+| FStar_Extraction_ML_Syntax.MLC_Int (s, Some (FStar_Const.Signed, FStar_Const.Int32)) -> begin
+(Prims.strcat s "l")
+end
+| FStar_Extraction_ML_Syntax.MLC_Int (s, Some (FStar_Const.Signed, FStar_Const.Int64)) -> begin
+(Prims.strcat s "L")
+end
+| (FStar_Extraction_ML_Syntax.MLC_Int (s, Some (_, FStar_Const.Int8))) | (FStar_Extraction_ML_Syntax.MLC_Int (s, Some (_, FStar_Const.Int16))) -> begin
+s
+end
+| FStar_Extraction_ML_Syntax.MLC_Int (s, None) -> begin
+(Prims.strcat "(Prims.parse_int \"" (Prims.strcat s "\")"))
+end
+| FStar_Extraction_ML_Syntax.MLC_Float (d) -> begin
+(FStar_Util.string_of_float d)
+end
+| FStar_Extraction_ML_Syntax.MLC_Bytes (bytes) -> begin
+(
+
+let uu____669 = (
+
+let uu____670 = (FStar_Bytes.f_encode escape_byte_hex bytes)
+in (Prims.strcat uu____670 "\""))
+in (Prims.strcat "\"" uu____669))
+end
+| FStar_Extraction_ML_Syntax.MLC_String (chars) -> begin
+(
+
+let uu____672 = (
+
+let uu____673 = (FStar_String.collect (escape_or FStar_Util.string_of_char) chars)
+in (Prims.strcat uu____673 "\""))
+in (Prims.strcat "\"" uu____672))
+end
+| uu____674 -> begin
+(failwith "TODO: extract integer constants properly into OCaml")
+end))
+
+
+let rec doc_of_mltype' : FStar_Extraction_ML_Syntax.mlsymbol  ->  level  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Format.doc = (fun currentModule outer ty -> (match (ty) with
+| FStar_Extraction_ML_Syntax.MLTY_Var (x) -> begin
+(
+
+let escape_tyvar = (fun s -> (match ((FStar_Util.starts_with s "\'_")) with
+| true -> begin
+(FStar_Util.replace_char s '_' 'u')
+end
+| uu____695 -> begin
+s
+end))
+in (
+
+let uu____696 = (
+
+let uu____697 = (FStar_Extraction_ML_Syntax.idsym x)
+in (FStar_All.pipe_left escape_tyvar uu____697))
+in (FStar_Format.text uu____696)))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Tuple (tys) -> begin
+(
+
+let doc1 = (FStar_List.map (doc_of_mltype currentModule ((t_prio_tpl), (Left))) tys)
+in (
+
+let doc2 = (
+
+let uu____705 = (
+
+let uu____706 = (FStar_Format.combine (FStar_Format.text " * ") doc1)
+in (FStar_Format.hbox uu____706))
+in (FStar_Format.parens uu____705))
+in doc2))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, name) -> begin
+(
+
+let args1 = (match (args) with
+| [] -> begin
+FStar_Format.empty
+end
+| (arg)::[] -> begin
+(doc_of_mltype currentModule ((t_prio_name), (Left)) arg)
+end
+| uu____715 -> begin
+(
+
+let args1 = (FStar_List.map (doc_of_mltype currentModule ((min_op_prec), (NonAssoc))) args)
+in (
+
+let uu____721 = (
+
+let uu____722 = (FStar_Format.combine (FStar_Format.text ", ") args1)
+in (FStar_Format.hbox uu____722))
+in (FStar_Format.parens uu____721)))
+end)
+in (
+
+let name1 = (ptsym currentModule name)
+in (
+
+let uu____724 = (FStar_Format.reduce1 ((args1)::((FStar_Format.text name1))::[]))
+in (FStar_Format.hbox uu____724))))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu____726, t2) -> begin
+(
+
+let d1 = (doc_of_mltype currentModule ((t_prio_fun), (Left)) t1)
+in (
+
+let d2 = (doc_of_mltype currentModule ((t_prio_fun), (Right)) t2)
+in (
+
+let uu____734 = (
+
+let uu____735 = (FStar_Format.reduce1 ((d1)::((FStar_Format.text " -> "))::(d2)::[]))
+in (FStar_Format.hbox uu____735))
+in (maybe_paren outer t_prio_fun uu____734))))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Top -> begin
+(
+
+let uu____736 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____736) with
+| true -> begin
+(FStar_Format.text "obj")
+end
+| uu____737 -> begin
+(FStar_Format.text "Obj.t")
+end))
+end))
+and doc_of_mltype : FStar_Extraction_ML_Syntax.mlsymbol  ->  level  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Format.doc = (fun currentModule outer ty -> (doc_of_mltype' currentModule outer (FStar_Extraction_ML_Util.resugar_mlty ty)))
+
+
+let rec doc_of_expr : FStar_Extraction_ML_Syntax.mlsymbol  ->  level  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Format.doc = (fun currentModule outer e -> (match (e.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_Coerce (e1, t, t') -> begin
+(
+
+let doc1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let uu____788 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____788) with
+| true -> begin
+(
+
+let uu____789 = (FStar_Format.reduce (((FStar_Format.text "Prims.checked_cast"))::(doc1)::[]))
+in (FStar_Format.parens uu____789))
+end
+| uu____790 -> begin
+(
+
+let uu____791 = (FStar_Format.reduce (((FStar_Format.text "Obj.magic "))::((FStar_Format.parens doc1))::[]))
+in (FStar_Format.parens uu____791))
+end)))
+end
+| FStar_Extraction_ML_Syntax.MLE_Seq (es) -> begin
+(
+
+let docs = (FStar_List.map (doc_of_expr currentModule ((min_op_prec), (NonAssoc))) es)
+in (
+
+let docs1 = (FStar_List.map (fun d -> (FStar_Format.reduce ((d)::((FStar_Format.text ";"))::(FStar_Format.hardline)::[]))) docs)
+in (
+
+let uu____801 = (FStar_Format.reduce docs1)
+in (FStar_Format.parens uu____801))))
+end
+| FStar_Extraction_ML_Syntax.MLE_Const (c) -> begin
+(
+
+let uu____803 = (string_of_mlconstant c)
+in (FStar_Format.text uu____803))
+end
+| FStar_Extraction_ML_Syntax.MLE_Var (x, uu____805) -> begin
+(FStar_Format.text x)
+end
+| FStar_Extraction_ML_Syntax.MLE_Name (path) -> begin
+(
+
+let uu____807 = (ptsym currentModule path)
+in (FStar_Format.text uu____807))
+end
+| FStar_Extraction_ML_Syntax.MLE_Record (path, fields) -> begin
+(
+
+let for1 = (fun uu____823 -> (match (uu____823) with
+| (name, e1) -> begin
+(
+
+let doc1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let uu____831 = (
+
+let uu____833 = (
+
+let uu____834 = (ptsym currentModule ((path), (name)))
+in (FStar_Format.text uu____834))
+in (uu____833)::((FStar_Format.text "="))::(doc1)::[])
+in (FStar_Format.reduce1 uu____831)))
+end))
+in (
+
+let uu____836 = (
+
+let uu____837 = (FStar_List.map for1 fields)
+in (FStar_Format.combine (FStar_Format.text "; ") uu____837))
+in (FStar_Format.cbrackets uu____836)))
+end
+| FStar_Extraction_ML_Syntax.MLE_CTor (ctor, []) -> begin
+(
+
+let name = (
+
+let uu____844 = (is_standard_constructor ctor)
+in (match (uu____844) with
+| true -> begin
+(
+
+let uu____845 = (
+
+let uu____848 = (as_standard_constructor ctor)
+in (FStar_Option.get uu____848))
+in (Prims.snd uu____845))
+end
+| uu____854 -> begin
+(ptctor currentModule ctor)
+end))
+in (FStar_Format.text name))
+end
+| FStar_Extraction_ML_Syntax.MLE_CTor (ctor, args) -> begin
+(
+
+let name = (
+
+let uu____860 = (is_standard_constructor ctor)
+in (match (uu____860) with
+| true -> begin
+(
+
+let uu____861 = (
+
+let uu____864 = (as_standard_constructor ctor)
+in (FStar_Option.get uu____864))
+in (Prims.snd uu____861))
+end
+| uu____870 -> begin
+(ptctor currentModule ctor)
+end))
+in (
+
+let args1 = (FStar_List.map (doc_of_expr currentModule ((min_op_prec), (NonAssoc))) args)
+in (
+
+let doc1 = (match (((name), (args1))) with
+| ("::", (x)::(xs)::[]) -> begin
+(FStar_Format.reduce (((FStar_Format.parens x))::((FStar_Format.text "::"))::(xs)::[]))
+end
+| (uu____880, uu____881) -> begin
+(
+
+let uu____884 = (
+
+let uu____886 = (
+
+let uu____888 = (
+
+let uu____889 = (FStar_Format.combine (FStar_Format.text ", ") args1)
+in (FStar_Format.parens uu____889))
+in (uu____888)::[])
+in ((FStar_Format.text name))::uu____886)
+in (FStar_Format.reduce1 uu____884))
+end)
+in (maybe_paren outer e_app_prio doc1))))
+end
+| FStar_Extraction_ML_Syntax.MLE_Tuple (es) -> begin
+(
+
+let docs = (FStar_List.map (fun x -> (
+
+let uu____895 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) x)
+in (FStar_Format.parens uu____895))) es)
+in (
+
+let docs1 = (
+
+let uu____899 = (FStar_Format.combine (FStar_Format.text ", ") docs)
+in (FStar_Format.parens uu____899))
+in docs1))
+end
+| FStar_Extraction_ML_Syntax.MLE_Let ((rec_, uu____901, lets), body) -> begin
+(
+
+let pre = (match ((e.FStar_Extraction_ML_Syntax.loc <> FStar_Extraction_ML_Syntax.dummy_loc)) with
+| true -> begin
+(
+
+let uu____911 = (
+
+let uu____913 = (
+
+let uu____915 = (doc_of_loc e.FStar_Extraction_ML_Syntax.loc)
+in (uu____915)::[])
+in (FStar_Format.hardline)::uu____913)
+in (FStar_Format.reduce uu____911))
+end
+| uu____916 -> begin
+FStar_Format.empty
+end)
+in (
+
+let doc1 = (doc_of_lets currentModule ((rec_), (false), (lets)))
+in (
+
+let body1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) body)
+in (
+
+let uu____922 = (
+
+let uu____923 = (
+
+let uu____925 = (
+
+let uu____927 = (
+
+let uu____929 = (FStar_Format.reduce1 (((FStar_Format.text "in"))::(body1)::[]))
+in (uu____929)::[])
+in (doc1)::uu____927)
+in (pre)::uu____925)
+in (FStar_Format.combine FStar_Format.hardline uu____923))
+in (FStar_Format.parens uu____922)))))
+end
+| FStar_Extraction_ML_Syntax.MLE_App (e1, args) -> begin
+(match (((e1.FStar_Extraction_ML_Syntax.expr), (args))) with
+| (FStar_Extraction_ML_Syntax.MLE_Name (p), ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Fun ((uu____936)::[], scrutinee); FStar_Extraction_ML_Syntax.mlty = uu____938; FStar_Extraction_ML_Syntax.loc = uu____939})::({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Fun (((arg, uu____941))::[], possible_match); FStar_Extraction_ML_Syntax.mlty = uu____943; FStar_Extraction_ML_Syntax.loc = uu____944})::[]) when (
+
+let uu____962 = (FStar_Extraction_ML_Syntax.string_of_mlpath p)
+in (uu____962 = "FStar.All.try_with")) -> begin
+(
+
+let branches = (match (possible_match) with
+| {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Match ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Var (arg'); FStar_Extraction_ML_Syntax.mlty = uu____975; FStar_Extraction_ML_Syntax.loc = uu____976}, branches); FStar_Extraction_ML_Syntax.mlty = uu____978; FStar_Extraction_ML_Syntax.loc = uu____979} when (
+
+let uu____990 = (FStar_Extraction_ML_Syntax.idsym arg)
+in (
+
+let uu____991 = (FStar_Extraction_ML_Syntax.idsym arg')
+in (uu____990 = uu____991))) -> begin
+branches
+end
+| e2 -> begin
+(((FStar_Extraction_ML_Syntax.MLP_Wild), (None), (e2)))::[]
+end)
+in (doc_of_expr currentModule outer {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Try (((scrutinee), (branches))); FStar_Extraction_ML_Syntax.mlty = possible_match.FStar_Extraction_ML_Syntax.mlty; FStar_Extraction_ML_Syntax.loc = possible_match.FStar_Extraction_ML_Syntax.loc}))
+end
+| (FStar_Extraction_ML_Syntax.MLE_Name (p), (e11)::(e2)::[]) when (is_bin_op p) -> begin
+(doc_of_binop currentModule p e11 e2)
+end
+| (FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____1012; FStar_Extraction_ML_Syntax.loc = uu____1013}, (unitVal)::[]), (e11)::(e2)::[]) when ((is_bin_op p) && (unitVal = FStar_Extraction_ML_Syntax.ml_unit)) -> begin
+(doc_of_binop currentModule p e11 e2)
+end
+| (FStar_Extraction_ML_Syntax.MLE_Name (p), (e11)::[]) when (is_uni_op p) -> begin
+(doc_of_uniop currentModule p e11)
+end
+| (FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (p); FStar_Extraction_ML_Syntax.mlty = uu____1023; FStar_Extraction_ML_Syntax.loc = uu____1024}, (unitVal)::[]), (e11)::[]) when ((is_uni_op p) && (unitVal = FStar_Extraction_ML_Syntax.ml_unit)) -> begin
+(doc_of_uniop currentModule p e11)
+end
+| uu____1029 -> begin
+(
+
+let e2 = (doc_of_expr currentModule ((e_app_prio), (ILeft)) e1)
+in (
+
+let args1 = (FStar_List.map (doc_of_expr currentModule ((e_app_prio), (IRight))) args)
+in (
+
+let uu____1040 = (FStar_Format.reduce1 ((e2)::args1))
+in (FStar_Format.parens uu____1040))))
+end)
+end
+| FStar_Extraction_ML_Syntax.MLE_Proj (e1, f) -> begin
+(
+
+let e2 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let doc1 = (
+
+let uu____1047 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____1047) with
+| true -> begin
+(FStar_Format.reduce ((e2)::((FStar_Format.text "."))::((FStar_Format.text (Prims.snd f)))::[]))
+end
+| uu____1049 -> begin
+(
+
+let uu____1050 = (
+
+let uu____1052 = (
+
+let uu____1054 = (
+
+let uu____1056 = (
+
+let uu____1057 = (ptsym currentModule f)
+in (FStar_Format.text uu____1057))
+in (uu____1056)::[])
+in ((FStar_Format.text "."))::uu____1054)
+in (e2)::uu____1052)
+in (FStar_Format.reduce uu____1050))
+end))
+in doc1))
+end
+| FStar_Extraction_ML_Syntax.MLE_Fun (ids, body) -> begin
+(
+
+let bvar_annot = (fun x xt -> (
+
+let uu____1075 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____1075) with
+| true -> begin
+(
+
+let uu____1076 = (
+
+let uu____1078 = (
+
+let uu____1080 = (
+
+let uu____1082 = (match (xt) with
+| Some (xxt) -> begin
+(
+
+let uu____1084 = (
+
+let uu____1086 = (
+
+let uu____1088 = (doc_of_mltype currentModule outer xxt)
+in (uu____1088)::[])
+in ((FStar_Format.text " : "))::uu____1086)
+in (FStar_Format.reduce1 uu____1084))
+end
+| uu____1089 -> begin
+(FStar_Format.text "")
+end)
+in (uu____1082)::((FStar_Format.text ")"))::[])
+in ((FStar_Format.text x))::uu____1080)
+in ((FStar_Format.text "("))::uu____1078)
+in (FStar_Format.reduce1 uu____1076))
+end
+| uu____1091 -> begin
+(FStar_Format.text x)
+end)))
+in (
+
+let ids1 = (FStar_List.map (fun uu____1098 -> (match (uu____1098) with
+| ((x, uu____1104), xt) -> begin
+(bvar_annot x (Some (xt)))
+end)) ids)
+in (
+
+let body1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) body)
+in (
+
+let doc1 = (
+
+let uu____1112 = (
+
+let uu____1114 = (
+
+let uu____1116 = (FStar_Format.reduce1 ids1)
+in (uu____1116)::((FStar_Format.text "->"))::(body1)::[])
+in ((FStar_Format.text "fun"))::uu____1114)
+in (FStar_Format.reduce1 uu____1112))
+in (FStar_Format.parens doc1)))))
+end
+| FStar_Extraction_ML_Syntax.MLE_If (cond, e1, None) -> begin
+(
+
+let cond1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) cond)
+in (
+
+let doc1 = (
+
+let uu____1124 = (
+
+let uu____1126 = (FStar_Format.reduce1 (((FStar_Format.text "if"))::(cond1)::((FStar_Format.text "then"))::((FStar_Format.text "begin"))::[]))
+in (
+
+let uu____1127 = (
+
+let uu____1129 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (uu____1129)::((FStar_Format.text "end"))::[])
+in (uu____1126)::uu____1127))
+in (FStar_Format.combine FStar_Format.hardline uu____1124))
+in (maybe_paren outer e_bin_prio_if doc1)))
+end
+| FStar_Extraction_ML_Syntax.MLE_If (cond, e1, Some (e2)) -> begin
+(
+
+let cond1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) cond)
+in (
+
+let doc1 = (
+
+let uu____1140 = (
+
+let uu____1142 = (FStar_Format.reduce1 (((FStar_Format.text "if"))::(cond1)::((FStar_Format.text "then"))::((FStar_Format.text "begin"))::[]))
+in (
+
+let uu____1143 = (
+
+let uu____1145 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let uu____1148 = (
+
+let uu____1150 = (FStar_Format.reduce1 (((FStar_Format.text "end"))::((FStar_Format.text "else"))::((FStar_Format.text "begin"))::[]))
+in (
+
+let uu____1151 = (
+
+let uu____1153 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e2)
+in (uu____1153)::((FStar_Format.text "end"))::[])
+in (uu____1150)::uu____1151))
+in (uu____1145)::uu____1148))
+in (uu____1142)::uu____1143))
+in (FStar_Format.combine FStar_Format.hardline uu____1140))
+in (maybe_paren outer e_bin_prio_if doc1)))
+end
+| FStar_Extraction_ML_Syntax.MLE_Match (cond, pats) -> begin
+(
+
+let cond1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) cond)
+in (
+
+let pats1 = (FStar_List.map (doc_of_branch currentModule) pats)
+in (
+
+let doc1 = (
+
+let uu____1175 = (FStar_Format.reduce1 (((FStar_Format.text "match"))::((FStar_Format.parens cond1))::((FStar_Format.text "with"))::[]))
+in (uu____1175)::pats1)
+in (
+
+let doc2 = (FStar_Format.combine FStar_Format.hardline doc1)
+in (FStar_Format.parens doc2)))))
+end
+| FStar_Extraction_ML_Syntax.MLE_Raise (exn, []) -> begin
+(
+
+let uu____1179 = (
+
+let uu____1181 = (
+
+let uu____1183 = (
+
+let uu____1184 = (ptctor currentModule exn)
+in (FStar_Format.text uu____1184))
+in (uu____1183)::[])
+in ((FStar_Format.text "raise"))::uu____1181)
+in (FStar_Format.reduce1 uu____1179))
+end
+| FStar_Extraction_ML_Syntax.MLE_Raise (exn, args) -> begin
+(
+
+let args1 = (FStar_List.map (doc_of_expr currentModule ((min_op_prec), (NonAssoc))) args)
+in (
+
+let uu____1193 = (
+
+let uu____1195 = (
+
+let uu____1197 = (
+
+let uu____1198 = (ptctor currentModule exn)
+in (FStar_Format.text uu____1198))
+in (
+
+let uu____1199 = (
+
+let uu____1201 = (
+
+let uu____1202 = (FStar_Format.combine (FStar_Format.text ", ") args1)
+in (FStar_Format.parens uu____1202))
+in (uu____1201)::[])
+in (uu____1197)::uu____1199))
+in ((FStar_Format.text "raise"))::uu____1195)
+in (FStar_Format.reduce1 uu____1193)))
+end
+| FStar_Extraction_ML_Syntax.MLE_Try (e1, pats) -> begin
+(
+
+let uu____1215 = (
+
+let uu____1217 = (
+
+let uu____1219 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let uu____1222 = (
+
+let uu____1224 = (
+
+let uu____1226 = (
+
+let uu____1227 = (FStar_List.map (doc_of_branch currentModule) pats)
+in (FStar_Format.combine FStar_Format.hardline uu____1227))
+in (uu____1226)::[])
+in ((FStar_Format.text "with"))::uu____1224)
+in (uu____1219)::uu____1222))
+in ((FStar_Format.text "try"))::uu____1217)
+in (FStar_Format.combine FStar_Format.hardline uu____1215))
+end))
+and doc_of_binop : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Format.doc = (fun currentModule p e1 e2 -> (
+
+let uu____1233 = (
+
+let uu____1239 = (as_bin_op p)
+in (FStar_Option.get uu____1239))
+in (match (uu____1233) with
+| (uu____1251, prio, txt) -> begin
+(
+
+let e11 = (doc_of_expr currentModule ((prio), (Left)) e1)
+in (
+
+let e21 = (doc_of_expr currentModule ((prio), (Right)) e2)
+in (
+
+let doc1 = (FStar_Format.reduce1 ((e11)::((FStar_Format.text txt))::(e21)::[]))
+in (FStar_Format.parens doc1))))
+end)))
+and doc_of_uniop : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Format.doc = (fun currentModule p e1 -> (
+
+let uu____1268 = (
+
+let uu____1271 = (as_uni_op p)
+in (FStar_Option.get uu____1271))
+in (match (uu____1268) with
+| (uu____1277, txt) -> begin
+(
+
+let e11 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e1)
+in (
+
+let doc1 = (FStar_Format.reduce1 (((FStar_Format.text txt))::((FStar_Format.parens e11))::[]))
+in (FStar_Format.parens doc1)))
+end)))
+and doc_of_pattern : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlpattern  ->  FStar_Format.doc = (fun currentModule pattern -> (match (pattern) with
+| FStar_Extraction_ML_Syntax.MLP_Wild -> begin
+(FStar_Format.text "_")
+end
+| FStar_Extraction_ML_Syntax.MLP_Const (c) -> begin
+(
+
+let uu____1286 = (string_of_mlconstant c)
+in (FStar_Format.text uu____1286))
+end
+| FStar_Extraction_ML_Syntax.MLP_Var (x) -> begin
+(FStar_Format.text (Prims.fst x))
+end
+| FStar_Extraction_ML_Syntax.MLP_Record (path, fields) -> begin
+(
+
+let for1 = (fun uu____1303 -> (match (uu____1303) with
+| (name, p) -> begin
+(
+
+let uu____1308 = (
+
+let uu____1310 = (
+
+let uu____1311 = (ptsym currentModule ((path), (name)))
+in (FStar_Format.text uu____1311))
+in (
+
+let uu____1313 = (
+
+let uu____1315 = (
+
+let uu____1317 = (doc_of_pattern currentModule p)
+in (uu____1317)::[])
+in ((FStar_Format.text "="))::uu____1315)
+in (uu____1310)::uu____1313))
+in (FStar_Format.reduce1 uu____1308))
+end))
+in (
+
+let uu____1318 = (
+
+let uu____1319 = (FStar_List.map for1 fields)
+in (FStar_Format.combine (FStar_Format.text "; ") uu____1319))
+in (FStar_Format.cbrackets uu____1318)))
+end
+| FStar_Extraction_ML_Syntax.MLP_CTor (ctor, []) -> begin
+(
+
+let name = (
+
+let uu____1326 = (is_standard_constructor ctor)
+in (match (uu____1326) with
+| true -> begin
+(
+
+let uu____1327 = (
+
+let uu____1330 = (as_standard_constructor ctor)
+in (FStar_Option.get uu____1330))
+in (Prims.snd uu____1327))
+end
+| uu____1336 -> begin
+(ptctor currentModule ctor)
+end))
+in (FStar_Format.text name))
+end
+| FStar_Extraction_ML_Syntax.MLP_CTor (ctor, pats) -> begin
+(
+
+let name = (
+
+let uu____1342 = (is_standard_constructor ctor)
+in (match (uu____1342) with
+| true -> begin
+(
+
+let uu____1343 = (
+
+let uu____1346 = (as_standard_constructor ctor)
+in (FStar_Option.get uu____1346))
+in (Prims.snd uu____1343))
+end
+| uu____1352 -> begin
+(ptctor currentModule ctor)
+end))
+in (
+
+let doc1 = (match (((name), (pats))) with
+| ("::", (x)::(xs)::[]) -> begin
+(
+
+let uu____1358 = (
+
+let uu____1360 = (
+
+let uu____1361 = (doc_of_pattern currentModule x)
+in (FStar_Format.parens uu____1361))
+in (
+
+let uu____1362 = (
+
+let uu____1364 = (
+
+let uu____1366 = (doc_of_pattern currentModule xs)
+in (uu____1366)::[])
+in ((FStar_Format.text "::"))::uu____1364)
+in (uu____1360)::uu____1362))
+in (FStar_Format.reduce uu____1358))
+end
+| (uu____1367, (FStar_Extraction_ML_Syntax.MLP_Tuple (uu____1368))::[]) -> begin
+(
+
+let uu____1371 = (
+
+let uu____1373 = (
+
+let uu____1375 = (
+
+let uu____1376 = (FStar_List.hd pats)
+in (doc_of_pattern currentModule uu____1376))
+in (uu____1375)::[])
+in ((FStar_Format.text name))::uu____1373)
+in (FStar_Format.reduce1 uu____1371))
+end
+| uu____1377 -> begin
+(
+
+let uu____1381 = (
+
+let uu____1383 = (
+
+let uu____1385 = (
+
+let uu____1386 = (
+
+let uu____1387 = (FStar_List.map (doc_of_pattern currentModule) pats)
+in (FStar_Format.combine (FStar_Format.text ", ") uu____1387))
+in (FStar_Format.parens uu____1386))
+in (uu____1385)::[])
+in ((FStar_Format.text name))::uu____1383)
+in (FStar_Format.reduce1 uu____1381))
+end)
+in (maybe_paren ((min_op_prec), (NonAssoc)) e_app_prio doc1)))
+end
+| FStar_Extraction_ML_Syntax.MLP_Tuple (ps) -> begin
+(
+
+let ps1 = (FStar_List.map (doc_of_pattern currentModule) ps)
+in (
+
+let uu____1395 = (FStar_Format.combine (FStar_Format.text ", ") ps1)
+in (FStar_Format.parens uu____1395)))
+end
+| FStar_Extraction_ML_Syntax.MLP_Branch (ps) -> begin
+(
+
+let ps1 = (FStar_List.map (doc_of_pattern currentModule) ps)
+in (
+
+let ps2 = (FStar_List.map FStar_Format.parens ps1)
+in (FStar_Format.combine (FStar_Format.text " | ") ps2)))
+end))
+and doc_of_branch : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlbranch  ->  FStar_Format.doc = (fun currentModule uu____1403 -> (match (uu____1403) with
+| (p, cond, e) -> begin
+(
+
+let case = (match (cond) with
+| None -> begin
+(
+
+let uu____1410 = (
+
+let uu____1412 = (
+
+let uu____1414 = (doc_of_pattern currentModule p)
+in (uu____1414)::[])
+in ((FStar_Format.text "|"))::uu____1412)
+in (FStar_Format.reduce1 uu____1410))
+end
+| Some (c) -> begin
+(
+
+let c1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) c)
+in (
+
+let uu____1419 = (
+
+let uu____1421 = (
+
+let uu____1423 = (doc_of_pattern currentModule p)
+in (uu____1423)::((FStar_Format.text "when"))::(c1)::[])
+in ((FStar_Format.text "|"))::uu____1421)
+in (FStar_Format.reduce1 uu____1419)))
+end)
+in (
+
+let uu____1424 = (
+
+let uu____1426 = (FStar_Format.reduce1 ((case)::((FStar_Format.text "->"))::((FStar_Format.text "begin"))::[]))
+in (
+
+let uu____1427 = (
+
+let uu____1429 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e)
+in (uu____1429)::((FStar_Format.text "end"))::[])
+in (uu____1426)::uu____1427))
+in (FStar_Format.combine FStar_Format.hardline uu____1424)))
+end))
+and doc_of_lets : FStar_Extraction_ML_Syntax.mlsymbol  ->  (FStar_Extraction_ML_Syntax.mlletflavor * Prims.bool * FStar_Extraction_ML_Syntax.mllb Prims.list)  ->  FStar_Format.doc = (fun currentModule uu____1433 -> (match (uu____1433) with
+| (rec_, top_level, lets) -> begin
+(
+
+let for1 = (fun uu____1446 -> (match (uu____1446) with
+| {FStar_Extraction_ML_Syntax.mllb_name = name; FStar_Extraction_ML_Syntax.mllb_tysc = tys; FStar_Extraction_ML_Syntax.mllb_add_unit = uu____1449; FStar_Extraction_ML_Syntax.mllb_def = e; FStar_Extraction_ML_Syntax.print_typ = pt} -> begin
+(
+
+let e1 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e)
+in (
+
+let ids = []
+in (
+
+let ids1 = (FStar_List.map (fun uu____1466 -> (match (uu____1466) with
+| (x, uu____1470) -> begin
+(FStar_Format.text x)
+end)) ids)
+in (
+
+let ty_annot = (match ((not (pt))) with
+| true -> begin
+(FStar_Format.text "")
+end
+| uu____1472 -> begin
+(
+
+let uu____1473 = ((FStar_Extraction_ML_Util.codegen_fsharp ()) && ((rec_ = FStar_Extraction_ML_Syntax.Rec) || top_level))
+in (match (uu____1473) with
+| true -> begin
+(match (tys) with
+| (Some ((_)::_, _)) | (None) -> begin
+(FStar_Format.text "")
+end
+| Some ([], ty) -> begin
+(
+
+let ty1 = (doc_of_mltype currentModule ((min_op_prec), (NonAssoc)) ty)
+in (FStar_Format.reduce1 (((FStar_Format.text ":"))::(ty1)::[])))
+end)
+end
+| uu____1489 -> begin
+(match (top_level) with
+| true -> begin
+(match (tys) with
+| (None) | (Some ((_)::_, _)) -> begin
+(FStar_Format.text "")
+end
+| Some ([], ty) -> begin
+(
+
+let ty1 = (doc_of_mltype currentModule ((min_op_prec), (NonAssoc)) ty)
+in (FStar_Format.reduce1 (((FStar_Format.text ":"))::(ty1)::[])))
+end)
+end
+| uu____1505 -> begin
+(FStar_Format.text "")
+end)
+end))
+end)
+in (
+
+let uu____1506 = (
+
+let uu____1508 = (
+
+let uu____1509 = (FStar_Extraction_ML_Syntax.idsym name)
+in (FStar_Format.text uu____1509))
+in (
+
+let uu____1510 = (
+
+let uu____1512 = (FStar_Format.reduce1 ids1)
+in (uu____1512)::(ty_annot)::((FStar_Format.text "="))::(e1)::[])
+in (uu____1508)::uu____1510))
+in (FStar_Format.reduce1 uu____1506))))))
+end))
+in (
+
+let letdoc = (match ((rec_ = FStar_Extraction_ML_Syntax.Rec)) with
+| true -> begin
+(FStar_Format.reduce1 (((FStar_Format.text "let"))::((FStar_Format.text "rec"))::[]))
+end
+| uu____1514 -> begin
+(FStar_Format.text "let")
+end)
+in (
+
+let lets1 = (FStar_List.map for1 lets)
+in (
+
+let lets2 = (FStar_List.mapi (fun i doc1 -> (FStar_Format.reduce1 (((match ((i = (Prims.parse_int "0"))) with
+| true -> begin
+letdoc
+end
+| uu____1521 -> begin
+(FStar_Format.text "and")
+end))::(doc1)::[]))) lets1)
+in (FStar_Format.combine FStar_Format.hardline lets2)))))
+end))
+and doc_of_loc : FStar_Extraction_ML_Syntax.mlloc  ->  FStar_Format.doc = (fun uu____1522 -> (match (uu____1522) with
+| (lineno, file) -> begin
+(
+
+let uu____1525 = ((FStar_Options.no_location_info ()) || (FStar_Extraction_ML_Util.codegen_fsharp ()))
+in (match (uu____1525) with
+| true -> begin
+FStar_Format.empty
+end
+| uu____1526 -> begin
+(
+
+let file1 = (FStar_Util.basename file)
+in (FStar_Format.reduce1 (((FStar_Format.text "#"))::((FStar_Format.num lineno))::((FStar_Format.text (Prims.strcat "\"" (Prims.strcat file1 "\""))))::[])))
+end))
+end))
+
+
+let doc_of_mltydecl : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mltydecl  ->  FStar_Format.doc = (fun currentModule decls -> (
+
+let for1 = (fun uu____1545 -> (match (uu____1545) with
+| (uu____1554, x, mangle_opt, tparams, body) -> begin
+(
+
+let x1 = (match (mangle_opt) with
+| None -> begin
+x
+end
+| Some (y) -> begin
+y
+end)
+in (
+
+let tparams1 = (match (tparams) with
+| [] -> begin
+FStar_Format.empty
+end
+| (x2)::[] -> begin
+(
+
+let uu____1569 = (FStar_Extraction_ML_Syntax.idsym x2)
+in (FStar_Format.text uu____1569))
+end
+| uu____1570 -> begin
+(
+
+let doc1 = (FStar_List.map (fun x2 -> (
+
+let uu____1575 = (FStar_Extraction_ML_Syntax.idsym x2)
+in (FStar_Format.text uu____1575))) tparams)
+in (
+
+let uu____1576 = (FStar_Format.combine (FStar_Format.text ", ") doc1)
+in (FStar_Format.parens uu____1576)))
+end)
+in (
+
+let forbody = (fun body1 -> (match (body1) with
+| FStar_Extraction_ML_Syntax.MLTD_Abbrev (ty) -> begin
+(doc_of_mltype currentModule ((min_op_prec), (NonAssoc)) ty)
+end
+| FStar_Extraction_ML_Syntax.MLTD_Record (fields) -> begin
+(
+
+let forfield = (fun uu____1593 -> (match (uu____1593) with
+| (name, ty) -> begin
+(
+
+let name1 = (FStar_Format.text name)
+in (
+
+let ty1 = (doc_of_mltype currentModule ((min_op_prec), (NonAssoc)) ty)
+in (FStar_Format.reduce1 ((name1)::((FStar_Format.text ":"))::(ty1)::[]))))
+end))
+in (
+
+let uu____1602 = (
+
+let uu____1603 = (FStar_List.map forfield fields)
+in (FStar_Format.combine (FStar_Format.text "; ") uu____1603))
+in (FStar_Format.cbrackets uu____1602)))
+end
+| FStar_Extraction_ML_Syntax.MLTD_DType (ctors) -> begin
+(
+
+let forctor = (fun uu____1618 -> (match (uu____1618) with
+| (name, tys) -> begin
+(match (tys) with
+| [] -> begin
+(FStar_Format.text name)
+end
+| uu____1626 -> begin
+(
+
+let tys1 = (FStar_List.map (doc_of_mltype currentModule ((t_prio_tpl), (Left))) tys)
+in (
+
+let tys2 = (FStar_Format.combine (FStar_Format.text " * ") tys1)
+in (FStar_Format.reduce1 (((FStar_Format.text name))::((FStar_Format.text "of"))::(tys2)::[]))))
+end)
+end))
+in (
+
+let ctors1 = (FStar_List.map forctor ctors)
+in (
+
+let ctors2 = (FStar_List.map (fun d -> (FStar_Format.reduce1 (((FStar_Format.text "|"))::(d)::[]))) ctors1)
+in (FStar_Format.combine FStar_Format.hardline ctors2))))
+end))
+in (
+
+let doc1 = (
+
+let uu____1642 = (
+
+let uu____1644 = (
+
+let uu____1646 = (
+
+let uu____1647 = (ptsym currentModule (([]), (x1)))
+in (FStar_Format.text uu____1647))
+in (uu____1646)::[])
+in (tparams1)::uu____1644)
+in (FStar_Format.reduce1 uu____1642))
+in (match (body) with
+| None -> begin
+doc1
+end
+| Some (body1) -> begin
+(
+
+let body2 = (forbody body1)
+in (
+
+let uu____1651 = (
+
+let uu____1653 = (FStar_Format.reduce1 ((doc1)::((FStar_Format.text "="))::[]))
+in (uu____1653)::(body2)::[])
+in (FStar_Format.combine FStar_Format.hardline uu____1651)))
+end)))))
+end))
+in (
+
+let doc1 = (FStar_List.map for1 decls)
+in (
+
+let doc2 = (match (((FStar_List.length doc1) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____1668 = (
+
+let uu____1670 = (
+
+let uu____1672 = (FStar_Format.combine (FStar_Format.text " \n and ") doc1)
+in (uu____1672)::[])
+in ((FStar_Format.text "type"))::uu____1670)
+in (FStar_Format.reduce1 uu____1668))
+end
+| uu____1673 -> begin
+(FStar_Format.text "")
+end)
+in doc2))))
+
+
+let rec doc_of_sig1 : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlsig1  ->  FStar_Format.doc = (fun currentModule s -> (match (s) with
+| FStar_Extraction_ML_Syntax.MLS_Mod (x, subsig) -> begin
+(
+
+let uu____1688 = (
+
+let uu____1690 = (FStar_Format.reduce1 (((FStar_Format.text "module"))::((FStar_Format.text x))::((FStar_Format.text "="))::[]))
+in (
+
+let uu____1691 = (
+
+let uu____1693 = (doc_of_sig currentModule subsig)
+in (
+
+let uu____1694 = (
+
+let uu____1696 = (FStar_Format.reduce1 (((FStar_Format.text "end"))::[]))
+in (uu____1696)::[])
+in (uu____1693)::uu____1694))
+in (uu____1690)::uu____1691))
+in (FStar_Format.combine FStar_Format.hardline uu____1688))
+end
+| FStar_Extraction_ML_Syntax.MLS_Exn (x, []) -> begin
+(FStar_Format.reduce1 (((FStar_Format.text "exception"))::((FStar_Format.text x))::[]))
+end
+| FStar_Extraction_ML_Syntax.MLS_Exn (x, args) -> begin
+(
+
+let args1 = (FStar_List.map (doc_of_mltype currentModule ((min_op_prec), (NonAssoc))) args)
+in (
+
+let args2 = (
+
+let uu____1708 = (FStar_Format.combine (FStar_Format.text " * ") args1)
+in (FStar_Format.parens uu____1708))
+in (FStar_Format.reduce1 (((FStar_Format.text "exception"))::((FStar_Format.text x))::((FStar_Format.text "of"))::(args2)::[]))))
+end
+| FStar_Extraction_ML_Syntax.MLS_Val (x, (uu____1710, ty)) -> begin
+(
+
+let ty1 = (doc_of_mltype currentModule ((min_op_prec), (NonAssoc)) ty)
+in (FStar_Format.reduce1 (((FStar_Format.text "val"))::((FStar_Format.text x))::((FStar_Format.text ": "))::(ty1)::[])))
+end
+| FStar_Extraction_ML_Syntax.MLS_Ty (decls) -> begin
+(doc_of_mltydecl currentModule decls)
+end))
+and doc_of_sig : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlsig  ->  FStar_Format.doc = (fun currentModule s -> (
+
+let docs = (FStar_List.map (doc_of_sig1 currentModule) s)
+in (
+
+let docs1 = (FStar_List.map (fun x -> (FStar_Format.reduce ((x)::(FStar_Format.hardline)::(FStar_Format.hardline)::[]))) docs)
+in (FStar_Format.reduce docs1))))
+
+
+let doc_of_mod1 : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlmodule1  ->  FStar_Format.doc = (fun currentModule m -> (match (m) with
+| FStar_Extraction_ML_Syntax.MLM_Exn (x, []) -> begin
+(FStar_Format.reduce1 (((FStar_Format.text "exception"))::((FStar_Format.text x))::[]))
+end
+| FStar_Extraction_ML_Syntax.MLM_Exn (x, args) -> begin
+(
+
+let args1 = (FStar_List.map (doc_of_mltype currentModule ((min_op_prec), (NonAssoc))) args)
+in (
+
+let args2 = (
+
+let uu____1742 = (FStar_Format.combine (FStar_Format.text " * ") args1)
+in (FStar_Format.parens uu____1742))
+in (FStar_Format.reduce1 (((FStar_Format.text "exception"))::((FStar_Format.text x))::((FStar_Format.text "of"))::(args2)::[]))))
+end
+| FStar_Extraction_ML_Syntax.MLM_Ty (decls) -> begin
+(doc_of_mltydecl currentModule decls)
+end
+| FStar_Extraction_ML_Syntax.MLM_Let (rec_, uu____1745, lets) -> begin
+(doc_of_lets currentModule ((rec_), (true), (lets)))
+end
+| FStar_Extraction_ML_Syntax.MLM_Top (e) -> begin
+(
+
+let uu____1751 = (
+
+let uu____1753 = (
+
+let uu____1755 = (
+
+let uu____1757 = (
+
+let uu____1759 = (doc_of_expr currentModule ((min_op_prec), (NonAssoc)) e)
+in (uu____1759)::[])
+in ((FStar_Format.text "="))::uu____1757)
+in ((FStar_Format.text "_"))::uu____1755)
+in ((FStar_Format.text "let"))::uu____1753)
+in (FStar_Format.reduce1 uu____1751))
+end
+| FStar_Extraction_ML_Syntax.MLM_Loc (loc) -> begin
+(doc_of_loc loc)
+end))
+
+
+let doc_of_mod : FStar_Extraction_ML_Syntax.mlsymbol  ->  FStar_Extraction_ML_Syntax.mlmodule  ->  FStar_Format.doc = (fun currentModule m -> (
+
+let docs = (FStar_List.map (fun x -> (
+
+let doc1 = (doc_of_mod1 currentModule x)
+in (doc1)::((match (x) with
+| FStar_Extraction_ML_Syntax.MLM_Loc (uu____1775) -> begin
+FStar_Format.empty
+end
+| uu____1776 -> begin
+FStar_Format.hardline
+end))::(FStar_Format.hardline)::[])) m)
+in (FStar_Format.reduce (FStar_List.flatten docs))))
+
+
+let rec doc_of_mllib_r : FStar_Extraction_ML_Syntax.mllib  ->  (Prims.string * FStar_Format.doc) Prims.list = (fun uu____1782 -> (match (uu____1782) with
+| FStar_Extraction_ML_Syntax.MLLib (mllib) -> begin
+(
+
+let rec for1_sig = (fun uu____1820 -> (match (uu____1820) with
+| (x, sigmod, FStar_Extraction_ML_Syntax.MLLib (sub1)) -> begin
+(
+
+let x1 = (FStar_Extraction_ML_Util.flatten_mlpath x)
+in (
+
+let head1 = (FStar_Format.reduce1 (((FStar_Format.text "module"))::((FStar_Format.text x1))::((FStar_Format.text ":"))::((FStar_Format.text "sig"))::[]))
+in (
+
+let tail1 = (FStar_Format.reduce1 (((FStar_Format.text "end"))::[]))
+in (
+
+let doc1 = (FStar_Option.map (fun uu____1859 -> (match (uu____1859) with
+| (s, uu____1863) -> begin
+(doc_of_sig x1 s)
+end)) sigmod)
+in (
+
+let sub2 = (FStar_List.map for1_sig sub1)
+in (
+
+let sub3 = (FStar_List.map (fun x2 -> (FStar_Format.reduce ((x2)::(FStar_Format.hardline)::(FStar_Format.hardline)::[]))) sub2)
+in (
+
+let uu____1878 = (
+
+let uu____1880 = (
+
+let uu____1882 = (
+
+let uu____1884 = (FStar_Format.reduce sub3)
+in (uu____1884)::((FStar_Format.cat tail1 FStar_Format.hardline))::[])
+in ((match (doc1) with
+| None -> begin
+FStar_Format.empty
+end
+| Some (s) -> begin
+(FStar_Format.cat s FStar_Format.hardline)
+end))::uu____1882)
+in ((FStar_Format.cat head1 FStar_Format.hardline))::uu____1880)
+in (FStar_Format.reduce uu____1878))))))))
+end))
+and for1_mod = (fun istop uu____1887 -> (match (uu____1887) with
+| (x, sigmod, FStar_Extraction_ML_Syntax.MLLib (sub1)) -> begin
+(
+
+let x1 = (FStar_Extraction_ML_Util.flatten_mlpath x)
+in (
+
+let head1 = (
+
+let uu____1921 = (
+
+let uu____1923 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____1923) with
+| true -> begin
+((FStar_Format.text "module"))::((FStar_Format.text x1))::[]
+end
+| uu____1925 -> begin
+(match ((not (istop))) with
+| true -> begin
+((FStar_Format.text "module"))::((FStar_Format.text x1))::((FStar_Format.text "="))::((FStar_Format.text "struct"))::[]
+end
+| uu____1927 -> begin
+[]
+end)
+end))
+in (FStar_Format.reduce1 uu____1921))
+in (
+
+let tail1 = (match ((not (istop))) with
+| true -> begin
+(FStar_Format.reduce1 (((FStar_Format.text "end"))::[]))
+end
+| uu____1929 -> begin
+(FStar_Format.reduce1 [])
+end)
+in (
+
+let doc1 = (FStar_Option.map (fun uu____1934 -> (match (uu____1934) with
+| (uu____1937, m) -> begin
+(doc_of_mod x1 m)
+end)) sigmod)
+in (
+
+let sub2 = (FStar_List.map (for1_mod false) sub1)
+in (
+
+let sub3 = (FStar_List.map (fun x2 -> (FStar_Format.reduce ((x2)::(FStar_Format.hardline)::(FStar_Format.hardline)::[]))) sub2)
+in (
+
+let prefix1 = (
+
+let uu____1955 = (FStar_Extraction_ML_Util.codegen_fsharp ())
+in (match (uu____1955) with
+| true -> begin
+((FStar_Format.cat (FStar_Format.text "#light \"off\"") FStar_Format.hardline))::[]
+end
+| uu____1957 -> begin
+[]
+end))
+in (
+
+let uu____1958 = (
+
+let uu____1960 = (
+
+let uu____1962 = (
+
+let uu____1964 = (
+
+let uu____1966 = (
+
+let uu____1968 = (
+
+let uu____1970 = (
+
+let uu____1972 = (FStar_Format.reduce sub3)
+in (uu____1972)::((FStar_Format.cat tail1 FStar_Format.hardline))::[])
+in ((match (doc1) with
+| None -> begin
+FStar_Format.empty
+end
+| Some (s) -> begin
+(FStar_Format.cat s FStar_Format.hardline)
+end))::uu____1970)
+in (FStar_Format.hardline)::uu____1968)
+in ((FStar_Format.text "open Prims"))::uu____1966)
+in (FStar_Format.hardline)::uu____1964)
+in (head1)::uu____1962)
+in (FStar_List.append prefix1 uu____1960))
+in (FStar_All.pipe_left FStar_Format.reduce uu____1958)))))))))
+end))
+in (
+
+let docs = (FStar_List.map (fun uu____1990 -> (match (uu____1990) with
+| (x, s, m) -> begin
+(
+
+let uu____2017 = (FStar_Extraction_ML_Util.flatten_mlpath x)
+in (
+
+let uu____2018 = (for1_mod true ((x), (s), (m)))
+in ((uu____2017), (uu____2018))))
+end)) mllib)
+in docs))
+end))
+
+
+let doc_of_mllib : FStar_Extraction_ML_Syntax.mllib  ->  (Prims.string * FStar_Format.doc) Prims.list = (fun mllib -> (doc_of_mllib_r mllib))
+
+
+let string_of_mlexpr : FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  Prims.string = (fun cmod e -> (
+
+let doc1 = (
+
+let uu____2038 = (FStar_Extraction_ML_Util.flatten_mlpath cmod)
+in (doc_of_expr uu____2038 ((min_op_prec), (NonAssoc)) e))
+in (FStar_Format.pretty (Prims.parse_int "0") doc1)))
+
+
+let string_of_mlty : FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.string = (fun cmod e -> (
+
+let doc1 = (
+
+let uu____2048 = (FStar_Extraction_ML_Util.flatten_mlpath cmod)
+in (doc_of_mltype uu____2048 ((min_op_prec), (NonAssoc)) e))
+in (FStar_Format.pretty (Prims.parse_int "0") doc1)))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -1,762 +1,907 @@
+
 open Prims
-let fail_exp lid t =
-  let uu____15 =
-    let uu____18 =
-      let uu____19 =
-        let uu____29 =
-          FStar_Syntax_Syntax.fvar FStar_Syntax_Const.failwith_lid
-            FStar_Syntax_Syntax.Delta_constant None in
-        let uu____30 =
-          let uu____32 = FStar_Syntax_Syntax.iarg t in
-          let uu____33 =
-            let uu____35 =
-              let uu____36 =
-                let uu____37 =
-                  let uu____40 =
-                    let uu____41 =
-                      let uu____42 =
-                        let uu____46 =
-                          let uu____47 =
-                            let uu____48 =
-                              FStar_Syntax_Print.lid_to_string lid in
-                            Prims.strcat "Not yet implemented:" uu____48 in
-                          FStar_Bytes.string_as_unicode_bytes uu____47 in
-                        (uu____46, FStar_Range.dummyRange) in
-                      FStar_Const.Const_string uu____42 in
-                    FStar_Syntax_Syntax.Tm_constant uu____41 in
-                  FStar_Syntax_Syntax.mk uu____40 in
-                uu____37 None FStar_Range.dummyRange in
-              FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____36 in
-            [uu____35] in
-          uu____32 :: uu____33 in
-        (uu____29, uu____30) in
-      FStar_Syntax_Syntax.Tm_app uu____19 in
-    FStar_Syntax_Syntax.mk uu____18 in
-  uu____15 None FStar_Range.dummyRange
-let mangle_projector_lid: FStar_Ident.lident -> FStar_Ident.lident =
-  fun x  -> x
-let lident_as_mlsymbol: FStar_Ident.lident -> Prims.string =
-  fun id  -> (id.FStar_Ident.ident).FStar_Ident.idText
-let binders_as_mlty_binders env bs =
-  FStar_Util.fold_map
-    (fun env1  ->
-       fun uu____100  ->
-         match uu____100 with
-         | (bv,uu____108) ->
-             let uu____109 =
-               let uu____110 =
-                 let uu____112 =
-                   let uu____113 = FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv in
-                   FStar_Extraction_ML_Syntax.MLTY_Var uu____113 in
-                 Some uu____112 in
-               FStar_Extraction_ML_UEnv.extend_ty env1 bv uu____110 in
-             let uu____114 = FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv in
-             (uu____109, uu____114)) env bs
-let extract_typ_abbrev:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Syntax_Syntax.term ->
-          (FStar_Extraction_ML_UEnv.env* FStar_Extraction_ML_Syntax.mlmodule1
-            Prims.list)
-  =
-  fun env  ->
-    fun fv  ->
-      fun quals  ->
-        fun def  ->
-          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          let def1 =
-            let uu____142 =
-              let uu____143 = FStar_Syntax_Subst.compress def in
-              FStar_All.pipe_right uu____143 FStar_Syntax_Util.unmeta in
-            FStar_All.pipe_right uu____142 FStar_Syntax_Util.un_uinst in
-          let def2 =
-            match def1.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_abs uu____145 ->
-                FStar_Extraction_ML_Term.normalize_abs def1
-            | uu____160 -> def1 in
-          let uu____161 =
-            match def2.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____168) ->
-                FStar_Syntax_Subst.open_term bs body
-            | uu____191 -> ([], def2) in
-          match uu____161 with
-          | (bs,body) ->
-              let assumed =
-                FStar_Util.for_some
-                  (fun uu___149_203  ->
-                     match uu___149_203 with
-                     | FStar_Syntax_Syntax.Assumption  -> true
-                     | uu____204 -> false) quals in
-              let uu____205 = binders_as_mlty_binders env bs in
-              (match uu____205 with
-               | (env1,ml_bs) ->
-                   let body1 =
-                     let uu____223 =
-                       FStar_Extraction_ML_Term.term_as_mlty env1 body in
-                     FStar_All.pipe_right uu____223
-                       (FStar_Extraction_ML_Util.eraseTypeDeep
-                          (FStar_Extraction_ML_Util.udelta_unfold env1)) in
-                   let mangled_projector =
-                     let uu____226 =
-                       FStar_All.pipe_right quals
-                         (FStar_Util.for_some
-                            (fun uu___150_228  ->
-                               match uu___150_228 with
-                               | FStar_Syntax_Syntax.Projector uu____229 ->
-                                   true
-                               | uu____232 -> false)) in
-                     if uu____226
-                     then
-                       let mname = mangle_projector_lid lid in
-                       Some ((mname.FStar_Ident.ident).FStar_Ident.idText)
-                     else None in
-                   let td =
-                     let uu____248 =
-                       let uu____259 = lident_as_mlsymbol lid in
-                       (assumed, uu____259, mangled_projector, ml_bs,
-                         (Some (FStar_Extraction_ML_Syntax.MLTD_Abbrev body1))) in
-                     [uu____248] in
-                   let def3 =
-                     let uu____287 =
-                       let uu____288 =
-                         FStar_Extraction_ML_Util.mlloc_of_range
-                           (FStar_Ident.range_of_lid lid) in
-                       FStar_Extraction_ML_Syntax.MLM_Loc uu____288 in
-                     [uu____287; FStar_Extraction_ML_Syntax.MLM_Ty td] in
-                   let env2 =
-                     let uu____290 =
-                       FStar_All.pipe_right quals
-                         (FStar_Util.for_some
-                            (fun uu___151_292  ->
-                               match uu___151_292 with
-                               | FStar_Syntax_Syntax.Assumption 
-                                 |FStar_Syntax_Syntax.New  -> true
-                               | uu____293 -> false)) in
-                     if uu____290
-                     then env1
-                     else FStar_Extraction_ML_UEnv.extend_tydef env1 fv td in
-                   (env2, def3))
+
+let fail_exp = (fun lid t -> (
+
+let uu____15 = (
+
+let uu____18 = (
+
+let uu____19 = (
+
+let uu____29 = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.failwith_lid FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____30 = (
+
+let uu____32 = (FStar_Syntax_Syntax.iarg t)
+in (
+
+let uu____33 = (
+
+let uu____35 = (
+
+let uu____36 = (
+
+let uu____37 = (
+
+let uu____40 = (
+
+let uu____41 = (
+
+let uu____42 = (
+
+let uu____46 = (
+
+let uu____47 = (
+
+let uu____48 = (FStar_Syntax_Print.lid_to_string lid)
+in (Prims.strcat "Not yet implemented:" uu____48))
+in (FStar_Bytes.string_as_unicode_bytes uu____47))
+in ((uu____46), (FStar_Range.dummyRange)))
+in FStar_Const.Const_string (uu____42))
+in FStar_Syntax_Syntax.Tm_constant (uu____41))
+in (FStar_Syntax_Syntax.mk uu____40))
+in (uu____37 None FStar_Range.dummyRange))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____36))
+in (uu____35)::[])
+in (uu____32)::uu____33))
+in ((uu____29), (uu____30))))
+in FStar_Syntax_Syntax.Tm_app (uu____19))
+in (FStar_Syntax_Syntax.mk uu____18))
+in (uu____15 None FStar_Range.dummyRange)))
+
+
+let mangle_projector_lid : FStar_Ident.lident  ->  FStar_Ident.lident = (fun x -> x)
+
+
+let lident_as_mlsymbol : FStar_Ident.lident  ->  FStar_Extraction_ML_Syntax.mlsymbol = (fun id -> id.FStar_Ident.ident.FStar_Ident.idText)
+
+
+let binders_as_mlty_binders = (fun env bs -> (FStar_Util.fold_map (fun env1 uu____100 -> (match (uu____100) with
+| (bv, uu____108) -> begin
+(
+
+let uu____109 = (
+
+let uu____110 = (
+
+let uu____112 = (
+
+let uu____113 = (FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv)
+in FStar_Extraction_ML_Syntax.MLTY_Var (uu____113))
+in Some (uu____112))
+in (FStar_Extraction_ML_UEnv.extend_ty env1 bv uu____110))
+in (
+
+let uu____114 = (FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv)
+in ((uu____109), (uu____114))))
+end)) env bs))
+
+
+let extract_typ_abbrev : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Syntax_Syntax.term  ->  (FStar_Extraction_ML_UEnv.env * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list) = (fun env fv quals def -> (
+
+let lid = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let def1 = (
+
+let uu____142 = (
+
+let uu____143 = (FStar_Syntax_Subst.compress def)
+in (FStar_All.pipe_right uu____143 FStar_Syntax_Util.unmeta))
+in (FStar_All.pipe_right uu____142 FStar_Syntax_Util.un_uinst))
+in (
+
+let def2 = (match (def1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_abs (uu____145) -> begin
+(FStar_Extraction_ML_Term.normalize_abs def1)
+end
+| uu____160 -> begin
+def1
+end)
+in (
+
+let uu____161 = (match (def2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_abs (bs, body, uu____168) -> begin
+(FStar_Syntax_Subst.open_term bs body)
+end
+| uu____191 -> begin
+(([]), (def2))
+end)
+in (match (uu____161) with
+| (bs, body) -> begin
+(
+
+let assumed = (FStar_Util.for_some (fun uu___147_203 -> (match (uu___147_203) with
+| FStar_Syntax_Syntax.Assumption -> begin
+true
+end
+| uu____204 -> begin
+false
+end)) quals)
+in (
+
+let uu____205 = (binders_as_mlty_binders env bs)
+in (match (uu____205) with
+| (env1, ml_bs) -> begin
+(
+
+let body1 = (
+
+let uu____223 = (FStar_Extraction_ML_Term.term_as_mlty env1 body)
+in (FStar_All.pipe_right uu____223 (FStar_Extraction_ML_Util.eraseTypeDeep (FStar_Extraction_ML_Util.udelta_unfold env1))))
+in (
+
+let mangled_projector = (
+
+let uu____226 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___148_228 -> (match (uu___148_228) with
+| FStar_Syntax_Syntax.Projector (uu____229) -> begin
+true
+end
+| uu____232 -> begin
+false
+end))))
+in (match (uu____226) with
+| true -> begin
+(
+
+let mname = (mangle_projector_lid lid)
+in Some (mname.FStar_Ident.ident.FStar_Ident.idText))
+end
+| uu____235 -> begin
+None
+end))
+in (
+
+let td = (
+
+let uu____248 = (
+
+let uu____259 = (lident_as_mlsymbol lid)
+in ((assumed), (uu____259), (mangled_projector), (ml_bs), (Some (FStar_Extraction_ML_Syntax.MLTD_Abbrev (body1)))))
+in (uu____248)::[])
+in (
+
+let def3 = (
+
+let uu____287 = (
+
+let uu____288 = (FStar_Extraction_ML_Util.mlloc_of_range (FStar_Ident.range_of_lid lid))
+in FStar_Extraction_ML_Syntax.MLM_Loc (uu____288))
+in (uu____287)::(FStar_Extraction_ML_Syntax.MLM_Ty (td))::[])
+in (
+
+let env2 = (
+
+let uu____290 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___149_292 -> (match (uu___149_292) with
+| (FStar_Syntax_Syntax.Assumption) | (FStar_Syntax_Syntax.New) -> begin
+true
+end
+| uu____293 -> begin
+false
+end))))
+in (match (uu____290) with
+| true -> begin
+env1
+end
+| uu____294 -> begin
+(FStar_Extraction_ML_UEnv.extend_tydef env1 fv td)
+end))
+in ((env2), (def3)))))))
+end)))
+end))))))
+
 type data_constructor =
-  {
-  dname: FStar_Ident.lident;
-  dtyp: FStar_Syntax_Syntax.typ;}
+{dname : FStar_Ident.lident; dtyp : FStar_Syntax_Syntax.typ}
+
 type inductive_family =
-  {
-  iname: FStar_Ident.lident;
-  iparams: FStar_Syntax_Syntax.binders;
-  ityp: FStar_Syntax_Syntax.term;
-  idatas: data_constructor Prims.list;
-  iquals: FStar_Syntax_Syntax.qualifier Prims.list;}
-let print_ifamily: inductive_family -> Prims.unit =
-  fun i  ->
-    let uu____354 = FStar_Syntax_Print.lid_to_string i.iname in
-    let uu____355 = FStar_Syntax_Print.binders_to_string " " i.iparams in
-    let uu____356 = FStar_Syntax_Print.term_to_string i.ityp in
-    let uu____357 =
-      let uu____358 =
-        FStar_All.pipe_right i.idatas
-          (FStar_List.map
-             (fun d  ->
-                let uu____363 = FStar_Syntax_Print.lid_to_string d.dname in
-                let uu____364 =
-                  let uu____365 = FStar_Syntax_Print.term_to_string d.dtyp in
-                  Prims.strcat " : " uu____365 in
-                Prims.strcat uu____363 uu____364)) in
-      FStar_All.pipe_right uu____358 (FStar_String.concat "\n\t\t") in
-    FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____354 uu____355 uu____356
-      uu____357
-let bundle_as_inductive_families env ses quals =
-  FStar_All.pipe_right ses
-    (FStar_List.collect
-       (fun uu___153_391  ->
-          match uu___153_391 with
-          | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,_us,bs,t,_mut_i,datas,quals1,r) ->
-              let uu____407 = FStar_Syntax_Subst.open_term bs t in
-              (match uu____407 with
-               | (bs1,t1) ->
-                   let datas1 =
-                     FStar_All.pipe_right ses
-                       (FStar_List.collect
-                          (fun uu___152_417  ->
-                             match uu___152_417 with
-                             | FStar_Syntax_Syntax.Sig_datacon
-                                 (d,uu____420,t2,l',nparams,uu____424,uu____425,uu____426)
-                                 when FStar_Ident.lid_equals l l' ->
-                                 let uu____431 =
-                                   FStar_Syntax_Util.arrow_formals t2 in
-                                 (match uu____431 with
-                                  | (bs',body) ->
-                                      let uu____452 =
-                                        FStar_Util.first_N
-                                          (FStar_List.length bs1) bs' in
-                                      (match uu____452 with
-                                       | (bs_params,rest) ->
-                                           let subst1 =
-                                             FStar_List.map2
-                                               (fun uu____488  ->
-                                                  fun uu____489  ->
-                                                    match (uu____488,
-                                                            uu____489)
-                                                    with
-                                                    | ((b',uu____499),
-                                                       (b,uu____501)) ->
-                                                        let uu____506 =
-                                                          let uu____511 =
-                                                            FStar_Syntax_Syntax.bv_to_name
-                                                              b in
-                                                          (b', uu____511) in
-                                                        FStar_Syntax_Syntax.NT
-                                                          uu____506)
-                                               bs_params bs1 in
-                                           let t3 =
-                                             let uu____513 =
-                                               let uu____516 =
-                                                 FStar_Syntax_Syntax.mk_Total
-                                                   body in
-                                               FStar_Syntax_Util.arrow rest
-                                                 uu____516 in
-                                             FStar_All.pipe_right uu____513
-                                               (FStar_Syntax_Subst.subst
-                                                  subst1) in
-                                           [{ dname = d; dtyp = t3 }]))
-                             | uu____521 -> [])) in
-                   [{
-                      iname = l;
-                      iparams = bs1;
-                      ityp = t1;
-                      idatas = datas1;
-                      iquals = quals1
-                    }])
-          | uu____522 -> []))
-type env_t = FStar_Extraction_ML_UEnv.env
-let extract_bundle:
-  env_t ->
-    FStar_Syntax_Syntax.sigelt ->
-      (env_t* FStar_Extraction_ML_Syntax.mlmodule1 Prims.list)
-  =
-  fun env  ->
-    fun se  ->
-      let extract_ctor ml_tyvars env1 ctor =
-        let mlt =
-          let uu____559 =
-            FStar_Extraction_ML_Term.term_as_mlty env1 ctor.dtyp in
-          FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env1) uu____559 in
-        let tys = (ml_tyvars, mlt) in
-        let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp in
-        let uu____570 =
-          let uu____571 =
-            FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false in
-          Prims.fst uu____571 in
-        let uu____574 =
-          let uu____578 = lident_as_mlsymbol ctor.dname in
-          let uu____579 = FStar_Extraction_ML_Util.argTypes mlt in
-          (uu____578, uu____579) in
-        (uu____570, uu____574) in
-      let extract_one_family env1 ind =
-        let uu____604 = binders_as_mlty_binders env1 ind.iparams in
-        match uu____604 with
-        | (env2,vars) ->
-            let uu____630 =
-              FStar_All.pipe_right ind.idatas
-                (FStar_Util.fold_map (extract_ctor vars) env2) in
-            (match uu____630 with
-             | (env3,ctors) ->
-                 let uu____669 = FStar_Syntax_Util.arrow_formals ind.ityp in
-                 (match uu____669 with
-                  | (indices,uu____690) ->
-                      let ml_params =
-                        let uu____705 =
-                          FStar_All.pipe_right indices
-                            (FStar_List.mapi
-                               (fun i  ->
-                                  fun uu____720  ->
-                                    let uu____723 =
-                                      let uu____724 =
-                                        FStar_Util.string_of_int i in
-                                      Prims.strcat "'dummyV" uu____724 in
-                                    (uu____723, (Prims.parse_int "0")))) in
-                        FStar_List.append vars uu____705 in
-                      let tbody =
-                        let uu____728 =
-                          FStar_Util.find_opt
-                            (fun uu___154_730  ->
-                               match uu___154_730 with
-                               | FStar_Syntax_Syntax.RecordType uu____731 ->
-                                   true
-                               | uu____736 -> false) ind.iquals in
-                        match uu____728 with
-                        | Some (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____743 = FStar_List.hd ctors in
-                            (match uu____743 with
-                             | (uu____750,c_ty) ->
-                                 let fields =
-                                   FStar_List.map2
-                                     (fun id  ->
-                                        fun ty  ->
-                                          let lid =
-                                            FStar_Ident.lid_of_ids
-                                              (FStar_List.append ns [id]) in
-                                          let uu____764 =
-                                            lident_as_mlsymbol lid in
-                                          (uu____764, ty)) ids c_ty in
-                                 FStar_Extraction_ML_Syntax.MLTD_Record
-                                   fields)
-                        | uu____765 ->
-                            FStar_Extraction_ML_Syntax.MLTD_DType ctors in
-                      let uu____767 =
-                        let uu____778 = lident_as_mlsymbol ind.iname in
-                        (false, uu____778, None, ml_params, (Some tbody)) in
-                      (env3, uu____767))) in
-      match se with
-      | FStar_Syntax_Syntax.Sig_bundle
-          ((FStar_Syntax_Syntax.Sig_datacon
-           (l,uu____798,t,uu____800,uu____801,uu____802,uu____803,uu____804))::[],(FStar_Syntax_Syntax.ExceptionConstructor
-           )::[],uu____805,r)
-          ->
-          let uu____815 = extract_ctor [] env { dname = l; dtyp = t } in
-          (match uu____815 with
-           | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | FStar_Syntax_Syntax.Sig_bundle (ses,quals,uu____837,r) ->
-          let ifams = bundle_as_inductive_families env ses quals in
-          let uu____848 = FStar_Util.fold_map extract_one_family env ifams in
-          (match uu____848 with
-           | (env1,td) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Ty td]))
-      | uu____900 -> failwith "Unexpected signature element"
-let rec extract_sig:
-  env_t ->
-    FStar_Syntax_Syntax.sigelt ->
-      (env_t* FStar_Extraction_ML_Syntax.mlmodule1 Prims.list)
-  =
-  fun g  ->
-    fun se  ->
-      FStar_Extraction_ML_UEnv.debug g
-        (fun u  ->
-           let uu____918 = FStar_Syntax_Print.sigelt_to_string se in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____918);
-      (match se with
-       | FStar_Syntax_Syntax.Sig_bundle _
-         |FStar_Syntax_Syntax.Sig_inductive_typ _
-          |FStar_Syntax_Syntax.Sig_datacon _ -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_new_effect (ed,uu____926) when
-           FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers
-             (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-           ->
-           let extend_env g1 lid ml_name tm tysc =
-             let uu____946 =
-               let uu____949 =
-                 FStar_Syntax_Syntax.lid_as_fv lid
-                   FStar_Syntax_Syntax.Delta_equational None in
-               FStar_Extraction_ML_UEnv.extend_fv' g1 uu____949 ml_name tysc
-                 false false in
-             match uu____946 with
-             | (g2,mangled_name) ->
-                 let lb =
-                   {
-                     FStar_Extraction_ML_Syntax.mllb_name = mangled_name;
-                     FStar_Extraction_ML_Syntax.mllb_tysc = None;
-                     FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                     FStar_Extraction_ML_Syntax.mllb_def = tm;
-                     FStar_Extraction_ML_Syntax.print_typ = false
-                   } in
-                 (g2,
-                   (FStar_Extraction_ML_Syntax.MLM_Let
-                      (FStar_Extraction_ML_Syntax.NonRec, [], [lb]))) in
-           let rec extract_fv tm =
-             let uu____963 =
-               let uu____964 = FStar_Syntax_Subst.compress tm in
-               uu____964.FStar_Syntax_Syntax.n in
-             match uu____963 with
-             | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____970) -> extract_fv tm1
-             | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let mlp =
-                   FStar_Extraction_ML_Syntax.mlpath_of_lident
-                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                 let uu____981 =
-                   let uu____986 = FStar_Extraction_ML_UEnv.lookup_fv g fv in
-                   FStar_All.pipe_left FStar_Util.right uu____986 in
-                 (match uu____981 with
-                  | (uu____1015,uu____1016,tysc,uu____1018) ->
-                      let uu____1019 =
-                        FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top)
-                          (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
-                      (uu____1019, tysc))
-             | uu____1020 -> failwith "Not an fv" in
-           let extract_action g1 a =
-             let uu____1032 = extract_fv a.FStar_Syntax_Syntax.action_defn in
-             match uu____1032 with
-             | (a_tm,ty_sc) ->
-                 let uu____1039 = FStar_Extraction_ML_UEnv.action_name ed a in
-                 (match uu____1039 with
-                  | (a_nm,a_lid) -> extend_env g1 a_lid a_nm a_tm ty_sc) in
-           let uu____1046 =
-             let uu____1049 =
-               extract_fv (Prims.snd ed.FStar_Syntax_Syntax.return_repr) in
-             match uu____1049 with
-             | (return_tm,ty_sc) ->
-                 let uu____1057 =
-                   FStar_Extraction_ML_UEnv.monad_op_name ed "return" in
-                 (match uu____1057 with
-                  | (return_nm,return_lid) ->
-                      extend_env g return_lid return_nm return_tm ty_sc) in
-           (match uu____1046 with
-            | (g1,return_decl) ->
-                let uu____1069 =
-                  let uu____1072 =
-                    extract_fv (Prims.snd ed.FStar_Syntax_Syntax.bind_repr) in
-                  match uu____1072 with
-                  | (bind_tm,ty_sc) ->
-                      let uu____1080 =
-                        FStar_Extraction_ML_UEnv.monad_op_name ed "bind" in
-                      (match uu____1080 with
-                       | (bind_nm,bind_lid) ->
-                           extend_env g1 bind_lid bind_nm bind_tm ty_sc) in
-                (match uu____1069 with
-                 | (g2,bind_decl) ->
-                     let uu____1092 =
-                       FStar_Util.fold_map extract_action g2
-                         ed.FStar_Syntax_Syntax.actions in
-                     (match uu____1092 with
-                      | (g3,actions) ->
-                          (g3,
-                            (FStar_List.append [return_decl; bind_decl]
-                               actions)))))
-       | FStar_Syntax_Syntax.Sig_new_effect uu____1104 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_declare_typ
-           (lid,uu____1109,t,quals,uu____1112) when
-           FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____1115 =
-             let uu____1116 =
-               FStar_All.pipe_right quals
-                 (FStar_Util.for_some
-                    (fun uu___155_1118  ->
-                       match uu___155_1118 with
-                       | FStar_Syntax_Syntax.Assumption  -> true
-                       | uu____1119 -> false)) in
-             FStar_All.pipe_right uu____1116 Prims.op_Negation in
-           if uu____1115
-           then (g, [])
-           else
-             (let uu____1125 = FStar_Syntax_Util.arrow_formals t in
-              match uu____1125 with
-              | (bs,uu____1137) ->
-                  let fv =
-                    FStar_Syntax_Syntax.lid_as_fv lid
-                      FStar_Syntax_Syntax.Delta_constant None in
-                  let uu____1149 =
-                    FStar_Syntax_Util.abs bs FStar_TypeChecker_Common.t_unit
-                      None in
-                  extract_typ_abbrev g fv quals uu____1149)
-       | FStar_Syntax_Syntax.Sig_let
-           ((false ,lb::[]),uu____1156,uu____1157,quals,uu____1159) when
-           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
-           ->
-           let uu____1170 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-           extract_typ_abbrev g uu____1170 quals lb.FStar_Syntax_Syntax.lbdef
-       | FStar_Syntax_Syntax.Sig_let (lbs,r,uu____1173,quals,attrs) ->
-           let elet =
-             (FStar_Syntax_Syntax.mk
-                (FStar_Syntax_Syntax.Tm_let
-                   (lbs, FStar_Syntax_Const.exp_false_bool))) None r in
-           let uu____1193 = FStar_Extraction_ML_Term.term_as_mlexpr g elet in
-           (match uu____1193 with
-            | (ml_let,uu____1201,uu____1202) ->
-                (match ml_let.FStar_Extraction_ML_Syntax.expr with
-                 | FStar_Extraction_ML_Syntax.MLE_Let
-                     ((flavor,uu____1207,bindings),uu____1209) ->
-                     let uu____1216 =
-                       FStar_List.fold_left2
-                         (fun uu____1223  ->
-                            fun ml_lb  ->
-                              fun uu____1225  ->
-                                match (uu____1223, uu____1225) with
-                                | ((env,ml_lbs),{
-                                                  FStar_Syntax_Syntax.lbname
-                                                    = lbname;
-                                                  FStar_Syntax_Syntax.lbunivs
-                                                    = uu____1238;
-                                                  FStar_Syntax_Syntax.lbtyp =
-                                                    t;
-                                                  FStar_Syntax_Syntax.lbeff =
-                                                    uu____1240;
-                                                  FStar_Syntax_Syntax.lbdef =
-                                                    uu____1241;_})
-                                    ->
-                                    let lb_lid =
-                                      let uu____1255 =
-                                        let uu____1260 =
-                                          FStar_Util.right lbname in
-                                        uu____1260.FStar_Syntax_Syntax.fv_name in
-                                      uu____1255.FStar_Syntax_Syntax.v in
-                                    let uu____1264 =
-                                      let uu____1267 =
-                                        FStar_All.pipe_right quals
-                                          (FStar_Util.for_some
-                                             (fun uu___156_1269  ->
-                                                match uu___156_1269 with
-                                                | FStar_Syntax_Syntax.Projector
-                                                    uu____1270 -> true
-                                                | uu____1273 -> false)) in
-                                      if uu____1267
-                                      then
-                                        let mname =
-                                          let uu____1277 =
-                                            mangle_projector_lid lb_lid in
-                                          FStar_All.pipe_right uu____1277
-                                            FStar_Extraction_ML_Syntax.mlpath_of_lident in
-                                        let uu____1278 =
-                                          let uu____1281 =
-                                            FStar_Util.right lbname in
-                                          let uu____1282 =
-                                            FStar_Util.must
-                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_tysc in
-                                          FStar_Extraction_ML_UEnv.extend_fv'
-                                            env uu____1281 mname uu____1282
-                                            ml_lb.FStar_Extraction_ML_Syntax.mllb_add_unit
-                                            false in
-                                        match uu____1278 with
-                                        | (env1,uu____1286) ->
-                                            (env1,
-                                              (let uu___161_1287 = ml_lb in
-                                               {
-                                                 FStar_Extraction_ML_Syntax.mllb_name
-                                                   =
-                                                   ((Prims.snd mname),
-                                                     (Prims.parse_int "0"));
-                                                 FStar_Extraction_ML_Syntax.mllb_tysc
-                                                   =
-                                                   (uu___161_1287.FStar_Extraction_ML_Syntax.mllb_tysc);
-                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
-                                                   =
-                                                   (uu___161_1287.FStar_Extraction_ML_Syntax.mllb_add_unit);
-                                                 FStar_Extraction_ML_Syntax.mllb_def
-                                                   =
-                                                   (uu___161_1287.FStar_Extraction_ML_Syntax.mllb_def);
-                                                 FStar_Extraction_ML_Syntax.print_typ
-                                                   =
-                                                   (uu___161_1287.FStar_Extraction_ML_Syntax.print_typ)
-                                               }))
-                                      else
-                                        (let uu____1290 =
-                                           let uu____1291 =
-                                             let uu____1294 =
-                                               FStar_Util.must
-                                                 ml_lb.FStar_Extraction_ML_Syntax.mllb_tysc in
-                                             FStar_Extraction_ML_UEnv.extend_lb
-                                               env lbname t uu____1294
-                                               ml_lb.FStar_Extraction_ML_Syntax.mllb_add_unit
-                                               false in
-                                           FStar_All.pipe_left Prims.fst
-                                             uu____1291 in
-                                         (uu____1290, ml_lb)) in
-                                    (match uu____1264 with
-                                     | (g1,ml_lb1) ->
-                                         (g1, (ml_lb1 :: ml_lbs)))) (g, [])
-                         bindings (Prims.snd lbs) in
-                     (match uu____1216 with
-                      | (g1,ml_lbs') ->
-                          let flags =
-                            FStar_List.choose
-                              (fun uu___157_1314  ->
-                                 match uu___157_1314 with
-                                 | FStar_Syntax_Syntax.Assumption  ->
-                                     Some FStar_Extraction_ML_Syntax.Assumed
-                                 | FStar_Syntax_Syntax.Private  ->
-                                     Some FStar_Extraction_ML_Syntax.Private
-                                 | FStar_Syntax_Syntax.NoExtract  ->
-                                     Some
-                                       FStar_Extraction_ML_Syntax.NoExtract
-                                 | uu____1316 -> None) quals in
-                          let flags' =
-                            FStar_List.choose
-                              (fun uu___158_1321  ->
-                                 match uu___158_1321 with
-                                 | {
-                                     FStar_Syntax_Syntax.n =
-                                       FStar_Syntax_Syntax.Tm_constant
-                                       (FStar_Const.Const_string
-                                       (data,uu____1326));
-                                     FStar_Syntax_Syntax.tk = uu____1327;
-                                     FStar_Syntax_Syntax.pos = uu____1328;
-                                     FStar_Syntax_Syntax.vars = uu____1329;_}
-                                     ->
-                                     Some
-                                       (FStar_Extraction_ML_Syntax.Attribute
-                                          (FStar_Util.string_of_unicode data))
-                                 | uu____1334 ->
-                                     (FStar_Util.print_warning
-                                        "Warning: unrecognized, non-string attribute, bother protz for a better error message";
-                                      None)) attrs in
-                          let uu____1338 =
-                            let uu____1340 =
-                              let uu____1341 =
-                                FStar_Extraction_ML_Util.mlloc_of_range r in
-                              FStar_Extraction_ML_Syntax.MLM_Loc uu____1341 in
-                            [uu____1340;
-                            FStar_Extraction_ML_Syntax.MLM_Let
-                              (flavor, (FStar_List.append flags flags'),
-                                (FStar_List.rev ml_lbs'))] in
-                          (g1, uu____1338))
-                 | uu____1345 ->
-                     let uu____1346 =
-                       let uu____1347 =
-                         FStar_Extraction_ML_Code.string_of_mlexpr
-                           g.FStar_Extraction_ML_UEnv.currentModule ml_let in
-                       FStar_Util.format1
-                         "Impossible: Translated a let to a non-let: %s"
-                         uu____1347 in
-                     failwith uu____1346))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____1352,t,quals,r) ->
-           let uu____1358 =
-             FStar_All.pipe_right quals
-               (FStar_List.contains FStar_Syntax_Syntax.Assumption) in
-           if uu____1358
-           then
-             let always_fail =
-               let imp =
-                 let uu____1367 = FStar_Syntax_Util.arrow_formals t in
-                 match uu____1367 with
-                 | ([],t1) -> fail_exp lid t1
-                 | (bs,t1) ->
-                     let uu____1399 = fail_exp lid t1 in
-                     FStar_Syntax_Util.abs bs uu____1399 None in
-               let uu____1405 =
-                 let uu____1414 =
-                   let uu____1418 =
-                     let uu____1420 =
-                       let uu____1421 =
-                         let uu____1424 =
-                           FStar_Syntax_Syntax.lid_as_fv lid
-                             FStar_Syntax_Syntax.Delta_constant None in
-                         FStar_Util.Inr uu____1424 in
-                       {
-                         FStar_Syntax_Syntax.lbname = uu____1421;
-                         FStar_Syntax_Syntax.lbunivs = [];
-                         FStar_Syntax_Syntax.lbtyp = t;
-                         FStar_Syntax_Syntax.lbeff =
-                           FStar_Syntax_Const.effect_ML_lid;
-                         FStar_Syntax_Syntax.lbdef = imp
-                       } in
-                     [uu____1420] in
-                   (false, uu____1418) in
-                 (uu____1414, r, [], quals, []) in
-               FStar_Syntax_Syntax.Sig_let uu____1405 in
-             let uu____1432 = extract_sig g always_fail in
-             (match uu____1432 with
-              | (g1,mlm) ->
-                  let uu____1443 =
-                    FStar_Util.find_map quals
-                      (fun uu___159_1445  ->
-                         match uu___159_1445 with
-                         | FStar_Syntax_Syntax.Discriminator l -> Some l
-                         | uu____1448 -> None) in
-                  (match uu____1443 with
-                   | Some l ->
-                       let uu____1453 =
-                         let uu____1455 =
-                           let uu____1456 =
-                             FStar_Extraction_ML_Util.mlloc_of_range r in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____1456 in
-                         let uu____1457 =
-                           let uu____1459 =
-                             FStar_Extraction_ML_Term.ind_discriminator_body
-                               g1 lid l in
-                           [uu____1459] in
-                         uu____1455 :: uu____1457 in
-                       (g1, uu____1453)
-                   | uu____1461 ->
-                       let uu____1463 =
-                         FStar_Util.find_map quals
-                           (fun uu___160_1465  ->
-                              match uu___160_1465 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____1468)
-                                  -> Some l
-                              | uu____1469 -> None) in
-                       (match uu____1463 with
-                        | Some uu____1473 -> (g1, [])
-                        | uu____1475 -> (g1, mlm))))
-           else (g, [])
-       | FStar_Syntax_Syntax.Sig_main (e,r) ->
-           let uu____1482 = FStar_Extraction_ML_Term.term_as_mlexpr g e in
-           (match uu____1482 with
-            | (ml_main,uu____1490,uu____1491) ->
-                let uu____1492 =
-                  let uu____1494 =
-                    let uu____1495 =
-                      FStar_Extraction_ML_Util.mlloc_of_range r in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____1495 in
-                  [uu____1494; FStar_Extraction_ML_Syntax.MLM_Top ml_main] in
-                (g, uu____1492))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____1497 ->
-           failwith "impossible -- removed by tc.fs"
-       | FStar_Syntax_Syntax.Sig_assume _
-         |FStar_Syntax_Syntax.Sig_sub_effect _
-          |FStar_Syntax_Syntax.Sig_effect_abbrev _ -> (g, [])
-       | FStar_Syntax_Syntax.Sig_pragma (p,uu____1508) ->
-           (if p = FStar_Syntax_Syntax.LightOff
-            then FStar_Options.set_ml_ish ()
-            else ();
-            (g, [])))
-let extract_iface:
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.modul -> env_t =
-  fun g  ->
-    fun m  ->
-      let uu____1518 =
-        FStar_Util.fold_map extract_sig g m.FStar_Syntax_Syntax.declarations in
-      FStar_All.pipe_right uu____1518 Prims.fst
-let extract:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.modul ->
-      (FStar_Extraction_ML_UEnv.env* FStar_Extraction_ML_Syntax.mllib
-        Prims.list)
-  =
-  fun g  ->
-    fun m  ->
-      FStar_Syntax_Syntax.reset_gensym ();
-      (let uu____1543 = FStar_Options.restore_cmd_line_options true in
-       let name =
-         FStar_Extraction_ML_Syntax.mlpath_of_lident
-           m.FStar_Syntax_Syntax.name in
-       let g1 =
-         let uu___162_1546 = g in
-         {
-           FStar_Extraction_ML_UEnv.tcenv =
-             (uu___162_1546.FStar_Extraction_ML_UEnv.tcenv);
-           FStar_Extraction_ML_UEnv.gamma =
-             (uu___162_1546.FStar_Extraction_ML_UEnv.gamma);
-           FStar_Extraction_ML_UEnv.tydefs =
-             (uu___162_1546.FStar_Extraction_ML_UEnv.tydefs);
-           FStar_Extraction_ML_UEnv.currentModule = name
-         } in
-       let uu____1547 =
-         FStar_Util.fold_map extract_sig g1
-           m.FStar_Syntax_Syntax.declarations in
-       match uu____1547 with
-       | (g2,sigs) ->
-           let mlm = FStar_List.flatten sigs in
-           let is_kremlin =
-             let uu____1564 = FStar_Options.codegen () in
-             match uu____1564 with
-             | Some "Kremlin" -> true
-             | uu____1566 -> false in
-           let uu____1568 =
-             (((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
-                (is_kremlin ||
-                   (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)))
-               &&
-               (FStar_Options.should_extract
-                  (m.FStar_Syntax_Syntax.name).FStar_Ident.str) in
-           if uu____1568
-           then
-             ((let uu____1573 =
-                 FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
-               FStar_Util.print1 "Extracted module %s\n" uu____1573);
-              (g2,
-                [FStar_Extraction_ML_Syntax.MLLib
-                   [(name, (Some ([], mlm)),
-                      (FStar_Extraction_ML_Syntax.MLLib []))]]))
-           else (g2, []))
+{iname : FStar_Ident.lident; iparams : FStar_Syntax_Syntax.binders; ityp : FStar_Syntax_Syntax.term; idatas : data_constructor Prims.list; iquals : FStar_Syntax_Syntax.qualifier Prims.list}
+
+
+let print_ifamily : inductive_family  ->  Prims.unit = (fun i -> (
+
+let uu____354 = (FStar_Syntax_Print.lid_to_string i.iname)
+in (
+
+let uu____355 = (FStar_Syntax_Print.binders_to_string " " i.iparams)
+in (
+
+let uu____356 = (FStar_Syntax_Print.term_to_string i.ityp)
+in (
+
+let uu____357 = (
+
+let uu____358 = (FStar_All.pipe_right i.idatas (FStar_List.map (fun d -> (
+
+let uu____363 = (FStar_Syntax_Print.lid_to_string d.dname)
+in (
+
+let uu____364 = (
+
+let uu____365 = (FStar_Syntax_Print.term_to_string d.dtyp)
+in (Prims.strcat " : " uu____365))
+in (Prims.strcat uu____363 uu____364))))))
+in (FStar_All.pipe_right uu____358 (FStar_String.concat "\n\t\t")))
+in (FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____354 uu____355 uu____356 uu____357))))))
+
+
+let bundle_as_inductive_families = (fun env ses quals -> (FStar_All.pipe_right ses (FStar_List.collect (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (l, _us, bs, t, _mut_i, datas, quals1) -> begin
+(
+
+let uu____406 = (FStar_Syntax_Subst.open_term bs t)
+in (match (uu____406) with
+| (bs1, t1) -> begin
+(
+
+let datas1 = (FStar_All.pipe_right ses (FStar_List.collect (fun se1 -> (match (se1.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (d, uu____419, t2, l', nparams, uu____423, uu____424) when (FStar_Ident.lid_equals l l') -> begin
+(
+
+let uu____429 = (FStar_Syntax_Util.arrow_formals t2)
+in (match (uu____429) with
+| (bs', body) -> begin
+(
+
+let uu____450 = (FStar_Util.first_N (FStar_List.length bs1) bs')
+in (match (uu____450) with
+| (bs_params, rest) -> begin
+(
+
+let subst1 = (FStar_List.map2 (fun uu____486 uu____487 -> (match (((uu____486), (uu____487))) with
+| ((b', uu____497), (b, uu____499)) -> begin
+(
+
+let uu____504 = (
+
+let uu____509 = (FStar_Syntax_Syntax.bv_to_name b)
+in ((b'), (uu____509)))
+in FStar_Syntax_Syntax.NT (uu____504))
+end)) bs_params bs1)
+in (
+
+let t3 = (
+
+let uu____511 = (
+
+let uu____514 = (FStar_Syntax_Syntax.mk_Total body)
+in (FStar_Syntax_Util.arrow rest uu____514))
+in (FStar_All.pipe_right uu____511 (FStar_Syntax_Subst.subst subst1)))
+in ({dname = d; dtyp = t3})::[]))
+end))
+end))
+end
+| uu____519 -> begin
+[]
+end))))
+in ({iname = l; iparams = bs1; ityp = t1; idatas = datas1; iquals = quals1})::[])
+end))
+end
+| uu____520 -> begin
+[]
+end)))))
+
+
+type env_t =
+FStar_Extraction_ML_UEnv.env
+
+
+let extract_bundle : env_t  ->  FStar_Syntax_Syntax.sigelt  ->  (env_t * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list) = (fun env se -> (
+
+let extract_ctor = (fun ml_tyvars env1 ctor -> (
+
+let mlt = (
+
+let uu____557 = (FStar_Extraction_ML_Term.term_as_mlty env1 ctor.dtyp)
+in (FStar_Extraction_ML_Util.eraseTypeDeep (FStar_Extraction_ML_Util.udelta_unfold env1) uu____557))
+in (
+
+let tys = ((ml_tyvars), (mlt))
+in (
+
+let fvv = (FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp)
+in (
+
+let uu____568 = (
+
+let uu____569 = (FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false)
+in (Prims.fst uu____569))
+in (
+
+let uu____572 = (
+
+let uu____576 = (lident_as_mlsymbol ctor.dname)
+in (
+
+let uu____577 = (FStar_Extraction_ML_Util.argTypes mlt)
+in ((uu____576), (uu____577))))
+in ((uu____568), (uu____572))))))))
+in (
+
+let extract_one_family = (fun env1 ind -> (
+
+let uu____602 = (binders_as_mlty_binders env1 ind.iparams)
+in (match (uu____602) with
+| (env2, vars) -> begin
+(
+
+let uu____628 = (FStar_All.pipe_right ind.idatas (FStar_Util.fold_map (extract_ctor vars) env2))
+in (match (uu____628) with
+| (env3, ctors) -> begin
+(
+
+let uu____667 = (FStar_Syntax_Util.arrow_formals ind.ityp)
+in (match (uu____667) with
+| (indices, uu____688) -> begin
+(
+
+let ml_params = (
+
+let uu____703 = (FStar_All.pipe_right indices (FStar_List.mapi (fun i uu____718 -> (
+
+let uu____721 = (
+
+let uu____722 = (FStar_Util.string_of_int i)
+in (Prims.strcat "\'dummyV" uu____722))
+in ((uu____721), ((Prims.parse_int "0")))))))
+in (FStar_List.append vars uu____703))
+in (
+
+let tbody = (
+
+let uu____726 = (FStar_Util.find_opt (fun uu___150_728 -> (match (uu___150_728) with
+| FStar_Syntax_Syntax.RecordType (uu____729) -> begin
+true
+end
+| uu____734 -> begin
+false
+end)) ind.iquals)
+in (match (uu____726) with
+| Some (FStar_Syntax_Syntax.RecordType (ns, ids)) -> begin
+(
+
+let uu____741 = (FStar_List.hd ctors)
+in (match (uu____741) with
+| (uu____748, c_ty) -> begin
+(
+
+let fields = (FStar_List.map2 (fun id ty -> (
+
+let lid = (FStar_Ident.lid_of_ids (FStar_List.append ns ((id)::[])))
+in (
+
+let uu____762 = (lident_as_mlsymbol lid)
+in ((uu____762), (ty))))) ids c_ty)
+in FStar_Extraction_ML_Syntax.MLTD_Record (fields))
+end))
+end
+| uu____763 -> begin
+FStar_Extraction_ML_Syntax.MLTD_DType (ctors)
+end))
+in (
+
+let uu____765 = (
+
+let uu____776 = (lident_as_mlsymbol ind.iname)
+in ((false), (uu____776), (None), (ml_params), (Some (tbody))))
+in ((env3), (uu____765)))))
+end))
+end))
+end)))
+in (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (l, uu____796, t, uu____798, uu____799, uu____800, uu____801); FStar_Syntax_Syntax.sigdoc = uu____802; FStar_Syntax_Syntax.sigrng = uu____803})::[], (FStar_Syntax_Syntax.ExceptionConstructor)::[], uu____804) -> begin
+(
+
+let uu____814 = (extract_ctor [] env {dname = l; dtyp = t})
+in (match (uu____814) with
+| (env1, ctor) -> begin
+((env1), ((FStar_Extraction_ML_Syntax.MLM_Exn (ctor))::[]))
+end))
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, uu____836) -> begin
+(
+
+let ifams = (bundle_as_inductive_families env ses quals)
+in (
+
+let uu____846 = (FStar_Util.fold_map extract_one_family env ifams)
+in (match (uu____846) with
+| (env1, td) -> begin
+((env1), ((FStar_Extraction_ML_Syntax.MLM_Ty (td))::[]))
+end)))
+end
+| uu____898 -> begin
+(failwith "Unexpected signature element")
+end))))
+
+
+let rec extract_sig : env_t  ->  FStar_Syntax_Syntax.sigelt  ->  (env_t * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list) = (fun g se -> ((FStar_Extraction_ML_UEnv.debug g (fun u -> (
+
+let uu____916 = (FStar_Syntax_Print.sigelt_to_string se)
+in (FStar_Util.print1 ">>>> extract_sig %s \n" uu____916))));
+(match (se.FStar_Syntax_Syntax.sigel) with
+| (FStar_Syntax_Syntax.Sig_bundle (_)) | (FStar_Syntax_Syntax.Sig_inductive_typ (_)) | (FStar_Syntax_Syntax.Sig_datacon (_)) -> begin
+(extract_bundle g se)
+end
+| FStar_Syntax_Syntax.Sig_new_effect (ed) when (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable)) -> begin
+(
+
+let extend_env = (fun g1 lid ml_name tm tysc -> (
+
+let uu____943 = (
+
+let uu____946 = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_equational None)
+in (FStar_Extraction_ML_UEnv.extend_fv' g1 uu____946 ml_name tysc false false))
+in (match (uu____943) with
+| (g2, mangled_name) -> begin
+(
+
+let lb = {FStar_Extraction_ML_Syntax.mllb_name = mangled_name; FStar_Extraction_ML_Syntax.mllb_tysc = None; FStar_Extraction_ML_Syntax.mllb_add_unit = false; FStar_Extraction_ML_Syntax.mllb_def = tm; FStar_Extraction_ML_Syntax.print_typ = false}
+in ((g2), (FStar_Extraction_ML_Syntax.MLM_Let (((FStar_Extraction_ML_Syntax.NonRec), ([]), ((lb)::[]))))))
+end)))
+in (
+
+let rec extract_fv = (fun tm -> (
+
+let uu____960 = (
+
+let uu____961 = (FStar_Syntax_Subst.compress tm)
+in uu____961.FStar_Syntax_Syntax.n)
+in (match (uu____960) with
+| FStar_Syntax_Syntax.Tm_uinst (tm1, uu____967) -> begin
+(extract_fv tm1)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let mlp = (FStar_Extraction_ML_Syntax.mlpath_of_lident fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (
+
+let uu____978 = (
+
+let uu____983 = (FStar_Extraction_ML_UEnv.lookup_fv g fv)
+in (FStar_All.pipe_left FStar_Util.right uu____983))
+in (match (uu____978) with
+| (uu____1012, uu____1013, tysc, uu____1015) -> begin
+(
+
+let uu____1016 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) (FStar_Extraction_ML_Syntax.MLE_Name (mlp)))
+in ((uu____1016), (tysc)))
+end)))
+end
+| uu____1017 -> begin
+(failwith "Not an fv")
+end)))
+in (
+
+let extract_action = (fun g1 a -> (
+
+let uu____1029 = (extract_fv a.FStar_Syntax_Syntax.action_defn)
+in (match (uu____1029) with
+| (a_tm, ty_sc) -> begin
+(
+
+let uu____1036 = (FStar_Extraction_ML_UEnv.action_name ed a)
+in (match (uu____1036) with
+| (a_nm, a_lid) -> begin
+(extend_env g1 a_lid a_nm a_tm ty_sc)
+end))
+end)))
+in (
+
+let uu____1043 = (
+
+let uu____1046 = (extract_fv (Prims.snd ed.FStar_Syntax_Syntax.return_repr))
+in (match (uu____1046) with
+| (return_tm, ty_sc) -> begin
+(
+
+let uu____1054 = (FStar_Extraction_ML_UEnv.monad_op_name ed "return")
+in (match (uu____1054) with
+| (return_nm, return_lid) -> begin
+(extend_env g return_lid return_nm return_tm ty_sc)
+end))
+end))
+in (match (uu____1043) with
+| (g1, return_decl) -> begin
+(
+
+let uu____1066 = (
+
+let uu____1069 = (extract_fv (Prims.snd ed.FStar_Syntax_Syntax.bind_repr))
+in (match (uu____1069) with
+| (bind_tm, ty_sc) -> begin
+(
+
+let uu____1077 = (FStar_Extraction_ML_UEnv.monad_op_name ed "bind")
+in (match (uu____1077) with
+| (bind_nm, bind_lid) -> begin
+(extend_env g1 bind_lid bind_nm bind_tm ty_sc)
+end))
+end))
+in (match (uu____1066) with
+| (g2, bind_decl) -> begin
+(
+
+let uu____1089 = (FStar_Util.fold_map extract_action g2 ed.FStar_Syntax_Syntax.actions)
+in (match (uu____1089) with
+| (g3, actions) -> begin
+((g3), ((FStar_List.append ((return_decl)::(bind_decl)::[]) actions)))
+end))
+end))
+end)))))
+end
+| FStar_Syntax_Syntax.Sig_new_effect (uu____1101) -> begin
+((g), ([]))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____1104, t, quals) when (FStar_Extraction_ML_Term.is_arity g t) -> begin
+(
+
+let uu____1109 = (
+
+let uu____1110 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___151_1112 -> (match (uu___151_1112) with
+| FStar_Syntax_Syntax.Assumption -> begin
+true
+end
+| uu____1113 -> begin
+false
+end))))
+in (FStar_All.pipe_right uu____1110 Prims.op_Negation))
+in (match (uu____1109) with
+| true -> begin
+((g), ([]))
+end
+| uu____1118 -> begin
+(
+
+let uu____1119 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____1119) with
+| (bs, uu____1131) -> begin
+(
+
+let fv = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____1143 = (FStar_Syntax_Util.abs bs FStar_TypeChecker_Common.t_unit None)
+in (extract_typ_abbrev g fv quals uu____1143)))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Sig_let ((false, (lb)::[]), uu____1150, quals, uu____1152) when (FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp) -> begin
+(
+
+let uu____1163 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (extract_typ_abbrev g uu____1163 quals lb.FStar_Syntax_Syntax.lbdef))
+end
+| FStar_Syntax_Syntax.Sig_let (lbs, uu____1165, quals, attrs) -> begin
+(
+
+let elet = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_let (((lbs), (FStar_Syntax_Const.exp_false_bool))))) None se.FStar_Syntax_Syntax.sigrng)
+in (
+
+let uu____1185 = (FStar_Extraction_ML_Term.term_as_mlexpr g elet)
+in (match (uu____1185) with
+| (ml_let, uu____1193, uu____1194) -> begin
+(match (ml_let.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_Let ((flavor, uu____1199, bindings), uu____1201) -> begin
+(
+
+let uu____1208 = (FStar_List.fold_left2 (fun uu____1215 ml_lb uu____1217 -> (match (((uu____1215), (uu____1217))) with
+| ((env, ml_lbs), {FStar_Syntax_Syntax.lbname = lbname; FStar_Syntax_Syntax.lbunivs = uu____1230; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = uu____1232; FStar_Syntax_Syntax.lbdef = uu____1233}) -> begin
+(
+
+let lb_lid = (
+
+let uu____1247 = (
+
+let uu____1252 = (FStar_Util.right lbname)
+in uu____1252.FStar_Syntax_Syntax.fv_name)
+in uu____1247.FStar_Syntax_Syntax.v)
+in (
+
+let uu____1256 = (
+
+let uu____1259 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___152_1261 -> (match (uu___152_1261) with
+| FStar_Syntax_Syntax.Projector (uu____1262) -> begin
+true
+end
+| uu____1265 -> begin
+false
+end))))
+in (match (uu____1259) with
+| true -> begin
+(
+
+let mname = (
+
+let uu____1269 = (mangle_projector_lid lb_lid)
+in (FStar_All.pipe_right uu____1269 FStar_Extraction_ML_Syntax.mlpath_of_lident))
+in (
+
+let uu____1270 = (
+
+let uu____1273 = (FStar_Util.right lbname)
+in (
+
+let uu____1274 = (FStar_Util.must ml_lb.FStar_Extraction_ML_Syntax.mllb_tysc)
+in (FStar_Extraction_ML_UEnv.extend_fv' env uu____1273 mname uu____1274 ml_lb.FStar_Extraction_ML_Syntax.mllb_add_unit false)))
+in (match (uu____1270) with
+| (env1, uu____1278) -> begin
+((env1), ((
+
+let uu___157_1279 = ml_lb
+in {FStar_Extraction_ML_Syntax.mllb_name = (((Prims.snd mname)), ((Prims.parse_int "0"))); FStar_Extraction_ML_Syntax.mllb_tysc = uu___157_1279.FStar_Extraction_ML_Syntax.mllb_tysc; FStar_Extraction_ML_Syntax.mllb_add_unit = uu___157_1279.FStar_Extraction_ML_Syntax.mllb_add_unit; FStar_Extraction_ML_Syntax.mllb_def = uu___157_1279.FStar_Extraction_ML_Syntax.mllb_def; FStar_Extraction_ML_Syntax.print_typ = uu___157_1279.FStar_Extraction_ML_Syntax.print_typ})))
+end)))
+end
+| uu____1281 -> begin
+(
+
+let uu____1282 = (
+
+let uu____1283 = (
+
+let uu____1286 = (FStar_Util.must ml_lb.FStar_Extraction_ML_Syntax.mllb_tysc)
+in (FStar_Extraction_ML_UEnv.extend_lb env lbname t uu____1286 ml_lb.FStar_Extraction_ML_Syntax.mllb_add_unit false))
+in (FStar_All.pipe_left Prims.fst uu____1283))
+in ((uu____1282), (ml_lb)))
+end))
+in (match (uu____1256) with
+| (g1, ml_lb1) -> begin
+((g1), ((ml_lb1)::ml_lbs))
+end)))
+end)) ((g), ([])) bindings (Prims.snd lbs))
+in (match (uu____1208) with
+| (g1, ml_lbs') -> begin
+(
+
+let flags = (FStar_List.choose (fun uu___153_1306 -> (match (uu___153_1306) with
+| FStar_Syntax_Syntax.Assumption -> begin
+Some (FStar_Extraction_ML_Syntax.Assumed)
+end
+| FStar_Syntax_Syntax.Private -> begin
+Some (FStar_Extraction_ML_Syntax.Private)
+end
+| FStar_Syntax_Syntax.NoExtract -> begin
+Some (FStar_Extraction_ML_Syntax.NoExtract)
+end
+| uu____1308 -> begin
+None
+end)) quals)
+in (
+
+let flags' = (FStar_List.choose (fun uu___154_1313 -> (match (uu___154_1313) with
+| {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (data, uu____1318)); FStar_Syntax_Syntax.tk = uu____1319; FStar_Syntax_Syntax.pos = uu____1320; FStar_Syntax_Syntax.vars = uu____1321} -> begin
+Some (FStar_Extraction_ML_Syntax.Attribute ((FStar_Util.string_of_unicode data)))
+end
+| uu____1326 -> begin
+((FStar_Util.print_warning "Warning: unrecognized, non-string attribute, bother protz for a better error message");
+None;
+)
+end)) attrs)
+in (
+
+let uu____1330 = (
+
+let uu____1332 = (
+
+let uu____1333 = (FStar_Extraction_ML_Util.mlloc_of_range se.FStar_Syntax_Syntax.sigrng)
+in FStar_Extraction_ML_Syntax.MLM_Loc (uu____1333))
+in (uu____1332)::(FStar_Extraction_ML_Syntax.MLM_Let (((flavor), ((FStar_List.append flags flags')), ((FStar_List.rev ml_lbs')))))::[])
+in ((g1), (uu____1330)))))
+end))
+end
+| uu____1337 -> begin
+(
+
+let uu____1338 = (
+
+let uu____1339 = (FStar_Extraction_ML_Code.string_of_mlexpr g.FStar_Extraction_ML_UEnv.currentModule ml_let)
+in (FStar_Util.format1 "Impossible: Translated a let to a non-let: %s" uu____1339))
+in (failwith uu____1338))
+end)
+end)))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____1344, t, quals) -> begin
+(
+
+let uu____1349 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Assumption))
+in (match (uu____1349) with
+| true -> begin
+(
+
+let always_fail = (
+
+let imp = (
+
+let uu____1358 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____1358) with
+| ([], t1) -> begin
+(fail_exp lid t1)
+end
+| (bs, t1) -> begin
+(
+
+let uu____1390 = (fail_exp lid t1)
+in (FStar_Syntax_Util.abs bs uu____1390 None))
+end))
+in (
+
+let uu___158_1396 = se
+in (
+
+let uu____1397 = (
+
+let uu____1398 = (
+
+let uu____1406 = (
+
+let uu____1410 = (
+
+let uu____1412 = (
+
+let uu____1413 = (
+
+let uu____1416 = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_constant None)
+in FStar_Util.Inr (uu____1416))
+in {FStar_Syntax_Syntax.lbname = uu____1413; FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_ML_lid; FStar_Syntax_Syntax.lbdef = imp})
+in (uu____1412)::[])
+in ((false), (uu____1410)))
+in ((uu____1406), ([]), (quals), ([])))
+in FStar_Syntax_Syntax.Sig_let (uu____1398))
+in {FStar_Syntax_Syntax.sigel = uu____1397; FStar_Syntax_Syntax.sigdoc = uu___158_1396.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___158_1396.FStar_Syntax_Syntax.sigrng})))
+in (
+
+let uu____1424 = (extract_sig g always_fail)
+in (match (uu____1424) with
+| (g1, mlm) -> begin
+(
+
+let uu____1435 = (FStar_Util.find_map quals (fun uu___155_1437 -> (match (uu___155_1437) with
+| FStar_Syntax_Syntax.Discriminator (l) -> begin
+Some (l)
+end
+| uu____1440 -> begin
+None
+end)))
+in (match (uu____1435) with
+| Some (l) -> begin
+(
+
+let uu____1445 = (
+
+let uu____1447 = (
+
+let uu____1448 = (FStar_Extraction_ML_Util.mlloc_of_range se.FStar_Syntax_Syntax.sigrng)
+in FStar_Extraction_ML_Syntax.MLM_Loc (uu____1448))
+in (
+
+let uu____1449 = (
+
+let uu____1451 = (FStar_Extraction_ML_Term.ind_discriminator_body g1 lid l)
+in (uu____1451)::[])
+in (uu____1447)::uu____1449))
+in ((g1), (uu____1445)))
+end
+| uu____1453 -> begin
+(
+
+let uu____1455 = (FStar_Util.find_map quals (fun uu___156_1457 -> (match (uu___156_1457) with
+| FStar_Syntax_Syntax.Projector (l, uu____1460) -> begin
+Some (l)
+end
+| uu____1461 -> begin
+None
+end)))
+in (match (uu____1455) with
+| Some (uu____1465) -> begin
+((g1), ([]))
+end
+| uu____1467 -> begin
+((g1), (mlm))
+end))
+end))
+end)))
+end
+| uu____1470 -> begin
+((g), ([]))
+end))
+end
+| FStar_Syntax_Syntax.Sig_main (e) -> begin
+(
+
+let uu____1473 = (FStar_Extraction_ML_Term.term_as_mlexpr g e)
+in (match (uu____1473) with
+| (ml_main, uu____1481, uu____1482) -> begin
+(
+
+let uu____1483 = (
+
+let uu____1485 = (
+
+let uu____1486 = (FStar_Extraction_ML_Util.mlloc_of_range se.FStar_Syntax_Syntax.sigrng)
+in FStar_Extraction_ML_Syntax.MLM_Loc (uu____1486))
+in (uu____1485)::(FStar_Extraction_ML_Syntax.MLM_Top (ml_main))::[])
+in ((g), (uu____1483)))
+end))
+end
+| FStar_Syntax_Syntax.Sig_new_effect_for_free (uu____1488) -> begin
+(failwith "impossible -- removed by tc.fs")
+end
+| (FStar_Syntax_Syntax.Sig_assume (_)) | (FStar_Syntax_Syntax.Sig_sub_effect (_)) | (FStar_Syntax_Syntax.Sig_effect_abbrev (_)) -> begin
+((g), ([]))
+end
+| FStar_Syntax_Syntax.Sig_pragma (p) -> begin
+((match ((p = FStar_Syntax_Syntax.LightOff)) with
+| true -> begin
+(FStar_Options.set_ml_ish ())
+end
+| uu____1498 -> begin
+()
+end);
+((g), ([]));
+)
+end);
+))
+
+
+let extract_iface : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.modul  ->  env_t = (fun g m -> (
+
+let uu____1506 = (FStar_Util.fold_map extract_sig g m.FStar_Syntax_Syntax.declarations)
+in (FStar_All.pipe_right uu____1506 Prims.fst)))
+
+
+let extract : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.modul  ->  (FStar_Extraction_ML_UEnv.env * FStar_Extraction_ML_Syntax.mllib Prims.list) = (fun g m -> ((FStar_Syntax_Syntax.reset_gensym ());
+(
+
+let uu____1531 = (FStar_Options.restore_cmd_line_options true)
+in (
+
+let name = (FStar_Extraction_ML_Syntax.mlpath_of_lident m.FStar_Syntax_Syntax.name)
+in (
+
+let g1 = (
+
+let uu___159_1534 = g
+in {FStar_Extraction_ML_UEnv.tcenv = uu___159_1534.FStar_Extraction_ML_UEnv.tcenv; FStar_Extraction_ML_UEnv.gamma = uu___159_1534.FStar_Extraction_ML_UEnv.gamma; FStar_Extraction_ML_UEnv.tydefs = uu___159_1534.FStar_Extraction_ML_UEnv.tydefs; FStar_Extraction_ML_UEnv.currentModule = name})
+in (
+
+let uu____1535 = (FStar_Util.fold_map extract_sig g1 m.FStar_Syntax_Syntax.declarations)
+in (match (uu____1535) with
+| (g2, sigs) -> begin
+(
+
+let mlm = (FStar_List.flatten sigs)
+in (
+
+let is_kremlin = (
+
+let uu____1552 = (FStar_Options.codegen ())
+in (match (uu____1552) with
+| Some ("Kremlin") -> begin
+true
+end
+| uu____1554 -> begin
+false
+end))
+in (
+
+let uu____1556 = (((m.FStar_Syntax_Syntax.name.FStar_Ident.str <> "Prims") && (is_kremlin || (not (m.FStar_Syntax_Syntax.is_interface)))) && (FStar_Options.should_extract m.FStar_Syntax_Syntax.name.FStar_Ident.str))
+in (match (uu____1556) with
+| true -> begin
+((
+
+let uu____1561 = (FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name)
+in (FStar_Util.print1 "Extracted module %s\n" uu____1561));
+((g2), ((FStar_Extraction_ML_Syntax.MLLib ((((name), (Some ((([]), (mlm)))), (FStar_Extraction_ML_Syntax.MLLib ([]))))::[]))::[]));
+)
+end
+| uu____1591 -> begin
+((g2), ([]))
+end))))
+end)))));
+))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
@@ -1,526 +1,1088 @@
+
 open Prims
-type mlsymbol = Prims.string
-type mlident = (mlsymbol* Prims.int)
-type mlpath = (mlsymbol Prims.list* mlsymbol)
-let ocamlkeywords: Prims.string Prims.list =
-  ["and";
-  "as";
-  "assert";
-  "asr";
-  "begin";
-  "class";
-  "constraint";
-  "do";
-  "done";
-  "downto";
-  "else";
-  "end";
-  "exception";
-  "external";
-  "false";
-  "for";
-  "fun";
-  "function";
-  "functor";
-  "if";
-  "in";
-  "include";
-  "inherit";
-  "initializer";
-  "land";
-  "lazy";
-  "let";
-  "lor";
-  "lsl";
-  "lsr";
-  "lxor";
-  "match";
-  "method";
-  "mod";
-  "module";
-  "mutable";
-  "new";
-  "object";
-  "of";
-  "open";
-  "or";
-  "private";
-  "rec";
-  "sig";
-  "struct";
-  "then";
-  "to";
-  "true";
-  "try";
-  "type";
-  "val";
-  "virtual";
-  "when";
-  "while";
-  "with";
-  "nonrec"]
-let is_reserved: Prims.string -> Prims.bool =
-  fun k  -> FStar_List.existsb (fun k'  -> k' = k) ocamlkeywords
-let idsym: mlident -> mlsymbol =
-  fun uu____13  -> match uu____13 with | (s,uu____15) -> s
-let string_of_mlpath: mlpath -> mlsymbol =
-  fun uu____18  ->
-    match uu____18 with
-    | (p,s) -> FStar_String.concat "." (FStar_List.append p [s])
+
+type mlsymbol =
+Prims.string
+
+
+type mlident =
+(mlsymbol * Prims.int)
+
+
+type mlpath =
+(mlsymbol Prims.list * mlsymbol)
+
+
+let ocamlkeywords : Prims.string Prims.list = ("and")::("as")::("assert")::("asr")::("begin")::("class")::("constraint")::("do")::("done")::("downto")::("else")::("end")::("exception")::("external")::("false")::("for")::("fun")::("function")::("functor")::("if")::("in")::("include")::("inherit")::("initializer")::("land")::("lazy")::("let")::("lor")::("lsl")::("lsr")::("lxor")::("match")::("method")::("mod")::("module")::("mutable")::("new")::("object")::("of")::("open")::("or")::("private")::("rec")::("sig")::("struct")::("then")::("to")::("true")::("try")::("type")::("val")::("virtual")::("when")::("while")::("with")::("nonrec")::[]
+
+
+let is_reserved : Prims.string  ->  Prims.bool = (fun k -> (FStar_List.existsb (fun k' -> (k' = k)) ocamlkeywords))
+
+
+let idsym : mlident  ->  mlsymbol = (fun uu____13 -> (match (uu____13) with
+| (s, uu____15) -> begin
+s
+end))
+
+
+let string_of_mlpath : mlpath  ->  mlsymbol = (fun uu____18 -> (match (uu____18) with
+| (p, s) -> begin
+(FStar_String.concat "." (FStar_List.append p ((s)::[])))
+end))
+
 type gensym_t =
-  {
-  gensym: Prims.unit -> mlident;
-  reset: Prims.unit -> Prims.unit;}
-let gs: gensym_t =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
-  let n_resets = FStar_Util.mk_ref (Prims.parse_int "0") in
-  {
-    gensym =
-      (fun uu____57  ->
-         FStar_Util.incr ctr;
-         (let uu____62 =
-            let uu____63 =
-              let uu____64 =
-                let uu____65 = FStar_ST.read n_resets in
-                FStar_Util.string_of_int uu____65 in
-              let uu____68 =
-                let uu____69 =
-                  let uu____70 = FStar_ST.read ctr in
-                  FStar_Util.string_of_int uu____70 in
-                Prims.strcat "_" uu____69 in
-              Prims.strcat uu____64 uu____68 in
-            Prims.strcat "_" uu____63 in
-          (uu____62, (Prims.parse_int "0"))));
-    reset =
-      (fun uu____73  ->
-         FStar_ST.write ctr (Prims.parse_int "0"); FStar_Util.incr n_resets)
-  }
-let gensym: Prims.unit -> mlident = fun uu____82  -> gs.gensym ()
-let reset_gensym: Prims.unit -> Prims.unit = fun uu____85  -> gs.reset ()
-let rec gensyms: Prims.int -> mlident Prims.list =
-  fun x  ->
-    match x with
-    | _0_28 when _0_28 = (Prims.parse_int "0") -> []
-    | n1 ->
-        let uu____92 = gensym () in
-        let uu____93 = gensyms (n1 - (Prims.parse_int "1")) in uu____92 ::
-          uu____93
-let mlpath_of_lident:
-  FStar_Ident.lident -> (Prims.string Prims.list* Prims.string) =
-  fun x  ->
-    if FStar_Ident.lid_equals x FStar_Syntax_Const.failwith_lid
-    then ([], ((x.FStar_Ident.ident).FStar_Ident.idText))
-    else
-      (let uu____100 =
-         FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns in
-       (uu____100, ((x.FStar_Ident.ident).FStar_Ident.idText)))
-type mlidents = mlident Prims.list
-type mlsymbols = mlsymbol Prims.list
+{gensym : Prims.unit  ->  mlident; reset : Prims.unit  ->  Prims.unit}
+
+
+let gs : gensym_t = (
+
+let ctr = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (
+
+let n_resets = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in {gensym = (fun uu____57 -> ((FStar_Util.incr ctr);
+(
+
+let uu____62 = (
+
+let uu____63 = (
+
+let uu____64 = (
+
+let uu____65 = (FStar_ST.read n_resets)
+in (FStar_Util.string_of_int uu____65))
+in (
+
+let uu____68 = (
+
+let uu____69 = (
+
+let uu____70 = (FStar_ST.read ctr)
+in (FStar_Util.string_of_int uu____70))
+in (Prims.strcat "_" uu____69))
+in (Prims.strcat uu____64 uu____68)))
+in (Prims.strcat "_" uu____63))
+in ((uu____62), ((Prims.parse_int "0"))));
+)); reset = (fun uu____73 -> ((FStar_ST.write ctr (Prims.parse_int "0"));
+(FStar_Util.incr n_resets);
+))}))
+
+
+let gensym : Prims.unit  ->  mlident = (fun uu____82 -> (gs.gensym ()))
+
+
+let reset_gensym : Prims.unit  ->  Prims.unit = (fun uu____85 -> (gs.reset ()))
+
+
+let rec gensyms : Prims.int  ->  mlident Prims.list = (fun x -> (match (x) with
+| _0_28 when (_0_28 = (Prims.parse_int "0")) -> begin
+[]
+end
+| n1 -> begin
+(
+
+let uu____92 = (gensym ())
+in (
+
+let uu____93 = (gensyms (n1 - (Prims.parse_int "1")))
+in (uu____92)::uu____93))
+end))
+
+
+let mlpath_of_lident : FStar_Ident.lident  ->  mlpath = (fun x -> (match ((FStar_Ident.lid_equals x FStar_Syntax_Const.failwith_lid)) with
+| true -> begin
+(([]), (x.FStar_Ident.ident.FStar_Ident.idText))
+end
+| uu____99 -> begin
+(
+
+let uu____100 = (FStar_List.map (fun x1 -> x1.FStar_Ident.idText) x.FStar_Ident.ns)
+in ((uu____100), (x.FStar_Ident.ident.FStar_Ident.idText)))
+end))
+
+
+type mlidents =
+mlident Prims.list
+
+
+type mlsymbols =
+mlsymbol Prims.list
+
 type e_tag =
-  | E_PURE
-  | E_GHOST
-  | E_IMPURE
-let uu___is_E_PURE: e_tag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | E_PURE  -> true | uu____109 -> false
-let uu___is_E_GHOST: e_tag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | E_GHOST  -> true | uu____113 -> false
-let uu___is_E_IMPURE: e_tag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | E_IMPURE  -> true | uu____117 -> false
-type mlloc = (Prims.int* Prims.string)
-let dummy_loc: (Prims.int* Prims.string) = ((Prims.parse_int "0"), "")
+| E_PURE
+| E_GHOST
+| E_IMPURE
+
+
+let uu___is_E_PURE : e_tag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| E_PURE -> begin
+true
+end
+| uu____109 -> begin
+false
+end))
+
+
+let uu___is_E_GHOST : e_tag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| E_GHOST -> begin
+true
+end
+| uu____113 -> begin
+false
+end))
+
+
+let uu___is_E_IMPURE : e_tag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| E_IMPURE -> begin
+true
+end
+| uu____117 -> begin
+false
+end))
+
+
+type mlloc =
+(Prims.int * Prims.string)
+
+
+let dummy_loc : (Prims.int * Prims.string) = (((Prims.parse_int "0")), (""))
+
 type mlty =
-  | MLTY_Var of mlident
-  | MLTY_Fun of (mlty* e_tag* mlty)
-  | MLTY_Named of (mlty Prims.list* mlpath)
-  | MLTY_Tuple of mlty Prims.list
-  | MLTY_Top
-let uu___is_MLTY_Var: mlty -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTY_Var _0 -> true | uu____145 -> false
-let __proj__MLTY_Var__item___0: mlty -> mlident =
-  fun projectee  -> match projectee with | MLTY_Var _0 -> _0
-let uu___is_MLTY_Fun: mlty -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTY_Fun _0 -> true | uu____160 -> false
-let __proj__MLTY_Fun__item___0: mlty -> (mlty* e_tag* mlty) =
-  fun projectee  -> match projectee with | MLTY_Fun _0 -> _0
-let uu___is_MLTY_Named: mlty -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTY_Named _0 -> true | uu____184 -> false
-let __proj__MLTY_Named__item___0: mlty -> (mlty Prims.list* mlpath) =
-  fun projectee  -> match projectee with | MLTY_Named _0 -> _0
-let uu___is_MLTY_Tuple: mlty -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTY_Tuple _0 -> true | uu____206 -> false
-let __proj__MLTY_Tuple__item___0: mlty -> mlty Prims.list =
-  fun projectee  -> match projectee with | MLTY_Tuple _0 -> _0
-let uu___is_MLTY_Top: mlty -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTY_Top  -> true | uu____220 -> false
-type mltyscheme = (mlidents* mlty)
+| MLTY_Var of mlident
+| MLTY_Fun of (mlty * e_tag * mlty)
+| MLTY_Named of (mlty Prims.list * mlpath)
+| MLTY_Tuple of mlty Prims.list
+| MLTY_Top
+
+
+let uu___is_MLTY_Var : mlty  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTY_Var (_0) -> begin
+true
+end
+| uu____145 -> begin
+false
+end))
+
+
+let __proj__MLTY_Var__item___0 : mlty  ->  mlident = (fun projectee -> (match (projectee) with
+| MLTY_Var (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTY_Fun : mlty  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTY_Fun (_0) -> begin
+true
+end
+| uu____160 -> begin
+false
+end))
+
+
+let __proj__MLTY_Fun__item___0 : mlty  ->  (mlty * e_tag * mlty) = (fun projectee -> (match (projectee) with
+| MLTY_Fun (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTY_Named : mlty  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTY_Named (_0) -> begin
+true
+end
+| uu____184 -> begin
+false
+end))
+
+
+let __proj__MLTY_Named__item___0 : mlty  ->  (mlty Prims.list * mlpath) = (fun projectee -> (match (projectee) with
+| MLTY_Named (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTY_Tuple : mlty  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTY_Tuple (_0) -> begin
+true
+end
+| uu____206 -> begin
+false
+end))
+
+
+let __proj__MLTY_Tuple__item___0 : mlty  ->  mlty Prims.list = (fun projectee -> (match (projectee) with
+| MLTY_Tuple (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTY_Top : mlty  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTY_Top -> begin
+true
+end
+| uu____220 -> begin
+false
+end))
+
+
+type mltyscheme =
+(mlidents * mlty)
+
 type mlconstant =
-  | MLC_Unit
-  | MLC_Bool of Prims.bool
-  | MLC_Int of (Prims.string* (FStar_Const.signedness* FStar_Const.width)
-  Prims.option)
-  | MLC_Float of FStar_BaseTypes.float
-  | MLC_Char of FStar_BaseTypes.char
-  | MLC_String of Prims.string
-  | MLC_Bytes of FStar_BaseTypes.byte Prims.array
-let uu___is_MLC_Unit: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Unit  -> true | uu____250 -> false
-let uu___is_MLC_Bool: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Bool _0 -> true | uu____255 -> false
-let __proj__MLC_Bool__item___0: mlconstant -> Prims.bool =
-  fun projectee  -> match projectee with | MLC_Bool _0 -> _0
-let uu___is_MLC_Int: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Int _0 -> true | uu____272 -> false
-let __proj__MLC_Int__item___0:
-  mlconstant ->
-    (Prims.string* (FStar_Const.signedness* FStar_Const.width) Prims.option)
-  = fun projectee  -> match projectee with | MLC_Int _0 -> _0
-let uu___is_MLC_Float: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Float _0 -> true | uu____299 -> false
-let __proj__MLC_Float__item___0: mlconstant -> FStar_BaseTypes.float =
-  fun projectee  -> match projectee with | MLC_Float _0 -> _0
-let uu___is_MLC_Char: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Char _0 -> true | uu____311 -> false
-let __proj__MLC_Char__item___0: mlconstant -> FStar_BaseTypes.char =
-  fun projectee  -> match projectee with | MLC_Char _0 -> _0
-let uu___is_MLC_String: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_String _0 -> true | uu____323 -> false
-let __proj__MLC_String__item___0: mlconstant -> Prims.string =
-  fun projectee  -> match projectee with | MLC_String _0 -> _0
-let uu___is_MLC_Bytes: mlconstant -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLC_Bytes _0 -> true | uu____336 -> false
-let __proj__MLC_Bytes__item___0:
-  mlconstant -> FStar_BaseTypes.byte Prims.array =
-  fun projectee  -> match projectee with | MLC_Bytes _0 -> _0
+| MLC_Unit
+| MLC_Bool of Prims.bool
+| MLC_Int of (Prims.string * (FStar_Const.signedness * FStar_Const.width) Prims.option)
+| MLC_Float of FStar_BaseTypes.float
+| MLC_Char of FStar_BaseTypes.char
+| MLC_String of Prims.string
+| MLC_Bytes of FStar_BaseTypes.byte Prims.array
+
+
+let uu___is_MLC_Unit : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Unit -> begin
+true
+end
+| uu____250 -> begin
+false
+end))
+
+
+let uu___is_MLC_Bool : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Bool (_0) -> begin
+true
+end
+| uu____255 -> begin
+false
+end))
+
+
+let __proj__MLC_Bool__item___0 : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Bool (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLC_Int : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Int (_0) -> begin
+true
+end
+| uu____272 -> begin
+false
+end))
+
+
+let __proj__MLC_Int__item___0 : mlconstant  ->  (Prims.string * (FStar_Const.signedness * FStar_Const.width) Prims.option) = (fun projectee -> (match (projectee) with
+| MLC_Int (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLC_Float : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Float (_0) -> begin
+true
+end
+| uu____299 -> begin
+false
+end))
+
+
+let __proj__MLC_Float__item___0 : mlconstant  ->  FStar_BaseTypes.float = (fun projectee -> (match (projectee) with
+| MLC_Float (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLC_Char : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Char (_0) -> begin
+true
+end
+| uu____311 -> begin
+false
+end))
+
+
+let __proj__MLC_Char__item___0 : mlconstant  ->  FStar_BaseTypes.char = (fun projectee -> (match (projectee) with
+| MLC_Char (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLC_String : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_String (_0) -> begin
+true
+end
+| uu____323 -> begin
+false
+end))
+
+
+let __proj__MLC_String__item___0 : mlconstant  ->  Prims.string = (fun projectee -> (match (projectee) with
+| MLC_String (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLC_Bytes : mlconstant  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLC_Bytes (_0) -> begin
+true
+end
+| uu____336 -> begin
+false
+end))
+
+
+let __proj__MLC_Bytes__item___0 : mlconstant  ->  FStar_BaseTypes.byte Prims.array = (fun projectee -> (match (projectee) with
+| MLC_Bytes (_0) -> begin
+_0
+end))
+
 type mlpattern =
-  | MLP_Wild
-  | MLP_Const of mlconstant
-  | MLP_Var of mlident
-  | MLP_CTor of (mlpath* mlpattern Prims.list)
-  | MLP_Branch of mlpattern Prims.list
-  | MLP_Record of (mlsymbol Prims.list* (mlsymbol* mlpattern) Prims.list)
-  | MLP_Tuple of mlpattern Prims.list
-let uu___is_MLP_Wild: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Wild  -> true | uu____379 -> false
-let uu___is_MLP_Const: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Const _0 -> true | uu____384 -> false
-let __proj__MLP_Const__item___0: mlpattern -> mlconstant =
-  fun projectee  -> match projectee with | MLP_Const _0 -> _0
-let uu___is_MLP_Var: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Var _0 -> true | uu____396 -> false
-let __proj__MLP_Var__item___0: mlpattern -> mlident =
-  fun projectee  -> match projectee with | MLP_Var _0 -> _0
-let uu___is_MLP_CTor: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_CTor _0 -> true | uu____411 -> false
-let __proj__MLP_CTor__item___0: mlpattern -> (mlpath* mlpattern Prims.list) =
-  fun projectee  -> match projectee with | MLP_CTor _0 -> _0
-let uu___is_MLP_Branch: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Branch _0 -> true | uu____433 -> false
-let __proj__MLP_Branch__item___0: mlpattern -> mlpattern Prims.list =
-  fun projectee  -> match projectee with | MLP_Branch _0 -> _0
-let uu___is_MLP_Record: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Record _0 -> true | uu____454 -> false
-let __proj__MLP_Record__item___0:
-  mlpattern -> (mlsymbol Prims.list* (mlsymbol* mlpattern) Prims.list) =
-  fun projectee  -> match projectee with | MLP_Record _0 -> _0
-let uu___is_MLP_Tuple: mlpattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLP_Tuple _0 -> true | uu____485 -> false
-let __proj__MLP_Tuple__item___0: mlpattern -> mlpattern Prims.list =
-  fun projectee  -> match projectee with | MLP_Tuple _0 -> _0
+| MLP_Wild
+| MLP_Const of mlconstant
+| MLP_Var of mlident
+| MLP_CTor of (mlpath * mlpattern Prims.list)
+| MLP_Branch of mlpattern Prims.list
+| MLP_Record of (mlsymbol Prims.list * (mlsymbol * mlpattern) Prims.list)
+| MLP_Tuple of mlpattern Prims.list
+
+
+let uu___is_MLP_Wild : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Wild -> begin
+true
+end
+| uu____379 -> begin
+false
+end))
+
+
+let uu___is_MLP_Const : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Const (_0) -> begin
+true
+end
+| uu____384 -> begin
+false
+end))
+
+
+let __proj__MLP_Const__item___0 : mlpattern  ->  mlconstant = (fun projectee -> (match (projectee) with
+| MLP_Const (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLP_Var : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Var (_0) -> begin
+true
+end
+| uu____396 -> begin
+false
+end))
+
+
+let __proj__MLP_Var__item___0 : mlpattern  ->  mlident = (fun projectee -> (match (projectee) with
+| MLP_Var (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLP_CTor : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_CTor (_0) -> begin
+true
+end
+| uu____411 -> begin
+false
+end))
+
+
+let __proj__MLP_CTor__item___0 : mlpattern  ->  (mlpath * mlpattern Prims.list) = (fun projectee -> (match (projectee) with
+| MLP_CTor (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLP_Branch : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Branch (_0) -> begin
+true
+end
+| uu____433 -> begin
+false
+end))
+
+
+let __proj__MLP_Branch__item___0 : mlpattern  ->  mlpattern Prims.list = (fun projectee -> (match (projectee) with
+| MLP_Branch (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLP_Record : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Record (_0) -> begin
+true
+end
+| uu____454 -> begin
+false
+end))
+
+
+let __proj__MLP_Record__item___0 : mlpattern  ->  (mlsymbol Prims.list * (mlsymbol * mlpattern) Prims.list) = (fun projectee -> (match (projectee) with
+| MLP_Record (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLP_Tuple : mlpattern  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLP_Tuple (_0) -> begin
+true
+end
+| uu____485 -> begin
+false
+end))
+
+
+let __proj__MLP_Tuple__item___0 : mlpattern  ->  mlpattern Prims.list = (fun projectee -> (match (projectee) with
+| MLP_Tuple (_0) -> begin
+_0
+end))
+
 type c_flag =
-  | Mutable
-  | Assumed
-  | Private
-  | NoExtract
-  | Attribute of Prims.string
-let uu___is_Mutable: c_flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mutable  -> true | uu____502 -> false
-let uu___is_Assumed: c_flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assumed  -> true | uu____506 -> false
-let uu___is_Private: c_flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Private  -> true | uu____510 -> false
-let uu___is_NoExtract: c_flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____514 -> false
-let uu___is_Attribute: c_flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Attribute _0 -> true | uu____519 -> false
-let __proj__Attribute__item___0: c_flag -> Prims.string =
-  fun projectee  -> match projectee with | Attribute _0 -> _0
+| Mutable
+| Assumed
+| Private
+| NoExtract
+| Attribute of Prims.string
+
+
+let uu___is_Mutable : c_flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mutable -> begin
+true
+end
+| uu____502 -> begin
+false
+end))
+
+
+let uu___is_Assumed : c_flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assumed -> begin
+true
+end
+| uu____506 -> begin
+false
+end))
+
+
+let uu___is_Private : c_flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Private -> begin
+true
+end
+| uu____510 -> begin
+false
+end))
+
+
+let uu___is_NoExtract : c_flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoExtract -> begin
+true
+end
+| uu____514 -> begin
+false
+end))
+
+
+let uu___is_Attribute : c_flag  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Attribute (_0) -> begin
+true
+end
+| uu____519 -> begin
+false
+end))
+
+
+let __proj__Attribute__item___0 : c_flag  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Attribute (_0) -> begin
+_0
+end))
+
 type mlletflavor =
-  | Rec
-  | NonRec
-let uu___is_Rec: mlletflavor -> Prims.bool =
-  fun projectee  -> match projectee with | Rec  -> true | uu____530 -> false
-let uu___is_NonRec: mlletflavor -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NonRec  -> true | uu____534 -> false
-type c_flags = c_flag Prims.list
+| Rec
+| NonRec
+
+
+let uu___is_Rec : mlletflavor  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Rec -> begin
+true
+end
+| uu____530 -> begin
+false
+end))
+
+
+let uu___is_NonRec : mlletflavor  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NonRec -> begin
+true
+end
+| uu____534 -> begin
+false
+end))
+
+
+type c_flags =
+c_flag Prims.list
+
 type mlexpr' =
-  | MLE_Const of mlconstant
-  | MLE_Var of mlident
-  | MLE_Name of mlpath
-  | MLE_Let of ((mlletflavor* c_flags* mllb Prims.list)* mlexpr)
-  | MLE_App of (mlexpr* mlexpr Prims.list)
-  | MLE_Fun of ((mlident* mlty) Prims.list* mlexpr)
-  | MLE_Match of (mlexpr* (mlpattern* mlexpr Prims.option* mlexpr)
-  Prims.list)
-  | MLE_Coerce of (mlexpr* mlty* mlty)
-  | MLE_CTor of (mlpath* mlexpr Prims.list)
-  | MLE_Seq of mlexpr Prims.list
-  | MLE_Tuple of mlexpr Prims.list
-  | MLE_Record of (mlsymbol Prims.list* (mlsymbol* mlexpr) Prims.list)
-  | MLE_Proj of (mlexpr* mlpath)
-  | MLE_If of (mlexpr* mlexpr* mlexpr Prims.option)
-  | MLE_Raise of (mlpath* mlexpr Prims.list)
-  | MLE_Try of (mlexpr* (mlpattern* mlexpr Prims.option* mlexpr) Prims.list)
-and mlexpr = {
-  expr: mlexpr';
-  mlty: mlty;
-  loc: mlloc;}
-and mllb =
-  {
-  mllb_name: mlident;
-  mllb_tysc: mltyscheme Prims.option;
-  mllb_add_unit: Prims.bool;
-  mllb_def: mlexpr;
-  print_typ: Prims.bool;}
-let uu___is_MLE_Const: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Const _0 -> true | uu____664 -> false
-let __proj__MLE_Const__item___0: mlexpr' -> mlconstant =
-  fun projectee  -> match projectee with | MLE_Const _0 -> _0
-let uu___is_MLE_Var: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Var _0 -> true | uu____676 -> false
-let __proj__MLE_Var__item___0: mlexpr' -> mlident =
-  fun projectee  -> match projectee with | MLE_Var _0 -> _0
-let uu___is_MLE_Name: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Name _0 -> true | uu____688 -> false
-let __proj__MLE_Name__item___0: mlexpr' -> mlpath =
-  fun projectee  -> match projectee with | MLE_Name _0 -> _0
-let uu___is_MLE_Let: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Let _0 -> true | uu____706 -> false
-let __proj__MLE_Let__item___0:
-  mlexpr' -> ((mlletflavor* c_flags* mllb Prims.list)* mlexpr) =
-  fun projectee  -> match projectee with | MLE_Let _0 -> _0
-let uu___is_MLE_App: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_App _0 -> true | uu____739 -> false
-let __proj__MLE_App__item___0: mlexpr' -> (mlexpr* mlexpr Prims.list) =
-  fun projectee  -> match projectee with | MLE_App _0 -> _0
-let uu___is_MLE_Fun: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Fun _0 -> true | uu____765 -> false
-let __proj__MLE_Fun__item___0:
-  mlexpr' -> ((mlident* mlty) Prims.list* mlexpr) =
-  fun projectee  -> match projectee with | MLE_Fun _0 -> _0
-let uu___is_MLE_Match: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Match _0 -> true | uu____799 -> false
-let __proj__MLE_Match__item___0:
-  mlexpr' -> (mlexpr* (mlpattern* mlexpr Prims.option* mlexpr) Prims.list) =
-  fun projectee  -> match projectee with | MLE_Match _0 -> _0
-let uu___is_MLE_Coerce: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Coerce _0 -> true | uu____835 -> false
-let __proj__MLE_Coerce__item___0: mlexpr' -> (mlexpr* mlty* mlty) =
-  fun projectee  -> match projectee with | MLE_Coerce _0 -> _0
-let uu___is_MLE_CTor: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_CTor _0 -> true | uu____859 -> false
-let __proj__MLE_CTor__item___0: mlexpr' -> (mlpath* mlexpr Prims.list) =
-  fun projectee  -> match projectee with | MLE_CTor _0 -> _0
-let uu___is_MLE_Seq: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Seq _0 -> true | uu____881 -> false
-let __proj__MLE_Seq__item___0: mlexpr' -> mlexpr Prims.list =
-  fun projectee  -> match projectee with | MLE_Seq _0 -> _0
-let uu___is_MLE_Tuple: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Tuple _0 -> true | uu____897 -> false
-let __proj__MLE_Tuple__item___0: mlexpr' -> mlexpr Prims.list =
-  fun projectee  -> match projectee with | MLE_Tuple _0 -> _0
-let uu___is_MLE_Record: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Record _0 -> true | uu____918 -> false
-let __proj__MLE_Record__item___0:
-  mlexpr' -> (mlsymbol Prims.list* (mlsymbol* mlexpr) Prims.list) =
-  fun projectee  -> match projectee with | MLE_Record _0 -> _0
-let uu___is_MLE_Proj: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Proj _0 -> true | uu____950 -> false
-let __proj__MLE_Proj__item___0: mlexpr' -> (mlexpr* mlpath) =
-  fun projectee  -> match projectee with | MLE_Proj _0 -> _0
-let uu___is_MLE_If: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_If _0 -> true | uu____972 -> false
-let __proj__MLE_If__item___0:
-  mlexpr' -> (mlexpr* mlexpr* mlexpr Prims.option) =
-  fun projectee  -> match projectee with | MLE_If _0 -> _0
-let uu___is_MLE_Raise: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Raise _0 -> true | uu____999 -> false
-let __proj__MLE_Raise__item___0: mlexpr' -> (mlpath* mlexpr Prims.list) =
-  fun projectee  -> match projectee with | MLE_Raise _0 -> _0
-let uu___is_MLE_Try: mlexpr' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLE_Try _0 -> true | uu____1027 -> false
-let __proj__MLE_Try__item___0:
-  mlexpr' -> (mlexpr* (mlpattern* mlexpr Prims.option* mlexpr) Prims.list) =
-  fun projectee  -> match projectee with | MLE_Try _0 -> _0
-type mlbranch = (mlpattern* mlexpr Prims.option* mlexpr)
-type mlletbinding = (mlletflavor* c_flags* mllb Prims.list)
+| MLE_Const of mlconstant
+| MLE_Var of mlident
+| MLE_Name of mlpath
+| MLE_Let of ((mlletflavor * c_flags * mllb Prims.list) * mlexpr)
+| MLE_App of (mlexpr * mlexpr Prims.list)
+| MLE_Fun of ((mlident * mlty) Prims.list * mlexpr)
+| MLE_Match of (mlexpr * (mlpattern * mlexpr Prims.option * mlexpr) Prims.list)
+| MLE_Coerce of (mlexpr * mlty * mlty)
+| MLE_CTor of (mlpath * mlexpr Prims.list)
+| MLE_Seq of mlexpr Prims.list
+| MLE_Tuple of mlexpr Prims.list
+| MLE_Record of (mlsymbol Prims.list * (mlsymbol * mlexpr) Prims.list)
+| MLE_Proj of (mlexpr * mlpath)
+| MLE_If of (mlexpr * mlexpr * mlexpr Prims.option)
+| MLE_Raise of (mlpath * mlexpr Prims.list)
+| MLE_Try of (mlexpr * (mlpattern * mlexpr Prims.option * mlexpr) Prims.list) 
+ and mlexpr =
+{expr : mlexpr'; mlty : mlty; loc : mlloc} 
+ and mllb =
+{mllb_name : mlident; mllb_tysc : mltyscheme Prims.option; mllb_add_unit : Prims.bool; mllb_def : mlexpr; print_typ : Prims.bool}
+
+
+let uu___is_MLE_Const : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Const (_0) -> begin
+true
+end
+| uu____664 -> begin
+false
+end))
+
+
+let __proj__MLE_Const__item___0 : mlexpr'  ->  mlconstant = (fun projectee -> (match (projectee) with
+| MLE_Const (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Var : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Var (_0) -> begin
+true
+end
+| uu____676 -> begin
+false
+end))
+
+
+let __proj__MLE_Var__item___0 : mlexpr'  ->  mlident = (fun projectee -> (match (projectee) with
+| MLE_Var (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Name : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Name (_0) -> begin
+true
+end
+| uu____688 -> begin
+false
+end))
+
+
+let __proj__MLE_Name__item___0 : mlexpr'  ->  mlpath = (fun projectee -> (match (projectee) with
+| MLE_Name (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Let : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Let (_0) -> begin
+true
+end
+| uu____706 -> begin
+false
+end))
+
+
+let __proj__MLE_Let__item___0 : mlexpr'  ->  ((mlletflavor * c_flags * mllb Prims.list) * mlexpr) = (fun projectee -> (match (projectee) with
+| MLE_Let (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_App : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_App (_0) -> begin
+true
+end
+| uu____739 -> begin
+false
+end))
+
+
+let __proj__MLE_App__item___0 : mlexpr'  ->  (mlexpr * mlexpr Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_App (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Fun : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Fun (_0) -> begin
+true
+end
+| uu____765 -> begin
+false
+end))
+
+
+let __proj__MLE_Fun__item___0 : mlexpr'  ->  ((mlident * mlty) Prims.list * mlexpr) = (fun projectee -> (match (projectee) with
+| MLE_Fun (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Match : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Match (_0) -> begin
+true
+end
+| uu____799 -> begin
+false
+end))
+
+
+let __proj__MLE_Match__item___0 : mlexpr'  ->  (mlexpr * (mlpattern * mlexpr Prims.option * mlexpr) Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_Match (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Coerce : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Coerce (_0) -> begin
+true
+end
+| uu____835 -> begin
+false
+end))
+
+
+let __proj__MLE_Coerce__item___0 : mlexpr'  ->  (mlexpr * mlty * mlty) = (fun projectee -> (match (projectee) with
+| MLE_Coerce (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_CTor : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_CTor (_0) -> begin
+true
+end
+| uu____859 -> begin
+false
+end))
+
+
+let __proj__MLE_CTor__item___0 : mlexpr'  ->  (mlpath * mlexpr Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_CTor (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Seq : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Seq (_0) -> begin
+true
+end
+| uu____881 -> begin
+false
+end))
+
+
+let __proj__MLE_Seq__item___0 : mlexpr'  ->  mlexpr Prims.list = (fun projectee -> (match (projectee) with
+| MLE_Seq (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Tuple : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Tuple (_0) -> begin
+true
+end
+| uu____897 -> begin
+false
+end))
+
+
+let __proj__MLE_Tuple__item___0 : mlexpr'  ->  mlexpr Prims.list = (fun projectee -> (match (projectee) with
+| MLE_Tuple (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Record : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Record (_0) -> begin
+true
+end
+| uu____918 -> begin
+false
+end))
+
+
+let __proj__MLE_Record__item___0 : mlexpr'  ->  (mlsymbol Prims.list * (mlsymbol * mlexpr) Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_Record (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Proj : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Proj (_0) -> begin
+true
+end
+| uu____950 -> begin
+false
+end))
+
+
+let __proj__MLE_Proj__item___0 : mlexpr'  ->  (mlexpr * mlpath) = (fun projectee -> (match (projectee) with
+| MLE_Proj (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_If : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_If (_0) -> begin
+true
+end
+| uu____972 -> begin
+false
+end))
+
+
+let __proj__MLE_If__item___0 : mlexpr'  ->  (mlexpr * mlexpr * mlexpr Prims.option) = (fun projectee -> (match (projectee) with
+| MLE_If (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Raise : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Raise (_0) -> begin
+true
+end
+| uu____999 -> begin
+false
+end))
+
+
+let __proj__MLE_Raise__item___0 : mlexpr'  ->  (mlpath * mlexpr Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_Raise (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLE_Try : mlexpr'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLE_Try (_0) -> begin
+true
+end
+| uu____1027 -> begin
+false
+end))
+
+
+let __proj__MLE_Try__item___0 : mlexpr'  ->  (mlexpr * (mlpattern * mlexpr Prims.option * mlexpr) Prims.list) = (fun projectee -> (match (projectee) with
+| MLE_Try (_0) -> begin
+_0
+end))
+
+
+type mlbranch =
+(mlpattern * mlexpr Prims.option * mlexpr)
+
+
+type mlletbinding =
+(mlletflavor * c_flags * mllb Prims.list)
+
 type mltybody =
-  | MLTD_Abbrev of mlty
-  | MLTD_Record of (mlsymbol* mlty) Prims.list
-  | MLTD_DType of (mlsymbol* mlty Prims.list) Prims.list
-let uu___is_MLTD_Abbrev: mltybody -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTD_Abbrev _0 -> true | uu____1118 -> false
-let __proj__MLTD_Abbrev__item___0: mltybody -> mlty =
-  fun projectee  -> match projectee with | MLTD_Abbrev _0 -> _0
-let uu___is_MLTD_Record: mltybody -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTD_Record _0 -> true | uu____1133 -> false
-let __proj__MLTD_Record__item___0: mltybody -> (mlsymbol* mlty) Prims.list =
-  fun projectee  -> match projectee with | MLTD_Record _0 -> _0
-let uu___is_MLTD_DType: mltybody -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLTD_DType _0 -> true | uu____1158 -> false
-let __proj__MLTD_DType__item___0:
-  mltybody -> (mlsymbol* mlty Prims.list) Prims.list =
-  fun projectee  -> match projectee with | MLTD_DType _0 -> _0
+| MLTD_Abbrev of mlty
+| MLTD_Record of (mlsymbol * mlty) Prims.list
+| MLTD_DType of (mlsymbol * mlty Prims.list) Prims.list
+
+
+let uu___is_MLTD_Abbrev : mltybody  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTD_Abbrev (_0) -> begin
+true
+end
+| uu____1118 -> begin
+false
+end))
+
+
+let __proj__MLTD_Abbrev__item___0 : mltybody  ->  mlty = (fun projectee -> (match (projectee) with
+| MLTD_Abbrev (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTD_Record : mltybody  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTD_Record (_0) -> begin
+true
+end
+| uu____1133 -> begin
+false
+end))
+
+
+let __proj__MLTD_Record__item___0 : mltybody  ->  (mlsymbol * mlty) Prims.list = (fun projectee -> (match (projectee) with
+| MLTD_Record (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLTD_DType : mltybody  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLTD_DType (_0) -> begin
+true
+end
+| uu____1158 -> begin
+false
+end))
+
+
+let __proj__MLTD_DType__item___0 : mltybody  ->  (mlsymbol * mlty Prims.list) Prims.list = (fun projectee -> (match (projectee) with
+| MLTD_DType (_0) -> begin
+_0
+end))
+
+
 type one_mltydecl =
-  (Prims.bool* mlsymbol* mlsymbol Prims.option* mlidents* mltybody
-    Prims.option)
-type mltydecl = one_mltydecl Prims.list
+(Prims.bool * mlsymbol * mlsymbol Prims.option * mlidents * mltybody Prims.option)
+
+
+type mltydecl =
+one_mltydecl Prims.list
+
 type mlmodule1 =
-  | MLM_Ty of mltydecl
-  | MLM_Let of mlletbinding
-  | MLM_Exn of (mlsymbol* mlty Prims.list)
-  | MLM_Top of mlexpr
-  | MLM_Loc of mlloc
-let uu___is_MLM_Ty: mlmodule1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLM_Ty _0 -> true | uu____1208 -> false
-let __proj__MLM_Ty__item___0: mlmodule1 -> mltydecl =
-  fun projectee  -> match projectee with | MLM_Ty _0 -> _0
-let uu___is_MLM_Let: mlmodule1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLM_Let _0 -> true | uu____1220 -> false
-let __proj__MLM_Let__item___0: mlmodule1 -> mlletbinding =
-  fun projectee  -> match projectee with | MLM_Let _0 -> _0
-let uu___is_MLM_Exn: mlmodule1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLM_Exn _0 -> true | uu____1235 -> false
-let __proj__MLM_Exn__item___0: mlmodule1 -> (mlsymbol* mlty Prims.list) =
-  fun projectee  -> match projectee with | MLM_Exn _0 -> _0
-let uu___is_MLM_Top: mlmodule1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLM_Top _0 -> true | uu____1256 -> false
-let __proj__MLM_Top__item___0: mlmodule1 -> mlexpr =
-  fun projectee  -> match projectee with | MLM_Top _0 -> _0
-let uu___is_MLM_Loc: mlmodule1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLM_Loc _0 -> true | uu____1268 -> false
-let __proj__MLM_Loc__item___0: mlmodule1 -> mlloc =
-  fun projectee  -> match projectee with | MLM_Loc _0 -> _0
-type mlmodule = mlmodule1 Prims.list
+| MLM_Ty of mltydecl
+| MLM_Let of mlletbinding
+| MLM_Exn of (mlsymbol * mlty Prims.list)
+| MLM_Top of mlexpr
+| MLM_Loc of mlloc
+
+
+let uu___is_MLM_Ty : mlmodule1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLM_Ty (_0) -> begin
+true
+end
+| uu____1208 -> begin
+false
+end))
+
+
+let __proj__MLM_Ty__item___0 : mlmodule1  ->  mltydecl = (fun projectee -> (match (projectee) with
+| MLM_Ty (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLM_Let : mlmodule1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLM_Let (_0) -> begin
+true
+end
+| uu____1220 -> begin
+false
+end))
+
+
+let __proj__MLM_Let__item___0 : mlmodule1  ->  mlletbinding = (fun projectee -> (match (projectee) with
+| MLM_Let (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLM_Exn : mlmodule1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLM_Exn (_0) -> begin
+true
+end
+| uu____1235 -> begin
+false
+end))
+
+
+let __proj__MLM_Exn__item___0 : mlmodule1  ->  (mlsymbol * mlty Prims.list) = (fun projectee -> (match (projectee) with
+| MLM_Exn (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLM_Top : mlmodule1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLM_Top (_0) -> begin
+true
+end
+| uu____1256 -> begin
+false
+end))
+
+
+let __proj__MLM_Top__item___0 : mlmodule1  ->  mlexpr = (fun projectee -> (match (projectee) with
+| MLM_Top (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLM_Loc : mlmodule1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLM_Loc (_0) -> begin
+true
+end
+| uu____1268 -> begin
+false
+end))
+
+
+let __proj__MLM_Loc__item___0 : mlmodule1  ->  mlloc = (fun projectee -> (match (projectee) with
+| MLM_Loc (_0) -> begin
+_0
+end))
+
+
+type mlmodule =
+mlmodule1 Prims.list
+
 type mlsig1 =
-  | MLS_Mod of (mlsymbol* mlsig1 Prims.list)
-  | MLS_Ty of mltydecl
-  | MLS_Val of (mlsymbol* mltyscheme)
-  | MLS_Exn of (mlsymbol* mlty Prims.list)
-let uu___is_MLS_Mod: mlsig1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLS_Mod _0 -> true | uu____1304 -> false
-let __proj__MLS_Mod__item___0: mlsig1 -> (mlsymbol* mlsig1 Prims.list) =
-  fun projectee  -> match projectee with | MLS_Mod _0 -> _0
-let uu___is_MLS_Ty: mlsig1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLS_Ty _0 -> true | uu____1325 -> false
-let __proj__MLS_Ty__item___0: mlsig1 -> mltydecl =
-  fun projectee  -> match projectee with | MLS_Ty _0 -> _0
-let uu___is_MLS_Val: mlsig1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLS_Val _0 -> true | uu____1339 -> false
-let __proj__MLS_Val__item___0: mlsig1 -> (mlsymbol* mltyscheme) =
-  fun projectee  -> match projectee with | MLS_Val _0 -> _0
-let uu___is_MLS_Exn: mlsig1 -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLS_Exn _0 -> true | uu____1360 -> false
-let __proj__MLS_Exn__item___0: mlsig1 -> (mlsymbol* mlty Prims.list) =
-  fun projectee  -> match projectee with | MLS_Exn _0 -> _0
-type mlsig = mlsig1 Prims.list
-let with_ty_loc: mlty -> mlexpr' -> mlloc -> mlexpr =
-  fun t  -> fun e  -> fun l  -> { expr = e; mlty = t; loc = l }
-let with_ty: mlty -> mlexpr' -> mlexpr =
-  fun t  -> fun e  -> with_ty_loc t e dummy_loc
+| MLS_Mod of (mlsymbol * mlsig1 Prims.list)
+| MLS_Ty of mltydecl
+| MLS_Val of (mlsymbol * mltyscheme)
+| MLS_Exn of (mlsymbol * mlty Prims.list)
+
+
+let uu___is_MLS_Mod : mlsig1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLS_Mod (_0) -> begin
+true
+end
+| uu____1304 -> begin
+false
+end))
+
+
+let __proj__MLS_Mod__item___0 : mlsig1  ->  (mlsymbol * mlsig1 Prims.list) = (fun projectee -> (match (projectee) with
+| MLS_Mod (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLS_Ty : mlsig1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLS_Ty (_0) -> begin
+true
+end
+| uu____1325 -> begin
+false
+end))
+
+
+let __proj__MLS_Ty__item___0 : mlsig1  ->  mltydecl = (fun projectee -> (match (projectee) with
+| MLS_Ty (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLS_Val : mlsig1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLS_Val (_0) -> begin
+true
+end
+| uu____1339 -> begin
+false
+end))
+
+
+let __proj__MLS_Val__item___0 : mlsig1  ->  (mlsymbol * mltyscheme) = (fun projectee -> (match (projectee) with
+| MLS_Val (_0) -> begin
+_0
+end))
+
+
+let uu___is_MLS_Exn : mlsig1  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLS_Exn (_0) -> begin
+true
+end
+| uu____1360 -> begin
+false
+end))
+
+
+let __proj__MLS_Exn__item___0 : mlsig1  ->  (mlsymbol * mlty Prims.list) = (fun projectee -> (match (projectee) with
+| MLS_Exn (_0) -> begin
+_0
+end))
+
+
+type mlsig =
+mlsig1 Prims.list
+
+
+let with_ty_loc : mlty  ->  mlexpr'  ->  mlloc  ->  mlexpr = (fun t e l -> {expr = e; mlty = t; loc = l})
+
+
+let with_ty : mlty  ->  mlexpr'  ->  mlexpr = (fun t e -> (with_ty_loc t e dummy_loc))
+
 type mllib =
-  | MLLib of (mlpath* (mlsig* mlmodule) Prims.option* mllib) Prims.list
-let uu___is_MLLib: mllib -> Prims.bool = fun projectee  -> true
-let __proj__MLLib__item___0:
-  mllib -> (mlpath* (mlsig* mlmodule) Prims.option* mllib) Prims.list =
-  fun projectee  -> match projectee with | MLLib _0 -> _0
-let ml_unit_ty: mlty = MLTY_Named ([], (["Prims"], "unit"))
-let ml_bool_ty: mlty = MLTY_Named ([], (["Prims"], "bool"))
-let ml_int_ty: mlty = MLTY_Named ([], (["Prims"], "int"))
-let ml_string_ty: mlty = MLTY_Named ([], (["Prims"], "string"))
-let ml_unit: mlexpr = with_ty ml_unit_ty (MLE_Const MLC_Unit)
-let mlp_lalloc: (Prims.string Prims.list* Prims.string) = (["SST"], "lalloc")
-let apply_obj_repr: mlexpr -> mlty -> mlexpr =
-  fun x  ->
-    fun t  ->
-      let obj_repr =
-        with_ty (MLTY_Fun (t, E_PURE, MLTY_Top)) (MLE_Name (["Obj"], "repr")) in
-      with_ty_loc MLTY_Top (MLE_App (obj_repr, [x])) x.loc
-let avoid_keyword: Prims.string -> Prims.string =
-  fun s  -> if is_reserved s then Prims.strcat s "_" else s
-let bv_as_mlident: FStar_Syntax_Syntax.bv -> mlident =
-  fun x  ->
-    let uu____1471 =
-      ((FStar_Util.starts_with
-          (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-          FStar_Ident.reserved_prefix)
-         || (FStar_Syntax_Syntax.is_null_bv x))
-        || (is_reserved (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText) in
-    if uu____1471
-    then
-      let uu____1472 =
-        let uu____1473 =
-          let uu____1474 =
-            FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
-          Prims.strcat "_" uu____1474 in
-        Prims.strcat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-          uu____1473 in
-      (uu____1472, (Prims.parse_int "0"))
-    else
-      (((x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText),
-        (Prims.parse_int "0"))
+| MLLib of (mlpath * (mlsig * mlmodule) Prims.option * mllib) Prims.list
+
+
+let uu___is_MLLib : mllib  ->  Prims.bool = (fun projectee -> true)
+
+
+let __proj__MLLib__item___0 : mllib  ->  (mlpath * (mlsig * mlmodule) Prims.option * mllib) Prims.list = (fun projectee -> (match (projectee) with
+| MLLib (_0) -> begin
+_0
+end))
+
+
+let ml_unit_ty : mlty = MLTY_Named ((([]), (((("Prims")::[]), ("unit")))))
+
+
+let ml_bool_ty : mlty = MLTY_Named ((([]), (((("Prims")::[]), ("bool")))))
+
+
+let ml_int_ty : mlty = MLTY_Named ((([]), (((("Prims")::[]), ("int")))))
+
+
+let ml_string_ty : mlty = MLTY_Named ((([]), (((("Prims")::[]), ("string")))))
+
+
+let ml_unit : mlexpr = (with_ty ml_unit_ty (MLE_Const (MLC_Unit)))
+
+
+let mlp_lalloc : (Prims.string Prims.list * Prims.string) = ((("SST")::[]), ("lalloc"))
+
+
+let apply_obj_repr : mlexpr  ->  mlty  ->  mlexpr = (fun x t -> (
+
+let obj_repr = (with_ty (MLTY_Fun (((t), (E_PURE), (MLTY_Top)))) (MLE_Name (((("Obj")::[]), ("repr")))))
+in (with_ty_loc MLTY_Top (MLE_App (((obj_repr), ((x)::[])))) x.loc)))
+
+
+let avoid_keyword : Prims.string  ->  Prims.string = (fun s -> (match ((is_reserved s)) with
+| true -> begin
+(Prims.strcat s "_")
+end
+| uu____1467 -> begin
+s
+end))
+
+
+let bv_as_mlident : FStar_Syntax_Syntax.bv  ->  mlident = (fun x -> (
+
+let uu____1471 = (((FStar_Util.starts_with x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText FStar_Ident.reserved_prefix) || (FStar_Syntax_Syntax.is_null_bv x)) || (is_reserved x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText))
+in (match (uu____1471) with
+| true -> begin
+(
+
+let uu____1472 = (
+
+let uu____1473 = (
+
+let uu____1474 = (FStar_Util.string_of_int x.FStar_Syntax_Syntax.index)
+in (Prims.strcat "_" uu____1474))
+in (Prims.strcat x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText uu____1473))
+in ((uu____1472), ((Prims.parse_int "0"))))
+end
+| uu____1475 -> begin
+((x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText), ((Prims.parse_int "0")))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -1,2543 +1,2783 @@
+
 open Prims
 exception Un_extractable
-let uu___is_Un_extractable: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Un_extractable  -> true | uu____4 -> false
-let type_leq:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
-  =
-  fun g  ->
-    fun t1  ->
-      fun t2  ->
-        FStar_Extraction_ML_Util.type_leq
-          (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2
-let type_leq_c:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlexpr Prims.option ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.mlty ->
-          (Prims.bool* FStar_Extraction_ML_Syntax.mlexpr Prims.option)
-  =
-  fun g  ->
-    fun t1  ->
-      fun t2  ->
-        FStar_Extraction_ML_Util.type_leq_c
-          (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2
-let erasableType:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty -> Prims.bool
-  =
-  fun g  ->
-    fun t  ->
-      FStar_Extraction_ML_Util.erasableType
-        (FStar_Extraction_ML_Util.udelta_unfold g) t
-let eraseTypeDeep:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun g  ->
-    fun t  ->
-      FStar_Extraction_ML_Util.eraseTypeDeep
-        (FStar_Extraction_ML_Util.udelta_unfold g) t
-let record_fields fs vs =
-  FStar_List.map2 (fun f  -> fun e  -> ((f.FStar_Ident.idText), e)) fs vs
-let fail r msg =
-  (let uu____78 =
-     let uu____79 = FStar_Range.string_of_range r in
-     FStar_Util.format2 "%s: %s\n" uu____79 msg in
-   FStar_All.pipe_left FStar_Util.print_string uu____78);
-  failwith msg
-let err_uninst env t uu____107 app =
-  match uu____107 with
-  | (vars,ty) ->
-      let uu____122 =
-        let uu____123 = FStar_Syntax_Print.term_to_string t in
-        let uu____124 =
-          let uu____125 =
-            FStar_All.pipe_right vars (FStar_List.map Prims.fst) in
-          FStar_All.pipe_right uu____125 (FStar_String.concat ", ") in
-        let uu____134 =
-          FStar_Extraction_ML_Code.string_of_mlty
-            env.FStar_Extraction_ML_UEnv.currentModule ty in
-        let uu____135 = FStar_Syntax_Print.term_to_string app in
-        FStar_Util.format4
-          "Variable %s has a polymorphic type (forall %s. %s); expected it to be fully instantiated, but got %s"
-          uu____123 uu____124 uu____134 uu____135 in
-      fail t.FStar_Syntax_Syntax.pos uu____122
-let err_ill_typed_application env t args ty =
-  let uu____166 =
-    let uu____167 = FStar_Syntax_Print.term_to_string t in
-    let uu____168 =
-      let uu____169 =
-        FStar_All.pipe_right args
-          (FStar_List.map
-             (fun uu____177  ->
-                match uu____177 with
-                | (x,uu____181) -> FStar_Syntax_Print.term_to_string x)) in
-      FStar_All.pipe_right uu____169 (FStar_String.concat " ") in
-    let uu____183 =
-      FStar_Extraction_ML_Code.string_of_mlty
-        env.FStar_Extraction_ML_UEnv.currentModule ty in
-    FStar_Util.format3
-      "Ill-typed application: application is %s \n remaining args are %s\nml type of head is %s\n"
-      uu____167 uu____168 uu____183 in
-  fail t.FStar_Syntax_Syntax.pos uu____166
-let err_value_restriction t =
-  let uu____195 =
-    let uu____196 = FStar_Syntax_Print.tag_of_term t in
-    let uu____197 = FStar_Syntax_Print.term_to_string t in
-    FStar_Util.format2
-      "Refusing to generalize because of the value restriction: (%s) %s"
-      uu____196 uu____197 in
-  fail t.FStar_Syntax_Syntax.pos uu____195
-let err_unexpected_eff t f0 f1 =
-  let uu____219 =
-    let uu____220 = FStar_Syntax_Print.term_to_string t in
-    FStar_Util.format3 "for expression %s, Expected effect %s; got effect %s"
-      uu____220 (FStar_Extraction_ML_Util.eff_to_string f0)
-      (FStar_Extraction_ML_Util.eff_to_string f1) in
-  fail t.FStar_Syntax_Syntax.pos uu____219
-let effect_as_etag:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Ident.lident -> FStar_Extraction_ML_Syntax.e_tag
-  =
-  let cache = FStar_Util.smap_create (Prims.parse_int "20") in
-  let rec delta_norm_eff g l =
-    let uu____234 = FStar_Util.smap_try_find cache l.FStar_Ident.str in
-    match uu____234 with
-    | Some l1 -> l1
-    | None  ->
-        let res =
-          let uu____238 =
-            FStar_TypeChecker_Env.lookup_effect_abbrev
-              g.FStar_Extraction_ML_UEnv.tcenv [FStar_Syntax_Syntax.U_zero] l in
-          match uu____238 with
-          | None  -> l
-          | Some (uu____244,c) ->
-              delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c) in
-        (FStar_Util.smap_add cache l.FStar_Ident.str res; res) in
-  fun g  ->
-    fun l  ->
-      let l1 = delta_norm_eff g l in
-      if FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid
-      then FStar_Extraction_ML_Syntax.E_PURE
-      else
-        if FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GHOST_lid
-        then FStar_Extraction_ML_Syntax.E_GHOST
-        else FStar_Extraction_ML_Syntax.E_IMPURE
-let rec is_arity:
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t in
-      let uu____261 =
-        let uu____262 = FStar_Syntax_Subst.compress t1 in
-        uu____262.FStar_Syntax_Syntax.n in
-      match uu____261 with
-      | FStar_Syntax_Syntax.Tm_unknown 
-        |FStar_Syntax_Syntax.Tm_delayed _
-         |FStar_Syntax_Syntax.Tm_ascribed _|FStar_Syntax_Syntax.Tm_meta _ ->
-          failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_uvar _
-        |FStar_Syntax_Syntax.Tm_constant _
-         |FStar_Syntax_Syntax.Tm_name _|FStar_Syntax_Syntax.Tm_bvar _ ->
-          false
-      | FStar_Syntax_Syntax.Tm_type uu____272 -> true
-      | FStar_Syntax_Syntax.Tm_arrow (uu____273,c) ->
-          is_arity env (FStar_Syntax_Util.comp_result c)
-      | FStar_Syntax_Syntax.Tm_fvar uu____285 ->
-          let t2 =
-            FStar_TypeChecker_Normalize.normalize
-              [FStar_TypeChecker_Normalize.AllowUnboundUniverses;
-              FStar_TypeChecker_Normalize.EraseUniverses;
-              FStar_TypeChecker_Normalize.UnfoldUntil
-                FStar_Syntax_Syntax.Delta_constant]
-              env.FStar_Extraction_ML_UEnv.tcenv t1 in
-          let uu____287 =
-            let uu____288 = FStar_Syntax_Subst.compress t2 in
-            uu____288.FStar_Syntax_Syntax.n in
-          (match uu____287 with
-           | FStar_Syntax_Syntax.Tm_fvar uu____291 -> false
-           | uu____292 -> is_arity env t2)
-      | FStar_Syntax_Syntax.Tm_app uu____293 ->
-          let uu____303 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____303 with | (head1,uu____314) -> is_arity env head1)
-      | FStar_Syntax_Syntax.Tm_uinst (head1,uu____330) -> is_arity env head1
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____336) ->
-          is_arity env x.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_abs (_,body,_)|FStar_Syntax_Syntax.Tm_let
-        (_,body) -> is_arity env body
-      | FStar_Syntax_Syntax.Tm_match (uu____365,branches) ->
-          (match branches with
-           | (uu____393,uu____394,e)::uu____396 -> is_arity env e
-           | uu____432 -> false)
-let rec is_type_aux:
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed _|FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____452 =
-            let uu____453 = FStar_Syntax_Print.tag_of_term t1 in
-            FStar_Util.format1 "Impossible: %s" uu____453 in
-          failwith uu____452
-      | FStar_Syntax_Syntax.Tm_constant uu____454 -> false
-      | FStar_Syntax_Syntax.Tm_type _
-        |FStar_Syntax_Syntax.Tm_refine _|FStar_Syntax_Syntax.Tm_arrow _ ->
-          true
-      | FStar_Syntax_Syntax.Tm_fvar fv when
-          FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.failwith_lid ->
-          false
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____460 =
-            FStar_TypeChecker_Env.is_type_constructor
-              env.FStar_Extraction_ML_UEnv.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          if uu____460
-          then true
-          else
-            (let uu____466 =
-               FStar_TypeChecker_Env.lookup_lid
-                 env.FStar_Extraction_ML_UEnv.tcenv
-                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             match uu____466 with
-             | ((uu____475,t2),uu____477) -> is_arity env t2)
-      | FStar_Syntax_Syntax.Tm_uvar (_,t2)
-        |FStar_Syntax_Syntax.Tm_bvar
-         { FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-           FStar_Syntax_Syntax.sort = t2;_}|FStar_Syntax_Syntax.Tm_name
-         { FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-           FStar_Syntax_Syntax.sort = t2;_}
-          -> is_arity env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____499,uu____500) ->
-          is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____530) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_abs (uu____535,body,uu____537) ->
-          is_type_aux env body
-      | FStar_Syntax_Syntax.Tm_let (uu____560,body) -> is_type_aux env body
-      | FStar_Syntax_Syntax.Tm_match (uu____572,branches) ->
-          (match branches with
-           | (uu____600,uu____601,e)::uu____603 -> is_type_aux env e
-           | uu____639 -> failwith "Empty branches")
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____652) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_app (head1,uu____658) -> is_type_aux env head1
-let is_type:
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let b = is_type_aux env t in
-      FStar_Extraction_ML_UEnv.debug env
-        (fun uu____681  ->
-           if b
-           then
-             let uu____682 = FStar_Syntax_Print.term_to_string t in
-             let uu____683 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.print2 "is_type %s (%s)\n" uu____682 uu____683
-           else
-             (let uu____685 = FStar_Syntax_Print.term_to_string t in
-              let uu____686 = FStar_Syntax_Print.tag_of_term t in
-              FStar_Util.print2 "not a type %s (%s)\n" uu____685 uu____686));
-      b
-let is_type_binder env x =
-  is_arity env (Prims.fst x).FStar_Syntax_Syntax.sort
-let is_constructor: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____706 =
-      let uu____707 = FStar_Syntax_Subst.compress t in
-      uu____707.FStar_Syntax_Syntax.n in
-    match uu____706 with
-    | FStar_Syntax_Syntax.Tm_fvar
-      { FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _;
-        FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Data_ctor );_}
-      |FStar_Syntax_Syntax.Tm_fvar
-      { FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _;
-        FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Record_ctor
-          _);_}
-        -> true
-    | uu____715 -> false
-let rec is_fstar_value: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____719 =
-      let uu____720 = FStar_Syntax_Subst.compress t in
-      uu____720.FStar_Syntax_Syntax.n in
-    match uu____719 with
-    | FStar_Syntax_Syntax.Tm_constant _
-      |FStar_Syntax_Syntax.Tm_bvar _
-       |FStar_Syntax_Syntax.Tm_fvar _|FStar_Syntax_Syntax.Tm_abs _ -> true
-    | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-        let uu____743 = is_constructor head1 in
-        if uu____743
-        then
-          FStar_All.pipe_right args
-            (FStar_List.for_all
-               (fun uu____751  ->
-                  match uu____751 with | (te,uu____755) -> is_fstar_value te))
-        else false
-    | FStar_Syntax_Syntax.Tm_meta (t1,_)|FStar_Syntax_Syntax.Tm_ascribed
-      (t1,_,_) -> is_fstar_value t1
-    | uu____781 -> false
-let rec is_ml_value: FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool =
-  fun e  ->
-    match e.FStar_Extraction_ML_Syntax.expr with
-    | FStar_Extraction_ML_Syntax.MLE_Const _
-      |FStar_Extraction_ML_Syntax.MLE_Var _
-       |FStar_Extraction_ML_Syntax.MLE_Name _
-        |FStar_Extraction_ML_Syntax.MLE_Fun _ -> true
-    | FStar_Extraction_ML_Syntax.MLE_CTor (_,exps)
-      |FStar_Extraction_ML_Syntax.MLE_Tuple exps ->
-        FStar_Util.for_all is_ml_value exps
-    | FStar_Extraction_ML_Syntax.MLE_Record (uu____794,fields) ->
-        FStar_Util.for_all
-          (fun uu____806  ->
-             match uu____806 with | (uu____809,e1) -> is_ml_value e1) fields
-    | uu____811 -> false
-let normalize_abs: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t0  ->
-    let rec aux bs t copt =
-      let t1 = FStar_Syntax_Subst.compress t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_abs (bs',body,copt1) ->
-          aux (FStar_List.append bs bs') body copt1
-      | uu____871 ->
-          let e' = FStar_Syntax_Util.unascribe t1 in
-          let uu____873 = FStar_Syntax_Util.is_fun e' in
-          if uu____873
-          then aux bs e' copt
-          else FStar_Syntax_Util.abs bs e' copt in
-    aux [] t0 None
-let unit_binder: FStar_Syntax_Syntax.binder =
-  let uu____882 =
-    FStar_Syntax_Syntax.new_bv None FStar_TypeChecker_Common.t_unit in
-  FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____882
-let check_pats_for_ite:
-  (FStar_Syntax_Syntax.pat* FStar_Syntax_Syntax.term Prims.option*
-    FStar_Syntax_Syntax.term) Prims.list ->
-    (Prims.bool* FStar_Syntax_Syntax.term Prims.option*
-      FStar_Syntax_Syntax.term Prims.option)
-  =
-  fun l  ->
-    let def = (false, None, None) in
-    if (FStar_List.length l) <> (Prims.parse_int "2")
-    then def
-    else
-      (let uu____926 = FStar_List.hd l in
-       match uu____926 with
-       | (p1,w1,e1) ->
-           let uu____945 =
-             let uu____950 = FStar_List.tl l in FStar_List.hd uu____950 in
-           (match uu____945 with
-            | (p2,w2,e2) ->
-                (match (w1, w2, (p1.FStar_Syntax_Syntax.v),
-                         (p2.FStar_Syntax_Syntax.v))
-                 with
-                 | (None ,None ,FStar_Syntax_Syntax.Pat_constant
-                    (FStar_Const.Const_bool (true
-                    )),FStar_Syntax_Syntax.Pat_constant
-                    (FStar_Const.Const_bool (false ))) ->
-                     (true, (Some e1), (Some e2))
-                 | (None ,None ,FStar_Syntax_Syntax.Pat_constant
-                    (FStar_Const.Const_bool (false
-                    )),FStar_Syntax_Syntax.Pat_constant
-                    (FStar_Const.Const_bool (true ))) ->
-                     (true, (Some e2), (Some e1))
-                 | uu____989 -> def)))
-let instantiate:
-  FStar_Extraction_ML_Syntax.mltyscheme ->
-    FStar_Extraction_ML_Syntax.mlty Prims.list ->
-      FStar_Extraction_ML_Syntax.mlty
-  = fun s  -> fun args  -> FStar_Extraction_ML_Util.subst s args
-let erasable:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
-  =
-  fun g  ->
-    fun f  ->
-      fun t  ->
-        (f = FStar_Extraction_ML_Syntax.E_GHOST) ||
-          ((f = FStar_Extraction_ML_Syntax.E_PURE) && (erasableType g t))
-let erase:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlexpr ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.e_tag ->
-          (FStar_Extraction_ML_Syntax.mlexpr*
-            FStar_Extraction_ML_Syntax.e_tag*
-            FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun g  ->
-    fun e  ->
-      fun ty  ->
-        fun f  ->
-          let e1 =
-            let uu____1032 = erasable g f ty in
-            if uu____1032
-            then
-              let uu____1033 =
-                type_leq g ty FStar_Extraction_ML_Syntax.ml_unit_ty in
-              (if uu____1033
-               then FStar_Extraction_ML_Syntax.ml_unit
-               else
-                 FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-                   (FStar_Extraction_ML_Syntax.MLE_Coerce
-                      (FStar_Extraction_ML_Syntax.ml_unit,
-                        FStar_Extraction_ML_Syntax.ml_unit_ty, ty)))
-            else e in
-          (e1, f, ty)
-let maybe_coerce:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlexpr ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlexpr
-  =
-  fun g  ->
-    fun e  ->
-      fun ty  ->
-        fun expect  ->
-          let ty1 = eraseTypeDeep g ty in
-          let uu____1049 = (type_leq_c g (Some e) ty1) expect in
-          match uu____1049 with
-          | (true ,Some e') -> e'
-          | uu____1055 ->
-              (FStar_Extraction_ML_UEnv.debug g
-                 (fun uu____1060  ->
-                    let uu____1061 =
-                      FStar_Extraction_ML_Code.string_of_mlexpr
-                        g.FStar_Extraction_ML_UEnv.currentModule e in
-                    let uu____1062 =
-                      FStar_Extraction_ML_Code.string_of_mlty
-                        g.FStar_Extraction_ML_UEnv.currentModule ty1 in
-                    let uu____1063 =
-                      FStar_Extraction_ML_Code.string_of_mlty
-                        g.FStar_Extraction_ML_UEnv.currentModule expect in
-                    FStar_Util.print3
-                      "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
-                      uu____1061 uu____1062 uu____1063);
-               FStar_All.pipe_left
-                 (FStar_Extraction_ML_Syntax.with_ty expect)
-                 (FStar_Extraction_ML_Syntax.MLE_Coerce (e, ty1, expect)))
-let bv_as_mlty:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun g  ->
-    fun bv  ->
-      let uu____1070 = FStar_Extraction_ML_UEnv.lookup_bv g bv in
-      match uu____1070 with
-      | FStar_Util.Inl (uu____1071,t) -> t
-      | uu____1079 -> FStar_Extraction_ML_Syntax.MLTY_Top
-let rec term_as_mlty:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun g  ->
-    fun t0  ->
-      let t =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.Iota;
-          FStar_TypeChecker_Normalize.Zeta;
-          FStar_TypeChecker_Normalize.EraseUniverses;
-          FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-          g.FStar_Extraction_ML_UEnv.tcenv t0 in
-      let mlt = term_as_mlty' g t in
-      let uu____1113 =
-        (fun t1  ->
-           match t1 with
-           | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
-           | FStar_Extraction_ML_Syntax.MLTY_Named uu____1115 ->
-               let uu____1119 = FStar_Extraction_ML_Util.udelta_unfold g t1 in
-               (match uu____1119 with
-                | None  -> false
-                | Some t2 ->
-                    (let rec is_top_ty t3 =
-                       match t3 with
-                       | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
-                       | FStar_Extraction_ML_Syntax.MLTY_Named uu____1126 ->
-                           let uu____1130 =
-                             FStar_Extraction_ML_Util.udelta_unfold g t3 in
-                           (match uu____1130 with
-                            | None  -> false
-                            | Some t4 -> is_top_ty t4)
-                       | uu____1133 -> false in
-                     is_top_ty) t2)
-           | uu____1134 -> false) mlt in
-      if uu____1113
-      then
-        let t1 =
-          FStar_TypeChecker_Normalize.normalize
-            [FStar_TypeChecker_Normalize.Beta;
-            FStar_TypeChecker_Normalize.Eager_unfolding;
-            FStar_TypeChecker_Normalize.UnfoldUntil
-              FStar_Syntax_Syntax.Delta_constant;
-            FStar_TypeChecker_Normalize.Iota;
-            FStar_TypeChecker_Normalize.Zeta;
-            FStar_TypeChecker_Normalize.EraseUniverses;
-            FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-            g.FStar_Extraction_ML_UEnv.tcenv t0 in
-        term_as_mlty' g t1
-      else mlt
-and term_as_mlty':
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_bvar _
-        |FStar_Syntax_Syntax.Tm_delayed _|FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____1142 =
-            let uu____1143 = FStar_Syntax_Print.term_to_string t1 in
-            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1143 in
-          failwith uu____1142
-      | FStar_Syntax_Syntax.Tm_constant uu____1144 ->
-          FStar_Extraction_ML_UEnv.unknownType
-      | FStar_Syntax_Syntax.Tm_uvar uu____1145 ->
-          FStar_Extraction_ML_UEnv.unknownType
-      | FStar_Syntax_Syntax.Tm_meta (t2,_)
-        |FStar_Syntax_Syntax.Tm_refine
-         ({ FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-            FStar_Syntax_Syntax.sort = t2;_},_)
-         |FStar_Syntax_Syntax.Tm_uinst (t2,_)|FStar_Syntax_Syntax.Tm_ascribed
-          (t2,_,_) -> term_as_mlty' env t2
-      | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
-      | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____1208 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____1208 with
-           | (bs1,c1) ->
-               let uu____1213 = binders_as_ml_binders env bs1 in
-               (match uu____1213 with
-                | (mlbs,env1) ->
-                    let t_ret =
-                      let eff =
-                        FStar_TypeChecker_Env.norm_eff_name
-                          env1.FStar_Extraction_ML_UEnv.tcenv
-                          (FStar_Syntax_Util.comp_effect_name c1) in
-                      let ed =
-                        FStar_TypeChecker_Env.get_effect_decl
-                          env1.FStar_Extraction_ML_UEnv.tcenv eff in
-                      let uu____1230 =
-                        FStar_All.pipe_right
-                          ed.FStar_Syntax_Syntax.qualifiers
-                          (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
-                      if uu____1230
-                      then
-                        let t2 =
-                          FStar_TypeChecker_Env.reify_comp
-                            env1.FStar_Extraction_ML_UEnv.tcenv c1
-                            FStar_Syntax_Syntax.U_unknown in
-                        let res = term_as_mlty' env1 t2 in res
-                      else
-                        term_as_mlty' env1 (FStar_Syntax_Util.comp_result c1) in
-                    let erase1 =
-                      effect_as_etag env1
-                        (FStar_Syntax_Util.comp_effect_name c1) in
-                    let uu____1236 =
-                      FStar_List.fold_right
-                        (fun uu____1243  ->
-                           fun uu____1244  ->
-                             match (uu____1243, uu____1244) with
-                             | ((uu____1255,t2),(tag,t')) ->
-                                 (FStar_Extraction_ML_Syntax.E_PURE,
-                                   (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                      (t2, tag, t')))) mlbs (erase1, t_ret) in
-                    (match uu____1236 with | (uu____1263,t2) -> t2)))
-      | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let res =
-            let uu____1282 =
-              let uu____1283 = FStar_Syntax_Util.un_uinst head1 in
-              uu____1283.FStar_Syntax_Syntax.n in
-            match uu____1282 with
-            | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
-            | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
-            | FStar_Syntax_Syntax.Tm_app (head2,args') ->
-                let uu____1304 =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app
-                       (head2, (FStar_List.append args' args))) None
-                    t1.FStar_Syntax_Syntax.pos in
-                term_as_mlty' env uu____1304
-            | uu____1320 -> FStar_Extraction_ML_UEnv.unknownType in
-          res
-      | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____1323) ->
-          let uu____1346 = FStar_Syntax_Subst.open_term bs ty in
-          (match uu____1346 with
-           | (bs1,ty1) ->
-               let uu____1351 = binders_as_ml_binders env bs1 in
-               (match uu____1351 with | (bts,env1) -> term_as_mlty' env1 ty1))
-      | FStar_Syntax_Syntax.Tm_type _
-        |FStar_Syntax_Syntax.Tm_let _|FStar_Syntax_Syntax.Tm_match _ ->
-          FStar_Extraction_ML_UEnv.unknownType
-and arg_as_mlty:
-  FStar_Extraction_ML_UEnv.env ->
-    (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) ->
-      FStar_Extraction_ML_Syntax.mlty
-  =
-  fun g  ->
-    fun uu____1369  ->
-      match uu____1369 with
-      | (a,uu____1373) ->
-          let uu____1374 = is_type g a in
-          if uu____1374
-          then term_as_mlty' g a
-          else FStar_Extraction_ML_UEnv.erasedContent
-and fv_app_as_mlty:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.args -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun g  ->
-    fun fv  ->
-      fun args  ->
-        let uu____1379 =
-          FStar_Syntax_Util.arrow_formals
-            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.ty in
-        match uu____1379 with
-        | (formals,t) ->
-            let mlargs = FStar_List.map (arg_as_mlty g) args in
-            let mlargs1 =
-              let n_args = FStar_List.length args in
-              if (FStar_List.length formals) > n_args
-              then
-                let uu____1423 = FStar_Util.first_N n_args formals in
-                match uu____1423 with
-                | (uu____1437,rest) ->
-                    let uu____1451 =
-                      FStar_List.map
-                        (fun uu____1455  ->
-                           FStar_Extraction_ML_UEnv.erasedContent) rest in
-                    FStar_List.append mlargs uu____1451
-              else mlargs in
-            let nm =
-              let uu____1460 =
-                FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g fv in
-              match uu____1460 with
-              | Some p -> p
-              | None  ->
-                  FStar_Extraction_ML_Syntax.mlpath_of_lident
-                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            FStar_Extraction_ML_Syntax.MLTY_Named (mlargs1, nm)
-and binders_as_ml_binders:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.binders ->
-      ((FStar_Extraction_ML_Syntax.mlident* FStar_Extraction_ML_Syntax.mlty)
-        Prims.list* FStar_Extraction_ML_UEnv.env)
-  =
-  fun g  ->
-    fun bs  ->
-      let uu____1475 =
-        FStar_All.pipe_right bs
-          (FStar_List.fold_left
-             (fun uu____1499  ->
-                fun b  ->
-                  match uu____1499 with
-                  | (ml_bs,env) ->
-                      let uu____1529 = is_type_binder g b in
-                      if uu____1529
-                      then
-                        let b1 = Prims.fst b in
-                        let env1 =
-                          FStar_Extraction_ML_UEnv.extend_ty env b1
-                            (Some FStar_Extraction_ML_Syntax.MLTY_Top) in
-                        let ml_b =
-                          let uu____1544 =
-                            FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1 in
-                          (uu____1544, FStar_Extraction_ML_Syntax.ml_unit_ty) in
-                        ((ml_b :: ml_bs), env1)
-                      else
-                        (let b1 = Prims.fst b in
-                         let t = term_as_mlty env b1.FStar_Syntax_Syntax.sort in
-                         let uu____1561 =
-                           FStar_Extraction_ML_UEnv.extend_bv env b1 
-                             ([], t) false false false in
-                         match uu____1561 with
-                         | (env1,b2) ->
-                             let ml_b =
-                               let uu____1579 =
-                                 FStar_Extraction_ML_UEnv.removeTick b2 in
-                               (uu____1579, t) in
-                             ((ml_b :: ml_bs), env1))) ([], g)) in
-      match uu____1475 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
-let mk_MLE_Seq:
-  FStar_Extraction_ML_Syntax.mlexpr ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr'
-  =
-  fun e1  ->
-    fun e2  ->
-      match ((e1.FStar_Extraction_ML_Syntax.expr),
-              (e2.FStar_Extraction_ML_Syntax.expr))
-      with
-      | (FStar_Extraction_ML_Syntax.MLE_Seq
-         es1,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
-          FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 es2)
-      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____1639) ->
-          FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 [e2])
-      | (uu____1641,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
-          FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
-      | uu____1644 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
-let mk_MLE_Let:
-  Prims.bool ->
-    FStar_Extraction_ML_Syntax.mlletbinding ->
-      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr'
-  =
-  fun top_level  ->
-    fun lbs  ->
-      fun body  ->
-        match lbs with
-        | (FStar_Extraction_ML_Syntax.NonRec ,quals,lb::[]) when
-            Prims.op_Negation top_level ->
-            (match lb.FStar_Extraction_ML_Syntax.mllb_tysc with
-             | Some ([],t) when t = FStar_Extraction_ML_Syntax.ml_unit_ty ->
-                 if
-                   body.FStar_Extraction_ML_Syntax.expr =
-                     FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
-                 then
-                   (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                 else
-                   (match body.FStar_Extraction_ML_Syntax.expr with
-                    | FStar_Extraction_ML_Syntax.MLE_Var x when
-                        x = lb.FStar_Extraction_ML_Syntax.mllb_name ->
-                        (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                    | uu____1666 when
-                        (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                          =
-                          FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
-                        -> body.FStar_Extraction_ML_Syntax.expr
-                    | uu____1667 ->
-                        mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def
-                          body)
-             | uu____1668 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
-        | uu____1670 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
-let resugar_pat:
-  FStar_Syntax_Syntax.fv_qual Prims.option ->
-    FStar_Extraction_ML_Syntax.mlpattern ->
-      FStar_Extraction_ML_Syntax.mlpattern
-  =
-  fun q  ->
-    fun p  ->
-      match p with
-      | FStar_Extraction_ML_Syntax.MLP_CTor (d,pats) ->
-          (match FStar_Extraction_ML_Util.is_xtuple d with
-           | Some n1 -> FStar_Extraction_ML_Syntax.MLP_Tuple pats
-           | uu____1684 ->
-               (match q with
-                | Some (FStar_Syntax_Syntax.Record_ctor (ty,fns)) ->
-                    let path =
-                      FStar_List.map FStar_Ident.text_of_id ty.FStar_Ident.ns in
-                    let fs = record_fields fns pats in
-                    FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
-                | uu____1700 -> p))
-      | uu____1702 -> p
-let rec extract_one_pat:
-  Prims.bool ->
-    Prims.bool ->
-      FStar_Extraction_ML_UEnv.env ->
-        FStar_Syntax_Syntax.pat ->
-          FStar_Extraction_ML_Syntax.mlty Prims.option ->
-            (FStar_Extraction_ML_UEnv.env*
-              (FStar_Extraction_ML_Syntax.mlpattern*
-              FStar_Extraction_ML_Syntax.mlexpr Prims.list) Prims.option*
-              Prims.bool)
-  =
-  fun disjunctive_pat  ->
-    fun imp  ->
-      fun g  ->
-        fun p  ->
-          fun expected_topt  ->
-            let ok t =
-              match expected_topt with
-              | None  -> true
-              | Some t' ->
-                  let ok = type_leq g t t' in
-                  (if Prims.op_Negation ok
-                   then
-                     FStar_Extraction_ML_UEnv.debug g
-                       (fun uu____1741  ->
-                          let uu____1742 =
-                            FStar_Extraction_ML_Code.string_of_mlty
-                              g.FStar_Extraction_ML_UEnv.currentModule t' in
-                          let uu____1743 =
-                            FStar_Extraction_ML_Code.string_of_mlty
-                              g.FStar_Extraction_ML_UEnv.currentModule t in
-                          FStar_Util.print2
-                            "Expected pattern type %s; got pattern type %s\n"
-                            uu____1742 uu____1743)
-                   else ();
-                   ok) in
-            match p.FStar_Syntax_Syntax.v with
-            | FStar_Syntax_Syntax.Pat_disj uu____1752 ->
-                failwith "Impossible: Nested disjunctive pattern"
-            | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
-                (c,None )) ->
-                let i = FStar_Const.Const_int (c, None) in
-                let x = FStar_Extraction_ML_Syntax.gensym () in
-                let when_clause =
-                  let uu____1777 =
-                    let uu____1778 =
-                      let uu____1782 =
-                        let uu____1784 =
-                          FStar_All.pipe_left
-                            (FStar_Extraction_ML_Syntax.with_ty
-                               FStar_Extraction_ML_Syntax.ml_int_ty)
-                            (FStar_Extraction_ML_Syntax.MLE_Var x) in
-                        let uu____1785 =
-                          let uu____1787 =
-                            let uu____1788 =
-                              let uu____1789 =
-                                FStar_Extraction_ML_Util.mlconst_of_const'
-                                  p.FStar_Syntax_Syntax.p i in
-                              FStar_All.pipe_left
-                                (fun _0_30  ->
-                                   FStar_Extraction_ML_Syntax.MLE_Const _0_30)
-                                uu____1789 in
-                            FStar_All.pipe_left
-                              (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.ml_int_ty)
-                              uu____1788 in
-                          [uu____1787] in
-                        uu____1784 :: uu____1785 in
-                      (FStar_Extraction_ML_Util.prims_op_equality,
-                        uu____1782) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____1778 in
-                  FStar_All.pipe_left
-                    (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_bool_ty) uu____1777 in
-                let uu____1791 = ok FStar_Extraction_ML_Syntax.ml_int_ty in
-                (g,
-                  (Some
-                     ((FStar_Extraction_ML_Syntax.MLP_Var x), [when_clause])),
-                  uu____1791)
-            | FStar_Syntax_Syntax.Pat_constant s ->
-                let t =
-                  FStar_TypeChecker_TcTerm.tc_constant FStar_Range.dummyRange
-                    s in
-                let mlty = term_as_mlty g t in
-                let uu____1803 =
-                  let uu____1808 =
-                    let uu____1812 =
-                      let uu____1813 =
-                        FStar_Extraction_ML_Util.mlconst_of_const'
-                          p.FStar_Syntax_Syntax.p s in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____1813 in
-                    (uu____1812, []) in
-                  Some uu____1808 in
-                let uu____1818 = ok mlty in (g, uu____1803, uu____1818)
-            | FStar_Syntax_Syntax.Pat_wild x when disjunctive_pat ->
-                (g, (Some (FStar_Extraction_ML_Syntax.MLP_Wild, [])), true)
-            | FStar_Syntax_Syntax.Pat_var x|FStar_Syntax_Syntax.Pat_wild x ->
-                let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort in
-                let uu____1834 =
-                  FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
-                    false imp in
-                (match uu____1834 with
-                 | (g1,x1) ->
-                     let uu____1847 = ok mlty in
-                     (g1,
-                       (if imp
-                        then None
-                        else
-                          Some ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____1847))
-            | FStar_Syntax_Syntax.Pat_dot_term uu____1864 -> (g, None, true)
-            | FStar_Syntax_Syntax.Pat_cons (f,pats) ->
-                let uu____1888 =
-                  let uu____1891 = FStar_Extraction_ML_UEnv.lookup_fv g f in
-                  match uu____1891 with
-                  | FStar_Util.Inr
-                      (uu____1894,{
-                                    FStar_Extraction_ML_Syntax.expr =
-                                      FStar_Extraction_ML_Syntax.MLE_Name n1;
-                                    FStar_Extraction_ML_Syntax.mlty =
-                                      uu____1896;
-                                    FStar_Extraction_ML_Syntax.loc =
-                                      uu____1897;_},ttys,uu____1899)
-                      -> (n1, ttys)
-                  | uu____1906 -> failwith "Expected a constructor" in
-                (match uu____1888 with
-                 | (d,tys) ->
-                     let nTyVars = FStar_List.length (Prims.fst tys) in
-                     let uu____1920 = FStar_Util.first_N nTyVars pats in
-                     (match uu____1920 with
-                      | (tysVarPats,restPats) ->
-                          let f_ty_opt =
-                            try
-                              let mlty_args =
-                                FStar_All.pipe_right tysVarPats
-                                  (FStar_List.map
-                                     (fun uu____1994  ->
-                                        match uu____1994 with
-                                        | (p1,uu____2000) ->
-                                            (match p1.FStar_Syntax_Syntax.v
-                                             with
-                                             | FStar_Syntax_Syntax.Pat_dot_term
-                                                 (uu____2005,t) ->
-                                                 term_as_mlty g t
-                                             | uu____2011 ->
-                                                 (FStar_Extraction_ML_UEnv.debug
-                                                    g
-                                                    (fun uu____2013  ->
-                                                       let uu____2014 =
-                                                         FStar_Syntax_Print.pat_to_string
-                                                           p1 in
-                                                       FStar_Util.print1
-                                                         "Pattern %s is not extractable"
-                                                         uu____2014);
-                                                  Prims.raise Un_extractable)))) in
-                              let f_ty =
-                                FStar_Extraction_ML_Util.subst tys mlty_args in
-                              let uu____2016 =
-                                FStar_Extraction_ML_Util.uncurry_mlty_fun
-                                  f_ty in
-                              Some uu____2016
-                            with | Un_extractable  -> None in
-                          let uu____2031 =
-                            FStar_Util.fold_map
-                              (fun g1  ->
-                                 fun uu____2046  ->
-                                   match uu____2046 with
-                                   | (p1,imp1) ->
-                                       let uu____2057 =
-                                         extract_one_pat disjunctive_pat true
-                                           g1 p1 None in
-                                       (match uu____2057 with
-                                        | (g2,p2,uu____2073) -> (g2, p2))) g
-                              tysVarPats in
-                          (match uu____2031 with
-                           | (g1,tyMLPats) ->
-                               let uu____2105 =
-                                 FStar_Util.fold_map
-                                   (fun uu____2131  ->
-                                      fun uu____2132  ->
-                                        match (uu____2131, uu____2132) with
-                                        | ((g2,f_ty_opt1),(p1,imp1)) ->
-                                            let uu____2181 =
-                                              match f_ty_opt1 with
-                                              | Some (hd1::rest,res) ->
-                                                  ((Some (rest, res)),
-                                                    (Some hd1))
-                                              | uu____2213 -> (None, None) in
-                                            (match uu____2181 with
-                                             | (f_ty_opt2,expected_ty) ->
-                                                 let uu____2250 =
-                                                   extract_one_pat
-                                                     disjunctive_pat false g2
-                                                     p1 expected_ty in
-                                                 (match uu____2250 with
-                                                  | (g3,p2,uu____2272) ->
-                                                      ((g3, f_ty_opt2), p2))))
-                                   (g1, f_ty_opt) restPats in
-                               (match uu____2105 with
-                                | ((g2,f_ty_opt1),restMLPats) ->
-                                    let uu____2333 =
-                                      let uu____2339 =
-                                        FStar_All.pipe_right
-                                          (FStar_List.append tyMLPats
-                                             restMLPats)
-                                          (FStar_List.collect
-                                             (fun uu___138_2364  ->
-                                                match uu___138_2364 with
-                                                | Some x -> [x]
-                                                | uu____2386 -> [])) in
-                                      FStar_All.pipe_right uu____2339
-                                        FStar_List.split in
-                                    (match uu____2333 with
-                                     | (mlPats,when_clauses) ->
-                                         let pat_ty_compat =
-                                           match f_ty_opt1 with
-                                           | Some ([],t) -> ok t
-                                           | uu____2425 -> false in
-                                         let uu____2430 =
-                                           let uu____2435 =
-                                             let uu____2439 =
-                                               resugar_pat
-                                                 f.FStar_Syntax_Syntax.fv_qual
-                                                 (FStar_Extraction_ML_Syntax.MLP_CTor
-                                                    (d, mlPats)) in
-                                             let uu____2441 =
-                                               FStar_All.pipe_right
-                                                 when_clauses
-                                                 FStar_List.flatten in
-                                             (uu____2439, uu____2441) in
-                                           Some uu____2435 in
-                                         (g2, uu____2430, pat_ty_compat))))))
-let extract_pat:
-  FStar_Extraction_ML_UEnv.env ->
-    (FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.withinfo_t ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        (FStar_Extraction_ML_UEnv.env* (FStar_Extraction_ML_Syntax.mlpattern*
-          FStar_Extraction_ML_Syntax.mlexpr Prims.option) Prims.list*
-          Prims.bool)
-  =
-  fun g  ->
-    fun p  ->
-      fun expected_t  ->
-        let extract_one_pat1 disj g1 p1 expected_t1 =
-          let uu____2502 = extract_one_pat disj false g1 p1 expected_t1 in
-          match uu____2502 with
-          | (g2,Some (x,v1),b) -> (g2, (x, v1), b)
-          | uu____2533 -> failwith "Impossible: Unable to translate pattern" in
-        let mk_when_clause whens =
-          match whens with
-          | [] -> None
-          | hd1::tl1 ->
-              let uu____2558 =
-                FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd1 tl1 in
-              Some uu____2558 in
-        match p.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_disj [] ->
-            failwith "Impossible: Empty disjunctive pattern"
-        | FStar_Syntax_Syntax.Pat_disj (p1::pats) ->
-            let uu____2584 = extract_one_pat1 true g p1 (Some expected_t) in
-            (match uu____2584 with
-             | (g',p2,b) ->
-                 let uu____2607 =
-                   FStar_Util.fold_map
-                     (fun b1  ->
-                        fun p3  ->
-                          let uu____2619 =
-                            extract_one_pat1 true g p3 (Some expected_t) in
-                          match uu____2619 with
-                          | (uu____2631,p4,b') -> ((b1 && b'), p4)) b pats in
-                 (match uu____2607 with
-                  | (b1,ps) ->
-                      let ps1 = p2 :: ps in
-                      let g1 = g' in
-                      let uu____2669 =
-                        FStar_All.pipe_right ps1
-                          (FStar_List.partition
-                             (fun uu___139_2697  ->
-                                match uu___139_2697 with
-                                | (uu____2701,uu____2702::uu____2703) -> true
-                                | uu____2706 -> false)) in
-                      (match uu____2669 with
-                       | (ps_when,rest) ->
-                           let ps2 =
-                             FStar_All.pipe_right ps_when
-                               (FStar_List.map
-                                  (fun uu____2754  ->
-                                     match uu____2754 with
-                                     | (x,whens) ->
-                                         let uu____2765 =
-                                           mk_when_clause whens in
-                                         (x, uu____2765))) in
-                           let res =
-                             match rest with
-                             | [] -> (g1, ps2, b1)
-                             | rest1 ->
-                                 let uu____2795 =
-                                   let uu____2800 =
-                                     let uu____2804 =
-                                       let uu____2805 =
-                                         FStar_List.map Prims.fst rest1 in
-                                       FStar_Extraction_ML_Syntax.MLP_Branch
-                                         uu____2805 in
-                                     (uu____2804, None) in
-                                   uu____2800 :: ps2 in
-                                 (g1, uu____2795, b1) in
-                           res)))
-        | uu____2819 ->
-            let uu____2820 = extract_one_pat1 false g p (Some expected_t) in
-            (match uu____2820 with
-             | (g1,(p1,whens),b) ->
-                 let when_clause = mk_when_clause whens in
-                 (g1, [(p1, when_clause)], b))
-let maybe_eta_data_and_project_record:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.fv_qual Prims.option ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.mlexpr ->
-          FStar_Extraction_ML_Syntax.mlexpr
-  =
-  fun g  ->
-    fun qual  ->
-      fun residualType  ->
-        fun mlAppExpr  ->
-          let rec eta_args more_args t =
-            match t with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____2902,t1) ->
-                let x = FStar_Extraction_ML_Syntax.gensym () in
-                let uu____2905 =
-                  let uu____2911 =
-                    let uu____2916 =
-                      FStar_All.pipe_left
-                        (FStar_Extraction_ML_Syntax.with_ty t0)
-                        (FStar_Extraction_ML_Syntax.MLE_Var x) in
-                    ((x, t0), uu____2916) in
-                  uu____2911 :: more_args in
-                eta_args uu____2905 t1
-            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____2923,uu____2924)
-                -> ((FStar_List.rev more_args), t)
-            | uu____2936 -> failwith "Impossible: Head type is not an arrow" in
-          let as_record qual1 e =
-            match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
-            | (FStar_Extraction_ML_Syntax.MLE_CTor (uu____2954,args),Some
-               (FStar_Syntax_Syntax.Record_ctor (tyname,fields))) ->
-                let path =
-                  FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns in
-                let fields1 = record_fields fields args in
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     e.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____2973 -> e in
-          let resugar_and_maybe_eta qual1 e =
-            let uu____2986 = eta_args [] residualType in
-            match uu____2986 with
-            | (eargs,tres) ->
-                (match eargs with
-                 | [] ->
-                     let uu____3014 = as_record qual1 e in
-                     FStar_Extraction_ML_Util.resugar_exp uu____3014
-                 | uu____3015 ->
-                     let uu____3021 = FStar_List.unzip eargs in
-                     (match uu____3021 with
-                      | (binders,eargs1) ->
-                          (match e.FStar_Extraction_ML_Syntax.expr with
-                           | FStar_Extraction_ML_Syntax.MLE_CTor (head1,args)
-                               ->
-                               let body =
-                                 let uu____3045 =
-                                   let uu____3046 =
-                                     FStar_All.pipe_left
-                                       (FStar_Extraction_ML_Syntax.with_ty
-                                          tres)
-                                       (FStar_Extraction_ML_Syntax.MLE_CTor
-                                          (head1,
-                                            (FStar_List.append args eargs1))) in
-                                   FStar_All.pipe_left (as_record qual1)
-                                     uu____3046 in
-                                 FStar_All.pipe_left
-                                   FStar_Extraction_ML_Util.resugar_exp
-                                   uu____3045 in
-                               FStar_All.pipe_left
-                                 (FStar_Extraction_ML_Syntax.with_ty
-                                    e.FStar_Extraction_ML_Syntax.mlty)
-                                 (FStar_Extraction_ML_Syntax.MLE_Fun
-                                    (binders, body))
-                           | uu____3051 ->
-                               failwith "Impossible: Not a constructor"))) in
-          match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
-          | (uu____3053,None ) -> mlAppExpr
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____3056;
-                FStar_Extraction_ML_Syntax.loc = uu____3057;_},mle::args),Some
-             (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
-              let f1 =
-                FStar_Ident.lid_of_ids
-                  (FStar_List.append constrname.FStar_Ident.ns [f]) in
-              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1 in
-              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn) in
-              let e =
-                match args with
-                | [] -> proj
-                | uu____3075 ->
-                    let uu____3077 =
-                      let uu____3081 =
-                        FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj in
-                      (uu____3081, args) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____3077 in
-              FStar_Extraction_ML_Syntax.with_ty
-                mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = _;
-                FStar_Extraction_ML_Syntax.loc = _;_},mlargs),Some
-             (FStar_Syntax_Syntax.Data_ctor ))
-            |(FStar_Extraction_ML_Syntax.MLE_App
-              ({
-                 FStar_Extraction_ML_Syntax.expr =
-                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                 FStar_Extraction_ML_Syntax.mlty = _;
-                 FStar_Extraction_ML_Syntax.loc = _;_},mlargs),Some
-              (FStar_Syntax_Syntax.Record_ctor _)) ->
-              let uu____3096 =
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____3096
-          | (FStar_Extraction_ML_Syntax.MLE_Name mlp,Some
-             (FStar_Syntax_Syntax.Data_ctor ))
-            |(FStar_Extraction_ML_Syntax.MLE_Name mlp,Some
-              (FStar_Syntax_Syntax.Record_ctor _)) ->
-              let uu____3102 =
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____3102
-          | uu____3104 -> mlAppExpr
-let maybe_downgrade_eff:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.e_tag
-  =
-  fun g  ->
-    fun f  ->
-      fun t  ->
-        let uu____3117 =
-          (f = FStar_Extraction_ML_Syntax.E_GHOST) &&
-            (type_leq g t FStar_Extraction_ML_Syntax.ml_unit_ty) in
-        if uu____3117 then FStar_Extraction_ML_Syntax.E_PURE else f
-let rec term_as_mlexpr:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Extraction_ML_Syntax.mlexpr* FStar_Extraction_ML_Syntax.e_tag*
-        FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun g  ->
-    fun t  ->
-      let uu____3158 = term_as_mlexpr' g t in
-      match uu____3158 with
-      | (e,tag,ty) ->
-          let tag1 = maybe_downgrade_eff g tag ty in
-          (FStar_Extraction_ML_UEnv.debug g
-             (fun u  ->
-                let uu____3171 =
-                  let uu____3172 = FStar_Syntax_Print.tag_of_term t in
-                  let uu____3173 = FStar_Syntax_Print.term_to_string t in
-                  let uu____3174 =
-                    FStar_Extraction_ML_Code.string_of_mlty
-                      g.FStar_Extraction_ML_UEnv.currentModule ty in
-                  FStar_Util.format4
-                    "term_as_mlexpr (%s) :  %s has ML type %s and effect %s\n"
-                    uu____3172 uu____3173 uu____3174
-                    (FStar_Extraction_ML_Util.eff_to_string tag1) in
-                FStar_Util.print_string uu____3171);
-           erase g e ty tag1)
-and check_term_as_mlexpr:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Extraction_ML_Syntax.e_tag ->
-        FStar_Extraction_ML_Syntax.mlty ->
-          (FStar_Extraction_ML_Syntax.mlexpr*
-            FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun g  ->
-    fun t  ->
-      fun f  ->
-        fun ty  ->
-          let uu____3181 = check_term_as_mlexpr' g t f ty in
-          match uu____3181 with
-          | (e,t1) ->
-              let uu____3188 = erase g e t1 f in
-              (match uu____3188 with | (r,uu____3195,t2) -> (r, t2))
-and check_term_as_mlexpr':
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Extraction_ML_Syntax.e_tag ->
-        FStar_Extraction_ML_Syntax.mlty ->
-          (FStar_Extraction_ML_Syntax.mlexpr*
-            FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun g  ->
-    fun e0  ->
-      fun f  ->
-        fun ty  ->
-          let uu____3203 = term_as_mlexpr g e0 in
-          match uu____3203 with
-          | (e,tag,t) ->
-              let tag1 = maybe_downgrade_eff g tag t in
-              if FStar_Extraction_ML_Util.eff_leq tag1 f
-              then let uu____3215 = maybe_coerce g e t ty in (uu____3215, ty)
-              else err_unexpected_eff e0 f tag1
-and term_as_mlexpr':
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Extraction_ML_Syntax.mlexpr* FStar_Extraction_ML_Syntax.e_tag*
-        FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun g  ->
-    fun top  ->
-      FStar_Extraction_ML_UEnv.debug g
-        (fun u  ->
-           let uu____3226 =
-             let uu____3227 =
-               FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
-             let uu____3228 = FStar_Syntax_Print.tag_of_term top in
-             let uu____3229 = FStar_Syntax_Print.term_to_string top in
-             FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____3227 uu____3228 uu____3229 in
-           FStar_Util.print_string uu____3226);
-      (let t = FStar_Syntax_Subst.compress top in
-       match t.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_unknown 
-         |FStar_Syntax_Syntax.Tm_delayed _
-          |FStar_Syntax_Syntax.Tm_uvar _|FStar_Syntax_Syntax.Tm_bvar _ ->
-           let uu____3237 =
-             let uu____3238 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____3238 in
-           failwith uu____3237
-       | FStar_Syntax_Syntax.Tm_type _
-         |FStar_Syntax_Syntax.Tm_refine _|FStar_Syntax_Syntax.Tm_arrow _ ->
-           (FStar_Extraction_ML_Syntax.ml_unit,
-             FStar_Extraction_ML_Syntax.E_PURE,
-             FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_meta
-           (t1,FStar_Syntax_Syntax.Meta_desugared
-            (FStar_Syntax_Syntax.Mutable_alloc ))
-           ->
-           let uu____3250 = term_as_mlexpr' g t1 in
-           (match uu____3250 with
-            | ({
-                 FStar_Extraction_ML_Syntax.expr =
-                   FStar_Extraction_ML_Syntax.MLE_Let
-                   ((FStar_Extraction_ML_Syntax.NonRec ,flags,bodies),continuation);
-                 FStar_Extraction_ML_Syntax.mlty = mlty;
-                 FStar_Extraction_ML_Syntax.loc = loc;_},tag,typ)
-                ->
-                ({
-                   FStar_Extraction_ML_Syntax.expr =
-                     (FStar_Extraction_ML_Syntax.MLE_Let
-                        ((FStar_Extraction_ML_Syntax.NonRec,
-                           (FStar_Extraction_ML_Syntax.Mutable :: flags),
-                           bodies), continuation));
-                   FStar_Extraction_ML_Syntax.mlty = mlty;
-                   FStar_Extraction_ML_Syntax.loc = loc
-                 }, tag, typ)
-            | uu____3277 -> failwith "impossible")
-       | FStar_Syntax_Syntax.Tm_meta
-           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____3286)) ->
-           let t2 = FStar_Syntax_Subst.compress t1 in
-           (match t2.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) when
-                FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
-                let ed =
-                  FStar_TypeChecker_Env.get_effect_decl
-                    g.FStar_Extraction_ML_UEnv.tcenv m in
-                let uu____3310 =
-                  let uu____3311 =
-                    FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers
-                      (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
-                  FStar_All.pipe_right uu____3311 Prims.op_Negation in
-                if uu____3310
-                then term_as_mlexpr' g t2
-                else
-                  (let ml_result_ty_1 =
-                     term_as_mlty g lb.FStar_Syntax_Syntax.lbtyp in
-                   let uu____3318 =
-                     term_as_mlexpr g lb.FStar_Syntax_Syntax.lbdef in
-                   match uu____3318 with
-                   | (comp_1,uu____3326,uu____3327) ->
-                       let uu____3328 =
-                         let k =
-                           let uu____3332 =
-                             let uu____3336 =
-                               let uu____3337 =
-                                 FStar_Util.left
-                                   lb.FStar_Syntax_Syntax.lbname in
-                               FStar_All.pipe_right uu____3337
-                                 FStar_Syntax_Syntax.mk_binder in
-                             [uu____3336] in
-                           FStar_Syntax_Util.abs uu____3332 body None in
-                         let uu____3343 = term_as_mlexpr g k in
-                         match uu____3343 with
-                         | (ml_k,uu____3350,t_k) ->
-                             let m_2 =
-                               match t_k with
-                               | FStar_Extraction_ML_Syntax.MLTY_Fun
-                                   (uu____3353,uu____3354,m_2) -> m_2
-                               | uu____3356 -> failwith "Impossible" in
-                             (ml_k, m_2) in
-                       (match uu____3328 with
-                        | (ml_k,ty) ->
-                            let bind1 =
-                              let uu____3363 =
-                                let uu____3364 =
-                                  let uu____3365 =
-                                    FStar_Extraction_ML_UEnv.monad_op_name ed
-                                      "bind" in
-                                  FStar_All.pipe_right uu____3365 Prims.fst in
-                                FStar_Extraction_ML_Syntax.MLE_Name
-                                  uu____3364 in
-                              FStar_All.pipe_left
-                                (FStar_Extraction_ML_Syntax.with_ty
-                                   FStar_Extraction_ML_Syntax.MLTY_Top)
-                                uu____3363 in
-                            let uu____3370 =
-                              FStar_All.pipe_left
-                                (FStar_Extraction_ML_Syntax.with_ty ty)
-                                (FStar_Extraction_ML_Syntax.MLE_App
-                                   (bind1, [comp_1; ml_k])) in
-                            (uu____3370, FStar_Extraction_ML_Syntax.E_IMPURE,
-                              ty)))
-            | uu____3372 -> term_as_mlexpr' g t2)
-       | FStar_Syntax_Syntax.Tm_meta (t1,_)|FStar_Syntax_Syntax.Tm_uinst
-         (t1,_) -> term_as_mlexpr' g t1
-       | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____3385 =
-             FStar_TypeChecker_TcTerm.type_of_tot_term
-               g.FStar_Extraction_ML_UEnv.tcenv t in
-           (match uu____3385 with
-            | (uu____3392,ty,uu____3394) ->
-                let ml_ty = term_as_mlty g ty in
-                let uu____3396 =
-                  let uu____3397 =
-                    let uu____3398 =
-                      FStar_Extraction_ML_Util.mlconst_of_const'
-                        t.FStar_Syntax_Syntax.pos c in
-                    FStar_All.pipe_left
-                      (fun _0_31  ->
-                         FStar_Extraction_ML_Syntax.MLE_Const _0_31)
-                      uu____3398 in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____3397 in
-                (uu____3396, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
-       | FStar_Syntax_Syntax.Tm_name _|FStar_Syntax_Syntax.Tm_fvar _ ->
-           let uu____3401 = is_type g t in
-           if uu____3401
-           then
-             (FStar_Extraction_ML_Syntax.ml_unit,
-               FStar_Extraction_ML_Syntax.E_PURE,
-               FStar_Extraction_ML_Syntax.ml_unit_ty)
-           else
-             (let uu____3406 = FStar_Extraction_ML_UEnv.lookup_term g t in
-              match uu____3406 with
-              | (FStar_Util.Inl uu____3413,uu____3414) ->
-                  (FStar_Extraction_ML_Syntax.ml_unit,
-                    FStar_Extraction_ML_Syntax.E_PURE,
-                    FStar_Extraction_ML_Syntax.ml_unit_ty)
-              | (FStar_Util.Inr (uu____3433,x,mltys,uu____3436),qual) ->
-                  (match mltys with
-                   | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
-                       ->
-                       (FStar_Extraction_ML_Syntax.ml_unit,
-                         FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | ([],t1) ->
-                       let uu____3461 =
-                         maybe_eta_data_and_project_record g qual t1 x in
-                       (uu____3461, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | uu____3462 -> err_uninst g t mltys t))
-       | FStar_Syntax_Syntax.Tm_abs (bs,body,copt) ->
-           let uu____3491 = FStar_Syntax_Subst.open_term bs body in
-           (match uu____3491 with
-            | (bs1,body1) ->
-                let uu____3499 = binders_as_ml_binders g bs1 in
-                (match uu____3499 with
-                 | (ml_bs,env) ->
-                     let uu____3516 = term_as_mlexpr env body1 in
-                     (match uu____3516 with
-                      | (ml_body,f,t1) ->
-                          let uu____3526 =
-                            FStar_List.fold_right
-                              (fun uu____3533  ->
-                                 fun uu____3534  ->
-                                   match (uu____3533, uu____3534) with
-                                   | ((uu____3545,targ),(f1,t2)) ->
-                                       (FStar_Extraction_ML_Syntax.E_PURE,
-                                         (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                            (targ, f1, t2)))) ml_bs (f, t1) in
-                          (match uu____3526 with
-                           | (f1,tfun) ->
-                               let uu____3558 =
-                                 FStar_All.pipe_left
-                                   (FStar_Extraction_ML_Syntax.with_ty tfun)
-                                   (FStar_Extraction_ML_Syntax.MLE_Fun
-                                      (ml_bs, ml_body)) in
-                               (uu____3558, f1, tfun)))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.tk = uu____3562;
-              FStar_Syntax_Syntax.pos = uu____3563;
-              FStar_Syntax_Syntax.vars = uu____3564;_},t1::[])
-           ->
-           let uu____3587 = term_as_mlexpr' g (Prims.fst t1) in
-           (match uu____3587 with
-            | (ml,e_tag,mlty) ->
-                (ml, FStar_Extraction_ML_Syntax.E_PURE, mlty))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____3599);
-              FStar_Syntax_Syntax.tk = uu____3600;
-              FStar_Syntax_Syntax.pos = uu____3601;
-              FStar_Syntax_Syntax.vars = uu____3602;_},t1::[])
-           ->
-           let uu____3625 = term_as_mlexpr' g (Prims.fst t1) in
-           (match uu____3625 with
-            | (ml,e_tag,mlty) ->
-                (ml, FStar_Extraction_ML_Syntax.E_IMPURE, mlty))
-       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-           let is_total uu___141_3661 =
-             match uu___141_3661 with
-             | FStar_Util.Inl l -> FStar_Syntax_Util.is_total_lcomp l
-             | FStar_Util.Inr (l,flags) ->
-                 (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid)
-                   ||
-                   (FStar_All.pipe_right flags
-                      (FStar_List.existsb
-                         (fun uu___140_3679  ->
-                            match uu___140_3679 with
-                            | FStar_Syntax_Syntax.TOTAL  -> true
-                            | uu____3680 -> false))) in
-           let uu____3681 =
-             let uu____3684 =
-               let uu____3685 = FStar_Syntax_Subst.compress head1 in
-               uu____3685.FStar_Syntax_Syntax.n in
-             ((head1.FStar_Syntax_Syntax.n), uu____3684) in
-           (match uu____3681 with
-            | (FStar_Syntax_Syntax.Tm_uvar uu____3691,uu____3692) ->
-                let t1 =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Beta;
-                    FStar_TypeChecker_Normalize.Iota;
-                    FStar_TypeChecker_Normalize.Zeta;
-                    FStar_TypeChecker_Normalize.EraseUniverses;
-                    FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                    g.FStar_Extraction_ML_UEnv.tcenv t in
-                term_as_mlexpr' g t1
-            | (uu____3702,FStar_Syntax_Syntax.Tm_abs (bs,uu____3704,Some lc))
-                when is_total lc ->
-                let t1 =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Beta;
-                    FStar_TypeChecker_Normalize.Iota;
-                    FStar_TypeChecker_Normalize.Zeta;
-                    FStar_TypeChecker_Normalize.EraseUniverses;
-                    FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                    g.FStar_Extraction_ML_UEnv.tcenv t in
-                term_as_mlexpr' g t1
-            | uu____3733 ->
-                let rec extract_app is_data uu____3761 uu____3762 restArgs =
-                  match (uu____3761, uu____3762) with
-                  | ((mlhead,mlargs_f),(f,t1)) ->
-                      (match (restArgs, t1) with
-                       | ([],uu____3810) ->
-                           let evaluation_order_guaranteed =
-                             (((FStar_List.length mlargs_f) =
-                                 (Prims.parse_int "1"))
-                                ||
-                                (FStar_Extraction_ML_Util.codegen_fsharp ()))
-                               ||
-                               (match head1.FStar_Syntax_Syntax.n with
-                                | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                    (FStar_Syntax_Syntax.fv_eq_lid fv
-                                       FStar_Syntax_Const.op_And)
-                                      ||
-                                      (FStar_Syntax_Syntax.fv_eq_lid fv
-                                         FStar_Syntax_Const.op_Or)
-                                | uu____3824 -> false) in
-                           let uu____3825 =
-                             if evaluation_order_guaranteed
-                             then
-                               let uu____3838 =
-                                 FStar_All.pipe_right
-                                   (FStar_List.rev mlargs_f)
-                                   (FStar_List.map Prims.fst) in
-                               ([], uu____3838)
-                             else
-                               FStar_List.fold_left
-                                 (fun uu____3863  ->
-                                    fun uu____3864  ->
-                                      match (uu____3863, uu____3864) with
-                                      | ((lbs,out_args),(arg,f1)) ->
-                                          if
-                                            (f1 =
-                                               FStar_Extraction_ML_Syntax.E_PURE)
-                                              ||
-                                              (f1 =
-                                                 FStar_Extraction_ML_Syntax.E_GHOST)
-                                          then (lbs, (arg :: out_args))
-                                          else
-                                            (let x =
-                                               FStar_Extraction_ML_Syntax.gensym
-                                                 () in
-                                             let uu____3919 =
-                                               let uu____3921 =
-                                                 FStar_All.pipe_left
-                                                   (FStar_Extraction_ML_Syntax.with_ty
-                                                      arg.FStar_Extraction_ML_Syntax.mlty)
-                                                   (FStar_Extraction_ML_Syntax.MLE_Var
-                                                      x) in
-                                               uu____3921 :: out_args in
-                                             (((x, arg) :: lbs), uu____3919)))
-                                 ([], []) mlargs_f in
-                           (match uu____3825 with
-                            | (lbs,mlargs) ->
-                                let app =
-                                  let uu____3948 =
-                                    FStar_All.pipe_left
-                                      (FStar_Extraction_ML_Syntax.with_ty t1)
-                                      (FStar_Extraction_ML_Syntax.MLE_App
-                                         (mlhead, mlargs)) in
-                                  FStar_All.pipe_left
-                                    (maybe_eta_data_and_project_record g
-                                       is_data t1) uu____3948 in
-                                let l_app =
-                                  FStar_List.fold_right
-                                    (fun uu____3953  ->
-                                       fun out  ->
-                                         match uu____3953 with
-                                         | (x,arg) ->
-                                             FStar_All.pipe_left
-                                               (FStar_Extraction_ML_Syntax.with_ty
-                                                  out.FStar_Extraction_ML_Syntax.mlty)
-                                               (mk_MLE_Let false
-                                                  (FStar_Extraction_ML_Syntax.NonRec,
-                                                    [],
-                                                    [{
-                                                       FStar_Extraction_ML_Syntax.mllb_name
-                                                         = x;
-                                                       FStar_Extraction_ML_Syntax.mllb_tysc
-                                                         =
-                                                         (Some
-                                                            ([],
-                                                              (arg.FStar_Extraction_ML_Syntax.mlty)));
-                                                       FStar_Extraction_ML_Syntax.mllb_add_unit
-                                                         = false;
-                                                       FStar_Extraction_ML_Syntax.mllb_def
-                                                         = arg;
-                                                       FStar_Extraction_ML_Syntax.print_typ
-                                                         = true
-                                                     }]) out)) lbs app in
-                                (l_app, f, t1))
-                       | ((arg,uu____3966)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
-                          (formal_t,f',t2)) when is_type g arg ->
-                           let uu____3984 =
-                             type_leq g formal_t
-                               FStar_Extraction_ML_Syntax.ml_unit_ty in
-                           if uu____3984
-                           then
-                             let uu____3988 =
-                               let uu____3991 =
-                                 FStar_Extraction_ML_Util.join
-                                   arg.FStar_Syntax_Syntax.pos f f' in
-                               (uu____3991, t2) in
-                             extract_app is_data
-                               (mlhead,
-                                 ((FStar_Extraction_ML_Syntax.ml_unit,
-                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                 mlargs_f)) uu____3988 rest
-                           else
-                             (let uu____3998 =
-                                let uu____3999 =
-                                  FStar_Extraction_ML_Code.string_of_mlexpr
-                                    g.FStar_Extraction_ML_UEnv.currentModule
-                                    mlhead in
-                                let uu____4000 =
-                                  FStar_Syntax_Print.term_to_string arg in
-                                let uu____4001 =
-                                  FStar_Syntax_Print.tag_of_term arg in
-                                let uu____4002 =
-                                  FStar_Extraction_ML_Code.string_of_mlty
-                                    g.FStar_Extraction_ML_UEnv.currentModule
-                                    formal_t in
-                                FStar_Util.format4
-                                  "Impossible: ill-typed application:\n\thead=%s, arg=%s, tag=%s\n\texpected type unit, got %s"
-                                  uu____3999 uu____4000 uu____4001 uu____4002 in
-                              failwith uu____3998)
-                       | ((e0,uu____4007)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
-                          (tExpected,f',t2)) ->
-                           let r = e0.FStar_Syntax_Syntax.pos in
-                           let uu____4026 = term_as_mlexpr g e0 in
-                           (match uu____4026 with
-                            | (e01,f0,tInferred) ->
-                                let e02 =
-                                  maybe_coerce g e01 tInferred tExpected in
-                                let uu____4037 =
-                                  let uu____4040 =
-                                    FStar_Extraction_ML_Util.join_l r
-                                      [f; f'; f0] in
-                                  (uu____4040, t2) in
-                                extract_app is_data
-                                  (mlhead, ((e02, f0) :: mlargs_f))
-                                  uu____4037 rest)
-                       | uu____4046 ->
-                           let uu____4053 =
-                             FStar_Extraction_ML_Util.udelta_unfold g t1 in
-                           (match uu____4053 with
-                            | Some t2 ->
-                                extract_app is_data (mlhead, mlargs_f)
-                                  (f, t2) restArgs
-                            | None  ->
-                                err_ill_typed_application g top restArgs t1)) in
-                let extract_app_maybe_projector is_data mlhead uu____4089
-                  args1 =
-                  match uu____4089 with
-                  | (f,t1) ->
-                      (match is_data with
-                       | Some (FStar_Syntax_Syntax.Record_projector
-                           uu____4108) ->
-                           let rec remove_implicits args2 f1 t2 =
-                             match (args2, t2) with
-                             | ((a0,Some (FStar_Syntax_Syntax.Implicit
-                                 uu____4158))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____4160,f',t3)) ->
-                                 let uu____4185 =
-                                   FStar_Extraction_ML_Util.join
-                                     a0.FStar_Syntax_Syntax.pos f1 f' in
-                                 remove_implicits args3 uu____4185 t3
-                             | uu____4186 -> (args2, f1, t2) in
-                           let uu____4201 = remove_implicits args1 f t1 in
-                           (match uu____4201 with
-                            | (args2,f1,t2) ->
-                                extract_app is_data (mlhead, []) (f1, t2)
-                                  args2)
-                       | uu____4234 ->
-                           extract_app is_data (mlhead, []) (f, t1) args1) in
-                let uu____4241 = is_type g t in
-                if uu____4241
-                then
-                  (FStar_Extraction_ML_Syntax.ml_unit,
-                    FStar_Extraction_ML_Syntax.E_PURE,
-                    FStar_Extraction_ML_Syntax.ml_unit_ty)
-                else
-                  (let head2 = FStar_Syntax_Util.un_uinst head1 in
-                   match head2.FStar_Syntax_Syntax.n with
-                   | FStar_Syntax_Syntax.Tm_name _
-                     |FStar_Syntax_Syntax.Tm_fvar _ ->
-                       let uu____4252 =
-                         let uu____4259 =
-                           FStar_Extraction_ML_UEnv.lookup_term g head2 in
-                         match uu____4259 with
-                         | (FStar_Util.Inr (uu____4269,x1,x2,x3),q) ->
-                             ((x1, x2, x3), q)
-                         | uu____4294 -> failwith "FIXME Ty" in
-                       (match uu____4252 with
-                        | ((head_ml,(vars,t1),inst_ok),qual) ->
-                            let has_typ_apps =
-                              match args with
-                              | (a,uu____4323)::uu____4324 -> is_type g a
-                              | uu____4338 -> false in
-                            let uu____4344 =
-                              match vars with
-                              | uu____4361::uu____4362 when
-                                  (Prims.op_Negation has_typ_apps) && inst_ok
-                                  -> (head_ml, t1, args)
-                              | uu____4369 ->
-                                  let n1 = FStar_List.length vars in
-                                  if n1 <= (FStar_List.length args)
-                                  then
-                                    let uu____4389 =
-                                      FStar_Util.first_N n1 args in
-                                    (match uu____4389 with
-                                     | (prefix1,rest) ->
-                                         let prefixAsMLTypes =
-                                           FStar_List.map
-                                             (fun uu____4442  ->
-                                                match uu____4442 with
-                                                | (x,uu____4446) ->
-                                                    term_as_mlty g x) prefix1 in
-                                         let t2 =
-                                           instantiate (vars, t1)
-                                             prefixAsMLTypes in
-                                         let head3 =
-                                           match head_ml.FStar_Extraction_ML_Syntax.expr
-                                           with
-                                           | FStar_Extraction_ML_Syntax.MLE_Name
-                                             _
-                                             |FStar_Extraction_ML_Syntax.MLE_Var
-                                             _ ->
-                                               let uu___145_4451 = head_ml in
-                                               {
-                                                 FStar_Extraction_ML_Syntax.expr
-                                                   =
-                                                   (uu___145_4451.FStar_Extraction_ML_Syntax.expr);
-                                                 FStar_Extraction_ML_Syntax.mlty
-                                                   = t2;
-                                                 FStar_Extraction_ML_Syntax.loc
-                                                   =
-                                                   (uu___145_4451.FStar_Extraction_ML_Syntax.loc)
-                                               }
-                                           | FStar_Extraction_ML_Syntax.MLE_App
-                                               (head3,{
-                                                        FStar_Extraction_ML_Syntax.expr
-                                                          =
-                                                          FStar_Extraction_ML_Syntax.MLE_Const
-                                                          (FStar_Extraction_ML_Syntax.MLC_Unit
-                                                          );
-                                                        FStar_Extraction_ML_Syntax.mlty
-                                                          = uu____4453;
-                                                        FStar_Extraction_ML_Syntax.loc
-                                                          = uu____4454;_}::[])
-                                               ->
-                                               FStar_All.pipe_right
-                                                 (FStar_Extraction_ML_Syntax.MLE_App
-                                                    ((let uu___146_4457 =
-                                                        head3 in
-                                                      {
-                                                        FStar_Extraction_ML_Syntax.expr
-                                                          =
-                                                          (uu___146_4457.FStar_Extraction_ML_Syntax.expr);
-                                                        FStar_Extraction_ML_Syntax.mlty
-                                                          =
-                                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                                             (FStar_Extraction_ML_Syntax.ml_unit_ty,
-                                                               FStar_Extraction_ML_Syntax.E_PURE,
-                                                               t2));
-                                                        FStar_Extraction_ML_Syntax.loc
-                                                          =
-                                                          (uu___146_4457.FStar_Extraction_ML_Syntax.loc)
-                                                      }),
-                                                      [FStar_Extraction_ML_Syntax.ml_unit]))
-                                                 (FStar_Extraction_ML_Syntax.with_ty
-                                                    t2)
-                                           | uu____4458 ->
-                                               failwith
-                                                 "Impossible: Unexpected head term" in
-                                         (head3, t2, rest))
-                                  else err_uninst g head2 (vars, t1) top in
-                            (match uu____4344 with
-                             | (head_ml1,head_t,args1) ->
-                                 (match args1 with
-                                  | [] ->
-                                      let uu____4496 =
-                                        maybe_eta_data_and_project_record g
-                                          qual head_t head_ml1 in
-                                      (uu____4496,
-                                        FStar_Extraction_ML_Syntax.E_PURE,
-                                        head_t)
-                                  | uu____4497 ->
-                                      extract_app_maybe_projector qual
-                                        head_ml1
-                                        (FStar_Extraction_ML_Syntax.E_PURE,
-                                          head_t) args1)))
-                   | uu____4503 ->
-                       let uu____4504 = term_as_mlexpr g head2 in
-                       (match uu____4504 with
-                        | (head3,f,t1) ->
-                            extract_app_maybe_projector None head3 (f, t1)
-                              args)))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____4516),f) ->
-           let t1 =
-             match tc with
-             | FStar_Util.Inl t1 -> term_as_mlty g t1
-             | FStar_Util.Inr c ->
-                 term_as_mlty g (FStar_Syntax_Util.comp_result c) in
-           let f1 =
-             match f with
-             | None  -> failwith "Ascription node with an empty effect label"
-             | Some l -> effect_as_etag g l in
-           let uu____4570 = check_term_as_mlexpr g e0 f1 t1 in
-           (match uu____4570 with | (e,t2) -> (e, f1, t2))
-       | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
-           let top_level = FStar_Syntax_Syntax.is_top_level lbs in
-           let uu____4591 =
-             if is_rec
-             then FStar_Syntax_Subst.open_let_rec lbs e'
-             else
-               (let uu____4599 = FStar_Syntax_Syntax.is_top_level lbs in
-                if uu____4599
-                then (lbs, e')
-                else
-                  (let lb = FStar_List.hd lbs in
-                   let x =
-                     let uu____4609 =
-                       FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                     FStar_Syntax_Syntax.freshen_bv uu____4609 in
-                   let lb1 =
-                     let uu___147_4611 = lb in
-                     {
-                       FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
-                       FStar_Syntax_Syntax.lbunivs =
-                         (uu___147_4611.FStar_Syntax_Syntax.lbunivs);
-                       FStar_Syntax_Syntax.lbtyp =
-                         (uu___147_4611.FStar_Syntax_Syntax.lbtyp);
-                       FStar_Syntax_Syntax.lbeff =
-                         (uu___147_4611.FStar_Syntax_Syntax.lbeff);
-                       FStar_Syntax_Syntax.lbdef =
-                         (uu___147_4611.FStar_Syntax_Syntax.lbdef)
-                     } in
-                   let e'1 =
-                     FStar_Syntax_Subst.subst
-                       [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x)] e' in
-                   ([lb1], e'1))) in
-           (match uu____4591 with
-            | (lbs1,e'1) ->
-                let lbs2 =
-                  if top_level
-                  then
-                    FStar_All.pipe_right lbs1
-                      (FStar_List.map
-                         (fun lb  ->
-                            let tcenv =
-                              let uu____4628 =
-                                FStar_Ident.lid_of_path
-                                  (FStar_List.append
-                                     (Prims.fst
-                                        g.FStar_Extraction_ML_UEnv.currentModule)
-                                     [Prims.snd
-                                        g.FStar_Extraction_ML_UEnv.currentModule])
-                                  FStar_Range.dummyRange in
-                              FStar_TypeChecker_Env.set_current_module
-                                g.FStar_Extraction_ML_UEnv.tcenv uu____4628 in
-                            FStar_Extraction_ML_UEnv.debug g
-                              (fun uu____4632  ->
-                                 FStar_Options.set_option "debug_level"
-                                   (FStar_Options.List
-                                      [FStar_Options.String "Norm";
-                                      FStar_Options.String "Extraction"]));
-                            (let lbdef =
-                               let uu____4636 = FStar_Options.ml_ish () in
-                               if uu____4636
-                               then lb.FStar_Syntax_Syntax.lbdef
-                               else
-                                 FStar_TypeChecker_Normalize.normalize
-                                   [FStar_TypeChecker_Normalize.AllowUnboundUniverses;
-                                   FStar_TypeChecker_Normalize.EraseUniverses;
-                                   FStar_TypeChecker_Normalize.Inlining;
-                                   FStar_TypeChecker_Normalize.Eager_unfolding;
-                                   FStar_TypeChecker_Normalize.Exclude
-                                     FStar_TypeChecker_Normalize.Zeta;
-                                   FStar_TypeChecker_Normalize.PureSubtermsWithinComputations;
-                                   FStar_TypeChecker_Normalize.Primops] tcenv
-                                   lb.FStar_Syntax_Syntax.lbdef in
-                             let uu___148_4640 = lb in
-                             {
-                               FStar_Syntax_Syntax.lbname =
-                                 (uu___148_4640.FStar_Syntax_Syntax.lbname);
-                               FStar_Syntax_Syntax.lbunivs =
-                                 (uu___148_4640.FStar_Syntax_Syntax.lbunivs);
-                               FStar_Syntax_Syntax.lbtyp =
-                                 (uu___148_4640.FStar_Syntax_Syntax.lbtyp);
-                               FStar_Syntax_Syntax.lbeff =
-                                 (uu___148_4640.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = lbdef
-                             })))
-                  else lbs1 in
-                let maybe_generalize uu____4654 =
-                  match uu____4654 with
-                  | { FStar_Syntax_Syntax.lbname = lbname_;
-                      FStar_Syntax_Syntax.lbunivs = uu____4665;
-                      FStar_Syntax_Syntax.lbtyp = t1;
-                      FStar_Syntax_Syntax.lbeff = lbeff;
-                      FStar_Syntax_Syntax.lbdef = e;_} ->
-                      let f_e = effect_as_etag g lbeff in
-                      let t2 = FStar_Syntax_Subst.compress t1 in
-                      (match t2.FStar_Syntax_Syntax.n with
-                       | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                           let uu____4708 = FStar_List.hd bs in
-                           FStar_All.pipe_right uu____4708 (is_type_binder g)
-                           ->
-                           let uu____4715 = FStar_Syntax_Subst.open_comp bs c in
-                           (match uu____4715 with
-                            | (bs1,c1) ->
-                                let uu____4729 =
-                                  let uu____4734 =
-                                    FStar_Util.prefix_until
-                                      (fun x  ->
-                                         let uu____4752 = is_type_binder g x in
-                                         Prims.op_Negation uu____4752) bs1 in
-                                  match uu____4734 with
-                                  | None  ->
-                                      (bs1,
-                                        (FStar_Syntax_Util.comp_result c1))
-                                  | Some (bs2,b,rest) ->
-                                      let uu____4800 =
-                                        FStar_Syntax_Util.arrow (b :: rest)
-                                          c1 in
-                                      (bs2, uu____4800) in
-                                (match uu____4729 with
-                                 | (tbinders,tbody) ->
-                                     let n_tbinders =
-                                       FStar_List.length tbinders in
-                                     let e1 =
-                                       let uu____4830 = normalize_abs e in
-                                       FStar_All.pipe_right uu____4830
-                                         FStar_Syntax_Util.unmeta in
-                                     (match e1.FStar_Syntax_Syntax.n with
-                                      | FStar_Syntax_Syntax.Tm_abs
-                                          (bs2,body,uu____4842) ->
-                                          let uu____4865 =
-                                            FStar_Syntax_Subst.open_term bs2
-                                              body in
-                                          (match uu____4865 with
-                                           | (bs3,body1) ->
-                                               if
-                                                 n_tbinders <=
-                                                   (FStar_List.length bs3)
-                                               then
-                                                 let uu____4895 =
-                                                   FStar_Util.first_N
-                                                     n_tbinders bs3 in
-                                                 (match uu____4895 with
-                                                  | (targs,rest_args) ->
-                                                      let expected_source_ty
-                                                        =
-                                                        let s =
-                                                          FStar_List.map2
-                                                            (fun uu____4938 
-                                                               ->
-                                                               fun uu____4939
-                                                                  ->
-                                                                 match 
-                                                                   (uu____4938,
-                                                                    uu____4939)
-                                                                 with
-                                                                 | ((x,uu____4949),
-                                                                    (y,uu____4951))
-                                                                    ->
-                                                                    let uu____4956
-                                                                    =
-                                                                    let uu____4961
-                                                                    =
-                                                                    FStar_Syntax_Syntax.bv_to_name
-                                                                    y in
-                                                                    (x,
-                                                                    uu____4961) in
-                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu____4956)
-                                                            tbinders targs in
-                                                        FStar_Syntax_Subst.subst
-                                                          s tbody in
-                                                      let env =
-                                                        FStar_List.fold_left
-                                                          (fun env  ->
-                                                             fun uu____4966 
-                                                               ->
-                                                               match uu____4966
-                                                               with
-                                                               | (a,uu____4970)
-                                                                   ->
-                                                                   FStar_Extraction_ML_UEnv.extend_ty
-                                                                    env a
-                                                                    None) g
-                                                          targs in
-                                                      let expected_t =
-                                                        term_as_mlty env
-                                                          expected_source_ty in
-                                                      let polytype =
-                                                        let uu____4978 =
-                                                          FStar_All.pipe_right
-                                                            targs
-                                                            (FStar_List.map
-                                                               (fun
-                                                                  uu____4992 
-                                                                  ->
-                                                                  match uu____4992
-                                                                  with
-                                                                  | (x,uu____4998)
-                                                                    ->
-                                                                    FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                                    x)) in
-                                                        (uu____4978,
-                                                          expected_t) in
-                                                      let add_unit =
-                                                        match rest_args with
-                                                        | [] ->
-                                                            let uu____5005 =
-                                                              is_fstar_value
-                                                                body1 in
-                                                            Prims.op_Negation
-                                                              uu____5005
-                                                        | uu____5006 -> false in
-                                                      let rest_args1 =
-                                                        if add_unit
-                                                        then unit_binder ::
-                                                          rest_args
-                                                        else rest_args in
-                                                      let body2 =
-                                                        match rest_args1 with
-                                                        | [] -> body1
-                                                        | uu____5015 ->
-                                                            FStar_Syntax_Util.abs
-                                                              rest_args1
-                                                              body1 None in
-                                                      (lbname_, f_e,
-                                                        (t2,
-                                                          (targs, polytype)),
-                                                        add_unit, body2))
-                                               else
-                                                 failwith
-                                                   "Not enough type binders")
-                                      | FStar_Syntax_Syntax.Tm_uinst _
-                                        |FStar_Syntax_Syntax.Tm_fvar _
-                                         |FStar_Syntax_Syntax.Tm_name _ ->
-                                          let env =
-                                            FStar_List.fold_left
-                                              (fun env  ->
-                                                 fun uu____5071  ->
-                                                   match uu____5071 with
-                                                   | (a,uu____5075) ->
-                                                       FStar_Extraction_ML_UEnv.extend_ty
-                                                         env a None) g
-                                              tbinders in
-                                          let expected_t =
-                                            term_as_mlty env tbody in
-                                          let polytype =
-                                            let uu____5083 =
-                                              FStar_All.pipe_right tbinders
-                                                (FStar_List.map
-                                                   (fun uu____5094  ->
-                                                      match uu____5094 with
-                                                      | (x,uu____5100) ->
-                                                          FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                            x)) in
-                                            (uu____5083, expected_t) in
-                                          let args =
-                                            FStar_All.pipe_right tbinders
-                                              (FStar_List.map
-                                                 (fun uu____5109  ->
-                                                    match uu____5109 with
-                                                    | (bv,uu____5113) ->
-                                                        let uu____5114 =
-                                                          FStar_Syntax_Syntax.bv_to_name
-                                                            bv in
-                                                        FStar_All.pipe_right
-                                                          uu____5114
-                                                          FStar_Syntax_Syntax.as_arg)) in
-                                          let e2 =
-                                            (FStar_Syntax_Syntax.mk
-                                               (FStar_Syntax_Syntax.Tm_app
-                                                  (e1, args))) None
-                                              e1.FStar_Syntax_Syntax.pos in
-                                          (lbname_, f_e,
-                                            (t2, (tbinders, polytype)),
-                                            false, e2)
-                                      | uu____5152 ->
-                                          err_value_restriction e1)))
-                       | uu____5162 ->
-                           let expected_t = term_as_mlty g t2 in
-                           (lbname_, f_e, (t2, ([], ([], expected_t))),
-                             false, e)) in
-                let check_lb env uu____5219 =
-                  match uu____5219 with
-                  | (nm,(lbname,f,(t1,(targs,polytype)),add_unit,e)) ->
-                      let env1 =
-                        FStar_List.fold_left
-                          (fun env1  ->
-                             fun uu____5290  ->
-                               match uu____5290 with
-                               | (a,uu____5294) ->
-                                   FStar_Extraction_ML_UEnv.extend_ty env1 a
-                                     None) env targs in
-                      let expected_t =
-                        if add_unit
-                        then
-                          FStar_Extraction_ML_Syntax.MLTY_Fun
-                            (FStar_Extraction_ML_Syntax.ml_unit_ty,
-                              FStar_Extraction_ML_Syntax.E_PURE,
-                              (Prims.snd polytype))
-                        else Prims.snd polytype in
-                      let uu____5297 =
-                        check_term_as_mlexpr env1 e f expected_t in
-                      (match uu____5297 with
-                       | (e1,uu____5303) ->
-                           let f1 = maybe_downgrade_eff env1 f expected_t in
-                           (f1,
-                             {
-                               FStar_Extraction_ML_Syntax.mllb_name = nm;
-                               FStar_Extraction_ML_Syntax.mllb_tysc =
-                                 (Some polytype);
-                               FStar_Extraction_ML_Syntax.mllb_add_unit =
-                                 add_unit;
-                               FStar_Extraction_ML_Syntax.mllb_def = e1;
-                               FStar_Extraction_ML_Syntax.print_typ = true
-                             })) in
-                let lbs3 =
-                  FStar_All.pipe_right lbs2 (FStar_List.map maybe_generalize) in
-                let uu____5338 =
-                  FStar_List.fold_right
-                    (fun lb  ->
-                       fun uu____5377  ->
-                         match uu____5377 with
-                         | (env,lbs4) ->
-                             let uu____5441 = lb in
-                             (match uu____5441 with
-                              | (lbname,uu____5466,(t1,(uu____5468,polytype)),add_unit,uu____5471)
-                                  ->
-                                  let uu____5478 =
-                                    FStar_Extraction_ML_UEnv.extend_lb env
-                                      lbname t1 polytype add_unit true in
-                                  (match uu____5478 with
-                                   | (env1,nm) -> (env1, ((nm, lb) :: lbs4)))))
-                    lbs3 (g, []) in
-                (match uu____5338 with
-                 | (env_body,lbs4) ->
-                     let env_def = if is_rec then env_body else g in
-                     let lbs5 =
-                       FStar_All.pipe_right lbs4
-                         (FStar_List.map (check_lb env_def)) in
-                     let e'_rng = e'1.FStar_Syntax_Syntax.pos in
-                     let uu____5621 = term_as_mlexpr env_body e'1 in
-                     (match uu____5621 with
-                      | (e'2,f',t') ->
-                          let f =
-                            let uu____5632 =
-                              let uu____5634 = FStar_List.map Prims.fst lbs5 in
-                              f' :: uu____5634 in
-                            FStar_Extraction_ML_Util.join_l e'_rng uu____5632 in
-                          let is_rec1 =
-                            if is_rec = true
-                            then FStar_Extraction_ML_Syntax.Rec
-                            else FStar_Extraction_ML_Syntax.NonRec in
-                          let uu____5640 =
-                            let uu____5641 =
-                              let uu____5642 =
-                                let uu____5643 =
-                                  FStar_List.map Prims.snd lbs5 in
-                                (is_rec1, [], uu____5643) in
-                              mk_MLE_Let top_level uu____5642 e'2 in
-                            let uu____5649 =
-                              FStar_Extraction_ML_Util.mlloc_of_range
-                                t.FStar_Syntax_Syntax.pos in
-                            FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____5641 uu____5649 in
-                          (uu____5640, f, t'))))
-       | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____5678 = term_as_mlexpr g scrutinee in
-           (match uu____5678 with
-            | (e,f_e,t_e) ->
-                let uu____5688 = check_pats_for_ite pats in
-                (match uu____5688 with
-                 | (b,then_e,else_e) ->
-                     let no_lift x t1 = x in
-                     if b
-                     then
-                       (match (then_e, else_e) with
-                        | (Some then_e1,Some else_e1) ->
-                            let uu____5723 = term_as_mlexpr g then_e1 in
-                            (match uu____5723 with
-                             | (then_mle,f_then,t_then) ->
-                                 let uu____5733 = term_as_mlexpr g else_e1 in
-                                 (match uu____5733 with
-                                  | (else_mle,f_else,t_else) ->
-                                      let uu____5743 =
-                                        let uu____5750 =
-                                          type_leq g t_then t_else in
-                                        if uu____5750
-                                        then (t_else, no_lift)
-                                        else
-                                          (let uu____5762 =
-                                             type_leq g t_else t_then in
-                                           if uu____5762
-                                           then (t_then, no_lift)
-                                           else
-                                             (FStar_Extraction_ML_Syntax.MLTY_Top,
-                                               FStar_Extraction_ML_Syntax.apply_obj_repr)) in
-                                      (match uu____5743 with
-                                       | (t_branch,maybe_lift) ->
-                                           let uu____5791 =
-                                             let uu____5792 =
-                                               let uu____5793 =
-                                                 let uu____5798 =
-                                                   maybe_lift then_mle t_then in
-                                                 let uu____5799 =
-                                                   let uu____5801 =
-                                                     maybe_lift else_mle
-                                                       t_else in
-                                                   Some uu____5801 in
-                                                 (e, uu____5798, uu____5799) in
-                                               FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____5793 in
-                                             FStar_All.pipe_left
-                                               (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____5792 in
-                                           let uu____5803 =
-                                             FStar_Extraction_ML_Util.join
-                                               then_e1.FStar_Syntax_Syntax.pos
-                                               f_then f_else in
-                                           (uu____5791, uu____5803, t_branch))))
-                        | uu____5804 ->
-                            failwith
-                              "ITE pats matched but then and else expressions not found?")
-                     else
-                       (let uu____5813 =
-                          FStar_All.pipe_right pats
-                            (FStar_Util.fold_map
-                               (fun compat  ->
-                                  fun br  ->
-                                    let uu____5863 =
-                                      FStar_Syntax_Subst.open_branch br in
-                                    match uu____5863 with
-                                    | (pat,when_opt,branch1) ->
-                                        let uu____5893 =
-                                          extract_pat g pat t_e in
-                                        (match uu____5893 with
-                                         | (env,p,pat_t_compat) ->
-                                             let uu____5924 =
-                                               match when_opt with
-                                               | None  ->
-                                                   (None,
-                                                     FStar_Extraction_ML_Syntax.E_PURE)
-                                               | Some w ->
-                                                   let uu____5939 =
-                                                     term_as_mlexpr env w in
-                                                   (match uu____5939 with
-                                                    | (w1,f_w,t_w) ->
-                                                        let w2 =
-                                                          maybe_coerce env w1
-                                                            t_w
-                                                            FStar_Extraction_ML_Syntax.ml_bool_ty in
-                                                        ((Some w2), f_w)) in
-                                             (match uu____5924 with
-                                              | (when_opt1,f_when) ->
-                                                  let uu____5967 =
-                                                    term_as_mlexpr env
-                                                      branch1 in
-                                                  (match uu____5967 with
-                                                   | (mlbranch,f_branch,t_branch)
-                                                       ->
-                                                       let uu____5986 =
-                                                         FStar_All.pipe_right
-                                                           p
-                                                           (FStar_List.map
-                                                              (fun uu____6023
-                                                                  ->
-                                                                 match uu____6023
-                                                                 with
-                                                                 | (p1,wopt)
-                                                                    ->
-                                                                    let when_clause
-                                                                    =
-                                                                    FStar_Extraction_ML_Util.conjoin_opt
-                                                                    wopt
-                                                                    when_opt1 in
-                                                                    (p1,
-                                                                    (when_clause,
-                                                                    f_when),
-                                                                    (mlbranch,
-                                                                    f_branch,
-                                                                    t_branch)))) in
-                                                       ((compat &&
-                                                           pat_t_compat),
-                                                         uu____5986))))) true) in
-                        match uu____5813 with
-                        | (pat_t_compat,mlbranches) ->
-                            let mlbranches1 = FStar_List.flatten mlbranches in
-                            let e1 =
-                              if pat_t_compat
-                              then e
-                              else
-                                (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____6109  ->
-                                      let uu____6110 =
-                                        FStar_Extraction_ML_Code.string_of_mlexpr
-                                          g.FStar_Extraction_ML_UEnv.currentModule
-                                          e in
-                                      let uu____6111 =
-                                        FStar_Extraction_ML_Code.string_of_mlty
-                                          g.FStar_Extraction_ML_UEnv.currentModule
-                                          t_e in
-                                      FStar_Util.print2
-                                        "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____6110 uu____6111);
-                                 FStar_All.pipe_left
-                                   (FStar_Extraction_ML_Syntax.with_ty t_e)
-                                   (FStar_Extraction_ML_Syntax.MLE_Coerce
-                                      (e, t_e,
-                                        FStar_Extraction_ML_Syntax.MLTY_Top))) in
-                            (match mlbranches1 with
-                             | [] ->
-                                 let uu____6124 =
-                                   let uu____6129 =
-                                     let uu____6138 =
-                                       FStar_Syntax_Syntax.lid_as_fv
-                                         FStar_Syntax_Const.failwith_lid
-                                         FStar_Syntax_Syntax.Delta_constant
-                                         None in
-                                     FStar_Extraction_ML_UEnv.lookup_fv g
-                                       uu____6138 in
-                                   FStar_All.pipe_left FStar_Util.right
-                                     uu____6129 in
-                                 (match uu____6124 with
-                                  | (uu____6160,fw,uu____6162,uu____6163) ->
-                                      let uu____6164 =
-                                        let uu____6165 =
-                                          let uu____6166 =
-                                            let uu____6170 =
-                                              let uu____6172 =
-                                                FStar_All.pipe_left
-                                                  (FStar_Extraction_ML_Syntax.with_ty
-                                                     FStar_Extraction_ML_Syntax.ml_string_ty)
-                                                  (FStar_Extraction_ML_Syntax.MLE_Const
-                                                     (FStar_Extraction_ML_Syntax.MLC_String
-                                                        "unreachable")) in
-                                              [uu____6172] in
-                                            (fw, uu____6170) in
-                                          FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____6166 in
-                                        FStar_All.pipe_left
-                                          (FStar_Extraction_ML_Syntax.with_ty
-                                             FStar_Extraction_ML_Syntax.ml_unit_ty)
-                                          uu____6165 in
-                                      (uu____6164,
-                                        FStar_Extraction_ML_Syntax.E_PURE,
-                                        FStar_Extraction_ML_Syntax.ml_unit_ty))
-                             | (uu____6174,uu____6175,(uu____6176,f_first,t_first))::rest
-                                 ->
-                                 let uu____6208 =
-                                   FStar_List.fold_left
-                                     (fun uu____6224  ->
-                                        fun uu____6225  ->
-                                          match (uu____6224, uu____6225) with
-                                          | ((topt,f),(uu____6255,uu____6256,
-                                                       (uu____6257,f_branch,t_branch)))
-                                              ->
-                                              let f1 =
-                                                FStar_Extraction_ML_Util.join
-                                                  top.FStar_Syntax_Syntax.pos
-                                                  f f_branch in
-                                              let topt1 =
-                                                match topt with
-                                                | None  -> None
-                                                | Some t1 ->
-                                                    let uu____6288 =
-                                                      type_leq g t1 t_branch in
-                                                    if uu____6288
-                                                    then Some t_branch
-                                                    else
-                                                      (let uu____6291 =
-                                                         type_leq g t_branch
-                                                           t1 in
-                                                       if uu____6291
-                                                       then Some t1
-                                                       else None) in
-                                              (topt1, f1))
-                                     ((Some t_first), f_first) rest in
-                                 (match uu____6208 with
-                                  | (topt,f_match) ->
-                                      let mlbranches2 =
-                                        FStar_All.pipe_right mlbranches1
-                                          (FStar_List.map
-                                             (fun uu____6337  ->
-                                                match uu____6337 with
-                                                | (p,(wopt,uu____6353),
-                                                   (b1,uu____6355,t1)) ->
-                                                    let b2 =
-                                                      match topt with
-                                                      | None  ->
-                                                          FStar_Extraction_ML_Syntax.apply_obj_repr
-                                                            b1 t1
-                                                      | Some uu____6366 -> b1 in
-                                                    (p, wopt, b2))) in
-                                      let t_match =
-                                        match topt with
-                                        | None  ->
-                                            FStar_Extraction_ML_Syntax.MLTY_Top
-                                        | Some t1 -> t1 in
-                                      let uu____6370 =
-                                        FStar_All.pipe_left
-                                          (FStar_Extraction_ML_Syntax.with_ty
-                                             t_match)
-                                          (FStar_Extraction_ML_Syntax.MLE_Match
-                                             (e1, mlbranches2)) in
-                                      (uu____6370, f_match, t_match)))))))
-let fresh: Prims.string -> (Prims.string* Prims.int) =
-  let c = FStar_Util.mk_ref (Prims.parse_int "0") in
-  fun x  ->
-    FStar_Util.incr c; (let uu____6388 = FStar_ST.read c in (x, uu____6388))
-let ind_discriminator_body:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Ident.lident ->
-      FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlmodule1
-  =
-  fun env  ->
-    fun discName  ->
-      fun constrName  ->
-        let uu____6400 =
-          let uu____6403 =
-            FStar_TypeChecker_Env.lookup_lid
-              env.FStar_Extraction_ML_UEnv.tcenv discName in
-          FStar_All.pipe_left Prims.fst uu____6403 in
-        match uu____6400 with
-        | (uu____6416,fstar_disc_type) ->
-            let wildcards =
-              let uu____6424 =
-                let uu____6425 = FStar_Syntax_Subst.compress fstar_disc_type in
-                uu____6425.FStar_Syntax_Syntax.n in
-              match uu____6424 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____6434) ->
-                  let uu____6445 =
-                    FStar_All.pipe_right binders
-                      (FStar_List.filter
-                         (fun uu___142_6460  ->
-                            match uu___142_6460 with
-                            | (uu____6464,Some (FStar_Syntax_Syntax.Implicit
-                               uu____6465)) -> true
-                            | uu____6467 -> false)) in
-                  FStar_All.pipe_right uu____6445
-                    (FStar_List.map
-                       (fun uu____6487  ->
-                          let uu____6491 = fresh "_" in
-                          (uu____6491, FStar_Extraction_ML_Syntax.MLTY_Top)))
-              | uu____6496 -> failwith "Discriminator must be a function" in
-            let mlid = fresh "_discr_" in
-            let targ = FStar_Extraction_ML_Syntax.MLTY_Top in
-            let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top in
-            let discrBody =
-              let uu____6508 =
-                let uu____6509 =
-                  let uu____6515 =
-                    let uu____6516 =
-                      let uu____6517 =
-                        let uu____6525 =
-                          let uu____6526 =
-                            let uu____6527 =
-                              let uu____6528 =
-                                FStar_Extraction_ML_Syntax.idsym mlid in
-                              ([], uu____6528) in
-                            FStar_Extraction_ML_Syntax.MLE_Name uu____6527 in
-                          FStar_All.pipe_left
-                            (FStar_Extraction_ML_Syntax.with_ty targ)
-                            uu____6526 in
-                        let uu____6530 =
-                          let uu____6536 =
-                            let uu____6541 =
-                              let uu____6542 =
-                                let uu____6546 =
-                                  FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                    constrName in
-                                (uu____6546,
-                                  [FStar_Extraction_ML_Syntax.MLP_Wild]) in
-                              FStar_Extraction_ML_Syntax.MLP_CTor uu____6542 in
-                            let uu____6548 =
-                              FStar_All.pipe_left
-                                (FStar_Extraction_ML_Syntax.with_ty
-                                   FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                (FStar_Extraction_ML_Syntax.MLE_Const
-                                   (FStar_Extraction_ML_Syntax.MLC_Bool true)) in
-                            (uu____6541, None, uu____6548) in
-                          let uu____6550 =
-                            let uu____6556 =
-                              let uu____6561 =
-                                FStar_All.pipe_left
-                                  (FStar_Extraction_ML_Syntax.with_ty
-                                     FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                  (FStar_Extraction_ML_Syntax.MLE_Const
-                                     (FStar_Extraction_ML_Syntax.MLC_Bool
-                                        false)) in
-                              (FStar_Extraction_ML_Syntax.MLP_Wild, None,
-                                uu____6561) in
-                            [uu____6556] in
-                          uu____6536 :: uu____6550 in
-                        (uu____6525, uu____6530) in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____6517 in
-                    FStar_All.pipe_left
-                      (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____6516 in
-                  ((FStar_List.append wildcards [(mlid, targ)]), uu____6515) in
-                FStar_Extraction_ML_Syntax.MLE_Fun uu____6509 in
-              FStar_All.pipe_left
-                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____6508 in
-            let uu____6599 =
-              let uu____6600 =
-                let uu____6602 =
-                  let uu____6603 =
-                    FStar_Extraction_ML_UEnv.convIdent
-                      discName.FStar_Ident.ident in
-                  {
-                    FStar_Extraction_ML_Syntax.mllb_name = uu____6603;
-                    FStar_Extraction_ML_Syntax.mllb_tysc = None;
-                    FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                    FStar_Extraction_ML_Syntax.mllb_def = discrBody;
-                    FStar_Extraction_ML_Syntax.print_typ = false
-                  } in
-                [uu____6602] in
-              (FStar_Extraction_ML_Syntax.NonRec, [], uu____6600) in
-            FStar_Extraction_ML_Syntax.MLM_Let uu____6599
+
+
+let uu___is_Un_extractable : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Un_extractable -> begin
+true
+end
+| uu____4 -> begin
+false
+end))
+
+
+let type_leq : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun g t1 t2 -> (FStar_Extraction_ML_Util.type_leq (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2))
+
+
+let type_leq_c : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlexpr Prims.option  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty  ->  (Prims.bool * FStar_Extraction_ML_Syntax.mlexpr Prims.option) = (fun g t1 t2 -> (FStar_Extraction_ML_Util.type_leq_c (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2))
+
+
+let erasableType : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun g t -> (FStar_Extraction_ML_Util.erasableType (FStar_Extraction_ML_Util.udelta_unfold g) t))
+
+
+let eraseTypeDeep : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty = (fun g t -> (FStar_Extraction_ML_Util.eraseTypeDeep (FStar_Extraction_ML_Util.udelta_unfold g) t))
+
+
+let record_fields = (fun fs vs -> (FStar_List.map2 (fun f e -> ((f.FStar_Ident.idText), (e))) fs vs))
+
+
+let fail = (fun r msg -> ((
+
+let uu____78 = (
+
+let uu____79 = (FStar_Range.string_of_range r)
+in (FStar_Util.format2 "%s: %s\n" uu____79 msg))
+in (FStar_All.pipe_left FStar_Util.print_string uu____78));
+(failwith msg);
+))
+
+
+let err_uninst = (fun env t uu____107 app -> (match (uu____107) with
+| (vars, ty) -> begin
+(
+
+let uu____122 = (
+
+let uu____123 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____124 = (
+
+let uu____125 = (FStar_All.pipe_right vars (FStar_List.map Prims.fst))
+in (FStar_All.pipe_right uu____125 (FStar_String.concat ", ")))
+in (
+
+let uu____134 = (FStar_Extraction_ML_Code.string_of_mlty env.FStar_Extraction_ML_UEnv.currentModule ty)
+in (
+
+let uu____135 = (FStar_Syntax_Print.term_to_string app)
+in (FStar_Util.format4 "Variable %s has a polymorphic type (forall %s. %s); expected it to be fully instantiated, but got %s" uu____123 uu____124 uu____134 uu____135)))))
+in (fail t.FStar_Syntax_Syntax.pos uu____122))
+end))
+
+
+let err_ill_typed_application = (fun env t args ty -> (
+
+let uu____166 = (
+
+let uu____167 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____168 = (
+
+let uu____169 = (FStar_All.pipe_right args (FStar_List.map (fun uu____177 -> (match (uu____177) with
+| (x, uu____181) -> begin
+(FStar_Syntax_Print.term_to_string x)
+end))))
+in (FStar_All.pipe_right uu____169 (FStar_String.concat " ")))
+in (
+
+let uu____183 = (FStar_Extraction_ML_Code.string_of_mlty env.FStar_Extraction_ML_UEnv.currentModule ty)
+in (FStar_Util.format3 "Ill-typed application: application is %s \n remaining args are %s\nml type of head is %s\n" uu____167 uu____168 uu____183))))
+in (fail t.FStar_Syntax_Syntax.pos uu____166)))
+
+
+let err_value_restriction = (fun t -> (
+
+let uu____195 = (
+
+let uu____196 = (FStar_Syntax_Print.tag_of_term t)
+in (
+
+let uu____197 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format2 "Refusing to generalize because of the value restriction: (%s) %s" uu____196 uu____197)))
+in (fail t.FStar_Syntax_Syntax.pos uu____195)))
+
+
+let err_unexpected_eff = (fun t f0 f1 -> (
+
+let uu____219 = (
+
+let uu____220 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format3 "for expression %s, Expected effect %s; got effect %s" uu____220 (FStar_Extraction_ML_Util.eff_to_string f0) (FStar_Extraction_ML_Util.eff_to_string f1)))
+in (fail t.FStar_Syntax_Syntax.pos uu____219)))
+
+
+let effect_as_etag : FStar_Extraction_ML_UEnv.env  ->  FStar_Ident.lident  ->  FStar_Extraction_ML_Syntax.e_tag = (
+
+let cache = (FStar_Util.smap_create (Prims.parse_int "20"))
+in (
+
+let rec delta_norm_eff = (fun g l -> (
+
+let uu____234 = (FStar_Util.smap_try_find cache l.FStar_Ident.str)
+in (match (uu____234) with
+| Some (l1) -> begin
+l1
+end
+| None -> begin
+(
+
+let res = (
+
+let uu____238 = (FStar_TypeChecker_Env.lookup_effect_abbrev g.FStar_Extraction_ML_UEnv.tcenv ((FStar_Syntax_Syntax.U_zero)::[]) l)
+in (match (uu____238) with
+| None -> begin
+l
+end
+| Some (uu____244, c) -> begin
+(delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c))
+end))
+in ((FStar_Util.smap_add cache l.FStar_Ident.str res);
+res;
+))
+end)))
+in (fun g l -> (
+
+let l1 = (delta_norm_eff g l)
+in (match ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid)) with
+| true -> begin
+FStar_Extraction_ML_Syntax.E_PURE
+end
+| uu____252 -> begin
+(match ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GHOST_lid)) with
+| true -> begin
+FStar_Extraction_ML_Syntax.E_GHOST
+end
+| uu____253 -> begin
+FStar_Extraction_ML_Syntax.E_IMPURE
+end)
+end)))))
+
+
+let rec is_arity : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let t1 = (FStar_Syntax_Util.unmeta t)
+in (
+
+let uu____261 = (
+
+let uu____262 = (FStar_Syntax_Subst.compress t1)
+in uu____262.FStar_Syntax_Syntax.n)
+in (match (uu____261) with
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_ascribed (_)) | (FStar_Syntax_Syntax.Tm_meta (_)) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) -> begin
+false
+end
+| FStar_Syntax_Syntax.Tm_type (uu____272) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____273, c) -> begin
+(is_arity env (FStar_Syntax_Util.comp_result c))
+end
+| FStar_Syntax_Syntax.Tm_fvar (uu____285) -> begin
+(
+
+let t2 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.AllowUnboundUniverses)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env.FStar_Extraction_ML_UEnv.tcenv t1)
+in (
+
+let uu____287 = (
+
+let uu____288 = (FStar_Syntax_Subst.compress t2)
+in uu____288.FStar_Syntax_Syntax.n)
+in (match (uu____287) with
+| FStar_Syntax_Syntax.Tm_fvar (uu____291) -> begin
+false
+end
+| uu____292 -> begin
+(is_arity env t2)
+end)))
+end
+| FStar_Syntax_Syntax.Tm_app (uu____293) -> begin
+(
+
+let uu____303 = (FStar_Syntax_Util.head_and_args t1)
+in (match (uu____303) with
+| (head1, uu____314) -> begin
+(is_arity env head1)
+end))
+end
+| FStar_Syntax_Syntax.Tm_uinst (head1, uu____330) -> begin
+(is_arity env head1)
+end
+| FStar_Syntax_Syntax.Tm_refine (x, uu____336) -> begin
+(is_arity env x.FStar_Syntax_Syntax.sort)
+end
+| (FStar_Syntax_Syntax.Tm_abs (_, body, _)) | (FStar_Syntax_Syntax.Tm_let (_, body)) -> begin
+(is_arity env body)
+end
+| FStar_Syntax_Syntax.Tm_match (uu____365, branches) -> begin
+(match (branches) with
+| ((uu____393, uu____394, e))::uu____396 -> begin
+(is_arity env e)
+end
+| uu____432 -> begin
+false
+end)
+end))))
+
+
+let rec is_type_aux : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+(
+
+let uu____452 = (
+
+let uu____453 = (FStar_Syntax_Print.tag_of_term t1)
+in (FStar_Util.format1 "Impossible: %s" uu____453))
+in (failwith uu____452))
+end
+| FStar_Syntax_Syntax.Tm_constant (uu____454) -> begin
+false
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_refine (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.failwith_lid) -> begin
+false
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____460 = (FStar_TypeChecker_Env.is_type_constructor env.FStar_Extraction_ML_UEnv.tcenv fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____460) with
+| true -> begin
+true
+end
+| uu____465 -> begin
+(
+
+let uu____466 = (FStar_TypeChecker_Env.lookup_lid env.FStar_Extraction_ML_UEnv.tcenv fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____466) with
+| ((uu____475, t2), uu____477) -> begin
+(is_arity env t2)
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_uvar (_, t2)) | (FStar_Syntax_Syntax.Tm_bvar ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t2})) | (FStar_Syntax_Syntax.Tm_name ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t2})) -> begin
+(is_arity env t2)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t2, uu____499, uu____500) -> begin
+(is_type_aux env t2)
+end
+| FStar_Syntax_Syntax.Tm_uinst (t2, uu____530) -> begin
+(is_type_aux env t2)
+end
+| FStar_Syntax_Syntax.Tm_abs (uu____535, body, uu____537) -> begin
+(is_type_aux env body)
+end
+| FStar_Syntax_Syntax.Tm_let (uu____560, body) -> begin
+(is_type_aux env body)
+end
+| FStar_Syntax_Syntax.Tm_match (uu____572, branches) -> begin
+(match (branches) with
+| ((uu____600, uu____601, e))::uu____603 -> begin
+(is_type_aux env e)
+end
+| uu____639 -> begin
+(failwith "Empty branches")
+end)
+end
+| FStar_Syntax_Syntax.Tm_meta (t2, uu____652) -> begin
+(is_type_aux env t2)
+end
+| FStar_Syntax_Syntax.Tm_app (head1, uu____658) -> begin
+(is_type_aux env head1)
+end)))
+
+
+let is_type : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let b = (is_type_aux env t)
+in ((FStar_Extraction_ML_UEnv.debug env (fun uu____681 -> (match (b) with
+| true -> begin
+(
+
+let uu____682 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____683 = (FStar_Syntax_Print.tag_of_term t)
+in (FStar_Util.print2 "is_type %s (%s)\n" uu____682 uu____683)))
+end
+| uu____684 -> begin
+(
+
+let uu____685 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____686 = (FStar_Syntax_Print.tag_of_term t)
+in (FStar_Util.print2 "not a type %s (%s)\n" uu____685 uu____686)))
+end)));
+b;
+)))
+
+
+let is_type_binder = (fun env x -> (is_arity env (Prims.fst x).FStar_Syntax_Syntax.sort))
+
+
+let is_constructor : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____706 = (
+
+let uu____707 = (FStar_Syntax_Subst.compress t)
+in uu____707.FStar_Syntax_Syntax.n)
+in (match (uu____706) with
+| (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Data_ctor)})) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Record_ctor (_))})) -> begin
+true
+end
+| uu____715 -> begin
+false
+end)))
+
+
+let rec is_fstar_value : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____719 = (
+
+let uu____720 = (FStar_Syntax_Subst.compress t)
+in uu____720.FStar_Syntax_Syntax.n)
+in (match (uu____719) with
+| (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let uu____743 = (is_constructor head1)
+in (match (uu____743) with
+| true -> begin
+(FStar_All.pipe_right args (FStar_List.for_all (fun uu____751 -> (match (uu____751) with
+| (te, uu____755) -> begin
+(is_fstar_value te)
+end))))
+end
+| uu____756 -> begin
+false
+end))
+end
+| (FStar_Syntax_Syntax.Tm_meta (t1, _)) | (FStar_Syntax_Syntax.Tm_ascribed (t1, _, _)) -> begin
+(is_fstar_value t1)
+end
+| uu____781 -> begin
+false
+end)))
+
+
+let rec is_ml_value : FStar_Extraction_ML_Syntax.mlexpr  ->  Prims.bool = (fun e -> (match (e.FStar_Extraction_ML_Syntax.expr) with
+| (FStar_Extraction_ML_Syntax.MLE_Const (_)) | (FStar_Extraction_ML_Syntax.MLE_Var (_)) | (FStar_Extraction_ML_Syntax.MLE_Name (_)) | (FStar_Extraction_ML_Syntax.MLE_Fun (_)) -> begin
+true
+end
+| (FStar_Extraction_ML_Syntax.MLE_CTor (_, exps)) | (FStar_Extraction_ML_Syntax.MLE_Tuple (exps)) -> begin
+(FStar_Util.for_all is_ml_value exps)
+end
+| FStar_Extraction_ML_Syntax.MLE_Record (uu____794, fields) -> begin
+(FStar_Util.for_all (fun uu____806 -> (match (uu____806) with
+| (uu____809, e1) -> begin
+(is_ml_value e1)
+end)) fields)
+end
+| uu____811 -> begin
+false
+end))
+
+
+let normalize_abs : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t0 -> (
+
+let rec aux = (fun bs t copt -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_abs (bs', body, copt1) -> begin
+(aux (FStar_List.append bs bs') body copt1)
+end
+| uu____871 -> begin
+(
+
+let e' = (FStar_Syntax_Util.unascribe t1)
+in (
+
+let uu____873 = (FStar_Syntax_Util.is_fun e')
+in (match (uu____873) with
+| true -> begin
+(aux bs e' copt)
+end
+| uu____874 -> begin
+(FStar_Syntax_Util.abs bs e' copt)
+end)))
+end)))
+in (aux [] t0 None)))
+
+
+let unit_binder : FStar_Syntax_Syntax.binder = (
+
+let uu____882 = (FStar_Syntax_Syntax.new_bv None FStar_TypeChecker_Common.t_unit)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____882))
+
+
+let check_pats_for_ite : (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term Prims.option * FStar_Syntax_Syntax.term) Prims.list  ->  (Prims.bool * FStar_Syntax_Syntax.term Prims.option * FStar_Syntax_Syntax.term Prims.option) = (fun l -> (
+
+let def = ((false), (None), (None))
+in (match (((FStar_List.length l) <> (Prims.parse_int "2"))) with
+| true -> begin
+def
+end
+| uu____925 -> begin
+(
+
+let uu____926 = (FStar_List.hd l)
+in (match (uu____926) with
+| (p1, w1, e1) -> begin
+(
+
+let uu____945 = (
+
+let uu____950 = (FStar_List.tl l)
+in (FStar_List.hd uu____950))
+in (match (uu____945) with
+| (p2, w2, e2) -> begin
+(match (((w1), (w2), (p1.FStar_Syntax_Syntax.v), (p2.FStar_Syntax_Syntax.v))) with
+| (None, None, FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true)), FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (false))) -> begin
+((true), (Some (e1)), (Some (e2)))
+end
+| (None, None, FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (false)), FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true))) -> begin
+((true), (Some (e2)), (Some (e1)))
+end
+| uu____989 -> begin
+def
+end)
+end))
+end))
+end)))
+
+
+let instantiate : FStar_Extraction_ML_Syntax.mltyscheme  ->  FStar_Extraction_ML_Syntax.mlty Prims.list  ->  FStar_Extraction_ML_Syntax.mlty = (fun s args -> (FStar_Extraction_ML_Util.subst s args))
+
+
+let erasable : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun g f t -> ((f = FStar_Extraction_ML_Syntax.E_GHOST) || ((f = FStar_Extraction_ML_Syntax.E_PURE) && (erasableType g t))))
+
+
+let erase : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.e_tag  ->  (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.e_tag * FStar_Extraction_ML_Syntax.mlty) = (fun g e ty f -> (
+
+let e1 = (
+
+let uu____1032 = (erasable g f ty)
+in (match (uu____1032) with
+| true -> begin
+(
+
+let uu____1033 = (type_leq g ty FStar_Extraction_ML_Syntax.ml_unit_ty)
+in (match (uu____1033) with
+| true -> begin
+FStar_Extraction_ML_Syntax.ml_unit
+end
+| uu____1034 -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty) (FStar_Extraction_ML_Syntax.MLE_Coerce (((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.ml_unit_ty), (ty)))))
+end))
+end
+| uu____1035 -> begin
+e
+end))
+in ((e1), (f), (ty))))
+
+
+let maybe_coerce : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlexpr = (fun g e ty expect -> (
+
+let ty1 = (eraseTypeDeep g ty)
+in (
+
+let uu____1049 = ((type_leq_c g (Some (e)) ty1) expect)
+in (match (uu____1049) with
+| (true, Some (e')) -> begin
+e'
+end
+| uu____1055 -> begin
+((FStar_Extraction_ML_UEnv.debug g (fun uu____1060 -> (
+
+let uu____1061 = (FStar_Extraction_ML_Code.string_of_mlexpr g.FStar_Extraction_ML_UEnv.currentModule e)
+in (
+
+let uu____1062 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule ty1)
+in (
+
+let uu____1063 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule expect)
+in (FStar_Util.print3 "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n" uu____1061 uu____1062 uu____1063))))));
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty expect) (FStar_Extraction_ML_Syntax.MLE_Coerce (((e), (ty1), (expect)))));
+)
+end))))
+
+
+let bv_as_mlty : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.bv  ->  FStar_Extraction_ML_Syntax.mlty = (fun g bv -> (
+
+let uu____1070 = (FStar_Extraction_ML_UEnv.lookup_bv g bv)
+in (match (uu____1070) with
+| FStar_Util.Inl (uu____1071, t) -> begin
+t
+end
+| uu____1079 -> begin
+FStar_Extraction_ML_Syntax.MLTY_Top
+end)))
+
+
+let rec term_as_mlty : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Extraction_ML_Syntax.mlty = (fun g t0 -> (
+
+let t = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) g.FStar_Extraction_ML_UEnv.tcenv t0)
+in (
+
+let mlt = (term_as_mlty' g t)
+in (
+
+let uu____1113 = ((fun t1 -> (match (t1) with
+| FStar_Extraction_ML_Syntax.MLTY_Top -> begin
+true
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (uu____1115) -> begin
+(
+
+let uu____1119 = (FStar_Extraction_ML_Util.udelta_unfold g t1)
+in (match (uu____1119) with
+| None -> begin
+false
+end
+| Some (t2) -> begin
+((
+
+let rec is_top_ty = (fun t3 -> (match (t3) with
+| FStar_Extraction_ML_Syntax.MLTY_Top -> begin
+true
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (uu____1126) -> begin
+(
+
+let uu____1130 = (FStar_Extraction_ML_Util.udelta_unfold g t3)
+in (match (uu____1130) with
+| None -> begin
+false
+end
+| Some (t4) -> begin
+(is_top_ty t4)
+end))
+end
+| uu____1133 -> begin
+false
+end))
+in is_top_ty) t2)
+end))
+end
+| uu____1134 -> begin
+false
+end)) mlt)
+in (match (uu____1113) with
+| true -> begin
+(
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) g.FStar_Extraction_ML_UEnv.tcenv t0)
+in (term_as_mlty' g t1))
+end
+| uu____1136 -> begin
+mlt
+end)))))
+and term_as_mlty' : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Extraction_ML_Syntax.mlty = (fun env t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+(
+
+let uu____1142 = (
+
+let uu____1143 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Impossible: Unexpected term %s" uu____1143))
+in (failwith uu____1142))
+end
+| FStar_Syntax_Syntax.Tm_constant (uu____1144) -> begin
+FStar_Extraction_ML_UEnv.unknownType
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____1145) -> begin
+FStar_Extraction_ML_UEnv.unknownType
+end
+| (FStar_Syntax_Syntax.Tm_meta (t2, _)) | (FStar_Syntax_Syntax.Tm_refine ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t2}, _)) | (FStar_Syntax_Syntax.Tm_uinst (t2, _)) | (FStar_Syntax_Syntax.Tm_ascribed (t2, _, _)) -> begin
+(term_as_mlty' env t2)
+end
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+(bv_as_mlty env bv)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(fv_app_as_mlty env fv [])
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____1208 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____1208) with
+| (bs1, c1) -> begin
+(
+
+let uu____1213 = (binders_as_ml_binders env bs1)
+in (match (uu____1213) with
+| (mlbs, env1) -> begin
+(
+
+let t_ret = (
+
+let eff = (FStar_TypeChecker_Env.norm_eff_name env1.FStar_Extraction_ML_UEnv.tcenv (FStar_Syntax_Util.comp_effect_name c1))
+in (
+
+let ed = (FStar_TypeChecker_Env.get_effect_decl env1.FStar_Extraction_ML_UEnv.tcenv eff)
+in (
+
+let uu____1230 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (match (uu____1230) with
+| true -> begin
+(
+
+let t2 = (FStar_TypeChecker_Env.reify_comp env1.FStar_Extraction_ML_UEnv.tcenv c1 FStar_Syntax_Syntax.U_unknown)
+in (
+
+let res = (term_as_mlty' env1 t2)
+in res))
+end
+| uu____1234 -> begin
+(term_as_mlty' env1 (FStar_Syntax_Util.comp_result c1))
+end))))
+in (
+
+let erase1 = (effect_as_etag env1 (FStar_Syntax_Util.comp_effect_name c1))
+in (
+
+let uu____1236 = (FStar_List.fold_right (fun uu____1243 uu____1244 -> (match (((uu____1243), (uu____1244))) with
+| ((uu____1255, t2), (tag, t')) -> begin
+((FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.MLTY_Fun (((t2), (tag), (t')))))
+end)) mlbs ((erase1), (t_ret)))
+in (match (uu____1236) with
+| (uu____1263, t2) -> begin
+t2
+end))))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let res = (
+
+let uu____1282 = (
+
+let uu____1283 = (FStar_Syntax_Util.un_uinst head1)
+in uu____1283.FStar_Syntax_Syntax.n)
+in (match (uu____1282) with
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+(bv_as_mlty env bv)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(fv_app_as_mlty env fv args)
+end
+| FStar_Syntax_Syntax.Tm_app (head2, args') -> begin
+(
+
+let uu____1304 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((head2), ((FStar_List.append args' args))))) None t1.FStar_Syntax_Syntax.pos)
+in (term_as_mlty' env uu____1304))
+end
+| uu____1320 -> begin
+FStar_Extraction_ML_UEnv.unknownType
+end))
+in res)
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, ty, uu____1323) -> begin
+(
+
+let uu____1346 = (FStar_Syntax_Subst.open_term bs ty)
+in (match (uu____1346) with
+| (bs1, ty1) -> begin
+(
+
+let uu____1351 = (binders_as_ml_binders env bs1)
+in (match (uu____1351) with
+| (bts, env1) -> begin
+(term_as_mlty' env1 ty1)
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_let (_)) | (FStar_Syntax_Syntax.Tm_match (_)) -> begin
+FStar_Extraction_ML_UEnv.unknownType
+end)))
+and arg_as_mlty : FStar_Extraction_ML_UEnv.env  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual)  ->  FStar_Extraction_ML_Syntax.mlty = (fun g uu____1369 -> (match (uu____1369) with
+| (a, uu____1373) -> begin
+(
+
+let uu____1374 = (is_type g a)
+in (match (uu____1374) with
+| true -> begin
+(term_as_mlty' g a)
+end
+| uu____1375 -> begin
+FStar_Extraction_ML_UEnv.erasedContent
+end))
+end))
+and fv_app_as_mlty : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.args  ->  FStar_Extraction_ML_Syntax.mlty = (fun g fv args -> (
+
+let uu____1379 = (FStar_Syntax_Util.arrow_formals fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.ty)
+in (match (uu____1379) with
+| (formals, t) -> begin
+(
+
+let mlargs = (FStar_List.map (arg_as_mlty g) args)
+in (
+
+let mlargs1 = (
+
+let n_args = (FStar_List.length args)
+in (match (((FStar_List.length formals) > n_args)) with
+| true -> begin
+(
+
+let uu____1423 = (FStar_Util.first_N n_args formals)
+in (match (uu____1423) with
+| (uu____1437, rest) -> begin
+(
+
+let uu____1451 = (FStar_List.map (fun uu____1455 -> FStar_Extraction_ML_UEnv.erasedContent) rest)
+in (FStar_List.append mlargs uu____1451))
+end))
+end
+| uu____1458 -> begin
+mlargs
+end))
+in (
+
+let nm = (
+
+let uu____1460 = (FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g fv)
+in (match (uu____1460) with
+| Some (p) -> begin
+p
+end
+| None -> begin
+(FStar_Extraction_ML_Syntax.mlpath_of_lident fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end))
+in FStar_Extraction_ML_Syntax.MLTY_Named (((mlargs1), (nm))))))
+end)))
+and binders_as_ml_binders : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.binders  ->  ((FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty) Prims.list * FStar_Extraction_ML_UEnv.env) = (fun g bs -> (
+
+let uu____1475 = (FStar_All.pipe_right bs (FStar_List.fold_left (fun uu____1499 b -> (match (uu____1499) with
+| (ml_bs, env) -> begin
+(
+
+let uu____1529 = (is_type_binder g b)
+in (match (uu____1529) with
+| true -> begin
+(
+
+let b1 = (Prims.fst b)
+in (
+
+let env1 = (FStar_Extraction_ML_UEnv.extend_ty env b1 (Some (FStar_Extraction_ML_Syntax.MLTY_Top)))
+in (
+
+let ml_b = (
+
+let uu____1544 = (FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1)
+in ((uu____1544), (FStar_Extraction_ML_Syntax.ml_unit_ty)))
+in (((ml_b)::ml_bs), (env1)))))
+end
+| uu____1558 -> begin
+(
+
+let b1 = (Prims.fst b)
+in (
+
+let t = (term_as_mlty env b1.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____1561 = (FStar_Extraction_ML_UEnv.extend_bv env b1 (([]), (t)) false false false)
+in (match (uu____1561) with
+| (env1, b2) -> begin
+(
+
+let ml_b = (
+
+let uu____1579 = (FStar_Extraction_ML_UEnv.removeTick b2)
+in ((uu____1579), (t)))
+in (((ml_b)::ml_bs), (env1)))
+end))))
+end))
+end)) (([]), (g))))
+in (match (uu____1475) with
+| (ml_bs, env) -> begin
+(((FStar_List.rev ml_bs)), (env))
+end)))
+
+
+let mk_MLE_Seq : FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr' = (fun e1 e2 -> (match (((e1.FStar_Extraction_ML_Syntax.expr), (e2.FStar_Extraction_ML_Syntax.expr))) with
+| (FStar_Extraction_ML_Syntax.MLE_Seq (es1), FStar_Extraction_ML_Syntax.MLE_Seq (es2)) -> begin
+FStar_Extraction_ML_Syntax.MLE_Seq ((FStar_List.append es1 es2))
+end
+| (FStar_Extraction_ML_Syntax.MLE_Seq (es1), uu____1639) -> begin
+FStar_Extraction_ML_Syntax.MLE_Seq ((FStar_List.append es1 ((e2)::[])))
+end
+| (uu____1641, FStar_Extraction_ML_Syntax.MLE_Seq (es2)) -> begin
+FStar_Extraction_ML_Syntax.MLE_Seq ((e1)::es2)
+end
+| uu____1644 -> begin
+FStar_Extraction_ML_Syntax.MLE_Seq ((e1)::(e2)::[])
+end))
+
+
+let mk_MLE_Let : Prims.bool  ->  FStar_Extraction_ML_Syntax.mlletbinding  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr' = (fun top_level lbs body -> (match (lbs) with
+| (FStar_Extraction_ML_Syntax.NonRec, quals, (lb)::[]) when (not (top_level)) -> begin
+(match (lb.FStar_Extraction_ML_Syntax.mllb_tysc) with
+| Some ([], t) when (t = FStar_Extraction_ML_Syntax.ml_unit_ty) -> begin
+(match ((body.FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr)) with
+| true -> begin
+lb.FStar_Extraction_ML_Syntax.mllb_def.FStar_Extraction_ML_Syntax.expr
+end
+| uu____1664 -> begin
+(match (body.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_Var (x) when (x = lb.FStar_Extraction_ML_Syntax.mllb_name) -> begin
+lb.FStar_Extraction_ML_Syntax.mllb_def.FStar_Extraction_ML_Syntax.expr
+end
+| uu____1666 when (lb.FStar_Extraction_ML_Syntax.mllb_def.FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr) -> begin
+body.FStar_Extraction_ML_Syntax.expr
+end
+| uu____1667 -> begin
+(mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def body)
+end)
+end)
+end
+| uu____1668 -> begin
+FStar_Extraction_ML_Syntax.MLE_Let (((lbs), (body)))
+end)
+end
+| uu____1670 -> begin
+FStar_Extraction_ML_Syntax.MLE_Let (((lbs), (body)))
+end))
+
+
+let resugar_pat : FStar_Syntax_Syntax.fv_qual Prims.option  ->  FStar_Extraction_ML_Syntax.mlpattern  ->  FStar_Extraction_ML_Syntax.mlpattern = (fun q p -> (match (p) with
+| FStar_Extraction_ML_Syntax.MLP_CTor (d, pats) -> begin
+(match ((FStar_Extraction_ML_Util.is_xtuple d)) with
+| Some (n1) -> begin
+FStar_Extraction_ML_Syntax.MLP_Tuple (pats)
+end
+| uu____1684 -> begin
+(match (q) with
+| Some (FStar_Syntax_Syntax.Record_ctor (ty, fns)) -> begin
+(
+
+let path = (FStar_List.map FStar_Ident.text_of_id ty.FStar_Ident.ns)
+in (
+
+let fs = (record_fields fns pats)
+in FStar_Extraction_ML_Syntax.MLP_Record (((path), (fs)))))
+end
+| uu____1700 -> begin
+p
+end)
+end)
+end
+| uu____1702 -> begin
+p
+end))
+
+
+let rec extract_one_pat : Prims.bool  ->  Prims.bool  ->  FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.pat  ->  FStar_Extraction_ML_Syntax.mlty Prims.option  ->  (FStar_Extraction_ML_UEnv.env * (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr Prims.list) Prims.option * Prims.bool) = (fun disjunctive_pat imp g p expected_topt -> (
+
+let ok = (fun t -> (match (expected_topt) with
+| None -> begin
+true
+end
+| Some (t') -> begin
+(
+
+let ok = (type_leq g t t')
+in ((match ((not (ok))) with
+| true -> begin
+(FStar_Extraction_ML_UEnv.debug g (fun uu____1741 -> (
+
+let uu____1742 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule t')
+in (
+
+let uu____1743 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule t)
+in (FStar_Util.print2 "Expected pattern type %s; got pattern type %s\n" uu____1742 uu____1743)))))
+end
+| uu____1744 -> begin
+()
+end);
+ok;
+))
+end))
+in (match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (uu____1752) -> begin
+(failwith "Impossible: Nested disjunctive pattern")
+end
+| FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int (c, None)) -> begin
+(
+
+let i = FStar_Const.Const_int (((c), (None)))
+in (
+
+let x = (FStar_Extraction_ML_Syntax.gensym ())
+in (
+
+let when_clause = (
+
+let uu____1777 = (
+
+let uu____1778 = (
+
+let uu____1782 = (
+
+let uu____1784 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_int_ty) (FStar_Extraction_ML_Syntax.MLE_Var (x)))
+in (
+
+let uu____1785 = (
+
+let uu____1787 = (
+
+let uu____1788 = (
+
+let uu____1789 = (FStar_Extraction_ML_Util.mlconst_of_const' p.FStar_Syntax_Syntax.p i)
+in (FStar_All.pipe_left (fun _0_30 -> FStar_Extraction_ML_Syntax.MLE_Const (_0_30)) uu____1789))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_int_ty) uu____1788))
+in (uu____1787)::[])
+in (uu____1784)::uu____1785))
+in ((FStar_Extraction_ML_Util.prims_op_equality), (uu____1782)))
+in FStar_Extraction_ML_Syntax.MLE_App (uu____1778))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_bool_ty) uu____1777))
+in (
+
+let uu____1791 = (ok FStar_Extraction_ML_Syntax.ml_int_ty)
+in ((g), (Some (((FStar_Extraction_ML_Syntax.MLP_Var (x)), ((when_clause)::[])))), (uu____1791))))))
+end
+| FStar_Syntax_Syntax.Pat_constant (s) -> begin
+(
+
+let t = (FStar_TypeChecker_TcTerm.tc_constant FStar_Range.dummyRange s)
+in (
+
+let mlty = (term_as_mlty g t)
+in (
+
+let uu____1803 = (
+
+let uu____1808 = (
+
+let uu____1812 = (
+
+let uu____1813 = (FStar_Extraction_ML_Util.mlconst_of_const' p.FStar_Syntax_Syntax.p s)
+in FStar_Extraction_ML_Syntax.MLP_Const (uu____1813))
+in ((uu____1812), ([])))
+in Some (uu____1808))
+in (
+
+let uu____1818 = (ok mlty)
+in ((g), (uu____1803), (uu____1818))))))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) when disjunctive_pat -> begin
+((g), (Some (((FStar_Extraction_ML_Syntax.MLP_Wild), ([])))), (true))
+end
+| (FStar_Syntax_Syntax.Pat_var (x)) | (FStar_Syntax_Syntax.Pat_wild (x)) -> begin
+(
+
+let mlty = (term_as_mlty g x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____1834 = (FStar_Extraction_ML_UEnv.extend_bv g x (([]), (mlty)) false false imp)
+in (match (uu____1834) with
+| (g1, x1) -> begin
+(
+
+let uu____1847 = (ok mlty)
+in ((g1), ((match (imp) with
+| true -> begin
+None
+end
+| uu____1859 -> begin
+Some (((FStar_Extraction_ML_Syntax.MLP_Var (x1)), ([])))
+end)), (uu____1847)))
+end)))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (uu____1864) -> begin
+((g), (None), (true))
+end
+| FStar_Syntax_Syntax.Pat_cons (f, pats) -> begin
+(
+
+let uu____1888 = (
+
+let uu____1891 = (FStar_Extraction_ML_UEnv.lookup_fv g f)
+in (match (uu____1891) with
+| FStar_Util.Inr (uu____1894, {FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (n1); FStar_Extraction_ML_Syntax.mlty = uu____1896; FStar_Extraction_ML_Syntax.loc = uu____1897}, ttys, uu____1899) -> begin
+((n1), (ttys))
+end
+| uu____1906 -> begin
+(failwith "Expected a constructor")
+end))
+in (match (uu____1888) with
+| (d, tys) -> begin
+(
+
+let nTyVars = (FStar_List.length (Prims.fst tys))
+in (
+
+let uu____1920 = (FStar_Util.first_N nTyVars pats)
+in (match (uu____1920) with
+| (tysVarPats, restPats) -> begin
+(
+
+let f_ty_opt = try
+(match (()) with
+| () -> begin
+(
+
+let mlty_args = (FStar_All.pipe_right tysVarPats (FStar_List.map (fun uu____1994 -> (match (uu____1994) with
+| (p1, uu____2000) -> begin
+(match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_dot_term (uu____2005, t) -> begin
+(term_as_mlty g t)
+end
+| uu____2011 -> begin
+((FStar_Extraction_ML_UEnv.debug g (fun uu____2013 -> (
+
+let uu____2014 = (FStar_Syntax_Print.pat_to_string p1)
+in (FStar_Util.print1 "Pattern %s is not extractable" uu____2014))));
+(Prims.raise Un_extractable);
+)
+end)
+end))))
+in (
+
+let f_ty = (FStar_Extraction_ML_Util.subst tys mlty_args)
+in (
+
+let uu____2016 = (FStar_Extraction_ML_Util.uncurry_mlty_fun f_ty)
+in Some (uu____2016))))
+end)
+with
+| Un_extractable -> begin
+None
+end
+in (
+
+let uu____2031 = (FStar_Util.fold_map (fun g1 uu____2046 -> (match (uu____2046) with
+| (p1, imp1) -> begin
+(
+
+let uu____2057 = (extract_one_pat disjunctive_pat true g1 p1 None)
+in (match (uu____2057) with
+| (g2, p2, uu____2073) -> begin
+((g2), (p2))
+end))
+end)) g tysVarPats)
+in (match (uu____2031) with
+| (g1, tyMLPats) -> begin
+(
+
+let uu____2105 = (FStar_Util.fold_map (fun uu____2131 uu____2132 -> (match (((uu____2131), (uu____2132))) with
+| ((g2, f_ty_opt1), (p1, imp1)) -> begin
+(
+
+let uu____2181 = (match (f_ty_opt1) with
+| Some ((hd1)::rest, res) -> begin
+((Some (((rest), (res)))), (Some (hd1)))
+end
+| uu____2213 -> begin
+((None), (None))
+end)
+in (match (uu____2181) with
+| (f_ty_opt2, expected_ty) -> begin
+(
+
+let uu____2250 = (extract_one_pat disjunctive_pat false g2 p1 expected_ty)
+in (match (uu____2250) with
+| (g3, p2, uu____2272) -> begin
+((((g3), (f_ty_opt2))), (p2))
+end))
+end))
+end)) ((g1), (f_ty_opt)) restPats)
+in (match (uu____2105) with
+| ((g2, f_ty_opt1), restMLPats) -> begin
+(
+
+let uu____2333 = (
+
+let uu____2339 = (FStar_All.pipe_right (FStar_List.append tyMLPats restMLPats) (FStar_List.collect (fun uu___136_2364 -> (match (uu___136_2364) with
+| Some (x) -> begin
+(x)::[]
+end
+| uu____2386 -> begin
+[]
+end))))
+in (FStar_All.pipe_right uu____2339 FStar_List.split))
+in (match (uu____2333) with
+| (mlPats, when_clauses) -> begin
+(
+
+let pat_ty_compat = (match (f_ty_opt1) with
+| Some ([], t) -> begin
+(ok t)
+end
+| uu____2425 -> begin
+false
+end)
+in (
+
+let uu____2430 = (
+
+let uu____2435 = (
+
+let uu____2439 = (resugar_pat f.FStar_Syntax_Syntax.fv_qual (FStar_Extraction_ML_Syntax.MLP_CTor (((d), (mlPats)))))
+in (
+
+let uu____2441 = (FStar_All.pipe_right when_clauses FStar_List.flatten)
+in ((uu____2439), (uu____2441))))
+in Some (uu____2435))
+in ((g2), (uu____2430), (pat_ty_compat))))
+end))
+end))
+end)))
+end)))
+end))
+end)))
+
+
+let extract_pat : FStar_Extraction_ML_UEnv.env  ->  (FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t  ->  FStar_Extraction_ML_Syntax.mlty  ->  (FStar_Extraction_ML_UEnv.env * (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr Prims.option) Prims.list * Prims.bool) = (fun g p expected_t -> (
+
+let extract_one_pat1 = (fun disj g1 p1 expected_t1 -> (
+
+let uu____2502 = (extract_one_pat disj false g1 p1 expected_t1)
+in (match (uu____2502) with
+| (g2, Some (x, v1), b) -> begin
+((g2), (((x), (v1))), (b))
+end
+| uu____2533 -> begin
+(failwith "Impossible: Unable to translate pattern")
+end)))
+in (
+
+let mk_when_clause = (fun whens -> (match (whens) with
+| [] -> begin
+None
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____2558 = (FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd1 tl1)
+in Some (uu____2558))
+end))
+in (match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible: Empty disjunctive pattern")
+end
+| FStar_Syntax_Syntax.Pat_disj ((p1)::pats) -> begin
+(
+
+let uu____2584 = (extract_one_pat1 true g p1 (Some (expected_t)))
+in (match (uu____2584) with
+| (g', p2, b) -> begin
+(
+
+let uu____2607 = (FStar_Util.fold_map (fun b1 p3 -> (
+
+let uu____2619 = (extract_one_pat1 true g p3 (Some (expected_t)))
+in (match (uu____2619) with
+| (uu____2631, p4, b') -> begin
+(((b1 && b')), (p4))
+end))) b pats)
+in (match (uu____2607) with
+| (b1, ps) -> begin
+(
+
+let ps1 = (p2)::ps
+in (
+
+let g1 = g'
+in (
+
+let uu____2669 = (FStar_All.pipe_right ps1 (FStar_List.partition (fun uu___137_2697 -> (match (uu___137_2697) with
+| (uu____2701, (uu____2702)::uu____2703) -> begin
+true
+end
+| uu____2706 -> begin
+false
+end))))
+in (match (uu____2669) with
+| (ps_when, rest) -> begin
+(
+
+let ps2 = (FStar_All.pipe_right ps_when (FStar_List.map (fun uu____2754 -> (match (uu____2754) with
+| (x, whens) -> begin
+(
+
+let uu____2765 = (mk_when_clause whens)
+in ((x), (uu____2765)))
+end))))
+in (
+
+let res = (match (rest) with
+| [] -> begin
+((g1), (ps2), (b1))
+end
+| rest1 -> begin
+(
+
+let uu____2795 = (
+
+let uu____2800 = (
+
+let uu____2804 = (
+
+let uu____2805 = (FStar_List.map Prims.fst rest1)
+in FStar_Extraction_ML_Syntax.MLP_Branch (uu____2805))
+in ((uu____2804), (None)))
+in (uu____2800)::ps2)
+in ((g1), (uu____2795), (b1)))
+end)
+in res))
+end))))
+end))
+end))
+end
+| uu____2819 -> begin
+(
+
+let uu____2820 = (extract_one_pat1 false g p (Some (expected_t)))
+in (match (uu____2820) with
+| (g1, (p1, whens), b) -> begin
+(
+
+let when_clause = (mk_when_clause whens)
+in ((g1), ((((p1), (when_clause)))::[]), (b)))
+end))
+end))))
+
+
+let maybe_eta_data_and_project_record : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.fv_qual Prims.option  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr = (fun g qual residualType mlAppExpr -> (
+
+let rec eta_args = (fun more_args t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu____2902, t1) -> begin
+(
+
+let x = (FStar_Extraction_ML_Syntax.gensym ())
+in (
+
+let uu____2905 = (
+
+let uu____2911 = (
+
+let uu____2916 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t0) (FStar_Extraction_ML_Syntax.MLE_Var (x)))
+in ((((x), (t0))), (uu____2916)))
+in (uu____2911)::more_args)
+in (eta_args uu____2905 t1)))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (uu____2923, uu____2924) -> begin
+(((FStar_List.rev more_args)), (t))
+end
+| uu____2936 -> begin
+(failwith "Impossible: Head type is not an arrow")
+end))
+in (
+
+let as_record = (fun qual1 e -> (match (((e.FStar_Extraction_ML_Syntax.expr), (qual1))) with
+| (FStar_Extraction_ML_Syntax.MLE_CTor (uu____2954, args), Some (FStar_Syntax_Syntax.Record_ctor (tyname, fields))) -> begin
+(
+
+let path = (FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns)
+in (
+
+let fields1 = (record_fields fields args)
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty e.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_Record (((path), (fields1)))))))
+end
+| uu____2973 -> begin
+e
+end))
+in (
+
+let resugar_and_maybe_eta = (fun qual1 e -> (
+
+let uu____2986 = (eta_args [] residualType)
+in (match (uu____2986) with
+| (eargs, tres) -> begin
+(match (eargs) with
+| [] -> begin
+(
+
+let uu____3014 = (as_record qual1 e)
+in (FStar_Extraction_ML_Util.resugar_exp uu____3014))
+end
+| uu____3015 -> begin
+(
+
+let uu____3021 = (FStar_List.unzip eargs)
+in (match (uu____3021) with
+| (binders, eargs1) -> begin
+(match (e.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_CTor (head1, args) -> begin
+(
+
+let body = (
+
+let uu____3045 = (
+
+let uu____3046 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty tres) (FStar_Extraction_ML_Syntax.MLE_CTor (((head1), ((FStar_List.append args eargs1))))))
+in (FStar_All.pipe_left (as_record qual1) uu____3046))
+in (FStar_All.pipe_left FStar_Extraction_ML_Util.resugar_exp uu____3045))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty e.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_Fun (((binders), (body))))))
+end
+| uu____3051 -> begin
+(failwith "Impossible: Not a constructor")
+end)
+end))
+end)
+end)))
+in (match (((mlAppExpr.FStar_Extraction_ML_Syntax.expr), (qual))) with
+| (uu____3053, None) -> begin
+mlAppExpr
+end
+| (FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (mlp); FStar_Extraction_ML_Syntax.mlty = uu____3056; FStar_Extraction_ML_Syntax.loc = uu____3057}, (mle)::args), Some (FStar_Syntax_Syntax.Record_projector (constrname, f))) -> begin
+(
+
+let f1 = (FStar_Ident.lid_of_ids (FStar_List.append constrname.FStar_Ident.ns ((f)::[])))
+in (
+
+let fn = (FStar_Extraction_ML_Util.mlpath_of_lid f1)
+in (
+
+let proj = FStar_Extraction_ML_Syntax.MLE_Proj (((mle), (fn)))
+in (
+
+let e = (match (args) with
+| [] -> begin
+proj
+end
+| uu____3075 -> begin
+(
+
+let uu____3077 = (
+
+let uu____3081 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) proj)
+in ((uu____3081), (args)))
+in FStar_Extraction_ML_Syntax.MLE_App (uu____3077))
+end)
+in (FStar_Extraction_ML_Syntax.with_ty mlAppExpr.FStar_Extraction_ML_Syntax.mlty e)))))
+end
+| ((FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (mlp); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}, mlargs), Some (FStar_Syntax_Syntax.Data_ctor))) | ((FStar_Extraction_ML_Syntax.MLE_App ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Name (mlp); FStar_Extraction_ML_Syntax.mlty = _; FStar_Extraction_ML_Syntax.loc = _}, mlargs), Some (FStar_Syntax_Syntax.Record_ctor (_)))) -> begin
+(
+
+let uu____3096 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty mlAppExpr.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_CTor (((mlp), (mlargs)))))
+in (FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____3096))
+end
+| ((FStar_Extraction_ML_Syntax.MLE_Name (mlp), Some (FStar_Syntax_Syntax.Data_ctor))) | ((FStar_Extraction_ML_Syntax.MLE_Name (mlp), Some (FStar_Syntax_Syntax.Record_ctor (_)))) -> begin
+(
+
+let uu____3102 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty mlAppExpr.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_CTor (((mlp), ([])))))
+in (FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____3102))
+end
+| uu____3104 -> begin
+mlAppExpr
+end)))))
+
+
+let maybe_downgrade_eff : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.e_tag = (fun g f t -> (
+
+let uu____3117 = ((f = FStar_Extraction_ML_Syntax.E_GHOST) && (type_leq g t FStar_Extraction_ML_Syntax.ml_unit_ty))
+in (match (uu____3117) with
+| true -> begin
+FStar_Extraction_ML_Syntax.E_PURE
+end
+| uu____3118 -> begin
+f
+end)))
+
+
+let rec term_as_mlexpr : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.e_tag * FStar_Extraction_ML_Syntax.mlty) = (fun g t -> (
+
+let uu____3158 = (term_as_mlexpr' g t)
+in (match (uu____3158) with
+| (e, tag, ty) -> begin
+(
+
+let tag1 = (maybe_downgrade_eff g tag ty)
+in ((FStar_Extraction_ML_UEnv.debug g (fun u -> (
+
+let uu____3171 = (
+
+let uu____3172 = (FStar_Syntax_Print.tag_of_term t)
+in (
+
+let uu____3173 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____3174 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule ty)
+in (FStar_Util.format4 "term_as_mlexpr (%s) :  %s has ML type %s and effect %s\n" uu____3172 uu____3173 uu____3174 (FStar_Extraction_ML_Util.eff_to_string tag1)))))
+in (FStar_Util.print_string uu____3171))));
+(erase g e ty tag1);
+))
+end)))
+and check_term_as_mlexpr : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.mlty  ->  (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.mlty) = (fun g t f ty -> (
+
+let uu____3181 = (check_term_as_mlexpr' g t f ty)
+in (match (uu____3181) with
+| (e, t1) -> begin
+(
+
+let uu____3188 = (erase g e t1 f)
+in (match (uu____3188) with
+| (r, uu____3195, t2) -> begin
+((r), (t2))
+end))
+end)))
+and check_term_as_mlexpr' : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.mlty  ->  (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.mlty) = (fun g e0 f ty -> (
+
+let uu____3203 = (term_as_mlexpr g e0)
+in (match (uu____3203) with
+| (e, tag, t) -> begin
+(
+
+let tag1 = (maybe_downgrade_eff g tag t)
+in (match ((FStar_Extraction_ML_Util.eff_leq tag1 f)) with
+| true -> begin
+(
+
+let uu____3215 = (maybe_coerce g e t ty)
+in ((uu____3215), (ty)))
+end
+| uu____3216 -> begin
+(err_unexpected_eff e0 f tag1)
+end))
+end)))
+and term_as_mlexpr' : FStar_Extraction_ML_UEnv.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.e_tag * FStar_Extraction_ML_Syntax.mlty) = (fun g top -> ((FStar_Extraction_ML_UEnv.debug g (fun u -> (
+
+let uu____3226 = (
+
+let uu____3227 = (FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3228 = (FStar_Syntax_Print.tag_of_term top)
+in (
+
+let uu____3229 = (FStar_Syntax_Print.term_to_string top)
+in (FStar_Util.format3 "%s: term_as_mlexpr\' (%s) :  %s \n" uu____3227 uu____3228 uu____3229))))
+in (FStar_Util.print_string uu____3226))));
+(
+
+let t = (FStar_Syntax_Subst.compress top)
+in (match (t.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) -> begin
+(
+
+let uu____3237 = (
+
+let uu____3238 = (FStar_Syntax_Print.tag_of_term t)
+in (FStar_Util.format1 "Impossible: Unexpected term: %s" uu____3238))
+in (failwith uu____3237))
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_refine (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) -> begin
+((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.ml_unit_ty))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Mutable_alloc)) -> begin
+(
+
+let uu____3250 = (term_as_mlexpr' g t1)
+in (match (uu____3250) with
+| ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Let ((FStar_Extraction_ML_Syntax.NonRec, flags, bodies), continuation); FStar_Extraction_ML_Syntax.mlty = mlty; FStar_Extraction_ML_Syntax.loc = loc}, tag, typ) -> begin
+(({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Let (((((FStar_Extraction_ML_Syntax.NonRec), ((FStar_Extraction_ML_Syntax.Mutable)::flags), (bodies))), (continuation))); FStar_Extraction_ML_Syntax.mlty = mlty; FStar_Extraction_ML_Syntax.loc = loc}), (tag), (typ))
+end
+| uu____3277 -> begin
+(failwith "impossible")
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, FStar_Syntax_Syntax.Meta_monadic (m, uu____3286)) -> begin
+(
+
+let t2 = (FStar_Syntax_Subst.compress t1)
+in (match (t2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), body) when (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname) -> begin
+(
+
+let ed = (FStar_TypeChecker_Env.get_effect_decl g.FStar_Extraction_ML_UEnv.tcenv m)
+in (
+
+let uu____3310 = (
+
+let uu____3311 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (FStar_All.pipe_right uu____3311 Prims.op_Negation))
+in (match (uu____3310) with
+| true -> begin
+(term_as_mlexpr' g t2)
+end
+| uu____3316 -> begin
+(
+
+let ml_result_ty_1 = (term_as_mlty g lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____3318 = (term_as_mlexpr g lb.FStar_Syntax_Syntax.lbdef)
+in (match (uu____3318) with
+| (comp_1, uu____3326, uu____3327) -> begin
+(
+
+let uu____3328 = (
+
+let k = (
+
+let uu____3332 = (
+
+let uu____3336 = (
+
+let uu____3337 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in (FStar_All.pipe_right uu____3337 FStar_Syntax_Syntax.mk_binder))
+in (uu____3336)::[])
+in (FStar_Syntax_Util.abs uu____3332 body None))
+in (
+
+let uu____3343 = (term_as_mlexpr g k)
+in (match (uu____3343) with
+| (ml_k, uu____3350, t_k) -> begin
+(
+
+let m_2 = (match (t_k) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3353, uu____3354, m_2) -> begin
+m_2
+end
+| uu____3356 -> begin
+(failwith "Impossible")
+end)
+in ((ml_k), (m_2)))
+end)))
+in (match (uu____3328) with
+| (ml_k, ty) -> begin
+(
+
+let bind1 = (
+
+let uu____3363 = (
+
+let uu____3364 = (
+
+let uu____3365 = (FStar_Extraction_ML_UEnv.monad_op_name ed "bind")
+in (FStar_All.pipe_right uu____3365 Prims.fst))
+in FStar_Extraction_ML_Syntax.MLE_Name (uu____3364))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) uu____3363))
+in (
+
+let uu____3370 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty) (FStar_Extraction_ML_Syntax.MLE_App (((bind1), ((comp_1)::(ml_k)::[])))))
+in ((uu____3370), (FStar_Extraction_ML_Syntax.E_IMPURE), (ty))))
+end))
+end)))
+end)))
+end
+| uu____3372 -> begin
+(term_as_mlexpr' g t2)
+end))
+end
+| (FStar_Syntax_Syntax.Tm_meta (t1, _)) | (FStar_Syntax_Syntax.Tm_uinst (t1, _)) -> begin
+(term_as_mlexpr' g t1)
+end
+| FStar_Syntax_Syntax.Tm_constant (c) -> begin
+(
+
+let uu____3385 = (FStar_TypeChecker_TcTerm.type_of_tot_term g.FStar_Extraction_ML_UEnv.tcenv t)
+in (match (uu____3385) with
+| (uu____3392, ty, uu____3394) -> begin
+(
+
+let ml_ty = (term_as_mlty g ty)
+in (
+
+let uu____3396 = (
+
+let uu____3397 = (
+
+let uu____3398 = (FStar_Extraction_ML_Util.mlconst_of_const' t.FStar_Syntax_Syntax.pos c)
+in (FStar_All.pipe_left (fun _0_31 -> FStar_Extraction_ML_Syntax.MLE_Const (_0_31)) uu____3398))
+in (FStar_Extraction_ML_Syntax.with_ty ml_ty uu____3397))
+in ((uu____3396), (FStar_Extraction_ML_Syntax.E_PURE), (ml_ty))))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+(
+
+let uu____3401 = (is_type g t)
+in (match (uu____3401) with
+| true -> begin
+((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.ml_unit_ty))
+end
+| uu____3405 -> begin
+(
+
+let uu____3406 = (FStar_Extraction_ML_UEnv.lookup_term g t)
+in (match (uu____3406) with
+| (FStar_Util.Inl (uu____3413), uu____3414) -> begin
+((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.ml_unit_ty))
+end
+| (FStar_Util.Inr (uu____3433, x, mltys, uu____3436), qual) -> begin
+(match (mltys) with
+| ([], t1) when (t1 = FStar_Extraction_ML_Syntax.ml_unit_ty) -> begin
+((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE), (t1))
+end
+| ([], t1) -> begin
+(
+
+let uu____3461 = (maybe_eta_data_and_project_record g qual t1 x)
+in ((uu____3461), (FStar_Extraction_ML_Syntax.E_PURE), (t1)))
+end
+| uu____3462 -> begin
+(err_uninst g t mltys t)
+end)
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, copt) -> begin
+(
+
+let uu____3491 = (FStar_Syntax_Subst.open_term bs body)
+in (match (uu____3491) with
+| (bs1, body1) -> begin
+(
+
+let uu____3499 = (binders_as_ml_binders g bs1)
+in (match (uu____3499) with
+| (ml_bs, env) -> begin
+(
+
+let uu____3516 = (term_as_mlexpr env body1)
+in (match (uu____3516) with
+| (ml_body, f, t1) -> begin
+(
+
+let uu____3526 = (FStar_List.fold_right (fun uu____3533 uu____3534 -> (match (((uu____3533), (uu____3534))) with
+| ((uu____3545, targ), (f1, t2)) -> begin
+((FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.MLTY_Fun (((targ), (f1), (t2)))))
+end)) ml_bs ((f), (t1)))
+in (match (uu____3526) with
+| (f1, tfun) -> begin
+(
+
+let uu____3558 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty tfun) (FStar_Extraction_ML_Syntax.MLE_Fun (((ml_bs), (ml_body)))))
+in ((uu____3558), (f1), (tfun)))
+end))
+end))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____3562; FStar_Syntax_Syntax.pos = uu____3563; FStar_Syntax_Syntax.vars = uu____3564}, (t1)::[]) -> begin
+(
+
+let uu____3587 = (term_as_mlexpr' g (Prims.fst t1))
+in (match (uu____3587) with
+| (ml, e_tag, mlty) -> begin
+((ml), (FStar_Extraction_ML_Syntax.E_PURE), (mlty))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (uu____3599)); FStar_Syntax_Syntax.tk = uu____3600; FStar_Syntax_Syntax.pos = uu____3601; FStar_Syntax_Syntax.vars = uu____3602}, (t1)::[]) -> begin
+(
+
+let uu____3625 = (term_as_mlexpr' g (Prims.fst t1))
+in (match (uu____3625) with
+| (ml, e_tag, mlty) -> begin
+((ml), (FStar_Extraction_ML_Syntax.E_IMPURE), (mlty))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let is_total = (fun uu___139_3661 -> (match (uu___139_3661) with
+| FStar_Util.Inl (l) -> begin
+(FStar_Syntax_Util.is_total_lcomp l)
+end
+| FStar_Util.Inr (l, flags) -> begin
+((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) || (FStar_All.pipe_right flags (FStar_List.existsb (fun uu___138_3679 -> (match (uu___138_3679) with
+| FStar_Syntax_Syntax.TOTAL -> begin
+true
+end
+| uu____3680 -> begin
+false
+end)))))
+end))
+in (
+
+let uu____3681 = (
+
+let uu____3684 = (
+
+let uu____3685 = (FStar_Syntax_Subst.compress head1)
+in uu____3685.FStar_Syntax_Syntax.n)
+in ((head1.FStar_Syntax_Syntax.n), (uu____3684)))
+in (match (uu____3681) with
+| (FStar_Syntax_Syntax.Tm_uvar (uu____3691), uu____3692) -> begin
+(
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) g.FStar_Extraction_ML_UEnv.tcenv t)
+in (term_as_mlexpr' g t1))
+end
+| (uu____3702, FStar_Syntax_Syntax.Tm_abs (bs, uu____3704, Some (lc))) when (is_total lc) -> begin
+(
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) g.FStar_Extraction_ML_UEnv.tcenv t)
+in (term_as_mlexpr' g t1))
+end
+| uu____3733 -> begin
+(
+
+let rec extract_app = (fun is_data uu____3761 uu____3762 restArgs -> (match (((uu____3761), (uu____3762))) with
+| ((mlhead, mlargs_f), (f, t1)) -> begin
+(match (((restArgs), (t1))) with
+| ([], uu____3810) -> begin
+(
+
+let evaluation_order_guaranteed = ((((FStar_List.length mlargs_f) = (Prims.parse_int "1")) || (FStar_Extraction_ML_Util.codegen_fsharp ())) || (match (head1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.op_And) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.op_Or))
+end
+| uu____3824 -> begin
+false
+end))
+in (
+
+let uu____3825 = (match (evaluation_order_guaranteed) with
+| true -> begin
+(
+
+let uu____3838 = (FStar_All.pipe_right (FStar_List.rev mlargs_f) (FStar_List.map Prims.fst))
+in (([]), (uu____3838)))
+end
+| uu____3854 -> begin
+(FStar_List.fold_left (fun uu____3863 uu____3864 -> (match (((uu____3863), (uu____3864))) with
+| ((lbs, out_args), (arg, f1)) -> begin
+(match (((f1 = FStar_Extraction_ML_Syntax.E_PURE) || (f1 = FStar_Extraction_ML_Syntax.E_GHOST))) with
+| true -> begin
+((lbs), ((arg)::out_args))
+end
+| uu____3917 -> begin
+(
+
+let x = (FStar_Extraction_ML_Syntax.gensym ())
+in (
+
+let uu____3919 = (
+
+let uu____3921 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty arg.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_Var (x)))
+in (uu____3921)::out_args)
+in (((((x), (arg)))::lbs), (uu____3919))))
+end)
+end)) (([]), ([])) mlargs_f)
+end)
+in (match (uu____3825) with
+| (lbs, mlargs) -> begin
+(
+
+let app = (
+
+let uu____3948 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t1) (FStar_Extraction_ML_Syntax.MLE_App (((mlhead), (mlargs)))))
+in (FStar_All.pipe_left (maybe_eta_data_and_project_record g is_data t1) uu____3948))
+in (
+
+let l_app = (FStar_List.fold_right (fun uu____3953 out -> (match (uu____3953) with
+| (x, arg) -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty out.FStar_Extraction_ML_Syntax.mlty) (mk_MLE_Let false ((FStar_Extraction_ML_Syntax.NonRec), ([]), (({FStar_Extraction_ML_Syntax.mllb_name = x; FStar_Extraction_ML_Syntax.mllb_tysc = Some ((([]), (arg.FStar_Extraction_ML_Syntax.mlty))); FStar_Extraction_ML_Syntax.mllb_add_unit = false; FStar_Extraction_ML_Syntax.mllb_def = arg; FStar_Extraction_ML_Syntax.print_typ = true})::[])) out))
+end)) lbs app)
+in ((l_app), (f), (t1))))
+end)))
+end
+| (((arg, uu____3966))::rest, FStar_Extraction_ML_Syntax.MLTY_Fun (formal_t, f', t2)) when (is_type g arg) -> begin
+(
+
+let uu____3984 = (type_leq g formal_t FStar_Extraction_ML_Syntax.ml_unit_ty)
+in (match (uu____3984) with
+| true -> begin
+(
+
+let uu____3988 = (
+
+let uu____3991 = (FStar_Extraction_ML_Util.join arg.FStar_Syntax_Syntax.pos f f')
+in ((uu____3991), (t2)))
+in (extract_app is_data ((mlhead), ((((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE)))::mlargs_f)) uu____3988 rest))
+end
+| uu____3997 -> begin
+(
+
+let uu____3998 = (
+
+let uu____3999 = (FStar_Extraction_ML_Code.string_of_mlexpr g.FStar_Extraction_ML_UEnv.currentModule mlhead)
+in (
+
+let uu____4000 = (FStar_Syntax_Print.term_to_string arg)
+in (
+
+let uu____4001 = (FStar_Syntax_Print.tag_of_term arg)
+in (
+
+let uu____4002 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule formal_t)
+in (FStar_Util.format4 "Impossible: ill-typed application:\n\thead=%s, arg=%s, tag=%s\n\texpected type unit, got %s" uu____3999 uu____4000 uu____4001 uu____4002)))))
+in (failwith uu____3998))
+end))
+end
+| (((e0, uu____4007))::rest, FStar_Extraction_ML_Syntax.MLTY_Fun (tExpected, f', t2)) -> begin
+(
+
+let r = e0.FStar_Syntax_Syntax.pos
+in (
+
+let uu____4026 = (term_as_mlexpr g e0)
+in (match (uu____4026) with
+| (e01, f0, tInferred) -> begin
+(
+
+let e02 = (maybe_coerce g e01 tInferred tExpected)
+in (
+
+let uu____4037 = (
+
+let uu____4040 = (FStar_Extraction_ML_Util.join_l r ((f)::(f')::(f0)::[]))
+in ((uu____4040), (t2)))
+in (extract_app is_data ((mlhead), ((((e02), (f0)))::mlargs_f)) uu____4037 rest)))
+end)))
+end
+| uu____4046 -> begin
+(
+
+let uu____4053 = (FStar_Extraction_ML_Util.udelta_unfold g t1)
+in (match (uu____4053) with
+| Some (t2) -> begin
+(extract_app is_data ((mlhead), (mlargs_f)) ((f), (t2)) restArgs)
+end
+| None -> begin
+(err_ill_typed_application g top restArgs t1)
+end))
+end)
+end))
+in (
+
+let extract_app_maybe_projector = (fun is_data mlhead uu____4089 args1 -> (match (uu____4089) with
+| (f, t1) -> begin
+(match (is_data) with
+| Some (FStar_Syntax_Syntax.Record_projector (uu____4108)) -> begin
+(
+
+let rec remove_implicits = (fun args2 f1 t2 -> (match (((args2), (t2))) with
+| (((a0, Some (FStar_Syntax_Syntax.Implicit (uu____4158))))::args3, FStar_Extraction_ML_Syntax.MLTY_Fun (uu____4160, f', t3)) -> begin
+(
+
+let uu____4185 = (FStar_Extraction_ML_Util.join a0.FStar_Syntax_Syntax.pos f1 f')
+in (remove_implicits args3 uu____4185 t3))
+end
+| uu____4186 -> begin
+((args2), (f1), (t2))
+end))
+in (
+
+let uu____4201 = (remove_implicits args1 f t1)
+in (match (uu____4201) with
+| (args2, f1, t2) -> begin
+(extract_app is_data ((mlhead), ([])) ((f1), (t2)) args2)
+end)))
+end
+| uu____4234 -> begin
+(extract_app is_data ((mlhead), ([])) ((f), (t1)) args1)
+end)
+end))
+in (
+
+let uu____4241 = (is_type g t)
+in (match (uu____4241) with
+| true -> begin
+((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.ml_unit_ty))
+end
+| uu____4245 -> begin
+(
+
+let head2 = (FStar_Syntax_Util.un_uinst head1)
+in (match (head2.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+(
+
+let uu____4252 = (
+
+let uu____4259 = (FStar_Extraction_ML_UEnv.lookup_term g head2)
+in (match (uu____4259) with
+| (FStar_Util.Inr (uu____4269, x1, x2, x3), q) -> begin
+((((x1), (x2), (x3))), (q))
+end
+| uu____4294 -> begin
+(failwith "FIXME Ty")
+end))
+in (match (uu____4252) with
+| ((head_ml, (vars, t1), inst_ok), qual) -> begin
+(
+
+let has_typ_apps = (match (args) with
+| ((a, uu____4323))::uu____4324 -> begin
+(is_type g a)
+end
+| uu____4338 -> begin
+false
+end)
+in (
+
+let uu____4344 = (match (vars) with
+| (uu____4361)::uu____4362 when ((not (has_typ_apps)) && inst_ok) -> begin
+((head_ml), (t1), (args))
+end
+| uu____4369 -> begin
+(
+
+let n1 = (FStar_List.length vars)
+in (match ((n1 <= (FStar_List.length args))) with
+| true -> begin
+(
+
+let uu____4389 = (FStar_Util.first_N n1 args)
+in (match (uu____4389) with
+| (prefix1, rest) -> begin
+(
+
+let prefixAsMLTypes = (FStar_List.map (fun uu____4442 -> (match (uu____4442) with
+| (x, uu____4446) -> begin
+(term_as_mlty g x)
+end)) prefix1)
+in (
+
+let t2 = (instantiate ((vars), (t1)) prefixAsMLTypes)
+in (
+
+let head3 = (match (head_ml.FStar_Extraction_ML_Syntax.expr) with
+| (FStar_Extraction_ML_Syntax.MLE_Name (_)) | (FStar_Extraction_ML_Syntax.MLE_Var (_)) -> begin
+(
+
+let uu___143_4451 = head_ml
+in {FStar_Extraction_ML_Syntax.expr = uu___143_4451.FStar_Extraction_ML_Syntax.expr; FStar_Extraction_ML_Syntax.mlty = t2; FStar_Extraction_ML_Syntax.loc = uu___143_4451.FStar_Extraction_ML_Syntax.loc})
+end
+| FStar_Extraction_ML_Syntax.MLE_App (head3, ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_Unit); FStar_Extraction_ML_Syntax.mlty = uu____4453; FStar_Extraction_ML_Syntax.loc = uu____4454})::[]) -> begin
+(FStar_All.pipe_right (FStar_Extraction_ML_Syntax.MLE_App ((((
+
+let uu___144_4457 = head3
+in {FStar_Extraction_ML_Syntax.expr = uu___144_4457.FStar_Extraction_ML_Syntax.expr; FStar_Extraction_ML_Syntax.mlty = FStar_Extraction_ML_Syntax.MLTY_Fun (((FStar_Extraction_ML_Syntax.ml_unit_ty), (FStar_Extraction_ML_Syntax.E_PURE), (t2))); FStar_Extraction_ML_Syntax.loc = uu___144_4457.FStar_Extraction_ML_Syntax.loc})), ((FStar_Extraction_ML_Syntax.ml_unit)::[])))) (FStar_Extraction_ML_Syntax.with_ty t2))
+end
+| uu____4458 -> begin
+(failwith "Impossible: Unexpected head term")
+end)
+in ((head3), (t2), (rest)))))
+end))
+end
+| uu____4464 -> begin
+(err_uninst g head2 ((vars), (t1)) top)
+end))
+end)
+in (match (uu____4344) with
+| (head_ml1, head_t, args1) -> begin
+(match (args1) with
+| [] -> begin
+(
+
+let uu____4496 = (maybe_eta_data_and_project_record g qual head_t head_ml1)
+in ((uu____4496), (FStar_Extraction_ML_Syntax.E_PURE), (head_t)))
+end
+| uu____4497 -> begin
+(extract_app_maybe_projector qual head_ml1 ((FStar_Extraction_ML_Syntax.E_PURE), (head_t)) args1)
+end)
+end)))
+end))
+end
+| uu____4503 -> begin
+(
+
+let uu____4504 = (term_as_mlexpr g head2)
+in (match (uu____4504) with
+| (head3, f, t1) -> begin
+(extract_app_maybe_projector None head3 ((f), (t1)) args)
+end))
+end))
+end))))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e0, (tc, uu____4516), f) -> begin
+(
+
+let t1 = (match (tc) with
+| FStar_Util.Inl (t1) -> begin
+(term_as_mlty g t1)
+end
+| FStar_Util.Inr (c) -> begin
+(term_as_mlty g (FStar_Syntax_Util.comp_result c))
+end)
+in (
+
+let f1 = (match (f) with
+| None -> begin
+(failwith "Ascription node with an empty effect label")
+end
+| Some (l) -> begin
+(effect_as_etag g l)
+end)
+in (
+
+let uu____4570 = (check_term_as_mlexpr g e0 f1 t1)
+in (match (uu____4570) with
+| (e, t2) -> begin
+((e), (f1), (t2))
+end))))
+end
+| FStar_Syntax_Syntax.Tm_let ((is_rec, lbs), e') -> begin
+(
+
+let top_level = (FStar_Syntax_Syntax.is_top_level lbs)
+in (
+
+let uu____4591 = (match (is_rec) with
+| true -> begin
+(FStar_Syntax_Subst.open_let_rec lbs e')
+end
+| uu____4598 -> begin
+(
+
+let uu____4599 = (FStar_Syntax_Syntax.is_top_level lbs)
+in (match (uu____4599) with
+| true -> begin
+((lbs), (e'))
+end
+| uu____4606 -> begin
+(
+
+let lb = (FStar_List.hd lbs)
+in (
+
+let x = (
+
+let uu____4609 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in (FStar_Syntax_Syntax.freshen_bv uu____4609))
+in (
+
+let lb1 = (
+
+let uu___145_4611 = lb
+in {FStar_Syntax_Syntax.lbname = FStar_Util.Inl (x); FStar_Syntax_Syntax.lbunivs = uu___145_4611.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___145_4611.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___145_4611.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___145_4611.FStar_Syntax_Syntax.lbdef})
+in (
+
+let e'1 = (FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x))))::[]) e')
+in (((lb1)::[]), (e'1))))))
+end))
+end)
+in (match (uu____4591) with
+| (lbs1, e'1) -> begin
+(
+
+let lbs2 = (match (top_level) with
+| true -> begin
+(FStar_All.pipe_right lbs1 (FStar_List.map (fun lb -> (
+
+let tcenv = (
+
+let uu____4628 = (FStar_Ident.lid_of_path (FStar_List.append (Prims.fst g.FStar_Extraction_ML_UEnv.currentModule) (((Prims.snd g.FStar_Extraction_ML_UEnv.currentModule))::[])) FStar_Range.dummyRange)
+in (FStar_TypeChecker_Env.set_current_module g.FStar_Extraction_ML_UEnv.tcenv uu____4628))
+in ((FStar_Extraction_ML_UEnv.debug g (fun uu____4632 -> (FStar_Options.set_option "debug_level" (FStar_Options.List ((FStar_Options.String ("Norm"))::(FStar_Options.String ("Extraction"))::[])))));
+(
+
+let lbdef = (
+
+let uu____4636 = (FStar_Options.ml_ish ())
+in (match (uu____4636) with
+| true -> begin
+lb.FStar_Syntax_Syntax.lbdef
+end
+| uu____4639 -> begin
+(FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.AllowUnboundUniverses)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.Inlining)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Zeta))::(FStar_TypeChecker_Normalize.PureSubtermsWithinComputations)::(FStar_TypeChecker_Normalize.Primops)::[]) tcenv lb.FStar_Syntax_Syntax.lbdef)
+end))
+in (
+
+let uu___146_4640 = lb
+in {FStar_Syntax_Syntax.lbname = uu___146_4640.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___146_4640.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___146_4640.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___146_4640.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = lbdef}));
+)))))
+end
+| uu____4641 -> begin
+lbs1
+end)
+in (
+
+let maybe_generalize = (fun uu____4654 -> (match (uu____4654) with
+| {FStar_Syntax_Syntax.lbname = lbname_; FStar_Syntax_Syntax.lbunivs = uu____4665; FStar_Syntax_Syntax.lbtyp = t1; FStar_Syntax_Syntax.lbeff = lbeff; FStar_Syntax_Syntax.lbdef = e} -> begin
+(
+
+let f_e = (effect_as_etag g lbeff)
+in (
+
+let t2 = (FStar_Syntax_Subst.compress t1)
+in (match (t2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) when (
+
+let uu____4708 = (FStar_List.hd bs)
+in (FStar_All.pipe_right uu____4708 (is_type_binder g))) -> begin
+(
+
+let uu____4715 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____4715) with
+| (bs1, c1) -> begin
+(
+
+let uu____4729 = (
+
+let uu____4734 = (FStar_Util.prefix_until (fun x -> (
+
+let uu____4752 = (is_type_binder g x)
+in (not (uu____4752)))) bs1)
+in (match (uu____4734) with
+| None -> begin
+((bs1), ((FStar_Syntax_Util.comp_result c1)))
+end
+| Some (bs2, b, rest) -> begin
+(
+
+let uu____4800 = (FStar_Syntax_Util.arrow ((b)::rest) c1)
+in ((bs2), (uu____4800)))
+end))
+in (match (uu____4729) with
+| (tbinders, tbody) -> begin
+(
+
+let n_tbinders = (FStar_List.length tbinders)
+in (
+
+let e1 = (
+
+let uu____4830 = (normalize_abs e)
+in (FStar_All.pipe_right uu____4830 FStar_Syntax_Util.unmeta))
+in (match (e1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_abs (bs2, body, uu____4842) -> begin
+(
+
+let uu____4865 = (FStar_Syntax_Subst.open_term bs2 body)
+in (match (uu____4865) with
+| (bs3, body1) -> begin
+(match ((n_tbinders <= (FStar_List.length bs3))) with
+| true -> begin
+(
+
+let uu____4895 = (FStar_Util.first_N n_tbinders bs3)
+in (match (uu____4895) with
+| (targs, rest_args) -> begin
+(
+
+let expected_source_ty = (
+
+let s = (FStar_List.map2 (fun uu____4938 uu____4939 -> (match (((uu____4938), (uu____4939))) with
+| ((x, uu____4949), (y, uu____4951)) -> begin
+(
+
+let uu____4956 = (
+
+let uu____4961 = (FStar_Syntax_Syntax.bv_to_name y)
+in ((x), (uu____4961)))
+in FStar_Syntax_Syntax.NT (uu____4956))
+end)) tbinders targs)
+in (FStar_Syntax_Subst.subst s tbody))
+in (
+
+let env = (FStar_List.fold_left (fun env uu____4966 -> (match (uu____4966) with
+| (a, uu____4970) -> begin
+(FStar_Extraction_ML_UEnv.extend_ty env a None)
+end)) g targs)
+in (
+
+let expected_t = (term_as_mlty env expected_source_ty)
+in (
+
+let polytype = (
+
+let uu____4978 = (FStar_All.pipe_right targs (FStar_List.map (fun uu____4992 -> (match (uu____4992) with
+| (x, uu____4998) -> begin
+(FStar_Extraction_ML_UEnv.bv_as_ml_tyvar x)
+end))))
+in ((uu____4978), (expected_t)))
+in (
+
+let add_unit = (match (rest_args) with
+| [] -> begin
+(
+
+let uu____5005 = (is_fstar_value body1)
+in (not (uu____5005)))
+end
+| uu____5006 -> begin
+false
+end)
+in (
+
+let rest_args1 = (match (add_unit) with
+| true -> begin
+(unit_binder)::rest_args
+end
+| uu____5013 -> begin
+rest_args
+end)
+in (
+
+let body2 = (match (rest_args1) with
+| [] -> begin
+body1
+end
+| uu____5015 -> begin
+(FStar_Syntax_Util.abs rest_args1 body1 None)
+end)
+in ((lbname_), (f_e), (((t2), (((targs), (polytype))))), (add_unit), (body2)))))))))
+end))
+end
+| uu____5054 -> begin
+(failwith "Not enough type binders")
+end)
+end))
+end
+| (FStar_Syntax_Syntax.Tm_uinst (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) -> begin
+(
+
+let env = (FStar_List.fold_left (fun env uu____5071 -> (match (uu____5071) with
+| (a, uu____5075) -> begin
+(FStar_Extraction_ML_UEnv.extend_ty env a None)
+end)) g tbinders)
+in (
+
+let expected_t = (term_as_mlty env tbody)
+in (
+
+let polytype = (
+
+let uu____5083 = (FStar_All.pipe_right tbinders (FStar_List.map (fun uu____5094 -> (match (uu____5094) with
+| (x, uu____5100) -> begin
+(FStar_Extraction_ML_UEnv.bv_as_ml_tyvar x)
+end))))
+in ((uu____5083), (expected_t)))
+in (
+
+let args = (FStar_All.pipe_right tbinders (FStar_List.map (fun uu____5109 -> (match (uu____5109) with
+| (bv, uu____5113) -> begin
+(
+
+let uu____5114 = (FStar_Syntax_Syntax.bv_to_name bv)
+in (FStar_All.pipe_right uu____5114 FStar_Syntax_Syntax.as_arg))
+end))))
+in (
+
+let e2 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((e1), (args))))) None e1.FStar_Syntax_Syntax.pos)
+in ((lbname_), (f_e), (((t2), (((tbinders), (polytype))))), (false), (e2)))))))
+end
+| uu____5152 -> begin
+(err_value_restriction e1)
+end)))
+end))
+end))
+end
+| uu____5162 -> begin
+(
+
+let expected_t = (term_as_mlty g t2)
+in ((lbname_), (f_e), (((t2), ((([]), ((([]), (expected_t))))))), (false), (e)))
+end)))
+end))
+in (
+
+let check_lb = (fun env uu____5219 -> (match (uu____5219) with
+| (nm, (lbname, f, (t1, (targs, polytype)), add_unit, e)) -> begin
+(
+
+let env1 = (FStar_List.fold_left (fun env1 uu____5290 -> (match (uu____5290) with
+| (a, uu____5294) -> begin
+(FStar_Extraction_ML_UEnv.extend_ty env1 a None)
+end)) env targs)
+in (
+
+let expected_t = (match (add_unit) with
+| true -> begin
+FStar_Extraction_ML_Syntax.MLTY_Fun (((FStar_Extraction_ML_Syntax.ml_unit_ty), (FStar_Extraction_ML_Syntax.E_PURE), ((Prims.snd polytype))))
+end
+| uu____5296 -> begin
+(Prims.snd polytype)
+end)
+in (
+
+let uu____5297 = (check_term_as_mlexpr env1 e f expected_t)
+in (match (uu____5297) with
+| (e1, uu____5303) -> begin
+(
+
+let f1 = (maybe_downgrade_eff env1 f expected_t)
+in ((f1), ({FStar_Extraction_ML_Syntax.mllb_name = nm; FStar_Extraction_ML_Syntax.mllb_tysc = Some (polytype); FStar_Extraction_ML_Syntax.mllb_add_unit = add_unit; FStar_Extraction_ML_Syntax.mllb_def = e1; FStar_Extraction_ML_Syntax.print_typ = true})))
+end))))
+end))
+in (
+
+let lbs3 = (FStar_All.pipe_right lbs2 (FStar_List.map maybe_generalize))
+in (
+
+let uu____5338 = (FStar_List.fold_right (fun lb uu____5377 -> (match (uu____5377) with
+| (env, lbs4) -> begin
+(
+
+let uu____5441 = lb
+in (match (uu____5441) with
+| (lbname, uu____5466, (t1, (uu____5468, polytype)), add_unit, uu____5471) -> begin
+(
+
+let uu____5478 = (FStar_Extraction_ML_UEnv.extend_lb env lbname t1 polytype add_unit true)
+in (match (uu____5478) with
+| (env1, nm) -> begin
+((env1), ((((nm), (lb)))::lbs4))
+end))
+end))
+end)) lbs3 ((g), ([])))
+in (match (uu____5338) with
+| (env_body, lbs4) -> begin
+(
+
+let env_def = (match (is_rec) with
+| true -> begin
+env_body
+end
+| uu____5582 -> begin
+g
+end)
+in (
+
+let lbs5 = (FStar_All.pipe_right lbs4 (FStar_List.map (check_lb env_def)))
+in (
+
+let e'_rng = e'1.FStar_Syntax_Syntax.pos
+in (
+
+let uu____5621 = (term_as_mlexpr env_body e'1)
+in (match (uu____5621) with
+| (e'2, f', t') -> begin
+(
+
+let f = (
+
+let uu____5632 = (
+
+let uu____5634 = (FStar_List.map Prims.fst lbs5)
+in (f')::uu____5634)
+in (FStar_Extraction_ML_Util.join_l e'_rng uu____5632))
+in (
+
+let is_rec1 = (match ((is_rec = true)) with
+| true -> begin
+FStar_Extraction_ML_Syntax.Rec
+end
+| uu____5639 -> begin
+FStar_Extraction_ML_Syntax.NonRec
+end)
+in (
+
+let uu____5640 = (
+
+let uu____5641 = (
+
+let uu____5642 = (
+
+let uu____5643 = (FStar_List.map Prims.snd lbs5)
+in ((is_rec1), ([]), (uu____5643)))
+in (mk_MLE_Let top_level uu____5642 e'2))
+in (
+
+let uu____5649 = (FStar_Extraction_ML_Util.mlloc_of_range t.FStar_Syntax_Syntax.pos)
+in (FStar_Extraction_ML_Syntax.with_ty_loc t' uu____5641 uu____5649)))
+in ((uu____5640), (f), (t')))))
+end)))))
+end))))))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_match (scrutinee, pats) -> begin
+(
+
+let uu____5678 = (term_as_mlexpr g scrutinee)
+in (match (uu____5678) with
+| (e, f_e, t_e) -> begin
+(
+
+let uu____5688 = (check_pats_for_ite pats)
+in (match (uu____5688) with
+| (b, then_e, else_e) -> begin
+(
+
+let no_lift = (fun x t1 -> x)
+in (match (b) with
+| true -> begin
+(match (((then_e), (else_e))) with
+| (Some (then_e1), Some (else_e1)) -> begin
+(
+
+let uu____5723 = (term_as_mlexpr g then_e1)
+in (match (uu____5723) with
+| (then_mle, f_then, t_then) -> begin
+(
+
+let uu____5733 = (term_as_mlexpr g else_e1)
+in (match (uu____5733) with
+| (else_mle, f_else, t_else) -> begin
+(
+
+let uu____5743 = (
+
+let uu____5750 = (type_leq g t_then t_else)
+in (match (uu____5750) with
+| true -> begin
+((t_else), (no_lift))
+end
+| uu____5761 -> begin
+(
+
+let uu____5762 = (type_leq g t_else t_then)
+in (match (uu____5762) with
+| true -> begin
+((t_then), (no_lift))
+end
+| uu____5773 -> begin
+((FStar_Extraction_ML_Syntax.MLTY_Top), (FStar_Extraction_ML_Syntax.apply_obj_repr))
+end))
+end))
+in (match (uu____5743) with
+| (t_branch, maybe_lift) -> begin
+(
+
+let uu____5791 = (
+
+let uu____5792 = (
+
+let uu____5793 = (
+
+let uu____5798 = (maybe_lift then_mle t_then)
+in (
+
+let uu____5799 = (
+
+let uu____5801 = (maybe_lift else_mle t_else)
+in Some (uu____5801))
+in ((e), (uu____5798), (uu____5799))))
+in FStar_Extraction_ML_Syntax.MLE_If (uu____5793))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t_branch) uu____5792))
+in (
+
+let uu____5803 = (FStar_Extraction_ML_Util.join then_e1.FStar_Syntax_Syntax.pos f_then f_else)
+in ((uu____5791), (uu____5803), (t_branch))))
+end))
+end))
+end))
+end
+| uu____5804 -> begin
+(failwith "ITE pats matched but then and else expressions not found?")
+end)
+end
+| uu____5812 -> begin
+(
+
+let uu____5813 = (FStar_All.pipe_right pats (FStar_Util.fold_map (fun compat br -> (
+
+let uu____5863 = (FStar_Syntax_Subst.open_branch br)
+in (match (uu____5863) with
+| (pat, when_opt, branch1) -> begin
+(
+
+let uu____5893 = (extract_pat g pat t_e)
+in (match (uu____5893) with
+| (env, p, pat_t_compat) -> begin
+(
+
+let uu____5924 = (match (when_opt) with
+| None -> begin
+((None), (FStar_Extraction_ML_Syntax.E_PURE))
+end
+| Some (w) -> begin
+(
+
+let uu____5939 = (term_as_mlexpr env w)
+in (match (uu____5939) with
+| (w1, f_w, t_w) -> begin
+(
+
+let w2 = (maybe_coerce env w1 t_w FStar_Extraction_ML_Syntax.ml_bool_ty)
+in ((Some (w2)), (f_w)))
+end))
+end)
+in (match (uu____5924) with
+| (when_opt1, f_when) -> begin
+(
+
+let uu____5967 = (term_as_mlexpr env branch1)
+in (match (uu____5967) with
+| (mlbranch, f_branch, t_branch) -> begin
+(
+
+let uu____5986 = (FStar_All.pipe_right p (FStar_List.map (fun uu____6023 -> (match (uu____6023) with
+| (p1, wopt) -> begin
+(
+
+let when_clause = (FStar_Extraction_ML_Util.conjoin_opt wopt when_opt1)
+in ((p1), (((when_clause), (f_when))), (((mlbranch), (f_branch), (t_branch)))))
+end))))
+in (((compat && pat_t_compat)), (uu____5986)))
+end))
+end))
+end))
+end))) true))
+in (match (uu____5813) with
+| (pat_t_compat, mlbranches) -> begin
+(
+
+let mlbranches1 = (FStar_List.flatten mlbranches)
+in (
+
+let e1 = (match (pat_t_compat) with
+| true -> begin
+e
+end
+| uu____6107 -> begin
+((FStar_Extraction_ML_UEnv.debug g (fun uu____6109 -> (
+
+let uu____6110 = (FStar_Extraction_ML_Code.string_of_mlexpr g.FStar_Extraction_ML_UEnv.currentModule e)
+in (
+
+let uu____6111 = (FStar_Extraction_ML_Code.string_of_mlty g.FStar_Extraction_ML_UEnv.currentModule t_e)
+in (FStar_Util.print2 "Coercing scrutinee %s from type %s because pattern type is incompatible\n" uu____6110 uu____6111)))));
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t_e) (FStar_Extraction_ML_Syntax.MLE_Coerce (((e), (t_e), (FStar_Extraction_ML_Syntax.MLTY_Top)))));
+)
+end)
+in (match (mlbranches1) with
+| [] -> begin
+(
+
+let uu____6124 = (
+
+let uu____6129 = (
+
+let uu____6138 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.failwith_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Extraction_ML_UEnv.lookup_fv g uu____6138))
+in (FStar_All.pipe_left FStar_Util.right uu____6129))
+in (match (uu____6124) with
+| (uu____6160, fw, uu____6162, uu____6163) -> begin
+(
+
+let uu____6164 = (
+
+let uu____6165 = (
+
+let uu____6166 = (
+
+let uu____6170 = (
+
+let uu____6172 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_string_ty) (FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_String ("unreachable"))))
+in (uu____6172)::[])
+in ((fw), (uu____6170)))
+in FStar_Extraction_ML_Syntax.MLE_App (uu____6166))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_unit_ty) uu____6165))
+in ((uu____6164), (FStar_Extraction_ML_Syntax.E_PURE), (FStar_Extraction_ML_Syntax.ml_unit_ty)))
+end))
+end
+| ((uu____6174, uu____6175, (uu____6176, f_first, t_first)))::rest -> begin
+(
+
+let uu____6208 = (FStar_List.fold_left (fun uu____6224 uu____6225 -> (match (((uu____6224), (uu____6225))) with
+| ((topt, f), (uu____6255, uu____6256, (uu____6257, f_branch, t_branch))) -> begin
+(
+
+let f1 = (FStar_Extraction_ML_Util.join top.FStar_Syntax_Syntax.pos f f_branch)
+in (
+
+let topt1 = (match (topt) with
+| None -> begin
+None
+end
+| Some (t1) -> begin
+(
+
+let uu____6288 = (type_leq g t1 t_branch)
+in (match (uu____6288) with
+| true -> begin
+Some (t_branch)
+end
+| uu____6290 -> begin
+(
+
+let uu____6291 = (type_leq g t_branch t1)
+in (match (uu____6291) with
+| true -> begin
+Some (t1)
+end
+| uu____6293 -> begin
+None
+end))
+end))
+end)
+in ((topt1), (f1))))
+end)) ((Some (t_first)), (f_first)) rest)
+in (match (uu____6208) with
+| (topt, f_match) -> begin
+(
+
+let mlbranches2 = (FStar_All.pipe_right mlbranches1 (FStar_List.map (fun uu____6337 -> (match (uu____6337) with
+| (p, (wopt, uu____6353), (b1, uu____6355, t1)) -> begin
+(
+
+let b2 = (match (topt) with
+| None -> begin
+(FStar_Extraction_ML_Syntax.apply_obj_repr b1 t1)
+end
+| Some (uu____6366) -> begin
+b1
+end)
+in ((p), (wopt), (b2)))
+end))))
+in (
+
+let t_match = (match (topt) with
+| None -> begin
+FStar_Extraction_ML_Syntax.MLTY_Top
+end
+| Some (t1) -> begin
+t1
+end)
+in (
+
+let uu____6370 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t_match) (FStar_Extraction_ML_Syntax.MLE_Match (((e1), (mlbranches2)))))
+in ((uu____6370), (f_match), (t_match)))))
+end))
+end)))
+end))
+end))
+end))
+end))
+end));
+))
+
+
+let fresh : Prims.string  ->  (Prims.string * Prims.int) = (
+
+let c = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (fun x -> ((FStar_Util.incr c);
+(
+
+let uu____6388 = (FStar_ST.read c)
+in ((x), (uu____6388)));
+)))
+
+
+let ind_discriminator_body : FStar_Extraction_ML_UEnv.env  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Extraction_ML_Syntax.mlmodule1 = (fun env discName constrName -> (
+
+let uu____6400 = (
+
+let uu____6403 = (FStar_TypeChecker_Env.lookup_lid env.FStar_Extraction_ML_UEnv.tcenv discName)
+in (FStar_All.pipe_left Prims.fst uu____6403))
+in (match (uu____6400) with
+| (uu____6416, fstar_disc_type) -> begin
+(
+
+let wildcards = (
+
+let uu____6424 = (
+
+let uu____6425 = (FStar_Syntax_Subst.compress fstar_disc_type)
+in uu____6425.FStar_Syntax_Syntax.n)
+in (match (uu____6424) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, uu____6434) -> begin
+(
+
+let uu____6445 = (FStar_All.pipe_right binders (FStar_List.filter (fun uu___140_6460 -> (match (uu___140_6460) with
+| (uu____6464, Some (FStar_Syntax_Syntax.Implicit (uu____6465))) -> begin
+true
+end
+| uu____6467 -> begin
+false
+end))))
+in (FStar_All.pipe_right uu____6445 (FStar_List.map (fun uu____6487 -> (
+
+let uu____6491 = (fresh "_")
+in ((uu____6491), (FStar_Extraction_ML_Syntax.MLTY_Top)))))))
+end
+| uu____6496 -> begin
+(failwith "Discriminator must be a function")
+end))
+in (
+
+let mlid = (fresh "_discr_")
+in (
+
+let targ = FStar_Extraction_ML_Syntax.MLTY_Top
+in (
+
+let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top
+in (
+
+let discrBody = (
+
+let uu____6508 = (
+
+let uu____6509 = (
+
+let uu____6515 = (
+
+let uu____6516 = (
+
+let uu____6517 = (
+
+let uu____6525 = (
+
+let uu____6526 = (
+
+let uu____6527 = (
+
+let uu____6528 = (FStar_Extraction_ML_Syntax.idsym mlid)
+in (([]), (uu____6528)))
+in FStar_Extraction_ML_Syntax.MLE_Name (uu____6527))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty targ) uu____6526))
+in (
+
+let uu____6530 = (
+
+let uu____6536 = (
+
+let uu____6541 = (
+
+let uu____6542 = (
+
+let uu____6546 = (FStar_Extraction_ML_Syntax.mlpath_of_lident constrName)
+in ((uu____6546), ((FStar_Extraction_ML_Syntax.MLP_Wild)::[])))
+in FStar_Extraction_ML_Syntax.MLP_CTor (uu____6542))
+in (
+
+let uu____6548 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_bool_ty) (FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_Bool (true))))
+in ((uu____6541), (None), (uu____6548))))
+in (
+
+let uu____6550 = (
+
+let uu____6556 = (
+
+let uu____6561 = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_bool_ty) (FStar_Extraction_ML_Syntax.MLE_Const (FStar_Extraction_ML_Syntax.MLC_Bool (false))))
+in ((FStar_Extraction_ML_Syntax.MLP_Wild), (None), (uu____6561)))
+in (uu____6556)::[])
+in (uu____6536)::uu____6550))
+in ((uu____6525), (uu____6530))))
+in FStar_Extraction_ML_Syntax.MLE_Match (uu____6517))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_bool_ty) uu____6516))
+in (((FStar_List.append wildcards ((((mlid), (targ)))::[]))), (uu____6515)))
+in FStar_Extraction_ML_Syntax.MLE_Fun (uu____6509))
+in (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____6508))
+in (
+
+let uu____6599 = (
+
+let uu____6600 = (
+
+let uu____6602 = (
+
+let uu____6603 = (FStar_Extraction_ML_UEnv.convIdent discName.FStar_Ident.ident)
+in {FStar_Extraction_ML_Syntax.mllb_name = uu____6603; FStar_Extraction_ML_Syntax.mllb_tysc = None; FStar_Extraction_ML_Syntax.mllb_add_unit = false; FStar_Extraction_ML_Syntax.mllb_def = discrBody; FStar_Extraction_ML_Syntax.print_typ = false})
+in (uu____6602)::[])
+in ((FStar_Extraction_ML_Syntax.NonRec), ([]), (uu____6600)))
+in FStar_Extraction_ML_Syntax.MLM_Let (uu____6599)))))))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
@@ -1,542 +1,628 @@
+
 open Prims
+
 type ty_or_exp_b =
-  ((FStar_Extraction_ML_Syntax.mlident* FStar_Extraction_ML_Syntax.mlty),
-    (FStar_Extraction_ML_Syntax.mlsymbol* FStar_Extraction_ML_Syntax.mlexpr*
-      FStar_Extraction_ML_Syntax.mltyscheme* Prims.bool))
-    FStar_Util.either
+((FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty), (FStar_Extraction_ML_Syntax.mlsymbol * FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.mltyscheme * Prims.bool)) FStar_Util.either
+
 type binding =
-  | Bv of (FStar_Syntax_Syntax.bv* ty_or_exp_b)
-  | Fv of (FStar_Syntax_Syntax.fv* ty_or_exp_b)
-let uu___is_Bv: binding -> Prims.bool =
-  fun projectee  -> match projectee with | Bv _0 -> true | uu____25 -> false
-let __proj__Bv__item___0: binding -> (FStar_Syntax_Syntax.bv* ty_or_exp_b) =
-  fun projectee  -> match projectee with | Bv _0 -> _0
-let uu___is_Fv: binding -> Prims.bool =
-  fun projectee  -> match projectee with | Fv _0 -> true | uu____45 -> false
-let __proj__Fv__item___0: binding -> (FStar_Syntax_Syntax.fv* ty_or_exp_b) =
-  fun projectee  -> match projectee with | Fv _0 -> _0
+| Bv of (FStar_Syntax_Syntax.bv * ty_or_exp_b)
+| Fv of (FStar_Syntax_Syntax.fv * ty_or_exp_b)
+
+
+let uu___is_Bv : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Bv (_0) -> begin
+true
+end
+| uu____25 -> begin
+false
+end))
+
+
+let __proj__Bv__item___0 : binding  ->  (FStar_Syntax_Syntax.bv * ty_or_exp_b) = (fun projectee -> (match (projectee) with
+| Bv (_0) -> begin
+_0
+end))
+
+
+let uu___is_Fv : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Fv (_0) -> begin
+true
+end
+| uu____45 -> begin
+false
+end))
+
+
+let __proj__Fv__item___0 : binding  ->  (FStar_Syntax_Syntax.fv * ty_or_exp_b) = (fun projectee -> (match (projectee) with
+| Fv (_0) -> begin
+_0
+end))
+
 type env =
-  {
-  tcenv: FStar_TypeChecker_Env.env;
-  gamma: binding Prims.list;
-  tydefs:
-    (FStar_Extraction_ML_Syntax.mlsymbol Prims.list*
-      FStar_Extraction_ML_Syntax.mltydecl) Prims.list;
-  currentModule: FStar_Extraction_ML_Syntax.mlpath;}
-let debug: env -> (Prims.unit -> Prims.unit) -> Prims.unit =
-  fun g  ->
-    fun f  ->
-      let c = FStar_Extraction_ML_Syntax.string_of_mlpath g.currentModule in
-      let uu____114 =
-        FStar_Options.debug_at_level c (FStar_Options.Other "Extraction") in
-      if uu____114 then f () else ()
-let mkFvvar:
-  FStar_Ident.lident -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.fv =
-  fun l  ->
-    fun t  ->
-      FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None
-let erasedContent: FStar_Extraction_ML_Syntax.mlty =
-  FStar_Extraction_ML_Syntax.ml_unit_ty
-let erasableTypeNoDelta: FStar_Extraction_ML_Syntax.mlty -> Prims.bool =
-  fun t  ->
-    if t = FStar_Extraction_ML_Syntax.ml_unit_ty
-    then true
-    else
-      (match t with
-       | FStar_Extraction_ML_Syntax.MLTY_Named
-           (uu____126,("FStar"::"Ghost"::[],"erased")) -> true
-       | uu____133 -> false)
-let unknownType: FStar_Extraction_ML_Syntax.mlty =
-  FStar_Extraction_ML_Syntax.MLTY_Top
-let prependTick uu____144 =
-  match uu____144 with
-  | (x,n1) ->
-      if FStar_Util.starts_with x "'"
-      then (x, n1)
-      else ((Prims.strcat "'A" x), n1)
-let removeTick uu____162 =
-  match uu____162 with
-  | (x,n1) ->
-      if FStar_Util.starts_with x "'"
-      then
-        let uu____169 = FStar_Util.substring_from x (Prims.parse_int "1") in
-        (uu____169, n1)
-      else (x, n1)
-let convRange: FStar_Range.range -> Prims.int = fun r  -> Prims.parse_int "0"
-let convIdent: FStar_Ident.ident -> (Prims.string* Prims.int) =
-  fun id  -> ((id.FStar_Ident.idText), (Prims.parse_int "0"))
-let bv_as_ml_tyvar: FStar_Syntax_Syntax.bv -> (Prims.string* Prims.int) =
-  fun x  ->
-    let uu____182 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
-    prependTick uu____182
-let bv_as_ml_termvar: FStar_Syntax_Syntax.bv -> (Prims.string* Prims.int) =
-  fun x  ->
-    let uu____190 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
-    removeTick uu____190
-let rec lookup_ty_local:
-  binding Prims.list ->
-    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun gamma  ->
-    fun b  ->
-      match gamma with
-      | (Bv (b',FStar_Util.Inl (mli,mlt)))::tl1 ->
-          if FStar_Syntax_Syntax.bv_eq b b'
-          then mlt
-          else lookup_ty_local tl1 b
-      | (Bv (b',FStar_Util.Inr uu____222))::tl1 ->
-          if FStar_Syntax_Syntax.bv_eq b b'
-          then
-            failwith
-              (Prims.strcat "Type/Expr clash: "
-                 (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-          else lookup_ty_local tl1 b
-      | uu____244::tl1 -> lookup_ty_local tl1 b
-      | [] ->
-          failwith
-            (Prims.strcat "extraction: unbound type var "
-               (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-let tyscheme_of_td uu____264 =
-  match uu____264 with
-  | (uu____271,uu____272,uu____273,vars,body_opt) ->
-      (match body_opt with
-       | Some (FStar_Extraction_ML_Syntax.MLTD_Abbrev t) -> Some (vars, t)
-       | uu____283 -> None)
-let lookup_ty_const:
-  env ->
-    FStar_Extraction_ML_Syntax.mlpath ->
-      FStar_Extraction_ML_Syntax.mltyscheme Prims.option
-  =
-  fun env  ->
-    fun uu____291  ->
-      match uu____291 with
-      | (module_name,ty_name) ->
-          FStar_Util.find_map env.tydefs
-            (fun uu____301  ->
-               match uu____301 with
-               | (m,tds) ->
-                   if module_name = m
-                   then
-                     FStar_Util.find_map tds
-                       (fun td  ->
-                          let uu____313 = td in
-                          match uu____313 with
-                          | (uu____315,n1,uu____317,uu____318,uu____319) ->
-                              if n1 = ty_name
-                              then tyscheme_of_td td
-                              else None)
-                   else None)
-let module_name_of_fv: FStar_Syntax_Syntax.fv -> Prims.string Prims.list =
-  fun fv  ->
-    FStar_All.pipe_right
-      ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ns
-      (FStar_List.map (fun i  -> i.FStar_Ident.idText))
-let maybe_mangle_type_projector:
-  env ->
-    FStar_Syntax_Syntax.fv ->
-      (FStar_Extraction_ML_Syntax.mlsymbol Prims.list*
-        FStar_Extraction_ML_Syntax.mlsymbol) Prims.option
-  =
-  fun env  ->
-    fun fv  ->
-      let mname = module_name_of_fv fv in
-      let ty_name =
-        (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText in
-      FStar_Util.find_map env.tydefs
-        (fun uu____360  ->
-           match uu____360 with
-           | (m,tds) ->
-               FStar_Util.find_map tds
-                 (fun uu____375  ->
-                    match uu____375 with
-                    | (uu____380,n1,mangle_opt,uu____383,uu____384) ->
-                        if m = mname
-                        then
-                          (if n1 = ty_name
-                           then
-                             match mangle_opt with
-                             | None  -> Some (m, n1)
-                             | Some mangled ->
-                                 let modul = m in Some (modul, mangled)
-                           else None)
-                        else None))
-let lookup_tyvar:
-  env -> FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty =
-  fun g  -> fun bt  -> lookup_ty_local g.gamma bt
-let lookup_fv_by_lid: env -> FStar_Ident.lident -> ty_or_exp_b =
-  fun g  ->
-    fun lid  ->
-      let x =
-        FStar_Util.find_map g.gamma
-          (fun uu___104_435  ->
-             match uu___104_435 with
-             | Fv (fv',x) when FStar_Syntax_Syntax.fv_eq_lid fv' lid ->
-                 Some x
-             | uu____439 -> None) in
-      match x with
-      | None  ->
-          let uu____440 =
-            FStar_Util.format1 "free Variable %s not found\n"
-              lid.FStar_Ident.nsstr in
-          failwith uu____440
-      | Some y -> y
-let lookup_fv: env -> FStar_Syntax_Syntax.fv -> ty_or_exp_b =
-  fun g  ->
-    fun fv  ->
-      let x =
-        FStar_Util.find_map g.gamma
-          (fun uu___105_450  ->
-             match uu___105_450 with
-             | Fv (fv',t) when FStar_Syntax_Syntax.fv_eq fv fv' -> Some t
-             | uu____454 -> None) in
-      match x with
-      | None  ->
-          let uu____455 =
-            let uu____456 =
-              FStar_Range.string_of_range
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p in
-            let uu____461 =
-              FStar_Syntax_Print.lid_to_string
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            FStar_Util.format2 "(%s) free Variable %s not found\n" uu____456
-              uu____461 in
-          failwith uu____455
-      | Some y -> y
-let lookup_bv: env -> FStar_Syntax_Syntax.bv -> ty_or_exp_b =
-  fun g  ->
-    fun bv  ->
-      let x =
-        FStar_Util.find_map g.gamma
-          (fun uu___106_475  ->
-             match uu___106_475 with
-             | Bv (bv',r) when FStar_Syntax_Syntax.bv_eq bv bv' -> Some r
-             | uu____479 -> None) in
-      match x with
-      | None  ->
-          let uu____480 =
-            let uu____481 =
-              FStar_Range.string_of_range
-                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange in
-            let uu____482 = FStar_Syntax_Print.bv_to_string bv in
-            FStar_Util.format2 "(%s) bound Variable %s not found\n" uu____481
-              uu____482 in
-          failwith uu____480
-      | Some y -> y
-let lookup:
-  env ->
-    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-      (ty_or_exp_b* FStar_Syntax_Syntax.fv_qual Prims.option)
-  =
-  fun g  ->
-    fun x  ->
-      match x with
-      | FStar_Util.Inl x1 ->
-          let uu____504 = lookup_bv g x1 in (uu____504, None)
-      | FStar_Util.Inr x1 ->
-          let uu____507 = lookup_fv g x1 in
-          (uu____507, (x1.FStar_Syntax_Syntax.fv_qual))
-let lookup_term:
-  env ->
-    FStar_Syntax_Syntax.term ->
-      (ty_or_exp_b* FStar_Syntax_Syntax.fv_qual Prims.option)
-  =
-  fun g  ->
-    fun t  ->
-      match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_name x -> lookup g (FStar_Util.Inl x)
-      | FStar_Syntax_Syntax.Tm_fvar x -> lookup g (FStar_Util.Inr x)
-      | uu____523 -> failwith "Impossible: lookup_term for a non-name"
-let extend_ty:
-  env ->
-    FStar_Syntax_Syntax.bv ->
-      FStar_Extraction_ML_Syntax.mlty Prims.option -> env
-  =
-  fun g  ->
-    fun a  ->
-      fun mapped_to  ->
-        let ml_a = bv_as_ml_tyvar a in
-        let mapped_to1 =
-          match mapped_to with
-          | None  -> FStar_Extraction_ML_Syntax.MLTY_Var ml_a
-          | Some t -> t in
-        let gamma = (Bv (a, (FStar_Util.Inl (ml_a, mapped_to1)))) ::
-          (g.gamma) in
-        let tcenv = FStar_TypeChecker_Env.push_bv g.tcenv a in
-        let uu___108_566 = g in
-        {
-          tcenv;
-          gamma;
-          tydefs = (uu___108_566.tydefs);
-          currentModule = (uu___108_566.currentModule)
-        }
-let find_uniq: binding Prims.list -> Prims.string -> Prims.string =
-  fun gamma  ->
-    fun mlident  ->
-      let rec find_uniq mlident1 i =
-        let suffix =
-          if i = (Prims.parse_int "0")
-          then ""
-          else FStar_Util.string_of_int i in
-        let target_mlident = Prims.strcat mlident1 suffix in
-        let has_collision =
-          FStar_List.existsb
-            (fun uu___107_586  ->
-               match uu___107_586 with
-               | Bv (_,FStar_Util.Inl (mlident',_))|Fv
-                 (_,FStar_Util.Inl (mlident',_)) ->
-                   target_mlident = (Prims.fst mlident')
-               | Fv (_,FStar_Util.Inr (mlident',_,_,_))|Bv
-                 (_,FStar_Util.Inr (mlident',_,_,_)) ->
-                   target_mlident = mlident') gamma in
-        if has_collision
-        then find_uniq mlident1 (i + (Prims.parse_int "1"))
-        else target_mlident in
-      find_uniq mlident (Prims.parse_int "0")
-let extend_bv:
-  env ->
-    FStar_Syntax_Syntax.bv ->
-      FStar_Extraction_ML_Syntax.mltyscheme ->
-        Prims.bool ->
-          Prims.bool ->
-            Prims.bool -> (env* FStar_Extraction_ML_Syntax.mlident)
-  =
-  fun g  ->
-    fun x  ->
-      fun t_x  ->
-        fun add_unit  ->
-          fun is_rec  ->
-            fun mk_unit  ->
-              let ml_ty =
-                match t_x with
-                | ([],t) -> t
-                | uu____683 -> FStar_Extraction_ML_Syntax.MLTY_Top in
-              let uu____684 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
-              match uu____684 with
-              | (mlident,nocluewhat) ->
-                  let mlsymbol = find_uniq g.gamma mlident in
-                  let mlident1 = (mlsymbol, nocluewhat) in
-                  let mlx = FStar_Extraction_ML_Syntax.MLE_Var mlident1 in
-                  let mlx1 =
-                    if mk_unit
-                    then FStar_Extraction_ML_Syntax.ml_unit
-                    else
-                      if add_unit
-                      then
-                        FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top)
-                          (FStar_Extraction_ML_Syntax.MLE_App
-                             ((FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top mlx),
-                               [FStar_Extraction_ML_Syntax.ml_unit]))
-                      else FStar_Extraction_ML_Syntax.with_ty ml_ty mlx in
-                  let gamma =
-                    (Bv (x, (FStar_Util.Inr (mlsymbol, mlx1, t_x, is_rec))))
-                    :: (g.gamma) in
-                  let tcenv =
-                    let uu____715 = FStar_Syntax_Syntax.binders_of_list [x] in
-                    FStar_TypeChecker_Env.push_binders g.tcenv uu____715 in
-                  ((let uu___109_718 = g in
-                    {
-                      tcenv;
-                      gamma;
-                      tydefs = (uu___109_718.tydefs);
-                      currentModule = (uu___109_718.currentModule)
-                    }), mlident1)
-let rec mltyFvars:
-  FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlident Prims.list
-  =
-  fun t  ->
-    match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Var x -> [x]
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,f,t2) ->
-        let uu____729 = mltyFvars t1 in
-        let uu____731 = mltyFvars t2 in FStar_List.append uu____729 uu____731
-    | FStar_Extraction_ML_Syntax.MLTY_Named (args,path) ->
-        FStar_List.collect mltyFvars args
-    | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-        FStar_List.collect mltyFvars ts
-    | FStar_Extraction_ML_Syntax.MLTY_Top  -> []
-let rec subsetMlidents:
-  FStar_Extraction_ML_Syntax.mlident Prims.list ->
-    FStar_Extraction_ML_Syntax.mlident Prims.list -> Prims.bool
-  =
-  fun la  ->
-    fun lb  ->
-      match la with
-      | h::tla -> (FStar_List.contains h lb) && (subsetMlidents tla lb)
-      | [] -> true
-let tySchemeIsClosed: FStar_Extraction_ML_Syntax.mltyscheme -> Prims.bool =
-  fun tys  ->
-    let uu____755 = mltyFvars (Prims.snd tys) in
-    subsetMlidents uu____755 (Prims.fst tys)
-let extend_fv':
-  env ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Extraction_ML_Syntax.mlpath ->
-        FStar_Extraction_ML_Syntax.mltyscheme ->
-          Prims.bool ->
-            Prims.bool -> (env* FStar_Extraction_ML_Syntax.mlident)
-  =
-  fun g  ->
-    fun x  ->
-      fun y  ->
-        fun t_x  ->
-          fun add_unit  ->
-            fun is_rec  ->
-              let uu____779 = tySchemeIsClosed t_x in
-              if uu____779
-              then
-                let ml_ty =
-                  match t_x with
-                  | ([],t) -> t
-                  | uu____785 -> FStar_Extraction_ML_Syntax.MLTY_Top in
-                let uu____786 =
-                  let uu____792 = y in
-                  match uu____792 with
-                  | (ns,i) ->
-                      let mlsymbol =
-                        FStar_Extraction_ML_Syntax.avoid_keyword i in
-                      ((ns, mlsymbol), mlsymbol) in
-                match uu____786 with
-                | (mlpath,mlsymbol) ->
-                    let mly = FStar_Extraction_ML_Syntax.MLE_Name mlpath in
-                    let mly1 =
-                      if add_unit
-                      then
-                        FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top)
-                          (FStar_Extraction_ML_Syntax.MLE_App
-                             ((FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top mly),
-                               [FStar_Extraction_ML_Syntax.ml_unit]))
-                      else FStar_Extraction_ML_Syntax.with_ty ml_ty mly in
-                    let gamma =
-                      (Fv (x, (FStar_Util.Inr (mlsymbol, mly1, t_x, is_rec))))
-                      :: (g.gamma) in
-                    ((let uu___110_839 = g in
-                      {
-                        tcenv = (uu___110_839.tcenv);
-                        gamma;
-                        tydefs = (uu___110_839.tydefs);
-                        currentModule = (uu___110_839.currentModule)
-                      }), (mlsymbol, (Prims.parse_int "0")))
-              else failwith "freevars found"
-let extend_fv:
-  env ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Extraction_ML_Syntax.mltyscheme ->
-        Prims.bool -> Prims.bool -> (env* FStar_Extraction_ML_Syntax.mlident)
-  =
-  fun g  ->
-    fun x  ->
-      fun t_x  ->
-        fun add_unit  ->
-          fun is_rec  ->
-            let mlp =
-              FStar_Extraction_ML_Syntax.mlpath_of_lident
-                (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            extend_fv' g x mlp t_x add_unit is_rec
-let extend_lb:
-  env ->
-    FStar_Syntax_Syntax.lbname ->
-      FStar_Syntax_Syntax.typ ->
-        FStar_Extraction_ML_Syntax.mltyscheme ->
-          Prims.bool ->
-            Prims.bool -> (env* FStar_Extraction_ML_Syntax.mlident)
-  =
-  fun g  ->
-    fun l  ->
-      fun t  ->
-        fun t_x  ->
-          fun add_unit  ->
-            fun is_rec  ->
-              match l with
-              | FStar_Util.Inl x -> extend_bv g x t_x add_unit is_rec false
-              | FStar_Util.Inr f ->
-                  let uu____893 =
-                    FStar_Extraction_ML_Syntax.mlpath_of_lident
-                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  (match uu____893 with
-                   | (p,y) -> extend_fv' g f (p, y) t_x add_unit is_rec)
-let extend_tydef:
-  env -> FStar_Syntax_Syntax.fv -> FStar_Extraction_ML_Syntax.mltydecl -> env
-  =
-  fun g  ->
-    fun fv  ->
-      fun td  ->
-        let m = module_name_of_fv fv in
-        let uu___111_916 = g in
-        {
-          tcenv = (uu___111_916.tcenv);
-          gamma = (uu___111_916.gamma);
-          tydefs = ((m, td) :: (g.tydefs));
-          currentModule = (uu___111_916.currentModule)
-        }
-let emptyMlPath:
-  (FStar_Extraction_ML_Syntax.mlsymbol Prims.list* Prims.string) = ([], "")
-let mkContext: FStar_TypeChecker_Env.env -> env =
-  fun e  ->
-    let env =
-      { tcenv = e; gamma = []; tydefs = []; currentModule = emptyMlPath } in
-    let a = ("'a", (- (Prims.parse_int "1"))) in
-    let failwith_ty =
-      ([a],
-        (FStar_Extraction_ML_Syntax.MLTY_Fun
-           ((FStar_Extraction_ML_Syntax.MLTY_Named
-               ([], (["Prims"], "string"))),
-             FStar_Extraction_ML_Syntax.E_IMPURE,
-             (FStar_Extraction_ML_Syntax.MLTY_Var a)))) in
-    let uu____953 =
-      let uu____956 =
-        let uu____957 =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.failwith_lid
-            FStar_Syntax_Syntax.Delta_constant None in
-        FStar_Util.Inr uu____957 in
-      extend_lb env uu____956 FStar_Syntax_Syntax.tun failwith_ty false false in
-    FStar_All.pipe_right uu____953 Prims.fst
-let monad_op_name:
-  FStar_Syntax_Syntax.eff_decl ->
-    Prims.string -> (FStar_Extraction_ML_Syntax.mlpath* FStar_Ident.lident)
-  =
-  fun ed  ->
-    fun nm  ->
-      let uu____968 =
-        (((ed.FStar_Syntax_Syntax.mname).FStar_Ident.ns),
-          ((ed.FStar_Syntax_Syntax.mname).FStar_Ident.ident)) in
-      match uu____968 with
-      | (module_name,eff_name) ->
-          let mangled_name =
-            Prims.strcat FStar_Ident.reserved_prefix
-              (Prims.strcat eff_name.FStar_Ident.idText (Prims.strcat "_" nm)) in
-          let mangled_lid =
-            FStar_Ident.lid_of_ids
-              (FStar_List.append module_name
-                 [FStar_Ident.id_of_text mangled_name]) in
-          let ml_name =
-            FStar_Extraction_ML_Syntax.mlpath_of_lident mangled_lid in
-          let lid =
-            FStar_All.pipe_right
-              (FStar_List.append
-                 (FStar_Ident.ids_of_lid ed.FStar_Syntax_Syntax.mname)
-                 [FStar_Ident.id_of_text nm]) FStar_Ident.lid_of_ids in
-          (ml_name, lid)
-let action_name:
-  FStar_Syntax_Syntax.eff_decl ->
-    FStar_Syntax_Syntax.action ->
-      (FStar_Extraction_ML_Syntax.mlpath* FStar_Ident.lident)
-  =
-  fun ed  ->
-    fun a  ->
-      monad_op_name ed
-        ((a.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText
-let bind_name:
-  FStar_Syntax_Syntax.eff_decl ->
-    (FStar_Extraction_ML_Syntax.mlpath* FStar_Ident.lident)
-  = fun ed  -> monad_op_name ed "bind"
-let return_name:
-  FStar_Syntax_Syntax.eff_decl ->
-    (FStar_Extraction_ML_Syntax.mlpath* FStar_Ident.lident)
-  = fun ed  -> monad_op_name ed "return"
+{tcenv : FStar_TypeChecker_Env.env; gamma : binding Prims.list; tydefs : (FStar_Extraction_ML_Syntax.mlsymbol Prims.list * FStar_Extraction_ML_Syntax.mltydecl) Prims.list; currentModule : FStar_Extraction_ML_Syntax.mlpath}
+
+
+let debug : env  ->  (Prims.unit  ->  Prims.unit)  ->  Prims.unit = (fun g f -> (
+
+let c = (FStar_Extraction_ML_Syntax.string_of_mlpath g.currentModule)
+in (
+
+let uu____114 = (FStar_Options.debug_at_level c (FStar_Options.Other ("Extraction")))
+in (match (uu____114) with
+| true -> begin
+(f ())
+end
+| uu____115 -> begin
+()
+end))))
+
+
+let mkFvvar : FStar_Ident.lident  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.fv = (fun l t -> (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None))
+
+
+let erasedContent : FStar_Extraction_ML_Syntax.mlty = FStar_Extraction_ML_Syntax.ml_unit_ty
+
+
+let erasableTypeNoDelta : FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun t -> (match ((t = FStar_Extraction_ML_Syntax.ml_unit_ty)) with
+| true -> begin
+true
+end
+| uu____125 -> begin
+(match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Named (uu____126, (("FStar")::("Ghost")::[], "erased")) -> begin
+true
+end
+| uu____133 -> begin
+false
+end)
+end))
+
+
+let unknownType : FStar_Extraction_ML_Syntax.mlty = FStar_Extraction_ML_Syntax.MLTY_Top
+
+
+let prependTick = (fun uu____144 -> (match (uu____144) with
+| (x, n1) -> begin
+(match ((FStar_Util.starts_with x "\'")) with
+| true -> begin
+((x), (n1))
+end
+| uu____151 -> begin
+(((Prims.strcat "\'A" x)), (n1))
+end)
+end))
+
+
+let removeTick = (fun uu____162 -> (match (uu____162) with
+| (x, n1) -> begin
+(match ((FStar_Util.starts_with x "\'")) with
+| true -> begin
+(
+
+let uu____169 = (FStar_Util.substring_from x (Prims.parse_int "1"))
+in ((uu____169), (n1)))
+end
+| uu____170 -> begin
+((x), (n1))
+end)
+end))
+
+
+let convRange : FStar_Range.range  ->  Prims.int = (fun r -> (Prims.parse_int "0"))
+
+
+let convIdent : FStar_Ident.ident  ->  FStar_Extraction_ML_Syntax.mlident = (fun id -> ((id.FStar_Ident.idText), ((Prims.parse_int "0"))))
+
+
+let bv_as_ml_tyvar : FStar_Syntax_Syntax.bv  ->  (Prims.string * Prims.int) = (fun x -> (
+
+let uu____182 = (FStar_Extraction_ML_Syntax.bv_as_mlident x)
+in (prependTick uu____182)))
+
+
+let bv_as_ml_termvar : FStar_Syntax_Syntax.bv  ->  (Prims.string * Prims.int) = (fun x -> (
+
+let uu____190 = (FStar_Extraction_ML_Syntax.bv_as_mlident x)
+in (removeTick uu____190)))
+
+
+let rec lookup_ty_local : binding Prims.list  ->  FStar_Syntax_Syntax.bv  ->  FStar_Extraction_ML_Syntax.mlty = (fun gamma b -> (match (gamma) with
+| (Bv (b', FStar_Util.Inl (mli, mlt)))::tl1 -> begin
+(match ((FStar_Syntax_Syntax.bv_eq b b')) with
+| true -> begin
+mlt
+end
+| uu____220 -> begin
+(lookup_ty_local tl1 b)
+end)
+end
+| (Bv (b', FStar_Util.Inr (uu____222)))::tl1 -> begin
+(match ((FStar_Syntax_Syntax.bv_eq b b')) with
+| true -> begin
+(failwith (Prims.strcat "Type/Expr clash: " b.FStar_Syntax_Syntax.ppname.FStar_Ident.idText))
+end
+| uu____243 -> begin
+(lookup_ty_local tl1 b)
+end)
+end
+| (uu____244)::tl1 -> begin
+(lookup_ty_local tl1 b)
+end
+| [] -> begin
+(failwith (Prims.strcat "extraction: unbound type var " b.FStar_Syntax_Syntax.ppname.FStar_Ident.idText))
+end))
+
+
+let tyscheme_of_td = (fun uu____264 -> (match (uu____264) with
+| (uu____271, uu____272, uu____273, vars, body_opt) -> begin
+(match (body_opt) with
+| Some (FStar_Extraction_ML_Syntax.MLTD_Abbrev (t)) -> begin
+Some (((vars), (t)))
+end
+| uu____283 -> begin
+None
+end)
+end))
+
+
+let lookup_ty_const : env  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mltyscheme Prims.option = (fun env uu____291 -> (match (uu____291) with
+| (module_name, ty_name) -> begin
+(FStar_Util.find_map env.tydefs (fun uu____301 -> (match (uu____301) with
+| (m, tds) -> begin
+(match ((module_name = m)) with
+| true -> begin
+(FStar_Util.find_map tds (fun td -> (
+
+let uu____313 = td
+in (match (uu____313) with
+| (uu____315, n1, uu____317, uu____318, uu____319) -> begin
+(match ((n1 = ty_name)) with
+| true -> begin
+(tyscheme_of_td td)
+end
+| uu____326 -> begin
+None
+end)
+end))))
+end
+| uu____327 -> begin
+None
+end)
+end)))
+end))
+
+
+let module_name_of_fv : FStar_Syntax_Syntax.fv  ->  Prims.string Prims.list = (fun fv -> (FStar_All.pipe_right fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.ns (FStar_List.map (fun i -> i.FStar_Ident.idText))))
+
+
+let maybe_mangle_type_projector : env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Extraction_ML_Syntax.mlpath Prims.option = (fun env fv -> (
+
+let mname = (module_name_of_fv fv)
+in (
+
+let ty_name = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.ident.FStar_Ident.idText
+in (FStar_Util.find_map env.tydefs (fun uu____360 -> (match (uu____360) with
+| (m, tds) -> begin
+(FStar_Util.find_map tds (fun uu____375 -> (match (uu____375) with
+| (uu____380, n1, mangle_opt, uu____383, uu____384) -> begin
+(match ((m = mname)) with
+| true -> begin
+(match ((n1 = ty_name)) with
+| true -> begin
+(match (mangle_opt) with
+| None -> begin
+Some (((m), (n1)))
+end
+| Some (mangled) -> begin
+(
+
+let modul = m
+in Some (((modul), (mangled))))
+end)
+end
+| uu____413 -> begin
+None
+end)
+end
+| uu____417 -> begin
+None
+end)
+end)))
+end))))))
+
+
+let lookup_tyvar : env  ->  FStar_Syntax_Syntax.bv  ->  FStar_Extraction_ML_Syntax.mlty = (fun g bt -> (lookup_ty_local g.gamma bt))
+
+
+let lookup_fv_by_lid : env  ->  FStar_Ident.lident  ->  ty_or_exp_b = (fun g lid -> (
+
+let x = (FStar_Util.find_map g.gamma (fun uu___102_435 -> (match (uu___102_435) with
+| Fv (fv', x) when (FStar_Syntax_Syntax.fv_eq_lid fv' lid) -> begin
+Some (x)
+end
+| uu____439 -> begin
+None
+end)))
+in (match (x) with
+| None -> begin
+(
+
+let uu____440 = (FStar_Util.format1 "free Variable %s not found\n" lid.FStar_Ident.nsstr)
+in (failwith uu____440))
+end
+| Some (y) -> begin
+y
+end)))
+
+
+let lookup_fv : env  ->  FStar_Syntax_Syntax.fv  ->  ty_or_exp_b = (fun g fv -> (
+
+let x = (FStar_Util.find_map g.gamma (fun uu___103_450 -> (match (uu___103_450) with
+| Fv (fv', t) when (FStar_Syntax_Syntax.fv_eq fv fv') -> begin
+Some (t)
+end
+| uu____454 -> begin
+None
+end)))
+in (match (x) with
+| None -> begin
+(
+
+let uu____455 = (
+
+let uu____456 = (FStar_Range.string_of_range fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.p)
+in (
+
+let uu____461 = (FStar_Syntax_Print.lid_to_string fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_Util.format2 "(%s) free Variable %s not found\n" uu____456 uu____461)))
+in (failwith uu____455))
+end
+| Some (y) -> begin
+y
+end)))
+
+
+let lookup_bv : env  ->  FStar_Syntax_Syntax.bv  ->  ty_or_exp_b = (fun g bv -> (
+
+let x = (FStar_Util.find_map g.gamma (fun uu___104_475 -> (match (uu___104_475) with
+| Bv (bv', r) when (FStar_Syntax_Syntax.bv_eq bv bv') -> begin
+Some (r)
+end
+| uu____479 -> begin
+None
+end)))
+in (match (x) with
+| None -> begin
+(
+
+let uu____480 = (
+
+let uu____481 = (FStar_Range.string_of_range bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idRange)
+in (
+
+let uu____482 = (FStar_Syntax_Print.bv_to_string bv)
+in (FStar_Util.format2 "(%s) bound Variable %s not found\n" uu____481 uu____482)))
+in (failwith uu____480))
+end
+| Some (y) -> begin
+y
+end)))
+
+
+let lookup : env  ->  (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either  ->  (ty_or_exp_b * FStar_Syntax_Syntax.fv_qual Prims.option) = (fun g x -> (match (x) with
+| FStar_Util.Inl (x1) -> begin
+(
+
+let uu____504 = (lookup_bv g x1)
+in ((uu____504), (None)))
+end
+| FStar_Util.Inr (x1) -> begin
+(
+
+let uu____507 = (lookup_fv g x1)
+in ((uu____507), (x1.FStar_Syntax_Syntax.fv_qual)))
+end))
+
+
+let lookup_term : env  ->  FStar_Syntax_Syntax.term  ->  (ty_or_exp_b * FStar_Syntax_Syntax.fv_qual Prims.option) = (fun g t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+(lookup g (FStar_Util.Inl (x)))
+end
+| FStar_Syntax_Syntax.Tm_fvar (x) -> begin
+(lookup g (FStar_Util.Inr (x)))
+end
+| uu____523 -> begin
+(failwith "Impossible: lookup_term for a non-name")
+end))
+
+
+let extend_ty : env  ->  FStar_Syntax_Syntax.bv  ->  FStar_Extraction_ML_Syntax.mlty Prims.option  ->  env = (fun g a mapped_to -> (
+
+let ml_a = (bv_as_ml_tyvar a)
+in (
+
+let mapped_to1 = (match (mapped_to) with
+| None -> begin
+FStar_Extraction_ML_Syntax.MLTY_Var (ml_a)
+end
+| Some (t) -> begin
+t
+end)
+in (
+
+let gamma = (Bv (((a), (FStar_Util.Inl (((ml_a), (mapped_to1)))))))::g.gamma
+in (
+
+let tcenv = (FStar_TypeChecker_Env.push_bv g.tcenv a)
+in (
+
+let uu___106_566 = g
+in {tcenv = tcenv; gamma = gamma; tydefs = uu___106_566.tydefs; currentModule = uu___106_566.currentModule}))))))
+
+
+let find_uniq : binding Prims.list  ->  Prims.string  ->  Prims.string = (fun gamma mlident -> (
+
+let rec find_uniq = (fun mlident1 i -> (
+
+let suffix = (match ((i = (Prims.parse_int "0"))) with
+| true -> begin
+""
+end
+| uu____583 -> begin
+(FStar_Util.string_of_int i)
+end)
+in (
+
+let target_mlident = (Prims.strcat mlident1 suffix)
+in (
+
+let has_collision = (FStar_List.existsb (fun uu___105_586 -> (match (uu___105_586) with
+| (Bv (_, FStar_Util.Inl (mlident', _))) | (Fv (_, FStar_Util.Inl (mlident', _))) -> begin
+(target_mlident = (Prims.fst mlident'))
+end
+| (Fv (_, FStar_Util.Inr (mlident', _, _, _))) | (Bv (_, FStar_Util.Inr (mlident', _, _, _))) -> begin
+(target_mlident = mlident')
+end)) gamma)
+in (match (has_collision) with
+| true -> begin
+(find_uniq mlident1 (i + (Prims.parse_int "1")))
+end
+| uu____657 -> begin
+target_mlident
+end)))))
+in (find_uniq mlident (Prims.parse_int "0"))))
+
+
+let extend_bv : env  ->  FStar_Syntax_Syntax.bv  ->  FStar_Extraction_ML_Syntax.mltyscheme  ->  Prims.bool  ->  Prims.bool  ->  Prims.bool  ->  (env * FStar_Extraction_ML_Syntax.mlident) = (fun g x t_x add_unit is_rec mk_unit -> (
+
+let ml_ty = (match (t_x) with
+| ([], t) -> begin
+t
+end
+| uu____683 -> begin
+FStar_Extraction_ML_Syntax.MLTY_Top
+end)
+in (
+
+let uu____684 = (FStar_Extraction_ML_Syntax.bv_as_mlident x)
+in (match (uu____684) with
+| (mlident, nocluewhat) -> begin
+(
+
+let mlsymbol = (find_uniq g.gamma mlident)
+in (
+
+let mlident1 = ((mlsymbol), (nocluewhat))
+in (
+
+let mlx = FStar_Extraction_ML_Syntax.MLE_Var (mlident1)
+in (
+
+let mlx1 = (match (mk_unit) with
+| true -> begin
+FStar_Extraction_ML_Syntax.ml_unit
+end
+| uu____695 -> begin
+(match (add_unit) with
+| true -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) (FStar_Extraction_ML_Syntax.MLE_App ((((FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top mlx)), ((FStar_Extraction_ML_Syntax.ml_unit)::[])))))
+end
+| uu____697 -> begin
+(FStar_Extraction_ML_Syntax.with_ty ml_ty mlx)
+end)
+end)
+in (
+
+let gamma = (Bv (((x), (FStar_Util.Inr (((mlsymbol), (mlx1), (t_x), (is_rec)))))))::g.gamma
+in (
+
+let tcenv = (
+
+let uu____715 = (FStar_Syntax_Syntax.binders_of_list ((x)::[]))
+in (FStar_TypeChecker_Env.push_binders g.tcenv uu____715))
+in (((
+
+let uu___107_718 = g
+in {tcenv = tcenv; gamma = gamma; tydefs = uu___107_718.tydefs; currentModule = uu___107_718.currentModule})), (mlident1))))))))
+end))))
+
+
+let rec mltyFvars : FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlident Prims.list = (fun t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Var (x) -> begin
+(x)::[]
+end
+| FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2) -> begin
+(
+
+let uu____729 = (mltyFvars t1)
+in (
+
+let uu____731 = (mltyFvars t2)
+in (FStar_List.append uu____729 uu____731)))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, path) -> begin
+(FStar_List.collect mltyFvars args)
+end
+| FStar_Extraction_ML_Syntax.MLTY_Tuple (ts) -> begin
+(FStar_List.collect mltyFvars ts)
+end
+| FStar_Extraction_ML_Syntax.MLTY_Top -> begin
+[]
+end))
+
+
+let rec subsetMlidents : FStar_Extraction_ML_Syntax.mlident Prims.list  ->  FStar_Extraction_ML_Syntax.mlident Prims.list  ->  Prims.bool = (fun la lb -> (match (la) with
+| (h)::tla -> begin
+((FStar_List.contains h lb) && (subsetMlidents tla lb))
+end
+| [] -> begin
+true
+end))
+
+
+let tySchemeIsClosed : FStar_Extraction_ML_Syntax.mltyscheme  ->  Prims.bool = (fun tys -> (
+
+let uu____755 = (mltyFvars (Prims.snd tys))
+in (subsetMlidents uu____755 (Prims.fst tys))))
+
+
+let extend_fv' : env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Extraction_ML_Syntax.mlpath  ->  FStar_Extraction_ML_Syntax.mltyscheme  ->  Prims.bool  ->  Prims.bool  ->  (env * FStar_Extraction_ML_Syntax.mlident) = (fun g x y t_x add_unit is_rec -> (
+
+let uu____779 = (tySchemeIsClosed t_x)
+in (match (uu____779) with
+| true -> begin
+(
+
+let ml_ty = (match (t_x) with
+| ([], t) -> begin
+t
+end
+| uu____785 -> begin
+FStar_Extraction_ML_Syntax.MLTY_Top
+end)
+in (
+
+let uu____786 = (
+
+let uu____792 = y
+in (match (uu____792) with
+| (ns, i) -> begin
+(
+
+let mlsymbol = (FStar_Extraction_ML_Syntax.avoid_keyword i)
+in ((((ns), (mlsymbol))), (mlsymbol)))
+end))
+in (match (uu____786) with
+| (mlpath, mlsymbol) -> begin
+(
+
+let mly = FStar_Extraction_ML_Syntax.MLE_Name (mlpath)
+in (
+
+let mly1 = (match (add_unit) with
+| true -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) (FStar_Extraction_ML_Syntax.MLE_App ((((FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top mly)), ((FStar_Extraction_ML_Syntax.ml_unit)::[])))))
+end
+| uu____820 -> begin
+(FStar_Extraction_ML_Syntax.with_ty ml_ty mly)
+end)
+in (
+
+let gamma = (Fv (((x), (FStar_Util.Inr (((mlsymbol), (mly1), (t_x), (is_rec)))))))::g.gamma
+in (((
+
+let uu___108_839 = g
+in {tcenv = uu___108_839.tcenv; gamma = gamma; tydefs = uu___108_839.tydefs; currentModule = uu___108_839.currentModule})), (((mlsymbol), ((Prims.parse_int "0"))))))))
+end)))
+end
+| uu____840 -> begin
+(failwith "freevars found")
+end)))
+
+
+let extend_fv : env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Extraction_ML_Syntax.mltyscheme  ->  Prims.bool  ->  Prims.bool  ->  (env * FStar_Extraction_ML_Syntax.mlident) = (fun g x t_x add_unit is_rec -> (
+
+let mlp = (FStar_Extraction_ML_Syntax.mlpath_of_lident x.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (extend_fv' g x mlp t_x add_unit is_rec)))
+
+
+let extend_lb : env  ->  FStar_Syntax_Syntax.lbname  ->  FStar_Syntax_Syntax.typ  ->  FStar_Extraction_ML_Syntax.mltyscheme  ->  Prims.bool  ->  Prims.bool  ->  (env * FStar_Extraction_ML_Syntax.mlident) = (fun g l t t_x add_unit is_rec -> (match (l) with
+| FStar_Util.Inl (x) -> begin
+(extend_bv g x t_x add_unit is_rec false)
+end
+| FStar_Util.Inr (f) -> begin
+(
+
+let uu____893 = (FStar_Extraction_ML_Syntax.mlpath_of_lident f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____893) with
+| (p, y) -> begin
+(extend_fv' g f ((p), (y)) t_x add_unit is_rec)
+end))
+end))
+
+
+let extend_tydef : env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Extraction_ML_Syntax.mltydecl  ->  env = (fun g fv td -> (
+
+let m = (module_name_of_fv fv)
+in (
+
+let uu___109_916 = g
+in {tcenv = uu___109_916.tcenv; gamma = uu___109_916.gamma; tydefs = (((m), (td)))::g.tydefs; currentModule = uu___109_916.currentModule})))
+
+
+let emptyMlPath : (FStar_Extraction_ML_Syntax.mlsymbol Prims.list * Prims.string) = (([]), (""))
+
+
+let mkContext : FStar_TypeChecker_Env.env  ->  env = (fun e -> (
+
+let env = {tcenv = e; gamma = []; tydefs = []; currentModule = emptyMlPath}
+in (
+
+let a = (("\'a"), ((~- ((Prims.parse_int "1")))))
+in (
+
+let failwith_ty = (((a)::[]), (FStar_Extraction_ML_Syntax.MLTY_Fun (((FStar_Extraction_ML_Syntax.MLTY_Named ((([]), (((("Prims")::[]), ("string")))))), (FStar_Extraction_ML_Syntax.E_IMPURE), (FStar_Extraction_ML_Syntax.MLTY_Var (a))))))
+in (
+
+let uu____953 = (
+
+let uu____956 = (
+
+let uu____957 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.failwith_lid FStar_Syntax_Syntax.Delta_constant None)
+in FStar_Util.Inr (uu____957))
+in (extend_lb env uu____956 FStar_Syntax_Syntax.tun failwith_ty false false))
+in (FStar_All.pipe_right uu____953 Prims.fst))))))
+
+
+let monad_op_name : FStar_Syntax_Syntax.eff_decl  ->  Prims.string  ->  (FStar_Extraction_ML_Syntax.mlpath * FStar_Ident.lident) = (fun ed nm -> (
+
+let uu____968 = ((ed.FStar_Syntax_Syntax.mname.FStar_Ident.ns), (ed.FStar_Syntax_Syntax.mname.FStar_Ident.ident))
+in (match (uu____968) with
+| (module_name, eff_name) -> begin
+(
+
+let mangled_name = (Prims.strcat FStar_Ident.reserved_prefix (Prims.strcat eff_name.FStar_Ident.idText (Prims.strcat "_" nm)))
+in (
+
+let mangled_lid = (FStar_Ident.lid_of_ids (FStar_List.append module_name (((FStar_Ident.id_of_text mangled_name))::[])))
+in (
+
+let ml_name = (FStar_Extraction_ML_Syntax.mlpath_of_lident mangled_lid)
+in (
+
+let lid = (FStar_All.pipe_right (FStar_List.append (FStar_Ident.ids_of_lid ed.FStar_Syntax_Syntax.mname) (((FStar_Ident.id_of_text nm))::[])) FStar_Ident.lid_of_ids)
+in ((ml_name), (lid))))))
+end)))
+
+
+let action_name : FStar_Syntax_Syntax.eff_decl  ->  FStar_Syntax_Syntax.action  ->  (FStar_Extraction_ML_Syntax.mlpath * FStar_Ident.lident) = (fun ed a -> (monad_op_name ed a.FStar_Syntax_Syntax.action_name.FStar_Ident.ident.FStar_Ident.idText))
+
+
+let bind_name : FStar_Syntax_Syntax.eff_decl  ->  (FStar_Extraction_ML_Syntax.mlpath * FStar_Ident.lident) = (fun ed -> (monad_op_name ed "bind"))
+
+
+let return_name : FStar_Syntax_Syntax.eff_decl  ->  (FStar_Extraction_ML_Syntax.mlpath * FStar_Ident.lident) = (fun ed -> (monad_op_name ed "return"))
+
+
+
+

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -1,517 +1,726 @@
+
 open Prims
-let pruneNones l =
-  FStar_List.fold_right
-    (fun x  -> fun ll  -> match x with | Some xs -> xs :: ll | None  -> ll) l
-    []
-let mlconst_of_const:
-  FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant =
-  fun sctt  ->
-    match sctt with
-    | FStar_Const.Const_range _|FStar_Const.Const_effect  ->
-        failwith "Unsupported constant"
-    | FStar_Const.Const_unit  -> FStar_Extraction_ML_Syntax.MLC_Unit
-    | FStar_Const.Const_char c -> FStar_Extraction_ML_Syntax.MLC_Char c
-    | FStar_Const.Const_int (s,i) ->
-        FStar_Extraction_ML_Syntax.MLC_Int (s, i)
-    | FStar_Const.Const_bool b -> FStar_Extraction_ML_Syntax.MLC_Bool b
-    | FStar_Const.Const_float d -> FStar_Extraction_ML_Syntax.MLC_Float d
-    | FStar_Const.Const_bytearray (bytes,uu____40) ->
-        FStar_Extraction_ML_Syntax.MLC_Bytes bytes
-    | FStar_Const.Const_string (bytes,uu____44) ->
-        FStar_Extraction_ML_Syntax.MLC_String
-          (FStar_Util.string_of_unicode bytes)
-    | FStar_Const.Const_reify |FStar_Const.Const_reflect _ ->
-        failwith "Unhandled constant: reify/reflect"
-let mlconst_of_const':
-  FStar_Range.range ->
-    FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant
-  =
-  fun p  ->
-    fun c  ->
-      try mlconst_of_const c
-      with
-      | uu____56 ->
-          let uu____57 =
-            let uu____58 = FStar_Range.string_of_range p in
-            let uu____59 = FStar_Syntax_Print.const_to_string c in
-            FStar_Util.format2 "(%s) Failed to translate constant %s "
-              uu____58 uu____59 in
-          failwith uu____57
-let rec subst_aux:
-  (FStar_Extraction_ML_Syntax.mlident* FStar_Extraction_ML_Syntax.mlty)
-    Prims.list ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun subst1  ->
-    fun t  ->
-      match t with
-      | FStar_Extraction_ML_Syntax.MLTY_Var x ->
-          let uu____73 =
-            FStar_Util.find_opt
-              (fun uu____79  -> match uu____79 with | (y,uu____83) -> y = x)
-              subst1 in
-          (match uu____73 with | Some ts -> Prims.snd ts | None  -> t)
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,f,t2) ->
-          let uu____94 =
-            let uu____98 = subst_aux subst1 t1 in
-            let uu____99 = subst_aux subst1 t2 in (uu____98, f, uu____99) in
-          FStar_Extraction_ML_Syntax.MLTY_Fun uu____94
-      | FStar_Extraction_ML_Syntax.MLTY_Named (args,path) ->
-          let uu____104 =
-            let uu____108 = FStar_List.map (subst_aux subst1) args in
-            (uu____108, path) in
-          FStar_Extraction_ML_Syntax.MLTY_Named uu____104
-      | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____113 = FStar_List.map (subst_aux subst1) ts in
-          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____113
-      | FStar_Extraction_ML_Syntax.MLTY_Top  ->
-          FStar_Extraction_ML_Syntax.MLTY_Top
-let subst:
-  FStar_Extraction_ML_Syntax.mltyscheme ->
-    FStar_Extraction_ML_Syntax.mlty Prims.list ->
-      FStar_Extraction_ML_Syntax.mlty
-  =
-  fun uu____120  ->
-    fun args  ->
-      match uu____120 with
-      | (formals,t) ->
-          if (FStar_List.length formals) <> (FStar_List.length args)
-          then
-            failwith
-              "Substitution must be fully applied (see GitHub issue #490)"
-          else
-            (let uu____130 = FStar_List.zip formals args in
-             subst_aux uu____130 t)
-let udelta_unfold:
-  FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty Prims.option
-  =
-  fun g  ->
-    fun uu___112_140  ->
-      match uu___112_140 with
-      | FStar_Extraction_ML_Syntax.MLTY_Named (args,n1) ->
-          let uu____146 = FStar_Extraction_ML_UEnv.lookup_ty_const g n1 in
-          (match uu____146 with
-           | Some ts -> let uu____150 = subst ts args in Some uu____150
-           | uu____151 -> None)
-      | uu____153 -> None
-let eff_leq:
-  FStar_Extraction_ML_Syntax.e_tag ->
-    FStar_Extraction_ML_Syntax.e_tag -> Prims.bool
-  =
-  fun f  ->
-    fun f'  ->
-      match (f, f') with
-      | (FStar_Extraction_ML_Syntax.E_PURE ,uu____160) -> true
-      | (FStar_Extraction_ML_Syntax.E_GHOST
-         ,FStar_Extraction_ML_Syntax.E_GHOST ) -> true
-      | (FStar_Extraction_ML_Syntax.E_IMPURE
-         ,FStar_Extraction_ML_Syntax.E_IMPURE ) -> true
-      | uu____161 -> false
-let eff_to_string: FStar_Extraction_ML_Syntax.e_tag -> Prims.string =
-  fun uu___113_166  ->
-    match uu___113_166 with
-    | FStar_Extraction_ML_Syntax.E_PURE  -> "Pure"
-    | FStar_Extraction_ML_Syntax.E_GHOST  -> "Ghost"
-    | FStar_Extraction_ML_Syntax.E_IMPURE  -> "Impure"
-let join:
-  FStar_Range.range ->
-    FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.e_tag -> FStar_Extraction_ML_Syntax.e_tag
-  =
-  fun r  ->
-    fun f  ->
-      fun f'  ->
-        match (f, f') with
-        | (FStar_Extraction_ML_Syntax.E_IMPURE
-           ,FStar_Extraction_ML_Syntax.E_PURE )
-          |(FStar_Extraction_ML_Syntax.E_PURE
-            ,FStar_Extraction_ML_Syntax.E_IMPURE )
-           |(FStar_Extraction_ML_Syntax.E_IMPURE
-             ,FStar_Extraction_ML_Syntax.E_IMPURE )
-            -> FStar_Extraction_ML_Syntax.E_IMPURE
-        | (FStar_Extraction_ML_Syntax.E_GHOST
-           ,FStar_Extraction_ML_Syntax.E_GHOST ) ->
-            FStar_Extraction_ML_Syntax.E_GHOST
-        | (FStar_Extraction_ML_Syntax.E_PURE
-           ,FStar_Extraction_ML_Syntax.E_GHOST ) ->
-            FStar_Extraction_ML_Syntax.E_GHOST
-        | (FStar_Extraction_ML_Syntax.E_GHOST
-           ,FStar_Extraction_ML_Syntax.E_PURE ) ->
-            FStar_Extraction_ML_Syntax.E_GHOST
-        | (FStar_Extraction_ML_Syntax.E_PURE
-           ,FStar_Extraction_ML_Syntax.E_PURE ) ->
-            FStar_Extraction_ML_Syntax.E_PURE
-        | uu____176 ->
-            let uu____179 =
-              let uu____180 = FStar_Range.string_of_range r in
-              FStar_Util.format3
-                "Impossible (%s): Inconsistent effects %s and %s" uu____180
-                (eff_to_string f) (eff_to_string f') in
-            failwith uu____179
-let join_l:
-  FStar_Range.range ->
-    FStar_Extraction_ML_Syntax.e_tag Prims.list ->
-      FStar_Extraction_ML_Syntax.e_tag
-  =
-  fun r  ->
-    fun fs  ->
-      FStar_List.fold_left (join r) FStar_Extraction_ML_Syntax.E_PURE fs
-let mk_ty_fun uu____200 =
-  FStar_List.fold_right
-    (fun uu____203  ->
-       fun t  ->
-         match uu____203 with
-         | (uu____207,t0) ->
-             FStar_Extraction_ML_Syntax.MLTY_Fun
-               (t0, FStar_Extraction_ML_Syntax.E_PURE, t))
+
+let pruneNones = (fun l -> (FStar_List.fold_right (fun x ll -> (match (x) with
+| Some (xs) -> begin
+(xs)::ll
+end
+| None -> begin
+ll
+end)) l []))
+
+
+let mlconst_of_const : FStar_Const.sconst  ->  FStar_Extraction_ML_Syntax.mlconstant = (fun sctt -> (match (sctt) with
+| (FStar_Const.Const_range (_)) | (FStar_Const.Const_effect) -> begin
+(failwith "Unsupported constant")
+end
+| FStar_Const.Const_unit -> begin
+FStar_Extraction_ML_Syntax.MLC_Unit
+end
+| FStar_Const.Const_char (c) -> begin
+FStar_Extraction_ML_Syntax.MLC_Char (c)
+end
+| FStar_Const.Const_int (s, i) -> begin
+FStar_Extraction_ML_Syntax.MLC_Int (((s), (i)))
+end
+| FStar_Const.Const_bool (b) -> begin
+FStar_Extraction_ML_Syntax.MLC_Bool (b)
+end
+| FStar_Const.Const_float (d) -> begin
+FStar_Extraction_ML_Syntax.MLC_Float (d)
+end
+| FStar_Const.Const_bytearray (bytes, uu____40) -> begin
+FStar_Extraction_ML_Syntax.MLC_Bytes (bytes)
+end
+| FStar_Const.Const_string (bytes, uu____44) -> begin
+FStar_Extraction_ML_Syntax.MLC_String ((FStar_Util.string_of_unicode bytes))
+end
+| (FStar_Const.Const_reify) | (FStar_Const.Const_reflect (_)) -> begin
+(failwith "Unhandled constant: reify/reflect")
+end))
+
+
+let mlconst_of_const' : FStar_Range.range  ->  FStar_Const.sconst  ->  FStar_Extraction_ML_Syntax.mlconstant = (fun p c -> try
+(match (()) with
+| () -> begin
+(mlconst_of_const c)
+end)
+with
+| uu____56 -> begin
+(
+
+let uu____57 = (
+
+let uu____58 = (FStar_Range.string_of_range p)
+in (
+
+let uu____59 = (FStar_Syntax_Print.const_to_string c)
+in (FStar_Util.format2 "(%s) Failed to translate constant %s " uu____58 uu____59)))
+in (failwith uu____57))
+end)
+
+
+let rec subst_aux : (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty) Prims.list  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty = (fun subst1 t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Var (x) -> begin
+(
+
+let uu____73 = (FStar_Util.find_opt (fun uu____79 -> (match (uu____79) with
+| (y, uu____83) -> begin
+(y = x)
+end)) subst1)
+in (match (uu____73) with
+| Some (ts) -> begin
+(Prims.snd ts)
+end
+| None -> begin
+t
+end))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2) -> begin
+(
+
+let uu____94 = (
+
+let uu____98 = (subst_aux subst1 t1)
+in (
+
+let uu____99 = (subst_aux subst1 t2)
+in ((uu____98), (f), (uu____99))))
+in FStar_Extraction_ML_Syntax.MLTY_Fun (uu____94))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, path) -> begin
+(
+
+let uu____104 = (
+
+let uu____108 = (FStar_List.map (subst_aux subst1) args)
+in ((uu____108), (path)))
+in FStar_Extraction_ML_Syntax.MLTY_Named (uu____104))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Tuple (ts) -> begin
+(
+
+let uu____113 = (FStar_List.map (subst_aux subst1) ts)
+in FStar_Extraction_ML_Syntax.MLTY_Tuple (uu____113))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Top -> begin
+FStar_Extraction_ML_Syntax.MLTY_Top
+end))
+
+
+let subst : FStar_Extraction_ML_Syntax.mltyscheme  ->  FStar_Extraction_ML_Syntax.mlty Prims.list  ->  FStar_Extraction_ML_Syntax.mlty = (fun uu____120 args -> (match (uu____120) with
+| (formals, t) -> begin
+(match (((FStar_List.length formals) <> (FStar_List.length args))) with
+| true -> begin
+(failwith "Substitution must be fully applied (see GitHub issue #490)")
+end
+| uu____129 -> begin
+(
+
+let uu____130 = (FStar_List.zip formals args)
+in (subst_aux uu____130 t))
+end)
+end))
+
+
+let udelta_unfold : FStar_Extraction_ML_UEnv.env  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty Prims.option = (fun g uu___110_140 -> (match (uu___110_140) with
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, n1) -> begin
+(
+
+let uu____146 = (FStar_Extraction_ML_UEnv.lookup_ty_const g n1)
+in (match (uu____146) with
+| Some (ts) -> begin
+(
+
+let uu____150 = (subst ts args)
+in Some (uu____150))
+end
+| uu____151 -> begin
+None
+end))
+end
+| uu____153 -> begin
+None
+end))
+
+
+let eff_leq : FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.e_tag  ->  Prims.bool = (fun f f' -> (match (((f), (f'))) with
+| (FStar_Extraction_ML_Syntax.E_PURE, uu____160) -> begin
+true
+end
+| (FStar_Extraction_ML_Syntax.E_GHOST, FStar_Extraction_ML_Syntax.E_GHOST) -> begin
+true
+end
+| (FStar_Extraction_ML_Syntax.E_IMPURE, FStar_Extraction_ML_Syntax.E_IMPURE) -> begin
+true
+end
+| uu____161 -> begin
+false
+end))
+
+
+let eff_to_string : FStar_Extraction_ML_Syntax.e_tag  ->  Prims.string = (fun uu___111_166 -> (match (uu___111_166) with
+| FStar_Extraction_ML_Syntax.E_PURE -> begin
+"Pure"
+end
+| FStar_Extraction_ML_Syntax.E_GHOST -> begin
+"Ghost"
+end
+| FStar_Extraction_ML_Syntax.E_IMPURE -> begin
+"Impure"
+end))
+
+
+let join : FStar_Range.range  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.e_tag  ->  FStar_Extraction_ML_Syntax.e_tag = (fun r f f' -> (match (((f), (f'))) with
+| ((FStar_Extraction_ML_Syntax.E_IMPURE, FStar_Extraction_ML_Syntax.E_PURE)) | ((FStar_Extraction_ML_Syntax.E_PURE, FStar_Extraction_ML_Syntax.E_IMPURE)) | ((FStar_Extraction_ML_Syntax.E_IMPURE, FStar_Extraction_ML_Syntax.E_IMPURE)) -> begin
+FStar_Extraction_ML_Syntax.E_IMPURE
+end
+| (FStar_Extraction_ML_Syntax.E_GHOST, FStar_Extraction_ML_Syntax.E_GHOST) -> begin
+FStar_Extraction_ML_Syntax.E_GHOST
+end
+| (FStar_Extraction_ML_Syntax.E_PURE, FStar_Extraction_ML_Syntax.E_GHOST) -> begin
+FStar_Extraction_ML_Syntax.E_GHOST
+end
+| (FStar_Extraction_ML_Syntax.E_GHOST, FStar_Extraction_ML_Syntax.E_PURE) -> begin
+FStar_Extraction_ML_Syntax.E_GHOST
+end
+| (FStar_Extraction_ML_Syntax.E_PURE, FStar_Extraction_ML_Syntax.E_PURE) -> begin
+FStar_Extraction_ML_Syntax.E_PURE
+end
+| uu____176 -> begin
+(
+
+let uu____179 = (
+
+let uu____180 = (FStar_Range.string_of_range r)
+in (FStar_Util.format3 "Impossible (%s): Inconsistent effects %s and %s" uu____180 (eff_to_string f) (eff_to_string f')))
+in (failwith uu____179))
+end))
+
+
+let join_l : FStar_Range.range  ->  FStar_Extraction_ML_Syntax.e_tag Prims.list  ->  FStar_Extraction_ML_Syntax.e_tag = (fun r fs -> (FStar_List.fold_left (join r) FStar_Extraction_ML_Syntax.E_PURE fs))
+
+
+let mk_ty_fun = (fun uu____200 -> (FStar_List.fold_right (fun uu____203 t -> (match (uu____203) with
+| (uu____207, t0) -> begin
+FStar_Extraction_ML_Syntax.MLTY_Fun (((t0), (FStar_Extraction_ML_Syntax.E_PURE), (t)))
+end))))
+
+
 type unfold_t =
-  FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlty Prims.option
-let rec type_leq_c:
-  unfold_t ->
-    FStar_Extraction_ML_Syntax.mlexpr Prims.option ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.mlty ->
-          (Prims.bool* FStar_Extraction_ML_Syntax.mlexpr Prims.option)
-  =
-  fun unfold_ty  ->
-    fun e  ->
-      fun t  ->
-        fun t'  ->
-          match (t, t') with
-          | (FStar_Extraction_ML_Syntax.MLTY_Var
-             x,FStar_Extraction_ML_Syntax.MLTY_Var y) ->
-              if (Prims.fst x) = (Prims.fst y)
-              then (true, e)
-              else (false, None)
-          | (FStar_Extraction_ML_Syntax.MLTY_Fun
-             (t1,f,t2),FStar_Extraction_ML_Syntax.MLTY_Fun (t1',f',t2')) ->
-              let mk_fun xs body =
-                match xs with
-                | [] -> body
-                | uu____275 ->
-                    let e1 =
-                      match body.FStar_Extraction_ML_Syntax.expr with
-                      | FStar_Extraction_ML_Syntax.MLE_Fun (ys,body1) ->
-                          FStar_Extraction_ML_Syntax.MLE_Fun
-                            ((FStar_List.append xs ys), body1)
-                      | uu____293 ->
-                          FStar_Extraction_ML_Syntax.MLE_Fun (xs, body) in
-                    let uu____297 =
-                      (mk_ty_fun ()) xs body.FStar_Extraction_ML_Syntax.mlty in
-                    FStar_Extraction_ML_Syntax.with_ty uu____297 e1 in
-              (match e with
-               | Some
-                   {
-                     FStar_Extraction_ML_Syntax.expr =
-                       FStar_Extraction_ML_Syntax.MLE_Fun (x::xs,body);
-                     FStar_Extraction_ML_Syntax.mlty = uu____304;
-                     FStar_Extraction_ML_Syntax.loc = uu____305;_}
-                   ->
-                   let uu____316 =
-                     (type_leq unfold_ty t1' t1) && (eff_leq f f') in
-                   if uu____316
-                   then
-                     (if
-                        (f = FStar_Extraction_ML_Syntax.E_PURE) &&
-                          (f' = FStar_Extraction_ML_Syntax.E_GHOST)
-                      then
-                        let uu____326 = type_leq unfold_ty t2 t2' in
-                        (if uu____326
-                         then
-                           let body1 =
-                             let uu____334 =
-                               type_leq unfold_ty t2
-                                 FStar_Extraction_ML_Syntax.ml_unit_ty in
-                             if uu____334
-                             then FStar_Extraction_ML_Syntax.ml_unit
-                             else
-                               FStar_All.pipe_left
-                                 (FStar_Extraction_ML_Syntax.with_ty t2')
-                                 (FStar_Extraction_ML_Syntax.MLE_Coerce
-                                    (FStar_Extraction_ML_Syntax.ml_unit,
-                                      FStar_Extraction_ML_Syntax.ml_unit_ty,
-                                      t2')) in
-                           let uu____339 =
-                             let uu____341 =
-                               let uu____342 =
-                                 let uu____345 =
-                                   (mk_ty_fun ()) [x]
-                                     body1.FStar_Extraction_ML_Syntax.mlty in
-                                 FStar_Extraction_ML_Syntax.with_ty uu____345 in
-                               FStar_All.pipe_left uu____342
-                                 (FStar_Extraction_ML_Syntax.MLE_Fun
-                                    ([x], body1)) in
-                             Some uu____341 in
-                           (true, uu____339)
-                         else (false, None))
-                      else
-                        (let uu____361 =
-                           let uu____365 =
-                             let uu____367 = mk_fun xs body in
-                             FStar_All.pipe_left (fun _0_29  -> Some _0_29)
-                               uu____367 in
-                           type_leq_c unfold_ty uu____365 t2 t2' in
-                         match uu____361 with
-                         | (ok,body1) ->
-                             let res =
-                               match body1 with
-                               | Some body2 ->
-                                   let uu____383 = mk_fun [x] body2 in
-                                   Some uu____383
-                               | uu____388 -> None in
-                             (ok, res)))
-                   else (false, None)
-               | uu____393 ->
-                   let uu____395 =
-                     ((type_leq unfold_ty t1' t1) && (eff_leq f f')) &&
-                       (type_leq unfold_ty t2 t2') in
-                   if uu____395 then (true, e) else (false, None))
-          | (FStar_Extraction_ML_Syntax.MLTY_Named
-             (args,path),FStar_Extraction_ML_Syntax.MLTY_Named (args',path'))
-              ->
-              if path = path'
-              then
-                let uu____419 =
-                  FStar_List.forall2 (type_leq unfold_ty) args args' in
-                (if uu____419 then (true, e) else (false, None))
-              else
-                (let uu____430 = unfold_ty t in
-                 match uu____430 with
-                 | Some t1 -> type_leq_c unfold_ty e t1 t'
-                 | None  ->
-                     let uu____440 = unfold_ty t' in
-                     (match uu____440 with
-                      | None  -> (false, None)
-                      | Some t'1 -> type_leq_c unfold_ty e t t'1))
-          | (FStar_Extraction_ML_Syntax.MLTY_Tuple
-             ts,FStar_Extraction_ML_Syntax.MLTY_Tuple ts') ->
-              let uu____455 = FStar_List.forall2 (type_leq unfold_ty) ts ts' in
-              if uu____455 then (true, e) else (false, None)
-          | (FStar_Extraction_ML_Syntax.MLTY_Top
-             ,FStar_Extraction_ML_Syntax.MLTY_Top ) -> (true, e)
-          | (FStar_Extraction_ML_Syntax.MLTY_Named uu____466,uu____467) ->
-              let uu____471 = unfold_ty t in
-              (match uu____471 with
-               | Some t1 -> type_leq_c unfold_ty e t1 t'
-               | uu____481 -> (false, None))
-          | (uu____484,FStar_Extraction_ML_Syntax.MLTY_Named uu____485) ->
-              let uu____489 = unfold_ty t' in
-              (match uu____489 with
-               | Some t'1 -> type_leq_c unfold_ty e t t'1
-               | uu____499 -> (false, None))
-          | uu____502 -> (false, None)
-and type_leq:
-  unfold_t ->
-    FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
-  =
-  fun g  ->
-    fun t1  ->
-      fun t2  ->
-        let uu____510 = type_leq_c g None t1 t2 in
-        FStar_All.pipe_right uu____510 Prims.fst
-let is_type_abstraction uu___114_536 =
-  match uu___114_536 with
-  | (FStar_Util.Inl uu____542,uu____543)::uu____544 -> true
-  | uu____556 -> false
-let is_xtuple:
-  (Prims.string Prims.list* Prims.string) -> Prims.int Prims.option =
-  fun uu____568  ->
-    match uu____568 with
-    | (ns,n1) ->
-        if ns = ["Prims"]
-        then
-          (match n1 with
-           | "Mktuple2" -> Some (Prims.parse_int "2")
-           | "Mktuple3" -> Some (Prims.parse_int "3")
-           | "Mktuple4" -> Some (Prims.parse_int "4")
-           | "Mktuple5" -> Some (Prims.parse_int "5")
-           | "Mktuple6" -> Some (Prims.parse_int "6")
-           | "Mktuple7" -> Some (Prims.parse_int "7")
-           | "Mktuple8" -> Some (Prims.parse_int "8")
-           | uu____580 -> None)
-        else None
-let resugar_exp:
-  FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr =
-  fun e  ->
-    match e.FStar_Extraction_ML_Syntax.expr with
-    | FStar_Extraction_ML_Syntax.MLE_CTor (mlp,args) ->
-        (match is_xtuple mlp with
-         | Some n1 ->
-             FStar_All.pipe_left
-               (FStar_Extraction_ML_Syntax.with_ty
-                  e.FStar_Extraction_ML_Syntax.mlty)
-               (FStar_Extraction_ML_Syntax.MLE_Tuple args)
-         | uu____590 -> e)
-    | uu____592 -> e
-let record_field_path:
-  FStar_Ident.lident Prims.list -> Prims.string Prims.list =
-  fun uu___115_597  ->
-    match uu___115_597 with
-    | f::uu____601 ->
-        let uu____603 = FStar_Util.prefix f.FStar_Ident.ns in
-        (match uu____603 with
-         | (ns,uu____609) ->
-             FStar_All.pipe_right ns
-               (FStar_List.map (fun id  -> id.FStar_Ident.idText)))
-    | uu____615 -> failwith "impos"
-let record_fields fs vs =
-  FStar_List.map2
-    (fun f  -> fun e  -> (((f.FStar_Ident.ident).FStar_Ident.idText), e)) fs
-    vs
-let is_xtuple_ty:
-  (Prims.string Prims.list* Prims.string) -> Prims.int Prims.option =
-  fun uu____647  ->
-    match uu____647 with
-    | (ns,n1) ->
-        if ns = ["Prims"]
-        then
-          (match n1 with
-           | "tuple2" -> Some (Prims.parse_int "2")
-           | "tuple3" -> Some (Prims.parse_int "3")
-           | "tuple4" -> Some (Prims.parse_int "4")
-           | "tuple5" -> Some (Prims.parse_int "5")
-           | "tuple6" -> Some (Prims.parse_int "6")
-           | "tuple7" -> Some (Prims.parse_int "7")
-           | "tuple8" -> Some (Prims.parse_int "8")
-           | uu____659 -> None)
-        else None
-let resugar_mlty:
-  FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty =
-  fun t  ->
-    match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Named (args,mlp) ->
-        (match is_xtuple_ty mlp with
-         | Some n1 -> FStar_Extraction_ML_Syntax.MLTY_Tuple args
-         | uu____669 -> t)
-    | uu____671 -> t
-let codegen_fsharp: Prims.unit -> Prims.bool =
-  fun uu____674  ->
-    let uu____675 =
-      let uu____676 = FStar_Options.codegen () in FStar_Option.get uu____676 in
-    uu____675 = "FSharp"
-let flatten_ns: Prims.string Prims.list -> Prims.string =
-  fun ns  ->
-    let uu____683 = codegen_fsharp () in
-    if uu____683
-    then FStar_String.concat "." ns
-    else FStar_String.concat "_" ns
-let flatten_mlpath: (Prims.string Prims.list* Prims.string) -> Prims.string =
-  fun uu____690  ->
-    match uu____690 with
-    | (ns,n1) ->
-        let uu____698 = codegen_fsharp () in
-        if uu____698
-        then FStar_String.concat "." (FStar_List.append ns [n1])
-        else FStar_String.concat "_" (FStar_List.append ns [n1])
-let mlpath_of_lid:
-  FStar_Ident.lident -> (Prims.string Prims.list* Prims.string) =
-  fun l  ->
-    let uu____706 =
-      FStar_All.pipe_right l.FStar_Ident.ns
-        (FStar_List.map (fun i  -> i.FStar_Ident.idText)) in
-    (uu____706, ((l.FStar_Ident.ident).FStar_Ident.idText))
-let rec erasableType:
-  unfold_t -> FStar_Extraction_ML_Syntax.mlty -> Prims.bool =
-  fun unfold_ty  ->
-    fun t  ->
-      if FStar_Extraction_ML_UEnv.erasableTypeNoDelta t
-      then true
-      else
-        (let uu____722 = unfold_ty t in
-         match uu____722 with
-         | Some t1 -> erasableType unfold_ty t1
-         | None  -> false)
-let rec eraseTypeDeep:
-  unfold_t ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
-  =
-  fun unfold_ty  ->
-    fun t  ->
-      match t with
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (tyd,etag,tycd) ->
-          if etag = FStar_Extraction_ML_Syntax.E_PURE
-          then
-            let uu____741 =
-              let uu____745 = eraseTypeDeep unfold_ty tyd in
-              let uu____749 = eraseTypeDeep unfold_ty tycd in
-              (uu____745, etag, uu____749) in
-            FStar_Extraction_ML_Syntax.MLTY_Fun uu____741
-          else t
-      | FStar_Extraction_ML_Syntax.MLTY_Named (lty,mlp) ->
-          let uu____758 = erasableType unfold_ty t in
-          if uu____758
-          then FStar_Extraction_ML_UEnv.erasedContent
-          else
-            (let uu____763 =
-               let uu____767 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
-               (uu____767, mlp) in
-             FStar_Extraction_ML_Syntax.MLTY_Named uu____763)
-      | FStar_Extraction_ML_Syntax.MLTY_Tuple lty ->
-          let uu____775 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
-          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____775
-      | uu____780 -> t
-let prims_op_equality: FStar_Extraction_ML_Syntax.mlexpr =
-  FStar_All.pipe_left
-    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
-    (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_Equality"))
-let prims_op_amp_amp: FStar_Extraction_ML_Syntax.mlexpr =
-  let uu____782 =
-    let uu____785 =
-      (mk_ty_fun ())
-        [(("x", (Prims.parse_int "0")),
-           FStar_Extraction_ML_Syntax.ml_bool_ty);
-        (("y", (Prims.parse_int "0")), FStar_Extraction_ML_Syntax.ml_bool_ty)]
-        FStar_Extraction_ML_Syntax.ml_bool_ty in
-    FStar_Extraction_ML_Syntax.with_ty uu____785 in
-  FStar_All.pipe_left uu____782
-    (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_AmpAmp"))
-let conjoin:
-  FStar_Extraction_ML_Syntax.mlexpr ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr
-  =
-  fun e1  ->
-    fun e2  ->
-      FStar_All.pipe_left
-        (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_bool_ty)
-        (FStar_Extraction_ML_Syntax.MLE_App (prims_op_amp_amp, [e1; e2]))
-let conjoin_opt:
-  FStar_Extraction_ML_Syntax.mlexpr Prims.option ->
-    FStar_Extraction_ML_Syntax.mlexpr Prims.option ->
-      FStar_Extraction_ML_Syntax.mlexpr Prims.option
-  =
-  fun e1  ->
-    fun e2  ->
-      match (e1, e2) with
-      | (None ,None ) -> None
-      | (Some x,None )|(None ,Some x) -> Some x
-      | (Some x,Some y) -> let uu____837 = conjoin x y in Some uu____837
-let mlloc_of_range: FStar_Range.range -> (Prims.int* Prims.string) =
-  fun r  ->
-    let pos = FStar_Range.start_of_range r in
-    let line = FStar_Range.line_of_pos pos in
-    let uu____845 = FStar_Range.file_of_range r in (line, uu____845)
-let rec argTypes:
-  FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlty Prims.list
-  =
-  fun t  ->
-    match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____853,b) ->
-        let uu____855 = argTypes b in a :: uu____855
-    | uu____857 -> []
-let rec uncurry_mlty_fun:
-  FStar_Extraction_ML_Syntax.mlty ->
-    (FStar_Extraction_ML_Syntax.mlty Prims.list*
-      FStar_Extraction_ML_Syntax.mlty)
-  =
-  fun t  ->
-    match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____868,b) ->
-        let uu____870 = uncurry_mlty_fun b in
-        (match uu____870 with | (args,res) -> ((a :: args), res))
-    | uu____882 -> ([], t)
+FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty Prims.option
+
+
+let rec type_leq_c : unfold_t  ->  FStar_Extraction_ML_Syntax.mlexpr Prims.option  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty  ->  (Prims.bool * FStar_Extraction_ML_Syntax.mlexpr Prims.option) = (fun unfold_ty e t t' -> (match (((t), (t'))) with
+| (FStar_Extraction_ML_Syntax.MLTY_Var (x), FStar_Extraction_ML_Syntax.MLTY_Var (y)) -> begin
+(match (((Prims.fst x) = (Prims.fst y))) with
+| true -> begin
+((true), (e))
+end
+| uu____252 -> begin
+((false), (None))
+end)
+end
+| (FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2), FStar_Extraction_ML_Syntax.MLTY_Fun (t1', f', t2')) -> begin
+(
+
+let mk_fun = (fun xs body -> (match (xs) with
+| [] -> begin
+body
+end
+| uu____275 -> begin
+(
+
+let e1 = (match (body.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_Fun (ys, body1) -> begin
+FStar_Extraction_ML_Syntax.MLE_Fun ((((FStar_List.append xs ys)), (body1)))
+end
+| uu____293 -> begin
+FStar_Extraction_ML_Syntax.MLE_Fun (((xs), (body)))
+end)
+in (
+
+let uu____297 = ((mk_ty_fun ()) xs body.FStar_Extraction_ML_Syntax.mlty)
+in (FStar_Extraction_ML_Syntax.with_ty uu____297 e1)))
+end))
+in (match (e) with
+| Some ({FStar_Extraction_ML_Syntax.expr = FStar_Extraction_ML_Syntax.MLE_Fun ((x)::xs, body); FStar_Extraction_ML_Syntax.mlty = uu____304; FStar_Extraction_ML_Syntax.loc = uu____305}) -> begin
+(
+
+let uu____316 = ((type_leq unfold_ty t1' t1) && (eff_leq f f'))
+in (match (uu____316) with
+| true -> begin
+(match (((f = FStar_Extraction_ML_Syntax.E_PURE) && (f' = FStar_Extraction_ML_Syntax.E_GHOST))) with
+| true -> begin
+(
+
+let uu____326 = (type_leq unfold_ty t2 t2')
+in (match (uu____326) with
+| true -> begin
+(
+
+let body1 = (
+
+let uu____334 = (type_leq unfold_ty t2 FStar_Extraction_ML_Syntax.ml_unit_ty)
+in (match (uu____334) with
+| true -> begin
+FStar_Extraction_ML_Syntax.ml_unit
+end
+| uu____338 -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t2') (FStar_Extraction_ML_Syntax.MLE_Coerce (((FStar_Extraction_ML_Syntax.ml_unit), (FStar_Extraction_ML_Syntax.ml_unit_ty), (t2')))))
+end))
+in (
+
+let uu____339 = (
+
+let uu____341 = (
+
+let uu____342 = (
+
+let uu____345 = ((mk_ty_fun ()) ((x)::[]) body1.FStar_Extraction_ML_Syntax.mlty)
+in (FStar_Extraction_ML_Syntax.with_ty uu____345))
+in (FStar_All.pipe_left uu____342 (FStar_Extraction_ML_Syntax.MLE_Fun ((((x)::[]), (body1))))))
+in Some (uu____341))
+in ((true), (uu____339))))
+end
+| uu____358 -> begin
+((false), (None))
+end))
+end
+| uu____360 -> begin
+(
+
+let uu____361 = (
+
+let uu____365 = (
+
+let uu____367 = (mk_fun xs body)
+in (FStar_All.pipe_left (fun _0_29 -> Some (_0_29)) uu____367))
+in (type_leq_c unfold_ty uu____365 t2 t2'))
+in (match (uu____361) with
+| (ok, body1) -> begin
+(
+
+let res = (match (body1) with
+| Some (body2) -> begin
+(
+
+let uu____383 = (mk_fun ((x)::[]) body2)
+in Some (uu____383))
+end
+| uu____388 -> begin
+None
+end)
+in ((ok), (res)))
+end))
+end)
+end
+| uu____391 -> begin
+((false), (None))
+end))
+end
+| uu____393 -> begin
+(
+
+let uu____395 = (((type_leq unfold_ty t1' t1) && (eff_leq f f')) && (type_leq unfold_ty t2 t2'))
+in (match (uu____395) with
+| true -> begin
+((true), (e))
+end
+| uu____406 -> begin
+((false), (None))
+end))
+end))
+end
+| (FStar_Extraction_ML_Syntax.MLTY_Named (args, path), FStar_Extraction_ML_Syntax.MLTY_Named (args', path')) -> begin
+(match ((path = path')) with
+| true -> begin
+(
+
+let uu____419 = (FStar_List.forall2 (type_leq unfold_ty) args args')
+in (match (uu____419) with
+| true -> begin
+((true), (e))
+end
+| uu____427 -> begin
+((false), (None))
+end))
+end
+| uu____429 -> begin
+(
+
+let uu____430 = (unfold_ty t)
+in (match (uu____430) with
+| Some (t1) -> begin
+(type_leq_c unfold_ty e t1 t')
+end
+| None -> begin
+(
+
+let uu____440 = (unfold_ty t')
+in (match (uu____440) with
+| None -> begin
+((false), (None))
+end
+| Some (t'1) -> begin
+(type_leq_c unfold_ty e t t'1)
+end))
+end))
+end)
+end
+| (FStar_Extraction_ML_Syntax.MLTY_Tuple (ts), FStar_Extraction_ML_Syntax.MLTY_Tuple (ts')) -> begin
+(
+
+let uu____455 = (FStar_List.forall2 (type_leq unfold_ty) ts ts')
+in (match (uu____455) with
+| true -> begin
+((true), (e))
+end
+| uu____463 -> begin
+((false), (None))
+end))
+end
+| (FStar_Extraction_ML_Syntax.MLTY_Top, FStar_Extraction_ML_Syntax.MLTY_Top) -> begin
+((true), (e))
+end
+| (FStar_Extraction_ML_Syntax.MLTY_Named (uu____466), uu____467) -> begin
+(
+
+let uu____471 = (unfold_ty t)
+in (match (uu____471) with
+| Some (t1) -> begin
+(type_leq_c unfold_ty e t1 t')
+end
+| uu____481 -> begin
+((false), (None))
+end))
+end
+| (uu____484, FStar_Extraction_ML_Syntax.MLTY_Named (uu____485)) -> begin
+(
+
+let uu____489 = (unfold_ty t')
+in (match (uu____489) with
+| Some (t'1) -> begin
+(type_leq_c unfold_ty e t t'1)
+end
+| uu____499 -> begin
+((false), (None))
+end))
+end
+| uu____502 -> begin
+((false), (None))
+end))
+and type_leq : unfold_t  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun g t1 t2 -> (
+
+let uu____510 = (type_leq_c g None t1 t2)
+in (FStar_All.pipe_right uu____510 Prims.fst)))
+
+
+let is_type_abstraction = (fun uu___112_536 -> (match (uu___112_536) with
+| ((FStar_Util.Inl (uu____542), uu____543))::uu____544 -> begin
+true
+end
+| uu____556 -> begin
+false
+end))
+
+
+let is_xtuple : (Prims.string Prims.list * Prims.string)  ->  Prims.int Prims.option = (fun uu____568 -> (match (uu____568) with
+| (ns, n1) -> begin
+(match ((ns = ("Prims")::[])) with
+| true -> begin
+(match (n1) with
+| "Mktuple2" -> begin
+Some ((Prims.parse_int "2"))
+end
+| "Mktuple3" -> begin
+Some ((Prims.parse_int "3"))
+end
+| "Mktuple4" -> begin
+Some ((Prims.parse_int "4"))
+end
+| "Mktuple5" -> begin
+Some ((Prims.parse_int "5"))
+end
+| "Mktuple6" -> begin
+Some ((Prims.parse_int "6"))
+end
+| "Mktuple7" -> begin
+Some ((Prims.parse_int "7"))
+end
+| "Mktuple8" -> begin
+Some ((Prims.parse_int "8"))
+end
+| uu____580 -> begin
+None
+end)
+end
+| uu____581 -> begin
+None
+end)
+end))
+
+
+let resugar_exp : FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr = (fun e -> (match (e.FStar_Extraction_ML_Syntax.expr) with
+| FStar_Extraction_ML_Syntax.MLE_CTor (mlp, args) -> begin
+(match ((is_xtuple mlp)) with
+| Some (n1) -> begin
+(FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty e.FStar_Extraction_ML_Syntax.mlty) (FStar_Extraction_ML_Syntax.MLE_Tuple (args)))
+end
+| uu____590 -> begin
+e
+end)
+end
+| uu____592 -> begin
+e
+end))
+
+
+let record_field_path : FStar_Ident.lident Prims.list  ->  Prims.string Prims.list = (fun uu___113_597 -> (match (uu___113_597) with
+| (f)::uu____601 -> begin
+(
+
+let uu____603 = (FStar_Util.prefix f.FStar_Ident.ns)
+in (match (uu____603) with
+| (ns, uu____609) -> begin
+(FStar_All.pipe_right ns (FStar_List.map (fun id -> id.FStar_Ident.idText)))
+end))
+end
+| uu____615 -> begin
+(failwith "impos")
+end))
+
+
+let record_fields = (fun fs vs -> (FStar_List.map2 (fun f e -> ((f.FStar_Ident.ident.FStar_Ident.idText), (e))) fs vs))
+
+
+let is_xtuple_ty : (Prims.string Prims.list * Prims.string)  ->  Prims.int Prims.option = (fun uu____647 -> (match (uu____647) with
+| (ns, n1) -> begin
+(match ((ns = ("Prims")::[])) with
+| true -> begin
+(match (n1) with
+| "tuple2" -> begin
+Some ((Prims.parse_int "2"))
+end
+| "tuple3" -> begin
+Some ((Prims.parse_int "3"))
+end
+| "tuple4" -> begin
+Some ((Prims.parse_int "4"))
+end
+| "tuple5" -> begin
+Some ((Prims.parse_int "5"))
+end
+| "tuple6" -> begin
+Some ((Prims.parse_int "6"))
+end
+| "tuple7" -> begin
+Some ((Prims.parse_int "7"))
+end
+| "tuple8" -> begin
+Some ((Prims.parse_int "8"))
+end
+| uu____659 -> begin
+None
+end)
+end
+| uu____660 -> begin
+None
+end)
+end))
+
+
+let resugar_mlty : FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty = (fun t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Named (args, mlp) -> begin
+(match ((is_xtuple_ty mlp)) with
+| Some (n1) -> begin
+FStar_Extraction_ML_Syntax.MLTY_Tuple (args)
+end
+| uu____669 -> begin
+t
+end)
+end
+| uu____671 -> begin
+t
+end))
+
+
+let codegen_fsharp : Prims.unit  ->  Prims.bool = (fun uu____674 -> (
+
+let uu____675 = (
+
+let uu____676 = (FStar_Options.codegen ())
+in (FStar_Option.get uu____676))
+in (uu____675 = "FSharp")))
+
+
+let flatten_ns : Prims.string Prims.list  ->  Prims.string = (fun ns -> (
+
+let uu____683 = (codegen_fsharp ())
+in (match (uu____683) with
+| true -> begin
+(FStar_String.concat "." ns)
+end
+| uu____684 -> begin
+(FStar_String.concat "_" ns)
+end)))
+
+
+let flatten_mlpath : (Prims.string Prims.list * Prims.string)  ->  Prims.string = (fun uu____690 -> (match (uu____690) with
+| (ns, n1) -> begin
+(
+
+let uu____698 = (codegen_fsharp ())
+in (match (uu____698) with
+| true -> begin
+(FStar_String.concat "." (FStar_List.append ns ((n1)::[])))
+end
+| uu____699 -> begin
+(FStar_String.concat "_" (FStar_List.append ns ((n1)::[])))
+end))
+end))
+
+
+let mlpath_of_lid : FStar_Ident.lident  ->  (Prims.string Prims.list * Prims.string) = (fun l -> (
+
+let uu____706 = (FStar_All.pipe_right l.FStar_Ident.ns (FStar_List.map (fun i -> i.FStar_Ident.idText)))
+in ((uu____706), (l.FStar_Ident.ident.FStar_Ident.idText))))
+
+
+let rec erasableType : unfold_t  ->  FStar_Extraction_ML_Syntax.mlty  ->  Prims.bool = (fun unfold_ty t -> (match ((FStar_Extraction_ML_UEnv.erasableTypeNoDelta t)) with
+| true -> begin
+true
+end
+| uu____721 -> begin
+(
+
+let uu____722 = (unfold_ty t)
+in (match (uu____722) with
+| Some (t1) -> begin
+(erasableType unfold_ty t1)
+end
+| None -> begin
+false
+end))
+end))
+
+
+let rec eraseTypeDeep : unfold_t  ->  FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty = (fun unfold_ty t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (tyd, etag, tycd) -> begin
+(match ((etag = FStar_Extraction_ML_Syntax.E_PURE)) with
+| true -> begin
+(
+
+let uu____741 = (
+
+let uu____745 = (eraseTypeDeep unfold_ty tyd)
+in (
+
+let uu____749 = (eraseTypeDeep unfold_ty tycd)
+in ((uu____745), (etag), (uu____749))))
+in FStar_Extraction_ML_Syntax.MLTY_Fun (uu____741))
+end
+| uu____753 -> begin
+t
+end)
+end
+| FStar_Extraction_ML_Syntax.MLTY_Named (lty, mlp) -> begin
+(
+
+let uu____758 = (erasableType unfold_ty t)
+in (match (uu____758) with
+| true -> begin
+FStar_Extraction_ML_UEnv.erasedContent
+end
+| uu____762 -> begin
+(
+
+let uu____763 = (
+
+let uu____767 = (FStar_List.map (eraseTypeDeep unfold_ty) lty)
+in ((uu____767), (mlp)))
+in FStar_Extraction_ML_Syntax.MLTY_Named (uu____763))
+end))
+end
+| FStar_Extraction_ML_Syntax.MLTY_Tuple (lty) -> begin
+(
+
+let uu____775 = (FStar_List.map (eraseTypeDeep unfold_ty) lty)
+in FStar_Extraction_ML_Syntax.MLTY_Tuple (uu____775))
+end
+| uu____780 -> begin
+t
+end))
+
+
+let prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr = (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top) (FStar_Extraction_ML_Syntax.MLE_Name (((("Prims")::[]), ("op_Equality")))))
+
+
+let prims_op_amp_amp : FStar_Extraction_ML_Syntax.mlexpr = (
+
+let uu____782 = (
+
+let uu____785 = ((mk_ty_fun ()) (((((("x"), ((Prims.parse_int "0")))), (FStar_Extraction_ML_Syntax.ml_bool_ty)))::((((("y"), ((Prims.parse_int "0")))), (FStar_Extraction_ML_Syntax.ml_bool_ty)))::[]) FStar_Extraction_ML_Syntax.ml_bool_ty)
+in (FStar_Extraction_ML_Syntax.with_ty uu____785))
+in (FStar_All.pipe_left uu____782 (FStar_Extraction_ML_Syntax.MLE_Name (((("Prims")::[]), ("op_AmpAmp"))))))
+
+
+let conjoin : FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr  ->  FStar_Extraction_ML_Syntax.mlexpr = (fun e1 e2 -> (FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_bool_ty) (FStar_Extraction_ML_Syntax.MLE_App (((prims_op_amp_amp), ((e1)::(e2)::[]))))))
+
+
+let conjoin_opt : FStar_Extraction_ML_Syntax.mlexpr Prims.option  ->  FStar_Extraction_ML_Syntax.mlexpr Prims.option  ->  FStar_Extraction_ML_Syntax.mlexpr Prims.option = (fun e1 e2 -> (match (((e1), (e2))) with
+| (None, None) -> begin
+None
+end
+| ((Some (x), None)) | ((None, Some (x))) -> begin
+Some (x)
+end
+| (Some (x), Some (y)) -> begin
+(
+
+let uu____837 = (conjoin x y)
+in Some (uu____837))
+end))
+
+
+let mlloc_of_range : FStar_Range.range  ->  (Prims.int * Prims.string) = (fun r -> (
+
+let pos = (FStar_Range.start_of_range r)
+in (
+
+let line = (FStar_Range.line_of_pos pos)
+in (
+
+let uu____845 = (FStar_Range.file_of_range r)
+in ((line), (uu____845))))))
+
+
+let rec argTypes : FStar_Extraction_ML_Syntax.mlty  ->  FStar_Extraction_ML_Syntax.mlty Prims.list = (fun t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu____853, b) -> begin
+(
+
+let uu____855 = (argTypes b)
+in (a)::uu____855)
+end
+| uu____857 -> begin
+[]
+end))
+
+
+let rec uncurry_mlty_fun : FStar_Extraction_ML_Syntax.mlty  ->  (FStar_Extraction_ML_Syntax.mlty Prims.list * FStar_Extraction_ML_Syntax.mlty) = (fun t -> (match (t) with
+| FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu____868, b) -> begin
+(
+
+let uu____870 = (uncurry_mlty_fun b)
+in (match (uu____870) with
+| (args, res) -> begin
+(((a)::args), (res))
+end))
+end
+| uu____882 -> begin
+(([]), (t))
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Format.ml
+++ b/src/ocaml-output/FStar_Format.ml
@@ -1,58 +1,134 @@
+
 open Prims
 type doc =
-  | Doc of Prims.string
-let uu___is_Doc: doc -> Prims.bool = fun projectee  -> true
-let __proj__Doc__item___0: doc -> Prims.string =
-  fun projectee  -> match projectee with | Doc _0 -> _0
-let empty: doc = Doc ""
-let hardline: doc = Doc "\n"
-let text: Prims.string -> doc = fun s  -> Doc s
-let num: Prims.int -> doc = fun i  -> Doc (Prims.string_of_int i)
-let break_: Prims.int -> doc = fun i  -> Doc ""
-let break0: doc = break_ (Prims.parse_int "0")
-let break1: doc = text " "
-let enclose: doc -> doc -> doc -> doc =
-  fun uu____26  ->
-    fun uu____27  ->
-      fun uu____28  ->
-        match (uu____26, uu____27, uu____28) with
-        | (Doc l,Doc r,Doc x) -> Doc (Prims.strcat l (Prims.strcat x r))
-let brackets: doc -> doc =
-  fun uu____34  ->
-    match uu____34 with | Doc d -> enclose (text "[") (text "]") (Doc d)
-let cbrackets: doc -> doc =
-  fun uu____38  ->
-    match uu____38 with | Doc d -> enclose (text "{") (text "}") (Doc d)
-let parens: doc -> doc =
-  fun uu____42  ->
-    match uu____42 with | Doc d -> enclose (text "(") (text ")") (Doc d)
-let cat: doc -> doc -> doc =
-  fun uu____48  ->
-    fun uu____49  ->
-      match (uu____48, uu____49) with
-      | (Doc d1,Doc d2) -> Doc (Prims.strcat d1 d2)
-let reduce: doc Prims.list -> doc =
-  fun docs  -> FStar_List.fold_left cat empty docs
-let group: doc -> doc = fun uu____59  -> match uu____59 with | Doc d -> Doc d
-let groups: doc Prims.list -> doc =
-  fun docs  -> let uu____66 = reduce docs in group uu____66
-let combine: doc -> doc Prims.list -> doc =
-  fun uu____72  ->
-    fun docs  ->
-      match uu____72 with
-      | Doc sep ->
-          let select uu____80 =
-            match uu____80 with | Doc d -> if d = "" then None else Some d in
-          let docs1 = FStar_List.choose select docs in
-          Doc (FStar_String.concat sep docs1)
-let cat1: doc -> doc -> doc = fun d1  -> fun d2  -> reduce [d1; break1; d2]
-let reduce1: doc Prims.list -> doc = fun docs  -> combine break1 docs
-let nest: Prims.int -> doc -> doc =
-  fun i  -> fun uu____103  -> match uu____103 with | Doc d -> Doc d
-let align: doc Prims.list -> doc =
-  fun docs  ->
-    let uu____110 = combine hardline docs in
-    match uu____110 with | Doc doc1 -> Doc doc1
-let hbox: doc -> doc = fun d  -> d
-let pretty: Prims.int -> doc -> Prims.string =
-  fun sz  -> fun uu____120  -> match uu____120 with | Doc doc1 -> doc1
+| Doc of Prims.string
+
+
+let uu___is_Doc : doc  ->  Prims.bool = (fun projectee -> true)
+
+
+let __proj__Doc__item___0 : doc  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Doc (_0) -> begin
+_0
+end))
+
+
+let empty : doc = Doc ("")
+
+
+let hardline : doc = Doc ("\n")
+
+
+let text : Prims.string  ->  doc = (fun s -> Doc (s))
+
+
+let num : Prims.int  ->  doc = (fun i -> Doc ((Prims.string_of_int i)))
+
+
+let break_ : Prims.int  ->  doc = (fun i -> Doc (""))
+
+
+let break0 : doc = (break_ (Prims.parse_int "0"))
+
+
+let break1 : doc = (text " ")
+
+
+let enclose : doc  ->  doc  ->  doc  ->  doc = (fun uu____26 uu____27 uu____28 -> (match (((uu____26), (uu____27), (uu____28))) with
+| (Doc (l), Doc (r), Doc (x)) -> begin
+Doc ((Prims.strcat l (Prims.strcat x r)))
+end))
+
+
+let brackets : doc  ->  doc = (fun uu____34 -> (match (uu____34) with
+| Doc (d) -> begin
+(enclose (text "[") (text "]") (Doc (d)))
+end))
+
+
+let cbrackets : doc  ->  doc = (fun uu____38 -> (match (uu____38) with
+| Doc (d) -> begin
+(enclose (text "{") (text "}") (Doc (d)))
+end))
+
+
+let parens : doc  ->  doc = (fun uu____42 -> (match (uu____42) with
+| Doc (d) -> begin
+(enclose (text "(") (text ")") (Doc (d)))
+end))
+
+
+let cat : doc  ->  doc  ->  doc = (fun uu____48 uu____49 -> (match (((uu____48), (uu____49))) with
+| (Doc (d1), Doc (d2)) -> begin
+Doc ((Prims.strcat d1 d2))
+end))
+
+
+let reduce : doc Prims.list  ->  doc = (fun docs -> (FStar_List.fold_left cat empty docs))
+
+
+let group : doc  ->  doc = (fun uu____59 -> (match (uu____59) with
+| Doc (d) -> begin
+Doc (d)
+end))
+
+
+let groups : doc Prims.list  ->  doc = (fun docs -> (
+
+let uu____66 = (reduce docs)
+in (group uu____66)))
+
+
+let combine : doc  ->  doc Prims.list  ->  doc = (fun uu____72 docs -> (match (uu____72) with
+| Doc (sep) -> begin
+(
+
+let select = (fun uu____80 -> (match (uu____80) with
+| Doc (d) -> begin
+(match ((d = "")) with
+| true -> begin
+None
+end
+| uu____84 -> begin
+Some (d)
+end)
+end))
+in (
+
+let docs1 = (FStar_List.choose select docs)
+in Doc ((FStar_String.concat sep docs1))))
+end))
+
+
+let cat1 : doc  ->  doc  ->  doc = (fun d1 d2 -> (reduce ((d1)::(break1)::(d2)::[])))
+
+
+let reduce1 : doc Prims.list  ->  doc = (fun docs -> (combine break1 docs))
+
+
+let nest : Prims.int  ->  doc  ->  doc = (fun i uu____103 -> (match (uu____103) with
+| Doc (d) -> begin
+Doc (d)
+end))
+
+
+let align : doc Prims.list  ->  doc = (fun docs -> (
+
+let uu____110 = (combine hardline docs)
+in (match (uu____110) with
+| Doc (doc1) -> begin
+Doc (doc1)
+end)))
+
+
+let hbox : doc  ->  doc = (fun d -> d)
+
+
+let pretty : Prims.int  ->  doc  ->  Prims.string = (fun sz uu____120 -> (match (uu____120) with
+| Doc (doc1) -> begin
+doc1
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Fsdoc_Generator.ml
+++ b/src/ocaml-output/FStar_Fsdoc_Generator.ml
@@ -1,280 +1,458 @@
+
 open Prims
-let one_toplevel:
-  FStar_Parser_AST.decl Prims.list ->
-    (FStar_Parser_AST.decl* FStar_Parser_AST.decl Prims.list) Prims.option
-  =
-  fun decls  ->
-    let uu____10 =
-      FStar_List.partition
-        (fun d  ->
-           match d.FStar_Parser_AST.d with
-           | FStar_Parser_AST.TopLevelModule uu____16 -> true
-           | uu____17 -> false) decls in
-    match uu____10 with
-    | (top,nontops) ->
-        (match top with | t::[] -> Some (t, nontops) | uu____37 -> None)
+
+let one_toplevel : FStar_Parser_AST.decl Prims.list  ->  (FStar_Parser_AST.decl * FStar_Parser_AST.decl Prims.list) Prims.option = (fun decls -> (
+
+let uu____10 = (FStar_List.partition (fun d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.TopLevelModule (uu____16) -> begin
+true
+end
+| uu____17 -> begin
+false
+end)) decls)
+in (match (uu____10) with
+| (top, nontops) -> begin
+(match (top) with
+| (t)::[] -> begin
+Some (((t), (nontops)))
+end
+| uu____37 -> begin
+None
+end)
+end)))
+
 type mforest =
-  | Leaf of (Prims.string* Prims.string)
-  | Branch of mforest FStar_Util.smap
-let uu___is_Leaf: mforest -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Leaf _0 -> true | uu____57 -> false
-let __proj__Leaf__item___0: mforest -> (Prims.string* Prims.string) =
-  fun projectee  -> match projectee with | Leaf _0 -> _0
-let uu___is_Branch: mforest -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Branch _0 -> true | uu____76 -> false
-let __proj__Branch__item___0: mforest -> mforest FStar_Util.smap =
-  fun projectee  -> match projectee with | Branch _0 -> _0
-let htree: mforest FStar_Util.smap =
-  FStar_Util.smap_create (Prims.parse_int "50")
-let string_of_optiont f y xo = match xo with | Some x -> f x | None  -> y
-let string_of_fsdoco:
-  (Prims.string* (Prims.string* Prims.string) Prims.list) Prims.option ->
-    Prims.string
-  =
-  fun d  ->
-    string_of_optiont
-      (fun x  ->
-         let uu____141 =
-           let uu____142 = FStar_Parser_AST.string_of_fsdoc x in
-           Prims.strcat uu____142 "*)" in
-         Prims.strcat "(*" uu____141) "" d
-let string_of_termo: FStar_Parser_AST.term Prims.option -> Prims.string =
-  fun t  -> string_of_optiont FStar_Parser_AST.term_to_string "" t
-let code_wrap: Prims.string -> Prims.string =
-  fun s  -> Prims.strcat "```fsharp\n" (Prims.strcat s "\n```\n")
-let string_of_tycon: FStar_Parser_AST.tycon -> Prims.string =
-  fun tycon  ->
-    match tycon with
-    | FStar_Parser_AST.TyconAbstract uu____154 -> "abstract"
-    | FStar_Parser_AST.TyconAbbrev uu____160 -> "abbrev"
-    | FStar_Parser_AST.TyconRecord (id,_bb,_ko,fields) ->
-        let uu____185 =
-          let uu____186 =
-            let uu____187 =
-              let uu____188 =
-                FStar_All.pipe_right fields
-                  (FStar_List.map
-                     (fun uu____205  ->
-                        match uu____205 with
-                        | (id1,t,doco) ->
-                            let uu____230 = string_of_fsdoco doco in
-                            let uu____231 =
-                              let uu____232 =
-                                let uu____233 =
-                                  FStar_Parser_AST.term_to_string t in
-                                Prims.strcat ":" uu____233 in
-                              Prims.strcat id1.FStar_Ident.idText uu____232 in
-                            Prims.strcat uu____230 uu____231)) in
-              FStar_All.pipe_right uu____188 (FStar_String.concat "; ") in
-            Prims.strcat uu____187 " }" in
-          Prims.strcat " = { " uu____186 in
-        Prims.strcat id.FStar_Ident.idText uu____185
-    | FStar_Parser_AST.TyconVariant (id,_bb,_ko,vars) ->
-        let uu____257 =
-          let uu____258 =
-            let uu____259 =
-              FStar_All.pipe_right vars
-                (FStar_List.map
-                   (fun uu____280  ->
-                      match uu____280 with
-                      | (id1,trmo,doco,u) ->
-                          let uu____310 = string_of_fsdoco doco in
-                          let uu____311 =
-                            let uu____312 =
-                              let uu____313 =
-                                string_of_optiont
-                                  FStar_Parser_AST.term_to_string "" trmo in
-                              Prims.strcat ":" uu____313 in
-                            Prims.strcat id1.FStar_Ident.idText uu____312 in
-                          Prims.strcat uu____310 uu____311)) in
-            FStar_All.pipe_right uu____259 (FStar_String.concat " | ") in
-          Prims.strcat " = " uu____258 in
-        Prims.strcat id.FStar_Ident.idText uu____257
-let string_of_decl': FStar_Parser_AST.decl' -> Prims.string =
-  fun d  ->
-    match d with
-    | FStar_Parser_AST.TopLevelModule l ->
-        Prims.strcat "module " l.FStar_Ident.str
-    | FStar_Parser_AST.Open l -> Prims.strcat "open " l.FStar_Ident.str
-    | FStar_Parser_AST.Include l -> Prims.strcat "include " l.FStar_Ident.str
-    | FStar_Parser_AST.ModuleAbbrev (i,l) ->
-        Prims.strcat "module "
-          (Prims.strcat i.FStar_Ident.idText
-             (Prims.strcat " = " l.FStar_Ident.str))
-    | FStar_Parser_AST.TopLevelLet (uu____323,pats) ->
-        let termty =
-          FStar_List.map
-            (fun uu____339  ->
-               match uu____339 with
-               | (p,t) ->
-                   let uu____346 = FStar_Parser_AST.pat_to_string p in
-                   let uu____347 = FStar_Parser_AST.term_to_string t in
-                   (uu____346, uu____347)) pats in
-        let termty' =
-          FStar_List.map
-            (fun uu____352  ->
-               match uu____352 with
-               | (p,t) -> Prims.strcat p (Prims.strcat ":" t)) termty in
-        Prims.strcat "let " (FStar_String.concat ", " termty')
-    | FStar_Parser_AST.Main uu____357 -> "main ..."
-    | FStar_Parser_AST.Assume (i,t) ->
-        let uu____360 =
-          let uu____361 =
-            let uu____362 = FStar_Parser_AST.term_to_string t in
-            Prims.strcat ":" uu____362 in
-          Prims.strcat i.FStar_Ident.idText uu____361 in
-        Prims.strcat "assume " uu____360
-    | FStar_Parser_AST.Tycon (uu____363,tys) ->
-        let uu____373 =
-          let uu____374 =
-            FStar_All.pipe_right tys
-              (FStar_List.map
-                 (fun uu____389  ->
-                    match uu____389 with
-                    | (t,d1) ->
-                        let uu____412 = string_of_tycon t in
-                        let uu____413 =
-                          let uu____414 = string_of_fsdoco d1 in
-                          Prims.strcat " " uu____414 in
-                        Prims.strcat uu____412 uu____413)) in
-          FStar_All.pipe_right uu____374 (FStar_String.concat " and ") in
-        Prims.strcat "type " uu____373
-    | FStar_Parser_AST.Val (i,t) ->
-        let uu____418 =
-          let uu____419 =
-            let uu____420 = FStar_Parser_AST.term_to_string t in
-            Prims.strcat ":" uu____420 in
-          Prims.strcat i.FStar_Ident.idText uu____419 in
-        Prims.strcat "val " uu____418
-    | FStar_Parser_AST.Exception (i,uu____422) ->
-        Prims.strcat "exception " i.FStar_Ident.idText
-    | FStar_Parser_AST.NewEffect (FStar_Parser_AST.DefineEffect (i,_,_,_))
-      |FStar_Parser_AST.NewEffect (FStar_Parser_AST.RedefineEffect (i,_,_))
-        -> Prims.strcat "new_effect " i.FStar_Ident.idText
-    | FStar_Parser_AST.SubEffect uu____434 -> "sub_effect"
-    | FStar_Parser_AST.Pragma uu____435 -> "pragma"
-    | FStar_Parser_AST.Fsdoc (comm,uu____437) -> comm
-let decl_documented: FStar_Parser_AST.decl -> Prims.bool =
-  fun d  ->
-    let tycon_documented tt =
-      let tyconvars_documented tycon =
-        match tycon with
-        | FStar_Parser_AST.TyconAbstract _|FStar_Parser_AST.TyconAbbrev _ ->
-            false
-        | FStar_Parser_AST.TyconRecord (uu____465,uu____466,uu____467,fields)
-            ->
-            FStar_List.existsb
-              (fun uu____487  ->
-                 match uu____487 with
-                 | (_id,_t,doco) -> FStar_Util.is_some doco) fields
-        | FStar_Parser_AST.TyconVariant (uu____497,uu____498,uu____499,vars)
-            ->
-            FStar_List.existsb
-              (fun uu____525  ->
-                 match uu____525 with
-                 | (_id,_t,doco,_u) -> FStar_Util.is_some doco) vars in
-      FStar_List.existsb
-        (fun uu____543  ->
-           match uu____543 with
-           | (tycon,doco) ->
-               (tyconvars_documented tycon) || (FStar_Util.is_some doco)) tt in
-    match d.FStar_Parser_AST.doc with
-    | Some uu____551 -> true
-    | uu____552 ->
-        (match d.FStar_Parser_AST.d with
-         | FStar_Parser_AST.Fsdoc uu____554 -> true
-         | FStar_Parser_AST.Tycon (uu____555,ty) -> tycon_documented ty
-         | uu____565 -> false)
-let document_decl:
-  (Prims.string -> Prims.unit) -> FStar_Parser_AST.decl -> Prims.unit =
-  fun w  ->
-    fun d  ->
-      if decl_documented d
-      then
-        let uu____577 = d in
-        match uu____577 with
-        | { FStar_Parser_AST.d = decl; FStar_Parser_AST.drange = uu____579;
-            FStar_Parser_AST.doc = fsdoc; FStar_Parser_AST.quals = uu____581;
-            FStar_Parser_AST.attrs = uu____582;_} ->
-            ((let uu____585 =
-                let uu____586 = string_of_decl' d.FStar_Parser_AST.d in
-                code_wrap uu____586 in
-              w uu____585);
-             (match fsdoc with
-              | Some (doc1,_kw) -> w (Prims.strcat "\n" doc1)
-              | uu____601 -> ());
-             w "")
-      else ()
-let document_toplevel name topdecl =
-  match topdecl.FStar_Parser_AST.d with
-  | FStar_Parser_AST.TopLevelModule uu____620 ->
-      (match topdecl.FStar_Parser_AST.doc with
-       | Some (doc1,kw) ->
-           let uu____638 =
-             FStar_List.tryFind
-               (fun uu____644  ->
-                  match uu____644 with | (k,v1) -> k = "summary") kw in
-           (match uu____638 with
-            | None  -> (None, (Some doc1))
-            | Some (uu____657,summary) -> ((Some summary), (Some doc1)))
-       | None  -> (None, None))
-  | uu____665 -> Prims.raise (FStar_Errors.Err "Not a TopLevelModule")
-let document_module: FStar_Parser_AST.modul -> FStar_Ident.lid =
-  fun m  ->
-    let uu____673 =
-      match m with
-      | FStar_Parser_AST.Module (n1,d) -> (n1, d, "module")
-      | FStar_Parser_AST.Interface (n1,d,uu____689) -> (n1, d, "interface") in
-    match uu____673 with
-    | (name,decls,_mt) ->
-        let uu____698 = one_toplevel decls in
-        (match uu____698 with
-         | Some (top_decl,other_decls) ->
-             let on =
-               FStar_Options.prepend_output_dir
-                 (Prims.strcat name.FStar_Ident.str ".md") in
-             let fd = FStar_Util.open_file_for_writing on in
-             let w = FStar_Util.append_to_file fd in
-             let no_summary = "fsdoc: no-summary-found" in
-             let no_comment = "fsdoc: no-comment-found" in
-             let uu____717 = document_toplevel name top_decl in
-             (match uu____717 with
-              | (summary,comment) ->
-                  let summary1 =
-                    match summary with | Some s -> s | None  -> no_summary in
-                  let comment1 =
-                    match comment with | Some s -> s | None  -> no_comment in
-                  ((let uu____733 =
-                      FStar_Util.format "# module %s" [name.FStar_Ident.str] in
-                    w uu____733);
-                   (let uu____735 = FStar_Util.format "%s\n" [summary1] in
-                    w uu____735);
-                   (let uu____737 = FStar_Util.format "%s\n" [comment1] in
-                    w uu____737);
-                   FStar_List.iter (document_decl w) other_decls;
-                   FStar_Util.close_file fd;
-                   name))
-         | None  ->
-             let uu____743 =
-               let uu____744 =
-                 FStar_Util.format1 "No singleton toplevel in module %s"
-                   name.FStar_Ident.str in
-               FStar_Errors.Err uu____744 in
-             Prims.raise uu____743)
-let generate: Prims.string Prims.list -> Prims.unit =
-  fun files  ->
-    let modules =
-      FStar_List.collect
-        (fun fn  ->
-           let uu____753 = FStar_Parser_Driver.parse_file fn in
-           Prims.fst uu____753) files in
-    let mods = FStar_List.map document_module modules in
-    let on = FStar_Options.prepend_output_dir "index.md" in
-    let fd = FStar_Util.open_file_for_writing on in
-    FStar_List.iter
-      (fun m  ->
-         let uu____768 = FStar_Util.format "%s\n" [m.FStar_Ident.str] in
-         FStar_Util.append_to_file fd uu____768) mods;
-    FStar_Util.close_file fd
+| Leaf of (Prims.string * Prims.string)
+| Branch of mforest FStar_Util.smap
+
+
+let uu___is_Leaf : mforest  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Leaf (_0) -> begin
+true
+end
+| uu____57 -> begin
+false
+end))
+
+
+let __proj__Leaf__item___0 : mforest  ->  (Prims.string * Prims.string) = (fun projectee -> (match (projectee) with
+| Leaf (_0) -> begin
+_0
+end))
+
+
+let uu___is_Branch : mforest  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Branch (_0) -> begin
+true
+end
+| uu____76 -> begin
+false
+end))
+
+
+let __proj__Branch__item___0 : mforest  ->  mforest FStar_Util.smap = (fun projectee -> (match (projectee) with
+| Branch (_0) -> begin
+_0
+end))
+
+
+let htree : mforest FStar_Util.smap = (FStar_Util.smap_create (Prims.parse_int "50"))
+
+
+let string_of_optiont = (fun f y xo -> (match (xo) with
+| Some (x) -> begin
+(f x)
+end
+| None -> begin
+y
+end))
+
+
+let string_of_fsdoco : FStar_Syntax_Syntax.fsdoc Prims.option  ->  Prims.string = (fun d -> (string_of_optiont (fun x -> (
+
+let uu____121 = (
+
+let uu____122 = (FStar_Syntax_Syntax.string_of_fsdoc x)
+in (Prims.strcat uu____122 "*)"))
+in (Prims.strcat "(*" uu____121))) "" d))
+
+
+let string_of_termo : FStar_Parser_AST.term Prims.option  ->  Prims.string = (fun t -> (string_of_optiont FStar_Parser_AST.term_to_string "" t))
+
+
+let code_wrap : Prims.string  ->  Prims.string = (fun s -> (Prims.strcat "```fsharp\n" (Prims.strcat s "\n```\n")))
+
+
+let string_of_tycon : FStar_Parser_AST.tycon  ->  Prims.string = (fun tycon -> (match (tycon) with
+| FStar_Parser_AST.TyconAbstract (uu____134) -> begin
+"abstract"
+end
+| FStar_Parser_AST.TyconAbbrev (uu____140) -> begin
+"abbrev"
+end
+| FStar_Parser_AST.TyconRecord (id, _bb, _ko, fields) -> begin
+(
+
+let uu____165 = (
+
+let uu____166 = (
+
+let uu____167 = (
+
+let uu____168 = (FStar_All.pipe_right fields (FStar_List.map (fun uu____180 -> (match (uu____180) with
+| (id1, t, doco) -> begin
+(
+
+let uu____190 = (string_of_fsdoco doco)
+in (
+
+let uu____191 = (
+
+let uu____192 = (
+
+let uu____193 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat ":" uu____193))
+in (Prims.strcat id1.FStar_Ident.idText uu____192))
+in (Prims.strcat uu____190 uu____191)))
+end))))
+in (FStar_All.pipe_right uu____168 (FStar_String.concat "; ")))
+in (Prims.strcat uu____167 " }"))
+in (Prims.strcat " = { " uu____166))
+in (Prims.strcat id.FStar_Ident.idText uu____165))
+end
+| FStar_Parser_AST.TyconVariant (id, _bb, _ko, vars) -> begin
+(
+
+let uu____217 = (
+
+let uu____218 = (
+
+let uu____219 = (FStar_All.pipe_right vars (FStar_List.map (fun uu____235 -> (match (uu____235) with
+| (id1, trmo, doco, u) -> begin
+(
+
+let uu____250 = (string_of_fsdoco doco)
+in (
+
+let uu____251 = (
+
+let uu____252 = (
+
+let uu____253 = (string_of_optiont FStar_Parser_AST.term_to_string "" trmo)
+in (Prims.strcat ":" uu____253))
+in (Prims.strcat id1.FStar_Ident.idText uu____252))
+in (Prims.strcat uu____250 uu____251)))
+end))))
+in (FStar_All.pipe_right uu____219 (FStar_String.concat " | ")))
+in (Prims.strcat " = " uu____218))
+in (Prims.strcat id.FStar_Ident.idText uu____217))
+end))
+
+
+let string_of_decl' : FStar_Parser_AST.decl'  ->  Prims.string = (fun d -> (match (d) with
+| FStar_Parser_AST.TopLevelModule (l) -> begin
+(Prims.strcat "module " l.FStar_Ident.str)
+end
+| FStar_Parser_AST.Open (l) -> begin
+(Prims.strcat "open " l.FStar_Ident.str)
+end
+| FStar_Parser_AST.Include (l) -> begin
+(Prims.strcat "include " l.FStar_Ident.str)
+end
+| FStar_Parser_AST.ModuleAbbrev (i, l) -> begin
+(Prims.strcat "module " (Prims.strcat i.FStar_Ident.idText (Prims.strcat " = " l.FStar_Ident.str)))
+end
+| FStar_Parser_AST.TopLevelLet (uu____263, pats) -> begin
+(
+
+let termty = (FStar_List.map (fun uu____279 -> (match (uu____279) with
+| (p, t) -> begin
+(
+
+let uu____286 = (FStar_Parser_AST.pat_to_string p)
+in (
+
+let uu____287 = (FStar_Parser_AST.term_to_string t)
+in ((uu____286), (uu____287))))
+end)) pats)
+in (
+
+let termty' = (FStar_List.map (fun uu____292 -> (match (uu____292) with
+| (p, t) -> begin
+(Prims.strcat p (Prims.strcat ":" t))
+end)) termty)
+in (Prims.strcat "let " (FStar_String.concat ", " termty'))))
+end
+| FStar_Parser_AST.Main (uu____297) -> begin
+"main ..."
+end
+| FStar_Parser_AST.Assume (i, t) -> begin
+(
+
+let uu____300 = (
+
+let uu____301 = (
+
+let uu____302 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat ":" uu____302))
+in (Prims.strcat i.FStar_Ident.idText uu____301))
+in (Prims.strcat "assume " uu____300))
+end
+| FStar_Parser_AST.Tycon (uu____303, tys) -> begin
+(
+
+let uu____313 = (
+
+let uu____314 = (FStar_All.pipe_right tys (FStar_List.map (fun uu____324 -> (match (uu____324) with
+| (t, d1) -> begin
+(
+
+let uu____332 = (string_of_tycon t)
+in (
+
+let uu____333 = (
+
+let uu____334 = (string_of_fsdoco d1)
+in (Prims.strcat " " uu____334))
+in (Prims.strcat uu____332 uu____333)))
+end))))
+in (FStar_All.pipe_right uu____314 (FStar_String.concat " and ")))
+in (Prims.strcat "type " uu____313))
+end
+| FStar_Parser_AST.Val (i, t) -> begin
+(
+
+let uu____338 = (
+
+let uu____339 = (
+
+let uu____340 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat ":" uu____340))
+in (Prims.strcat i.FStar_Ident.idText uu____339))
+in (Prims.strcat "val " uu____338))
+end
+| FStar_Parser_AST.Exception (i, uu____342) -> begin
+(Prims.strcat "exception " i.FStar_Ident.idText)
+end
+| (FStar_Parser_AST.NewEffect (FStar_Parser_AST.DefineEffect (i, _, _, _))) | (FStar_Parser_AST.NewEffect (FStar_Parser_AST.RedefineEffect (i, _, _))) -> begin
+(Prims.strcat "new_effect " i.FStar_Ident.idText)
+end
+| FStar_Parser_AST.SubEffect (uu____354) -> begin
+"sub_effect"
+end
+| FStar_Parser_AST.Pragma (uu____355) -> begin
+"pragma"
+end
+| FStar_Parser_AST.Fsdoc (comm, uu____357) -> begin
+comm
+end))
+
+
+let decl_documented : FStar_Parser_AST.decl  ->  Prims.bool = (fun d -> (
+
+let tycon_documented = (fun tt -> (
+
+let tyconvars_documented = (fun tycon -> (match (tycon) with
+| (FStar_Parser_AST.TyconAbstract (_)) | (FStar_Parser_AST.TyconAbbrev (_)) -> begin
+false
+end
+| FStar_Parser_AST.TyconRecord (uu____385, uu____386, uu____387, fields) -> begin
+(FStar_List.existsb (fun uu____407 -> (match (uu____407) with
+| (_id, _t, doco) -> begin
+(FStar_Util.is_some doco)
+end)) fields)
+end
+| FStar_Parser_AST.TyconVariant (uu____417, uu____418, uu____419, vars) -> begin
+(FStar_List.existsb (fun uu____445 -> (match (uu____445) with
+| (_id, _t, doco, _u) -> begin
+(FStar_Util.is_some doco)
+end)) vars)
+end))
+in (FStar_List.existsb (fun uu____463 -> (match (uu____463) with
+| (tycon, doco) -> begin
+((tyconvars_documented tycon) || (FStar_Util.is_some doco))
+end)) tt)))
+in (match (d.FStar_Parser_AST.doc) with
+| Some (uu____471) -> begin
+true
+end
+| uu____472 -> begin
+(match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Fsdoc (uu____474) -> begin
+true
+end
+| FStar_Parser_AST.Tycon (uu____475, ty) -> begin
+(tycon_documented ty)
+end
+| uu____485 -> begin
+false
+end)
+end)))
+
+
+let document_decl : (Prims.string  ->  Prims.unit)  ->  FStar_Parser_AST.decl  ->  Prims.unit = (fun w d -> (match ((decl_documented d)) with
+| true -> begin
+(
+
+let uu____497 = d
+in (match (uu____497) with
+| {FStar_Parser_AST.d = decl; FStar_Parser_AST.drange = uu____499; FStar_Parser_AST.doc = fsdoc; FStar_Parser_AST.quals = uu____501; FStar_Parser_AST.attrs = uu____502} -> begin
+((
+
+let uu____505 = (
+
+let uu____506 = (string_of_decl' d.FStar_Parser_AST.d)
+in (code_wrap uu____506))
+in (w uu____505));
+(match (fsdoc) with
+| Some (doc1, _kw) -> begin
+(w (Prims.strcat "\n" doc1))
+end
+| uu____521 -> begin
+()
+end);
+(w "");
+)
+end))
+end
+| uu____523 -> begin
+()
+end))
+
+
+let document_toplevel = (fun name topdecl -> (match (topdecl.FStar_Parser_AST.d) with
+| FStar_Parser_AST.TopLevelModule (uu____540) -> begin
+(match (topdecl.FStar_Parser_AST.doc) with
+| Some (doc1, kw) -> begin
+(
+
+let uu____558 = (FStar_List.tryFind (fun uu____564 -> (match (uu____564) with
+| (k, v1) -> begin
+(k = "summary")
+end)) kw)
+in (match (uu____558) with
+| None -> begin
+((None), (Some (doc1)))
+end
+| Some (uu____577, summary) -> begin
+((Some (summary)), (Some (doc1)))
+end))
+end
+| None -> begin
+((None), (None))
+end)
+end
+| uu____585 -> begin
+(Prims.raise (FStar_Errors.Err ("Not a TopLevelModule")))
+end))
+
+
+let document_module : FStar_Parser_AST.modul  ->  FStar_Ident.lid = (fun m -> (
+
+let uu____593 = (match (m) with
+| FStar_Parser_AST.Module (n1, d) -> begin
+((n1), (d), ("module"))
+end
+| FStar_Parser_AST.Interface (n1, d, uu____609) -> begin
+((n1), (d), ("interface"))
+end)
+in (match (uu____593) with
+| (name, decls, _mt) -> begin
+(
+
+let uu____618 = (one_toplevel decls)
+in (match (uu____618) with
+| Some (top_decl, other_decls) -> begin
+(
+
+let on = (FStar_Options.prepend_output_dir (Prims.strcat name.FStar_Ident.str ".md"))
+in (
+
+let fd = (FStar_Util.open_file_for_writing on)
+in (
+
+let w = (FStar_Util.append_to_file fd)
+in (
+
+let no_summary = "fsdoc: no-summary-found"
+in (
+
+let no_comment = "fsdoc: no-comment-found"
+in (
+
+let uu____637 = (document_toplevel name top_decl)
+in (match (uu____637) with
+| (summary, comment) -> begin
+(
+
+let summary1 = (match (summary) with
+| Some (s) -> begin
+s
+end
+| None -> begin
+no_summary
+end)
+in (
+
+let comment1 = (match (comment) with
+| Some (s) -> begin
+s
+end
+| None -> begin
+no_comment
+end)
+in ((
+
+let uu____653 = (FStar_Util.format "# module %s" ((name.FStar_Ident.str)::[]))
+in (w uu____653));
+(
+
+let uu____655 = (FStar_Util.format "%s\n" ((summary1)::[]))
+in (w uu____655));
+(
+
+let uu____657 = (FStar_Util.format "%s\n" ((comment1)::[]))
+in (w uu____657));
+(FStar_List.iter (document_decl w) other_decls);
+(FStar_Util.close_file fd);
+name;
+)))
+end)))))))
+end
+| None -> begin
+(
+
+let uu____663 = (
+
+let uu____664 = (FStar_Util.format1 "No singleton toplevel in module %s" name.FStar_Ident.str)
+in FStar_Errors.Err (uu____664))
+in (Prims.raise uu____663))
+end))
+end)))
+
+
+let generate : Prims.string Prims.list  ->  Prims.unit = (fun files -> (
+
+let modules = (FStar_List.collect (fun fn -> (
+
+let uu____673 = (FStar_Parser_Driver.parse_file fn)
+in (Prims.fst uu____673))) files)
+in (
+
+let mods = (FStar_List.map document_module modules)
+in (
+
+let on = (FStar_Options.prepend_output_dir "index.md")
+in (
+
+let fd = (FStar_Util.open_file_for_writing on)
+in ((FStar_List.iter (fun m -> (
+
+let uu____688 = (FStar_Util.format "%s\n" ((m.FStar_Ident.str)::[]))
+in (FStar_Util.append_to_file fd uu____688))) mods);
+(FStar_Util.close_file fd);
+))))))
+
+
+
+

--- a/src/ocaml-output/FStar_Ident.ml
+++ b/src/ocaml-output/FStar_Ident.ml
@@ -1,91 +1,134 @@
+
 open Prims
-type ident = {
-  idText: Prims.string;
-  idRange: FStar_Range.range;}
+type ident =
+{idText : Prims.string; idRange : FStar_Range.range}
+
 type lident =
-  {
-  ns: ident Prims.list;
-  ident: ident;
-  nsstr: Prims.string;
-  str: Prims.string;}
-type lid = lident
-let mk_ident: (Prims.string* FStar_Range.range) -> ident =
-  fun uu____50  ->
-    match uu____50 with | (text,range) -> { idText = text; idRange = range }
-let reserved_prefix: Prims.string = "uu___"
-let gen: FStar_Range.range -> ident =
-  let x = FStar_Util.mk_ref (Prims.parse_int "0") in
-  fun r  ->
-    (let uu____62 =
-       let uu____63 = FStar_ST.read x in uu____63 + (Prims.parse_int "1") in
-     FStar_ST.write x uu____62);
-    (let uu____68 =
-       let uu____71 =
-         let uu____72 =
-           let uu____73 = FStar_ST.read x in Prims.string_of_int uu____73 in
-         Prims.strcat reserved_prefix uu____72 in
-       (uu____71, r) in
-     mk_ident uu____68)
-let id_of_text: Prims.string -> ident =
-  fun str  -> mk_ident (str, FStar_Range.dummyRange)
-let text_of_id: ident -> Prims.string = fun id  -> id.idText
-let text_of_path: Prims.string Prims.list -> Prims.string =
-  fun path  -> FStar_Util.concat_l "." path
-let path_of_text: Prims.string -> Prims.string Prims.list =
-  fun text  -> FStar_String.split ['.'] text
-let path_of_ns: ident Prims.list -> Prims.string Prims.list =
-  fun ns  -> FStar_List.map text_of_id ns
-let path_of_lid: lident -> Prims.string Prims.list =
-  fun lid  ->
-    FStar_List.map text_of_id (FStar_List.append lid.ns [lid.ident])
-let ids_of_lid: lident -> ident Prims.list =
-  fun lid  -> FStar_List.append lid.ns [lid.ident]
-let lid_of_ns_and_id: ident Prims.list -> ident -> lident =
-  fun ns  ->
-    fun id  ->
-      let nsstr =
-        let uu____114 = FStar_List.map text_of_id ns in
-        FStar_All.pipe_right uu____114 text_of_path in
-      {
-        ns;
-        ident = id;
-        nsstr;
-        str =
-          (if nsstr = ""
-           then id.idText
-           else Prims.strcat nsstr (Prims.strcat "." id.idText))
-      }
-let lid_of_ids: ident Prims.list -> lident =
-  fun ids  ->
-    let uu____123 = FStar_Util.prefix ids in
-    match uu____123 with | (ns,id) -> lid_of_ns_and_id ns id
-let lid_of_path: Prims.string Prims.list -> FStar_Range.range -> lident =
-  fun path  ->
-    fun pos  ->
-      let ids = FStar_List.map (fun s  -> mk_ident (s, pos)) path in
-      lid_of_ids ids
-let text_of_lid: lident -> Prims.string = fun lid  -> lid.str
-let lid_equals: lident -> lident -> Prims.bool =
-  fun l1  -> fun l2  -> l1.str = l2.str
-let ident_equals: ident -> ident -> Prims.bool =
-  fun id1  -> fun id2  -> id1.idText = id2.idText
-let range_of_lid: lid -> FStar_Range.range = fun lid  -> (lid.ident).idRange
-let set_lid_range: lident -> FStar_Range.range -> lident =
-  fun l  ->
-    fun r  ->
-      let uu___45_166 = l in
-      {
-        ns = (uu___45_166.ns);
-        ident =
-          (let uu___46_167 = l.ident in
-           { idText = (uu___46_167.idText); idRange = r });
-        nsstr = (uu___45_166.nsstr);
-        str = (uu___45_166.str)
-      }
-let lid_add_suffix: lident -> Prims.string -> lident =
-  fun l  ->
-    fun s  ->
-      let path = path_of_lid l in
-      lid_of_path (FStar_List.append path [s]) (range_of_lid l)
-let string_of_lid: lident -> Prims.string =
-  fun lid  -> let uu____179 = path_of_lid lid in text_of_path uu____179
+{ns : ident Prims.list; ident : ident; nsstr : Prims.string; str : Prims.string}
+
+
+type lid =
+lident
+
+
+let mk_ident : (Prims.string * FStar_Range.range)  ->  ident = (fun uu____50 -> (match (uu____50) with
+| (text, range) -> begin
+{idText = text; idRange = range}
+end))
+
+
+let reserved_prefix : Prims.string = "uu___"
+
+
+let gen : FStar_Range.range  ->  ident = (
+
+let x = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (fun r -> ((
+
+let uu____62 = (
+
+let uu____63 = (FStar_ST.read x)
+in (uu____63 + (Prims.parse_int "1")))
+in (FStar_ST.write x uu____62));
+(
+
+let uu____68 = (
+
+let uu____71 = (
+
+let uu____72 = (
+
+let uu____73 = (FStar_ST.read x)
+in (Prims.string_of_int uu____73))
+in (Prims.strcat reserved_prefix uu____72))
+in ((uu____71), (r)))
+in (mk_ident uu____68));
+)))
+
+
+let id_of_text : Prims.string  ->  ident = (fun str -> (mk_ident ((str), (FStar_Range.dummyRange))))
+
+
+let text_of_id : ident  ->  Prims.string = (fun id -> id.idText)
+
+
+let text_of_path : Prims.string Prims.list  ->  Prims.string = (fun path -> (FStar_Util.concat_l "." path))
+
+
+let path_of_text : Prims.string  ->  Prims.string Prims.list = (fun text -> (FStar_String.split (('.')::[]) text))
+
+
+let path_of_ns : ident Prims.list  ->  Prims.string Prims.list = (fun ns -> (FStar_List.map text_of_id ns))
+
+
+let path_of_lid : lident  ->  Prims.string Prims.list = (fun lid -> (FStar_List.map text_of_id (FStar_List.append lid.ns ((lid.ident)::[]))))
+
+
+let ids_of_lid : lident  ->  ident Prims.list = (fun lid -> (FStar_List.append lid.ns ((lid.ident)::[])))
+
+
+let lid_of_ns_and_id : ident Prims.list  ->  ident  ->  lident = (fun ns id -> (
+
+let nsstr = (
+
+let uu____114 = (FStar_List.map text_of_id ns)
+in (FStar_All.pipe_right uu____114 text_of_path))
+in {ns = ns; ident = id; nsstr = nsstr; str = (match ((nsstr = "")) with
+| true -> begin
+id.idText
+end
+| uu____117 -> begin
+(Prims.strcat nsstr (Prims.strcat "." id.idText))
+end)}))
+
+
+let lid_of_ids : ident Prims.list  ->  lident = (fun ids -> (
+
+let uu____123 = (FStar_Util.prefix ids)
+in (match (uu____123) with
+| (ns, id) -> begin
+(lid_of_ns_and_id ns id)
+end)))
+
+
+let lid_of_path : Prims.string Prims.list  ->  FStar_Range.range  ->  lident = (fun path pos -> (
+
+let ids = (FStar_List.map (fun s -> (mk_ident ((s), (pos)))) path)
+in (lid_of_ids ids)))
+
+
+let text_of_lid : lident  ->  Prims.string = (fun lid -> lid.str)
+
+
+let lid_equals : lident  ->  lident  ->  Prims.bool = (fun l1 l2 -> (l1.str = l2.str))
+
+
+let ident_equals : ident  ->  ident  ->  Prims.bool = (fun id1 id2 -> (id1.idText = id2.idText))
+
+
+let range_of_lid : lid  ->  FStar_Range.range = (fun lid -> lid.ident.idRange)
+
+
+let set_lid_range : lident  ->  FStar_Range.range  ->  lident = (fun l r -> (
+
+let uu___45_166 = l
+in {ns = uu___45_166.ns; ident = (
+
+let uu___46_167 = l.ident
+in {idText = uu___46_167.idText; idRange = r}); nsstr = uu___45_166.nsstr; str = uu___45_166.str}))
+
+
+let lid_add_suffix : lident  ->  Prims.string  ->  lident = (fun l s -> (
+
+let path = (path_of_lid l)
+in (lid_of_path (FStar_List.append path ((s)::[])) (range_of_lid l))))
+
+
+let string_of_lid : lident  ->  Prims.string = (fun lid -> (
+
+let uu____179 = (path_of_lid lid)
+in (text_of_path uu____179)))
+
+
+
+

--- a/src/ocaml-output/FStar_Indent.ml
+++ b/src/ocaml-output/FStar_Indent.ml
@@ -1,34 +1,43 @@
+
 open Prims
-let generate: FStar_Parser_ParseIt.filename Prims.list -> Prims.unit =
-  fun filenames  ->
-    let parse_and_indent filename =
-      let uu____10 = FStar_Parser_Driver.parse_file filename in
-      match uu____10 with
-      | (moduls,comments) ->
-          let leftover_comments =
-            FStar_List.fold_left
-              (fun comments1  ->
-                 fun module_  ->
-                   let uu____36 =
-                     FStar_Parser_ToDocument.modul_with_comments_to_document
-                       module_ comments1 in
-                   match uu____36 with
-                   | (doc1,comments2) ->
-                       (FStar_Pprint.pretty_out_channel
-                          (FStar_Util.float_of_string "1.0")
-                          (Prims.parse_int "100") doc1 FStar_Util.stdout;
-                        comments2)) (FStar_List.rev comments) moduls in
-          let left_over_doc =
-            let uu____57 =
-              let uu____59 =
-                let uu____61 =
-                  let uu____63 =
-                    FStar_Parser_ToDocument.comments_to_document
-                      leftover_comments in
-                  [uu____63] in
-                FStar_Pprint.hardline :: uu____61 in
-              FStar_Pprint.hardline :: uu____59 in
-            FStar_Pprint.concat uu____57 in
-          FStar_Pprint.pretty_out_channel (FStar_Util.float_of_string "1.0")
-            (Prims.parse_int "100") left_over_doc FStar_Util.stdout in
-    FStar_List.iter parse_and_indent filenames
+
+let generate : FStar_Parser_ParseIt.filename Prims.list  ->  Prims.unit = (fun filenames -> (
+
+let parse_and_indent = (fun filename -> (
+
+let uu____10 = (FStar_Parser_Driver.parse_file filename)
+in (match (uu____10) with
+| (moduls, comments) -> begin
+(
+
+let leftover_comments = (FStar_List.fold_left (fun comments1 module_ -> (
+
+let uu____36 = (FStar_Parser_ToDocument.modul_with_comments_to_document module_ comments1)
+in (match (uu____36) with
+| (doc1, comments2) -> begin
+((FStar_Pprint.pretty_out_channel (FStar_Util.float_of_string "1.0") (Prims.parse_int "100") doc1 FStar_Util.stdout);
+comments2;
+)
+end))) (FStar_List.rev comments) moduls)
+in (
+
+let left_over_doc = (
+
+let uu____57 = (
+
+let uu____59 = (
+
+let uu____61 = (
+
+let uu____63 = (FStar_Parser_ToDocument.comments_to_document leftover_comments)
+in (uu____63)::[])
+in (FStar_Pprint.hardline)::uu____61)
+in (FStar_Pprint.hardline)::uu____59)
+in (FStar_Pprint.concat uu____57))
+in (FStar_Pprint.pretty_out_channel (FStar_Util.float_of_string "1.0") (Prims.parse_int "100") left_over_doc FStar_Util.stdout)))
+end)))
+in (FStar_List.iter parse_and_indent filenames)))
+
+
+
+

--- a/src/ocaml-output/FStar_Interactive.ml
+++ b/src/ocaml-output/FStar_Interactive.ml
@@ -1,871 +1,1253 @@
+
 open Prims
-let tc_one_file remaining uenv =
-  let uu____26 = uenv in
-  match uu____26 with
-  | (dsenv,env) ->
-      let uu____40 =
-        match remaining with
-        | intf::impl::remaining1 when
-            FStar_Universal.needs_interleaving intf impl ->
-            let uu____61 =
-              FStar_Universal.tc_one_file_and_intf (Some intf) impl dsenv env in
-            (match uu____61 with
-             | (uu____76,dsenv1,env1) ->
-                 (((Some intf), impl), dsenv1, env1, remaining1))
-        | intf_or_impl::remaining1 ->
-            let uu____93 =
-              FStar_Universal.tc_one_file_and_intf None intf_or_impl dsenv
-                env in
-            (match uu____93 with
-             | (uu____108,dsenv1,env1) ->
-                 ((None, intf_or_impl), dsenv1, env1, remaining1))
-        | [] -> failwith "Impossible" in
-      (match uu____40 with
-       | ((intf,impl),dsenv1,env1,remaining1) ->
-           ((intf, impl), (dsenv1, env1), None, remaining1))
-let tc_prims:
-  Prims.unit -> (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) =
-  fun uu____165  ->
-    let uu____166 = FStar_Universal.tc_prims () in
-    match uu____166 with | (uu____174,dsenv,env) -> (dsenv, env)
-type env_t = (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-type modul_t = FStar_Syntax_Syntax.modul Prims.option
-type stack_t = (env_t* modul_t) Prims.list
-let pop uu____199 msg =
-  match uu____199 with
-  | (uu____203,env) ->
-      (FStar_Universal.pop_context env msg; FStar_Options.pop ())
-let push:
-  (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) ->
-    Prims.bool ->
-      Prims.bool ->
-        Prims.string -> (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun uu____218  ->
-    fun lax1  ->
-      fun restore_cmd_line_options1  ->
-        fun msg  ->
-          match uu____218 with
-          | (dsenv,env) ->
-              let env1 =
-                let uu___222_229 = env in
-                {
-                  FStar_TypeChecker_Env.solver =
-                    (uu___222_229.FStar_TypeChecker_Env.solver);
-                  FStar_TypeChecker_Env.range =
-                    (uu___222_229.FStar_TypeChecker_Env.range);
-                  FStar_TypeChecker_Env.curmodule =
-                    (uu___222_229.FStar_TypeChecker_Env.curmodule);
-                  FStar_TypeChecker_Env.gamma =
-                    (uu___222_229.FStar_TypeChecker_Env.gamma);
-                  FStar_TypeChecker_Env.gamma_cache =
-                    (uu___222_229.FStar_TypeChecker_Env.gamma_cache);
-                  FStar_TypeChecker_Env.modules =
-                    (uu___222_229.FStar_TypeChecker_Env.modules);
-                  FStar_TypeChecker_Env.expected_typ =
-                    (uu___222_229.FStar_TypeChecker_Env.expected_typ);
-                  FStar_TypeChecker_Env.sigtab =
-                    (uu___222_229.FStar_TypeChecker_Env.sigtab);
-                  FStar_TypeChecker_Env.is_pattern =
-                    (uu___222_229.FStar_TypeChecker_Env.is_pattern);
-                  FStar_TypeChecker_Env.instantiate_imp =
-                    (uu___222_229.FStar_TypeChecker_Env.instantiate_imp);
-                  FStar_TypeChecker_Env.effects =
-                    (uu___222_229.FStar_TypeChecker_Env.effects);
-                  FStar_TypeChecker_Env.generalize =
-                    (uu___222_229.FStar_TypeChecker_Env.generalize);
-                  FStar_TypeChecker_Env.letrecs =
-                    (uu___222_229.FStar_TypeChecker_Env.letrecs);
-                  FStar_TypeChecker_Env.top_level =
-                    (uu___222_229.FStar_TypeChecker_Env.top_level);
-                  FStar_TypeChecker_Env.check_uvars =
-                    (uu___222_229.FStar_TypeChecker_Env.check_uvars);
-                  FStar_TypeChecker_Env.use_eq =
-                    (uu___222_229.FStar_TypeChecker_Env.use_eq);
-                  FStar_TypeChecker_Env.is_iface =
-                    (uu___222_229.FStar_TypeChecker_Env.is_iface);
-                  FStar_TypeChecker_Env.admit =
-                    (uu___222_229.FStar_TypeChecker_Env.admit);
-                  FStar_TypeChecker_Env.lax = lax1;
-                  FStar_TypeChecker_Env.lax_universes =
-                    (uu___222_229.FStar_TypeChecker_Env.lax_universes);
-                  FStar_TypeChecker_Env.type_of =
-                    (uu___222_229.FStar_TypeChecker_Env.type_of);
-                  FStar_TypeChecker_Env.universe_of =
-                    (uu___222_229.FStar_TypeChecker_Env.universe_of);
-                  FStar_TypeChecker_Env.use_bv_sorts =
-                    (uu___222_229.FStar_TypeChecker_Env.use_bv_sorts);
-                  FStar_TypeChecker_Env.qname_and_index =
-                    (uu___222_229.FStar_TypeChecker_Env.qname_and_index)
-                } in
-              let res = FStar_Universal.push_context (dsenv, env1) msg in
-              (FStar_Options.push ();
-               if restore_cmd_line_options1
-               then
-                 (let uu____235 =
-                    FStar_Options.restore_cmd_line_options false in
-                  FStar_All.pipe_right uu____235 Prims.ignore)
-               else ();
-               res)
-let mark:
-  (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) ->
-    (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun uu____243  ->
-    match uu____243 with
-    | (dsenv,env) ->
-        let dsenv1 = FStar_ToSyntax_Env.mark dsenv in
-        let env1 = FStar_TypeChecker_Env.mark env in
-        (FStar_Options.push (); (dsenv1, env1))
-let reset_mark uu____263 =
-  match uu____263 with
-  | (uu____266,env) ->
-      let dsenv = FStar_ToSyntax_Env.reset_mark () in
-      let env1 = FStar_TypeChecker_Env.reset_mark env in
-      (FStar_Options.pop (); (dsenv, env1))
-let cleanup uu____279 =
-  match uu____279 with
-  | (dsenv,env) -> FStar_TypeChecker_Env.cleanup_interactive env
-let commit_mark:
-  (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) ->
-    (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun uu____290  ->
-    match uu____290 with
-    | (dsenv,env) ->
-        let dsenv1 = FStar_ToSyntax_Env.commit_mark dsenv in
-        let env1 = FStar_TypeChecker_Env.commit_mark env in (dsenv1, env1)
-let check_frag:
-  (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) ->
-    FStar_Syntax_Syntax.modul Prims.option ->
-      FStar_Parser_ParseIt.input_frag ->
-        (FStar_Syntax_Syntax.modul Prims.option* (FStar_ToSyntax_Env.env*
-          FStar_TypeChecker_Env.env)* Prims.int) Prims.option
-  =
-  fun uu____315  ->
-    fun curmod  ->
-      fun text1  ->
-        match uu____315 with
-        | (dsenv,env) ->
-            (try
-               let uu____345 =
-                 FStar_Universal.tc_one_fragment curmod dsenv env text1 in
-               match uu____345 with
-               | Some (m,dsenv1,env1) ->
-                   let uu____367 =
-                     let uu____374 = FStar_Errors.get_err_count () in
-                     (m, (dsenv1, env1), uu____374) in
-                   Some uu____367
-               | uu____384 -> None
-             with
-             | FStar_Errors.Error (msg,r) when
-                 let uu____406 = FStar_Options.trace_error () in
-                 Prims.op_Negation uu____406 ->
-                 (FStar_TypeChecker_Err.add_errors env [(msg, r)]; None)
-             | FStar_Errors.Err msg when
-                 let uu____419 = FStar_Options.trace_error () in
-                 Prims.op_Negation uu____419 ->
-                 ((let uu____421 =
-                     let uu____425 =
-                       let uu____428 = FStar_TypeChecker_Env.get_range env in
-                       (msg, uu____428) in
-                     [uu____425] in
-                   FStar_TypeChecker_Err.add_errors env uu____421);
-                  None))
-let report_fail: Prims.unit -> Prims.unit =
-  fun uu____441  ->
-    (let uu____443 = FStar_Errors.report_all () in
-     FStar_All.pipe_right uu____443 Prims.ignore);
-    FStar_ST.write FStar_Errors.num_errs (Prims.parse_int "0")
+
+let tc_one_file = (fun remaining uenv -> (
+
+let uu____26 = uenv
+in (match (uu____26) with
+| (dsenv, env) -> begin
+(
+
+let uu____40 = (match (remaining) with
+| (intf)::(impl)::remaining1 when (FStar_Universal.needs_interleaving intf impl) -> begin
+(
+
+let uu____61 = (FStar_Universal.tc_one_file_and_intf (Some (intf)) impl dsenv env)
+in (match (uu____61) with
+| (uu____76, dsenv1, env1) -> begin
+((((Some (intf)), (impl))), (dsenv1), (env1), (remaining1))
+end))
+end
+| (intf_or_impl)::remaining1 -> begin
+(
+
+let uu____93 = (FStar_Universal.tc_one_file_and_intf None intf_or_impl dsenv env)
+in (match (uu____93) with
+| (uu____108, dsenv1, env1) -> begin
+((((None), (intf_or_impl))), (dsenv1), (env1), (remaining1))
+end))
+end
+| [] -> begin
+(failwith "Impossible")
+end)
+in (match (uu____40) with
+| ((intf, impl), dsenv1, env1, remaining1) -> begin
+((((intf), (impl))), (((dsenv1), (env1))), (None), (remaining1))
+end))
+end)))
+
+
+let tc_prims : Prims.unit  ->  (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____165 -> (
+
+let uu____166 = (FStar_Universal.tc_prims ())
+in (match (uu____166) with
+| (uu____174, dsenv, env) -> begin
+((dsenv), (env))
+end)))
+
+
+type env_t =
+(FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)
+
+
+type modul_t =
+FStar_Syntax_Syntax.modul Prims.option
+
+
+type stack_t =
+(env_t * modul_t) Prims.list
+
+
+let pop = (fun uu____199 msg -> (match (uu____199) with
+| (uu____203, env) -> begin
+((FStar_Universal.pop_context env msg);
+(FStar_Options.pop ());
+)
+end))
+
+
+let push : (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)  ->  Prims.bool  ->  Prims.bool  ->  Prims.string  ->  (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____218 lax1 restore_cmd_line_options1 msg -> (match (uu____218) with
+| (dsenv, env) -> begin
+(
+
+let env1 = (
+
+let uu___219_229 = env
+in {FStar_TypeChecker_Env.solver = uu___219_229.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___219_229.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___219_229.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___219_229.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___219_229.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___219_229.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___219_229.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___219_229.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___219_229.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___219_229.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___219_229.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___219_229.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___219_229.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___219_229.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___219_229.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___219_229.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___219_229.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___219_229.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = lax1; FStar_TypeChecker_Env.lax_universes = uu___219_229.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___219_229.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___219_229.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___219_229.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___219_229.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let res = (FStar_Universal.push_context ((dsenv), (env1)) msg)
+in ((FStar_Options.push ());
+(match (restore_cmd_line_options1) with
+| true -> begin
+(
+
+let uu____235 = (FStar_Options.restore_cmd_line_options false)
+in (FStar_All.pipe_right uu____235 Prims.ignore))
+end
+| uu____236 -> begin
+()
+end);
+res;
+)))
+end))
+
+
+let mark : (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)  ->  (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____243 -> (match (uu____243) with
+| (dsenv, env) -> begin
+(
+
+let dsenv1 = (FStar_ToSyntax_Env.mark dsenv)
+in (
+
+let env1 = (FStar_TypeChecker_Env.mark env)
+in ((FStar_Options.push ());
+((dsenv1), (env1));
+)))
+end))
+
+
+let reset_mark = (fun uu____263 -> (match (uu____263) with
+| (uu____266, env) -> begin
+(
+
+let dsenv = (FStar_ToSyntax_Env.reset_mark ())
+in (
+
+let env1 = (FStar_TypeChecker_Env.reset_mark env)
+in ((FStar_Options.pop ());
+((dsenv), (env1));
+)))
+end))
+
+
+let cleanup = (fun uu____279 -> (match (uu____279) with
+| (dsenv, env) -> begin
+(FStar_TypeChecker_Env.cleanup_interactive env)
+end))
+
+
+let commit_mark : (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)  ->  (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____290 -> (match (uu____290) with
+| (dsenv, env) -> begin
+(
+
+let dsenv1 = (FStar_ToSyntax_Env.commit_mark dsenv)
+in (
+
+let env1 = (FStar_TypeChecker_Env.commit_mark env)
+in ((dsenv1), (env1))))
+end))
+
+
+let check_frag : (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)  ->  FStar_Syntax_Syntax.modul Prims.option  ->  FStar_Parser_ParseIt.input_frag  ->  (FStar_Syntax_Syntax.modul Prims.option * (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) * Prims.int) Prims.option = (fun uu____315 curmod text1 -> (match (uu____315) with
+| (dsenv, env) -> begin
+try
+(match (()) with
+| () -> begin
+(
+
+let uu____345 = (FStar_Universal.tc_one_fragment curmod dsenv env text1)
+in (match (uu____345) with
+| Some (m, dsenv1, env1) -> begin
+(
+
+let uu____367 = (
+
+let uu____374 = (FStar_Errors.get_err_count ())
+in ((m), (((dsenv1), (env1))), (uu____374)))
+in Some (uu____367))
+end
+| uu____384 -> begin
+None
+end))
+end)
+with
+| FStar_Errors.Error (msg, r) when (
+
+let uu____406 = (FStar_Options.trace_error ())
+in (not (uu____406))) -> begin
+((FStar_TypeChecker_Err.add_errors env ((((msg), (r)))::[]));
+None;
+)
+end
+| FStar_Errors.Err (msg) when (
+
+let uu____419 = (FStar_Options.trace_error ())
+in (not (uu____419))) -> begin
+((
+
+let uu____421 = (
+
+let uu____425 = (
+
+let uu____428 = (FStar_TypeChecker_Env.get_range env)
+in ((msg), (uu____428)))
+in (uu____425)::[])
+in (FStar_TypeChecker_Err.add_errors env uu____421));
+None;
+)
+end
+end))
+
+
+let report_fail : Prims.unit  ->  Prims.unit = (fun uu____441 -> ((
+
+let uu____443 = (FStar_Errors.report_all ())
+in (FStar_All.pipe_right uu____443 Prims.ignore));
+(FStar_ST.write FStar_Errors.num_errs (Prims.parse_int "0"));
+))
+
 type input_chunks =
-  | Push of (Prims.bool* Prims.int* Prims.int)
-  | Pop of Prims.string
-  | Code of (Prims.string* (Prims.string* Prims.string))
-  | Info of (Prims.string* Prims.bool* (Prims.string* Prims.int* Prims.int)
-  Prims.option)
-  | Completions of Prims.string
-let uu___is_Push: input_chunks -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Push _0 -> true | uu____485 -> false
-let __proj__Push__item___0:
-  input_chunks -> (Prims.bool* Prims.int* Prims.int) =
-  fun projectee  -> match projectee with | Push _0 -> _0
-let uu___is_Pop: input_chunks -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pop _0 -> true | uu____506 -> false
-let __proj__Pop__item___0: input_chunks -> Prims.string =
-  fun projectee  -> match projectee with | Pop _0 -> _0
-let uu___is_Code: input_chunks -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Code _0 -> true | uu____522 -> false
-let __proj__Code__item___0:
-  input_chunks -> (Prims.string* (Prims.string* Prims.string)) =
-  fun projectee  -> match projectee with | Code _0 -> _0
-let uu___is_Info: input_chunks -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Info _0 -> true | uu____553 -> false
-let __proj__Info__item___0:
-  input_chunks ->
-    (Prims.string* Prims.bool* (Prims.string* Prims.int* Prims.int)
-      Prims.option)
-  = fun projectee  -> match projectee with | Info _0 -> _0
-let uu___is_Completions: input_chunks -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Completions _0 -> true | uu____586 -> false
-let __proj__Completions__item___0: input_chunks -> Prims.string =
-  fun projectee  -> match projectee with | Completions _0 -> _0
+| Push of (Prims.bool * Prims.int * Prims.int)
+| Pop of Prims.string
+| Code of (Prims.string * (Prims.string * Prims.string))
+| Info of (Prims.string * Prims.bool * (Prims.string * Prims.int * Prims.int) Prims.option)
+| Completions of Prims.string
+
+
+let uu___is_Push : input_chunks  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Push (_0) -> begin
+true
+end
+| uu____485 -> begin
+false
+end))
+
+
+let __proj__Push__item___0 : input_chunks  ->  (Prims.bool * Prims.int * Prims.int) = (fun projectee -> (match (projectee) with
+| Push (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pop : input_chunks  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pop (_0) -> begin
+true
+end
+| uu____506 -> begin
+false
+end))
+
+
+let __proj__Pop__item___0 : input_chunks  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Pop (_0) -> begin
+_0
+end))
+
+
+let uu___is_Code : input_chunks  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Code (_0) -> begin
+true
+end
+| uu____522 -> begin
+false
+end))
+
+
+let __proj__Code__item___0 : input_chunks  ->  (Prims.string * (Prims.string * Prims.string)) = (fun projectee -> (match (projectee) with
+| Code (_0) -> begin
+_0
+end))
+
+
+let uu___is_Info : input_chunks  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Info (_0) -> begin
+true
+end
+| uu____553 -> begin
+false
+end))
+
+
+let __proj__Info__item___0 : input_chunks  ->  (Prims.string * Prims.bool * (Prims.string * Prims.int * Prims.int) Prims.option) = (fun projectee -> (match (projectee) with
+| Info (_0) -> begin
+_0
+end))
+
+
+let uu___is_Completions : input_chunks  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Completions (_0) -> begin
+true
+end
+| uu____586 -> begin
+false
+end))
+
+
+let __proj__Completions__item___0 : input_chunks  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Completions (_0) -> begin
+_0
+end))
+
 type interactive_state =
-  {
-  chunk: FStar_Util.string_builder;
-  stdin: FStar_Util.stream_reader Prims.option FStar_ST.ref;
-  buffer: input_chunks Prims.list FStar_ST.ref;
-  log: FStar_Util.file_handle Prims.option FStar_ST.ref;}
-let the_interactive_state: interactive_state =
-  let uu____649 = FStar_Util.new_string_builder () in
-  let uu____650 = FStar_Util.mk_ref None in
-  let uu____655 = FStar_Util.mk_ref [] in
-  let uu____660 = FStar_Util.mk_ref None in
-  { chunk = uu____649; stdin = uu____650; buffer = uu____655; log = uu____660
-  }
-let rec read_chunk: Prims.unit -> input_chunks =
-  fun uu____673  ->
-    let s = the_interactive_state in
-    let log =
-      let uu____678 = FStar_Options.debug_any () in
-      if uu____678
-      then
-        let transcript =
-          let uu____682 = FStar_ST.read s.log in
-          match uu____682 with
-          | Some transcript -> transcript
-          | None  ->
-              let transcript = FStar_Util.open_file_for_writing "transcript" in
-              (FStar_ST.write s.log (Some transcript); transcript) in
-        fun line  ->
-          (FStar_Util.append_to_file transcript line;
-           FStar_Util.flush_file transcript)
-      else (fun uu____696  -> ()) in
-    let stdin =
-      let uu____698 = FStar_ST.read s.stdin in
-      match uu____698 with
-      | Some i -> i
-      | None  ->
-          let i = FStar_Util.open_stdin () in
-          (FStar_ST.write s.stdin (Some i); i) in
-    let line =
-      let uu____710 = FStar_Util.read_line stdin in
-      match uu____710 with
-      | None  -> FStar_All.exit (Prims.parse_int "0")
-      | Some l -> l in
-    log line;
-    (let l = FStar_Util.trim_string line in
-     if FStar_Util.starts_with l "#end"
-     then
-       let responses =
-         match FStar_Util.split l " " with
-         | uu____720::ok::fail1::[] -> (ok, fail1)
-         | uu____723 -> ("ok", "fail") in
-       let str = FStar_Util.string_of_string_builder s.chunk in
-       (FStar_Util.clear_string_builder s.chunk; Code (str, responses))
-     else
-       if FStar_Util.starts_with l "#pop"
-       then (FStar_Util.clear_string_builder s.chunk; Pop l)
-       else
-         if FStar_Util.starts_with l "#push"
-         then
-           (FStar_Util.clear_string_builder s.chunk;
-            (let lc_lax =
-               let uu____734 =
-                 FStar_Util.substring_from l (FStar_String.length "#push") in
-               FStar_Util.trim_string uu____734 in
-             let lc =
-               match FStar_Util.split lc_lax " " with
-               | l1::c::"#lax"::[] ->
-                   let uu____746 = FStar_Util.int_of_string l1 in
-                   let uu____747 = FStar_Util.int_of_string c in
-                   (true, uu____746, uu____747)
-               | l1::c::[] ->
-                   let uu____750 = FStar_Util.int_of_string l1 in
-                   let uu____751 = FStar_Util.int_of_string c in
-                   (false, uu____750, uu____751)
-               | uu____752 ->
-                   (FStar_Util.print_warning
-                      (Prims.strcat
-                         "Error locations may be wrong, unrecognized string after #push: "
-                         lc_lax);
-                    (false, (Prims.parse_int "1"), (Prims.parse_int "0"))) in
-             Push lc))
-         else
-           if FStar_Util.starts_with l "#info "
-           then
-             (match FStar_Util.split l " " with
-              | uu____756::symbol::[] ->
-                  (FStar_Util.clear_string_builder s.chunk;
-                   Info (symbol, true, None))
-              | uu____766::symbol::file::row::col::[] ->
-                  (FStar_Util.clear_string_builder s.chunk;
-                   (let uu____772 =
-                      let uu____780 =
-                        let uu____785 =
-                          let uu____789 = FStar_Util.int_of_string row in
-                          let uu____790 = FStar_Util.int_of_string col in
-                          (file, uu____789, uu____790) in
-                        Some uu____785 in
-                      (symbol, false, uu____780) in
-                    Info uu____772))
-              | uu____798 ->
-                  (FStar_Util.print_error
-                     (Prims.strcat "Unrecognized \"#info\" request: " l);
-                   FStar_All.exit (Prims.parse_int "1")))
-           else
-             if FStar_Util.starts_with l "#completions "
-             then
-               (match FStar_Util.split l " " with
-                | uu____802::prefix1::"#"::[] ->
-                    (FStar_Util.clear_string_builder s.chunk;
-                     Completions prefix1)
-                | uu____805 ->
-                    (FStar_Util.print_error
-                       (Prims.strcat
-                          "Unrecognized \"#completions\" request: " l);
-                     FStar_All.exit (Prims.parse_int "1")))
-             else
-               if l = "#finish"
-               then FStar_All.exit (Prims.parse_int "0")
-               else
-                 (FStar_Util.string_builder_append s.chunk line;
-                  FStar_Util.string_builder_append s.chunk "\n";
-                  read_chunk ()))
-let shift_chunk: Prims.unit -> input_chunks =
-  fun uu____814  ->
-    let s = the_interactive_state in
-    let uu____816 = FStar_ST.read s.buffer in
-    match uu____816 with
-    | [] -> read_chunk ()
-    | chunk::chunks -> (FStar_ST.write s.buffer chunks; chunk)
-let fill_buffer: Prims.unit -> Prims.unit =
-  fun uu____830  ->
-    let s = the_interactive_state in
-    let uu____832 =
-      let uu____834 = FStar_ST.read s.buffer in
-      let uu____839 = let uu____841 = read_chunk () in [uu____841] in
-      FStar_List.append uu____834 uu____839 in
-    FStar_ST.write s.buffer uu____832
-let deps_of_our_file:
-  Prims.string -> (Prims.string Prims.list* Prims.string Prims.option) =
-  fun filename  ->
-    let deps =
-      FStar_Dependencies.find_deps_if_needed
-        FStar_Parser_Dep.VerifyFigureItOut [filename] in
-    let uu____854 =
-      FStar_List.partition
-        (fun x  ->
-           let uu____860 = FStar_Parser_Dep.lowercase_module_name x in
-           let uu____861 = FStar_Parser_Dep.lowercase_module_name filename in
-           uu____860 <> uu____861) deps in
-    match uu____854 with
-    | (deps1,same_name) ->
-        let maybe_intf =
-          match same_name with
-          | intf::impl::[] ->
-              ((let uu____878 =
-                  (let uu____879 = FStar_Parser_Dep.is_interface intf in
-                   Prims.op_Negation uu____879) ||
-                    (let uu____880 = FStar_Parser_Dep.is_implementation impl in
-                     Prims.op_Negation uu____880) in
-                if uu____878
-                then
-                  let uu____881 =
-                    FStar_Util.format2
-                      "Found %s and %s but not an interface + implementation"
-                      intf impl in
-                  FStar_Util.print_warning uu____881
-                else ());
-               Some intf)
-          | impl::[] -> None
-          | uu____884 ->
-              ((let uu____887 =
-                  FStar_Util.format1 "Unexpected: ended up with %s"
-                    (FStar_String.concat " " same_name) in
-                FStar_Util.print_warning uu____887);
-               None) in
-        (deps1, maybe_intf)
+{chunk : FStar_Util.string_builder; stdin : FStar_Util.stream_reader Prims.option FStar_ST.ref; buffer : input_chunks Prims.list FStar_ST.ref; log : FStar_Util.file_handle Prims.option FStar_ST.ref}
+
+
+let the_interactive_state : interactive_state = (
+
+let uu____649 = (FStar_Util.new_string_builder ())
+in (
+
+let uu____650 = (FStar_Util.mk_ref None)
+in (
+
+let uu____655 = (FStar_Util.mk_ref [])
+in (
+
+let uu____660 = (FStar_Util.mk_ref None)
+in {chunk = uu____649; stdin = uu____650; buffer = uu____655; log = uu____660}))))
+
+
+let rec read_chunk : Prims.unit  ->  input_chunks = (fun uu____673 -> (
+
+let s = the_interactive_state
+in (
+
+let log = (
+
+let uu____678 = (FStar_Options.debug_any ())
+in (match (uu____678) with
+| true -> begin
+(
+
+let transcript = (
+
+let uu____682 = (FStar_ST.read s.log)
+in (match (uu____682) with
+| Some (transcript) -> begin
+transcript
+end
+| None -> begin
+(
+
+let transcript = (FStar_Util.open_file_for_writing "transcript")
+in ((FStar_ST.write s.log (Some (transcript)));
+transcript;
+))
+end))
+in (fun line -> ((FStar_Util.append_to_file transcript line);
+(FStar_Util.flush_file transcript);
+)))
+end
+| uu____695 -> begin
+(fun uu____696 -> ())
+end))
+in (
+
+let stdin = (
+
+let uu____698 = (FStar_ST.read s.stdin)
+in (match (uu____698) with
+| Some (i) -> begin
+i
+end
+| None -> begin
+(
+
+let i = (FStar_Util.open_stdin ())
+in ((FStar_ST.write s.stdin (Some (i)));
+i;
+))
+end))
+in (
+
+let line = (
+
+let uu____710 = (FStar_Util.read_line stdin)
+in (match (uu____710) with
+| None -> begin
+(FStar_All.exit (Prims.parse_int "0"))
+end
+| Some (l) -> begin
+l
+end))
+in ((log line);
+(
+
+let l = (FStar_Util.trim_string line)
+in (match ((FStar_Util.starts_with l "#end")) with
+| true -> begin
+(
+
+let responses = (match ((FStar_Util.split l " ")) with
+| (uu____720)::(ok)::(fail1)::[] -> begin
+((ok), (fail1))
+end
+| uu____723 -> begin
+(("ok"), ("fail"))
+end)
+in (
+
+let str = (FStar_Util.string_of_string_builder s.chunk)
+in ((FStar_Util.clear_string_builder s.chunk);
+Code (((str), (responses)));
+)))
+end
+| uu____729 -> begin
+(match ((FStar_Util.starts_with l "#pop")) with
+| true -> begin
+((FStar_Util.clear_string_builder s.chunk);
+Pop (l);
+)
+end
+| uu____731 -> begin
+(match ((FStar_Util.starts_with l "#push")) with
+| true -> begin
+((FStar_Util.clear_string_builder s.chunk);
+(
+
+let lc_lax = (
+
+let uu____734 = (FStar_Util.substring_from l (FStar_String.length "#push"))
+in (FStar_Util.trim_string uu____734))
+in (
+
+let lc = (match ((FStar_Util.split lc_lax " ")) with
+| (l1)::(c)::("#lax")::[] -> begin
+(
+
+let uu____746 = (FStar_Util.int_of_string l1)
+in (
+
+let uu____747 = (FStar_Util.int_of_string c)
+in ((true), (uu____746), (uu____747))))
+end
+| (l1)::(c)::[] -> begin
+(
+
+let uu____750 = (FStar_Util.int_of_string l1)
+in (
+
+let uu____751 = (FStar_Util.int_of_string c)
+in ((false), (uu____750), (uu____751))))
+end
+| uu____752 -> begin
+((FStar_Util.print_warning (Prims.strcat "Error locations may be wrong, unrecognized string after #push: " lc_lax));
+((false), ((Prims.parse_int "1")), ((Prims.parse_int "0")));
+)
+end)
+in Push (lc)));
+)
+end
+| uu____755 -> begin
+(match ((FStar_Util.starts_with l "#info ")) with
+| true -> begin
+(match ((FStar_Util.split l " ")) with
+| (uu____756)::(symbol)::[] -> begin
+((FStar_Util.clear_string_builder s.chunk);
+Info (((symbol), (true), (None)));
+)
+end
+| (uu____766)::(symbol)::(file)::(row)::(col)::[] -> begin
+((FStar_Util.clear_string_builder s.chunk);
+(
+
+let uu____772 = (
+
+let uu____780 = (
+
+let uu____785 = (
+
+let uu____789 = (FStar_Util.int_of_string row)
+in (
+
+let uu____790 = (FStar_Util.int_of_string col)
+in ((file), (uu____789), (uu____790))))
+in Some (uu____785))
+in ((symbol), (false), (uu____780)))
+in Info (uu____772));
+)
+end
+| uu____798 -> begin
+((FStar_Util.print_error (Prims.strcat "Unrecognized \"#info\" request: " l));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end)
+end
+| uu____801 -> begin
+(match ((FStar_Util.starts_with l "#completions ")) with
+| true -> begin
+(match ((FStar_Util.split l " ")) with
+| (uu____802)::(prefix1)::("#")::[] -> begin
+((FStar_Util.clear_string_builder s.chunk);
+Completions (prefix1);
+)
+end
+| uu____805 -> begin
+((FStar_Util.print_error (Prims.strcat "Unrecognized \"#completions\" request: " l));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end)
+end
+| uu____808 -> begin
+(match ((l = "#finish")) with
+| true -> begin
+(FStar_All.exit (Prims.parse_int "0"))
+end
+| uu____809 -> begin
+((FStar_Util.string_builder_append s.chunk line);
+(FStar_Util.string_builder_append s.chunk "\n");
+(read_chunk ());
+)
+end)
+end)
+end)
+end)
+end)
+end));
+))))))
+
+
+let shift_chunk : Prims.unit  ->  input_chunks = (fun uu____814 -> (
+
+let s = the_interactive_state
+in (
+
+let uu____816 = (FStar_ST.read s.buffer)
+in (match (uu____816) with
+| [] -> begin
+(read_chunk ())
+end
+| (chunk)::chunks -> begin
+((FStar_ST.write s.buffer chunks);
+chunk;
+)
+end))))
+
+
+let fill_buffer : Prims.unit  ->  Prims.unit = (fun uu____830 -> (
+
+let s = the_interactive_state
+in (
+
+let uu____832 = (
+
+let uu____834 = (FStar_ST.read s.buffer)
+in (
+
+let uu____839 = (
+
+let uu____841 = (read_chunk ())
+in (uu____841)::[])
+in (FStar_List.append uu____834 uu____839)))
+in (FStar_ST.write s.buffer uu____832))))
+
+
+let deps_of_our_file : Prims.string  ->  (Prims.string Prims.list * Prims.string Prims.option) = (fun filename -> (
+
+let deps = (FStar_Dependencies.find_deps_if_needed FStar_Parser_Dep.VerifyFigureItOut ((filename)::[]))
+in (
+
+let uu____854 = (FStar_List.partition (fun x -> (
+
+let uu____860 = (FStar_Parser_Dep.lowercase_module_name x)
+in (
+
+let uu____861 = (FStar_Parser_Dep.lowercase_module_name filename)
+in (uu____860 <> uu____861)))) deps)
+in (match (uu____854) with
+| (deps1, same_name) -> begin
+(
+
+let maybe_intf = (match (same_name) with
+| (intf)::(impl)::[] -> begin
+((
+
+let uu____878 = ((
+
+let uu____879 = (FStar_Parser_Dep.is_interface intf)
+in (not (uu____879))) || (
+
+let uu____880 = (FStar_Parser_Dep.is_implementation impl)
+in (not (uu____880))))
+in (match (uu____878) with
+| true -> begin
+(
+
+let uu____881 = (FStar_Util.format2 "Found %s and %s but not an interface + implementation" intf impl)
+in (FStar_Util.print_warning uu____881))
+end
+| uu____882 -> begin
+()
+end));
+Some (intf);
+)
+end
+| (impl)::[] -> begin
+None
+end
+| uu____884 -> begin
+((
+
+let uu____887 = (FStar_Util.format1 "Unexpected: ended up with %s" (FStar_String.concat " " same_name))
+in (FStar_Util.print_warning uu____887));
+None;
+)
+end)
+in ((deps1), (maybe_intf)))
+end))))
+
+
 type m_timestamps =
-  (Prims.string Prims.option* Prims.string* FStar_Util.time Prims.option*
-    FStar_Util.time) Prims.list
-let rec tc_deps:
-  modul_t ->
-    stack_t ->
-      env_t ->
-        Prims.string Prims.list ->
-          m_timestamps -> (stack_t* env_t* m_timestamps)
-  =
-  fun m  ->
-    fun stack  ->
-      fun env  ->
-        fun remaining  ->
-          fun ts  ->
-            match remaining with
-            | [] -> (stack, env, ts)
-            | uu____920 ->
-                let stack1 = (env, m) :: stack in
-                let env1 =
-                  let uu____931 = FStar_Options.lax () in
-                  push env uu____931 true "typecheck_modul" in
-                let uu____932 = tc_one_file remaining env1 in
-                (match uu____932 with
-                 | ((intf,impl),env2,modl,remaining1) ->
-                     let uu____965 =
-                       let intf_t =
-                         match intf with
-                         | Some intf1 ->
-                             let uu____973 =
-                               FStar_Util.get_file_last_modification_time
-                                 intf1 in
-                             Some uu____973
-                         | None  -> None in
-                       let impl_t =
-                         FStar_Util.get_file_last_modification_time impl in
-                       (intf_t, impl_t) in
-                     (match uu____965 with
-                      | (intf_t,impl_t) ->
-                          tc_deps m stack1 env2 remaining1
-                            ((intf, impl, intf_t, impl_t) :: ts)))
-let update_deps:
-  Prims.string ->
-    modul_t ->
-      stack_t -> env_t -> m_timestamps -> (stack_t* env_t* m_timestamps)
-  =
-  fun filename  ->
-    fun m  ->
-      fun stk  ->
-        fun env  ->
-          fun ts  ->
-            let is_stale intf impl intf_t impl_t =
-              let impl_mt = FStar_Util.get_file_last_modification_time impl in
-              (FStar_Util.is_before impl_t impl_mt) ||
-                (match (intf, intf_t) with
-                 | (Some intf1,Some intf_t1) ->
-                     let intf_mt =
-                       FStar_Util.get_file_last_modification_time intf1 in
-                     FStar_Util.is_before intf_t1 intf_mt
-                 | (None ,None ) -> false
-                 | (uu____1039,uu____1040) ->
-                     failwith
-                       "Impossible, if the interface is None, the timestamp entry should also be None") in
-            let rec iterate depnames st env' ts1 good_stack good_ts =
-              let match_dep depnames1 intf impl =
-                match intf with
-                | None  ->
-                    (match depnames1 with
-                     | dep1::depnames' ->
-                         if dep1 = impl
-                         then (true, depnames')
-                         else (false, depnames1)
-                     | uu____1104 -> (false, depnames1))
-                | Some intf1 ->
-                    (match depnames1 with
-                     | depintf::dep1::depnames' ->
-                         if (depintf = intf1) && (dep1 = impl)
-                         then (true, depnames')
-                         else (false, depnames1)
-                     | uu____1121 -> (false, depnames1)) in
-              let rec pop_tc_and_stack env1 stack ts2 =
-                match ts2 with
-                | [] -> env1
-                | uu____1168::ts3 ->
-                    (pop env1 "";
-                     (let uu____1190 =
-                        let uu____1198 = FStar_List.hd stack in
-                        let uu____1203 = FStar_List.tl stack in
-                        (uu____1198, uu____1203) in
-                      match uu____1190 with
-                      | ((env2,uu____1217),stack1) ->
-                          pop_tc_and_stack env2 stack1 ts3)) in
-              match ts1 with
-              | ts_elt::ts' ->
-                  let uu____1251 = ts_elt in
-                  (match uu____1251 with
-                   | (intf,impl,intf_t,impl_t) ->
-                       let uu____1269 = match_dep depnames intf impl in
-                       (match uu____1269 with
-                        | (b,depnames') ->
-                            let uu____1280 =
-                              (Prims.op_Negation b) ||
-                                (is_stale intf impl intf_t impl_t) in
-                            if uu____1280
-                            then
-                              let env1 =
-                                pop_tc_and_stack env'
-                                  (FStar_List.rev_append st []) ts1 in
-                              tc_deps m good_stack env1 depnames good_ts
-                            else
-                              (let uu____1292 =
-                                 let uu____1300 = FStar_List.hd st in
-                                 let uu____1305 = FStar_List.tl st in
-                                 (uu____1300, uu____1305) in
-                               match uu____1292 with
-                               | (stack_elt,st') ->
-                                   iterate depnames' st' env' ts' (stack_elt
-                                     :: good_stack) (ts_elt :: good_ts))))
-              | [] -> tc_deps m good_stack env' depnames good_ts in
-            let uu____1345 = deps_of_our_file filename in
-            match uu____1345 with
-            | (filenames,uu____1354) ->
-                iterate filenames (FStar_List.rev_append stk []) env
-                  (FStar_List.rev_append ts []) [] []
-let rec go:
-  (Prims.int* Prims.int) ->
-    Prims.string -> stack_t -> modul_t -> env_t -> m_timestamps -> Prims.unit
-  =
-  fun line_col  ->
-    fun filename  ->
-      fun stack  ->
-        fun curmod  ->
-          fun env  ->
-            fun ts  ->
-              let uu____1405 = shift_chunk () in
-              match uu____1405 with
-              | Info (symbol,fqn_only,pos_opt) ->
-                  let uu____1417 = env in
-                  (match uu____1417 with
-                   | (dsenv,tcenv) ->
-                       let info_at_pos_opt =
-                         match pos_opt with
-                         | None  -> None
-                         | Some (file,row,col) ->
-                             FStar_TypeChecker_Err.info_at_pos
-                               (Prims.snd env) file row col in
-                       let info_opt =
-                         match info_at_pos_opt with
-                         | Some uu____1435 -> info_at_pos_opt
-                         | None  ->
-                             if symbol = ""
-                             then None
-                             else
-                               (let lid =
-                                  let uu____1439 =
-                                    FStar_List.map FStar_Ident.id_of_text
-                                      (FStar_Util.split symbol ".") in
-                                  FStar_Ident.lid_of_ids uu____1439 in
-                                let lid1 =
-                                  let uu____1442 =
-                                    FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                                      dsenv lid in
-                                  match uu____1442 with
-                                  | None  -> lid
-                                  | Some lid1 -> lid1 in
-                                let uu____1445 =
-                                  FStar_TypeChecker_Env.try_lookup_lid
-                                    (Prims.snd env) lid1 in
-                                FStar_All.pipe_right uu____1445
-                                  (FStar_Util.map_option
-                                     (fun uu____1461  ->
-                                        match uu____1461 with
-                                        | ((uu____1466,typ),range) ->
-                                            FStar_TypeChecker_Err.format_info
-                                              (Prims.snd env) symbol typ
-                                              range))) in
-                       ((match info_opt with
-                         | None  -> FStar_Util.print_string "\n#done-nok\n"
-                         | Some s -> FStar_Util.print1 "%s\n#done-ok\n" s);
-                        go line_col filename stack curmod env ts))
-              | Completions search_term ->
-                  let rec measure_anchored_match search_term1 candidate =
-                    match (search_term1, candidate) with
-                    | ([],uu____1495) -> Some ([], (Prims.parse_int "0"))
-                    | (uu____1503,[]) -> None
-                    | (hs::ts1,hc::tc) ->
-                        let hc_text = FStar_Ident.text_of_id hc in
-                        if FStar_Util.starts_with hc_text hs
-                        then
-                          (match ts1 with
-                           | [] -> Some (candidate, (FStar_String.length hs))
-                           | uu____1533 ->
-                               let uu____1535 = measure_anchored_match ts1 tc in
-                               FStar_All.pipe_right uu____1535
-                                 (FStar_Util.map_option
-                                    (fun uu____1554  ->
-                                       match uu____1554 with
-                                       | (matched,len) ->
-                                           ((hc :: matched),
-                                             (((FStar_String.length hc_text)
-                                                 + (Prims.parse_int "1"))
-                                                + len)))))
-                        else None in
-                  let rec locate_match needle candidate =
-                    let uu____1590 = measure_anchored_match needle candidate in
-                    match uu____1590 with
-                    | Some (matched,n1) -> Some ([], matched, n1)
-                    | None  ->
-                        (match candidate with
-                         | [] -> None
-                         | hc::tc ->
-                             let uu____1632 = locate_match needle tc in
-                             FStar_All.pipe_right uu____1632
-                               (FStar_Util.map_option
-                                  (fun uu____1661  ->
-                                     match uu____1661 with
-                                     | (prefix1,matched,len) ->
-                                         ((hc :: prefix1), matched, len)))) in
-                  let str_of_ids ids =
-                    let uu____1687 =
-                      FStar_List.map FStar_Ident.text_of_id ids in
-                    FStar_Util.concat_l "." uu____1687 in
-                  let match_lident_against needle lident =
-                    locate_match needle
-                      (FStar_List.append lident.FStar_Ident.ns
-                         [lident.FStar_Ident.ident]) in
-                  let shorten_namespace uu____1716 =
-                    match uu____1716 with
-                    | (prefix1,matched,match_len) ->
-                        let naked_match =
-                          match matched with
-                          | uu____1734::[] -> true
-                          | uu____1735 -> false in
-                        let uu____1737 =
-                          FStar_ToSyntax_Env.shorten_module_path
-                            (Prims.fst env) prefix1 naked_match in
-                        (match uu____1737 with
-                         | (stripped_ns,shortened) ->
-                             let uu____1752 = str_of_ids shortened in
-                             let uu____1753 = str_of_ids matched in
-                             let uu____1754 = str_of_ids stripped_ns in
-                             (uu____1752, uu____1753, uu____1754, match_len)) in
-                  let prepare_candidate uu____1765 =
-                    match uu____1765 with
-                    | (prefix1,matched,stripped_ns,match_len) ->
-                        if prefix1 = ""
-                        then (matched, stripped_ns, match_len)
-                        else
-                          ((Prims.strcat prefix1 (Prims.strcat "." matched)),
-                            stripped_ns,
-                            (((FStar_String.length prefix1) + match_len) +
-                               (Prims.parse_int "1"))) in
-                  let needle = FStar_Util.split search_term "." in
-                  let all_lidents_in_env =
-                    FStar_TypeChecker_Env.lidents (Prims.snd env) in
-                  let matches =
-                    let case_a_find_transitive_includes orig_ns m id =
-                      let dsenv = Prims.fst env in
-                      let exported_names =
-                        FStar_ToSyntax_Env.transitive_exported_ids dsenv m in
-                      let matched_length =
-                        FStar_List.fold_left
-                          (fun out  ->
-                             fun s  ->
-                               ((FStar_String.length s) + out) +
-                                 (Prims.parse_int "1"))
-                          (FStar_String.length id) orig_ns in
-                      FStar_All.pipe_right exported_names
-                        (FStar_List.filter_map
-                           (fun n1  ->
-                              if FStar_Util.starts_with n1 id
-                              then
-                                let lid =
-                                  FStar_Ident.lid_of_ns_and_id
-                                    (FStar_Ident.ids_of_lid m)
-                                    (FStar_Ident.id_of_text n1) in
-                                let uu____1848 =
-                                  FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                                    dsenv lid in
-                                FStar_Option.map
-                                  (fun fqn  ->
-                                     let uu____1856 =
-                                       let uu____1858 =
-                                         FStar_List.map
-                                           FStar_Ident.id_of_text orig_ns in
-                                       FStar_List.append uu____1858
-                                         [fqn.FStar_Ident.ident] in
-                                     ([], uu____1856, matched_length))
-                                  uu____1848
-                              else None)) in
-                    let case_b_find_matches_in_env uu____1877 =
-                      let uu____1884 = env in
-                      match uu____1884 with
-                      | (dsenv,uu____1892) ->
-                          let matches =
-                            FStar_List.filter_map
-                              (match_lident_against needle)
-                              all_lidents_in_env in
-                          FStar_All.pipe_right matches
-                            (FStar_List.filter
-                               (fun uu____1922  ->
-                                  match uu____1922 with
-                                  | (ns,id,uu____1930) ->
-                                      let uu____1935 =
-                                        let uu____1937 =
-                                          FStar_Ident.lid_of_ids id in
-                                        FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                                          dsenv uu____1937 in
-                                      (match uu____1935 with
-                                       | None  -> false
-                                       | Some l ->
-                                           let uu____1939 =
-                                             FStar_Ident.lid_of_ids
-                                               (FStar_List.append ns id) in
-                                           FStar_Ident.lid_equals l
-                                             uu____1939))) in
-                    let uu____1940 = FStar_Util.prefix needle in
-                    match uu____1940 with
-                    | (ns,id) ->
-                        let matched_ids =
-                          match ns with
-                          | [] -> case_b_find_matches_in_env ()
-                          | uu____1965 ->
-                              let l =
-                                FStar_Ident.lid_of_path ns
-                                  FStar_Range.dummyRange in
-                              let uu____1968 =
-                                FStar_ToSyntax_Env.resolve_module_name
-                                  (Prims.fst env) l true in
-                              (match uu____1968 with
-                               | None  -> case_b_find_matches_in_env ()
-                               | Some m ->
-                                   case_a_find_transitive_includes ns m id) in
-                        FStar_All.pipe_right matched_ids
-                          (FStar_List.map
-                             (fun x  ->
-                                let uu____2001 = shorten_namespace x in
-                                prepare_candidate uu____2001)) in
-                  ((let uu____2007 =
-                      FStar_Util.sort_with
-                        (fun uu____2015  ->
-                           fun uu____2016  ->
-                             match (uu____2015, uu____2016) with
-                             | ((cd1,ns1,uu____2031),(cd2,ns2,uu____2034)) ->
-                                 (match FStar_String.compare cd1 cd2 with
-                                  | _0_32 when _0_32 = (Prims.parse_int "0")
-                                      -> FStar_String.compare ns1 ns2
-                                  | n1 -> n1)) matches in
-                    FStar_List.iter
-                      (fun uu____2045  ->
-                         match uu____2045 with
-                         | (candidate,ns,match_len) ->
-                             let uu____2052 =
-                               FStar_Util.string_of_int match_len in
-                             FStar_Util.print3 "%s %s %s \n" uu____2052 ns
-                               candidate) uu____2007);
-                   FStar_Util.print_string "#done-ok\n";
-                   go line_col filename stack curmod env ts)
-              | Pop msg ->
-                  (pop env msg;
-                   (let uu____2056 =
-                      match stack with
-                      | [] ->
-                          (FStar_Util.print_error "too many pops";
-                           FStar_All.exit (Prims.parse_int "1"))
-                      | hd1::tl1 -> (hd1, tl1) in
-                    match uu____2056 with
-                    | ((env1,curmod1),stack1) ->
-                        (if
-                           (FStar_List.length stack1) =
-                             (FStar_List.length ts)
-                         then cleanup env1
-                         else ();
-                         go line_col filename stack1 curmod1 env1 ts)))
-              | Push (lax1,l,c) ->
-                  let uu____2123 =
-                    if (FStar_List.length stack) = (FStar_List.length ts)
-                    then
-                      let uu____2146 =
-                        update_deps filename curmod stack env ts in
-                      (true, uu____2146)
-                    else (false, (stack, env, ts)) in
-                  (match uu____2123 with
-                   | (restore_cmd_line_options1,(stack1,env1,ts1)) ->
-                       let stack2 = (env1, curmod) :: stack1 in
-                       let env2 =
-                         push env1 lax1 restore_cmd_line_options1 "#push" in
-                       go (l, c) filename stack2 curmod env2 ts1)
-              | Code (text1,(ok,fail1)) ->
-                  let fail2 curmod1 env_mark =
-                    report_fail ();
-                    FStar_Util.print1 "%s\n" fail1;
-                    (let env1 = reset_mark env_mark in
-                     go line_col filename stack curmod1 env1 ts) in
-                  let env_mark = mark env in
-                  let frag =
-                    {
-                      FStar_Parser_ParseIt.frag_text = text1;
-                      FStar_Parser_ParseIt.frag_line = (Prims.fst line_col);
-                      FStar_Parser_ParseIt.frag_col = (Prims.snd line_col)
-                    } in
-                  let res = check_frag env_mark curmod frag in
-                  (match res with
-                   | Some (curmod1,env1,n_errs) ->
-                       if n_errs = (Prims.parse_int "0")
-                       then
-                         (FStar_Util.print1 "\n%s\n" ok;
-                          (let env2 = commit_mark env1 in
-                           go line_col filename stack curmod1 env2 ts))
-                       else fail2 curmod1 env_mark
-                   | uu____2226 -> fail2 curmod env_mark)
-let interactive_mode: Prims.string -> Prims.unit =
-  fun filename  ->
-    (let uu____2238 =
-       let uu____2239 = FStar_Options.codegen () in
-       FStar_Option.isSome uu____2239 in
-     if uu____2238
-     then
-       FStar_Util.print_warning
-         "code-generation is not supported in interactive mode, ignoring the codegen flag"
-     else ());
-    (let uu____2242 = deps_of_our_file filename in
-     match uu____2242 with
-     | (filenames,maybe_intf) ->
-         let env = tc_prims () in
-         let uu____2256 = tc_deps None [] env filenames [] in
-         (match uu____2256 with
-          | (stack,env1,ts) ->
-              let uu____2271 =
-                match maybe_intf with
-                | Some intf ->
-                    let frag =
-                      let uu____2284 = FStar_Util.file_get_contents intf in
-                      {
-                        FStar_Parser_ParseIt.frag_text = uu____2284;
-                        FStar_Parser_ParseIt.frag_line =
-                          (Prims.parse_int "0");
-                        FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")
-                      } in
-                    let uu____2285 = check_frag env1 None frag in
-                    (match uu____2285 with
-                     | Some (curmod,env2,n_errs) ->
-                         (if n_errs <> (Prims.parse_int "0")
-                          then
-                            ((let uu____2315 =
-                                FStar_Util.format1
-                                  "Found the interface %s but it has errors!"
-                                  intf in
-                              FStar_Util.print_warning uu____2315);
-                             FStar_All.exit (Prims.parse_int "1"))
-                          else ();
-                          FStar_Util.print_string
-                            "Reminder: fst+fsti in interactive mode is unsound.\n";
-                          (curmod, env2))
-                     | None  ->
-                         ((let uu____2328 =
-                             FStar_Util.format1
-                               "Found the interface %s but could not parse it first!"
-                               intf in
-                           FStar_Util.print_warning uu____2328);
-                          FStar_All.exit (Prims.parse_int "1")))
-                | None  -> (None, env1) in
-              (match uu____2271 with
-               | (initial_mod,env2) ->
-                   let uu____2343 =
-                     (FStar_Options.record_hints ()) ||
-                       (FStar_Options.use_hints ()) in
-                   if uu____2343
-                   then
-                     let uu____2344 =
-                       let uu____2345 = FStar_Options.file_list () in
-                       FStar_List.hd uu____2345 in
-                     FStar_SMTEncoding_Solver.with_hints_db uu____2344
-                       (fun uu____2347  ->
-                          go ((Prims.parse_int "1"), (Prims.parse_int "0"))
-                            filename stack initial_mod env2 ts)
-                   else
-                     go ((Prims.parse_int "1"), (Prims.parse_int "0"))
-                       filename stack initial_mod env2 ts)))
+(Prims.string Prims.option * Prims.string * FStar_Util.time Prims.option * FStar_Util.time) Prims.list
+
+
+let rec tc_deps : modul_t  ->  stack_t  ->  env_t  ->  Prims.string Prims.list  ->  m_timestamps  ->  (stack_t * env_t * m_timestamps) = (fun m stack env remaining ts -> (match (remaining) with
+| [] -> begin
+((stack), (env), (ts))
+end
+| uu____920 -> begin
+(
+
+let stack1 = (((env), (m)))::stack
+in (
+
+let env1 = (
+
+let uu____931 = (FStar_Options.lax ())
+in (push env uu____931 true "typecheck_modul"))
+in (
+
+let uu____932 = (tc_one_file remaining env1)
+in (match (uu____932) with
+| ((intf, impl), env2, modl, remaining1) -> begin
+(
+
+let uu____965 = (
+
+let intf_t = (match (intf) with
+| Some (intf1) -> begin
+(
+
+let uu____973 = (FStar_Util.get_file_last_modification_time intf1)
+in Some (uu____973))
+end
+| None -> begin
+None
+end)
+in (
+
+let impl_t = (FStar_Util.get_file_last_modification_time impl)
+in ((intf_t), (impl_t))))
+in (match (uu____965) with
+| (intf_t, impl_t) -> begin
+(tc_deps m stack1 env2 remaining1 ((((intf), (impl), (intf_t), (impl_t)))::ts))
+end))
+end))))
+end))
+
+
+let update_deps : Prims.string  ->  modul_t  ->  stack_t  ->  env_t  ->  m_timestamps  ->  (stack_t * env_t * m_timestamps) = (fun filename m stk env ts -> (
+
+let is_stale = (fun intf impl intf_t impl_t -> (
+
+let impl_mt = (FStar_Util.get_file_last_modification_time impl)
+in ((FStar_Util.is_before impl_t impl_mt) || (match (((intf), (intf_t))) with
+| (Some (intf1), Some (intf_t1)) -> begin
+(
+
+let intf_mt = (FStar_Util.get_file_last_modification_time intf1)
+in (FStar_Util.is_before intf_t1 intf_mt))
+end
+| (None, None) -> begin
+false
+end
+| (uu____1039, uu____1040) -> begin
+(failwith "Impossible, if the interface is None, the timestamp entry should also be None")
+end))))
+in (
+
+let rec iterate = (fun depnames st env' ts1 good_stack good_ts -> (
+
+let match_dep = (fun depnames1 intf impl -> (match (intf) with
+| None -> begin
+(match (depnames1) with
+| (dep1)::depnames' -> begin
+(match ((dep1 = impl)) with
+| true -> begin
+((true), (depnames'))
+end
+| uu____1102 -> begin
+((false), (depnames1))
+end)
+end
+| uu____1104 -> begin
+((false), (depnames1))
+end)
+end
+| Some (intf1) -> begin
+(match (depnames1) with
+| (depintf)::(dep1)::depnames' -> begin
+(match (((depintf = intf1) && (dep1 = impl))) with
+| true -> begin
+((true), (depnames'))
+end
+| uu____1119 -> begin
+((false), (depnames1))
+end)
+end
+| uu____1121 -> begin
+((false), (depnames1))
+end)
+end))
+in (
+
+let rec pop_tc_and_stack = (fun env1 stack ts2 -> (match (ts2) with
+| [] -> begin
+env1
+end
+| (uu____1168)::ts3 -> begin
+((pop env1 "");
+(
+
+let uu____1190 = (
+
+let uu____1198 = (FStar_List.hd stack)
+in (
+
+let uu____1203 = (FStar_List.tl stack)
+in ((uu____1198), (uu____1203))))
+in (match (uu____1190) with
+| ((env2, uu____1217), stack1) -> begin
+(pop_tc_and_stack env2 stack1 ts3)
+end));
+)
+end))
+in (match (ts1) with
+| (ts_elt)::ts' -> begin
+(
+
+let uu____1251 = ts_elt
+in (match (uu____1251) with
+| (intf, impl, intf_t, impl_t) -> begin
+(
+
+let uu____1269 = (match_dep depnames intf impl)
+in (match (uu____1269) with
+| (b, depnames') -> begin
+(
+
+let uu____1280 = ((not (b)) || (is_stale intf impl intf_t impl_t))
+in (match (uu____1280) with
+| true -> begin
+(
+
+let env1 = (pop_tc_and_stack env' (FStar_List.rev_append st []) ts1)
+in (tc_deps m good_stack env1 depnames good_ts))
+end
+| uu____1291 -> begin
+(
+
+let uu____1292 = (
+
+let uu____1300 = (FStar_List.hd st)
+in (
+
+let uu____1305 = (FStar_List.tl st)
+in ((uu____1300), (uu____1305))))
+in (match (uu____1292) with
+| (stack_elt, st') -> begin
+(iterate depnames' st' env' ts' ((stack_elt)::good_stack) ((ts_elt)::good_ts))
+end))
+end))
+end))
+end))
+end
+| [] -> begin
+(tc_deps m good_stack env' depnames good_ts)
+end))))
+in (
+
+let uu____1345 = (deps_of_our_file filename)
+in (match (uu____1345) with
+| (filenames, uu____1354) -> begin
+(iterate filenames (FStar_List.rev_append stk []) env (FStar_List.rev_append ts []) [] [])
+end)))))
+
+
+let rec go : (Prims.int * Prims.int)  ->  Prims.string  ->  stack_t  ->  modul_t  ->  env_t  ->  m_timestamps  ->  Prims.unit = (fun line_col filename stack curmod env ts -> (
+
+let uu____1405 = (shift_chunk ())
+in (match (uu____1405) with
+| Info (symbol, fqn_only, pos_opt) -> begin
+(
+
+let uu____1417 = env
+in (match (uu____1417) with
+| (dsenv, tcenv) -> begin
+(
+
+let info_at_pos_opt = (match (pos_opt) with
+| None -> begin
+None
+end
+| Some (file, row, col) -> begin
+(FStar_TypeChecker_Err.info_at_pos (Prims.snd env) file row col)
+end)
+in (
+
+let info_opt = (match (info_at_pos_opt) with
+| Some (uu____1435) -> begin
+info_at_pos_opt
+end
+| None -> begin
+(match ((symbol = "")) with
+| true -> begin
+None
+end
+| uu____1437 -> begin
+(
+
+let lid = (
+
+let uu____1439 = (FStar_List.map FStar_Ident.id_of_text (FStar_Util.split symbol "."))
+in (FStar_Ident.lid_of_ids uu____1439))
+in (
+
+let lid1 = (
+
+let uu____1442 = (FStar_ToSyntax_Env.resolve_to_fully_qualified_name dsenv lid)
+in (match (uu____1442) with
+| None -> begin
+lid
+end
+| Some (lid1) -> begin
+lid1
+end))
+in (
+
+let uu____1445 = (FStar_TypeChecker_Env.try_lookup_lid (Prims.snd env) lid1)
+in (FStar_All.pipe_right uu____1445 (FStar_Util.map_option (fun uu____1461 -> (match (uu____1461) with
+| ((uu____1466, typ), range) -> begin
+(FStar_TypeChecker_Err.format_info (Prims.snd env) symbol typ range)
+end)))))))
+end)
+end)
+in ((match (info_opt) with
+| None -> begin
+(FStar_Util.print_string "\n#done-nok\n")
+end
+| Some (s) -> begin
+(FStar_Util.print1 "%s\n#done-ok\n" s)
+end);
+(go line_col filename stack curmod env ts);
+)))
+end))
+end
+| Completions (search_term) -> begin
+(
+
+let rec measure_anchored_match = (fun search_term1 candidate -> (match (((search_term1), (candidate))) with
+| ([], uu____1495) -> begin
+Some ((([]), ((Prims.parse_int "0"))))
+end
+| (uu____1503, []) -> begin
+None
+end
+| ((hs)::ts1, (hc)::tc) -> begin
+(
+
+let hc_text = (FStar_Ident.text_of_id hc)
+in (match ((FStar_Util.starts_with hc_text hs)) with
+| true -> begin
+(match (ts1) with
+| [] -> begin
+Some (((candidate), ((FStar_String.length hs))))
+end
+| uu____1533 -> begin
+(
+
+let uu____1535 = (measure_anchored_match ts1 tc)
+in (FStar_All.pipe_right uu____1535 (FStar_Util.map_option (fun uu____1554 -> (match (uu____1554) with
+| (matched, len) -> begin
+(((hc)::matched), ((((FStar_String.length hc_text) + (Prims.parse_int "1")) + len)))
+end)))))
+end)
+end
+| uu____1569 -> begin
+None
+end))
+end))
+in (
+
+let rec locate_match = (fun needle candidate -> (
+
+let uu____1590 = (measure_anchored_match needle candidate)
+in (match (uu____1590) with
+| Some (matched, n1) -> begin
+Some ((([]), (matched), (n1)))
+end
+| None -> begin
+(match (candidate) with
+| [] -> begin
+None
+end
+| (hc)::tc -> begin
+(
+
+let uu____1632 = (locate_match needle tc)
+in (FStar_All.pipe_right uu____1632 (FStar_Util.map_option (fun uu____1661 -> (match (uu____1661) with
+| (prefix1, matched, len) -> begin
+(((hc)::prefix1), (matched), (len))
+end)))))
+end)
+end)))
+in (
+
+let str_of_ids = (fun ids -> (
+
+let uu____1687 = (FStar_List.map FStar_Ident.text_of_id ids)
+in (FStar_Util.concat_l "." uu____1687)))
+in (
+
+let match_lident_against = (fun needle lident -> (locate_match needle (FStar_List.append lident.FStar_Ident.ns ((lident.FStar_Ident.ident)::[]))))
+in (
+
+let shorten_namespace = (fun uu____1716 -> (match (uu____1716) with
+| (prefix1, matched, match_len) -> begin
+(
+
+let naked_match = (match (matched) with
+| (uu____1734)::[] -> begin
+true
+end
+| uu____1735 -> begin
+false
+end)
+in (
+
+let uu____1737 = (FStar_ToSyntax_Env.shorten_module_path (Prims.fst env) prefix1 naked_match)
+in (match (uu____1737) with
+| (stripped_ns, shortened) -> begin
+(
+
+let uu____1752 = (str_of_ids shortened)
+in (
+
+let uu____1753 = (str_of_ids matched)
+in (
+
+let uu____1754 = (str_of_ids stripped_ns)
+in ((uu____1752), (uu____1753), (uu____1754), (match_len)))))
+end)))
+end))
+in (
+
+let prepare_candidate = (fun uu____1765 -> (match (uu____1765) with
+| (prefix1, matched, stripped_ns, match_len) -> begin
+(match ((prefix1 = "")) with
+| true -> begin
+((matched), (stripped_ns), (match_len))
+end
+| uu____1780 -> begin
+(((Prims.strcat prefix1 (Prims.strcat "." matched))), (stripped_ns), ((((FStar_String.length prefix1) + match_len) + (Prims.parse_int "1"))))
+end)
+end))
+in (
+
+let needle = (FStar_Util.split search_term ".")
+in (
+
+let all_lidents_in_env = (FStar_TypeChecker_Env.lidents (Prims.snd env))
+in (
+
+let matches = (
+
+let case_a_find_transitive_includes = (fun orig_ns m id -> (
+
+let dsenv = (Prims.fst env)
+in (
+
+let exported_names = (FStar_ToSyntax_Env.transitive_exported_ids dsenv m)
+in (
+
+let matched_length = (FStar_List.fold_left (fun out s -> (((FStar_String.length s) + out) + (Prims.parse_int "1"))) (FStar_String.length id) orig_ns)
+in (FStar_All.pipe_right exported_names (FStar_List.filter_map (fun n1 -> (match ((FStar_Util.starts_with n1 id)) with
+| true -> begin
+(
+
+let lid = (FStar_Ident.lid_of_ns_and_id (FStar_Ident.ids_of_lid m) (FStar_Ident.id_of_text n1))
+in (
+
+let uu____1848 = (FStar_ToSyntax_Env.resolve_to_fully_qualified_name dsenv lid)
+in (FStar_Option.map (fun fqn -> (
+
+let uu____1856 = (
+
+let uu____1858 = (FStar_List.map FStar_Ident.id_of_text orig_ns)
+in (FStar_List.append uu____1858 ((fqn.FStar_Ident.ident)::[])))
+in (([]), (uu____1856), (matched_length)))) uu____1848)))
+end
+| uu____1862 -> begin
+None
+end))))))))
+in (
+
+let case_b_find_matches_in_env = (fun uu____1877 -> (
+
+let uu____1884 = env
+in (match (uu____1884) with
+| (dsenv, uu____1892) -> begin
+(
+
+let matches = (FStar_List.filter_map (match_lident_against needle) all_lidents_in_env)
+in (FStar_All.pipe_right matches (FStar_List.filter (fun uu____1922 -> (match (uu____1922) with
+| (ns, id, uu____1930) -> begin
+(
+
+let uu____1935 = (
+
+let uu____1937 = (FStar_Ident.lid_of_ids id)
+in (FStar_ToSyntax_Env.resolve_to_fully_qualified_name dsenv uu____1937))
+in (match (uu____1935) with
+| None -> begin
+false
+end
+| Some (l) -> begin
+(
+
+let uu____1939 = (FStar_Ident.lid_of_ids (FStar_List.append ns id))
+in (FStar_Ident.lid_equals l uu____1939))
+end))
+end)))))
+end)))
+in (
+
+let uu____1940 = (FStar_Util.prefix needle)
+in (match (uu____1940) with
+| (ns, id) -> begin
+(
+
+let matched_ids = (match (ns) with
+| [] -> begin
+(case_b_find_matches_in_env ())
+end
+| uu____1965 -> begin
+(
+
+let l = (FStar_Ident.lid_of_path ns FStar_Range.dummyRange)
+in (
+
+let uu____1968 = (FStar_ToSyntax_Env.resolve_module_name (Prims.fst env) l true)
+in (match (uu____1968) with
+| None -> begin
+(case_b_find_matches_in_env ())
+end
+| Some (m) -> begin
+(case_a_find_transitive_includes ns m id)
+end)))
+end)
+in (FStar_All.pipe_right matched_ids (FStar_List.map (fun x -> (
+
+let uu____2001 = (shorten_namespace x)
+in (prepare_candidate uu____2001))))))
+end))))
+in ((
+
+let uu____2007 = (FStar_Util.sort_with (fun uu____2015 uu____2016 -> (match (((uu____2015), (uu____2016))) with
+| ((cd1, ns1, uu____2031), (cd2, ns2, uu____2034)) -> begin
+(match ((FStar_String.compare cd1 cd2)) with
+| _0_32 when (_0_32 = (Prims.parse_int "0")) -> begin
+(FStar_String.compare ns1 ns2)
+end
+| n1 -> begin
+n1
+end)
+end)) matches)
+in (FStar_List.iter (fun uu____2045 -> (match (uu____2045) with
+| (candidate, ns, match_len) -> begin
+(
+
+let uu____2052 = (FStar_Util.string_of_int match_len)
+in (FStar_Util.print3 "%s %s %s \n" uu____2052 ns candidate))
+end)) uu____2007));
+(FStar_Util.print_string "#done-ok\n");
+(go line_col filename stack curmod env ts);
+))))))))))
+end
+| Pop (msg) -> begin
+((pop env msg);
+(
+
+let uu____2056 = (match (stack) with
+| [] -> begin
+((FStar_Util.print_error "too many pops");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| (hd1)::tl1 -> begin
+((hd1), (tl1))
+end)
+in (match (uu____2056) with
+| ((env1, curmod1), stack1) -> begin
+((match (((FStar_List.length stack1) = (FStar_List.length ts))) with
+| true -> begin
+(cleanup env1)
+end
+| uu____2119 -> begin
+()
+end);
+(go line_col filename stack1 curmod1 env1 ts);
+)
+end));
+)
+end
+| Push (lax1, l, c) -> begin
+(
+
+let uu____2123 = (match (((FStar_List.length stack) = (FStar_List.length ts))) with
+| true -> begin
+(
+
+let uu____2146 = (update_deps filename curmod stack env ts)
+in ((true), (uu____2146)))
+end
+| uu____2153 -> begin
+((false), (((stack), (env), (ts))))
+end)
+in (match (uu____2123) with
+| (restore_cmd_line_options1, (stack1, env1, ts1)) -> begin
+(
+
+let stack2 = (((env1), (curmod)))::stack1
+in (
+
+let env2 = (push env1 lax1 restore_cmd_line_options1 "#push")
+in (go ((l), (c)) filename stack2 curmod env2 ts1)))
+end))
+end
+| Code (text1, (ok, fail1)) -> begin
+(
+
+let fail2 = (fun curmod1 env_mark -> ((report_fail ());
+(FStar_Util.print1 "%s\n" fail1);
+(
+
+let env1 = (reset_mark env_mark)
+in (go line_col filename stack curmod1 env1 ts));
+))
+in (
+
+let env_mark = (mark env)
+in (
+
+let frag = {FStar_Parser_ParseIt.frag_text = text1; FStar_Parser_ParseIt.frag_line = (Prims.fst line_col); FStar_Parser_ParseIt.frag_col = (Prims.snd line_col)}
+in (
+
+let res = (check_frag env_mark curmod frag)
+in (match (res) with
+| Some (curmod1, env1, n_errs) -> begin
+(match ((n_errs = (Prims.parse_int "0"))) with
+| true -> begin
+((FStar_Util.print1 "\n%s\n" ok);
+(
+
+let env2 = (commit_mark env1)
+in (go line_col filename stack curmod1 env2 ts));
+)
+end
+| uu____2225 -> begin
+(fail2 curmod1 env_mark)
+end)
+end
+| uu____2226 -> begin
+(fail2 curmod env_mark)
+end)))))
+end)))
+
+
+let interactive_mode : Prims.string  ->  Prims.unit = (fun filename -> ((
+
+let uu____2238 = (
+
+let uu____2239 = (FStar_Options.codegen ())
+in (FStar_Option.isSome uu____2239))
+in (match (uu____2238) with
+| true -> begin
+(FStar_Util.print_warning "code-generation is not supported in interactive mode, ignoring the codegen flag")
+end
+| uu____2241 -> begin
+()
+end));
+(
+
+let uu____2242 = (deps_of_our_file filename)
+in (match (uu____2242) with
+| (filenames, maybe_intf) -> begin
+(
+
+let env = (tc_prims ())
+in (
+
+let uu____2256 = (tc_deps None [] env filenames [])
+in (match (uu____2256) with
+| (stack, env1, ts) -> begin
+(
+
+let uu____2271 = (match (maybe_intf) with
+| Some (intf) -> begin
+(
+
+let frag = (
+
+let uu____2284 = (FStar_Util.file_get_contents intf)
+in {FStar_Parser_ParseIt.frag_text = uu____2284; FStar_Parser_ParseIt.frag_line = (Prims.parse_int "0"); FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")})
+in (
+
+let uu____2285 = (check_frag env1 None frag)
+in (match (uu____2285) with
+| Some (curmod, env2, n_errs) -> begin
+((match ((n_errs <> (Prims.parse_int "0"))) with
+| true -> begin
+((
+
+let uu____2315 = (FStar_Util.format1 "Found the interface %s but it has errors!" intf)
+in (FStar_Util.print_warning uu____2315));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| uu____2316 -> begin
+()
+end);
+(FStar_Util.print_string "Reminder: fst+fsti in interactive mode is unsound.\n");
+((curmod), (env2));
+)
+end
+| None -> begin
+((
+
+let uu____2328 = (FStar_Util.format1 "Found the interface %s but could not parse it first!" intf)
+in (FStar_Util.print_warning uu____2328));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end)))
+end
+| None -> begin
+((None), (env1))
+end)
+in (match (uu____2271) with
+| (initial_mod, env2) -> begin
+(
+
+let uu____2343 = ((FStar_Options.record_hints ()) || (FStar_Options.use_hints ()))
+in (match (uu____2343) with
+| true -> begin
+(
+
+let uu____2344 = (
+
+let uu____2345 = (FStar_Options.file_list ())
+in (FStar_List.hd uu____2345))
+in (FStar_SMTEncoding_Solver.with_hints_db uu____2344 (fun uu____2347 -> (go (((Prims.parse_int "1")), ((Prims.parse_int "0"))) filename stack initial_mod env2 ts))))
+end
+| uu____2348 -> begin
+(go (((Prims.parse_int "1")), ((Prims.parse_int "0"))) filename stack initial_mod env2 ts)
+end))
+end))
+end)))
+end));
+))
+
+
+
+

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -1,247 +1,410 @@
+
 open Prims
-let uu___225: Prims.unit = FStar_Version.dummy ()
-let process_args:
-  Prims.unit -> (FStar_Getopt.parse_cmdline_res* Prims.string Prims.list) =
-  fun uu____6  -> FStar_Options.parse_cmd_line ()
-let cleanup: Prims.unit -> Prims.unit =
-  fun uu____12  -> FStar_Util.kill_all ()
-let finished_message:
-  ((Prims.bool* FStar_Ident.lident)* Prims.int) Prims.list ->
-    Prims.int -> Prims.unit
-  =
-  fun fmods  ->
-    fun errs  ->
-      let print_to =
-        if errs > (Prims.parse_int "0")
-        then FStar_Util.print_error
-        else FStar_Util.print_string in
-      let uu____35 =
-        let uu____36 = FStar_Options.silent () in Prims.op_Negation uu____36 in
-      if uu____35
-      then
-        (FStar_All.pipe_right fmods
-           (FStar_List.iter
-              (fun uu____47  ->
-                 match uu____47 with
-                 | ((iface,name),time) ->
-                     let tag =
-                       if iface then "i'face (or impl+i'face)" else "module" in
-                     let uu____59 =
-                       FStar_Options.should_print_message
-                         name.FStar_Ident.str in
-                     if uu____59
-                     then
-                       (if time >= (Prims.parse_int "0")
-                        then
-                          let uu____60 =
-                            let uu____61 = FStar_Util.string_of_int time in
-                            FStar_Util.format3
-                              "Verified %s: %s (%s milliseconds)\n" tag
-                              (FStar_Ident.text_of_lid name) uu____61 in
-                          print_to uu____60
-                        else
-                          (let uu____63 =
-                             FStar_Util.format2 "Verified %s: %s\n" tag
-                               (FStar_Ident.text_of_lid name) in
-                           print_to uu____63))
-                     else ()));
-         if errs > (Prims.parse_int "0")
-         then
-           (if errs = (Prims.parse_int "1")
-            then FStar_Util.print_error "1 error was reported (see above)\n"
-            else
-              (let uu____66 = FStar_Util.string_of_int errs in
-               FStar_Util.print1_error
-                 "%s errors were reported (see above)\n" uu____66))
-         else
-           (let uu____68 =
-              let uu____69 =
-                FStar_Util.colorize_bold
-                  "All verification conditions discharged successfully" in
-              FStar_Util.format1 "%s\n" uu____69 in
-            FStar_Util.print_string uu____68))
-      else ()
-let report_errors:
-  ((Prims.bool* FStar_Ident.lident)* Prims.int) Prims.list -> Prims.unit =
-  fun fmods  ->
-    let errs = FStar_Errors.get_err_count () in
-    if errs > (Prims.parse_int "0")
-    then (finished_message fmods errs; FStar_All.exit (Prims.parse_int "1"))
-    else ()
-let codegen:
-  (FStar_Syntax_Syntax.modul Prims.list* FStar_TypeChecker_Env.env) ->
-    Prims.unit
-  =
-  fun uu____92  ->
-    match uu____92 with
-    | (umods,env) ->
-        let opt = FStar_Options.codegen () in
-        if opt <> None
-        then
-          let mllibs =
-            let uu____106 =
-              let uu____111 = FStar_Extraction_ML_UEnv.mkContext env in
-              FStar_Util.fold_map FStar_Extraction_ML_Modul.extract uu____111
-                umods in
-            FStar_All.pipe_left Prims.snd uu____106 in
-          let mllibs1 = FStar_List.flatten mllibs in
-          let ext =
-            match opt with
-            | Some "FSharp" -> ".fs"
-            | Some "OCaml" -> ".ml"
-            | Some "Kremlin" -> ".krml"
-            | uu____124 -> failwith "Unrecognized option" in
-          (match opt with
-           | Some "FSharp"|Some "OCaml" ->
-               let outdir = FStar_Options.output_dir () in
-               FStar_List.iter (FStar_Extraction_ML_PrintML.print outdir ext)
-                 mllibs1
-           | Some "Kremlin" ->
-               let programs =
-                 let uu____130 =
-                   FStar_List.map FStar_Extraction_Kremlin.translate mllibs1 in
-                 FStar_List.flatten uu____130 in
-               let bin = (FStar_Extraction_Kremlin.current_version, programs) in
-               let uu____136 = FStar_Options.prepend_output_dir "out.krml" in
-               FStar_Util.save_value_to_file uu____136 bin
-           | uu____137 -> failwith "Unrecognized option")
-        else ()
-let go uu____146 =
-  let uu____147 = process_args () in
-  match uu____147 with
-  | (res,filenames) ->
-      (match res with
-       | FStar_Getopt.Help  ->
-           (FStar_Options.display_usage ();
-            FStar_All.exit (Prims.parse_int "0"))
-       | FStar_Getopt.Error msg -> FStar_Util.print_string msg
-       | FStar_Getopt.Success  ->
-           let uu____157 =
-             let uu____158 = FStar_Options.dep () in uu____158 <> None in
-           if uu____157
-           then
-             let uu____161 =
-               FStar_Parser_Dep.collect FStar_Parser_Dep.VerifyAll filenames in
-             FStar_Parser_Dep.print uu____161
-           else
-             (let uu____176 = FStar_Options.interactive () in
-              if uu____176
-              then
-                ((let uu____178 = FStar_Options.explicit_deps () in
-                  if uu____178
-                  then
-                    (FStar_Util.print_error
-                       "--explicit_deps incompatible with --in|n";
-                     FStar_All.exit (Prims.parse_int "1"))
-                  else ());
-                 if (FStar_List.length filenames) <> (Prims.parse_int "1")
-                 then
-                   (FStar_Util.print_error
-                      "fstar-mode.el should pass the current filename to F*\n";
-                    FStar_All.exit (Prims.parse_int "1"))
-                 else ();
-                 (let filename = FStar_List.hd filenames in
-                  let filename1 =
-                    FStar_Common.try_convert_file_name_to_mixed filename in
-                  (let uu____189 =
-                     let uu____190 = FStar_Options.verify_module () in
-                     uu____190 <> [] in
-                   if uu____189
-                   then
-                     FStar_Util.print_warning
-                       "Interactive mode; ignoring --verify_module"
-                   else ());
-                  FStar_Interactive.interactive_mode filename1))
-              else
-                (let uu____195 = FStar_Options.doc () in
-                 if uu____195
-                 then FStar_Fsdoc_Generator.generate filenames
-                 else
-                   (let uu____197 = FStar_Options.indent () in
-                    if uu____197
-                    then
-                      (if FStar_Platform.is_fstar_compiler_using_ocaml
-                       then FStar_Indent.generate filenames
-                       else
-                         failwith
-                           "You seem to be using the F#-generated version ofthe compiler ; reindenting is not known to work yet with this version")
-                    else
-                      if
-                        (FStar_List.length filenames) >=
-                          (Prims.parse_int "1")
-                      then
-                        (let verify_mode =
-                           let uu____204 = FStar_Options.verify_all () in
-                           if uu____204
-                           then
-                             ((let uu____206 =
-                                 let uu____207 =
-                                   FStar_Options.verify_module () in
-                                 uu____207 <> [] in
-                               if uu____206
-                               then
-                                 (FStar_Util.print_error
-                                    "--verify_module is incompatible with --verify_all";
-                                  FStar_All.exit (Prims.parse_int "1"))
-                               else ());
-                              FStar_Parser_Dep.VerifyAll)
-                           else
-                             (let uu____213 =
-                                let uu____214 =
-                                  FStar_Options.verify_module () in
-                                uu____214 <> [] in
-                              if uu____213
-                              then FStar_Parser_Dep.VerifyUserList
-                              else FStar_Parser_Dep.VerifyFigureItOut) in
-                         let filenames1 =
-                           FStar_Dependencies.find_deps_if_needed verify_mode
-                             filenames in
-                         let uu____220 =
-                           FStar_Universal.batch_mode_tc filenames1 in
-                         match uu____220 with
-                         | (fmods,dsenv,env) ->
-                             let module_names_and_times =
-                               FStar_All.pipe_right fmods
-                                 (FStar_List.map
-                                    (fun uu____256  ->
-                                       match uu____256 with
-                                       | (x,t) ->
-                                           ((FStar_Universal.module_or_interface_name
-                                               x), t))) in
-                             (report_errors module_names_and_times;
-                              (let uu____269 =
-                                 let uu____273 =
-                                   FStar_All.pipe_right fmods
-                                     (FStar_List.map Prims.fst) in
-                                 (uu____273, env) in
-                               codegen uu____269);
-                              finished_message module_names_and_times
-                                (Prims.parse_int "0")))
-                      else FStar_Util.print_error "no file provided\n"))))
-let main uu____289 =
-  try go (); cleanup (); FStar_All.exit (Prims.parse_int "0")
-  with
-  | e ->
-      (if FStar_Errors.handleable e
-       then FStar_Errors.handle_err false e
-       else ();
-       (let uu____298 = FStar_Options.trace_error () in
-        if uu____298
-        then
-          let uu____299 = FStar_Util.message_of_exn e in
-          let uu____300 = FStar_Util.trace_of_exn e in
-          FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____299
-            uu____300
-        else
-          if Prims.op_Negation (FStar_Errors.handleable e)
-          then
-            (let uu____302 = FStar_Util.message_of_exn e in
-             FStar_Util.print1_error
-               "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n"
-               uu____302)
-          else ());
-       cleanup ();
-       (let uu____306 = FStar_Errors.report_all () in
-        FStar_All.pipe_right uu____306 Prims.ignore);
-       report_errors [];
-       FStar_All.exit (Prims.parse_int "1"))
+
+let uu___222 : Prims.unit = (FStar_Version.dummy ())
+
+
+let process_args : Prims.unit  ->  (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list) = (fun uu____6 -> (FStar_Options.parse_cmd_line ()))
+
+
+let cleanup : Prims.unit  ->  Prims.unit = (fun uu____12 -> (FStar_Util.kill_all ()))
+
+
+let finished_message : ((Prims.bool * FStar_Ident.lident) * Prims.int) Prims.list  ->  Prims.int  ->  Prims.unit = (fun fmods errs -> (
+
+let print_to = (match ((errs > (Prims.parse_int "0"))) with
+| true -> begin
+FStar_Util.print_error
+end
+| uu____34 -> begin
+FStar_Util.print_string
+end)
+in (
+
+let uu____35 = (
+
+let uu____36 = (FStar_Options.silent ())
+in (not (uu____36)))
+in (match (uu____35) with
+| true -> begin
+((FStar_All.pipe_right fmods (FStar_List.iter (fun uu____47 -> (match (uu____47) with
+| ((iface, name), time) -> begin
+(
+
+let tag = (match (iface) with
+| true -> begin
+"i\'face (or impl+i\'face)"
+end
+| uu____58 -> begin
+"module"
+end)
+in (
+
+let uu____59 = (FStar_Options.should_print_message name.FStar_Ident.str)
+in (match (uu____59) with
+| true -> begin
+(match ((time >= (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____60 = (
+
+let uu____61 = (FStar_Util.string_of_int time)
+in (FStar_Util.format3 "Verified %s: %s (%s milliseconds)\n" tag (FStar_Ident.text_of_lid name) uu____61))
+in (print_to uu____60))
+end
+| uu____62 -> begin
+(
+
+let uu____63 = (FStar_Util.format2 "Verified %s: %s\n" tag (FStar_Ident.text_of_lid name))
+in (print_to uu____63))
+end)
+end
+| uu____64 -> begin
+()
+end)))
+end))));
+(match ((errs > (Prims.parse_int "0"))) with
+| true -> begin
+(match ((errs = (Prims.parse_int "1"))) with
+| true -> begin
+(FStar_Util.print_error "1 error was reported (see above)\n")
+end
+| uu____65 -> begin
+(
+
+let uu____66 = (FStar_Util.string_of_int errs)
+in (FStar_Util.print1_error "%s errors were reported (see above)\n" uu____66))
+end)
+end
+| uu____67 -> begin
+(
+
+let uu____68 = (
+
+let uu____69 = (FStar_Util.colorize_bold "All verification conditions discharged successfully")
+in (FStar_Util.format1 "%s\n" uu____69))
+in (FStar_Util.print_string uu____68))
+end);
+)
+end
+| uu____70 -> begin
+()
+end))))
+
+
+let report_errors : ((Prims.bool * FStar_Ident.lident) * Prims.int) Prims.list  ->  Prims.unit = (fun fmods -> (
+
+let errs = (FStar_Errors.get_err_count ())
+in (match ((errs > (Prims.parse_int "0"))) with
+| true -> begin
+((finished_message fmods errs);
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| uu____86 -> begin
+()
+end)))
+
+
+let codegen : (FStar_Syntax_Syntax.modul Prims.list * FStar_TypeChecker_Env.env)  ->  Prims.unit = (fun uu____92 -> (match (uu____92) with
+| (umods, env) -> begin
+(
+
+let opt = (FStar_Options.codegen ())
+in (match ((opt <> None)) with
+| true -> begin
+(
+
+let mllibs = (
+
+let uu____106 = (
+
+let uu____111 = (FStar_Extraction_ML_UEnv.mkContext env)
+in (FStar_Util.fold_map FStar_Extraction_ML_Modul.extract uu____111 umods))
+in (FStar_All.pipe_left Prims.snd uu____106))
+in (
+
+let mllibs1 = (FStar_List.flatten mllibs)
+in (
+
+let ext = (match (opt) with
+| Some ("FSharp") -> begin
+".fs"
+end
+| Some ("OCaml") -> begin
+".ml"
+end
+| Some ("Kremlin") -> begin
+".krml"
+end
+| uu____124 -> begin
+(failwith "Unrecognized option")
+end)
+in (match (opt) with
+| (Some ("FSharp")) | (Some ("OCaml")) -> begin
+(
+
+let outdir = (FStar_Options.output_dir ())
+in (FStar_List.iter (FStar_Extraction_ML_PrintML.print outdir ext) mllibs1))
+end
+| Some ("Kremlin") -> begin
+(
+
+let programs = (
+
+let uu____130 = (FStar_List.map FStar_Extraction_Kremlin.translate mllibs1)
+in (FStar_List.flatten uu____130))
+in (
+
+let bin = ((FStar_Extraction_Kremlin.current_version), (programs))
+in (
+
+let uu____136 = (FStar_Options.prepend_output_dir "out.krml")
+in (FStar_Util.save_value_to_file uu____136 bin))))
+end
+| uu____137 -> begin
+(failwith "Unrecognized option")
+end))))
+end
+| uu____139 -> begin
+()
+end))
+end))
+
+
+let go = (fun uu____146 -> (
+
+let uu____147 = (process_args ())
+in (match (uu____147) with
+| (res, filenames) -> begin
+(match (res) with
+| FStar_Getopt.Help -> begin
+((FStar_Options.display_usage ());
+(FStar_All.exit (Prims.parse_int "0"));
+)
+end
+| FStar_Getopt.Error (msg) -> begin
+(FStar_Util.print_string msg)
+end
+| FStar_Getopt.Success -> begin
+(
+
+let uu____157 = (
+
+let uu____158 = (FStar_Options.dep ())
+in (uu____158 <> None))
+in (match (uu____157) with
+| true -> begin
+(
+
+let uu____161 = (FStar_Parser_Dep.collect FStar_Parser_Dep.VerifyAll filenames)
+in (FStar_Parser_Dep.print uu____161))
+end
+| uu____175 -> begin
+(
+
+let uu____176 = (FStar_Options.interactive ())
+in (match (uu____176) with
+| true -> begin
+((
+
+let uu____178 = (FStar_Options.explicit_deps ())
+in (match (uu____178) with
+| true -> begin
+((FStar_Util.print_error "--explicit_deps incompatible with --in|n");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| uu____180 -> begin
+()
+end));
+(match (((FStar_List.length filenames) <> (Prims.parse_int "1"))) with
+| true -> begin
+((FStar_Util.print_error "fstar-mode.el should pass the current filename to F*\n");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| uu____185 -> begin
+()
+end);
+(
+
+let filename = (FStar_List.hd filenames)
+in (
+
+let filename1 = (FStar_Common.try_convert_file_name_to_mixed filename)
+in ((
+
+let uu____189 = (
+
+let uu____190 = (FStar_Options.verify_module ())
+in (uu____190 <> []))
+in (match (uu____189) with
+| true -> begin
+(FStar_Util.print_warning "Interactive mode; ignoring --verify_module")
+end
+| uu____193 -> begin
+()
+end));
+(FStar_Interactive.interactive_mode filename1);
+)));
+)
+end
+| uu____194 -> begin
+(
+
+let uu____195 = (FStar_Options.doc ())
+in (match (uu____195) with
+| true -> begin
+(FStar_Fsdoc_Generator.generate filenames)
+end
+| uu____196 -> begin
+(
+
+let uu____197 = (FStar_Options.indent ())
+in (match (uu____197) with
+| true -> begin
+(match (FStar_Platform.is_fstar_compiler_using_ocaml) with
+| true -> begin
+(FStar_Indent.generate filenames)
+end
+| uu____198 -> begin
+(failwith "You seem to be using the F#-generated version ofthe compiler ; reindenting is not known to work yet with this version")
+end)
+end
+| uu____199 -> begin
+(match (((FStar_List.length filenames) >= (Prims.parse_int "1"))) with
+| true -> begin
+(
+
+let verify_mode = (
+
+let uu____204 = (FStar_Options.verify_all ())
+in (match (uu____204) with
+| true -> begin
+((
+
+let uu____206 = (
+
+let uu____207 = (FStar_Options.verify_module ())
+in (uu____207 <> []))
+in (match (uu____206) with
+| true -> begin
+((FStar_Util.print_error "--verify_module is incompatible with --verify_all");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| uu____211 -> begin
+()
+end));
+FStar_Parser_Dep.VerifyAll;
+)
+end
+| uu____212 -> begin
+(
+
+let uu____213 = (
+
+let uu____214 = (FStar_Options.verify_module ())
+in (uu____214 <> []))
+in (match (uu____213) with
+| true -> begin
+FStar_Parser_Dep.VerifyUserList
+end
+| uu____217 -> begin
+FStar_Parser_Dep.VerifyFigureItOut
+end))
+end))
+in (
+
+let filenames1 = (FStar_Dependencies.find_deps_if_needed verify_mode filenames)
+in (
+
+let uu____220 = (FStar_Universal.batch_mode_tc filenames1)
+in (match (uu____220) with
+| (fmods, dsenv, env) -> begin
+(
+
+let module_names_and_times = (FStar_All.pipe_right fmods (FStar_List.map (fun uu____256 -> (match (uu____256) with
+| (x, t) -> begin
+(((FStar_Universal.module_or_interface_name x)), (t))
+end))))
+in ((report_errors module_names_and_times);
+(
+
+let uu____269 = (
+
+let uu____273 = (FStar_All.pipe_right fmods (FStar_List.map Prims.fst))
+in ((uu____273), (env)))
+in (codegen uu____269));
+(finished_message module_names_and_times (Prims.parse_int "0"));
+))
+end))))
+end
+| uu____282 -> begin
+(FStar_Util.print_error "no file provided\n")
+end)
+end))
+end))
+end))
+end))
+end)
+end)))
+
+
+let main = (fun uu____289 -> try
+(match (()) with
+| () -> begin
+((go ());
+(cleanup ());
+(FStar_All.exit (Prims.parse_int "0"));
+)
+end)
+with
+| e -> begin
+((match ((FStar_Errors.handleable e)) with
+| true -> begin
+(FStar_Errors.handle_err false e)
+end
+| uu____297 -> begin
+()
+end);
+(
+
+let uu____298 = (FStar_Options.trace_error ())
+in (match (uu____298) with
+| true -> begin
+(
+
+let uu____299 = (FStar_Util.message_of_exn e)
+in (
+
+let uu____300 = (FStar_Util.trace_of_exn e)
+in (FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____299 uu____300)))
+end
+| uu____301 -> begin
+(match ((not ((FStar_Errors.handleable e)))) with
+| true -> begin
+(
+
+let uu____302 = (FStar_Util.message_of_exn e)
+in (FStar_Util.print1_error "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n" uu____302))
+end
+| uu____303 -> begin
+()
+end)
+end));
+(cleanup ());
+(
+
+let uu____306 = (FStar_Errors.report_all ())
+in (FStar_All.pipe_right uu____306 Prims.ignore));
+(report_errors []);
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end)
+
+
+
+

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1,1218 +1,1521 @@
+
 open Prims
 type debug_level_t =
-  | Low
-  | Medium
-  | High
-  | Extreme
-  | Other of Prims.string
-let uu___is_Low: debug_level_t -> Prims.bool =
-  fun projectee  -> match projectee with | Low  -> true | uu____7 -> false
-let uu___is_Medium: debug_level_t -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Medium  -> true | uu____11 -> false
-let uu___is_High: debug_level_t -> Prims.bool =
-  fun projectee  -> match projectee with | High  -> true | uu____15 -> false
-let uu___is_Extreme: debug_level_t -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Extreme  -> true | uu____19 -> false
-let uu___is_Other: debug_level_t -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Other _0 -> true | uu____24 -> false
-let __proj__Other__item___0: debug_level_t -> Prims.string =
-  fun projectee  -> match projectee with | Other _0 -> _0
+| Low
+| Medium
+| High
+| Extreme
+| Other of Prims.string
+
+
+let uu___is_Low : debug_level_t  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Low -> begin
+true
+end
+| uu____7 -> begin
+false
+end))
+
+
+let uu___is_Medium : debug_level_t  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Medium -> begin
+true
+end
+| uu____11 -> begin
+false
+end))
+
+
+let uu___is_High : debug_level_t  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| High -> begin
+true
+end
+| uu____15 -> begin
+false
+end))
+
+
+let uu___is_Extreme : debug_level_t  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Extreme -> begin
+true
+end
+| uu____19 -> begin
+false
+end))
+
+
+let uu___is_Other : debug_level_t  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Other (_0) -> begin
+true
+end
+| uu____24 -> begin
+false
+end))
+
+
+let __proj__Other__item___0 : debug_level_t  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Other (_0) -> begin
+_0
+end))
+
 type option_val =
-  | Bool of Prims.bool
-  | String of Prims.string
-  | Int of Prims.int
-  | List of option_val Prims.list
-  | Unset
-let uu___is_Bool: option_val -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Bool _0 -> true | uu____49 -> false
-let __proj__Bool__item___0: option_val -> Prims.bool =
-  fun projectee  -> match projectee with | Bool _0 -> _0
-let uu___is_String: option_val -> Prims.bool =
-  fun projectee  ->
-    match projectee with | String _0 -> true | uu____61 -> false
-let __proj__String__item___0: option_val -> Prims.string =
-  fun projectee  -> match projectee with | String _0 -> _0
-let uu___is_Int: option_val -> Prims.bool =
-  fun projectee  -> match projectee with | Int _0 -> true | uu____73 -> false
-let __proj__Int__item___0: option_val -> Prims.int =
-  fun projectee  -> match projectee with | Int _0 -> _0
-let uu___is_List: option_val -> Prims.bool =
-  fun projectee  ->
-    match projectee with | List _0 -> true | uu____86 -> false
-let __proj__List__item___0: option_val -> option_val Prims.list =
-  fun projectee  -> match projectee with | List _0 -> _0
-let uu___is_Unset: option_val -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unset  -> true | uu____100 -> false
+| Bool of Prims.bool
+| String of Prims.string
+| Int of Prims.int
+| List of option_val Prims.list
+| Unset
+
+
+let uu___is_Bool : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Bool (_0) -> begin
+true
+end
+| uu____49 -> begin
+false
+end))
+
+
+let __proj__Bool__item___0 : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Bool (_0) -> begin
+_0
+end))
+
+
+let uu___is_String : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| String (_0) -> begin
+true
+end
+| uu____61 -> begin
+false
+end))
+
+
+let __proj__String__item___0 : option_val  ->  Prims.string = (fun projectee -> (match (projectee) with
+| String (_0) -> begin
+_0
+end))
+
+
+let uu___is_Int : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int (_0) -> begin
+true
+end
+| uu____73 -> begin
+false
+end))
+
+
+let __proj__Int__item___0 : option_val  ->  Prims.int = (fun projectee -> (match (projectee) with
+| Int (_0) -> begin
+_0
+end))
+
+
+let uu___is_List : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| List (_0) -> begin
+true
+end
+| uu____86 -> begin
+false
+end))
+
+
+let __proj__List__item___0 : option_val  ->  option_val Prims.list = (fun projectee -> (match (projectee) with
+| List (_0) -> begin
+_0
+end))
+
+
+let uu___is_Unset : option_val  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unset -> begin
+true
+end
+| uu____100 -> begin
+false
+end))
+
 type options =
-  | Set
-  | Reset
-  | Restore
-let uu___is_Set: options -> Prims.bool =
-  fun projectee  -> match projectee with | Set  -> true | uu____104 -> false
-let uu___is_Reset: options -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Reset  -> true | uu____108 -> false
-let uu___is_Restore: options -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Restore  -> true | uu____112 -> false
-let __unit_tests__: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
-let __unit_tests: Prims.unit -> Prims.bool =
-  fun uu____118  -> FStar_ST.read __unit_tests__
-let __set_unit_tests: Prims.unit -> Prims.unit =
-  fun uu____123  -> FStar_ST.write __unit_tests__ true
-let __clear_unit_tests: Prims.unit -> Prims.unit =
-  fun uu____128  -> FStar_ST.write __unit_tests__ false
-let as_bool: option_val -> Prims.bool =
-  fun uu___47_133  ->
-    match uu___47_133 with
-    | Bool b -> b
-    | uu____135 -> failwith "Impos: expected Bool"
-let as_int: option_val -> Prims.int =
-  fun uu___48_138  ->
-    match uu___48_138 with
-    | Int b -> b
-    | uu____140 -> failwith "Impos: expected Int"
-let as_string: option_val -> Prims.string =
-  fun uu___49_143  ->
-    match uu___49_143 with
-    | String b -> b
-    | uu____145 -> failwith "Impos: expected String"
-let as_list as_t uu___50_161 =
-  match uu___50_161 with
-  | List ts -> FStar_All.pipe_right ts (FStar_List.map as_t)
-  | uu____168 -> failwith "Impos: expected List"
-let as_option as_t uu___51_185 =
-  match uu___51_185 with
-  | Unset  -> None
-  | v1 -> let uu____189 = as_t v1 in Some uu____189
-let fstar_options: option_val FStar_Util.smap Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref []
-let peek: Prims.unit -> option_val FStar_Util.smap =
-  fun uu____201  ->
-    let uu____202 = FStar_ST.read fstar_options in FStar_List.hd uu____202
-let pop: Prims.unit -> Prims.unit =
-  fun uu____212  ->
-    let uu____213 = FStar_ST.read fstar_options in
-    match uu____213 with
-    | []|_::[] -> failwith "TOO MANY POPS!"
-    | uu____224::tl1 -> FStar_ST.write fstar_options tl1
-let push: Prims.unit -> Prims.unit =
-  fun uu____236  ->
-    let uu____237 =
-      let uu____240 =
-        let uu____242 = peek () in FStar_Util.smap_copy uu____242 in
-      let uu____244 = FStar_ST.read fstar_options in uu____240 :: uu____244 in
-    FStar_ST.write fstar_options uu____237
-let set_option: Prims.string -> option_val -> Prims.unit =
-  fun k  ->
-    fun v1  -> let uu____262 = peek () in FStar_Util.smap_add uu____262 k v1
-let set_option': (Prims.string* option_val) -> Prims.unit =
-  fun uu____268  -> match uu____268 with | (k,v1) -> set_option k v1
-let light_off_files: Prims.string Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref []
-let add_light_off_file: Prims.string -> Prims.unit =
-  fun filename  ->
-    let uu____281 =
-      let uu____283 = FStar_ST.read light_off_files in filename :: uu____283 in
-    FStar_ST.write light_off_files uu____281
-let init: Prims.unit -> Prims.unit =
-  fun uu____293  ->
-    let vals =
-      [("__temp_no_proj", (List []));
-      ("_fstar_home", (String ""));
-      ("_include_path", (List []));
-      ("admit_smt_queries", (Bool false));
-      ("cardinality", (String "off"));
-      ("codegen", Unset);
-      ("codegen-lib", (List []));
-      ("debug", (List []));
-      ("debug_level", (List []));
-      ("dep", Unset);
-      ("detail_errors", (Bool false));
-      ("doc", (Bool false));
-      ("dump_module", (List []));
-      ("eager_inference", (Bool false));
-      ("explicit_deps", (Bool false));
-      ("extract_all", (Bool false));
-      ("extract_module", (List []));
-      ("extract_namespace", (List []));
-      ("fs_typ_app", (Bool false));
-      ("fsi", (Bool false));
-      ("fstar_home", Unset);
-      ("full_context_dependency", (Bool true));
-      ("hide_genident_nums", (Bool false));
-      ("hide_uvar_nums", (Bool false));
-      ("hint_info", (Bool false));
-      ("in", (Bool false));
-      ("include", (List []));
-      ("indent", (Bool false));
-      ("initial_fuel", (Int (Prims.parse_int "2")));
-      ("initial_ifuel", (Int (Prims.parse_int "1")));
-      ("inline_arith", (Bool false));
-      ("lax", (Bool false));
-      ("log_queries", (Bool false));
-      ("log_types", (Bool false));
-      ("max_fuel", (Int (Prims.parse_int "8")));
-      ("max_ifuel", (Int (Prims.parse_int "2")));
-      ("min_fuel", (Int (Prims.parse_int "1")));
-      ("MLish", (Bool false));
-      ("n_cores", (Int (Prims.parse_int "1")));
-      ("no_default_includes", (Bool false));
-      ("no_extract", (List []));
-      ("no_location_info", (Bool false));
-      ("no_warn_top_level_effects", (Bool true));
-      ("odir", Unset);
-      ("prims", Unset);
-      ("pretype", (Bool true));
-      ("prims_ref", Unset);
-      ("print_before_norm", (Bool false));
-      ("print_bound_var_types", (Bool false));
-      ("print_effect_args", (Bool false));
-      ("print_fuels", (Bool false));
-      ("print_full_names", (Bool false));
-      ("print_implicits", (Bool false));
-      ("print_universes", (Bool false));
-      ("print_z3_statistics", (Bool false));
-      ("prn", (Bool false));
-      ("record_hints", (Bool false));
-      ("reuse_hint_for", Unset);
-      ("show_signatures", (List []));
-      ("silent", (Bool false));
-      ("smt", Unset);
-      ("split_cases", (Int (Prims.parse_int "0")));
-      ("timing", (Bool false));
-      ("trace_error", (Bool false));
-      ("unthrottle_inductives", (Bool false));
-      ("use_eq_at_higher_order", (Bool false));
-      ("use_hints", (Bool false));
-      ("use_tactics", (Bool false));
-      ("verify", (Bool true));
-      ("verify_all", (Bool false));
-      ("verify_module", (List []));
-      ("warn_default_effects", (Bool false));
-      ("z3refresh", (Bool false));
-      ("z3rlimit", (Int (Prims.parse_int "5")));
-      ("z3seed", (Int (Prims.parse_int "0")));
-      ("z3timeout", (Int (Prims.parse_int "5")));
-      ("z3cliopt", (List []));
-      ("__no_positivity", (Bool false))] in
-    let o = peek () in
-    FStar_Util.smap_clear o;
-    FStar_All.pipe_right vals (FStar_List.iter set_option')
-let clear: Prims.unit -> Prims.unit =
-  fun uu____466  ->
-    let o = FStar_Util.smap_create (Prims.parse_int "50") in
-    FStar_ST.write fstar_options [o];
-    FStar_ST.write light_off_files [];
-    init ()
-let _run: Prims.unit = clear ()
-let lookup_opt s c =
-  let uu____497 =
-    let uu____499 = peek () in FStar_Util.smap_try_find uu____499 s in
-  match uu____497 with
-  | None  ->
-      failwith
-        (Prims.strcat "Impossible: option " (Prims.strcat s " not found"))
-  | Some s1 -> c s1
-let get_admit_smt_queries: Prims.unit -> Prims.bool =
-  fun uu____504  -> lookup_opt "admit_smt_queries" as_bool
-let get_cardinality: Prims.unit -> Prims.string =
-  fun uu____507  -> lookup_opt "cardinality" as_string
-let get_codegen: Prims.unit -> Prims.string Prims.option =
-  fun uu____511  -> lookup_opt "codegen" (as_option as_string)
-let get_codegen_lib: Prims.unit -> Prims.string Prims.list =
-  fun uu____516  -> lookup_opt "codegen-lib" (as_list as_string)
-let get_debug: Prims.unit -> Prims.string Prims.list =
-  fun uu____521  -> lookup_opt "debug" (as_list as_string)
-let get_debug_level: Prims.unit -> Prims.string Prims.list =
-  fun uu____526  -> lookup_opt "debug_level" (as_list as_string)
-let get_dep: Prims.unit -> Prims.string Prims.option =
-  fun uu____531  -> lookup_opt "dep" (as_option as_string)
-let get_detail_errors: Prims.unit -> Prims.bool =
-  fun uu____535  -> lookup_opt "detail_errors" as_bool
-let get_doc: Prims.unit -> Prims.bool =
-  fun uu____538  -> lookup_opt "doc" as_bool
-let get_dump_module: Prims.unit -> Prims.string Prims.list =
-  fun uu____542  -> lookup_opt "dump_module" (as_list as_string)
-let get_eager_inference: Prims.unit -> Prims.bool =
-  fun uu____546  -> lookup_opt "eager_inference" as_bool
-let get_explicit_deps: Prims.unit -> Prims.bool =
-  fun uu____549  -> lookup_opt "explicit_deps" as_bool
-let get_extract_all: Prims.unit -> Prims.bool =
-  fun uu____552  -> lookup_opt "extract_all" as_bool
-let get_extract_module: Prims.unit -> Prims.string Prims.list =
-  fun uu____556  -> lookup_opt "extract_module" (as_list as_string)
-let get_extract_namespace: Prims.unit -> Prims.string Prims.list =
-  fun uu____561  -> lookup_opt "extract_namespace" (as_list as_string)
-let get_fs_typ_app: Prims.unit -> Prims.bool =
-  fun uu____565  -> lookup_opt "fs_typ_app" as_bool
-let get_fstar_home: Prims.unit -> Prims.string Prims.option =
-  fun uu____569  -> lookup_opt "fstar_home" (as_option as_string)
-let get_hide_genident_nums: Prims.unit -> Prims.bool =
-  fun uu____573  -> lookup_opt "hide_genident_nums" as_bool
-let get_hide_uvar_nums: Prims.unit -> Prims.bool =
-  fun uu____576  -> lookup_opt "hide_uvar_nums" as_bool
-let get_hint_info: Prims.unit -> Prims.bool =
-  fun uu____579  -> lookup_opt "hint_info" as_bool
-let get_in: Prims.unit -> Prims.bool =
-  fun uu____582  -> lookup_opt "in" as_bool
-let get_include: Prims.unit -> Prims.string Prims.list =
-  fun uu____586  -> lookup_opt "include" (as_list as_string)
-let get_indent: Prims.unit -> Prims.bool =
-  fun uu____590  -> lookup_opt "indent" as_bool
-let get_initial_fuel: Prims.unit -> Prims.int =
-  fun uu____593  -> lookup_opt "initial_fuel" as_int
-let get_initial_ifuel: Prims.unit -> Prims.int =
-  fun uu____596  -> lookup_opt "initial_ifuel" as_int
-let get_inline_arith: Prims.unit -> Prims.bool =
-  fun uu____599  -> lookup_opt "inline_arith" as_bool
-let get_lax: Prims.unit -> Prims.bool =
-  fun uu____602  -> lookup_opt "lax" as_bool
-let get_log_queries: Prims.unit -> Prims.bool =
-  fun uu____605  -> lookup_opt "log_queries" as_bool
-let get_log_types: Prims.unit -> Prims.bool =
-  fun uu____608  -> lookup_opt "log_types" as_bool
-let get_max_fuel: Prims.unit -> Prims.int =
-  fun uu____611  -> lookup_opt "max_fuel" as_int
-let get_max_ifuel: Prims.unit -> Prims.int =
-  fun uu____614  -> lookup_opt "max_ifuel" as_int
-let get_min_fuel: Prims.unit -> Prims.int =
-  fun uu____617  -> lookup_opt "min_fuel" as_int
-let get_MLish: Prims.unit -> Prims.bool =
-  fun uu____620  -> lookup_opt "MLish" as_bool
-let get_n_cores: Prims.unit -> Prims.int =
-  fun uu____623  -> lookup_opt "n_cores" as_int
-let get_no_default_includes: Prims.unit -> Prims.bool =
-  fun uu____626  -> lookup_opt "no_default_includes" as_bool
-let get_no_extract: Prims.unit -> Prims.string Prims.list =
-  fun uu____630  -> lookup_opt "no_extract" (as_list as_string)
-let get_no_location_info: Prims.unit -> Prims.bool =
-  fun uu____634  -> lookup_opt "no_location_info" as_bool
-let get_warn_top_level_effects: Prims.unit -> Prims.bool =
-  fun uu____637  -> lookup_opt "no_warn_top_level_effects" as_bool
-let get_odir: Prims.unit -> Prims.string Prims.option =
-  fun uu____641  -> lookup_opt "odir" (as_option as_string)
-let get_prims: Prims.unit -> Prims.string Prims.option =
-  fun uu____646  -> lookup_opt "prims" (as_option as_string)
-let get_print_before_norm: Prims.unit -> Prims.bool =
-  fun uu____650  -> lookup_opt "print_before_norm" as_bool
-let get_print_bound_var_types: Prims.unit -> Prims.bool =
-  fun uu____653  -> lookup_opt "print_bound_var_types" as_bool
-let get_print_effect_args: Prims.unit -> Prims.bool =
-  fun uu____656  -> lookup_opt "print_effect_args" as_bool
-let get_print_fuels: Prims.unit -> Prims.bool =
-  fun uu____659  -> lookup_opt "print_fuels" as_bool
-let get_print_full_names: Prims.unit -> Prims.bool =
-  fun uu____662  -> lookup_opt "print_full_names" as_bool
-let get_print_implicits: Prims.unit -> Prims.bool =
-  fun uu____665  -> lookup_opt "print_implicits" as_bool
-let get_print_universes: Prims.unit -> Prims.bool =
-  fun uu____668  -> lookup_opt "print_universes" as_bool
-let get_print_z3_statistics: Prims.unit -> Prims.bool =
-  fun uu____671  -> lookup_opt "print_z3_statistics" as_bool
-let get_prn: Prims.unit -> Prims.bool =
-  fun uu____674  -> lookup_opt "prn" as_bool
-let get_record_hints: Prims.unit -> Prims.bool =
-  fun uu____677  -> lookup_opt "record_hints" as_bool
-let get_reuse_hint_for: Prims.unit -> Prims.string Prims.option =
-  fun uu____681  -> lookup_opt "reuse_hint_for" (as_option as_string)
-let get_show_signatures: Prims.unit -> Prims.string Prims.list =
-  fun uu____686  -> lookup_opt "show_signatures" (as_list as_string)
-let get_silent: Prims.unit -> Prims.bool =
-  fun uu____690  -> lookup_opt "silent" as_bool
-let get_smt: Prims.unit -> Prims.string Prims.option =
-  fun uu____694  -> lookup_opt "smt" (as_option as_string)
-let get_split_cases: Prims.unit -> Prims.int =
-  fun uu____698  -> lookup_opt "split_cases" as_int
-let get_timing: Prims.unit -> Prims.bool =
-  fun uu____701  -> lookup_opt "timing" as_bool
-let get_trace_error: Prims.unit -> Prims.bool =
-  fun uu____704  -> lookup_opt "trace_error" as_bool
-let get_unthrottle_inductives: Prims.unit -> Prims.bool =
-  fun uu____707  -> lookup_opt "unthrottle_inductives" as_bool
-let get_use_eq_at_higher_order: Prims.unit -> Prims.bool =
-  fun uu____710  -> lookup_opt "use_eq_at_higher_order" as_bool
-let get_use_hints: Prims.unit -> Prims.bool =
-  fun uu____713  -> lookup_opt "use_hints" as_bool
-let get_use_tactics: Prims.unit -> Prims.bool =
-  fun uu____716  -> lookup_opt "use_tactics" as_bool
-let get_verify_all: Prims.unit -> Prims.bool =
-  fun uu____719  -> lookup_opt "verify_all" as_bool
-let get_verify_module: Prims.unit -> Prims.string Prims.list =
-  fun uu____723  -> lookup_opt "verify_module" (as_list as_string)
-let get___temp_no_proj: Prims.unit -> Prims.string Prims.list =
-  fun uu____728  -> lookup_opt "__temp_no_proj" (as_list as_string)
-let get_version: Prims.unit -> Prims.bool =
-  fun uu____732  -> lookup_opt "version" as_bool
-let get_warn_default_effects: Prims.unit -> Prims.bool =
-  fun uu____735  -> lookup_opt "warn_default_effects" as_bool
-let get_z3cliopt: Prims.unit -> Prims.string Prims.list =
-  fun uu____739  -> lookup_opt "z3cliopt" (as_list as_string)
-let get_z3refresh: Prims.unit -> Prims.bool =
-  fun uu____743  -> lookup_opt "z3refresh" as_bool
-let get_z3rlimit: Prims.unit -> Prims.int =
-  fun uu____746  -> lookup_opt "z3rlimit" as_int
-let get_z3seed: Prims.unit -> Prims.int =
-  fun uu____749  -> lookup_opt "z3seed" as_int
-let get_z3timeout: Prims.unit -> Prims.int =
-  fun uu____752  -> lookup_opt "z3timeout" as_int
-let get_no_positivity: Prims.unit -> Prims.bool =
-  fun uu____755  -> lookup_opt "__no_positivity" as_bool
-let dlevel: Prims.string -> debug_level_t =
-  fun uu___52_758  ->
-    match uu___52_758 with
-    | "Low" -> Low
-    | "Medium" -> Medium
-    | "High" -> High
-    | "Extreme" -> Extreme
-    | s -> Other s
-let one_debug_level_geq: debug_level_t -> debug_level_t -> Prims.bool =
-  fun l1  ->
-    fun l2  ->
-      match l1 with
-      | Other _|Low  -> l1 = l2
-      | Medium  -> (l2 = Low) || (l2 = Medium)
-      | High  -> ((l2 = Low) || (l2 = Medium)) || (l2 = High)
-      | Extreme  ->
-          (((l2 = Low) || (l2 = Medium)) || (l2 = High)) || (l2 = Extreme)
-let debug_level_geq: debug_level_t -> Prims.bool =
-  fun l2  ->
-    let uu____770 = get_debug_level () in
-    FStar_All.pipe_right uu____770
-      (FStar_Util.for_some (fun l1  -> one_debug_level_geq (dlevel l1) l2))
-let include_path_base_dirs: Prims.string Prims.list = ["/lib"; "/lib/fstar"]
-let universe_include_path_base_dirs: Prims.string Prims.list =
-  ["/ulib"; "/lib/fstar"]
-let _version: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
-let _platform: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
-let _compiler: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
-let _date: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
-let _commit: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
-let display_version: Prims.unit -> Prims.unit =
-  fun uu____798  ->
-    let uu____799 =
-      let uu____800 = FStar_ST.read _version in
-      let uu____803 = FStar_ST.read _platform in
-      let uu____806 = FStar_ST.read _compiler in
-      let uu____809 = FStar_ST.read _date in
-      let uu____812 = FStar_ST.read _commit in
-      FStar_Util.format5
-        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____800
-        uu____803 uu____806 uu____809 uu____812 in
-    FStar_Util.print_string uu____799
-let display_usage_aux specs =
-  FStar_Util.print_string "fstar.exe [options] file[s]\n";
-  FStar_List.iter
-    (fun uu____842  ->
-       match uu____842 with
-       | (uu____848,flag,p,doc) ->
-           (match p with
-            | FStar_Getopt.ZeroArgs ig ->
-                if doc = ""
-                then
-                  let uu____857 =
-                    let uu____858 = FStar_Util.colorize_bold flag in
-                    FStar_Util.format1 "  --%s\n" uu____858 in
-                  FStar_Util.print_string uu____857
-                else
-                  (let uu____860 =
-                     let uu____861 = FStar_Util.colorize_bold flag in
-                     FStar_Util.format2 "  --%s  %s\n" uu____861 doc in
-                   FStar_Util.print_string uu____860)
-            | FStar_Getopt.OneArg (uu____862,argname) ->
-                if doc = ""
-                then
-                  let uu____868 =
-                    let uu____869 = FStar_Util.colorize_bold flag in
-                    let uu____870 = FStar_Util.colorize_bold argname in
-                    FStar_Util.format2 "  --%s %s\n" uu____869 uu____870 in
-                  FStar_Util.print_string uu____868
-                else
-                  (let uu____872 =
-                     let uu____873 = FStar_Util.colorize_bold flag in
-                     let uu____874 = FStar_Util.colorize_bold argname in
-                     FStar_Util.format3 "  --%s %s  %s\n" uu____873 uu____874
-                       doc in
-                   FStar_Util.print_string uu____872))) specs
-let mk_spec:
-  (FStar_BaseTypes.char* Prims.string* option_val FStar_Getopt.opt_variant*
-    Prims.string) -> FStar_Getopt.opt
-  =
-  fun o  ->
-    let uu____888 = o in
-    match uu____888 with
-    | (ns,name,arg,desc) ->
-        let arg1 =
-          match arg with
-          | FStar_Getopt.ZeroArgs f ->
-              let g uu____909 =
-                let uu____910 = let uu____913 = f () in (name, uu____913) in
-                set_option' uu____910 in
-              FStar_Getopt.ZeroArgs g
-          | FStar_Getopt.OneArg (f,d) ->
-              let g x =
-                let uu____924 = let uu____927 = f x in (name, uu____927) in
-                set_option' uu____924 in
-              FStar_Getopt.OneArg (g, d) in
-        (ns, name, arg1, desc)
-let cons_extract_module: Prims.string -> option_val =
-  fun s  ->
-    let uu____934 =
-      let uu____936 =
-        let uu____938 = get_extract_module () in (FStar_String.lowercase s)
-          :: uu____938 in
-      FStar_All.pipe_right uu____936
-        (FStar_List.map (fun _0_25  -> String _0_25)) in
-    List uu____934
-let cons_extract_namespace: Prims.string -> option_val =
-  fun s  ->
-    let uu____945 =
-      let uu____947 =
-        let uu____949 = get_extract_namespace () in
-        (FStar_String.lowercase s) :: uu____949 in
-      FStar_All.pipe_right uu____947
-        (FStar_List.map (fun _0_26  -> String _0_26)) in
-    List uu____945
-let add_extract_module: Prims.string -> Prims.unit =
-  fun s  ->
-    let uu____956 = cons_extract_module s in
-    set_option "extract_module" uu____956
-let add_extract_namespace: Prims.string -> Prims.unit =
-  fun s  ->
-    let uu____960 = cons_extract_namespace s in
-    set_option "extract_namespace" uu____960
-let cons_verify_module: Prims.string -> option_val =
-  fun s  ->
-    let uu____964 =
-      let uu____966 =
-        let uu____968 = get_verify_module () in (FStar_String.lowercase s) ::
-          uu____968 in
-      FStar_All.pipe_right uu____966
-        (FStar_List.map (fun _0_27  -> String _0_27)) in
-    List uu____964
-let add_verify_module: Prims.string -> Prims.unit =
-  fun s  ->
-    let uu____975 = cons_verify_module s in
-    set_option "verify_module" uu____975
-let rec specs:
-  Prims.unit ->
-    (FStar_Char.char* Prims.string* Prims.unit FStar_Getopt.opt_variant*
-      Prims.string) Prims.list
-  =
-  fun uu____983  ->
-    let specs1 =
-      [(FStar_Getopt.noshort, "admit_smt_queries",
-         (FStar_Getopt.OneArg
-            (((fun s  ->
-                 if s = "true"
-                 then Bool true
-                 else
-                   if s = "false"
-                   then Bool false
-                   else failwith "Invalid argument to --admit_smt_queries")),
-              "[true|false]")),
-         "Admit SMT queries, unsafe! (default 'false')");
-      (FStar_Getopt.noshort, "cardinality",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1012 = validate_cardinality x in String uu____1012)),
-             "[off|warn|check]")),
-        "Check cardinality constraints on inductive data types (default 'off')");
-      (FStar_Getopt.noshort, "codegen",
-        (FStar_Getopt.OneArg
-           (((fun s  -> let uu____1022 = parse_codegen s in String uu____1022)),
-             "[OCaml|FSharp|Kremlin]")), "Generate code for execution");
-      (FStar_Getopt.noshort, "codegen-lib",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                let uu____1032 =
-                  let uu____1034 =
-                    let uu____1036 = get_codegen_lib () in s :: uu____1036 in
-                  FStar_All.pipe_right uu____1034
-                    (FStar_List.map (fun _0_28  -> String _0_28)) in
-                List uu____1032)), "[namespace]")),
-        "External runtime library (i.e. M.N.x extracts to M.N.X instead of M_N.x)");
-      (FStar_Getopt.noshort, "debug",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1049 =
-                  let uu____1051 =
-                    let uu____1053 = get_debug () in x :: uu____1053 in
-                  FStar_All.pipe_right uu____1051
-                    (FStar_List.map (fun _0_29  -> String _0_29)) in
-                List uu____1049)), "[module name]")),
-        "Print lots of debugging information while checking module");
-      (FStar_Getopt.noshort, "debug_level",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1066 =
-                  let uu____1068 =
-                    let uu____1070 = get_debug_level () in x :: uu____1070 in
-                  FStar_All.pipe_right uu____1068
-                    (FStar_List.map (fun _0_30  -> String _0_30)) in
-                List uu____1066)), "[Low|Medium|High|Extreme|...]")),
-        "Control the verbosity of debugging info");
-      (FStar_Getopt.noshort, "dep",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                if (x = "make") || (x = "graph")
-                then String x
-                else failwith "invalid argument to 'dep'")), "[make|graph]")),
-        "Output the transitive closure of the dependency graph in a format suitable for the given tool");
-      (FStar_Getopt.noshort, "detail_errors",
-        (FStar_Getopt.ZeroArgs ((fun uu____1090  -> Bool true))),
-        "Emit a detailed error report by asking the SMT solver many queries; will take longer;\n         implies n_cores=1");
-      (FStar_Getopt.noshort, "doc",
-        (FStar_Getopt.ZeroArgs ((fun uu____1097  -> Bool true))),
-        "Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory.");
-      (FStar_Getopt.noshort, "dump_module",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1107 =
-                  let uu____1109 =
-                    let uu____1111 = get_dump_module () in x :: uu____1111 in
-                  FStar_All.pipe_right uu____1109
-                    (FStar_List.map (fun _0_31  -> String _0_31)) in
-                FStar_All.pipe_right uu____1107 (fun _0_32  -> List _0_32))),
-             "[module name]")), "");
-      (FStar_Getopt.noshort, "eager_inference",
-        (FStar_Getopt.ZeroArgs ((fun uu____1122  -> Bool true))),
-        "Solve all type-inference constraints eagerly; more efficient but at the cost of generality");
-      (FStar_Getopt.noshort, "explicit_deps",
-        (FStar_Getopt.ZeroArgs ((fun uu____1129  -> Bool true))),
-        "Do not find dependencies automatically, the user provides them on the command-line");
-      (FStar_Getopt.noshort, "extract_all",
-        (FStar_Getopt.ZeroArgs ((fun uu____1136  -> Bool true))),
-        "Discover the complete dependency graph and do not stop at interface boundaries");
-      (FStar_Getopt.noshort, "extract_module",
-        (FStar_Getopt.OneArg (cons_extract_module, "[module name]")),
-        "Only extract the specified modules (instead of the possibly-partial dependency graph)");
-      (FStar_Getopt.noshort, "extract_namespace",
-        (FStar_Getopt.OneArg (cons_extract_namespace, "[namespace name]")),
-        "Only extract modules in the specified namespace");
-      (FStar_Getopt.noshort, "fstar_home",
-        (FStar_Getopt.OneArg (((fun _0_33  -> String _0_33)), "[dir]")),
-        "Set the FSTAR_HOME variable to [dir]");
-      (FStar_Getopt.noshort, "hide_genident_nums",
-        (FStar_Getopt.ZeroArgs ((fun uu____1167  -> Bool true))),
-        "Don't print generated identifier numbers");
-      (FStar_Getopt.noshort, "hide_uvar_nums",
-        (FStar_Getopt.ZeroArgs ((fun uu____1174  -> Bool true))),
-        "Don't print unification variable numbers");
-      (FStar_Getopt.noshort, "hint_info",
-        (FStar_Getopt.ZeroArgs ((fun uu____1181  -> Bool true))),
-        "Print information regarding hints");
-      (FStar_Getopt.noshort, "in",
-        (FStar_Getopt.ZeroArgs ((fun uu____1188  -> Bool true))),
-        "Interactive mode; reads input from stdin");
-      (FStar_Getopt.noshort, "include",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                let uu____1198 =
-                  let uu____1200 =
-                    let uu____1202 = get_include () in
-                    FStar_List.append uu____1202 [s] in
-                  FStar_All.pipe_right uu____1200
-                    (FStar_List.map (fun _0_34  -> String _0_34)) in
-                List uu____1198)), "[path]")),
-        "A directory in which to search for files included on the command line");
-      (FStar_Getopt.noshort, "indent",
-        (FStar_Getopt.ZeroArgs ((fun uu____1212  -> Bool true))),
-        "Parses and outputs the files on the command line");
-      (FStar_Getopt.noshort, "initial_fuel",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1222 = FStar_Util.int_of_string x in Int uu____1222)),
-             "[non-negative integer]")),
-        "Number of unrolling of recursive functions to try initially (default 2)");
-      (FStar_Getopt.noshort, "initial_ifuel",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1232 = FStar_Util.int_of_string x in Int uu____1232)),
-             "[non-negative integer]")),
-        "Number of unrolling of inductive datatypes to try at first (default 1)");
-      (FStar_Getopt.noshort, "inline_arith",
-        (FStar_Getopt.ZeroArgs ((fun uu____1239  -> Bool true))),
-        "Inline definitions of arithmetic functions in the SMT encoding");
-      (FStar_Getopt.noshort, "lax",
-        (FStar_Getopt.ZeroArgs ((fun uu____1246  -> Bool true))),
-        "Run the lax-type checker only (admit all verification conditions)");
-      (FStar_Getopt.noshort, "log_types",
-        (FStar_Getopt.ZeroArgs ((fun uu____1253  -> Bool true))),
-        "Print types computed for data/val/let-bindings");
-      (FStar_Getopt.noshort, "log_queries",
-        (FStar_Getopt.ZeroArgs ((fun uu____1260  -> Bool true))),
-        "Log the Z3 queries in several queries-*.smt2 files, as we go");
-      (FStar_Getopt.noshort, "max_fuel",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1270 = FStar_Util.int_of_string x in Int uu____1270)),
-             "[non-negative integer]")),
-        "Number of unrolling of recursive functions to try at most (default 8)");
-      (FStar_Getopt.noshort, "max_ifuel",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1280 = FStar_Util.int_of_string x in Int uu____1280)),
-             "[non-negative integer]")),
-        "Number of unrolling of inductive datatypes to try at most (default 2)");
-      (FStar_Getopt.noshort, "min_fuel",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1290 = FStar_Util.int_of_string x in Int uu____1290)),
-             "[non-negative integer]")),
-        "Minimum number of unrolling of recursive functions to try (default 1)");
-      (FStar_Getopt.noshort, "MLish",
-        (FStar_Getopt.ZeroArgs ((fun uu____1297  -> Bool true))),
-        "Trigger various specializations for compiling the F* compiler itself (not meant for user code)");
-      (FStar_Getopt.noshort, "n_cores",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1307 = FStar_Util.int_of_string x in Int uu____1307)),
-             "[positive integer]")),
-        "Maximum number of cores to use for the solver (implies detail_errors = false) (default 1)");
-      (FStar_Getopt.noshort, "no_default_includes",
-        (FStar_Getopt.ZeroArgs ((fun uu____1314  -> Bool true))),
-        "Ignore the default module search paths");
-      (FStar_Getopt.noshort, "no_extract",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1324 =
-                  let uu____1326 =
-                    let uu____1328 = get_no_extract () in x :: uu____1328 in
-                  FStar_All.pipe_right uu____1326
-                    (FStar_List.map (fun _0_35  -> String _0_35)) in
-                List uu____1324)), "[module name]")),
-        "Do not extract code from this module");
-      (FStar_Getopt.noshort, "no_location_info",
-        (FStar_Getopt.ZeroArgs ((fun uu____1338  -> Bool true))),
-        "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)");
-      (FStar_Getopt.noshort, "odir",
-        (FStar_Getopt.OneArg (((fun _0_36  -> String _0_36)), "[dir]")),
-        "Place output in directory [dir]");
-      (FStar_Getopt.noshort, "prims",
-        (FStar_Getopt.OneArg (((fun _0_37  -> String _0_37)), "file")), "");
-      (FStar_Getopt.noshort, "print_before_norm",
-        (FStar_Getopt.ZeroArgs ((fun uu____1361  -> Bool true))),
-        "Do not normalize types before printing (for debugging)");
-      (FStar_Getopt.noshort, "print_bound_var_types",
-        (FStar_Getopt.ZeroArgs ((fun uu____1368  -> Bool true))),
-        "Print the types of bound variables");
-      (FStar_Getopt.noshort, "print_effect_args",
-        (FStar_Getopt.ZeroArgs ((fun uu____1375  -> Bool true))),
-        "Print inferred predicate transformers for all computation types");
-      (FStar_Getopt.noshort, "print_fuels",
-        (FStar_Getopt.ZeroArgs ((fun uu____1382  -> Bool true))),
-        "Print the fuel amounts used for each successful query");
-      (FStar_Getopt.noshort, "print_full_names",
-        (FStar_Getopt.ZeroArgs ((fun uu____1389  -> Bool true))),
-        "Print full names of variables");
-      (FStar_Getopt.noshort, "print_implicits",
-        (FStar_Getopt.ZeroArgs ((fun uu____1396  -> Bool true))),
-        "Print implicit arguments");
-      (FStar_Getopt.noshort, "print_universes",
-        (FStar_Getopt.ZeroArgs ((fun uu____1403  -> Bool true))),
-        "Print universes");
-      (FStar_Getopt.noshort, "print_z3_statistics",
-        (FStar_Getopt.ZeroArgs ((fun uu____1410  -> Bool true))),
-        "Print Z3 statistics for each SMT query");
-      (FStar_Getopt.noshort, "prn",
-        (FStar_Getopt.ZeroArgs ((fun uu____1417  -> Bool true))),
-        "Print full names (deprecated; use --print_full_names instead)");
-      (FStar_Getopt.noshort, "record_hints",
-        (FStar_Getopt.ZeroArgs ((fun uu____1424  -> Bool true))),
-        "Record a database of hints for efficient proof replay");
-      (FStar_Getopt.noshort, "reuse_hint_for",
-        (FStar_Getopt.OneArg
-           (((fun _0_38  -> String _0_38)),
-             "top-level name in the current module")),
-        "Optimistically, attempt using the recorded hint for 'f' when trying to verify some other term 'g'");
-      (FStar_Getopt.noshort, "show_signatures",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1442 =
-                  let uu____1444 =
-                    let uu____1446 = get_show_signatures () in x ::
-                      uu____1446 in
-                  FStar_All.pipe_right uu____1444
-                    (FStar_List.map (fun _0_39  -> String _0_39)) in
-                List uu____1442)), "[module name]")),
-        "Show the checked signatures for all top-level symbols in the module");
-      (FStar_Getopt.noshort, "silent",
-        (FStar_Getopt.ZeroArgs ((fun uu____1456  -> Bool true))), " ");
-      (FStar_Getopt.noshort, "smt",
-        (FStar_Getopt.OneArg (((fun _0_40  -> String _0_40)), "[path]")),
-        "Path to the SMT solver (usually Z3, but could be any SMT2-compatible solver)");
-      (FStar_Getopt.noshort, "split_cases",
-        (FStar_Getopt.OneArg
-           (((fun n1  ->
-                let uu____1474 = FStar_Util.int_of_string n1 in
-                Int uu____1474)), "[positive integer]")),
-        "Partition VC of a match into groups of [n] cases");
-      (FStar_Getopt.noshort, "timing",
-        (FStar_Getopt.ZeroArgs ((fun uu____1481  -> Bool true))),
-        "Print the time it takes to verify each top-level definition");
-      (FStar_Getopt.noshort, "trace_error",
-        (FStar_Getopt.ZeroArgs ((fun uu____1488  -> Bool true))),
-        "Don't print an error message; show an exception trace instead");
-      (FStar_Getopt.noshort, "unthrottle_inductives",
-        (FStar_Getopt.ZeroArgs ((fun uu____1495  -> Bool true))),
-        "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)");
-      (FStar_Getopt.noshort, "use_eq_at_higher_order",
-        (FStar_Getopt.ZeroArgs ((fun uu____1502  -> Bool true))),
-        "Use equality constraints when comparing higher-order types (Temporary)");
-      (FStar_Getopt.noshort, "use_hints",
-        (FStar_Getopt.ZeroArgs ((fun uu____1509  -> Bool true))),
-        "Use a previously recorded hints database for proof replay");
-      (FStar_Getopt.noshort, "use_tactics",
-        (FStar_Getopt.ZeroArgs ((fun uu____1516  -> Bool true))),
-        "Pre-process a verification condition using a user-provided tactic (a flag to support migration to tactics gradually)");
-      (FStar_Getopt.noshort, "verify_all",
-        (FStar_Getopt.ZeroArgs ((fun uu____1523  -> Bool true))),
-        "With automatic dependencies, verify all the dependencies, not just the files passed on the command-line.");
-      (FStar_Getopt.noshort, "verify_module",
-        (FStar_Getopt.OneArg (cons_verify_module, "[module name]")),
-        "Name of the module to verify");
-      (FStar_Getopt.noshort, "__temp_no_proj",
-        (FStar_Getopt.OneArg
-           (((fun x  ->
-                let uu____1541 =
-                  let uu____1543 =
-                    let uu____1545 = get___temp_no_proj () in x :: uu____1545 in
-                  FStar_All.pipe_right uu____1543
-                    (FStar_List.map (fun _0_41  -> String _0_41)) in
-                List uu____1541)), "[module name]")),
-        "Don't generate projectors for this module");
-      ('v', "version",
-        (FStar_Getopt.ZeroArgs
-           ((fun uu____1555  ->
-               display_version (); FStar_All.exit (Prims.parse_int "0")))),
-        "Display version number");
-      (FStar_Getopt.noshort, "warn_default_effects",
-        (FStar_Getopt.ZeroArgs ((fun uu____1563  -> Bool true))),
-        "Warn when (a -> b) is desugared to (a -> Tot b)");
-      (FStar_Getopt.noshort, "z3cliopt",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                let uu____1573 =
-                  let uu____1575 =
-                    let uu____1577 = get_z3cliopt () in
-                    FStar_List.append uu____1577 [s] in
-                  FStar_All.pipe_right uu____1575
-                    (FStar_List.map (fun _0_42  -> String _0_42)) in
-                List uu____1573)), "[option]")), "Z3 command line options");
-      (FStar_Getopt.noshort, "z3refresh",
-        (FStar_Getopt.ZeroArgs ((fun uu____1587  -> Bool false))),
-        "Restart Z3 after each query; useful for ensuring proof robustness");
-      (FStar_Getopt.noshort, "z3rlimit",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                let uu____1597 = FStar_Util.int_of_string s in Int uu____1597)),
-             "[positive integer]")),
-        "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)");
-      (FStar_Getopt.noshort, "z3seed",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                let uu____1607 = FStar_Util.int_of_string s in Int uu____1607)),
-             "[positive integer]")), "Set the Z3 random seed (default 0)");
-      (FStar_Getopt.noshort, "z3timeout",
-        (FStar_Getopt.OneArg
-           (((fun s  ->
-                FStar_Util.print_string
-                  "Warning: z3timeout ignored; use z3rlimit instead\n";
-                (let uu____1618 = FStar_Util.int_of_string s in
-                 Int uu____1618))), "[positive integer]")),
-        "Set the Z3 per-query (soft) timeout to [t] seconds (default 5)");
-      (FStar_Getopt.noshort, "__no_positivity",
-        (FStar_Getopt.ZeroArgs ((fun uu____1625  -> Bool true))),
-        "Don't check positivity of inductive types")] in
-    let uu____1631 = FStar_List.map mk_spec specs1 in
-    ('h', "help",
-      (FStar_Getopt.ZeroArgs
-         (fun x  ->
-            display_usage_aux specs1; FStar_All.exit (Prims.parse_int "0"))),
-      "Display this information") :: uu____1631
-and parse_codegen: Prims.string -> Prims.string =
-  fun s  ->
-    match s with
-    | "Kremlin"|"OCaml"|"FSharp" -> s
-    | uu____1652 ->
-        (FStar_Util.print_string "Wrong argument to codegen flag\n";
-         (let uu____1655 = specs () in display_usage_aux uu____1655);
-         FStar_All.exit (Prims.parse_int "1"))
-and validate_cardinality: Prims.string -> Prims.string =
-  fun x  ->
-    match x with
-    | "warn"|"check"|"off" -> x
-    | uu____1663 ->
-        (FStar_Util.print_string "Wrong argument to cardinality flag\n";
-         (let uu____1666 = specs () in display_usage_aux uu____1666);
-         FStar_All.exit (Prims.parse_int "1"))
-let settable: Prims.string -> Prims.bool =
-  fun uu___53_1675  ->
-    match uu___53_1675 with
-    | "admit_smt_queries"
-      |"cardinality"
-       |"debug"
-        |"debug_level"
-         |"detail_errors"
-          |"eager_inference"
-           |"hide_genident_nums"
-            |"hide_uvar_nums"
-             |"hint_info"
-              |"initial_fuel"
-               |"initial_ifuel"
-                |"inline_arith"
-                 |"lax"
-                  |"log_types"
-                   |"log_queries"
-                    |"max_fuel"
-                     |"max_ifuel"
-                      |"min_fuel"
-                       |"print_before_norm"
-                        |"print_bound_var_types"
-                         |"print_effect_args"
-                          |"print_fuels"
-                           |"print_full_names"
-                            |"print_implicits"
-                             |"print_universes"
-                              |"print_z3_statistics"
-                               |"prn"
-                                |"show_signatures"
-                                 |"silent"
-                                  |"split_cases"
-                                   |"timing"
-                                    |"trace_error"
-                                     |"unthrottle_inductives"
-                                      |"use_eq_at_higher_order"
-                                       |"use_tactics"
-                                        |"__temp_no_proj"
-                                         |"no_warn_top_level_effects"
-                                          |"reuse_hint_for"|"z3refresh"
-        -> true
-    | uu____1676 -> false
-let resettable: Prims.string -> Prims.bool =
-  fun s  ->
-    (((settable s) || (s = "z3timeout")) || (s = "z3rlimit")) ||
-      (s = "z3seed")
-let all_specs: FStar_Getopt.opt Prims.list = specs ()
-let settable_specs:
-  (FStar_BaseTypes.char* Prims.string* Prims.unit FStar_Getopt.opt_variant*
-    Prims.string) Prims.list
-  =
-  FStar_All.pipe_right all_specs
-    (FStar_List.filter
-       (fun uu____1699  ->
-          match uu____1699 with
-          | (uu____1705,x,uu____1707,uu____1708) -> settable x))
-let resettable_specs:
-  (FStar_BaseTypes.char* Prims.string* Prims.unit FStar_Getopt.opt_variant*
-    Prims.string) Prims.list
-  =
-  FStar_All.pipe_right all_specs
-    (FStar_List.filter
-       (fun uu____1729  ->
-          match uu____1729 with
-          | (uu____1735,x,uu____1737,uu____1738) -> resettable x))
-let display_usage: Prims.unit -> Prims.unit =
-  fun uu____1743  ->
-    let uu____1744 = specs () in display_usage_aux uu____1744
-let fstar_home: Prims.unit -> Prims.string =
-  fun uu____1753  ->
-    let uu____1754 = get_fstar_home () in
-    match uu____1754 with
-    | None  ->
-        let x = FStar_Util.get_exec_dir () in
-        let x1 = Prims.strcat x "/.." in
-        (set_option' ("fstar_home", (String x1)); x1)
-    | Some x -> x
-let set_options: options -> Prims.string -> FStar_Getopt.parse_cmdline_res =
-  fun o  ->
-    fun s  ->
-      let specs1 =
-        match o with
-        | Set  -> resettable_specs
-        | Reset  -> resettable_specs
-        | Restore  -> all_specs in
-      FStar_Getopt.parse_string specs1 (fun uu____1779  -> ()) s
-let file_list_: Prims.string Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let parse_cmd_line:
-  Prims.unit -> (FStar_Getopt.parse_cmdline_res* Prims.string Prims.list) =
-  fun uu____1790  ->
-    let res =
-      let uu____1792 = specs () in
-      FStar_Getopt.parse_cmdline uu____1792
-        (fun i  ->
-           let uu____1795 =
-             let uu____1797 = FStar_ST.read file_list_ in
-             FStar_List.append uu____1797 [i] in
-           FStar_ST.write file_list_ uu____1795) in
-    let uu____1805 = FStar_ST.read file_list_ in (res, uu____1805)
-let file_list: Prims.unit -> Prims.string Prims.list =
-  fun uu____1814  -> FStar_ST.read file_list_
-let restore_cmd_line_options: Prims.bool -> FStar_Getopt.parse_cmdline_res =
-  fun should_clear  ->
-    let old_verify_module = get_verify_module () in
-    if should_clear then clear () else init ();
-    (let r =
-       let uu____1826 = specs () in
-       FStar_Getopt.parse_cmdline uu____1826 (fun x  -> ()) in
-     (let uu____1830 =
-        let uu____1833 =
-          let uu____1834 =
-            FStar_List.map (fun _0_43  -> String _0_43) old_verify_module in
-          List uu____1834 in
-        ("verify_module", uu____1833) in
-      set_option' uu____1830);
-     r)
-let should_verify: Prims.string -> Prims.bool =
-  fun m  ->
-    let uu____1839 = get_lax () in
-    if uu____1839
-    then false
-    else
-      (let uu____1841 = get_verify_all () in
-       if uu____1841
-       then true
-       else
-         (let uu____1843 = get_verify_module () in
-          match uu____1843 with
-          | [] ->
-              let uu____1845 = file_list () in
-              FStar_List.existsML
-                (fun f  ->
-                   let f1 = FStar_Util.basename f in
-                   let f2 =
-                     let uu____1850 =
-                       let uu____1851 =
-                         let uu____1852 =
-                           let uu____1853 = FStar_Util.get_file_extension f1 in
-                           FStar_String.length uu____1853 in
-                         (FStar_String.length f1) - uu____1852 in
-                       uu____1851 - (Prims.parse_int "1") in
-                     FStar_String.substring f1 (Prims.parse_int "0")
-                       uu____1850 in
-                   (FStar_String.lowercase f2) = m) uu____1845
-          | l -> FStar_List.contains (FStar_String.lowercase m) l))
-let dont_gen_projectors: Prims.string -> Prims.bool =
-  fun m  ->
-    let uu____1863 = get___temp_no_proj () in
-    FStar_List.contains m uu____1863
-let should_print_message: Prims.string -> Prims.bool =
-  fun m  ->
-    let uu____1868 = should_verify m in
-    if uu____1868 then m <> "Prims" else false
-let include_path: Prims.unit -> Prims.string Prims.list =
-  fun uu____1873  ->
-    let uu____1874 = get_no_default_includes () in
-    if uu____1874
-    then get_include ()
-    else
-      (let h = fstar_home () in
-       let defs = universe_include_path_base_dirs in
-       let uu____1880 =
-         let uu____1882 =
-           FStar_All.pipe_right defs
-             (FStar_List.map (fun x  -> Prims.strcat h x)) in
-         FStar_All.pipe_right uu____1882
-           (FStar_List.filter FStar_Util.file_exists) in
-       let uu____1889 =
-         let uu____1891 = get_include () in
-         FStar_List.append uu____1891 ["."] in
-       FStar_List.append uu____1880 uu____1889)
-let find_file: Prims.string -> Prims.string Prims.option =
-  fun filename  ->
-    let uu____1897 = FStar_Util.is_path_absolute filename in
-    if uu____1897
-    then (if FStar_Util.file_exists filename then Some filename else None)
-    else
-      (let uu____1902 =
-         let uu____1904 = include_path () in FStar_List.rev uu____1904 in
-       FStar_Util.find_map uu____1902
-         (fun p  ->
-            let path = FStar_Util.join_paths p filename in
-            if FStar_Util.file_exists path then Some path else None))
-let prims: Prims.unit -> Prims.string =
-  fun uu____1912  ->
-    let uu____1913 = get_prims () in
-    match uu____1913 with
-    | None  ->
-        let filename = "prims.fst" in
-        let uu____1916 = find_file filename in
-        (match uu____1916 with
-         | Some result -> result
-         | None  ->
-             let uu____1919 =
-               let uu____1920 =
-                 FStar_Util.format1
-                   "unable to find required file \"%s\" in the module search path.\n"
-                   filename in
-               FStar_Util.Failure uu____1920 in
-             Prims.raise uu____1919)
-    | Some x -> x
-let prepend_output_dir: Prims.string -> Prims.string =
-  fun fname  ->
-    let uu____1925 = get_odir () in
-    match uu____1925 with
-    | None  -> fname
-    | Some x -> Prims.strcat x (Prims.strcat "/" fname)
-let __temp_no_proj: Prims.string -> Prims.bool =
-  fun s  ->
-    let uu____1931 = get___temp_no_proj () in
-    FStar_All.pipe_right uu____1931 (FStar_List.contains s)
-let admit_smt_queries: Prims.unit -> Prims.bool =
-  fun uu____1936  -> get_admit_smt_queries ()
-let check_cardinality: Prims.unit -> Prims.bool =
-  fun uu____1939  ->
-    let uu____1940 = get_cardinality () in uu____1940 = "check"
-let codegen: Prims.unit -> Prims.string Prims.option =
-  fun uu____1944  -> get_codegen ()
-let codegen_libs: Prims.unit -> Prims.string Prims.list Prims.list =
-  fun uu____1949  ->
-    let uu____1950 = get_codegen_lib () in
-    FStar_All.pipe_right uu____1950
-      (FStar_List.map (fun x  -> FStar_Util.split x "."))
-let debug_any: Prims.unit -> Prims.bool =
-  fun uu____1959  -> let uu____1960 = get_debug () in uu____1960 <> []
-let debug_at_level: Prims.string -> debug_level_t -> Prims.bool =
-  fun modul  ->
-    fun level  ->
-      ((modul = "") ||
-         (let uu____1969 = get_debug () in
-          FStar_All.pipe_right uu____1969 (FStar_List.contains modul)))
-        && (debug_level_geq level)
-let dep: Prims.unit -> Prims.string Prims.option =
-  fun uu____1975  -> get_dep ()
-let detail_errors: Prims.unit -> Prims.bool =
-  fun uu____1978  -> get_detail_errors ()
-let doc: Prims.unit -> Prims.bool = fun uu____1981  -> get_doc ()
-let dump_module: Prims.string -> Prims.bool =
-  fun s  ->
-    let uu____1985 = get_dump_module () in
-    FStar_All.pipe_right uu____1985 (FStar_List.contains s)
-let eager_inference: Prims.unit -> Prims.bool =
-  fun uu____1990  -> get_eager_inference ()
-let explicit_deps: Prims.unit -> Prims.bool =
-  fun uu____1993  -> get_explicit_deps ()
-let extract_all: Prims.unit -> Prims.bool =
-  fun uu____1996  -> get_extract_all ()
-let fs_typ_app: Prims.string -> Prims.bool =
-  fun filename  ->
-    let uu____2000 = FStar_ST.read light_off_files in
-    FStar_List.contains filename uu____2000
-let full_context_dependency: Prims.unit -> Prims.bool =
-  fun uu____2007  -> true
-let hide_genident_nums: Prims.unit -> Prims.bool =
-  fun uu____2010  -> get_hide_genident_nums ()
-let hide_uvar_nums: Prims.unit -> Prims.bool =
-  fun uu____2013  -> get_hide_uvar_nums ()
-let hint_info: Prims.unit -> Prims.bool = fun uu____2016  -> get_hint_info ()
-let indent: Prims.unit -> Prims.bool = fun uu____2019  -> get_indent ()
-let initial_fuel: Prims.unit -> Prims.int =
-  fun uu____2022  ->
-    let uu____2023 = get_initial_fuel () in
-    let uu____2024 = get_max_fuel () in Prims.min uu____2023 uu____2024
-let initial_ifuel: Prims.unit -> Prims.int =
-  fun uu____2027  ->
-    let uu____2028 = get_initial_ifuel () in
-    let uu____2029 = get_max_ifuel () in Prims.min uu____2028 uu____2029
-let inline_arith: Prims.unit -> Prims.bool =
-  fun uu____2032  -> get_inline_arith ()
-let interactive: Prims.unit -> Prims.bool = fun uu____2035  -> get_in ()
-let lax: Prims.unit -> Prims.bool = fun uu____2038  -> get_lax ()
-let log_queries: Prims.unit -> Prims.bool =
-  fun uu____2041  -> get_log_queries ()
-let log_types: Prims.unit -> Prims.bool = fun uu____2044  -> get_log_types ()
-let max_fuel: Prims.unit -> Prims.int = fun uu____2047  -> get_max_fuel ()
-let max_ifuel: Prims.unit -> Prims.int = fun uu____2050  -> get_max_ifuel ()
-let min_fuel: Prims.unit -> Prims.int = fun uu____2053  -> get_min_fuel ()
-let ml_ish: Prims.unit -> Prims.bool = fun uu____2056  -> get_MLish ()
-let set_ml_ish: Prims.unit -> Prims.unit =
-  fun uu____2059  -> set_option "MLish" (Bool true)
-let n_cores: Prims.unit -> Prims.int = fun uu____2062  -> get_n_cores ()
-let no_default_includes: Prims.unit -> Prims.bool =
-  fun uu____2065  -> get_no_default_includes ()
-let no_extract: Prims.string -> Prims.bool =
-  fun s  ->
-    let uu____2069 = get_no_extract () in
-    FStar_All.pipe_right uu____2069 (FStar_List.contains s)
-let no_location_info: Prims.unit -> Prims.bool =
-  fun uu____2074  -> get_no_location_info ()
-let norm_then_print: Prims.unit -> Prims.bool =
-  fun uu____2077  ->
-    let uu____2078 = get_print_before_norm () in uu____2078 = false
-let output_dir: Prims.unit -> Prims.string Prims.option =
-  fun uu____2082  -> get_odir ()
-let print_bound_var_types: Prims.unit -> Prims.bool =
-  fun uu____2085  -> get_print_bound_var_types ()
-let print_effect_args: Prims.unit -> Prims.bool =
-  fun uu____2088  -> get_print_effect_args ()
-let print_fuels: Prims.unit -> Prims.bool =
-  fun uu____2091  -> get_print_fuels ()
-let print_implicits: Prims.unit -> Prims.bool =
-  fun uu____2094  -> get_print_implicits ()
-let print_real_names: Prims.unit -> Prims.bool =
-  fun uu____2097  -> (get_prn ()) || (get_print_full_names ())
-let print_universes: Prims.unit -> Prims.bool =
-  fun uu____2100  -> get_print_universes ()
-let print_z3_statistics: Prims.unit -> Prims.bool =
-  fun uu____2103  -> get_print_z3_statistics ()
-let record_hints: Prims.unit -> Prims.bool =
-  fun uu____2106  -> get_record_hints ()
-let reuse_hint_for: Prims.unit -> Prims.string Prims.option =
-  fun uu____2110  -> get_reuse_hint_for ()
-let silent: Prims.unit -> Prims.bool = fun uu____2113  -> get_silent ()
-let split_cases: Prims.unit -> Prims.int =
-  fun uu____2116  -> get_split_cases ()
-let timing: Prims.unit -> Prims.bool = fun uu____2119  -> get_timing ()
-let trace_error: Prims.unit -> Prims.bool =
-  fun uu____2122  -> get_trace_error ()
-let unthrottle_inductives: Prims.unit -> Prims.bool =
-  fun uu____2125  -> get_unthrottle_inductives ()
-let use_eq_at_higher_order: Prims.unit -> Prims.bool =
-  fun uu____2128  -> get_use_eq_at_higher_order ()
-let use_hints: Prims.unit -> Prims.bool = fun uu____2131  -> get_use_hints ()
-let use_tactics: Prims.unit -> Prims.bool =
-  fun uu____2134  -> get_use_tactics ()
-let verify_all: Prims.unit -> Prims.bool =
-  fun uu____2137  -> get_verify_all ()
-let verify_module: Prims.unit -> Prims.string Prims.list =
-  fun uu____2141  -> get_verify_module ()
-let warn_cardinality: Prims.unit -> Prims.bool =
-  fun uu____2144  ->
-    let uu____2145 = get_cardinality () in uu____2145 = "warn"
-let warn_default_effects: Prims.unit -> Prims.bool =
-  fun uu____2148  -> get_warn_default_effects ()
-let warn_top_level_effects: Prims.unit -> Prims.bool =
-  fun uu____2151  -> get_warn_top_level_effects ()
-let z3_exe: Prims.unit -> Prims.string =
-  fun uu____2154  ->
-    let uu____2155 = get_smt () in
-    match uu____2155 with | None  -> FStar_Platform.exe "z3" | Some s -> s
-let z3_cliopt: Prims.unit -> Prims.string Prims.list =
-  fun uu____2161  -> get_z3cliopt ()
-let z3_refresh: Prims.unit -> Prims.bool =
-  fun uu____2164  -> get_z3refresh ()
-let z3_rlimit: Prims.unit -> Prims.int = fun uu____2167  -> get_z3rlimit ()
-let z3_seed: Prims.unit -> Prims.int = fun uu____2170  -> get_z3seed ()
-let z3_timeout: Prims.unit -> Prims.int = fun uu____2173  -> get_z3timeout ()
-let no_positivity: Prims.unit -> Prims.bool =
-  fun uu____2176  -> get_no_positivity ()
-let should_extract: Prims.string -> Prims.bool =
-  fun m  ->
-    (let uu____2180 = no_extract m in Prims.op_Negation uu____2180) &&
-      ((extract_all ()) ||
-         (let uu____2181 = get_extract_module () in
-          match uu____2181 with
-          | [] ->
-              let uu____2183 = get_extract_namespace () in
-              (match uu____2183 with
-               | [] -> true
-               | ns ->
-                   FStar_Util.for_some
-                     (FStar_Util.starts_with (FStar_String.lowercase m)) ns)
-          | l -> FStar_List.contains (FStar_String.lowercase m) l))
+| Set
+| Reset
+| Restore
+
+
+let uu___is_Set : options  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Set -> begin
+true
+end
+| uu____104 -> begin
+false
+end))
+
+
+let uu___is_Reset : options  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reset -> begin
+true
+end
+| uu____108 -> begin
+false
+end))
+
+
+let uu___is_Restore : options  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Restore -> begin
+true
+end
+| uu____112 -> begin
+false
+end))
+
+
+let __unit_tests__ : Prims.bool FStar_ST.ref = (FStar_Util.mk_ref false)
+
+
+let __unit_tests : Prims.unit  ->  Prims.bool = (fun uu____118 -> (FStar_ST.read __unit_tests__))
+
+
+let __set_unit_tests : Prims.unit  ->  Prims.unit = (fun uu____123 -> (FStar_ST.write __unit_tests__ true))
+
+
+let __clear_unit_tests : Prims.unit  ->  Prims.unit = (fun uu____128 -> (FStar_ST.write __unit_tests__ false))
+
+
+let as_bool : option_val  ->  Prims.bool = (fun uu___47_133 -> (match (uu___47_133) with
+| Bool (b) -> begin
+b
+end
+| uu____135 -> begin
+(failwith "Impos: expected Bool")
+end))
+
+
+let as_int : option_val  ->  Prims.int = (fun uu___48_138 -> (match (uu___48_138) with
+| Int (b) -> begin
+b
+end
+| uu____140 -> begin
+(failwith "Impos: expected Int")
+end))
+
+
+let as_string : option_val  ->  Prims.string = (fun uu___49_143 -> (match (uu___49_143) with
+| String (b) -> begin
+b
+end
+| uu____145 -> begin
+(failwith "Impos: expected String")
+end))
+
+
+let as_list = (fun as_t uu___50_161 -> (match (uu___50_161) with
+| List (ts) -> begin
+(FStar_All.pipe_right ts (FStar_List.map as_t))
+end
+| uu____168 -> begin
+(failwith "Impos: expected List")
+end))
+
+
+let as_option = (fun as_t uu___51_185 -> (match (uu___51_185) with
+| Unset -> begin
+None
+end
+| v1 -> begin
+(
+
+let uu____189 = (as_t v1)
+in Some (uu____189))
+end))
+
+
+let fstar_options : option_val FStar_Util.smap Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let peek : Prims.unit  ->  option_val FStar_Util.smap = (fun uu____201 -> (
+
+let uu____202 = (FStar_ST.read fstar_options)
+in (FStar_List.hd uu____202)))
+
+
+let pop : Prims.unit  ->  Prims.unit = (fun uu____212 -> (
+
+let uu____213 = (FStar_ST.read fstar_options)
+in (match (uu____213) with
+| ([]) | ((_)::[]) -> begin
+(failwith "TOO MANY POPS!")
+end
+| (uu____224)::tl1 -> begin
+(FStar_ST.write fstar_options tl1)
+end)))
+
+
+let push : Prims.unit  ->  Prims.unit = (fun uu____236 -> (
+
+let uu____237 = (
+
+let uu____240 = (
+
+let uu____242 = (peek ())
+in (FStar_Util.smap_copy uu____242))
+in (
+
+let uu____244 = (FStar_ST.read fstar_options)
+in (uu____240)::uu____244))
+in (FStar_ST.write fstar_options uu____237)))
+
+
+let set_option : Prims.string  ->  option_val  ->  Prims.unit = (fun k v1 -> (
+
+let uu____262 = (peek ())
+in (FStar_Util.smap_add uu____262 k v1)))
+
+
+let set_option' : (Prims.string * option_val)  ->  Prims.unit = (fun uu____268 -> (match (uu____268) with
+| (k, v1) -> begin
+(set_option k v1)
+end))
+
+
+let light_off_files : Prims.string Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let add_light_off_file : Prims.string  ->  Prims.unit = (fun filename -> (
+
+let uu____281 = (
+
+let uu____283 = (FStar_ST.read light_off_files)
+in (filename)::uu____283)
+in (FStar_ST.write light_off_files uu____281)))
+
+
+let init : Prims.unit  ->  Prims.unit = (fun uu____293 -> (
+
+let vals = ((("__temp_no_proj"), (List ([]))))::((("_fstar_home"), (String (""))))::((("_include_path"), (List ([]))))::((("admit_smt_queries"), (Bool (false))))::((("cardinality"), (String ("off"))))::((("codegen"), (Unset)))::((("codegen-lib"), (List ([]))))::((("debug"), (List ([]))))::((("debug_level"), (List ([]))))::((("dep"), (Unset)))::((("detail_errors"), (Bool (false))))::((("doc"), (Bool (false))))::((("dump_module"), (List ([]))))::((("eager_inference"), (Bool (false))))::((("explicit_deps"), (Bool (false))))::((("extract_all"), (Bool (false))))::((("extract_module"), (List ([]))))::((("extract_namespace"), (List ([]))))::((("fs_typ_app"), (Bool (false))))::((("fsi"), (Bool (false))))::((("fstar_home"), (Unset)))::((("full_context_dependency"), (Bool (true))))::((("hide_genident_nums"), (Bool (false))))::((("hide_uvar_nums"), (Bool (false))))::((("hint_info"), (Bool (false))))::((("in"), (Bool (false))))::((("include"), (List ([]))))::((("indent"), (Bool (false))))::((("initial_fuel"), (Int ((Prims.parse_int "2")))))::((("initial_ifuel"), (Int ((Prims.parse_int "1")))))::((("inline_arith"), (Bool (false))))::((("lax"), (Bool (false))))::((("log_queries"), (Bool (false))))::((("log_types"), (Bool (false))))::((("max_fuel"), (Int ((Prims.parse_int "8")))))::((("max_ifuel"), (Int ((Prims.parse_int "2")))))::((("min_fuel"), (Int ((Prims.parse_int "1")))))::((("MLish"), (Bool (false))))::((("n_cores"), (Int ((Prims.parse_int "1")))))::((("no_default_includes"), (Bool (false))))::((("no_extract"), (List ([]))))::((("no_location_info"), (Bool (false))))::((("no_warn_top_level_effects"), (Bool (true))))::((("odir"), (Unset)))::((("prims"), (Unset)))::((("pretype"), (Bool (true))))::((("prims_ref"), (Unset)))::((("print_before_norm"), (Bool (false))))::((("print_bound_var_types"), (Bool (false))))::((("print_effect_args"), (Bool (false))))::((("print_fuels"), (Bool (false))))::((("print_full_names"), (Bool (false))))::((("print_implicits"), (Bool (false))))::((("print_universes"), (Bool (false))))::((("print_z3_statistics"), (Bool (false))))::((("prn"), (Bool (false))))::((("record_hints"), (Bool (false))))::((("reuse_hint_for"), (Unset)))::((("show_signatures"), (List ([]))))::((("silent"), (Bool (false))))::((("smt"), (Unset)))::((("split_cases"), (Int ((Prims.parse_int "0")))))::((("timing"), (Bool (false))))::((("trace_error"), (Bool (false))))::((("unthrottle_inductives"), (Bool (false))))::((("use_eq_at_higher_order"), (Bool (false))))::((("use_hints"), (Bool (false))))::((("use_tactics"), (Bool (false))))::((("verify"), (Bool (true))))::((("verify_all"), (Bool (false))))::((("verify_module"), (List ([]))))::((("warn_default_effects"), (Bool (false))))::((("z3refresh"), (Bool (false))))::((("z3rlimit"), (Int ((Prims.parse_int "5")))))::((("z3seed"), (Int ((Prims.parse_int "0")))))::((("z3timeout"), (Int ((Prims.parse_int "5")))))::((("z3cliopt"), (List ([]))))::((("__no_positivity"), (Bool (false))))::[]
+in (
+
+let o = (peek ())
+in ((FStar_Util.smap_clear o);
+(FStar_All.pipe_right vals (FStar_List.iter set_option'));
+))))
+
+
+let clear : Prims.unit  ->  Prims.unit = (fun uu____466 -> (
+
+let o = (FStar_Util.smap_create (Prims.parse_int "50"))
+in ((FStar_ST.write fstar_options ((o)::[]));
+(FStar_ST.write light_off_files []);
+(init ());
+)))
+
+
+let _run : Prims.unit = (clear ())
+
+
+let lookup_opt = (fun s c -> (
+
+let uu____497 = (
+
+let uu____499 = (peek ())
+in (FStar_Util.smap_try_find uu____499 s))
+in (match (uu____497) with
+| None -> begin
+(failwith (Prims.strcat "Impossible: option " (Prims.strcat s " not found")))
+end
+| Some (s1) -> begin
+(c s1)
+end)))
+
+
+let get_admit_smt_queries : Prims.unit  ->  Prims.bool = (fun uu____504 -> (lookup_opt "admit_smt_queries" as_bool))
+
+
+let get_cardinality : Prims.unit  ->  Prims.string = (fun uu____507 -> (lookup_opt "cardinality" as_string))
+
+
+let get_codegen : Prims.unit  ->  Prims.string Prims.option = (fun uu____511 -> (lookup_opt "codegen" (as_option as_string)))
+
+
+let get_codegen_lib : Prims.unit  ->  Prims.string Prims.list = (fun uu____516 -> (lookup_opt "codegen-lib" (as_list as_string)))
+
+
+let get_debug : Prims.unit  ->  Prims.string Prims.list = (fun uu____521 -> (lookup_opt "debug" (as_list as_string)))
+
+
+let get_debug_level : Prims.unit  ->  Prims.string Prims.list = (fun uu____526 -> (lookup_opt "debug_level" (as_list as_string)))
+
+
+let get_dep : Prims.unit  ->  Prims.string Prims.option = (fun uu____531 -> (lookup_opt "dep" (as_option as_string)))
+
+
+let get_detail_errors : Prims.unit  ->  Prims.bool = (fun uu____535 -> (lookup_opt "detail_errors" as_bool))
+
+
+let get_doc : Prims.unit  ->  Prims.bool = (fun uu____538 -> (lookup_opt "doc" as_bool))
+
+
+let get_dump_module : Prims.unit  ->  Prims.string Prims.list = (fun uu____542 -> (lookup_opt "dump_module" (as_list as_string)))
+
+
+let get_eager_inference : Prims.unit  ->  Prims.bool = (fun uu____546 -> (lookup_opt "eager_inference" as_bool))
+
+
+let get_explicit_deps : Prims.unit  ->  Prims.bool = (fun uu____549 -> (lookup_opt "explicit_deps" as_bool))
+
+
+let get_extract_all : Prims.unit  ->  Prims.bool = (fun uu____552 -> (lookup_opt "extract_all" as_bool))
+
+
+let get_extract_module : Prims.unit  ->  Prims.string Prims.list = (fun uu____556 -> (lookup_opt "extract_module" (as_list as_string)))
+
+
+let get_extract_namespace : Prims.unit  ->  Prims.string Prims.list = (fun uu____561 -> (lookup_opt "extract_namespace" (as_list as_string)))
+
+
+let get_fs_typ_app : Prims.unit  ->  Prims.bool = (fun uu____565 -> (lookup_opt "fs_typ_app" as_bool))
+
+
+let get_fstar_home : Prims.unit  ->  Prims.string Prims.option = (fun uu____569 -> (lookup_opt "fstar_home" (as_option as_string)))
+
+
+let get_hide_genident_nums : Prims.unit  ->  Prims.bool = (fun uu____573 -> (lookup_opt "hide_genident_nums" as_bool))
+
+
+let get_hide_uvar_nums : Prims.unit  ->  Prims.bool = (fun uu____576 -> (lookup_opt "hide_uvar_nums" as_bool))
+
+
+let get_hint_info : Prims.unit  ->  Prims.bool = (fun uu____579 -> (lookup_opt "hint_info" as_bool))
+
+
+let get_in : Prims.unit  ->  Prims.bool = (fun uu____582 -> (lookup_opt "in" as_bool))
+
+
+let get_include : Prims.unit  ->  Prims.string Prims.list = (fun uu____586 -> (lookup_opt "include" (as_list as_string)))
+
+
+let get_indent : Prims.unit  ->  Prims.bool = (fun uu____590 -> (lookup_opt "indent" as_bool))
+
+
+let get_initial_fuel : Prims.unit  ->  Prims.int = (fun uu____593 -> (lookup_opt "initial_fuel" as_int))
+
+
+let get_initial_ifuel : Prims.unit  ->  Prims.int = (fun uu____596 -> (lookup_opt "initial_ifuel" as_int))
+
+
+let get_inline_arith : Prims.unit  ->  Prims.bool = (fun uu____599 -> (lookup_opt "inline_arith" as_bool))
+
+
+let get_lax : Prims.unit  ->  Prims.bool = (fun uu____602 -> (lookup_opt "lax" as_bool))
+
+
+let get_log_queries : Prims.unit  ->  Prims.bool = (fun uu____605 -> (lookup_opt "log_queries" as_bool))
+
+
+let get_log_types : Prims.unit  ->  Prims.bool = (fun uu____608 -> (lookup_opt "log_types" as_bool))
+
+
+let get_max_fuel : Prims.unit  ->  Prims.int = (fun uu____611 -> (lookup_opt "max_fuel" as_int))
+
+
+let get_max_ifuel : Prims.unit  ->  Prims.int = (fun uu____614 -> (lookup_opt "max_ifuel" as_int))
+
+
+let get_min_fuel : Prims.unit  ->  Prims.int = (fun uu____617 -> (lookup_opt "min_fuel" as_int))
+
+
+let get_MLish : Prims.unit  ->  Prims.bool = (fun uu____620 -> (lookup_opt "MLish" as_bool))
+
+
+let get_n_cores : Prims.unit  ->  Prims.int = (fun uu____623 -> (lookup_opt "n_cores" as_int))
+
+
+let get_no_default_includes : Prims.unit  ->  Prims.bool = (fun uu____626 -> (lookup_opt "no_default_includes" as_bool))
+
+
+let get_no_extract : Prims.unit  ->  Prims.string Prims.list = (fun uu____630 -> (lookup_opt "no_extract" (as_list as_string)))
+
+
+let get_no_location_info : Prims.unit  ->  Prims.bool = (fun uu____634 -> (lookup_opt "no_location_info" as_bool))
+
+
+let get_warn_top_level_effects : Prims.unit  ->  Prims.bool = (fun uu____637 -> (lookup_opt "no_warn_top_level_effects" as_bool))
+
+
+let get_odir : Prims.unit  ->  Prims.string Prims.option = (fun uu____641 -> (lookup_opt "odir" (as_option as_string)))
+
+
+let get_prims : Prims.unit  ->  Prims.string Prims.option = (fun uu____646 -> (lookup_opt "prims" (as_option as_string)))
+
+
+let get_print_before_norm : Prims.unit  ->  Prims.bool = (fun uu____650 -> (lookup_opt "print_before_norm" as_bool))
+
+
+let get_print_bound_var_types : Prims.unit  ->  Prims.bool = (fun uu____653 -> (lookup_opt "print_bound_var_types" as_bool))
+
+
+let get_print_effect_args : Prims.unit  ->  Prims.bool = (fun uu____656 -> (lookup_opt "print_effect_args" as_bool))
+
+
+let get_print_fuels : Prims.unit  ->  Prims.bool = (fun uu____659 -> (lookup_opt "print_fuels" as_bool))
+
+
+let get_print_full_names : Prims.unit  ->  Prims.bool = (fun uu____662 -> (lookup_opt "print_full_names" as_bool))
+
+
+let get_print_implicits : Prims.unit  ->  Prims.bool = (fun uu____665 -> (lookup_opt "print_implicits" as_bool))
+
+
+let get_print_universes : Prims.unit  ->  Prims.bool = (fun uu____668 -> (lookup_opt "print_universes" as_bool))
+
+
+let get_print_z3_statistics : Prims.unit  ->  Prims.bool = (fun uu____671 -> (lookup_opt "print_z3_statistics" as_bool))
+
+
+let get_prn : Prims.unit  ->  Prims.bool = (fun uu____674 -> (lookup_opt "prn" as_bool))
+
+
+let get_record_hints : Prims.unit  ->  Prims.bool = (fun uu____677 -> (lookup_opt "record_hints" as_bool))
+
+
+let get_reuse_hint_for : Prims.unit  ->  Prims.string Prims.option = (fun uu____681 -> (lookup_opt "reuse_hint_for" (as_option as_string)))
+
+
+let get_show_signatures : Prims.unit  ->  Prims.string Prims.list = (fun uu____686 -> (lookup_opt "show_signatures" (as_list as_string)))
+
+
+let get_silent : Prims.unit  ->  Prims.bool = (fun uu____690 -> (lookup_opt "silent" as_bool))
+
+
+let get_smt : Prims.unit  ->  Prims.string Prims.option = (fun uu____694 -> (lookup_opt "smt" (as_option as_string)))
+
+
+let get_split_cases : Prims.unit  ->  Prims.int = (fun uu____698 -> (lookup_opt "split_cases" as_int))
+
+
+let get_timing : Prims.unit  ->  Prims.bool = (fun uu____701 -> (lookup_opt "timing" as_bool))
+
+
+let get_trace_error : Prims.unit  ->  Prims.bool = (fun uu____704 -> (lookup_opt "trace_error" as_bool))
+
+
+let get_unthrottle_inductives : Prims.unit  ->  Prims.bool = (fun uu____707 -> (lookup_opt "unthrottle_inductives" as_bool))
+
+
+let get_use_eq_at_higher_order : Prims.unit  ->  Prims.bool = (fun uu____710 -> (lookup_opt "use_eq_at_higher_order" as_bool))
+
+
+let get_use_hints : Prims.unit  ->  Prims.bool = (fun uu____713 -> (lookup_opt "use_hints" as_bool))
+
+
+let get_use_tactics : Prims.unit  ->  Prims.bool = (fun uu____716 -> (lookup_opt "use_tactics" as_bool))
+
+
+let get_verify_all : Prims.unit  ->  Prims.bool = (fun uu____719 -> (lookup_opt "verify_all" as_bool))
+
+
+let get_verify_module : Prims.unit  ->  Prims.string Prims.list = (fun uu____723 -> (lookup_opt "verify_module" (as_list as_string)))
+
+
+let get___temp_no_proj : Prims.unit  ->  Prims.string Prims.list = (fun uu____728 -> (lookup_opt "__temp_no_proj" (as_list as_string)))
+
+
+let get_version : Prims.unit  ->  Prims.bool = (fun uu____732 -> (lookup_opt "version" as_bool))
+
+
+let get_warn_default_effects : Prims.unit  ->  Prims.bool = (fun uu____735 -> (lookup_opt "warn_default_effects" as_bool))
+
+
+let get_z3cliopt : Prims.unit  ->  Prims.string Prims.list = (fun uu____739 -> (lookup_opt "z3cliopt" (as_list as_string)))
+
+
+let get_z3refresh : Prims.unit  ->  Prims.bool = (fun uu____743 -> (lookup_opt "z3refresh" as_bool))
+
+
+let get_z3rlimit : Prims.unit  ->  Prims.int = (fun uu____746 -> (lookup_opt "z3rlimit" as_int))
+
+
+let get_z3seed : Prims.unit  ->  Prims.int = (fun uu____749 -> (lookup_opt "z3seed" as_int))
+
+
+let get_z3timeout : Prims.unit  ->  Prims.int = (fun uu____752 -> (lookup_opt "z3timeout" as_int))
+
+
+let get_no_positivity : Prims.unit  ->  Prims.bool = (fun uu____755 -> (lookup_opt "__no_positivity" as_bool))
+
+
+let dlevel : Prims.string  ->  debug_level_t = (fun uu___52_758 -> (match (uu___52_758) with
+| "Low" -> begin
+Low
+end
+| "Medium" -> begin
+Medium
+end
+| "High" -> begin
+High
+end
+| "Extreme" -> begin
+Extreme
+end
+| s -> begin
+Other (s)
+end))
+
+
+let one_debug_level_geq : debug_level_t  ->  debug_level_t  ->  Prims.bool = (fun l1 l2 -> (match (l1) with
+| (Other (_)) | (Low) -> begin
+(l1 = l2)
+end
+| Medium -> begin
+((l2 = Low) || (l2 = Medium))
+end
+| High -> begin
+(((l2 = Low) || (l2 = Medium)) || (l2 = High))
+end
+| Extreme -> begin
+((((l2 = Low) || (l2 = Medium)) || (l2 = High)) || (l2 = Extreme))
+end))
+
+
+let debug_level_geq : debug_level_t  ->  Prims.bool = (fun l2 -> (
+
+let uu____770 = (get_debug_level ())
+in (FStar_All.pipe_right uu____770 (FStar_Util.for_some (fun l1 -> (one_debug_level_geq (dlevel l1) l2))))))
+
+
+let include_path_base_dirs : Prims.string Prims.list = ("/lib")::("/lib/fstar")::[]
+
+
+let universe_include_path_base_dirs : Prims.string Prims.list = ("/ulib")::("/lib/fstar")::[]
+
+
+let _version : Prims.string FStar_ST.ref = (FStar_Util.mk_ref "")
+
+
+let _platform : Prims.string FStar_ST.ref = (FStar_Util.mk_ref "")
+
+
+let _compiler : Prims.string FStar_ST.ref = (FStar_Util.mk_ref "")
+
+
+let _date : Prims.string FStar_ST.ref = (FStar_Util.mk_ref "")
+
+
+let _commit : Prims.string FStar_ST.ref = (FStar_Util.mk_ref "")
+
+
+let display_version : Prims.unit  ->  Prims.unit = (fun uu____798 -> (
+
+let uu____799 = (
+
+let uu____800 = (FStar_ST.read _version)
+in (
+
+let uu____803 = (FStar_ST.read _platform)
+in (
+
+let uu____806 = (FStar_ST.read _compiler)
+in (
+
+let uu____809 = (FStar_ST.read _date)
+in (
+
+let uu____812 = (FStar_ST.read _commit)
+in (FStar_Util.format5 "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____800 uu____803 uu____806 uu____809 uu____812))))))
+in (FStar_Util.print_string uu____799)))
+
+
+let display_usage_aux = (fun specs -> ((FStar_Util.print_string "fstar.exe [options] file[s]\n");
+(FStar_List.iter (fun uu____842 -> (match (uu____842) with
+| (uu____848, flag, p, doc) -> begin
+(match (p) with
+| FStar_Getopt.ZeroArgs (ig) -> begin
+(match ((doc = "")) with
+| true -> begin
+(
+
+let uu____857 = (
+
+let uu____858 = (FStar_Util.colorize_bold flag)
+in (FStar_Util.format1 "  --%s\n" uu____858))
+in (FStar_Util.print_string uu____857))
+end
+| uu____859 -> begin
+(
+
+let uu____860 = (
+
+let uu____861 = (FStar_Util.colorize_bold flag)
+in (FStar_Util.format2 "  --%s  %s\n" uu____861 doc))
+in (FStar_Util.print_string uu____860))
+end)
+end
+| FStar_Getopt.OneArg (uu____862, argname) -> begin
+(match ((doc = "")) with
+| true -> begin
+(
+
+let uu____868 = (
+
+let uu____869 = (FStar_Util.colorize_bold flag)
+in (
+
+let uu____870 = (FStar_Util.colorize_bold argname)
+in (FStar_Util.format2 "  --%s %s\n" uu____869 uu____870)))
+in (FStar_Util.print_string uu____868))
+end
+| uu____871 -> begin
+(
+
+let uu____872 = (
+
+let uu____873 = (FStar_Util.colorize_bold flag)
+in (
+
+let uu____874 = (FStar_Util.colorize_bold argname)
+in (FStar_Util.format3 "  --%s %s  %s\n" uu____873 uu____874 doc)))
+in (FStar_Util.print_string uu____872))
+end)
+end)
+end)) specs);
+))
+
+
+let mk_spec : (FStar_BaseTypes.char * Prims.string * option_val FStar_Getopt.opt_variant * Prims.string)  ->  FStar_Getopt.opt = (fun o -> (
+
+let uu____888 = o
+in (match (uu____888) with
+| (ns, name, arg, desc) -> begin
+(
+
+let arg1 = (match (arg) with
+| FStar_Getopt.ZeroArgs (f) -> begin
+(
+
+let g = (fun uu____909 -> (
+
+let uu____910 = (
+
+let uu____913 = (f ())
+in ((name), (uu____913)))
+in (set_option' uu____910)))
+in FStar_Getopt.ZeroArgs (g))
+end
+| FStar_Getopt.OneArg (f, d) -> begin
+(
+
+let g = (fun x -> (
+
+let uu____924 = (
+
+let uu____927 = (f x)
+in ((name), (uu____927)))
+in (set_option' uu____924)))
+in FStar_Getopt.OneArg (((g), (d))))
+end)
+in ((ns), (name), (arg1), (desc)))
+end)))
+
+
+let cons_extract_module : Prims.string  ->  option_val = (fun s -> (
+
+let uu____934 = (
+
+let uu____936 = (
+
+let uu____938 = (get_extract_module ())
+in ((FStar_String.lowercase s))::uu____938)
+in (FStar_All.pipe_right uu____936 (FStar_List.map (fun _0_25 -> String (_0_25)))))
+in List (uu____934)))
+
+
+let cons_extract_namespace : Prims.string  ->  option_val = (fun s -> (
+
+let uu____945 = (
+
+let uu____947 = (
+
+let uu____949 = (get_extract_namespace ())
+in ((FStar_String.lowercase s))::uu____949)
+in (FStar_All.pipe_right uu____947 (FStar_List.map (fun _0_26 -> String (_0_26)))))
+in List (uu____945)))
+
+
+let add_extract_module : Prims.string  ->  Prims.unit = (fun s -> (
+
+let uu____956 = (cons_extract_module s)
+in (set_option "extract_module" uu____956)))
+
+
+let add_extract_namespace : Prims.string  ->  Prims.unit = (fun s -> (
+
+let uu____960 = (cons_extract_namespace s)
+in (set_option "extract_namespace" uu____960)))
+
+
+let cons_verify_module : Prims.string  ->  option_val = (fun s -> (
+
+let uu____964 = (
+
+let uu____966 = (
+
+let uu____968 = (get_verify_module ())
+in ((FStar_String.lowercase s))::uu____968)
+in (FStar_All.pipe_right uu____966 (FStar_List.map (fun _0_27 -> String (_0_27)))))
+in List (uu____964)))
+
+
+let add_verify_module : Prims.string  ->  Prims.unit = (fun s -> (
+
+let uu____975 = (cons_verify_module s)
+in (set_option "verify_module" uu____975)))
+
+
+let rec specs : Prims.unit  ->  FStar_Getopt.opt Prims.list = (fun uu____983 -> (
+
+let specs1 = (((FStar_Getopt.noshort), ("admit_smt_queries"), (FStar_Getopt.OneArg ((((fun s -> (match ((s = "true")) with
+| true -> begin
+Bool (true)
+end
+| uu____1001 -> begin
+(match ((s = "false")) with
+| true -> begin
+Bool (false)
+end
+| uu____1002 -> begin
+(failwith "Invalid argument to --admit_smt_queries")
+end)
+end))), ("[true|false]")))), ("Admit SMT queries, unsafe! (default \'false\')")))::(((FStar_Getopt.noshort), ("cardinality"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1012 = (validate_cardinality x)
+in String (uu____1012)))), ("[off|warn|check]")))), ("Check cardinality constraints on inductive data types (default \'off\')")))::(((FStar_Getopt.noshort), ("codegen"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1022 = (parse_codegen s)
+in String (uu____1022)))), ("[OCaml|FSharp|Kremlin]")))), ("Generate code for execution")))::(((FStar_Getopt.noshort), ("codegen-lib"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1032 = (
+
+let uu____1034 = (
+
+let uu____1036 = (get_codegen_lib ())
+in (s)::uu____1036)
+in (FStar_All.pipe_right uu____1034 (FStar_List.map (fun _0_28 -> String (_0_28)))))
+in List (uu____1032)))), ("[namespace]")))), ("External runtime library (i.e. M.N.x extracts to M.N.X instead of M_N.x)")))::(((FStar_Getopt.noshort), ("debug"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1049 = (
+
+let uu____1051 = (
+
+let uu____1053 = (get_debug ())
+in (x)::uu____1053)
+in (FStar_All.pipe_right uu____1051 (FStar_List.map (fun _0_29 -> String (_0_29)))))
+in List (uu____1049)))), ("[module name]")))), ("Print lots of debugging information while checking module")))::(((FStar_Getopt.noshort), ("debug_level"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1066 = (
+
+let uu____1068 = (
+
+let uu____1070 = (get_debug_level ())
+in (x)::uu____1070)
+in (FStar_All.pipe_right uu____1068 (FStar_List.map (fun _0_30 -> String (_0_30)))))
+in List (uu____1066)))), ("[Low|Medium|High|Extreme|...]")))), ("Control the verbosity of debugging info")))::(((FStar_Getopt.noshort), ("dep"), (FStar_Getopt.OneArg ((((fun x -> (match (((x = "make") || (x = "graph"))) with
+| true -> begin
+String (x)
+end
+| uu____1083 -> begin
+(failwith "invalid argument to \'dep\'")
+end))), ("[make|graph]")))), ("Output the transitive closure of the dependency graph in a format suitable for the given tool")))::(((FStar_Getopt.noshort), ("detail_errors"), (FStar_Getopt.ZeroArgs ((fun uu____1090 -> Bool (true)))), ("Emit a detailed error report by asking the SMT solver many queries; will take longer;\n         implies n_cores=1")))::(((FStar_Getopt.noshort), ("doc"), (FStar_Getopt.ZeroArgs ((fun uu____1097 -> Bool (true)))), ("Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory.")))::(((FStar_Getopt.noshort), ("dump_module"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1107 = (
+
+let uu____1109 = (
+
+let uu____1111 = (get_dump_module ())
+in (x)::uu____1111)
+in (FStar_All.pipe_right uu____1109 (FStar_List.map (fun _0_31 -> String (_0_31)))))
+in (FStar_All.pipe_right uu____1107 (fun _0_32 -> List (_0_32)))))), ("[module name]")))), ("")))::(((FStar_Getopt.noshort), ("eager_inference"), (FStar_Getopt.ZeroArgs ((fun uu____1122 -> Bool (true)))), ("Solve all type-inference constraints eagerly; more efficient but at the cost of generality")))::(((FStar_Getopt.noshort), ("explicit_deps"), (FStar_Getopt.ZeroArgs ((fun uu____1129 -> Bool (true)))), ("Do not find dependencies automatically, the user provides them on the command-line")))::(((FStar_Getopt.noshort), ("extract_all"), (FStar_Getopt.ZeroArgs ((fun uu____1136 -> Bool (true)))), ("Discover the complete dependency graph and do not stop at interface boundaries")))::(((FStar_Getopt.noshort), ("extract_module"), (FStar_Getopt.OneArg (((cons_extract_module), ("[module name]")))), ("Only extract the specified modules (instead of the possibly-partial dependency graph)")))::(((FStar_Getopt.noshort), ("extract_namespace"), (FStar_Getopt.OneArg (((cons_extract_namespace), ("[namespace name]")))), ("Only extract modules in the specified namespace")))::(((FStar_Getopt.noshort), ("fstar_home"), (FStar_Getopt.OneArg ((((fun _0_33 -> String (_0_33))), ("[dir]")))), ("Set the FSTAR_HOME variable to [dir]")))::(((FStar_Getopt.noshort), ("hide_genident_nums"), (FStar_Getopt.ZeroArgs ((fun uu____1167 -> Bool (true)))), ("Don\'t print generated identifier numbers")))::(((FStar_Getopt.noshort), ("hide_uvar_nums"), (FStar_Getopt.ZeroArgs ((fun uu____1174 -> Bool (true)))), ("Don\'t print unification variable numbers")))::(((FStar_Getopt.noshort), ("hint_info"), (FStar_Getopt.ZeroArgs ((fun uu____1181 -> Bool (true)))), ("Print information regarding hints")))::(((FStar_Getopt.noshort), ("in"), (FStar_Getopt.ZeroArgs ((fun uu____1188 -> Bool (true)))), ("Interactive mode; reads input from stdin")))::(((FStar_Getopt.noshort), ("include"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1198 = (
+
+let uu____1200 = (
+
+let uu____1202 = (get_include ())
+in (FStar_List.append uu____1202 ((s)::[])))
+in (FStar_All.pipe_right uu____1200 (FStar_List.map (fun _0_34 -> String (_0_34)))))
+in List (uu____1198)))), ("[path]")))), ("A directory in which to search for files included on the command line")))::(((FStar_Getopt.noshort), ("indent"), (FStar_Getopt.ZeroArgs ((fun uu____1212 -> Bool (true)))), ("Parses and outputs the files on the command line")))::(((FStar_Getopt.noshort), ("initial_fuel"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1222 = (FStar_Util.int_of_string x)
+in Int (uu____1222)))), ("[non-negative integer]")))), ("Number of unrolling of recursive functions to try initially (default 2)")))::(((FStar_Getopt.noshort), ("initial_ifuel"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1232 = (FStar_Util.int_of_string x)
+in Int (uu____1232)))), ("[non-negative integer]")))), ("Number of unrolling of inductive datatypes to try at first (default 1)")))::(((FStar_Getopt.noshort), ("inline_arith"), (FStar_Getopt.ZeroArgs ((fun uu____1239 -> Bool (true)))), ("Inline definitions of arithmetic functions in the SMT encoding")))::(((FStar_Getopt.noshort), ("lax"), (FStar_Getopt.ZeroArgs ((fun uu____1246 -> Bool (true)))), ("Run the lax-type checker only (admit all verification conditions)")))::(((FStar_Getopt.noshort), ("log_types"), (FStar_Getopt.ZeroArgs ((fun uu____1253 -> Bool (true)))), ("Print types computed for data/val/let-bindings")))::(((FStar_Getopt.noshort), ("log_queries"), (FStar_Getopt.ZeroArgs ((fun uu____1260 -> Bool (true)))), ("Log the Z3 queries in several queries-*.smt2 files, as we go")))::(((FStar_Getopt.noshort), ("max_fuel"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1270 = (FStar_Util.int_of_string x)
+in Int (uu____1270)))), ("[non-negative integer]")))), ("Number of unrolling of recursive functions to try at most (default 8)")))::(((FStar_Getopt.noshort), ("max_ifuel"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1280 = (FStar_Util.int_of_string x)
+in Int (uu____1280)))), ("[non-negative integer]")))), ("Number of unrolling of inductive datatypes to try at most (default 2)")))::(((FStar_Getopt.noshort), ("min_fuel"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1290 = (FStar_Util.int_of_string x)
+in Int (uu____1290)))), ("[non-negative integer]")))), ("Minimum number of unrolling of recursive functions to try (default 1)")))::(((FStar_Getopt.noshort), ("MLish"), (FStar_Getopt.ZeroArgs ((fun uu____1297 -> Bool (true)))), ("Trigger various specializations for compiling the F* compiler itself (not meant for user code)")))::(((FStar_Getopt.noshort), ("n_cores"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1307 = (FStar_Util.int_of_string x)
+in Int (uu____1307)))), ("[positive integer]")))), ("Maximum number of cores to use for the solver (implies detail_errors = false) (default 1)")))::(((FStar_Getopt.noshort), ("no_default_includes"), (FStar_Getopt.ZeroArgs ((fun uu____1314 -> Bool (true)))), ("Ignore the default module search paths")))::(((FStar_Getopt.noshort), ("no_extract"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1324 = (
+
+let uu____1326 = (
+
+let uu____1328 = (get_no_extract ())
+in (x)::uu____1328)
+in (FStar_All.pipe_right uu____1326 (FStar_List.map (fun _0_35 -> String (_0_35)))))
+in List (uu____1324)))), ("[module name]")))), ("Do not extract code from this module")))::(((FStar_Getopt.noshort), ("no_location_info"), (FStar_Getopt.ZeroArgs ((fun uu____1338 -> Bool (true)))), ("Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)")))::(((FStar_Getopt.noshort), ("odir"), (FStar_Getopt.OneArg ((((fun _0_36 -> String (_0_36))), ("[dir]")))), ("Place output in directory [dir]")))::(((FStar_Getopt.noshort), ("prims"), (FStar_Getopt.OneArg ((((fun _0_37 -> String (_0_37))), ("file")))), ("")))::(((FStar_Getopt.noshort), ("print_before_norm"), (FStar_Getopt.ZeroArgs ((fun uu____1361 -> Bool (true)))), ("Do not normalize types before printing (for debugging)")))::(((FStar_Getopt.noshort), ("print_bound_var_types"), (FStar_Getopt.ZeroArgs ((fun uu____1368 -> Bool (true)))), ("Print the types of bound variables")))::(((FStar_Getopt.noshort), ("print_effect_args"), (FStar_Getopt.ZeroArgs ((fun uu____1375 -> Bool (true)))), ("Print inferred predicate transformers for all computation types")))::(((FStar_Getopt.noshort), ("print_fuels"), (FStar_Getopt.ZeroArgs ((fun uu____1382 -> Bool (true)))), ("Print the fuel amounts used for each successful query")))::(((FStar_Getopt.noshort), ("print_full_names"), (FStar_Getopt.ZeroArgs ((fun uu____1389 -> Bool (true)))), ("Print full names of variables")))::(((FStar_Getopt.noshort), ("print_implicits"), (FStar_Getopt.ZeroArgs ((fun uu____1396 -> Bool (true)))), ("Print implicit arguments")))::(((FStar_Getopt.noshort), ("print_universes"), (FStar_Getopt.ZeroArgs ((fun uu____1403 -> Bool (true)))), ("Print universes")))::(((FStar_Getopt.noshort), ("print_z3_statistics"), (FStar_Getopt.ZeroArgs ((fun uu____1410 -> Bool (true)))), ("Print Z3 statistics for each SMT query")))::(((FStar_Getopt.noshort), ("prn"), (FStar_Getopt.ZeroArgs ((fun uu____1417 -> Bool (true)))), ("Print full names (deprecated; use --print_full_names instead)")))::(((FStar_Getopt.noshort), ("record_hints"), (FStar_Getopt.ZeroArgs ((fun uu____1424 -> Bool (true)))), ("Record a database of hints for efficient proof replay")))::(((FStar_Getopt.noshort), ("reuse_hint_for"), (FStar_Getopt.OneArg ((((fun _0_38 -> String (_0_38))), ("top-level name in the current module")))), ("Optimistically, attempt using the recorded hint for \'f\' when trying to verify some other term \'g\'")))::(((FStar_Getopt.noshort), ("show_signatures"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1442 = (
+
+let uu____1444 = (
+
+let uu____1446 = (get_show_signatures ())
+in (x)::uu____1446)
+in (FStar_All.pipe_right uu____1444 (FStar_List.map (fun _0_39 -> String (_0_39)))))
+in List (uu____1442)))), ("[module name]")))), ("Show the checked signatures for all top-level symbols in the module")))::(((FStar_Getopt.noshort), ("silent"), (FStar_Getopt.ZeroArgs ((fun uu____1456 -> Bool (true)))), (" ")))::(((FStar_Getopt.noshort), ("smt"), (FStar_Getopt.OneArg ((((fun _0_40 -> String (_0_40))), ("[path]")))), ("Path to the SMT solver (usually Z3, but could be any SMT2-compatible solver)")))::(((FStar_Getopt.noshort), ("split_cases"), (FStar_Getopt.OneArg ((((fun n1 -> (
+
+let uu____1474 = (FStar_Util.int_of_string n1)
+in Int (uu____1474)))), ("[positive integer]")))), ("Partition VC of a match into groups of [n] cases")))::(((FStar_Getopt.noshort), ("timing"), (FStar_Getopt.ZeroArgs ((fun uu____1481 -> Bool (true)))), ("Print the time it takes to verify each top-level definition")))::(((FStar_Getopt.noshort), ("trace_error"), (FStar_Getopt.ZeroArgs ((fun uu____1488 -> Bool (true)))), ("Don\'t print an error message; show an exception trace instead")))::(((FStar_Getopt.noshort), ("unthrottle_inductives"), (FStar_Getopt.ZeroArgs ((fun uu____1495 -> Bool (true)))), ("Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)")))::(((FStar_Getopt.noshort), ("use_eq_at_higher_order"), (FStar_Getopt.ZeroArgs ((fun uu____1502 -> Bool (true)))), ("Use equality constraints when comparing higher-order types (Temporary)")))::(((FStar_Getopt.noshort), ("use_hints"), (FStar_Getopt.ZeroArgs ((fun uu____1509 -> Bool (true)))), ("Use a previously recorded hints database for proof replay")))::(((FStar_Getopt.noshort), ("use_tactics"), (FStar_Getopt.ZeroArgs ((fun uu____1516 -> Bool (true)))), ("Pre-process a verification condition using a user-provided tactic (a flag to support migration to tactics gradually)")))::(((FStar_Getopt.noshort), ("verify_all"), (FStar_Getopt.ZeroArgs ((fun uu____1523 -> Bool (true)))), ("With automatic dependencies, verify all the dependencies, not just the files passed on the command-line.")))::(((FStar_Getopt.noshort), ("verify_module"), (FStar_Getopt.OneArg (((cons_verify_module), ("[module name]")))), ("Name of the module to verify")))::(((FStar_Getopt.noshort), ("__temp_no_proj"), (FStar_Getopt.OneArg ((((fun x -> (
+
+let uu____1541 = (
+
+let uu____1543 = (
+
+let uu____1545 = (get___temp_no_proj ())
+in (x)::uu____1545)
+in (FStar_All.pipe_right uu____1543 (FStar_List.map (fun _0_41 -> String (_0_41)))))
+in List (uu____1541)))), ("[module name]")))), ("Don\'t generate projectors for this module")))::((('v'), ("version"), (FStar_Getopt.ZeroArgs ((fun uu____1555 -> ((display_version ());
+(FStar_All.exit (Prims.parse_int "0"));
+)))), ("Display version number")))::(((FStar_Getopt.noshort), ("warn_default_effects"), (FStar_Getopt.ZeroArgs ((fun uu____1563 -> Bool (true)))), ("Warn when (a -> b) is desugared to (a -> Tot b)")))::(((FStar_Getopt.noshort), ("z3cliopt"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1573 = (
+
+let uu____1575 = (
+
+let uu____1577 = (get_z3cliopt ())
+in (FStar_List.append uu____1577 ((s)::[])))
+in (FStar_All.pipe_right uu____1575 (FStar_List.map (fun _0_42 -> String (_0_42)))))
+in List (uu____1573)))), ("[option]")))), ("Z3 command line options")))::(((FStar_Getopt.noshort), ("z3refresh"), (FStar_Getopt.ZeroArgs ((fun uu____1587 -> Bool (false)))), ("Restart Z3 after each query; useful for ensuring proof robustness")))::(((FStar_Getopt.noshort), ("z3rlimit"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1597 = (FStar_Util.int_of_string s)
+in Int (uu____1597)))), ("[positive integer]")))), ("Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)")))::(((FStar_Getopt.noshort), ("z3seed"), (FStar_Getopt.OneArg ((((fun s -> (
+
+let uu____1607 = (FStar_Util.int_of_string s)
+in Int (uu____1607)))), ("[positive integer]")))), ("Set the Z3 random seed (default 0)")))::(((FStar_Getopt.noshort), ("z3timeout"), (FStar_Getopt.OneArg ((((fun s -> ((FStar_Util.print_string "Warning: z3timeout ignored; use z3rlimit instead\n");
+(
+
+let uu____1618 = (FStar_Util.int_of_string s)
+in Int (uu____1618));
+))), ("[positive integer]")))), ("Set the Z3 per-query (soft) timeout to [t] seconds (default 5)")))::(((FStar_Getopt.noshort), ("__no_positivity"), (FStar_Getopt.ZeroArgs ((fun uu____1625 -> Bool (true)))), ("Don\'t check positivity of inductive types")))::[]
+in (
+
+let uu____1631 = (FStar_List.map mk_spec specs1)
+in ((('h'), ("help"), (FStar_Getopt.ZeroArgs ((fun x -> ((display_usage_aux specs1);
+(FStar_All.exit (Prims.parse_int "0"));
+)))), ("Display this information")))::uu____1631)))
+and parse_codegen : Prims.string  ->  Prims.string = (fun s -> (match (s) with
+| ("Kremlin") | ("OCaml") | ("FSharp") -> begin
+s
+end
+| uu____1652 -> begin
+((FStar_Util.print_string "Wrong argument to codegen flag\n");
+(
+
+let uu____1655 = (specs ())
+in (display_usage_aux uu____1655));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end))
+and validate_cardinality : Prims.string  ->  Prims.string = (fun x -> (match (x) with
+| ("warn") | ("check") | ("off") -> begin
+x
+end
+| uu____1663 -> begin
+((FStar_Util.print_string "Wrong argument to cardinality flag\n");
+(
+
+let uu____1666 = (specs ())
+in (display_usage_aux uu____1666));
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end))
+
+
+let settable : Prims.string  ->  Prims.bool = (fun uu___53_1675 -> (match (uu___53_1675) with
+| ("admit_smt_queries") | ("cardinality") | ("debug") | ("debug_level") | ("detail_errors") | ("eager_inference") | ("hide_genident_nums") | ("hide_uvar_nums") | ("hint_info") | ("initial_fuel") | ("initial_ifuel") | ("inline_arith") | ("lax") | ("log_types") | ("log_queries") | ("max_fuel") | ("max_ifuel") | ("min_fuel") | ("print_before_norm") | ("print_bound_var_types") | ("print_effect_args") | ("print_fuels") | ("print_full_names") | ("print_implicits") | ("print_universes") | ("print_z3_statistics") | ("prn") | ("show_signatures") | ("silent") | ("split_cases") | ("timing") | ("trace_error") | ("unthrottle_inductives") | ("use_eq_at_higher_order") | ("use_tactics") | ("__temp_no_proj") | ("no_warn_top_level_effects") | ("reuse_hint_for") | ("z3refresh") -> begin
+true
+end
+| uu____1676 -> begin
+false
+end))
+
+
+let resettable : Prims.string  ->  Prims.bool = (fun s -> ((((settable s) || (s = "z3timeout")) || (s = "z3rlimit")) || (s = "z3seed")))
+
+
+let all_specs : FStar_Getopt.opt Prims.list = (specs ())
+
+
+let settable_specs : (FStar_BaseTypes.char * Prims.string * Prims.unit FStar_Getopt.opt_variant * Prims.string) Prims.list = (FStar_All.pipe_right all_specs (FStar_List.filter (fun uu____1699 -> (match (uu____1699) with
+| (uu____1705, x, uu____1707, uu____1708) -> begin
+(settable x)
+end))))
+
+
+let resettable_specs : (FStar_BaseTypes.char * Prims.string * Prims.unit FStar_Getopt.opt_variant * Prims.string) Prims.list = (FStar_All.pipe_right all_specs (FStar_List.filter (fun uu____1729 -> (match (uu____1729) with
+| (uu____1735, x, uu____1737, uu____1738) -> begin
+(resettable x)
+end))))
+
+
+let display_usage : Prims.unit  ->  Prims.unit = (fun uu____1743 -> (
+
+let uu____1744 = (specs ())
+in (display_usage_aux uu____1744)))
+
+
+let fstar_home : Prims.unit  ->  Prims.string = (fun uu____1753 -> (
+
+let uu____1754 = (get_fstar_home ())
+in (match (uu____1754) with
+| None -> begin
+(
+
+let x = (FStar_Util.get_exec_dir ())
+in (
+
+let x1 = (Prims.strcat x "/..")
+in ((set_option' (("fstar_home"), (String (x1))));
+x1;
+)))
+end
+| Some (x) -> begin
+x
+end)))
+
+
+let set_options : options  ->  Prims.string  ->  FStar_Getopt.parse_cmdline_res = (fun o s -> (
+
+let specs1 = (match (o) with
+| Set -> begin
+resettable_specs
+end
+| Reset -> begin
+resettable_specs
+end
+| Restore -> begin
+all_specs
+end)
+in (FStar_Getopt.parse_string specs1 (fun uu____1779 -> ()) s)))
+
+
+let file_list_ : Prims.string Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let parse_cmd_line : Prims.unit  ->  (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list) = (fun uu____1790 -> (
+
+let res = (
+
+let uu____1792 = (specs ())
+in (FStar_Getopt.parse_cmdline uu____1792 (fun i -> (
+
+let uu____1795 = (
+
+let uu____1797 = (FStar_ST.read file_list_)
+in (FStar_List.append uu____1797 ((i)::[])))
+in (FStar_ST.write file_list_ uu____1795)))))
+in (
+
+let uu____1805 = (FStar_ST.read file_list_)
+in ((res), (uu____1805)))))
+
+
+let file_list : Prims.unit  ->  Prims.string Prims.list = (fun uu____1814 -> (FStar_ST.read file_list_))
+
+
+let restore_cmd_line_options : Prims.bool  ->  FStar_Getopt.parse_cmdline_res = (fun should_clear -> (
+
+let old_verify_module = (get_verify_module ())
+in ((match (should_clear) with
+| true -> begin
+(clear ())
+end
+| uu____1824 -> begin
+(init ())
+end);
+(
+
+let r = (
+
+let uu____1826 = (specs ())
+in (FStar_Getopt.parse_cmdline uu____1826 (fun x -> ())))
+in ((
+
+let uu____1830 = (
+
+let uu____1833 = (
+
+let uu____1834 = (FStar_List.map (fun _0_43 -> String (_0_43)) old_verify_module)
+in List (uu____1834))
+in (("verify_module"), (uu____1833)))
+in (set_option' uu____1830));
+r;
+));
+)))
+
+
+let should_verify : Prims.string  ->  Prims.bool = (fun m -> (
+
+let uu____1839 = (get_lax ())
+in (match (uu____1839) with
+| true -> begin
+false
+end
+| uu____1840 -> begin
+(
+
+let uu____1841 = (get_verify_all ())
+in (match (uu____1841) with
+| true -> begin
+true
+end
+| uu____1842 -> begin
+(
+
+let uu____1843 = (get_verify_module ())
+in (match (uu____1843) with
+| [] -> begin
+(
+
+let uu____1845 = (file_list ())
+in (FStar_List.existsML (fun f -> (
+
+let f1 = (FStar_Util.basename f)
+in (
+
+let f2 = (
+
+let uu____1850 = (
+
+let uu____1851 = (
+
+let uu____1852 = (
+
+let uu____1853 = (FStar_Util.get_file_extension f1)
+in (FStar_String.length uu____1853))
+in ((FStar_String.length f1) - uu____1852))
+in (uu____1851 - (Prims.parse_int "1")))
+in (FStar_String.substring f1 (Prims.parse_int "0") uu____1850))
+in ((FStar_String.lowercase f2) = m)))) uu____1845))
+end
+| l -> begin
+(FStar_List.contains (FStar_String.lowercase m) l)
+end))
+end))
+end)))
+
+
+let dont_gen_projectors : Prims.string  ->  Prims.bool = (fun m -> (
+
+let uu____1863 = (get___temp_no_proj ())
+in (FStar_List.contains m uu____1863)))
+
+
+let should_print_message : Prims.string  ->  Prims.bool = (fun m -> (
+
+let uu____1868 = (should_verify m)
+in (match (uu____1868) with
+| true -> begin
+(m <> "Prims")
+end
+| uu____1869 -> begin
+false
+end)))
+
+
+let include_path : Prims.unit  ->  Prims.string Prims.list = (fun uu____1873 -> (
+
+let uu____1874 = (get_no_default_includes ())
+in (match (uu____1874) with
+| true -> begin
+(get_include ())
+end
+| uu____1876 -> begin
+(
+
+let h = (fstar_home ())
+in (
+
+let defs = universe_include_path_base_dirs
+in (
+
+let uu____1880 = (
+
+let uu____1882 = (FStar_All.pipe_right defs (FStar_List.map (fun x -> (Prims.strcat h x))))
+in (FStar_All.pipe_right uu____1882 (FStar_List.filter FStar_Util.file_exists)))
+in (
+
+let uu____1889 = (
+
+let uu____1891 = (get_include ())
+in (FStar_List.append uu____1891 ((".")::[])))
+in (FStar_List.append uu____1880 uu____1889)))))
+end)))
+
+
+let find_file : Prims.string  ->  Prims.string Prims.option = (fun filename -> (
+
+let uu____1897 = (FStar_Util.is_path_absolute filename)
+in (match (uu____1897) with
+| true -> begin
+(match ((FStar_Util.file_exists filename)) with
+| true -> begin
+Some (filename)
+end
+| uu____1900 -> begin
+None
+end)
+end
+| uu____1901 -> begin
+(
+
+let uu____1902 = (
+
+let uu____1904 = (include_path ())
+in (FStar_List.rev uu____1904))
+in (FStar_Util.find_map uu____1902 (fun p -> (
+
+let path = (FStar_Util.join_paths p filename)
+in (match ((FStar_Util.file_exists path)) with
+| true -> begin
+Some (path)
+end
+| uu____1909 -> begin
+None
+end)))))
+end)))
+
+
+let prims : Prims.unit  ->  Prims.string = (fun uu____1912 -> (
+
+let uu____1913 = (get_prims ())
+in (match (uu____1913) with
+| None -> begin
+(
+
+let filename = "prims.fst"
+in (
+
+let uu____1916 = (find_file filename)
+in (match (uu____1916) with
+| Some (result) -> begin
+result
+end
+| None -> begin
+(
+
+let uu____1919 = (
+
+let uu____1920 = (FStar_Util.format1 "unable to find required file \"%s\" in the module search path.\n" filename)
+in FStar_Util.Failure (uu____1920))
+in (Prims.raise uu____1919))
+end)))
+end
+| Some (x) -> begin
+x
+end)))
+
+
+let prepend_output_dir : Prims.string  ->  Prims.string = (fun fname -> (
+
+let uu____1925 = (get_odir ())
+in (match (uu____1925) with
+| None -> begin
+fname
+end
+| Some (x) -> begin
+(Prims.strcat x (Prims.strcat "/" fname))
+end)))
+
+
+let __temp_no_proj : Prims.string  ->  Prims.bool = (fun s -> (
+
+let uu____1931 = (get___temp_no_proj ())
+in (FStar_All.pipe_right uu____1931 (FStar_List.contains s))))
+
+
+let admit_smt_queries : Prims.unit  ->  Prims.bool = (fun uu____1936 -> (get_admit_smt_queries ()))
+
+
+let check_cardinality : Prims.unit  ->  Prims.bool = (fun uu____1939 -> (
+
+let uu____1940 = (get_cardinality ())
+in (uu____1940 = "check")))
+
+
+let codegen : Prims.unit  ->  Prims.string Prims.option = (fun uu____1944 -> (get_codegen ()))
+
+
+let codegen_libs : Prims.unit  ->  Prims.string Prims.list Prims.list = (fun uu____1949 -> (
+
+let uu____1950 = (get_codegen_lib ())
+in (FStar_All.pipe_right uu____1950 (FStar_List.map (fun x -> (FStar_Util.split x "."))))))
+
+
+let debug_any : Prims.unit  ->  Prims.bool = (fun uu____1959 -> (
+
+let uu____1960 = (get_debug ())
+in (uu____1960 <> [])))
+
+
+let debug_at_level : Prims.string  ->  debug_level_t  ->  Prims.bool = (fun modul level -> (((modul = "") || (
+
+let uu____1969 = (get_debug ())
+in (FStar_All.pipe_right uu____1969 (FStar_List.contains modul)))) && (debug_level_geq level)))
+
+
+let dep : Prims.unit  ->  Prims.string Prims.option = (fun uu____1975 -> (get_dep ()))
+
+
+let detail_errors : Prims.unit  ->  Prims.bool = (fun uu____1978 -> (get_detail_errors ()))
+
+
+let doc : Prims.unit  ->  Prims.bool = (fun uu____1981 -> (get_doc ()))
+
+
+let dump_module : Prims.string  ->  Prims.bool = (fun s -> (
+
+let uu____1985 = (get_dump_module ())
+in (FStar_All.pipe_right uu____1985 (FStar_List.contains s))))
+
+
+let eager_inference : Prims.unit  ->  Prims.bool = (fun uu____1990 -> (get_eager_inference ()))
+
+
+let explicit_deps : Prims.unit  ->  Prims.bool = (fun uu____1993 -> (get_explicit_deps ()))
+
+
+let extract_all : Prims.unit  ->  Prims.bool = (fun uu____1996 -> (get_extract_all ()))
+
+
+let fs_typ_app : Prims.string  ->  Prims.bool = (fun filename -> (
+
+let uu____2000 = (FStar_ST.read light_off_files)
+in (FStar_List.contains filename uu____2000)))
+
+
+let full_context_dependency : Prims.unit  ->  Prims.bool = (fun uu____2007 -> true)
+
+
+let hide_genident_nums : Prims.unit  ->  Prims.bool = (fun uu____2010 -> (get_hide_genident_nums ()))
+
+
+let hide_uvar_nums : Prims.unit  ->  Prims.bool = (fun uu____2013 -> (get_hide_uvar_nums ()))
+
+
+let hint_info : Prims.unit  ->  Prims.bool = (fun uu____2016 -> (get_hint_info ()))
+
+
+let indent : Prims.unit  ->  Prims.bool = (fun uu____2019 -> (get_indent ()))
+
+
+let initial_fuel : Prims.unit  ->  Prims.int = (fun uu____2022 -> (
+
+let uu____2023 = (get_initial_fuel ())
+in (
+
+let uu____2024 = (get_max_fuel ())
+in (Prims.min uu____2023 uu____2024))))
+
+
+let initial_ifuel : Prims.unit  ->  Prims.int = (fun uu____2027 -> (
+
+let uu____2028 = (get_initial_ifuel ())
+in (
+
+let uu____2029 = (get_max_ifuel ())
+in (Prims.min uu____2028 uu____2029))))
+
+
+let inline_arith : Prims.unit  ->  Prims.bool = (fun uu____2032 -> (get_inline_arith ()))
+
+
+let interactive : Prims.unit  ->  Prims.bool = (fun uu____2035 -> (get_in ()))
+
+
+let lax : Prims.unit  ->  Prims.bool = (fun uu____2038 -> (get_lax ()))
+
+
+let log_queries : Prims.unit  ->  Prims.bool = (fun uu____2041 -> (get_log_queries ()))
+
+
+let log_types : Prims.unit  ->  Prims.bool = (fun uu____2044 -> (get_log_types ()))
+
+
+let max_fuel : Prims.unit  ->  Prims.int = (fun uu____2047 -> (get_max_fuel ()))
+
+
+let max_ifuel : Prims.unit  ->  Prims.int = (fun uu____2050 -> (get_max_ifuel ()))
+
+
+let min_fuel : Prims.unit  ->  Prims.int = (fun uu____2053 -> (get_min_fuel ()))
+
+
+let ml_ish : Prims.unit  ->  Prims.bool = (fun uu____2056 -> (get_MLish ()))
+
+
+let set_ml_ish : Prims.unit  ->  Prims.unit = (fun uu____2059 -> (set_option "MLish" (Bool (true))))
+
+
+let n_cores : Prims.unit  ->  Prims.int = (fun uu____2062 -> (get_n_cores ()))
+
+
+let no_default_includes : Prims.unit  ->  Prims.bool = (fun uu____2065 -> (get_no_default_includes ()))
+
+
+let no_extract : Prims.string  ->  Prims.bool = (fun s -> (
+
+let uu____2069 = (get_no_extract ())
+in (FStar_All.pipe_right uu____2069 (FStar_List.contains s))))
+
+
+let no_location_info : Prims.unit  ->  Prims.bool = (fun uu____2074 -> (get_no_location_info ()))
+
+
+let norm_then_print : Prims.unit  ->  Prims.bool = (fun uu____2077 -> (
+
+let uu____2078 = (get_print_before_norm ())
+in (uu____2078 = false)))
+
+
+let output_dir : Prims.unit  ->  Prims.string Prims.option = (fun uu____2082 -> (get_odir ()))
+
+
+let print_bound_var_types : Prims.unit  ->  Prims.bool = (fun uu____2085 -> (get_print_bound_var_types ()))
+
+
+let print_effect_args : Prims.unit  ->  Prims.bool = (fun uu____2088 -> (get_print_effect_args ()))
+
+
+let print_fuels : Prims.unit  ->  Prims.bool = (fun uu____2091 -> (get_print_fuels ()))
+
+
+let print_implicits : Prims.unit  ->  Prims.bool = (fun uu____2094 -> (get_print_implicits ()))
+
+
+let print_real_names : Prims.unit  ->  Prims.bool = (fun uu____2097 -> ((get_prn ()) || (get_print_full_names ())))
+
+
+let print_universes : Prims.unit  ->  Prims.bool = (fun uu____2100 -> (get_print_universes ()))
+
+
+let print_z3_statistics : Prims.unit  ->  Prims.bool = (fun uu____2103 -> (get_print_z3_statistics ()))
+
+
+let record_hints : Prims.unit  ->  Prims.bool = (fun uu____2106 -> (get_record_hints ()))
+
+
+let reuse_hint_for : Prims.unit  ->  Prims.string Prims.option = (fun uu____2110 -> (get_reuse_hint_for ()))
+
+
+let silent : Prims.unit  ->  Prims.bool = (fun uu____2113 -> (get_silent ()))
+
+
+let split_cases : Prims.unit  ->  Prims.int = (fun uu____2116 -> (get_split_cases ()))
+
+
+let timing : Prims.unit  ->  Prims.bool = (fun uu____2119 -> (get_timing ()))
+
+
+let trace_error : Prims.unit  ->  Prims.bool = (fun uu____2122 -> (get_trace_error ()))
+
+
+let unthrottle_inductives : Prims.unit  ->  Prims.bool = (fun uu____2125 -> (get_unthrottle_inductives ()))
+
+
+let use_eq_at_higher_order : Prims.unit  ->  Prims.bool = (fun uu____2128 -> (get_use_eq_at_higher_order ()))
+
+
+let use_hints : Prims.unit  ->  Prims.bool = (fun uu____2131 -> (get_use_hints ()))
+
+
+let use_tactics : Prims.unit  ->  Prims.bool = (fun uu____2134 -> (get_use_tactics ()))
+
+
+let verify_all : Prims.unit  ->  Prims.bool = (fun uu____2137 -> (get_verify_all ()))
+
+
+let verify_module : Prims.unit  ->  Prims.string Prims.list = (fun uu____2141 -> (get_verify_module ()))
+
+
+let warn_cardinality : Prims.unit  ->  Prims.bool = (fun uu____2144 -> (
+
+let uu____2145 = (get_cardinality ())
+in (uu____2145 = "warn")))
+
+
+let warn_default_effects : Prims.unit  ->  Prims.bool = (fun uu____2148 -> (get_warn_default_effects ()))
+
+
+let warn_top_level_effects : Prims.unit  ->  Prims.bool = (fun uu____2151 -> (get_warn_top_level_effects ()))
+
+
+let z3_exe : Prims.unit  ->  Prims.string = (fun uu____2154 -> (
+
+let uu____2155 = (get_smt ())
+in (match (uu____2155) with
+| None -> begin
+(FStar_Platform.exe "z3")
+end
+| Some (s) -> begin
+s
+end)))
+
+
+let z3_cliopt : Prims.unit  ->  Prims.string Prims.list = (fun uu____2161 -> (get_z3cliopt ()))
+
+
+let z3_refresh : Prims.unit  ->  Prims.bool = (fun uu____2164 -> (get_z3refresh ()))
+
+
+let z3_rlimit : Prims.unit  ->  Prims.int = (fun uu____2167 -> (get_z3rlimit ()))
+
+
+let z3_seed : Prims.unit  ->  Prims.int = (fun uu____2170 -> (get_z3seed ()))
+
+
+let z3_timeout : Prims.unit  ->  Prims.int = (fun uu____2173 -> (get_z3timeout ()))
+
+
+let no_positivity : Prims.unit  ->  Prims.bool = (fun uu____2176 -> (get_no_positivity ()))
+
+
+let should_extract : Prims.string  ->  Prims.bool = (fun m -> ((
+
+let uu____2180 = (no_extract m)
+in (not (uu____2180))) && ((extract_all ()) || (
+
+let uu____2181 = (get_extract_module ())
+in (match (uu____2181) with
+| [] -> begin
+(
+
+let uu____2183 = (get_extract_namespace ())
+in (match (uu____2183) with
+| [] -> begin
+true
+end
+| ns -> begin
+(FStar_Util.for_some (FStar_Util.starts_with (FStar_String.lowercase m)) ns)
+end))
+end
+| l -> begin
+(FStar_List.contains (FStar_String.lowercase m) l)
+end)))))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -1,1547 +1,2919 @@
+
 open Prims
-let old_mk_tuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____8 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "Tuple%s" uu____8 in
-      let uu____9 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____9 r
-let old_mk_tuple_data_lid:
-  Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____17 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "MkTuple%s" uu____17 in
-      let uu____18 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____18 r
-let old_mk_dtuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____26 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "DTuple%s" uu____26 in
-      let uu____27 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____27 r
-let old_mk_dtuple_data_lid:
-  Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____35 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "MkDTuple%s" uu____35 in
-      let uu____36 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____36 r
+
+let old_mk_tuple_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____8 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "Tuple%s" uu____8))
+in (
+
+let uu____9 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____9 r))))
+
+
+let old_mk_tuple_data_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____17 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "MkTuple%s" uu____17))
+in (
+
+let uu____18 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____18 r))))
+
+
+let old_mk_dtuple_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____26 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "DTuple%s" uu____26))
+in (
+
+let uu____27 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____27 r))))
+
+
+let old_mk_dtuple_data_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____35 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "MkDTuple%s" uu____35))
+in (
+
+let uu____36 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____36 r))))
+
 type level =
-  | Un
-  | Expr
-  | Type_level
-  | Kind
-  | Formula
-let uu___is_Un: level -> Prims.bool =
-  fun projectee  -> match projectee with | Un  -> true | uu____40 -> false
-let uu___is_Expr: level -> Prims.bool =
-  fun projectee  -> match projectee with | Expr  -> true | uu____44 -> false
-let uu___is_Type_level: level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Type_level  -> true | uu____48 -> false
-let uu___is_Kind: level -> Prims.bool =
-  fun projectee  -> match projectee with | Kind  -> true | uu____52 -> false
-let uu___is_Formula: level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Formula  -> true | uu____56 -> false
+| Un
+| Expr
+| Type_level
+| Kind
+| Formula
+
+
+let uu___is_Un : level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Un -> begin
+true
+end
+| uu____40 -> begin
+false
+end))
+
+
+let uu___is_Expr : level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Expr -> begin
+true
+end
+| uu____44 -> begin
+false
+end))
+
+
+let uu___is_Type_level : level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Type_level -> begin
+true
+end
+| uu____48 -> begin
+false
+end))
+
+
+let uu___is_Kind : level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Kind -> begin
+true
+end
+| uu____52 -> begin
+false
+end))
+
+
+let uu___is_Formula : level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Formula -> begin
+true
+end
+| uu____56 -> begin
+false
+end))
+
 type imp =
-  | FsTypApp
-  | Hash
-  | UnivApp
-  | Nothing
-let uu___is_FsTypApp: imp -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FsTypApp  -> true | uu____60 -> false
-let uu___is_Hash: imp -> Prims.bool =
-  fun projectee  -> match projectee with | Hash  -> true | uu____64 -> false
-let uu___is_UnivApp: imp -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UnivApp  -> true | uu____68 -> false
-let uu___is_Nothing: imp -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Nothing  -> true | uu____72 -> false
+| FsTypApp
+| Hash
+| UnivApp
+| Nothing
+
+
+let uu___is_FsTypApp : imp  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FsTypApp -> begin
+true
+end
+| uu____60 -> begin
+false
+end))
+
+
+let uu___is_Hash : imp  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Hash -> begin
+true
+end
+| uu____64 -> begin
+false
+end))
+
+
+let uu___is_UnivApp : imp  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UnivApp -> begin
+true
+end
+| uu____68 -> begin
+false
+end))
+
+
+let uu___is_Nothing : imp  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Nothing -> begin
+true
+end
+| uu____72 -> begin
+false
+end))
+
 type arg_qualifier =
-  | Implicit
-  | Equality
-let uu___is_Implicit: arg_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Implicit  -> true | uu____76 -> false
-let uu___is_Equality: arg_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Equality  -> true | uu____80 -> false
-type aqual = arg_qualifier Prims.option
+| Implicit
+| Equality
+
+
+let uu___is_Implicit : arg_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Implicit -> begin
+true
+end
+| uu____76 -> begin
+false
+end))
+
+
+let uu___is_Equality : arg_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Equality -> begin
+true
+end
+| uu____80 -> begin
+false
+end))
+
+
+type aqual =
+arg_qualifier Prims.option
+
 type let_qualifier =
-  | NoLetQualifier
-  | Rec
-  | Mutable
-let uu___is_NoLetQualifier: let_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoLetQualifier  -> true | uu____85 -> false
-let uu___is_Rec: let_qualifier -> Prims.bool =
-  fun projectee  -> match projectee with | Rec  -> true | uu____89 -> false
-let uu___is_Mutable: let_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mutable  -> true | uu____93 -> false
+| NoLetQualifier
+| Rec
+| Mutable
+
+
+let uu___is_NoLetQualifier : let_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoLetQualifier -> begin
+true
+end
+| uu____85 -> begin
+false
+end))
+
+
+let uu___is_Rec : let_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Rec -> begin
+true
+end
+| uu____89 -> begin
+false
+end))
+
+
+let uu___is_Mutable : let_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mutable -> begin
+true
+end
+| uu____93 -> begin
+false
+end))
+
 type term' =
-  | Wild
-  | Const of FStar_Const.sconst
-  | Op of (Prims.string* term Prims.list)
-  | Tvar of FStar_Ident.ident
-  | Uvar of FStar_Ident.ident
-  | Var of FStar_Ident.lid
-  | Name of FStar_Ident.lid
-  | Projector of (FStar_Ident.lid* FStar_Ident.ident)
-  | Construct of (FStar_Ident.lid* (term* imp) Prims.list)
-  | Abs of (pattern Prims.list* term)
-  | App of (term* term* imp)
-  | Let of (let_qualifier* (pattern* term) Prims.list* term)
-  | LetOpen of (FStar_Ident.lid* term)
-  | Seq of (term* term)
-  | If of (term* term* term)
-  | Match of (term* (pattern* term Prims.option* term) Prims.list)
-  | TryWith of (term* (pattern* term Prims.option* term) Prims.list)
-  | Ascribed of (term* term* term Prims.option)
-  | Record of (term Prims.option* (FStar_Ident.lid* term) Prims.list)
-  | Project of (term* FStar_Ident.lid)
-  | Product of (binder Prims.list* term)
-  | Sum of (binder Prims.list* term)
-  | QForall of (binder Prims.list* term Prims.list Prims.list* term)
-  | QExists of (binder Prims.list* term Prims.list Prims.list* term)
-  | Refine of (binder* term)
-  | NamedTyp of (FStar_Ident.ident* term)
-  | Paren of term
-  | Requires of (term* Prims.string Prims.option)
-  | Ensures of (term* Prims.string Prims.option)
-  | Labeled of (term* Prims.string* Prims.bool)
-  | Assign of (FStar_Ident.ident* term)
-  | Discrim of FStar_Ident.lid
-  | Attributes of term Prims.list
-and term = {
-  tm: term';
-  range: FStar_Range.range;
-  level: level;}
-and binder' =
-  | Variable of FStar_Ident.ident
-  | TVariable of FStar_Ident.ident
-  | Annotated of (FStar_Ident.ident* term)
-  | TAnnotated of (FStar_Ident.ident* term)
-  | NoName of term
-and binder =
-  {
-  b: binder';
-  brange: FStar_Range.range;
-  blevel: level;
-  aqual: aqual;}
-and pattern' =
-  | PatWild
-  | PatConst of FStar_Const.sconst
-  | PatApp of (pattern* pattern Prims.list)
-  | PatVar of (FStar_Ident.ident* arg_qualifier Prims.option)
-  | PatName of FStar_Ident.lid
-  | PatTvar of (FStar_Ident.ident* arg_qualifier Prims.option)
-  | PatList of pattern Prims.list
-  | PatTuple of (pattern Prims.list* Prims.bool)
-  | PatRecord of (FStar_Ident.lid* pattern) Prims.list
-  | PatAscribed of (pattern* term)
-  | PatOr of pattern Prims.list
-  | PatOp of Prims.string
-and pattern = {
-  pat: pattern';
-  prange: FStar_Range.range;}
-let uu___is_Wild: term' -> Prims.bool =
-  fun projectee  -> match projectee with | Wild  -> true | uu____380 -> false
-let uu___is_Const: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Const _0 -> true | uu____385 -> false
-let __proj__Const__item___0: term' -> FStar_Const.sconst =
-  fun projectee  -> match projectee with | Const _0 -> _0
-let uu___is_Op: term' -> Prims.bool =
-  fun projectee  -> match projectee with | Op _0 -> true | uu____400 -> false
-let __proj__Op__item___0: term' -> (Prims.string* term Prims.list) =
-  fun projectee  -> match projectee with | Op _0 -> _0
-let uu___is_Tvar: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tvar _0 -> true | uu____421 -> false
-let __proj__Tvar__item___0: term' -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | Tvar _0 -> _0
-let uu___is_Uvar: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Uvar _0 -> true | uu____433 -> false
-let __proj__Uvar__item___0: term' -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | Uvar _0 -> _0
-let uu___is_Var: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Var _0 -> true | uu____445 -> false
-let __proj__Var__item___0: term' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Var _0 -> _0
-let uu___is_Name: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Name _0 -> true | uu____457 -> false
-let __proj__Name__item___0: term' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Name _0 -> _0
-let uu___is_Projector: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Projector _0 -> true | uu____471 -> false
-let __proj__Projector__item___0:
-  term' -> (FStar_Ident.lid* FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Projector _0 -> _0
-let uu___is_Construct: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Construct _0 -> true | uu____494 -> false
-let __proj__Construct__item___0:
-  term' -> (FStar_Ident.lid* (term* imp) Prims.list) =
-  fun projectee  -> match projectee with | Construct _0 -> _0
-let uu___is_Abs: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Abs _0 -> true | uu____524 -> false
-let __proj__Abs__item___0: term' -> (pattern Prims.list* term) =
-  fun projectee  -> match projectee with | Abs _0 -> _0
-let uu___is_App: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | App _0 -> true | uu____548 -> false
-let __proj__App__item___0: term' -> (term* term* imp) =
-  fun projectee  -> match projectee with | App _0 -> _0
-let uu___is_Let: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Let _0 -> true | uu____575 -> false
-let __proj__Let__item___0:
-  term' -> (let_qualifier* (pattern* term) Prims.list* term) =
-  fun projectee  -> match projectee with | Let _0 -> _0
-let uu___is_LetOpen: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LetOpen _0 -> true | uu____607 -> false
-let __proj__LetOpen__item___0: term' -> (FStar_Ident.lid* term) =
-  fun projectee  -> match projectee with | LetOpen _0 -> _0
-let uu___is_Seq: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Seq _0 -> true | uu____627 -> false
-let __proj__Seq__item___0: term' -> (term* term) =
-  fun projectee  -> match projectee with | Seq _0 -> _0
-let uu___is_If: term' -> Prims.bool =
-  fun projectee  -> match projectee with | If _0 -> true | uu____648 -> false
-let __proj__If__item___0: term' -> (term* term* term) =
-  fun projectee  -> match projectee with | If _0 -> _0
-let uu___is_Match: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Match _0 -> true | uu____676 -> false
-let __proj__Match__item___0:
-  term' -> (term* (pattern* term Prims.option* term) Prims.list) =
-  fun projectee  -> match projectee with | Match _0 -> _0
-let uu___is_TryWith: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TryWith _0 -> true | uu____716 -> false
-let __proj__TryWith__item___0:
-  term' -> (term* (pattern* term Prims.option* term) Prims.list) =
-  fun projectee  -> match projectee with | TryWith _0 -> _0
-let uu___is_Ascribed: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Ascribed _0 -> true | uu____753 -> false
-let __proj__Ascribed__item___0: term' -> (term* term* term Prims.option) =
-  fun projectee  -> match projectee with | Ascribed _0 -> _0
-let uu___is_Record: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Record _0 -> true | uu____783 -> false
-let __proj__Record__item___0:
-  term' -> (term Prims.option* (FStar_Ident.lid* term) Prims.list) =
-  fun projectee  -> match projectee with | Record _0 -> _0
-let uu___is_Project: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Project _0 -> true | uu____815 -> false
-let __proj__Project__item___0: term' -> (term* FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Project _0 -> _0
-let uu___is_Product: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Product _0 -> true | uu____836 -> false
-let __proj__Product__item___0: term' -> (binder Prims.list* term) =
-  fun projectee  -> match projectee with | Product _0 -> _0
-let uu___is_Sum: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sum _0 -> true | uu____860 -> false
-let __proj__Sum__item___0: term' -> (binder Prims.list* term) =
-  fun projectee  -> match projectee with | Sum _0 -> _0
-let uu___is_QForall: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | QForall _0 -> true | uu____887 -> false
-let __proj__QForall__item___0:
-  term' -> (binder Prims.list* term Prims.list Prims.list* term) =
-  fun projectee  -> match projectee with | QForall _0 -> _0
-let uu___is_QExists: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | QExists _0 -> true | uu____923 -> false
-let __proj__QExists__item___0:
-  term' -> (binder Prims.list* term Prims.list Prims.list* term) =
-  fun projectee  -> match projectee with | QExists _0 -> _0
-let uu___is_Refine: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Refine _0 -> true | uu____955 -> false
-let __proj__Refine__item___0: term' -> (binder* term) =
-  fun projectee  -> match projectee with | Refine _0 -> _0
-let uu___is_NamedTyp: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NamedTyp _0 -> true | uu____975 -> false
-let __proj__NamedTyp__item___0: term' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | NamedTyp _0 -> _0
-let uu___is_Paren: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Paren _0 -> true | uu____993 -> false
-let __proj__Paren__item___0: term' -> term =
-  fun projectee  -> match projectee with | Paren _0 -> _0
-let uu___is_Requires: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Requires _0 -> true | uu____1008 -> false
-let __proj__Requires__item___0: term' -> (term* Prims.string Prims.option) =
-  fun projectee  -> match projectee with | Requires _0 -> _0
-let uu___is_Ensures: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Ensures _0 -> true | uu____1032 -> false
-let __proj__Ensures__item___0: term' -> (term* Prims.string Prims.option) =
-  fun projectee  -> match projectee with | Ensures _0 -> _0
-let uu___is_Labeled: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Labeled _0 -> true | uu____1056 -> false
-let __proj__Labeled__item___0: term' -> (term* Prims.string* Prims.bool) =
-  fun projectee  -> match projectee with | Labeled _0 -> _0
-let uu___is_Assign: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assign _0 -> true | uu____1079 -> false
-let __proj__Assign__item___0: term' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | Assign _0 -> _0
-let uu___is_Discrim: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Discrim _0 -> true | uu____1097 -> false
-let __proj__Discrim__item___0: term' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Discrim _0 -> _0
-let uu___is_Attributes: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Attributes _0 -> true | uu____1110 -> false
-let __proj__Attributes__item___0: term' -> term Prims.list =
-  fun projectee  -> match projectee with | Attributes _0 -> _0
-let uu___is_Variable: binder' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Variable _0 -> true | uu____1137 -> false
-let __proj__Variable__item___0: binder' -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | Variable _0 -> _0
-let uu___is_TVariable: binder' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TVariable _0 -> true | uu____1149 -> false
-let __proj__TVariable__item___0: binder' -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | TVariable _0 -> _0
-let uu___is_Annotated: binder' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Annotated _0 -> true | uu____1163 -> false
-let __proj__Annotated__item___0: binder' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | Annotated _0 -> _0
-let uu___is_TAnnotated: binder' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TAnnotated _0 -> true | uu____1183 -> false
-let __proj__TAnnotated__item___0: binder' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | TAnnotated _0 -> _0
-let uu___is_NoName: binder' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoName _0 -> true | uu____1201 -> false
-let __proj__NoName__item___0: binder' -> term =
-  fun projectee  -> match projectee with | NoName _0 -> _0
-let uu___is_PatWild: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatWild  -> true | uu____1228 -> false
-let uu___is_PatConst: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatConst _0 -> true | uu____1233 -> false
-let __proj__PatConst__item___0: pattern' -> FStar_Const.sconst =
-  fun projectee  -> match projectee with | PatConst _0 -> _0
-let uu___is_PatApp: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatApp _0 -> true | uu____1248 -> false
-let __proj__PatApp__item___0: pattern' -> (pattern* pattern Prims.list) =
-  fun projectee  -> match projectee with | PatApp _0 -> _0
-let uu___is_PatVar: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatVar _0 -> true | uu____1272 -> false
-let __proj__PatVar__item___0:
-  pattern' -> (FStar_Ident.ident* arg_qualifier Prims.option) =
-  fun projectee  -> match projectee with | PatVar _0 -> _0
-let uu___is_PatName: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatName _0 -> true | uu____1293 -> false
-let __proj__PatName__item___0: pattern' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | PatName _0 -> _0
-let uu___is_PatTvar: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatTvar _0 -> true | uu____1308 -> false
-let __proj__PatTvar__item___0:
-  pattern' -> (FStar_Ident.ident* arg_qualifier Prims.option) =
-  fun projectee  -> match projectee with | PatTvar _0 -> _0
-let uu___is_PatList: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatList _0 -> true | uu____1330 -> false
-let __proj__PatList__item___0: pattern' -> pattern Prims.list =
-  fun projectee  -> match projectee with | PatList _0 -> _0
-let uu___is_PatTuple: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatTuple _0 -> true | uu____1348 -> false
-let __proj__PatTuple__item___0: pattern' -> (pattern Prims.list* Prims.bool)
-  = fun projectee  -> match projectee with | PatTuple _0 -> _0
-let uu___is_PatRecord: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatRecord _0 -> true | uu____1372 -> false
-let __proj__PatRecord__item___0:
-  pattern' -> (FStar_Ident.lid* pattern) Prims.list =
-  fun projectee  -> match projectee with | PatRecord _0 -> _0
-let uu___is_PatAscribed: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatAscribed _0 -> true | uu____1395 -> false
-let __proj__PatAscribed__item___0: pattern' -> (pattern* term) =
-  fun projectee  -> match projectee with | PatAscribed _0 -> _0
-let uu___is_PatOr: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatOr _0 -> true | uu____1414 -> false
-let __proj__PatOr__item___0: pattern' -> pattern Prims.list =
-  fun projectee  -> match projectee with | PatOr _0 -> _0
-let uu___is_PatOp: pattern' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PatOp _0 -> true | uu____1429 -> false
-let __proj__PatOp__item___0: pattern' -> Prims.string =
-  fun projectee  -> match projectee with | PatOp _0 -> _0
-type branch = (pattern* term Prims.option* term)
-type knd = term
-type typ = term
-type expr = term
-type fsdoc = (Prims.string* (Prims.string* Prims.string) Prims.list)
+| Wild
+| Const of FStar_Const.sconst
+| Op of (Prims.string * term Prims.list)
+| Tvar of FStar_Ident.ident
+| Uvar of FStar_Ident.ident
+| Var of FStar_Ident.lid
+| Name of FStar_Ident.lid
+| Projector of (FStar_Ident.lid * FStar_Ident.ident)
+| Construct of (FStar_Ident.lid * (term * imp) Prims.list)
+| Abs of (pattern Prims.list * term)
+| App of (term * term * imp)
+| Let of (let_qualifier * (pattern * term) Prims.list * term)
+| LetOpen of (FStar_Ident.lid * term)
+| Seq of (term * term)
+| If of (term * term * term)
+| Match of (term * (pattern * term Prims.option * term) Prims.list)
+| TryWith of (term * (pattern * term Prims.option * term) Prims.list)
+| Ascribed of (term * term * term Prims.option)
+| Record of (term Prims.option * (FStar_Ident.lid * term) Prims.list)
+| Project of (term * FStar_Ident.lid)
+| Product of (binder Prims.list * term)
+| Sum of (binder Prims.list * term)
+| QForall of (binder Prims.list * term Prims.list Prims.list * term)
+| QExists of (binder Prims.list * term Prims.list Prims.list * term)
+| Refine of (binder * term)
+| NamedTyp of (FStar_Ident.ident * term)
+| Paren of term
+| Requires of (term * Prims.string Prims.option)
+| Ensures of (term * Prims.string Prims.option)
+| Labeled of (term * Prims.string * Prims.bool)
+| Assign of (FStar_Ident.ident * term)
+| Discrim of FStar_Ident.lid
+| Attributes of term Prims.list 
+ and term =
+{tm : term'; range : FStar_Range.range; level : level} 
+ and binder' =
+| Variable of FStar_Ident.ident
+| TVariable of FStar_Ident.ident
+| Annotated of (FStar_Ident.ident * term)
+| TAnnotated of (FStar_Ident.ident * term)
+| NoName of term 
+ and binder =
+{b : binder'; brange : FStar_Range.range; blevel : level; aqual : aqual} 
+ and pattern' =
+| PatWild
+| PatConst of FStar_Const.sconst
+| PatApp of (pattern * pattern Prims.list)
+| PatVar of (FStar_Ident.ident * arg_qualifier Prims.option)
+| PatName of FStar_Ident.lid
+| PatTvar of (FStar_Ident.ident * arg_qualifier Prims.option)
+| PatList of pattern Prims.list
+| PatTuple of (pattern Prims.list * Prims.bool)
+| PatRecord of (FStar_Ident.lid * pattern) Prims.list
+| PatAscribed of (pattern * term)
+| PatOr of pattern Prims.list
+| PatOp of Prims.string 
+ and pattern =
+{pat : pattern'; prange : FStar_Range.range}
+
+
+let uu___is_Wild : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Wild -> begin
+true
+end
+| uu____380 -> begin
+false
+end))
+
+
+let uu___is_Const : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Const (_0) -> begin
+true
+end
+| uu____385 -> begin
+false
+end))
+
+
+let __proj__Const__item___0 : term'  ->  FStar_Const.sconst = (fun projectee -> (match (projectee) with
+| Const (_0) -> begin
+_0
+end))
+
+
+let uu___is_Op : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Op (_0) -> begin
+true
+end
+| uu____400 -> begin
+false
+end))
+
+
+let __proj__Op__item___0 : term'  ->  (Prims.string * term Prims.list) = (fun projectee -> (match (projectee) with
+| Op (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tvar : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tvar (_0) -> begin
+true
+end
+| uu____421 -> begin
+false
+end))
+
+
+let __proj__Tvar__item___0 : term'  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| Tvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_Uvar : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Uvar (_0) -> begin
+true
+end
+| uu____433 -> begin
+false
+end))
+
+
+let __proj__Uvar__item___0 : term'  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| Uvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_Var : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Var (_0) -> begin
+true
+end
+| uu____445 -> begin
+false
+end))
+
+
+let __proj__Var__item___0 : term'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Var (_0) -> begin
+_0
+end))
+
+
+let uu___is_Name : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Name (_0) -> begin
+true
+end
+| uu____457 -> begin
+false
+end))
+
+
+let __proj__Name__item___0 : term'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Name (_0) -> begin
+_0
+end))
+
+
+let uu___is_Projector : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Projector (_0) -> begin
+true
+end
+| uu____471 -> begin
+false
+end))
+
+
+let __proj__Projector__item___0 : term'  ->  (FStar_Ident.lid * FStar_Ident.ident) = (fun projectee -> (match (projectee) with
+| Projector (_0) -> begin
+_0
+end))
+
+
+let uu___is_Construct : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Construct (_0) -> begin
+true
+end
+| uu____494 -> begin
+false
+end))
+
+
+let __proj__Construct__item___0 : term'  ->  (FStar_Ident.lid * (term * imp) Prims.list) = (fun projectee -> (match (projectee) with
+| Construct (_0) -> begin
+_0
+end))
+
+
+let uu___is_Abs : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Abs (_0) -> begin
+true
+end
+| uu____524 -> begin
+false
+end))
+
+
+let __proj__Abs__item___0 : term'  ->  (pattern Prims.list * term) = (fun projectee -> (match (projectee) with
+| Abs (_0) -> begin
+_0
+end))
+
+
+let uu___is_App : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+true
+end
+| uu____548 -> begin
+false
+end))
+
+
+let __proj__App__item___0 : term'  ->  (term * term * imp) = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+_0
+end))
+
+
+let uu___is_Let : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+true
+end
+| uu____575 -> begin
+false
+end))
+
+
+let __proj__Let__item___0 : term'  ->  (let_qualifier * (pattern * term) Prims.list * term) = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+_0
+end))
+
+
+let uu___is_LetOpen : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LetOpen (_0) -> begin
+true
+end
+| uu____607 -> begin
+false
+end))
+
+
+let __proj__LetOpen__item___0 : term'  ->  (FStar_Ident.lid * term) = (fun projectee -> (match (projectee) with
+| LetOpen (_0) -> begin
+_0
+end))
+
+
+let uu___is_Seq : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Seq (_0) -> begin
+true
+end
+| uu____627 -> begin
+false
+end))
+
+
+let __proj__Seq__item___0 : term'  ->  (term * term) = (fun projectee -> (match (projectee) with
+| Seq (_0) -> begin
+_0
+end))
+
+
+let uu___is_If : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| If (_0) -> begin
+true
+end
+| uu____648 -> begin
+false
+end))
+
+
+let __proj__If__item___0 : term'  ->  (term * term * term) = (fun projectee -> (match (projectee) with
+| If (_0) -> begin
+_0
+end))
+
+
+let uu___is_Match : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Match (_0) -> begin
+true
+end
+| uu____676 -> begin
+false
+end))
+
+
+let __proj__Match__item___0 : term'  ->  (term * (pattern * term Prims.option * term) Prims.list) = (fun projectee -> (match (projectee) with
+| Match (_0) -> begin
+_0
+end))
+
+
+let uu___is_TryWith : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TryWith (_0) -> begin
+true
+end
+| uu____716 -> begin
+false
+end))
+
+
+let __proj__TryWith__item___0 : term'  ->  (term * (pattern * term Prims.option * term) Prims.list) = (fun projectee -> (match (projectee) with
+| TryWith (_0) -> begin
+_0
+end))
+
+
+let uu___is_Ascribed : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Ascribed (_0) -> begin
+true
+end
+| uu____753 -> begin
+false
+end))
+
+
+let __proj__Ascribed__item___0 : term'  ->  (term * term * term Prims.option) = (fun projectee -> (match (projectee) with
+| Ascribed (_0) -> begin
+_0
+end))
+
+
+let uu___is_Record : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Record (_0) -> begin
+true
+end
+| uu____783 -> begin
+false
+end))
+
+
+let __proj__Record__item___0 : term'  ->  (term Prims.option * (FStar_Ident.lid * term) Prims.list) = (fun projectee -> (match (projectee) with
+| Record (_0) -> begin
+_0
+end))
+
+
+let uu___is_Project : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Project (_0) -> begin
+true
+end
+| uu____815 -> begin
+false
+end))
+
+
+let __proj__Project__item___0 : term'  ->  (term * FStar_Ident.lid) = (fun projectee -> (match (projectee) with
+| Project (_0) -> begin
+_0
+end))
+
+
+let uu___is_Product : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Product (_0) -> begin
+true
+end
+| uu____836 -> begin
+false
+end))
+
+
+let __proj__Product__item___0 : term'  ->  (binder Prims.list * term) = (fun projectee -> (match (projectee) with
+| Product (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sum : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sum (_0) -> begin
+true
+end
+| uu____860 -> begin
+false
+end))
+
+
+let __proj__Sum__item___0 : term'  ->  (binder Prims.list * term) = (fun projectee -> (match (projectee) with
+| Sum (_0) -> begin
+_0
+end))
+
+
+let uu___is_QForall : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| QForall (_0) -> begin
+true
+end
+| uu____887 -> begin
+false
+end))
+
+
+let __proj__QForall__item___0 : term'  ->  (binder Prims.list * term Prims.list Prims.list * term) = (fun projectee -> (match (projectee) with
+| QForall (_0) -> begin
+_0
+end))
+
+
+let uu___is_QExists : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| QExists (_0) -> begin
+true
+end
+| uu____923 -> begin
+false
+end))
+
+
+let __proj__QExists__item___0 : term'  ->  (binder Prims.list * term Prims.list Prims.list * term) = (fun projectee -> (match (projectee) with
+| QExists (_0) -> begin
+_0
+end))
+
+
+let uu___is_Refine : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Refine (_0) -> begin
+true
+end
+| uu____955 -> begin
+false
+end))
+
+
+let __proj__Refine__item___0 : term'  ->  (binder * term) = (fun projectee -> (match (projectee) with
+| Refine (_0) -> begin
+_0
+end))
+
+
+let uu___is_NamedTyp : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NamedTyp (_0) -> begin
+true
+end
+| uu____975 -> begin
+false
+end))
+
+
+let __proj__NamedTyp__item___0 : term'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| NamedTyp (_0) -> begin
+_0
+end))
+
+
+let uu___is_Paren : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Paren (_0) -> begin
+true
+end
+| uu____993 -> begin
+false
+end))
+
+
+let __proj__Paren__item___0 : term'  ->  term = (fun projectee -> (match (projectee) with
+| Paren (_0) -> begin
+_0
+end))
+
+
+let uu___is_Requires : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Requires (_0) -> begin
+true
+end
+| uu____1008 -> begin
+false
+end))
+
+
+let __proj__Requires__item___0 : term'  ->  (term * Prims.string Prims.option) = (fun projectee -> (match (projectee) with
+| Requires (_0) -> begin
+_0
+end))
+
+
+let uu___is_Ensures : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Ensures (_0) -> begin
+true
+end
+| uu____1032 -> begin
+false
+end))
+
+
+let __proj__Ensures__item___0 : term'  ->  (term * Prims.string Prims.option) = (fun projectee -> (match (projectee) with
+| Ensures (_0) -> begin
+_0
+end))
+
+
+let uu___is_Labeled : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Labeled (_0) -> begin
+true
+end
+| uu____1056 -> begin
+false
+end))
+
+
+let __proj__Labeled__item___0 : term'  ->  (term * Prims.string * Prims.bool) = (fun projectee -> (match (projectee) with
+| Labeled (_0) -> begin
+_0
+end))
+
+
+let uu___is_Assign : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assign (_0) -> begin
+true
+end
+| uu____1079 -> begin
+false
+end))
+
+
+let __proj__Assign__item___0 : term'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| Assign (_0) -> begin
+_0
+end))
+
+
+let uu___is_Discrim : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Discrim (_0) -> begin
+true
+end
+| uu____1097 -> begin
+false
+end))
+
+
+let __proj__Discrim__item___0 : term'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Discrim (_0) -> begin
+_0
+end))
+
+
+let uu___is_Attributes : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Attributes (_0) -> begin
+true
+end
+| uu____1110 -> begin
+false
+end))
+
+
+let __proj__Attributes__item___0 : term'  ->  term Prims.list = (fun projectee -> (match (projectee) with
+| Attributes (_0) -> begin
+_0
+end))
+
+
+let uu___is_Variable : binder'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Variable (_0) -> begin
+true
+end
+| uu____1137 -> begin
+false
+end))
+
+
+let __proj__Variable__item___0 : binder'  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| Variable (_0) -> begin
+_0
+end))
+
+
+let uu___is_TVariable : binder'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TVariable (_0) -> begin
+true
+end
+| uu____1149 -> begin
+false
+end))
+
+
+let __proj__TVariable__item___0 : binder'  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| TVariable (_0) -> begin
+_0
+end))
+
+
+let uu___is_Annotated : binder'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Annotated (_0) -> begin
+true
+end
+| uu____1163 -> begin
+false
+end))
+
+
+let __proj__Annotated__item___0 : binder'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| Annotated (_0) -> begin
+_0
+end))
+
+
+let uu___is_TAnnotated : binder'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TAnnotated (_0) -> begin
+true
+end
+| uu____1183 -> begin
+false
+end))
+
+
+let __proj__TAnnotated__item___0 : binder'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| TAnnotated (_0) -> begin
+_0
+end))
+
+
+let uu___is_NoName : binder'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoName (_0) -> begin
+true
+end
+| uu____1201 -> begin
+false
+end))
+
+
+let __proj__NoName__item___0 : binder'  ->  term = (fun projectee -> (match (projectee) with
+| NoName (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatWild : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatWild -> begin
+true
+end
+| uu____1228 -> begin
+false
+end))
+
+
+let uu___is_PatConst : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatConst (_0) -> begin
+true
+end
+| uu____1233 -> begin
+false
+end))
+
+
+let __proj__PatConst__item___0 : pattern'  ->  FStar_Const.sconst = (fun projectee -> (match (projectee) with
+| PatConst (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatApp : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatApp (_0) -> begin
+true
+end
+| uu____1248 -> begin
+false
+end))
+
+
+let __proj__PatApp__item___0 : pattern'  ->  (pattern * pattern Prims.list) = (fun projectee -> (match (projectee) with
+| PatApp (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatVar : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatVar (_0) -> begin
+true
+end
+| uu____1272 -> begin
+false
+end))
+
+
+let __proj__PatVar__item___0 : pattern'  ->  (FStar_Ident.ident * arg_qualifier Prims.option) = (fun projectee -> (match (projectee) with
+| PatVar (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatName : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatName (_0) -> begin
+true
+end
+| uu____1293 -> begin
+false
+end))
+
+
+let __proj__PatName__item___0 : pattern'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| PatName (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatTvar : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatTvar (_0) -> begin
+true
+end
+| uu____1308 -> begin
+false
+end))
+
+
+let __proj__PatTvar__item___0 : pattern'  ->  (FStar_Ident.ident * arg_qualifier Prims.option) = (fun projectee -> (match (projectee) with
+| PatTvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatList : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatList (_0) -> begin
+true
+end
+| uu____1330 -> begin
+false
+end))
+
+
+let __proj__PatList__item___0 : pattern'  ->  pattern Prims.list = (fun projectee -> (match (projectee) with
+| PatList (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatTuple : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatTuple (_0) -> begin
+true
+end
+| uu____1348 -> begin
+false
+end))
+
+
+let __proj__PatTuple__item___0 : pattern'  ->  (pattern Prims.list * Prims.bool) = (fun projectee -> (match (projectee) with
+| PatTuple (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatRecord : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatRecord (_0) -> begin
+true
+end
+| uu____1372 -> begin
+false
+end))
+
+
+let __proj__PatRecord__item___0 : pattern'  ->  (FStar_Ident.lid * pattern) Prims.list = (fun projectee -> (match (projectee) with
+| PatRecord (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatAscribed : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatAscribed (_0) -> begin
+true
+end
+| uu____1395 -> begin
+false
+end))
+
+
+let __proj__PatAscribed__item___0 : pattern'  ->  (pattern * term) = (fun projectee -> (match (projectee) with
+| PatAscribed (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatOr : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatOr (_0) -> begin
+true
+end
+| uu____1414 -> begin
+false
+end))
+
+
+let __proj__PatOr__item___0 : pattern'  ->  pattern Prims.list = (fun projectee -> (match (projectee) with
+| PatOr (_0) -> begin
+_0
+end))
+
+
+let uu___is_PatOp : pattern'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PatOp (_0) -> begin
+true
+end
+| uu____1429 -> begin
+false
+end))
+
+
+let __proj__PatOp__item___0 : pattern'  ->  Prims.string = (fun projectee -> (match (projectee) with
+| PatOp (_0) -> begin
+_0
+end))
+
+
+type branch =
+(pattern * term Prims.option * term)
+
+
+type knd =
+term
+
+
+type typ =
+term
+
+
+type expr =
+term
+
 type tycon =
-  | TyconAbstract of (FStar_Ident.ident* binder Prims.list* knd
-  Prims.option)
-  | TyconAbbrev of (FStar_Ident.ident* binder Prims.list* knd Prims.option*
-  term)
-  | TyconRecord of (FStar_Ident.ident* binder Prims.list* knd Prims.option*
-  (FStar_Ident.ident* term* fsdoc Prims.option) Prims.list)
-  | TyconVariant of (FStar_Ident.ident* binder Prims.list* knd Prims.option*
-  (FStar_Ident.ident* term Prims.option* fsdoc Prims.option* Prims.bool)
-  Prims.list)
-let uu___is_TyconAbstract: tycon -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TyconAbstract _0 -> true | uu____1510 -> false
-let __proj__TyconAbstract__item___0:
-  tycon -> (FStar_Ident.ident* binder Prims.list* knd Prims.option) =
-  fun projectee  -> match projectee with | TyconAbstract _0 -> _0
-let uu___is_TyconAbbrev: tycon -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TyconAbbrev _0 -> true | uu____1543 -> false
-let __proj__TyconAbbrev__item___0:
-  tycon -> (FStar_Ident.ident* binder Prims.list* knd Prims.option* term) =
-  fun projectee  -> match projectee with | TyconAbbrev _0 -> _0
-let uu___is_TyconRecord: tycon -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TyconRecord _0 -> true | uu____1584 -> false
-let __proj__TyconRecord__item___0:
-  tycon ->
-    (FStar_Ident.ident* binder Prims.list* knd Prims.option*
-      (FStar_Ident.ident* term* fsdoc Prims.option) Prims.list)
-  = fun projectee  -> match projectee with | TyconRecord _0 -> _0
-let uu___is_TyconVariant: tycon -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TyconVariant _0 -> true | uu____1642 -> false
-let __proj__TyconVariant__item___0:
-  tycon ->
-    (FStar_Ident.ident* binder Prims.list* knd Prims.option*
-      (FStar_Ident.ident* term Prims.option* fsdoc Prims.option* Prims.bool)
-      Prims.list)
-  = fun projectee  -> match projectee with | TyconVariant _0 -> _0
+| TyconAbstract of (FStar_Ident.ident * binder Prims.list * knd Prims.option)
+| TyconAbbrev of (FStar_Ident.ident * binder Prims.list * knd Prims.option * term)
+| TyconRecord of (FStar_Ident.ident * binder Prims.list * knd Prims.option * (FStar_Ident.ident * term * FStar_Syntax_Syntax.fsdoc Prims.option) Prims.list)
+| TyconVariant of (FStar_Ident.ident * binder Prims.list * knd Prims.option * (FStar_Ident.ident * term Prims.option * FStar_Syntax_Syntax.fsdoc Prims.option * Prims.bool) Prims.list)
+
+
+let uu___is_TyconAbstract : tycon  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TyconAbstract (_0) -> begin
+true
+end
+| uu____1505 -> begin
+false
+end))
+
+
+let __proj__TyconAbstract__item___0 : tycon  ->  (FStar_Ident.ident * binder Prims.list * knd Prims.option) = (fun projectee -> (match (projectee) with
+| TyconAbstract (_0) -> begin
+_0
+end))
+
+
+let uu___is_TyconAbbrev : tycon  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TyconAbbrev (_0) -> begin
+true
+end
+| uu____1538 -> begin
+false
+end))
+
+
+let __proj__TyconAbbrev__item___0 : tycon  ->  (FStar_Ident.ident * binder Prims.list * knd Prims.option * term) = (fun projectee -> (match (projectee) with
+| TyconAbbrev (_0) -> begin
+_0
+end))
+
+
+let uu___is_TyconRecord : tycon  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TyconRecord (_0) -> begin
+true
+end
+| uu____1579 -> begin
+false
+end))
+
+
+let __proj__TyconRecord__item___0 : tycon  ->  (FStar_Ident.ident * binder Prims.list * knd Prims.option * (FStar_Ident.ident * term * FStar_Syntax_Syntax.fsdoc Prims.option) Prims.list) = (fun projectee -> (match (projectee) with
+| TyconRecord (_0) -> begin
+_0
+end))
+
+
+let uu___is_TyconVariant : tycon  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TyconVariant (_0) -> begin
+true
+end
+| uu____1637 -> begin
+false
+end))
+
+
+let __proj__TyconVariant__item___0 : tycon  ->  (FStar_Ident.ident * binder Prims.list * knd Prims.option * (FStar_Ident.ident * term Prims.option * FStar_Syntax_Syntax.fsdoc Prims.option * Prims.bool) Prims.list) = (fun projectee -> (match (projectee) with
+| TyconVariant (_0) -> begin
+_0
+end))
+
 type qualifier =
-  | Private
-  | Abstract
-  | Noeq
-  | Unopteq
-  | Assumption
-  | DefaultEffect
-  | TotalEffect
-  | Effect_qual
-  | New
-  | Inline
-  | Visible
-  | Unfold_for_unification_and_vcgen
-  | Inline_for_extraction
-  | Irreducible
-  | NoExtract
-  | Reifiable
-  | Reflectable
-  | Opaque
-  | Logic
-let uu___is_Private: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Private  -> true | uu____1692 -> false
-let uu___is_Abstract: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Abstract  -> true | uu____1696 -> false
-let uu___is_Noeq: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Noeq  -> true | uu____1700 -> false
-let uu___is_Unopteq: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unopteq  -> true | uu____1704 -> false
-let uu___is_Assumption: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assumption  -> true | uu____1708 -> false
-let uu___is_DefaultEffect: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DefaultEffect  -> true | uu____1712 -> false
-let uu___is_TotalEffect: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TotalEffect  -> true | uu____1716 -> false
-let uu___is_Effect_qual: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Effect_qual  -> true | uu____1720 -> false
-let uu___is_New: qualifier -> Prims.bool =
-  fun projectee  -> match projectee with | New  -> true | uu____1724 -> false
-let uu___is_Inline: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Inline  -> true | uu____1728 -> false
-let uu___is_Visible: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Visible  -> true | uu____1732 -> false
-let uu___is_Unfold_for_unification_and_vcgen: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Unfold_for_unification_and_vcgen  -> true
-    | uu____1736 -> false
-let uu___is_Inline_for_extraction: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Inline_for_extraction  -> true
-    | uu____1740 -> false
-let uu___is_Irreducible: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Irreducible  -> true | uu____1744 -> false
-let uu___is_NoExtract: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____1748 -> false
-let uu___is_Reifiable: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Reifiable  -> true | uu____1752 -> false
-let uu___is_Reflectable: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Reflectable  -> true | uu____1756 -> false
-let uu___is_Opaque: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Opaque  -> true | uu____1760 -> false
-let uu___is_Logic: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Logic  -> true | uu____1764 -> false
-type qualifiers = qualifier Prims.list
-type attributes_ = term Prims.list
+| Private
+| Abstract
+| Noeq
+| Unopteq
+| Assumption
+| DefaultEffect
+| TotalEffect
+| Effect_qual
+| New
+| Inline
+| Visible
+| Unfold_for_unification_and_vcgen
+| Inline_for_extraction
+| Irreducible
+| NoExtract
+| Reifiable
+| Reflectable
+| Opaque
+| Logic
+
+
+let uu___is_Private : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Private -> begin
+true
+end
+| uu____1687 -> begin
+false
+end))
+
+
+let uu___is_Abstract : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Abstract -> begin
+true
+end
+| uu____1691 -> begin
+false
+end))
+
+
+let uu___is_Noeq : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Noeq -> begin
+true
+end
+| uu____1695 -> begin
+false
+end))
+
+
+let uu___is_Unopteq : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unopteq -> begin
+true
+end
+| uu____1699 -> begin
+false
+end))
+
+
+let uu___is_Assumption : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assumption -> begin
+true
+end
+| uu____1703 -> begin
+false
+end))
+
+
+let uu___is_DefaultEffect : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DefaultEffect -> begin
+true
+end
+| uu____1707 -> begin
+false
+end))
+
+
+let uu___is_TotalEffect : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TotalEffect -> begin
+true
+end
+| uu____1711 -> begin
+false
+end))
+
+
+let uu___is_Effect_qual : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Effect_qual -> begin
+true
+end
+| uu____1715 -> begin
+false
+end))
+
+
+let uu___is_New : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| New -> begin
+true
+end
+| uu____1719 -> begin
+false
+end))
+
+
+let uu___is_Inline : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Inline -> begin
+true
+end
+| uu____1723 -> begin
+false
+end))
+
+
+let uu___is_Visible : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Visible -> begin
+true
+end
+| uu____1727 -> begin
+false
+end))
+
+
+let uu___is_Unfold_for_unification_and_vcgen : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unfold_for_unification_and_vcgen -> begin
+true
+end
+| uu____1731 -> begin
+false
+end))
+
+
+let uu___is_Inline_for_extraction : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Inline_for_extraction -> begin
+true
+end
+| uu____1735 -> begin
+false
+end))
+
+
+let uu___is_Irreducible : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Irreducible -> begin
+true
+end
+| uu____1739 -> begin
+false
+end))
+
+
+let uu___is_NoExtract : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoExtract -> begin
+true
+end
+| uu____1743 -> begin
+false
+end))
+
+
+let uu___is_Reifiable : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reifiable -> begin
+true
+end
+| uu____1747 -> begin
+false
+end))
+
+
+let uu___is_Reflectable : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reflectable -> begin
+true
+end
+| uu____1751 -> begin
+false
+end))
+
+
+let uu___is_Opaque : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Opaque -> begin
+true
+end
+| uu____1755 -> begin
+false
+end))
+
+
+let uu___is_Logic : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Logic -> begin
+true
+end
+| uu____1759 -> begin
+false
+end))
+
+
+type qualifiers =
+qualifier Prims.list
+
+
+type attributes_ =
+term Prims.list
+
 type decoration =
-  | Qualifier of qualifier
-  | DeclAttributes of term Prims.list
-  | Doc of fsdoc
-let uu___is_Qualifier: decoration -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Qualifier _0 -> true | uu____1781 -> false
-let __proj__Qualifier__item___0: decoration -> qualifier =
-  fun projectee  -> match projectee with | Qualifier _0 -> _0
-let uu___is_DeclAttributes: decoration -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DeclAttributes _0 -> true | uu____1794 -> false
-let __proj__DeclAttributes__item___0: decoration -> term Prims.list =
-  fun projectee  -> match projectee with | DeclAttributes _0 -> _0
-let uu___is_Doc: decoration -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Doc _0 -> true | uu____1809 -> false
-let __proj__Doc__item___0: decoration -> fsdoc =
-  fun projectee  -> match projectee with | Doc _0 -> _0
+| Qualifier of qualifier
+| DeclAttributes of term Prims.list
+| Doc of FStar_Syntax_Syntax.fsdoc
+
+
+let uu___is_Qualifier : decoration  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Qualifier (_0) -> begin
+true
+end
+| uu____1776 -> begin
+false
+end))
+
+
+let __proj__Qualifier__item___0 : decoration  ->  qualifier = (fun projectee -> (match (projectee) with
+| Qualifier (_0) -> begin
+_0
+end))
+
+
+let uu___is_DeclAttributes : decoration  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DeclAttributes (_0) -> begin
+true
+end
+| uu____1789 -> begin
+false
+end))
+
+
+let __proj__DeclAttributes__item___0 : decoration  ->  term Prims.list = (fun projectee -> (match (projectee) with
+| DeclAttributes (_0) -> begin
+_0
+end))
+
+
+let uu___is_Doc : decoration  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Doc (_0) -> begin
+true
+end
+| uu____1804 -> begin
+false
+end))
+
+
+let __proj__Doc__item___0 : decoration  ->  FStar_Syntax_Syntax.fsdoc = (fun projectee -> (match (projectee) with
+| Doc (_0) -> begin
+_0
+end))
+
 type lift_op =
-  | NonReifiableLift of term
-  | ReifiableLift of (term* term)
-  | LiftForFree of term
-let uu___is_NonReifiableLift: lift_op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NonReifiableLift _0 -> true | uu____1832 -> false
-let __proj__NonReifiableLift__item___0: lift_op -> term =
-  fun projectee  -> match projectee with | NonReifiableLift _0 -> _0
-let uu___is_ReifiableLift: lift_op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ReifiableLift _0 -> true | uu____1846 -> false
-let __proj__ReifiableLift__item___0: lift_op -> (term* term) =
-  fun projectee  -> match projectee with | ReifiableLift _0 -> _0
-let uu___is_LiftForFree: lift_op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LiftForFree _0 -> true | uu____1864 -> false
-let __proj__LiftForFree__item___0: lift_op -> term =
-  fun projectee  -> match projectee with | LiftForFree _0 -> _0
+| NonReifiableLift of term
+| ReifiableLift of (term * term)
+| LiftForFree of term
+
+
+let uu___is_NonReifiableLift : lift_op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NonReifiableLift (_0) -> begin
+true
+end
+| uu____1827 -> begin
+false
+end))
+
+
+let __proj__NonReifiableLift__item___0 : lift_op  ->  term = (fun projectee -> (match (projectee) with
+| NonReifiableLift (_0) -> begin
+_0
+end))
+
+
+let uu___is_ReifiableLift : lift_op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ReifiableLift (_0) -> begin
+true
+end
+| uu____1841 -> begin
+false
+end))
+
+
+let __proj__ReifiableLift__item___0 : lift_op  ->  (term * term) = (fun projectee -> (match (projectee) with
+| ReifiableLift (_0) -> begin
+_0
+end))
+
+
+let uu___is_LiftForFree : lift_op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LiftForFree (_0) -> begin
+true
+end
+| uu____1859 -> begin
+false
+end))
+
+
+let __proj__LiftForFree__item___0 : lift_op  ->  term = (fun projectee -> (match (projectee) with
+| LiftForFree (_0) -> begin
+_0
+end))
+
 type lift =
-  {
-  msource: FStar_Ident.lid;
-  mdest: FStar_Ident.lid;
-  lift_op: lift_op;}
+{msource : FStar_Ident.lid; mdest : FStar_Ident.lid; lift_op : lift_op}
+
 type pragma =
-  | SetOptions of Prims.string
-  | ResetOptions of Prims.string Prims.option
-  | LightOff
-let uu___is_SetOptions: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SetOptions _0 -> true | uu____1904 -> false
-let __proj__SetOptions__item___0: pragma -> Prims.string =
-  fun projectee  -> match projectee with | SetOptions _0 -> _0
-let uu___is_ResetOptions: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ResetOptions _0 -> true | uu____1917 -> false
-let __proj__ResetOptions__item___0: pragma -> Prims.string Prims.option =
-  fun projectee  -> match projectee with | ResetOptions _0 -> _0
-let uu___is_LightOff: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LightOff  -> true | uu____1931 -> false
+| SetOptions of Prims.string
+| ResetOptions of Prims.string Prims.option
+| LightOff
+
+
+let uu___is_SetOptions : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SetOptions (_0) -> begin
+true
+end
+| uu____1899 -> begin
+false
+end))
+
+
+let __proj__SetOptions__item___0 : pragma  ->  Prims.string = (fun projectee -> (match (projectee) with
+| SetOptions (_0) -> begin
+_0
+end))
+
+
+let uu___is_ResetOptions : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ResetOptions (_0) -> begin
+true
+end
+| uu____1912 -> begin
+false
+end))
+
+
+let __proj__ResetOptions__item___0 : pragma  ->  Prims.string Prims.option = (fun projectee -> (match (projectee) with
+| ResetOptions (_0) -> begin
+_0
+end))
+
+
+let uu___is_LightOff : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LightOff -> begin
+true
+end
+| uu____1926 -> begin
+false
+end))
+
 type decl' =
-  | TopLevelModule of FStar_Ident.lid
-  | Open of FStar_Ident.lid
-  | Include of FStar_Ident.lid
-  | ModuleAbbrev of (FStar_Ident.ident* FStar_Ident.lid)
-  | TopLevelLet of (let_qualifier* (pattern* term) Prims.list)
-  | Main of term
-  | Tycon of (Prims.bool* (tycon* fsdoc Prims.option) Prims.list)
-  | Val of (FStar_Ident.ident* term)
-  | Exception of (FStar_Ident.ident* term Prims.option)
-  | NewEffect of effect_decl
-  | SubEffect of lift
-  | Pragma of pragma
-  | Fsdoc of fsdoc
-  | Assume of (FStar_Ident.ident* term)
-and decl =
-  {
-  d: decl';
-  drange: FStar_Range.range;
-  doc: fsdoc Prims.option;
-  quals: qualifiers;
-  attrs: attributes_;}
-and effect_decl =
-  | DefineEffect of (FStar_Ident.ident* binder Prims.list* term* decl
-  Prims.list)
-  | RedefineEffect of (FStar_Ident.ident* binder Prims.list* term)
-let uu___is_TopLevelModule: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TopLevelModule _0 -> true | uu____2030 -> false
-let __proj__TopLevelModule__item___0: decl' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | TopLevelModule _0 -> _0
-let uu___is_Open: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Open _0 -> true | uu____2042 -> false
-let __proj__Open__item___0: decl' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Open _0 -> _0
-let uu___is_Include: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Include _0 -> true | uu____2054 -> false
-let __proj__Include__item___0: decl' -> FStar_Ident.lid =
-  fun projectee  -> match projectee with | Include _0 -> _0
-let uu___is_ModuleAbbrev: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ModuleAbbrev _0 -> true | uu____2068 -> false
-let __proj__ModuleAbbrev__item___0:
-  decl' -> (FStar_Ident.ident* FStar_Ident.lid) =
-  fun projectee  -> match projectee with | ModuleAbbrev _0 -> _0
-let uu___is_TopLevelLet: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TopLevelLet _0 -> true | uu____2091 -> false
-let __proj__TopLevelLet__item___0:
-  decl' -> (let_qualifier* (pattern* term) Prims.list) =
-  fun projectee  -> match projectee with | TopLevelLet _0 -> _0
-let uu___is_Main: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Main _0 -> true | uu____2118 -> false
-let __proj__Main__item___0: decl' -> term =
-  fun projectee  -> match projectee with | Main _0 -> _0
-let uu___is_Tycon: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tycon _0 -> true | uu____2136 -> false
-let __proj__Tycon__item___0:
-  decl' -> (Prims.bool* (tycon* fsdoc Prims.option) Prims.list) =
-  fun projectee  -> match projectee with | Tycon _0 -> _0
-let uu___is_Val: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Val _0 -> true | uu____2168 -> false
-let __proj__Val__item___0: decl' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | Val _0 -> _0
-let uu___is_Exception: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Exception _0 -> true | uu____2189 -> false
-let __proj__Exception__item___0:
-  decl' -> (FStar_Ident.ident* term Prims.option) =
-  fun projectee  -> match projectee with | Exception _0 -> _0
-let uu___is_NewEffect: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NewEffect _0 -> true | uu____2210 -> false
-let __proj__NewEffect__item___0: decl' -> effect_decl =
-  fun projectee  -> match projectee with | NewEffect _0 -> _0
-let uu___is_SubEffect: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SubEffect _0 -> true | uu____2222 -> false
-let __proj__SubEffect__item___0: decl' -> lift =
-  fun projectee  -> match projectee with | SubEffect _0 -> _0
-let uu___is_Pragma: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pragma _0 -> true | uu____2234 -> false
-let __proj__Pragma__item___0: decl' -> pragma =
-  fun projectee  -> match projectee with | Pragma _0 -> _0
-let uu___is_Fsdoc: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Fsdoc _0 -> true | uu____2246 -> false
-let __proj__Fsdoc__item___0: decl' -> fsdoc =
-  fun projectee  -> match projectee with | Fsdoc _0 -> _0
-let uu___is_Assume: decl' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assume _0 -> true | uu____2260 -> false
-let __proj__Assume__item___0: decl' -> (FStar_Ident.ident* term) =
-  fun projectee  -> match projectee with | Assume _0 -> _0
-let uu___is_DefineEffect: effect_decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DefineEffect _0 -> true | uu____2306 -> false
-let __proj__DefineEffect__item___0:
-  effect_decl ->
-    (FStar_Ident.ident* binder Prims.list* term* decl Prims.list)
-  = fun projectee  -> match projectee with | DefineEffect _0 -> _0
-let uu___is_RedefineEffect: effect_decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | RedefineEffect _0 -> true | uu____2340 -> false
-let __proj__RedefineEffect__item___0:
-  effect_decl -> (FStar_Ident.ident* binder Prims.list* term) =
-  fun projectee  -> match projectee with | RedefineEffect _0 -> _0
+| TopLevelModule of FStar_Ident.lid
+| Open of FStar_Ident.lid
+| Include of FStar_Ident.lid
+| ModuleAbbrev of (FStar_Ident.ident * FStar_Ident.lid)
+| TopLevelLet of (let_qualifier * (pattern * term) Prims.list)
+| Main of term
+| Tycon of (Prims.bool * (tycon * FStar_Syntax_Syntax.fsdoc Prims.option) Prims.list)
+| Val of (FStar_Ident.ident * term)
+| Exception of (FStar_Ident.ident * term Prims.option)
+| NewEffect of effect_decl
+| SubEffect of lift
+| Pragma of pragma
+| Fsdoc of FStar_Syntax_Syntax.fsdoc
+| Assume of (FStar_Ident.ident * term) 
+ and decl =
+{d : decl'; drange : FStar_Range.range; doc : FStar_Syntax_Syntax.fsdoc Prims.option; quals : qualifiers; attrs : attributes_} 
+ and effect_decl =
+| DefineEffect of (FStar_Ident.ident * binder Prims.list * term * decl Prims.list)
+| RedefineEffect of (FStar_Ident.ident * binder Prims.list * term)
+
+
+let uu___is_TopLevelModule : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TopLevelModule (_0) -> begin
+true
+end
+| uu____2025 -> begin
+false
+end))
+
+
+let __proj__TopLevelModule__item___0 : decl'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| TopLevelModule (_0) -> begin
+_0
+end))
+
+
+let uu___is_Open : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Open (_0) -> begin
+true
+end
+| uu____2037 -> begin
+false
+end))
+
+
+let __proj__Open__item___0 : decl'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Open (_0) -> begin
+_0
+end))
+
+
+let uu___is_Include : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Include (_0) -> begin
+true
+end
+| uu____2049 -> begin
+false
+end))
+
+
+let __proj__Include__item___0 : decl'  ->  FStar_Ident.lid = (fun projectee -> (match (projectee) with
+| Include (_0) -> begin
+_0
+end))
+
+
+let uu___is_ModuleAbbrev : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ModuleAbbrev (_0) -> begin
+true
+end
+| uu____2063 -> begin
+false
+end))
+
+
+let __proj__ModuleAbbrev__item___0 : decl'  ->  (FStar_Ident.ident * FStar_Ident.lid) = (fun projectee -> (match (projectee) with
+| ModuleAbbrev (_0) -> begin
+_0
+end))
+
+
+let uu___is_TopLevelLet : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TopLevelLet (_0) -> begin
+true
+end
+| uu____2086 -> begin
+false
+end))
+
+
+let __proj__TopLevelLet__item___0 : decl'  ->  (let_qualifier * (pattern * term) Prims.list) = (fun projectee -> (match (projectee) with
+| TopLevelLet (_0) -> begin
+_0
+end))
+
+
+let uu___is_Main : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Main (_0) -> begin
+true
+end
+| uu____2113 -> begin
+false
+end))
+
+
+let __proj__Main__item___0 : decl'  ->  term = (fun projectee -> (match (projectee) with
+| Main (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tycon : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tycon (_0) -> begin
+true
+end
+| uu____2131 -> begin
+false
+end))
+
+
+let __proj__Tycon__item___0 : decl'  ->  (Prims.bool * (tycon * FStar_Syntax_Syntax.fsdoc Prims.option) Prims.list) = (fun projectee -> (match (projectee) with
+| Tycon (_0) -> begin
+_0
+end))
+
+
+let uu___is_Val : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Val (_0) -> begin
+true
+end
+| uu____2163 -> begin
+false
+end))
+
+
+let __proj__Val__item___0 : decl'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| Val (_0) -> begin
+_0
+end))
+
+
+let uu___is_Exception : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exception (_0) -> begin
+true
+end
+| uu____2184 -> begin
+false
+end))
+
+
+let __proj__Exception__item___0 : decl'  ->  (FStar_Ident.ident * term Prims.option) = (fun projectee -> (match (projectee) with
+| Exception (_0) -> begin
+_0
+end))
+
+
+let uu___is_NewEffect : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NewEffect (_0) -> begin
+true
+end
+| uu____2205 -> begin
+false
+end))
+
+
+let __proj__NewEffect__item___0 : decl'  ->  effect_decl = (fun projectee -> (match (projectee) with
+| NewEffect (_0) -> begin
+_0
+end))
+
+
+let uu___is_SubEffect : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SubEffect (_0) -> begin
+true
+end
+| uu____2217 -> begin
+false
+end))
+
+
+let __proj__SubEffect__item___0 : decl'  ->  lift = (fun projectee -> (match (projectee) with
+| SubEffect (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pragma : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pragma (_0) -> begin
+true
+end
+| uu____2229 -> begin
+false
+end))
+
+
+let __proj__Pragma__item___0 : decl'  ->  pragma = (fun projectee -> (match (projectee) with
+| Pragma (_0) -> begin
+_0
+end))
+
+
+let uu___is_Fsdoc : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Fsdoc (_0) -> begin
+true
+end
+| uu____2241 -> begin
+false
+end))
+
+
+let __proj__Fsdoc__item___0 : decl'  ->  FStar_Syntax_Syntax.fsdoc = (fun projectee -> (match (projectee) with
+| Fsdoc (_0) -> begin
+_0
+end))
+
+
+let uu___is_Assume : decl'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assume (_0) -> begin
+true
+end
+| uu____2255 -> begin
+false
+end))
+
+
+let __proj__Assume__item___0 : decl'  ->  (FStar_Ident.ident * term) = (fun projectee -> (match (projectee) with
+| Assume (_0) -> begin
+_0
+end))
+
+
+let uu___is_DefineEffect : effect_decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DefineEffect (_0) -> begin
+true
+end
+| uu____2301 -> begin
+false
+end))
+
+
+let __proj__DefineEffect__item___0 : effect_decl  ->  (FStar_Ident.ident * binder Prims.list * term * decl Prims.list) = (fun projectee -> (match (projectee) with
+| DefineEffect (_0) -> begin
+_0
+end))
+
+
+let uu___is_RedefineEffect : effect_decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| RedefineEffect (_0) -> begin
+true
+end
+| uu____2335 -> begin
+false
+end))
+
+
+let __proj__RedefineEffect__item___0 : effect_decl  ->  (FStar_Ident.ident * binder Prims.list * term) = (fun projectee -> (match (projectee) with
+| RedefineEffect (_0) -> begin
+_0
+end))
+
 type modul =
-  | Module of (FStar_Ident.lid* decl Prims.list)
-  | Interface of (FStar_Ident.lid* decl Prims.list* Prims.bool)
-let uu___is_Module: modul -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Module _0 -> true | uu____2380 -> false
-let __proj__Module__item___0: modul -> (FStar_Ident.lid* decl Prims.list) =
-  fun projectee  -> match projectee with | Module _0 -> _0
-let uu___is_Interface: modul -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Interface _0 -> true | uu____2405 -> false
-let __proj__Interface__item___0:
-  modul -> (FStar_Ident.lid* decl Prims.list* Prims.bool) =
-  fun projectee  -> match projectee with | Interface _0 -> _0
-type file = modul Prims.list
-type inputFragment = (file,decl Prims.list) FStar_Util.either
-let check_id: FStar_Ident.ident -> Prims.unit =
-  fun id  ->
-    let first_char =
-      FStar_String.substring id.FStar_Ident.idText (Prims.parse_int "0")
-        (Prims.parse_int "1") in
-    if (FStar_String.lowercase first_char) = first_char
-    then ()
-    else
-      (let uu____2434 =
-         let uu____2435 =
-           let uu____2438 =
-             FStar_Util.format1
-               "Invalid identifer '%s'; expected a symbol that begins with a lower-case character"
-               id.FStar_Ident.idText in
-           (uu____2438, (id.FStar_Ident.idRange)) in
-         FStar_Errors.Error uu____2435 in
-       Prims.raise uu____2434)
-let at_most_one s r l =
-  match l with
-  | x::[] -> Some x
-  | [] -> None
-  | uu____2460 ->
-      let uu____2462 =
-        let uu____2463 =
-          let uu____2466 =
-            FStar_Util.format1 "At most one %s is allowed on declarations" s in
-          (uu____2466, r) in
-        FStar_Errors.Error uu____2463 in
-      Prims.raise uu____2462
-let mk_decl: decl' -> FStar_Range.range -> decoration Prims.list -> decl =
-  fun d  ->
-    fun r  ->
-      fun decorations  ->
-        let doc1 =
-          let uu____2481 =
-            FStar_List.choose
-              (fun uu___106_2483  ->
-                 match uu___106_2483 with
-                 | Doc d1 -> Some d1
-                 | uu____2486 -> None) decorations in
-          at_most_one "fsdoc" r uu____2481 in
-        let attributes_ =
-          let uu____2490 =
-            FStar_List.choose
-              (fun uu___107_2494  ->
-                 match uu___107_2494 with
-                 | DeclAttributes a -> Some a
-                 | uu____2500 -> None) decorations in
-          at_most_one "attribute set" r uu____2490 in
-        let attributes_1 = FStar_Util.dflt [] attributes_ in
-        let qualifiers =
-          FStar_List.choose
-            (fun uu___108_2508  ->
-               match uu___108_2508 with
-               | Qualifier q -> Some q
-               | uu____2511 -> None) decorations in
-        { d; drange = r; doc = doc1; quals = qualifiers; attrs = attributes_1
-        }
-let mk_binder: binder' -> FStar_Range.range -> level -> aqual -> binder =
-  fun b  ->
-    fun r  -> fun l  -> fun i  -> { b; brange = r; blevel = l; aqual = i }
-let mk_term: term' -> FStar_Range.range -> level -> term =
-  fun t  -> fun r  -> fun l  -> { tm = t; range = r; level = l }
-let mk_uminus: term -> FStar_Range.range -> level -> term =
-  fun t  ->
-    fun r  ->
-      fun l  ->
-        let t1 =
-          match t.tm with
-          | Const (FStar_Const.Const_int
-              (s,Some (FStar_Const.Signed ,width))) ->
-              Const
-                (FStar_Const.Const_int
-                   ((Prims.strcat "-" s), (Some (FStar_Const.Signed, width))))
-          | uu____2555 -> Op ("-", [t]) in
-        mk_term t1 r l
-let mk_pattern: pattern' -> FStar_Range.range -> pattern =
-  fun p  -> fun r  -> { pat = p; prange = r }
-let un_curry_abs: pattern Prims.list -> term -> term' =
-  fun ps  ->
-    fun body  ->
-      match body.tm with
-      | Abs (p',body') -> Abs ((FStar_List.append ps p'), body')
-      | uu____2576 -> Abs (ps, body)
-let mk_function:
-  (pattern* term Prims.option* term) Prims.list ->
-    FStar_Range.range -> FStar_Range.range -> term
-  =
-  fun branches  ->
-    fun r1  ->
-      fun r2  ->
-        let x = let i = FStar_Syntax_Syntax.next_id () in FStar_Ident.gen r1 in
-        let uu____2599 =
-          let uu____2600 =
-            let uu____2604 =
-              let uu____2605 =
-                let uu____2606 =
-                  let uu____2614 =
-                    let uu____2615 =
-                      let uu____2616 = FStar_Ident.lid_of_ids [x] in
-                      Var uu____2616 in
-                    mk_term uu____2615 r1 Expr in
-                  (uu____2614, branches) in
-                Match uu____2606 in
-              mk_term uu____2605 r2 Expr in
-            ([mk_pattern (PatVar (x, None)) r1], uu____2604) in
-          Abs uu____2600 in
-        mk_term uu____2599 r2 Expr
-let un_function: pattern -> term -> (pattern* term) Prims.option =
-  fun p  ->
-    fun tm  ->
-      match ((p.pat), (tm.tm)) with
-      | (PatVar uu____2636,Abs (pats,body)) ->
-          Some ((mk_pattern (PatApp (p, pats)) p.prange), body)
-      | uu____2647 -> None
-let lid_with_range:
-  FStar_Ident.lident -> FStar_Range.range -> FStar_Ident.lident =
-  fun lid  ->
-    fun r  ->
-      let uu____2658 = FStar_Ident.path_of_lid lid in
-      FStar_Ident.lid_of_path uu____2658 r
-let consPat: FStar_Range.range -> pattern -> pattern -> pattern' =
-  fun r  ->
-    fun hd1  ->
-      fun tl1  ->
-        PatApp
-          ((mk_pattern (PatName FStar_Syntax_Const.cons_lid) r), [hd1; tl1])
-let consTerm: FStar_Range.range -> term -> term -> term =
-  fun r  ->
-    fun hd1  ->
-      fun tl1  ->
-        mk_term
-          (Construct
-             (FStar_Syntax_Const.cons_lid, [(hd1, Nothing); (tl1, Nothing)]))
-          r Expr
-let lexConsTerm: FStar_Range.range -> term -> term -> term =
-  fun r  ->
-    fun hd1  ->
-      fun tl1  ->
-        mk_term
-          (Construct
-             (FStar_Syntax_Const.lexcons_lid,
-               [(hd1, Nothing); (tl1, Nothing)])) r Expr
-let mkConsList: FStar_Range.range -> term Prims.list -> term =
-  fun r  ->
-    fun elts  ->
-      let nil = mk_term (Construct (FStar_Syntax_Const.nil_lid, [])) r Expr in
-      FStar_List.fold_right (fun e  -> fun tl1  -> consTerm r e tl1) elts nil
-let mkLexList: FStar_Range.range -> term Prims.list -> term =
-  fun r  ->
-    fun elts  ->
-      let nil =
-        mk_term (Construct (FStar_Syntax_Const.lextop_lid, [])) r Expr in
-      FStar_List.fold_right (fun e  -> fun tl1  -> lexConsTerm r e tl1) elts
-        nil
-let ml_comp: term -> term =
-  fun t  ->
-    let ml = mk_term (Name FStar_Syntax_Const.effect_ML_lid) t.range Expr in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
-let tot_comp: term -> term =
-  fun t  ->
-    let ml = mk_term (Name FStar_Syntax_Const.effect_Tot_lid) t.range Expr in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
-let mkApp: term -> (term* imp) Prims.list -> FStar_Range.range -> term =
-  fun t  ->
-    fun args  ->
-      fun r  ->
-        match args with
-        | [] -> t
-        | uu____2765 ->
-            (match t.tm with
-             | Name s -> mk_term (Construct (s, args)) r Un
-             | uu____2773 ->
-                 FStar_List.fold_left
-                   (fun t1  ->
-                      fun uu____2777  ->
-                        match uu____2777 with
-                        | (a,imp) -> mk_term (App (t1, a, imp)) r Un) t args)
-let mkRefSet: FStar_Range.range -> term Prims.list -> term =
-  fun r  ->
-    fun elts  ->
-      let uu____2790 =
-        (FStar_Syntax_Const.tset_empty, FStar_Syntax_Const.tset_singleton,
-          FStar_Syntax_Const.tset_union) in
-      match uu____2790 with
-      | (empty_lid,singleton_lid,union_lid) ->
-          let empty1 =
-            mk_term (Var (FStar_Ident.set_lid_range empty_lid r)) r Expr in
-          let ref_constr =
-            mk_term
-              (Var (FStar_Ident.set_lid_range FStar_Syntax_Const.heap_ref r))
-              r Expr in
-          let singleton1 =
-            mk_term (Var (FStar_Ident.set_lid_range singleton_lid r)) r Expr in
-          let union1 =
-            mk_term (Var (FStar_Ident.set_lid_range union_lid r)) r Expr in
-          FStar_List.fold_right
-            (fun e  ->
-               fun tl1  ->
-                 let e1 = mkApp ref_constr [(e, Nothing)] r in
-                 let single_e = mkApp singleton1 [(e1, Nothing)] r in
-                 mkApp union1 [(single_e, Nothing); (tl1, Nothing)] r) elts
-            empty1
-let mkExplicitApp: term -> term Prims.list -> FStar_Range.range -> term =
-  fun t  ->
-    fun args  ->
-      fun r  ->
-        match args with
-        | [] -> t
-        | uu____2830 ->
-            (match t.tm with
-             | Name s ->
-                 let uu____2833 =
-                   let uu____2834 =
-                     let uu____2840 =
-                       FStar_List.map (fun a  -> (a, Nothing)) args in
-                     (s, uu____2840) in
-                   Construct uu____2834 in
-                 mk_term uu____2833 r Un
-             | uu____2850 ->
-                 FStar_List.fold_left
-                   (fun t1  -> fun a  -> mk_term (App (t1, a, Nothing)) r Un)
-                   t args)
-let mkAdmitMagic: FStar_Range.range -> term =
-  fun r  ->
-    let unit_const = mk_term (Const FStar_Const.Const_unit) r Expr in
-    let admit1 =
-      let admit_name =
-        mk_term
-          (Var (FStar_Ident.set_lid_range FStar_Syntax_Const.admit_lid r)) r
-          Expr in
-      mkExplicitApp admit_name [unit_const] r in
-    let magic1 =
-      let magic_name =
-        mk_term
-          (Var (FStar_Ident.set_lid_range FStar_Syntax_Const.magic_lid r)) r
-          Expr in
-      mkExplicitApp magic_name [unit_const] r in
-    let admit_magic = mk_term (Seq (admit1, magic1)) r Expr in admit_magic
-let mkWildAdmitMagic r =
-  let uu____2873 = mkAdmitMagic r in
-  ((mk_pattern PatWild r), None, uu____2873)
-let focusBranches branches r =
-  let should_filter = FStar_Util.for_some Prims.fst branches in
-  if should_filter
-  then
-    (FStar_Errors.warn r "Focusing on only some cases";
-     (let focussed =
-        let uu____2929 = FStar_List.filter Prims.fst branches in
-        FStar_All.pipe_right uu____2929 (FStar_List.map Prims.snd) in
-      let uu____2973 = let uu____2979 = mkWildAdmitMagic r in [uu____2979] in
-      FStar_List.append focussed uu____2973))
-  else FStar_All.pipe_right branches (FStar_List.map Prims.snd)
-let focusLetBindings lbs r =
-  let should_filter = FStar_Util.for_some Prims.fst lbs in
-  if should_filter
-  then
-    (FStar_Errors.warn r
-       "Focusing on only some cases in this (mutually) recursive definition";
-     FStar_List.map
-       (fun uu____3065  ->
-          match uu____3065 with
-          | (f,lb) ->
-              if f
-              then lb
-              else
-                (let uu____3081 = mkAdmitMagic r in
-                 ((Prims.fst lb), uu____3081))) lbs)
-  else FStar_All.pipe_right lbs (FStar_List.map Prims.snd)
-let mkFsTypApp: term -> term Prims.list -> FStar_Range.range -> term =
-  fun t  ->
-    fun args  ->
-      fun r  ->
-        let uu____3110 = FStar_List.map (fun a  -> (a, FsTypApp)) args in
-        mkApp t uu____3110 r
-let mkTuple: term Prims.list -> FStar_Range.range -> term =
-  fun args  ->
-    fun r  ->
-      let cons1 =
-        FStar_Syntax_Util.mk_tuple_data_lid (FStar_List.length args) r in
-      let uu____3129 = FStar_List.map (fun x  -> (x, Nothing)) args in
-      mkApp (mk_term (Name cons1) r Expr) uu____3129 r
-let mkDTuple: term Prims.list -> FStar_Range.range -> term =
-  fun args  ->
-    fun r  ->
-      let cons1 =
-        FStar_Syntax_Util.mk_dtuple_data_lid (FStar_List.length args) r in
-      let uu____3148 = FStar_List.map (fun x  -> (x, Nothing)) args in
-      mkApp (mk_term (Name cons1) r Expr) uu____3148 r
-let mkRefinedBinder:
-  FStar_Ident.ident ->
-    term ->
-      Prims.bool -> term Prims.option -> FStar_Range.range -> aqual -> binder
-  =
-  fun id  ->
-    fun t  ->
-      fun should_bind_var  ->
-        fun refopt  ->
-          fun m  ->
-            fun implicit  ->
-              let b = mk_binder (Annotated (id, t)) m Type_level implicit in
-              match refopt with
-              | None  -> b
-              | Some phi ->
-                  if should_bind_var
-                  then
-                    mk_binder
-                      (Annotated
-                         (id, (mk_term (Refine (b, phi)) m Type_level))) m
-                      Type_level implicit
-                  else
-                    (let x = FStar_Ident.gen t.range in
-                     let b1 =
-                       mk_binder (Annotated (x, t)) m Type_level implicit in
-                     mk_binder
-                       (Annotated
-                          (id, (mk_term (Refine (b1, phi)) m Type_level))) m
-                       Type_level implicit)
-let mkRefinedPattern:
-  pattern ->
-    term ->
-      Prims.bool ->
-        term Prims.option ->
-          FStar_Range.range -> FStar_Range.range -> pattern
-  =
-  fun pat  ->
-    fun t  ->
-      fun should_bind_pat  ->
-        fun phi_opt  ->
-          fun t_range  ->
-            fun range  ->
-              let t1 =
-                match phi_opt with
-                | None  -> t
-                | Some phi ->
-                    if should_bind_pat
-                    then
-                      (match pat.pat with
-                       | PatVar (x,uu____3203) ->
-                           mk_term
-                             (Refine
-                                ((mk_binder (Annotated (x, t)) t_range
-                                    Type_level None), phi)) range Type_level
-                       | uu____3206 ->
-                           let x = FStar_Ident.gen t_range in
-                           let phi1 =
-                             let x_var =
-                               let uu____3210 =
-                                 let uu____3211 = FStar_Ident.lid_of_ids [x] in
-                                 Var uu____3211 in
-                               mk_term uu____3210 phi.range Formula in
-                             let pat_branch = (pat, None, phi) in
-                             let otherwise_branch =
-                               let uu____3223 =
-                                 let uu____3224 =
-                                   let uu____3225 =
-                                     FStar_Ident.lid_of_path ["False"]
-                                       phi.range in
-                                   Name uu____3225 in
-                                 mk_term uu____3224 phi.range Formula in
-                               ((mk_pattern PatWild phi.range), None,
-                                 uu____3223) in
-                             mk_term
-                               (Match (x_var, [pat_branch; otherwise_branch]))
-                               phi.range Formula in
-                           mk_term
-                             (Refine
-                                ((mk_binder (Annotated (x, t)) t_range
-                                    Type_level None), phi1)) range Type_level)
-                    else
-                      (let x = FStar_Ident.gen t.range in
-                       mk_term
-                         (Refine
-                            ((mk_binder (Annotated (x, t)) t_range Type_level
-                                None), phi)) range Type_level) in
-              mk_pattern (PatAscribed (pat, t1)) range
-let rec extract_named_refinement:
-  term -> (FStar_Ident.ident* term* term Prims.option) Prims.option =
-  fun t1  ->
-    match t1.tm with
-    | NamedTyp (x,t) -> Some (x, t, None)
-    | Refine
-        ({ b = Annotated (x,t); brange = uu____3268; blevel = uu____3269;
-           aqual = uu____3270;_},t')
-        -> Some (x, t, (Some t'))
-    | Paren t -> extract_named_refinement t
-    | uu____3278 -> None
-let rec as_mlist:
-  modul Prims.list ->
-    ((FStar_Ident.lid* decl)* decl Prims.list) ->
-      decl Prims.list -> modul Prims.list
-  =
-  fun out  ->
-    fun cur  ->
-      fun ds  ->
-        let uu____3308 = cur in
-        match uu____3308 with
-        | ((m_name,m_decl),cur1) ->
-            (match ds with
-             | [] ->
-                 FStar_List.rev
-                   ((Module (m_name, (m_decl :: (FStar_List.rev cur1)))) ::
-                   out)
-             | d::ds1 ->
-                 (match d.d with
-                  | TopLevelModule m' ->
-                      as_mlist
-                        ((Module (m_name, (m_decl :: (FStar_List.rev cur1))))
-                        :: out) ((m', d), []) ds1
-                  | uu____3333 ->
-                      as_mlist out ((m_name, m_decl), (d :: cur1)) ds1))
-let as_frag:
-  Prims.bool ->
-    FStar_Range.range ->
-      decl ->
-        decl Prims.list ->
-          (modul Prims.list,decl Prims.list) FStar_Util.either
-  =
-  fun is_light  ->
-    fun light_range  ->
-      fun d  ->
-        fun ds  ->
-          match d.d with
-          | TopLevelModule m ->
-              let ds1 =
-                if is_light
-                then
-                  let uu____3367 = mk_decl (Pragma LightOff) light_range [] in
-                  uu____3367 :: ds
-                else ds in
-              let ms = as_mlist [] ((m, d), []) ds1 in
-              ((let uu____3375 = FStar_List.tl ms in
-                match uu____3375 with
-                | (Module (m',uu____3378))::uu____3379 ->
-                    let msg =
-                      "Support for more than one module in a file is deprecated" in
-                    let uu____3384 =
-                      FStar_Range.string_of_range
-                        (FStar_Ident.range_of_lid m') in
-                    FStar_Util.print2_warning "%s (Warning): %s\n" uu____3384
-                      msg
-                | uu____3385 -> ());
-               FStar_Util.Inl ms)
-          | uu____3389 ->
-              let ds1 = d :: ds in
-              (FStar_List.iter
-                 (fun uu___109_3393  ->
-                    match uu___109_3393 with
-                    | { d = TopLevelModule uu____3394; drange = r;
-                        doc = uu____3396; quals = uu____3397;
-                        attrs = uu____3398;_} ->
-                        Prims.raise
-                          (FStar_Errors.Error
-                             ("Unexpected module declaration", r))
-                    | uu____3400 -> ()) ds1;
-               FStar_Util.Inr ds1)
-let compile_op: Prims.int -> Prims.string -> Prims.string =
-  fun arity  ->
-    fun s  ->
-      let name_of_char uu___110_3412 =
-        match uu___110_3412 with
-        | '&' -> "Amp"
-        | '@' -> "At"
-        | '+' -> "Plus"
-        | '-' when arity = (Prims.parse_int "1") -> "Minus"
-        | '-' -> "Subtraction"
-        | '/' -> "Slash"
-        | '<' -> "Less"
-        | '=' -> "Equals"
-        | '>' -> "Greater"
-        | '_' -> "Underscore"
-        | '|' -> "Bar"
-        | '!' -> "Bang"
-        | '^' -> "Hat"
-        | '%' -> "Percent"
-        | '*' -> "Star"
-        | '?' -> "Question"
-        | ':' -> "Colon"
-        | uu____3413 -> "UNKNOWN" in
-      match s with
-      | ".[]<-" -> "op_String_Assignment"
-      | ".()<-" -> "op_Array_Assignment"
-      | ".[]" -> "op_String_Access"
-      | ".()" -> "op_Array_Access"
-      | uu____3414 ->
-          let uu____3415 =
-            let uu____3416 =
-              let uu____3418 = FStar_String.list_of_string s in
-              FStar_List.map name_of_char uu____3418 in
-            FStar_String.concat "_" uu____3416 in
-          Prims.strcat "op_" uu____3415
-let compile_op': Prims.string -> Prims.string =
-  fun s  -> compile_op (- (Prims.parse_int "1")) s
-let string_of_fsdoc:
-  (Prims.string* (Prims.string* Prims.string) Prims.list) -> Prims.string =
-  fun uu____3430  ->
-    match uu____3430 with
-    | (comment,keywords) ->
-        let uu____3444 =
-          let uu____3445 =
-            FStar_List.map
-              (fun uu____3449  ->
-                 match uu____3449 with
-                 | (k,v1) -> Prims.strcat k (Prims.strcat "->" v1)) keywords in
-          FStar_String.concat "," uu____3445 in
-        Prims.strcat comment uu____3444
-let string_of_let_qualifier: let_qualifier -> Prims.string =
-  fun uu___111_3456  ->
-    match uu___111_3456 with
-    | NoLetQualifier  -> ""
-    | Rec  -> "rec"
-    | Mutable  -> "mutable"
-let to_string_l sep f l =
-  let uu____3481 = FStar_List.map f l in FStar_String.concat sep uu____3481
-let imp_to_string: imp -> Prims.string =
-  fun uu___112_3485  ->
-    match uu___112_3485 with | Hash  -> "#" | uu____3486 -> ""
-let rec term_to_string: term -> Prims.string =
-  fun x  ->
-    match x.tm with
-    | Wild  -> "_"
-    | Requires (t,uu____3497) ->
-        let uu____3500 = term_to_string t in
-        FStar_Util.format1 "(requires %s)" uu____3500
-    | Ensures (t,uu____3502) ->
-        let uu____3505 = term_to_string t in
-        FStar_Util.format1 "(ensures %s)" uu____3505
-    | Labeled (t,l,uu____3508) ->
-        let uu____3509 = term_to_string t in
-        FStar_Util.format2 "(labeled %s %s)" l uu____3509
-    | Const c -> FStar_Syntax_Print.const_to_string c
-    | Op (s,xs) ->
-        let uu____3515 =
-          let uu____3516 =
-            FStar_List.map
-              (fun x1  -> FStar_All.pipe_right x1 term_to_string) xs in
-          FStar_String.concat ", " uu____3516 in
-        FStar_Util.format2 "%s(%s)" s uu____3515
-    | Tvar id|Uvar id -> id.FStar_Ident.idText
-    | Var l|Name l -> l.FStar_Ident.str
-    | Construct (l,args) ->
-        let uu____3529 =
-          to_string_l " "
-            (fun uu____3532  ->
-               match uu____3532 with
-               | (a,imp) ->
-                   let uu____3537 = term_to_string a in
-                   FStar_Util.format2 "%s%s" (imp_to_string imp) uu____3537)
-            args in
-        FStar_Util.format2 "(%s %s)" l.FStar_Ident.str uu____3529
-    | Abs (pats,t) ->
-        let uu____3542 = to_string_l " " pat_to_string pats in
-        let uu____3543 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "(fun %s -> %s)" uu____3542 uu____3543
-    | App (t1,t2,imp) ->
-        let uu____3547 = FStar_All.pipe_right t1 term_to_string in
-        let uu____3548 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format3 "%s %s%s" uu____3547 (imp_to_string imp)
-          uu____3548
-    | Let (Rec ,lbs,body) ->
-        let uu____3557 =
-          to_string_l " and "
-            (fun uu____3560  ->
-               match uu____3560 with
-               | (p,b) ->
-                   let uu____3565 = FStar_All.pipe_right p pat_to_string in
-                   let uu____3566 = FStar_All.pipe_right b term_to_string in
-                   FStar_Util.format2 "%s=%s" uu____3565 uu____3566) lbs in
-        let uu____3567 = FStar_All.pipe_right body term_to_string in
-        FStar_Util.format2 "let rec %s in %s" uu____3557 uu____3567
-    | Let (q,(pat,tm)::[],body) ->
-        let uu____3579 = FStar_All.pipe_right pat pat_to_string in
-        let uu____3580 = FStar_All.pipe_right tm term_to_string in
-        let uu____3581 = FStar_All.pipe_right body term_to_string in
-        FStar_Util.format4 "let %s %s = %s in %s" (string_of_let_qualifier q)
-          uu____3579 uu____3580 uu____3581
-    | Seq (t1,t2) ->
-        let uu____3584 = FStar_All.pipe_right t1 term_to_string in
-        let uu____3585 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format2 "%s; %s" uu____3584 uu____3585
-    | If (t1,t2,t3) ->
-        let uu____3589 = FStar_All.pipe_right t1 term_to_string in
-        let uu____3590 = FStar_All.pipe_right t2 term_to_string in
-        let uu____3591 = FStar_All.pipe_right t3 term_to_string in
-        FStar_Util.format3 "if %s then %s else %s" uu____3589 uu____3590
-          uu____3591
-    | Match (t,branches) ->
-        let uu____3604 = FStar_All.pipe_right t term_to_string in
-        let uu____3605 =
-          to_string_l " | "
-            (fun uu____3610  ->
-               match uu____3610 with
-               | (p,w,e) ->
-                   let uu____3620 = FStar_All.pipe_right p pat_to_string in
-                   let uu____3621 =
-                     match w with
-                     | None  -> ""
-                     | Some e1 ->
-                         let uu____3623 = term_to_string e1 in
-                         FStar_Util.format1 "when %s" uu____3623 in
-                   let uu____3624 = FStar_All.pipe_right e term_to_string in
-                   FStar_Util.format3 "%s %s -> %s" uu____3620 uu____3621
-                     uu____3624) branches in
-        FStar_Util.format2 "match %s with %s" uu____3604 uu____3605
-    | Ascribed (t1,t2,None ) ->
-        let uu____3628 = FStar_All.pipe_right t1 term_to_string in
-        let uu____3629 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format2 "(%s : %s)" uu____3628 uu____3629
-    | Ascribed (t1,t2,Some tac) ->
-        let uu____3634 = FStar_All.pipe_right t1 term_to_string in
-        let uu____3635 = FStar_All.pipe_right t2 term_to_string in
-        let uu____3636 = FStar_All.pipe_right tac term_to_string in
-        FStar_Util.format3 "(%s : %s by %s)" uu____3634 uu____3635 uu____3636
-    | Record (Some e,fields) ->
-        let uu____3646 = FStar_All.pipe_right e term_to_string in
-        let uu____3647 =
-          to_string_l " "
-            (fun uu____3650  ->
-               match uu____3650 with
-               | (l,e1) ->
-                   let uu____3655 = FStar_All.pipe_right e1 term_to_string in
-                   FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____3655)
-            fields in
-        FStar_Util.format2 "{%s with %s}" uu____3646 uu____3647
-    | Record (None ,fields) ->
-        let uu____3664 =
-          to_string_l " "
-            (fun uu____3667  ->
-               match uu____3667 with
-               | (l,e) ->
-                   let uu____3672 = FStar_All.pipe_right e term_to_string in
-                   FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____3672)
-            fields in
-        FStar_Util.format1 "{%s}" uu____3664
-    | Project (e,l) ->
-        let uu____3675 = FStar_All.pipe_right e term_to_string in
-        FStar_Util.format2 "%s.%s" uu____3675 l.FStar_Ident.str
-    | Product ([],t) -> term_to_string t
-    | Product (b::hd1::tl1,t) ->
-        term_to_string
-          (mk_term
-             (Product
-                ([b], (mk_term (Product ((hd1 :: tl1), t)) x.range x.level)))
-             x.range x.level)
-    | Product (b::[],t) when x.level = Type_level ->
-        let uu____3689 = FStar_All.pipe_right b binder_to_string in
-        let uu____3690 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s -> %s" uu____3689 uu____3690
-    | Product (b::[],t) when x.level = Kind ->
-        let uu____3694 = FStar_All.pipe_right b binder_to_string in
-        let uu____3695 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s => %s" uu____3694 uu____3695
-    | Sum (binders,t) ->
-        let uu____3700 =
-          let uu____3701 =
-            FStar_All.pipe_right binders (FStar_List.map binder_to_string) in
-          FStar_All.pipe_right uu____3701 (FStar_String.concat " * ") in
-        let uu____3706 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s * %s" uu____3700 uu____3706
-    | QForall (bs,pats,t) ->
-        let uu____3716 = to_string_l " " binder_to_string bs in
-        let uu____3717 =
-          to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu____3719 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____3716 uu____3717
-          uu____3719
-    | QExists (bs,pats,t) ->
-        let uu____3729 = to_string_l " " binder_to_string bs in
-        let uu____3730 =
-          to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu____3732 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____3729 uu____3730
-          uu____3732
-    | Refine (b,t) ->
-        let uu____3735 = FStar_All.pipe_right b binder_to_string in
-        let uu____3736 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s:{%s}" uu____3735 uu____3736
-    | NamedTyp (x1,t) ->
-        let uu____3739 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s:%s" x1.FStar_Ident.idText uu____3739
-    | Paren t ->
-        let uu____3741 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format1 "(%s)" uu____3741
-    | Product (bs,t) ->
-        let uu____3746 =
-          let uu____3747 =
-            FStar_All.pipe_right bs (FStar_List.map binder_to_string) in
-          FStar_All.pipe_right uu____3747 (FStar_String.concat ",") in
-        let uu____3752 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "Unidentified product: [%s] %s" uu____3746
-          uu____3752
-    | t -> "_"
-and binder_to_string: binder -> Prims.string =
-  fun x  ->
-    let s =
-      match x.b with
-      | Variable i -> i.FStar_Ident.idText
-      | TVariable i -> FStar_Util.format1 "%s:_" i.FStar_Ident.idText
-      | TAnnotated (i,t)|Annotated (i,t) ->
-          let uu____3760 = FStar_All.pipe_right t term_to_string in
-          FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____3760
-      | NoName t -> FStar_All.pipe_right t term_to_string in
-    let uu____3762 = aqual_to_string x.aqual in
-    FStar_Util.format2 "%s%s" uu____3762 s
-and aqual_to_string: aqual -> Prims.string =
-  fun uu___113_3763  ->
-    match uu___113_3763 with
-    | Some (Equality ) -> "$"
-    | Some (Implicit ) -> "#"
-    | uu____3764 -> ""
-and pat_to_string: pattern -> Prims.string =
-  fun x  ->
-    match x.pat with
-    | PatWild  -> "_"
-    | PatConst c -> FStar_Syntax_Print.const_to_string c
-    | PatApp (p,ps) ->
-        let uu____3771 = FStar_All.pipe_right p pat_to_string in
-        let uu____3772 = to_string_l " " pat_to_string ps in
-        FStar_Util.format2 "(%s %s)" uu____3771 uu____3772
-    | PatTvar (i,aq)|PatVar (i,aq) ->
-        let uu____3779 = aqual_to_string aq in
-        FStar_Util.format2 "%s%s" uu____3779 i.FStar_Ident.idText
-    | PatName l -> l.FStar_Ident.str
-    | PatList l ->
-        let uu____3783 = to_string_l "; " pat_to_string l in
-        FStar_Util.format1 "[%s]" uu____3783
-    | PatTuple (l,false ) ->
-        let uu____3787 = to_string_l ", " pat_to_string l in
-        FStar_Util.format1 "(%s)" uu____3787
-    | PatTuple (l,true ) ->
-        let uu____3791 = to_string_l ", " pat_to_string l in
-        FStar_Util.format1 "(|%s|)" uu____3791
-    | PatRecord l ->
-        let uu____3796 =
-          to_string_l "; "
-            (fun uu____3799  ->
-               match uu____3799 with
-               | (f,e) ->
-                   let uu____3804 = FStar_All.pipe_right e pat_to_string in
-                   FStar_Util.format2 "%s=%s" f.FStar_Ident.str uu____3804) l in
-        FStar_Util.format1 "{%s}" uu____3796
-    | PatOr l -> to_string_l "|\n " pat_to_string l
-    | PatOp op -> FStar_Util.format1 "(%s)" op
-    | PatAscribed (p,t) ->
-        let uu____3810 = FStar_All.pipe_right p pat_to_string in
-        let uu____3811 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "(%s:%s)" uu____3810 uu____3811
-let rec head_id_of_pat: pattern -> FStar_Ident.lid Prims.list =
-  fun p  ->
-    match p.pat with
-    | PatName l -> [l]
-    | PatVar (i,uu____3819) ->
-        let uu____3822 = FStar_Ident.lid_of_ids [i] in [uu____3822]
-    | PatApp (p1,uu____3824) -> head_id_of_pat p1
-    | PatAscribed (p1,uu____3828) -> head_id_of_pat p1
-    | uu____3829 -> []
-let lids_of_let defs =
-  FStar_All.pipe_right defs
-    (FStar_List.collect
-       (fun uu____3850  ->
-          match uu____3850 with | (p,uu____3855) -> head_id_of_pat p))
-let id_of_tycon: tycon -> Prims.string =
-  fun uu___114_3858  ->
-    match uu___114_3858 with
-    | TyconAbstract (i,_,_)
-      |TyconAbbrev (i,_,_,_)|TyconRecord (i,_,_,_)|TyconVariant (i,_,_,_) ->
-        i.FStar_Ident.idText
-let decl_to_string: decl -> Prims.string =
-  fun d  ->
-    match d.d with
-    | TopLevelModule l -> Prims.strcat "module " l.FStar_Ident.str
-    | Open l -> Prims.strcat "open " l.FStar_Ident.str
-    | Include l -> Prims.strcat "include " l.FStar_Ident.str
-    | ModuleAbbrev (i,l) ->
-        FStar_Util.format2 "module %s = %s" i.FStar_Ident.idText
-          l.FStar_Ident.str
-    | TopLevelLet (uu____3899,pats) ->
-        let uu____3907 =
-          let uu____3908 =
-            let uu____3910 = lids_of_let pats in
-            FStar_All.pipe_right uu____3910
-              (FStar_List.map (fun l  -> l.FStar_Ident.str)) in
-          FStar_All.pipe_right uu____3908 (FStar_String.concat ", ") in
-        Prims.strcat "let " uu____3907
-    | Main uu____3916 -> "main ..."
-    | Assume (i,uu____3918) -> Prims.strcat "assume " i.FStar_Ident.idText
-    | Tycon (uu____3919,tys) ->
-        let uu____3929 =
-          let uu____3930 =
-            FStar_All.pipe_right tys
-              (FStar_List.map
-                 (fun uu____3940  ->
-                    match uu____3940 with | (x,uu____3945) -> id_of_tycon x)) in
-          FStar_All.pipe_right uu____3930 (FStar_String.concat ", ") in
-        Prims.strcat "type " uu____3929
-    | Val (i,uu____3950) -> Prims.strcat "val " i.FStar_Ident.idText
-    | Exception (i,uu____3952) ->
-        Prims.strcat "exception " i.FStar_Ident.idText
-    | NewEffect (DefineEffect (i,_,_,_))|NewEffect (RedefineEffect (i,_,_))
-        -> Prims.strcat "new_effect " i.FStar_Ident.idText
-    | SubEffect uu____3964 -> "sub_effect"
-    | Pragma uu____3965 -> "pragma"
-    | Fsdoc uu____3966 -> "fsdoc"
-let modul_to_string: modul -> Prims.string =
-  fun m  ->
-    match m with
-    | Module (_,decls)|Interface (_,decls,_) ->
-        let uu____3978 =
-          FStar_All.pipe_right decls (FStar_List.map decl_to_string) in
-        FStar_All.pipe_right uu____3978 (FStar_String.concat "\n")
-let error msg tm r =
-  let tm1 = FStar_All.pipe_right tm term_to_string in
-  let tm2 =
-    if (FStar_String.length tm1) >= (Prims.parse_int "80")
-    then
-      let uu____4005 =
-        FStar_Util.substring tm1 (Prims.parse_int "0") (Prims.parse_int "77") in
-      Prims.strcat uu____4005 "..."
-    else tm1 in
-  Prims.raise
-    (FStar_Errors.Error ((Prims.strcat msg (Prims.strcat "\n" tm2)), r))
+| Module of (FStar_Ident.lid * decl Prims.list)
+| Interface of (FStar_Ident.lid * decl Prims.list * Prims.bool)
+
+
+let uu___is_Module : modul  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Module (_0) -> begin
+true
+end
+| uu____2375 -> begin
+false
+end))
+
+
+let __proj__Module__item___0 : modul  ->  (FStar_Ident.lid * decl Prims.list) = (fun projectee -> (match (projectee) with
+| Module (_0) -> begin
+_0
+end))
+
+
+let uu___is_Interface : modul  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Interface (_0) -> begin
+true
+end
+| uu____2400 -> begin
+false
+end))
+
+
+let __proj__Interface__item___0 : modul  ->  (FStar_Ident.lid * decl Prims.list * Prims.bool) = (fun projectee -> (match (projectee) with
+| Interface (_0) -> begin
+_0
+end))
+
+
+type file =
+modul Prims.list
+
+
+type inputFragment =
+(file, decl Prims.list) FStar_Util.either
+
+
+let check_id : FStar_Ident.ident  ->  Prims.unit = (fun id -> (
+
+let first_char = (FStar_String.substring id.FStar_Ident.idText (Prims.parse_int "0") (Prims.parse_int "1"))
+in (match (((FStar_String.lowercase first_char) = first_char)) with
+| true -> begin
+()
+end
+| uu____2428 -> begin
+(
+
+let uu____2429 = (
+
+let uu____2430 = (
+
+let uu____2433 = (FStar_Util.format1 "Invalid identifer \'%s\'; expected a symbol that begins with a lower-case character" id.FStar_Ident.idText)
+in ((uu____2433), (id.FStar_Ident.idRange)))
+in FStar_Errors.Error (uu____2430))
+in (Prims.raise uu____2429))
+end)))
+
+
+let at_most_one = (fun s r l -> (match (l) with
+| (x)::[] -> begin
+Some (x)
+end
+| [] -> begin
+None
+end
+| uu____2455 -> begin
+(
+
+let uu____2457 = (
+
+let uu____2458 = (
+
+let uu____2461 = (FStar_Util.format1 "At most one %s is allowed on declarations" s)
+in ((uu____2461), (r)))
+in FStar_Errors.Error (uu____2458))
+in (Prims.raise uu____2457))
+end))
+
+
+let mk_decl : decl'  ->  FStar_Range.range  ->  decoration Prims.list  ->  decl = (fun d r decorations -> (
+
+let doc1 = (
+
+let uu____2476 = (FStar_List.choose (fun uu___106_2478 -> (match (uu___106_2478) with
+| Doc (d1) -> begin
+Some (d1)
+end
+| uu____2481 -> begin
+None
+end)) decorations)
+in (at_most_one "fsdoc" r uu____2476))
+in (
+
+let attributes_ = (
+
+let uu____2485 = (FStar_List.choose (fun uu___107_2489 -> (match (uu___107_2489) with
+| DeclAttributes (a) -> begin
+Some (a)
+end
+| uu____2495 -> begin
+None
+end)) decorations)
+in (at_most_one "attribute set" r uu____2485))
+in (
+
+let attributes_1 = (FStar_Util.dflt [] attributes_)
+in (
+
+let qualifiers = (FStar_List.choose (fun uu___108_2503 -> (match (uu___108_2503) with
+| Qualifier (q) -> begin
+Some (q)
+end
+| uu____2506 -> begin
+None
+end)) decorations)
+in {d = d; drange = r; doc = doc1; quals = qualifiers; attrs = attributes_1})))))
+
+
+let sigelt_of_decl : decl  ->  FStar_Syntax_Syntax.sigelt'  ->  FStar_Syntax_Syntax.sigelt = (fun d e -> {FStar_Syntax_Syntax.sigel = e; FStar_Syntax_Syntax.sigdoc = d.doc; FStar_Syntax_Syntax.sigrng = d.drange})
+
+
+let mk_binder : binder'  ->  FStar_Range.range  ->  level  ->  aqual  ->  binder = (fun b r l i -> {b = b; brange = r; blevel = l; aqual = i})
+
+
+let mk_term : term'  ->  FStar_Range.range  ->  level  ->  term = (fun t r l -> {tm = t; range = r; level = l})
+
+
+let mk_uminus : term  ->  FStar_Range.range  ->  level  ->  term = (fun t r l -> (
+
+let t1 = (match (t.tm) with
+| Const (FStar_Const.Const_int (s, Some (FStar_Const.Signed, width))) -> begin
+Const (FStar_Const.Const_int ((((Prims.strcat "-" s)), (Some (((FStar_Const.Signed), (width)))))))
+end
+| uu____2556 -> begin
+Op ((("-"), ((t)::[])))
+end)
+in (mk_term t1 r l)))
+
+
+let mk_pattern : pattern'  ->  FStar_Range.range  ->  pattern = (fun p r -> {pat = p; prange = r})
+
+
+let un_curry_abs : pattern Prims.list  ->  term  ->  term' = (fun ps body -> (match (body.tm) with
+| Abs (p', body') -> begin
+Abs ((((FStar_List.append ps p')), (body')))
+end
+| uu____2577 -> begin
+Abs (((ps), (body)))
+end))
+
+
+let mk_function : (pattern * term Prims.option * term) Prims.list  ->  FStar_Range.range  ->  FStar_Range.range  ->  term = (fun branches r1 r2 -> (
+
+let x = (
+
+let i = (FStar_Syntax_Syntax.next_id ())
+in (FStar_Ident.gen r1))
+in (
+
+let uu____2600 = (
+
+let uu____2601 = (
+
+let uu____2605 = (
+
+let uu____2606 = (
+
+let uu____2607 = (
+
+let uu____2615 = (
+
+let uu____2616 = (
+
+let uu____2617 = (FStar_Ident.lid_of_ids ((x)::[]))
+in Var (uu____2617))
+in (mk_term uu____2616 r1 Expr))
+in ((uu____2615), (branches)))
+in Match (uu____2607))
+in (mk_term uu____2606 r2 Expr))
+in ((((mk_pattern (PatVar (((x), (None)))) r1))::[]), (uu____2605)))
+in Abs (uu____2601))
+in (mk_term uu____2600 r2 Expr))))
+
+
+let un_function : pattern  ->  term  ->  (pattern * term) Prims.option = (fun p tm -> (match (((p.pat), (tm.tm))) with
+| (PatVar (uu____2637), Abs (pats, body)) -> begin
+Some ((((mk_pattern (PatApp (((p), (pats)))) p.prange)), (body)))
+end
+| uu____2648 -> begin
+None
+end))
+
+
+let lid_with_range : FStar_Ident.lident  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun lid r -> (
+
+let uu____2659 = (FStar_Ident.path_of_lid lid)
+in (FStar_Ident.lid_of_path uu____2659 r)))
+
+
+let consPat : FStar_Range.range  ->  pattern  ->  pattern  ->  pattern' = (fun r hd1 tl1 -> PatApp ((((mk_pattern (PatName (FStar_Syntax_Const.cons_lid)) r)), ((hd1)::(tl1)::[]))))
+
+
+let consTerm : FStar_Range.range  ->  term  ->  term  ->  term = (fun r hd1 tl1 -> (mk_term (Construct (((FStar_Syntax_Const.cons_lid), ((((hd1), (Nothing)))::(((tl1), (Nothing)))::[])))) r Expr))
+
+
+let lexConsTerm : FStar_Range.range  ->  term  ->  term  ->  term = (fun r hd1 tl1 -> (mk_term (Construct (((FStar_Syntax_Const.lexcons_lid), ((((hd1), (Nothing)))::(((tl1), (Nothing)))::[])))) r Expr))
+
+
+let mkConsList : FStar_Range.range  ->  term Prims.list  ->  term = (fun r elts -> (
+
+let nil = (mk_term (Construct (((FStar_Syntax_Const.nil_lid), ([])))) r Expr)
+in (FStar_List.fold_right (fun e tl1 -> (consTerm r e tl1)) elts nil)))
+
+
+let mkLexList : FStar_Range.range  ->  term Prims.list  ->  term = (fun r elts -> (
+
+let nil = (mk_term (Construct (((FStar_Syntax_Const.lextop_lid), ([])))) r Expr)
+in (FStar_List.fold_right (fun e tl1 -> (lexConsTerm r e tl1)) elts nil)))
+
+
+let ml_comp : term  ->  term = (fun t -> (
+
+let ml = (mk_term (Name (FStar_Syntax_Const.effect_ML_lid)) t.range Expr)
+in (
+
+let t1 = (mk_term (App (((ml), (t), (Nothing)))) t.range Expr)
+in t1)))
+
+
+let tot_comp : term  ->  term = (fun t -> (
+
+let ml = (mk_term (Name (FStar_Syntax_Const.effect_Tot_lid)) t.range Expr)
+in (
+
+let t1 = (mk_term (App (((ml), (t), (Nothing)))) t.range Expr)
+in t1)))
+
+
+let mkApp : term  ->  (term * imp) Prims.list  ->  FStar_Range.range  ->  term = (fun t args r -> (match (args) with
+| [] -> begin
+t
+end
+| uu____2766 -> begin
+(match (t.tm) with
+| Name (s) -> begin
+(mk_term (Construct (((s), (args)))) r Un)
+end
+| uu____2774 -> begin
+(FStar_List.fold_left (fun t1 uu____2778 -> (match (uu____2778) with
+| (a, imp) -> begin
+(mk_term (App (((t1), (a), (imp)))) r Un)
+end)) t args)
+end)
+end))
+
+
+let mkRefSet : FStar_Range.range  ->  term Prims.list  ->  term = (fun r elts -> (
+
+let uu____2791 = ((FStar_Syntax_Const.tset_empty), (FStar_Syntax_Const.tset_singleton), (FStar_Syntax_Const.tset_union))
+in (match (uu____2791) with
+| (empty_lid, singleton_lid, union_lid) -> begin
+(
+
+let empty1 = (mk_term (Var ((FStar_Ident.set_lid_range empty_lid r))) r Expr)
+in (
+
+let ref_constr = (mk_term (Var ((FStar_Ident.set_lid_range FStar_Syntax_Const.heap_ref r))) r Expr)
+in (
+
+let singleton1 = (mk_term (Var ((FStar_Ident.set_lid_range singleton_lid r))) r Expr)
+in (
+
+let union1 = (mk_term (Var ((FStar_Ident.set_lid_range union_lid r))) r Expr)
+in (FStar_List.fold_right (fun e tl1 -> (
+
+let e1 = (mkApp ref_constr ((((e), (Nothing)))::[]) r)
+in (
+
+let single_e = (mkApp singleton1 ((((e1), (Nothing)))::[]) r)
+in (mkApp union1 ((((single_e), (Nothing)))::(((tl1), (Nothing)))::[]) r)))) elts empty1)))))
+end)))
+
+
+let mkExplicitApp : term  ->  term Prims.list  ->  FStar_Range.range  ->  term = (fun t args r -> (match (args) with
+| [] -> begin
+t
+end
+| uu____2831 -> begin
+(match (t.tm) with
+| Name (s) -> begin
+(
+
+let uu____2834 = (
+
+let uu____2835 = (
+
+let uu____2841 = (FStar_List.map (fun a -> ((a), (Nothing))) args)
+in ((s), (uu____2841)))
+in Construct (uu____2835))
+in (mk_term uu____2834 r Un))
+end
+| uu____2851 -> begin
+(FStar_List.fold_left (fun t1 a -> (mk_term (App (((t1), (a), (Nothing)))) r Un)) t args)
+end)
+end))
+
+
+let mkAdmitMagic : FStar_Range.range  ->  term = (fun r -> (
+
+let unit_const = (mk_term (Const (FStar_Const.Const_unit)) r Expr)
+in (
+
+let admit1 = (
+
+let admit_name = (mk_term (Var ((FStar_Ident.set_lid_range FStar_Syntax_Const.admit_lid r))) r Expr)
+in (mkExplicitApp admit_name ((unit_const)::[]) r))
+in (
+
+let magic1 = (
+
+let magic_name = (mk_term (Var ((FStar_Ident.set_lid_range FStar_Syntax_Const.magic_lid r))) r Expr)
+in (mkExplicitApp magic_name ((unit_const)::[]) r))
+in (
+
+let admit_magic = (mk_term (Seq (((admit1), (magic1)))) r Expr)
+in admit_magic)))))
+
+
+let mkWildAdmitMagic = (fun r -> (
+
+let uu____2874 = (mkAdmitMagic r)
+in (((mk_pattern PatWild r)), (None), (uu____2874))))
+
+
+let focusBranches = (fun branches r -> (
+
+let should_filter = (FStar_Util.for_some Prims.fst branches)
+in (match (should_filter) with
+| true -> begin
+((FStar_Errors.warn r "Focusing on only some cases");
+(
+
+let focussed = (
+
+let uu____2930 = (FStar_List.filter Prims.fst branches)
+in (FStar_All.pipe_right uu____2930 (FStar_List.map Prims.snd)))
+in (
+
+let uu____2974 = (
+
+let uu____2980 = (mkWildAdmitMagic r)
+in (uu____2980)::[])
+in (FStar_List.append focussed uu____2974)));
+)
+end
+| uu____2997 -> begin
+(FStar_All.pipe_right branches (FStar_List.map Prims.snd))
+end)))
+
+
+let focusLetBindings = (fun lbs r -> (
+
+let should_filter = (FStar_Util.for_some Prims.fst lbs)
+in (match (should_filter) with
+| true -> begin
+((FStar_Errors.warn r "Focusing on only some cases in this (mutually) recursive definition");
+(FStar_List.map (fun uu____3066 -> (match (uu____3066) with
+| (f, lb) -> begin
+(match (f) with
+| true -> begin
+lb
+end
+| uu____3081 -> begin
+(
+
+let uu____3082 = (mkAdmitMagic r)
+in (((Prims.fst lb)), (uu____3082)))
+end)
+end)) lbs);
+)
+end
+| uu____3083 -> begin
+(FStar_All.pipe_right lbs (FStar_List.map Prims.snd))
+end)))
+
+
+let mkFsTypApp : term  ->  term Prims.list  ->  FStar_Range.range  ->  term = (fun t args r -> (
+
+let uu____3111 = (FStar_List.map (fun a -> ((a), (FsTypApp))) args)
+in (mkApp t uu____3111 r)))
+
+
+let mkTuple : term Prims.list  ->  FStar_Range.range  ->  term = (fun args r -> (
+
+let cons1 = (FStar_Syntax_Util.mk_tuple_data_lid (FStar_List.length args) r)
+in (
+
+let uu____3130 = (FStar_List.map (fun x -> ((x), (Nothing))) args)
+in (mkApp (mk_term (Name (cons1)) r Expr) uu____3130 r))))
+
+
+let mkDTuple : term Prims.list  ->  FStar_Range.range  ->  term = (fun args r -> (
+
+let cons1 = (FStar_Syntax_Util.mk_dtuple_data_lid (FStar_List.length args) r)
+in (
+
+let uu____3149 = (FStar_List.map (fun x -> ((x), (Nothing))) args)
+in (mkApp (mk_term (Name (cons1)) r Expr) uu____3149 r))))
+
+
+let mkRefinedBinder : FStar_Ident.ident  ->  term  ->  Prims.bool  ->  term Prims.option  ->  FStar_Range.range  ->  aqual  ->  binder = (fun id t should_bind_var refopt m implicit -> (
+
+let b = (mk_binder (Annotated (((id), (t)))) m Type_level implicit)
+in (match (refopt) with
+| None -> begin
+b
+end
+| Some (phi) -> begin
+(match (should_bind_var) with
+| true -> begin
+(mk_binder (Annotated (((id), ((mk_term (Refine (((b), (phi)))) m Type_level))))) m Type_level implicit)
+end
+| uu____3178 -> begin
+(
+
+let x = (FStar_Ident.gen t.range)
+in (
+
+let b1 = (mk_binder (Annotated (((x), (t)))) m Type_level implicit)
+in (mk_binder (Annotated (((id), ((mk_term (Refine (((b1), (phi)))) m Type_level))))) m Type_level implicit)))
+end)
+end)))
+
+
+let mkRefinedPattern : pattern  ->  term  ->  Prims.bool  ->  term Prims.option  ->  FStar_Range.range  ->  FStar_Range.range  ->  pattern = (fun pat t should_bind_pat phi_opt t_range range -> (
+
+let t1 = (match (phi_opt) with
+| None -> begin
+t
+end
+| Some (phi) -> begin
+(match (should_bind_pat) with
+| true -> begin
+(match (pat.pat) with
+| PatVar (x, uu____3204) -> begin
+(mk_term (Refine ((((mk_binder (Annotated (((x), (t)))) t_range Type_level None)), (phi)))) range Type_level)
+end
+| uu____3207 -> begin
+(
+
+let x = (FStar_Ident.gen t_range)
+in (
+
+let phi1 = (
+
+let x_var = (
+
+let uu____3211 = (
+
+let uu____3212 = (FStar_Ident.lid_of_ids ((x)::[]))
+in Var (uu____3212))
+in (mk_term uu____3211 phi.range Formula))
+in (
+
+let pat_branch = ((pat), (None), (phi))
+in (
+
+let otherwise_branch = (
+
+let uu____3224 = (
+
+let uu____3225 = (
+
+let uu____3226 = (FStar_Ident.lid_of_path (("False")::[]) phi.range)
+in Name (uu____3226))
+in (mk_term uu____3225 phi.range Formula))
+in (((mk_pattern PatWild phi.range)), (None), (uu____3224)))
+in (mk_term (Match (((x_var), ((pat_branch)::(otherwise_branch)::[])))) phi.range Formula))))
+in (mk_term (Refine ((((mk_binder (Annotated (((x), (t)))) t_range Type_level None)), (phi1)))) range Type_level)))
+end)
+end
+| uu____3245 -> begin
+(
+
+let x = (FStar_Ident.gen t.range)
+in (mk_term (Refine ((((mk_binder (Annotated (((x), (t)))) t_range Type_level None)), (phi)))) range Type_level))
+end)
+end)
+in (mk_pattern (PatAscribed (((pat), (t1)))) range)))
+
+
+let rec extract_named_refinement : term  ->  (FStar_Ident.ident * term * term Prims.option) Prims.option = (fun t1 -> (match (t1.tm) with
+| NamedTyp (x, t) -> begin
+Some (((x), (t), (None)))
+end
+| Refine ({b = Annotated (x, t); brange = uu____3269; blevel = uu____3270; aqual = uu____3271}, t') -> begin
+Some (((x), (t), (Some (t'))))
+end
+| Paren (t) -> begin
+(extract_named_refinement t)
+end
+| uu____3279 -> begin
+None
+end))
+
+
+let rec as_mlist : modul Prims.list  ->  ((FStar_Ident.lid * decl) * decl Prims.list)  ->  decl Prims.list  ->  modul Prims.list = (fun out cur ds -> (
+
+let uu____3309 = cur
+in (match (uu____3309) with
+| ((m_name, m_decl), cur1) -> begin
+(match (ds) with
+| [] -> begin
+(FStar_List.rev ((Module (((m_name), ((m_decl)::(FStar_List.rev cur1)))))::out))
+end
+| (d)::ds1 -> begin
+(match (d.d) with
+| TopLevelModule (m') -> begin
+(as_mlist ((Module (((m_name), ((m_decl)::(FStar_List.rev cur1)))))::out) ((((m'), (d))), ([])) ds1)
+end
+| uu____3334 -> begin
+(as_mlist out ((((m_name), (m_decl))), ((d)::cur1)) ds1)
+end)
+end)
+end)))
+
+
+let as_frag : Prims.bool  ->  FStar_Range.range  ->  decl  ->  decl Prims.list  ->  (modul Prims.list, decl Prims.list) FStar_Util.either = (fun is_light light_range d ds -> (match (d.d) with
+| TopLevelModule (m) -> begin
+(
+
+let ds1 = (match (is_light) with
+| true -> begin
+(
+
+let uu____3368 = (mk_decl (Pragma (LightOff)) light_range [])
+in (uu____3368)::ds)
+end
+| uu____3369 -> begin
+ds
+end)
+in (
+
+let ms = (as_mlist [] ((((m), (d))), ([])) ds1)
+in ((
+
+let uu____3376 = (FStar_List.tl ms)
+in (match (uu____3376) with
+| (Module (m', uu____3379))::uu____3380 -> begin
+(
+
+let msg = "Support for more than one module in a file is deprecated"
+in (
+
+let uu____3385 = (FStar_Range.string_of_range (FStar_Ident.range_of_lid m'))
+in (FStar_Util.print2_warning "%s (Warning): %s\n" uu____3385 msg)))
+end
+| uu____3386 -> begin
+()
+end));
+FStar_Util.Inl (ms);
+)))
+end
+| uu____3390 -> begin
+(
+
+let ds1 = (d)::ds
+in ((FStar_List.iter (fun uu___109_3394 -> (match (uu___109_3394) with
+| {d = TopLevelModule (uu____3395); drange = r; doc = uu____3397; quals = uu____3398; attrs = uu____3399} -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected module declaration"), (r)))))
+end
+| uu____3401 -> begin
+()
+end)) ds1);
+FStar_Util.Inr (ds1);
+))
+end))
+
+
+let compile_op : Prims.int  ->  Prims.string  ->  Prims.string = (fun arity s -> (
+
+let name_of_char = (fun uu___110_3413 -> (match (uu___110_3413) with
+| '&' -> begin
+"Amp"
+end
+| '@' -> begin
+"At"
+end
+| '+' -> begin
+"Plus"
+end
+| '-' when (arity = (Prims.parse_int "1")) -> begin
+"Minus"
+end
+| '-' -> begin
+"Subtraction"
+end
+| '/' -> begin
+"Slash"
+end
+| '<' -> begin
+"Less"
+end
+| '=' -> begin
+"Equals"
+end
+| '>' -> begin
+"Greater"
+end
+| '_' -> begin
+"Underscore"
+end
+| '|' -> begin
+"Bar"
+end
+| '!' -> begin
+"Bang"
+end
+| '^' -> begin
+"Hat"
+end
+| '%' -> begin
+"Percent"
+end
+| '*' -> begin
+"Star"
+end
+| '?' -> begin
+"Question"
+end
+| ':' -> begin
+"Colon"
+end
+| uu____3414 -> begin
+"UNKNOWN"
+end))
+in (match (s) with
+| ".[]<-" -> begin
+"op_String_Assignment"
+end
+| ".()<-" -> begin
+"op_Array_Assignment"
+end
+| ".[]" -> begin
+"op_String_Access"
+end
+| ".()" -> begin
+"op_Array_Access"
+end
+| uu____3415 -> begin
+(
+
+let uu____3416 = (
+
+let uu____3417 = (
+
+let uu____3419 = (FStar_String.list_of_string s)
+in (FStar_List.map name_of_char uu____3419))
+in (FStar_String.concat "_" uu____3417))
+in (Prims.strcat "op_" uu____3416))
+end)))
+
+
+let compile_op' : Prims.string  ->  Prims.string = (fun s -> (compile_op (~- ((Prims.parse_int "1"))) s))
+
+
+let string_of_let_qualifier : let_qualifier  ->  Prims.string = (fun uu___111_3426 -> (match (uu___111_3426) with
+| NoLetQualifier -> begin
+""
+end
+| Rec -> begin
+"rec"
+end
+| Mutable -> begin
+"mutable"
+end))
+
+
+let to_string_l = (fun sep f l -> (
+
+let uu____3451 = (FStar_List.map f l)
+in (FStar_String.concat sep uu____3451)))
+
+
+let imp_to_string : imp  ->  Prims.string = (fun uu___112_3455 -> (match (uu___112_3455) with
+| Hash -> begin
+"#"
+end
+| uu____3456 -> begin
+""
+end))
+
+
+let rec term_to_string : term  ->  Prims.string = (fun x -> (match (x.tm) with
+| Wild -> begin
+"_"
+end
+| Requires (t, uu____3467) -> begin
+(
+
+let uu____3470 = (term_to_string t)
+in (FStar_Util.format1 "(requires %s)" uu____3470))
+end
+| Ensures (t, uu____3472) -> begin
+(
+
+let uu____3475 = (term_to_string t)
+in (FStar_Util.format1 "(ensures %s)" uu____3475))
+end
+| Labeled (t, l, uu____3478) -> begin
+(
+
+let uu____3479 = (term_to_string t)
+in (FStar_Util.format2 "(labeled %s %s)" l uu____3479))
+end
+| Const (c) -> begin
+(FStar_Syntax_Print.const_to_string c)
+end
+| Op (s, xs) -> begin
+(
+
+let uu____3485 = (
+
+let uu____3486 = (FStar_List.map (fun x1 -> (FStar_All.pipe_right x1 term_to_string)) xs)
+in (FStar_String.concat ", " uu____3486))
+in (FStar_Util.format2 "%s(%s)" s uu____3485))
+end
+| (Tvar (id)) | (Uvar (id)) -> begin
+id.FStar_Ident.idText
+end
+| (Var (l)) | (Name (l)) -> begin
+l.FStar_Ident.str
+end
+| Construct (l, args) -> begin
+(
+
+let uu____3499 = (to_string_l " " (fun uu____3502 -> (match (uu____3502) with
+| (a, imp) -> begin
+(
+
+let uu____3507 = (term_to_string a)
+in (FStar_Util.format2 "%s%s" (imp_to_string imp) uu____3507))
+end)) args)
+in (FStar_Util.format2 "(%s %s)" l.FStar_Ident.str uu____3499))
+end
+| Abs (pats, t) -> begin
+(
+
+let uu____3512 = (to_string_l " " pat_to_string pats)
+in (
+
+let uu____3513 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "(fun %s -> %s)" uu____3512 uu____3513)))
+end
+| App (t1, t2, imp) -> begin
+(
+
+let uu____3517 = (FStar_All.pipe_right t1 term_to_string)
+in (
+
+let uu____3518 = (FStar_All.pipe_right t2 term_to_string)
+in (FStar_Util.format3 "%s %s%s" uu____3517 (imp_to_string imp) uu____3518)))
+end
+| Let (Rec, lbs, body) -> begin
+(
+
+let uu____3527 = (to_string_l " and " (fun uu____3530 -> (match (uu____3530) with
+| (p, b) -> begin
+(
+
+let uu____3535 = (FStar_All.pipe_right p pat_to_string)
+in (
+
+let uu____3536 = (FStar_All.pipe_right b term_to_string)
+in (FStar_Util.format2 "%s=%s" uu____3535 uu____3536)))
+end)) lbs)
+in (
+
+let uu____3537 = (FStar_All.pipe_right body term_to_string)
+in (FStar_Util.format2 "let rec %s in %s" uu____3527 uu____3537)))
+end
+| Let (q, ((pat, tm))::[], body) -> begin
+(
+
+let uu____3549 = (FStar_All.pipe_right pat pat_to_string)
+in (
+
+let uu____3550 = (FStar_All.pipe_right tm term_to_string)
+in (
+
+let uu____3551 = (FStar_All.pipe_right body term_to_string)
+in (FStar_Util.format4 "let %s %s = %s in %s" (string_of_let_qualifier q) uu____3549 uu____3550 uu____3551))))
+end
+| Seq (t1, t2) -> begin
+(
+
+let uu____3554 = (FStar_All.pipe_right t1 term_to_string)
+in (
+
+let uu____3555 = (FStar_All.pipe_right t2 term_to_string)
+in (FStar_Util.format2 "%s; %s" uu____3554 uu____3555)))
+end
+| If (t1, t2, t3) -> begin
+(
+
+let uu____3559 = (FStar_All.pipe_right t1 term_to_string)
+in (
+
+let uu____3560 = (FStar_All.pipe_right t2 term_to_string)
+in (
+
+let uu____3561 = (FStar_All.pipe_right t3 term_to_string)
+in (FStar_Util.format3 "if %s then %s else %s" uu____3559 uu____3560 uu____3561))))
+end
+| Match (t, branches) -> begin
+(
+
+let uu____3574 = (FStar_All.pipe_right t term_to_string)
+in (
+
+let uu____3575 = (to_string_l " | " (fun uu____3580 -> (match (uu____3580) with
+| (p, w, e) -> begin
+(
+
+let uu____3590 = (FStar_All.pipe_right p pat_to_string)
+in (
+
+let uu____3591 = (match (w) with
+| None -> begin
+""
+end
+| Some (e1) -> begin
+(
+
+let uu____3593 = (term_to_string e1)
+in (FStar_Util.format1 "when %s" uu____3593))
+end)
+in (
+
+let uu____3594 = (FStar_All.pipe_right e term_to_string)
+in (FStar_Util.format3 "%s %s -> %s" uu____3590 uu____3591 uu____3594))))
+end)) branches)
+in (FStar_Util.format2 "match %s with %s" uu____3574 uu____3575)))
+end
+| Ascribed (t1, t2, None) -> begin
+(
+
+let uu____3598 = (FStar_All.pipe_right t1 term_to_string)
+in (
+
+let uu____3599 = (FStar_All.pipe_right t2 term_to_string)
+in (FStar_Util.format2 "(%s : %s)" uu____3598 uu____3599)))
+end
+| Ascribed (t1, t2, Some (tac)) -> begin
+(
+
+let uu____3604 = (FStar_All.pipe_right t1 term_to_string)
+in (
+
+let uu____3605 = (FStar_All.pipe_right t2 term_to_string)
+in (
+
+let uu____3606 = (FStar_All.pipe_right tac term_to_string)
+in (FStar_Util.format3 "(%s : %s by %s)" uu____3604 uu____3605 uu____3606))))
+end
+| Record (Some (e), fields) -> begin
+(
+
+let uu____3616 = (FStar_All.pipe_right e term_to_string)
+in (
+
+let uu____3617 = (to_string_l " " (fun uu____3620 -> (match (uu____3620) with
+| (l, e1) -> begin
+(
+
+let uu____3625 = (FStar_All.pipe_right e1 term_to_string)
+in (FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____3625))
+end)) fields)
+in (FStar_Util.format2 "{%s with %s}" uu____3616 uu____3617)))
+end
+| Record (None, fields) -> begin
+(
+
+let uu____3634 = (to_string_l " " (fun uu____3637 -> (match (uu____3637) with
+| (l, e) -> begin
+(
+
+let uu____3642 = (FStar_All.pipe_right e term_to_string)
+in (FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____3642))
+end)) fields)
+in (FStar_Util.format1 "{%s}" uu____3634))
+end
+| Project (e, l) -> begin
+(
+
+let uu____3645 = (FStar_All.pipe_right e term_to_string)
+in (FStar_Util.format2 "%s.%s" uu____3645 l.FStar_Ident.str))
+end
+| Product ([], t) -> begin
+(term_to_string t)
+end
+| Product ((b)::(hd1)::tl1, t) -> begin
+(term_to_string (mk_term (Product ((((b)::[]), ((mk_term (Product ((((hd1)::tl1), (t)))) x.range x.level))))) x.range x.level))
+end
+| Product ((b)::[], t) when (x.level = Type_level) -> begin
+(
+
+let uu____3659 = (FStar_All.pipe_right b binder_to_string)
+in (
+
+let uu____3660 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s -> %s" uu____3659 uu____3660)))
+end
+| Product ((b)::[], t) when (x.level = Kind) -> begin
+(
+
+let uu____3664 = (FStar_All.pipe_right b binder_to_string)
+in (
+
+let uu____3665 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s => %s" uu____3664 uu____3665)))
+end
+| Sum (binders, t) -> begin
+(
+
+let uu____3670 = (
+
+let uu____3671 = (FStar_All.pipe_right binders (FStar_List.map binder_to_string))
+in (FStar_All.pipe_right uu____3671 (FStar_String.concat " * ")))
+in (
+
+let uu____3676 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s * %s" uu____3670 uu____3676)))
+end
+| QForall (bs, pats, t) -> begin
+(
+
+let uu____3686 = (to_string_l " " binder_to_string bs)
+in (
+
+let uu____3687 = (to_string_l " \\/ " (to_string_l "; " term_to_string) pats)
+in (
+
+let uu____3689 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____3686 uu____3687 uu____3689))))
+end
+| QExists (bs, pats, t) -> begin
+(
+
+let uu____3699 = (to_string_l " " binder_to_string bs)
+in (
+
+let uu____3700 = (to_string_l " \\/ " (to_string_l "; " term_to_string) pats)
+in (
+
+let uu____3702 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____3699 uu____3700 uu____3702))))
+end
+| Refine (b, t) -> begin
+(
+
+let uu____3705 = (FStar_All.pipe_right b binder_to_string)
+in (
+
+let uu____3706 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s:{%s}" uu____3705 uu____3706)))
+end
+| NamedTyp (x1, t) -> begin
+(
+
+let uu____3709 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s:%s" x1.FStar_Ident.idText uu____3709))
+end
+| Paren (t) -> begin
+(
+
+let uu____3711 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format1 "(%s)" uu____3711))
+end
+| Product (bs, t) -> begin
+(
+
+let uu____3716 = (
+
+let uu____3717 = (FStar_All.pipe_right bs (FStar_List.map binder_to_string))
+in (FStar_All.pipe_right uu____3717 (FStar_String.concat ",")))
+in (
+
+let uu____3722 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "Unidentified product: [%s] %s" uu____3716 uu____3722)))
+end
+| t -> begin
+"_"
+end))
+and binder_to_string : binder  ->  Prims.string = (fun x -> (
+
+let s = (match (x.b) with
+| Variable (i) -> begin
+i.FStar_Ident.idText
+end
+| TVariable (i) -> begin
+(FStar_Util.format1 "%s:_" i.FStar_Ident.idText)
+end
+| (TAnnotated (i, t)) | (Annotated (i, t)) -> begin
+(
+
+let uu____3730 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____3730))
+end
+| NoName (t) -> begin
+(FStar_All.pipe_right t term_to_string)
+end)
+in (
+
+let uu____3732 = (aqual_to_string x.aqual)
+in (FStar_Util.format2 "%s%s" uu____3732 s))))
+and aqual_to_string : aqual  ->  Prims.string = (fun uu___113_3733 -> (match (uu___113_3733) with
+| Some (Equality) -> begin
+"$"
+end
+| Some (Implicit) -> begin
+"#"
+end
+| uu____3734 -> begin
+""
+end))
+and pat_to_string : pattern  ->  Prims.string = (fun x -> (match (x.pat) with
+| PatWild -> begin
+"_"
+end
+| PatConst (c) -> begin
+(FStar_Syntax_Print.const_to_string c)
+end
+| PatApp (p, ps) -> begin
+(
+
+let uu____3741 = (FStar_All.pipe_right p pat_to_string)
+in (
+
+let uu____3742 = (to_string_l " " pat_to_string ps)
+in (FStar_Util.format2 "(%s %s)" uu____3741 uu____3742)))
+end
+| (PatTvar (i, aq)) | (PatVar (i, aq)) -> begin
+(
+
+let uu____3749 = (aqual_to_string aq)
+in (FStar_Util.format2 "%s%s" uu____3749 i.FStar_Ident.idText))
+end
+| PatName (l) -> begin
+l.FStar_Ident.str
+end
+| PatList (l) -> begin
+(
+
+let uu____3753 = (to_string_l "; " pat_to_string l)
+in (FStar_Util.format1 "[%s]" uu____3753))
+end
+| PatTuple (l, false) -> begin
+(
+
+let uu____3757 = (to_string_l ", " pat_to_string l)
+in (FStar_Util.format1 "(%s)" uu____3757))
+end
+| PatTuple (l, true) -> begin
+(
+
+let uu____3761 = (to_string_l ", " pat_to_string l)
+in (FStar_Util.format1 "(|%s|)" uu____3761))
+end
+| PatRecord (l) -> begin
+(
+
+let uu____3766 = (to_string_l "; " (fun uu____3769 -> (match (uu____3769) with
+| (f, e) -> begin
+(
+
+let uu____3774 = (FStar_All.pipe_right e pat_to_string)
+in (FStar_Util.format2 "%s=%s" f.FStar_Ident.str uu____3774))
+end)) l)
+in (FStar_Util.format1 "{%s}" uu____3766))
+end
+| PatOr (l) -> begin
+(to_string_l "|\n " pat_to_string l)
+end
+| PatOp (op) -> begin
+(FStar_Util.format1 "(%s)" op)
+end
+| PatAscribed (p, t) -> begin
+(
+
+let uu____3780 = (FStar_All.pipe_right p pat_to_string)
+in (
+
+let uu____3781 = (FStar_All.pipe_right t term_to_string)
+in (FStar_Util.format2 "(%s:%s)" uu____3780 uu____3781)))
+end))
+
+
+let rec head_id_of_pat : pattern  ->  FStar_Ident.lid Prims.list = (fun p -> (match (p.pat) with
+| PatName (l) -> begin
+(l)::[]
+end
+| PatVar (i, uu____3789) -> begin
+(
+
+let uu____3792 = (FStar_Ident.lid_of_ids ((i)::[]))
+in (uu____3792)::[])
+end
+| PatApp (p1, uu____3794) -> begin
+(head_id_of_pat p1)
+end
+| PatAscribed (p1, uu____3798) -> begin
+(head_id_of_pat p1)
+end
+| uu____3799 -> begin
+[]
+end))
+
+
+let lids_of_let = (fun defs -> (FStar_All.pipe_right defs (FStar_List.collect (fun uu____3820 -> (match (uu____3820) with
+| (p, uu____3825) -> begin
+(head_id_of_pat p)
+end)))))
+
+
+let id_of_tycon : tycon  ->  Prims.string = (fun uu___114_3828 -> (match (uu___114_3828) with
+| (TyconAbstract (i, _, _)) | (TyconAbbrev (i, _, _, _)) | (TyconRecord (i, _, _, _)) | (TyconVariant (i, _, _, _)) -> begin
+i.FStar_Ident.idText
+end))
+
+
+let decl_to_string : decl  ->  Prims.string = (fun d -> (match (d.d) with
+| TopLevelModule (l) -> begin
+(Prims.strcat "module " l.FStar_Ident.str)
+end
+| Open (l) -> begin
+(Prims.strcat "open " l.FStar_Ident.str)
+end
+| Include (l) -> begin
+(Prims.strcat "include " l.FStar_Ident.str)
+end
+| ModuleAbbrev (i, l) -> begin
+(FStar_Util.format2 "module %s = %s" i.FStar_Ident.idText l.FStar_Ident.str)
+end
+| TopLevelLet (uu____3869, pats) -> begin
+(
+
+let uu____3877 = (
+
+let uu____3878 = (
+
+let uu____3880 = (lids_of_let pats)
+in (FStar_All.pipe_right uu____3880 (FStar_List.map (fun l -> l.FStar_Ident.str))))
+in (FStar_All.pipe_right uu____3878 (FStar_String.concat ", ")))
+in (Prims.strcat "let " uu____3877))
+end
+| Main (uu____3886) -> begin
+"main ..."
+end
+| Assume (i, uu____3888) -> begin
+(Prims.strcat "assume " i.FStar_Ident.idText)
+end
+| Tycon (uu____3889, tys) -> begin
+(
+
+let uu____3899 = (
+
+let uu____3900 = (FStar_All.pipe_right tys (FStar_List.map (fun uu____3910 -> (match (uu____3910) with
+| (x, uu____3915) -> begin
+(id_of_tycon x)
+end))))
+in (FStar_All.pipe_right uu____3900 (FStar_String.concat ", ")))
+in (Prims.strcat "type " uu____3899))
+end
+| Val (i, uu____3920) -> begin
+(Prims.strcat "val " i.FStar_Ident.idText)
+end
+| Exception (i, uu____3922) -> begin
+(Prims.strcat "exception " i.FStar_Ident.idText)
+end
+| (NewEffect (DefineEffect (i, _, _, _))) | (NewEffect (RedefineEffect (i, _, _))) -> begin
+(Prims.strcat "new_effect " i.FStar_Ident.idText)
+end
+| SubEffect (uu____3934) -> begin
+"sub_effect"
+end
+| Pragma (uu____3935) -> begin
+"pragma"
+end
+| Fsdoc (uu____3936) -> begin
+"fsdoc"
+end))
+
+
+let modul_to_string : modul  ->  Prims.string = (fun m -> (match (m) with
+| (Module (_, decls)) | (Interface (_, decls, _)) -> begin
+(
+
+let uu____3948 = (FStar_All.pipe_right decls (FStar_List.map decl_to_string))
+in (FStar_All.pipe_right uu____3948 (FStar_String.concat "\n")))
+end))
+
+
+let error = (fun msg tm r -> (
+
+let tm1 = (FStar_All.pipe_right tm term_to_string)
+in (
+
+let tm2 = (match (((FStar_String.length tm1) >= (Prims.parse_int "80"))) with
+| true -> begin
+(
+
+let uu____3975 = (FStar_Util.substring tm1 (Prims.parse_int "0") (Prims.parse_int "77"))
+in (Prims.strcat uu____3975 "..."))
+end
+| uu____3976 -> begin
+tm1
+end)
+in (Prims.raise (FStar_Errors.Error ((((Prims.strcat msg (Prims.strcat "\n" tm2))), (r))))))))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1,803 +1,1269 @@
+
 open Prims
 type verify_mode =
-  | VerifyAll
-  | VerifyUserList
-  | VerifyFigureItOut
-let uu___is_VerifyAll: verify_mode -> Prims.bool =
-  fun projectee  ->
-    match projectee with | VerifyAll  -> true | uu____4 -> false
-let uu___is_VerifyUserList: verify_mode -> Prims.bool =
-  fun projectee  ->
-    match projectee with | VerifyUserList  -> true | uu____8 -> false
-let uu___is_VerifyFigureItOut: verify_mode -> Prims.bool =
-  fun projectee  ->
-    match projectee with | VerifyFigureItOut  -> true | uu____12 -> false
+| VerifyAll
+| VerifyUserList
+| VerifyFigureItOut
+
+
+let uu___is_VerifyAll : verify_mode  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| VerifyAll -> begin
+true
+end
+| uu____4 -> begin
+false
+end))
+
+
+let uu___is_VerifyUserList : verify_mode  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| VerifyUserList -> begin
+true
+end
+| uu____8 -> begin
+false
+end))
+
+
+let uu___is_VerifyFigureItOut : verify_mode  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| VerifyFigureItOut -> begin
+true
+end
+| uu____12 -> begin
+false
+end))
+
+
 type map =
-  (Prims.string Prims.option* Prims.string Prims.option) FStar_Util.smap
+(Prims.string Prims.option * Prims.string Prims.option) FStar_Util.smap
+
 type color =
-  | White
-  | Gray
-  | Black
-let uu___is_White: color -> Prims.bool =
-  fun projectee  -> match projectee with | White  -> true | uu____21 -> false
-let uu___is_Gray: color -> Prims.bool =
-  fun projectee  -> match projectee with | Gray  -> true | uu____25 -> false
-let uu___is_Black: color -> Prims.bool =
-  fun projectee  -> match projectee with | Black  -> true | uu____29 -> false
-let check_and_strip_suffix: Prims.string -> Prims.string Prims.option =
-  fun f  ->
-    let suffixes = [".fsti"; ".fst"; ".fsi"; ".fs"] in
-    let matches =
-      FStar_List.map
-        (fun ext  ->
-           let lext = FStar_String.length ext in
-           let l = FStar_String.length f in
-           let uu____46 =
-             (l > lext) &&
-               (let uu____52 = FStar_String.substring f (l - lext) lext in
-                uu____52 = ext) in
-           if uu____46
-           then
-             let uu____61 =
-               FStar_String.substring f (Prims.parse_int "0") (l - lext) in
-             Some uu____61
-           else None) suffixes in
-    let uu____68 = FStar_List.filter FStar_Util.is_some matches in
-    match uu____68 with | (Some m)::uu____74 -> Some m | uu____78 -> None
-let is_interface: Prims.string -> Prims.bool =
-  fun f  ->
-    let uu____84 =
-      FStar_String.get f ((FStar_String.length f) - (Prims.parse_int "1")) in
-    uu____84 = 'i'
-let is_implementation: Prims.string -> Prims.bool =
-  fun f  -> let uu____91 = is_interface f in Prims.op_Negation uu____91
-let list_of_option uu___115_100 =
-  match uu___115_100 with | Some x -> [x] | None  -> []
-let list_of_pair uu____114 =
-  match uu____114 with
-  | (intf,impl) ->
-      FStar_List.append (list_of_option intf) (list_of_option impl)
-let lowercase_module_name: Prims.string -> Prims.string =
-  fun f  ->
-    let uu____128 =
-      let uu____130 = FStar_Util.basename f in
-      check_and_strip_suffix uu____130 in
-    match uu____128 with
-    | Some longname -> FStar_String.lowercase longname
-    | None  ->
-        let uu____132 =
-          let uu____133 = FStar_Util.format1 "not a valid FStar file: %s\n" f in
-          FStar_Errors.Err uu____133 in
-        Prims.raise uu____132
-let build_map:
-  Prims.string Prims.list ->
-    (Prims.string Prims.option* Prims.string Prims.option) FStar_Util.smap
-  =
-  fun filenames  ->
-    let include_directories = FStar_Options.include_path () in
-    let include_directories1 =
-      FStar_List.map FStar_Common.try_convert_file_name_to_mixed
-        include_directories in
-    let include_directories2 =
-      FStar_List.map FStar_Util.normalize_file_path include_directories1 in
-    let include_directories3 = FStar_List.unique include_directories2 in
-    let cwd =
-      let uu____148 = FStar_Util.getcwd () in
-      FStar_Util.normalize_file_path uu____148 in
-    let map1 = FStar_Util.smap_create (Prims.parse_int "41") in
-    let add_entry key full_path =
-      let uu____166 = FStar_Util.smap_try_find map1 key in
-      match uu____166 with
-      | Some (intf,impl) ->
-          let uu____186 = is_interface full_path in
-          if uu____186
-          then FStar_Util.smap_add map1 key ((Some full_path), impl)
-          else FStar_Util.smap_add map1 key (intf, (Some full_path))
-      | None  ->
-          let uu____204 = is_interface full_path in
-          if uu____204
-          then FStar_Util.smap_add map1 key ((Some full_path), None)
-          else FStar_Util.smap_add map1 key (None, (Some full_path)) in
-    FStar_List.iter
-      (fun d  ->
-         if FStar_Util.file_exists d
-         then
-           let files = FStar_Util.readdir d in
-           FStar_List.iter
-             (fun f  ->
-                let f1 = FStar_Util.basename f in
-                let uu____224 = check_and_strip_suffix f1 in
-                match uu____224 with
-                | Some longname ->
-                    let full_path =
-                      if d = cwd then f1 else FStar_Util.join_paths d f1 in
-                    let key = FStar_String.lowercase longname in
-                    add_entry key full_path
-                | None  -> ()) files
-         else
-           (let uu____231 =
-              let uu____232 =
-                FStar_Util.format1 "not a valid include directory: %s\n" d in
-              FStar_Errors.Err uu____232 in
-            Prims.raise uu____231)) include_directories3;
-    FStar_List.iter
-      (fun f  ->
-         let uu____235 = lowercase_module_name f in add_entry uu____235 f)
-      filenames;
-    map1
-let enter_namespace: map -> map -> Prims.string -> Prims.bool =
-  fun original_map  ->
-    fun working_map  ->
-      fun prefix1  ->
-        let found = FStar_Util.mk_ref false in
-        let prefix2 = Prims.strcat prefix1 "." in
-        (let uu____250 =
-           let uu____252 = FStar_Util.smap_keys original_map in
-           FStar_List.unique uu____252 in
-         FStar_List.iter
-           (fun k  ->
-              if FStar_Util.starts_with k prefix2
-              then
-                let suffix =
-                  FStar_String.substring k (FStar_String.length prefix2)
-                    ((FStar_String.length k) - (FStar_String.length prefix2)) in
-                let filename =
-                  let uu____272 = FStar_Util.smap_try_find original_map k in
-                  FStar_Util.must uu____272 in
-                (FStar_Util.smap_add working_map suffix filename;
-                 FStar_ST.write found true)
-              else ()) uu____250);
-        FStar_ST.read found
-let string_of_lid: FStar_Ident.lident -> Prims.bool -> Prims.string =
-  fun l  ->
-    fun last1  ->
-      let suffix =
-        if last1 then [(l.FStar_Ident.ident).FStar_Ident.idText] else [] in
-      let names =
-        let uu____308 =
-          FStar_List.map (fun x  -> x.FStar_Ident.idText) l.FStar_Ident.ns in
-        FStar_List.append uu____308 suffix in
-      FStar_String.concat "." names
-let lowercase_join_longident:
-  FStar_Ident.lident -> Prims.bool -> Prims.string =
-  fun l  ->
-    fun last1  ->
-      let uu____317 = string_of_lid l last1 in
-      FStar_String.lowercase uu____317
-let check_module_declaration_against_filename:
-  FStar_Ident.lident -> Prims.string -> Prims.unit =
-  fun lid  ->
-    fun filename  ->
-      let k' = lowercase_join_longident lid true in
-      let uu____325 =
-        let uu____326 =
-          let uu____327 =
-            let uu____328 =
-              let uu____330 = FStar_Util.basename filename in
-              check_and_strip_suffix uu____330 in
-            FStar_Util.must uu____328 in
-          FStar_String.lowercase uu____327 in
-        uu____326 <> k' in
-      if uu____325
-      then
-        let uu____331 =
-          let uu____333 = string_of_lid lid true in [uu____333; filename] in
-        FStar_Util.fprint FStar_Util.stderr
-          "Warning: the module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect.\n"
-          uu____331
-      else ()
+| White
+| Gray
+| Black
+
+
+let uu___is_White : color  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| White -> begin
+true
+end
+| uu____21 -> begin
+false
+end))
+
+
+let uu___is_Gray : color  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Gray -> begin
+true
+end
+| uu____25 -> begin
+false
+end))
+
+
+let uu___is_Black : color  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Black -> begin
+true
+end
+| uu____29 -> begin
+false
+end))
+
+
+let check_and_strip_suffix : Prims.string  ->  Prims.string Prims.option = (fun f -> (
+
+let suffixes = (".fsti")::(".fst")::(".fsi")::(".fs")::[]
+in (
+
+let matches = (FStar_List.map (fun ext -> (
+
+let lext = (FStar_String.length ext)
+in (
+
+let l = (FStar_String.length f)
+in (
+
+let uu____46 = ((l > lext) && (
+
+let uu____52 = (FStar_String.substring f (l - lext) lext)
+in (uu____52 = ext)))
+in (match (uu____46) with
+| true -> begin
+(
+
+let uu____61 = (FStar_String.substring f (Prims.parse_int "0") (l - lext))
+in Some (uu____61))
+end
+| uu____67 -> begin
+None
+end))))) suffixes)
+in (
+
+let uu____68 = (FStar_List.filter FStar_Util.is_some matches)
+in (match (uu____68) with
+| (Some (m))::uu____74 -> begin
+Some (m)
+end
+| uu____78 -> begin
+None
+end)))))
+
+
+let is_interface : Prims.string  ->  Prims.bool = (fun f -> (
+
+let uu____84 = (FStar_String.get f ((FStar_String.length f) - (Prims.parse_int "1")))
+in (uu____84 = 'i')))
+
+
+let is_implementation : Prims.string  ->  Prims.bool = (fun f -> (
+
+let uu____91 = (is_interface f)
+in (not (uu____91))))
+
+
+let list_of_option = (fun uu___115_100 -> (match (uu___115_100) with
+| Some (x) -> begin
+(x)::[]
+end
+| None -> begin
+[]
+end))
+
+
+let list_of_pair = (fun uu____114 -> (match (uu____114) with
+| (intf, impl) -> begin
+(FStar_List.append (list_of_option intf) (list_of_option impl))
+end))
+
+
+let lowercase_module_name : Prims.string  ->  Prims.string = (fun f -> (
+
+let uu____128 = (
+
+let uu____130 = (FStar_Util.basename f)
+in (check_and_strip_suffix uu____130))
+in (match (uu____128) with
+| Some (longname) -> begin
+(FStar_String.lowercase longname)
+end
+| None -> begin
+(
+
+let uu____132 = (
+
+let uu____133 = (FStar_Util.format1 "not a valid FStar file: %s\n" f)
+in FStar_Errors.Err (uu____133))
+in (Prims.raise uu____132))
+end)))
+
+
+let build_map : Prims.string Prims.list  ->  map = (fun filenames -> (
+
+let include_directories = (FStar_Options.include_path ())
+in (
+
+let include_directories1 = (FStar_List.map FStar_Common.try_convert_file_name_to_mixed include_directories)
+in (
+
+let include_directories2 = (FStar_List.map FStar_Util.normalize_file_path include_directories1)
+in (
+
+let include_directories3 = (FStar_List.unique include_directories2)
+in (
+
+let cwd = (
+
+let uu____148 = (FStar_Util.getcwd ())
+in (FStar_Util.normalize_file_path uu____148))
+in (
+
+let map1 = (FStar_Util.smap_create (Prims.parse_int "41"))
+in (
+
+let add_entry = (fun key full_path -> (
+
+let uu____166 = (FStar_Util.smap_try_find map1 key)
+in (match (uu____166) with
+| Some (intf, impl) -> begin
+(
+
+let uu____186 = (is_interface full_path)
+in (match (uu____186) with
+| true -> begin
+(FStar_Util.smap_add map1 key ((Some (full_path)), (impl)))
+end
+| uu____193 -> begin
+(FStar_Util.smap_add map1 key ((intf), (Some (full_path))))
+end))
+end
+| None -> begin
+(
+
+let uu____204 = (is_interface full_path)
+in (match (uu____204) with
+| true -> begin
+(FStar_Util.smap_add map1 key ((Some (full_path)), (None)))
+end
+| uu____211 -> begin
+(FStar_Util.smap_add map1 key ((None), (Some (full_path))))
+end))
+end)))
+in ((FStar_List.iter (fun d -> (match ((FStar_Util.file_exists d)) with
+| true -> begin
+(
+
+let files = (FStar_Util.readdir d)
+in (FStar_List.iter (fun f -> (
+
+let f1 = (FStar_Util.basename f)
+in (
+
+let uu____224 = (check_and_strip_suffix f1)
+in (match (uu____224) with
+| Some (longname) -> begin
+(
+
+let full_path = (match ((d = cwd)) with
+| true -> begin
+f1
+end
+| uu____228 -> begin
+(FStar_Util.join_paths d f1)
+end)
+in (
+
+let key = (FStar_String.lowercase longname)
+in (add_entry key full_path)))
+end
+| None -> begin
+()
+end)))) files))
+end
+| uu____230 -> begin
+(
+
+let uu____231 = (
+
+let uu____232 = (FStar_Util.format1 "not a valid include directory: %s\n" d)
+in FStar_Errors.Err (uu____232))
+in (Prims.raise uu____231))
+end)) include_directories3);
+(FStar_List.iter (fun f -> (
+
+let uu____235 = (lowercase_module_name f)
+in (add_entry uu____235 f))) filenames);
+map1;
+)))))))))
+
+
+let enter_namespace : map  ->  map  ->  Prims.string  ->  Prims.bool = (fun original_map working_map prefix1 -> (
+
+let found = (FStar_Util.mk_ref false)
+in (
+
+let prefix2 = (Prims.strcat prefix1 ".")
+in ((
+
+let uu____250 = (
+
+let uu____252 = (FStar_Util.smap_keys original_map)
+in (FStar_List.unique uu____252))
+in (FStar_List.iter (fun k -> (match ((FStar_Util.starts_with k prefix2)) with
+| true -> begin
+(
+
+let suffix = (FStar_String.substring k (FStar_String.length prefix2) ((FStar_String.length k) - (FStar_String.length prefix2)))
+in (
+
+let filename = (
+
+let uu____272 = (FStar_Util.smap_try_find original_map k)
+in (FStar_Util.must uu____272))
+in ((FStar_Util.smap_add working_map suffix filename);
+(FStar_ST.write found true);
+)))
+end
+| uu____293 -> begin
+()
+end)) uu____250));
+(FStar_ST.read found);
+))))
+
+
+let string_of_lid : FStar_Ident.lident  ->  Prims.bool  ->  Prims.string = (fun l last1 -> (
+
+let suffix = (match (last1) with
+| true -> begin
+(l.FStar_Ident.ident.FStar_Ident.idText)::[]
+end
+| uu____305 -> begin
+[]
+end)
+in (
+
+let names = (
+
+let uu____308 = (FStar_List.map (fun x -> x.FStar_Ident.idText) l.FStar_Ident.ns)
+in (FStar_List.append uu____308 suffix))
+in (FStar_String.concat "." names))))
+
+
+let lowercase_join_longident : FStar_Ident.lident  ->  Prims.bool  ->  Prims.string = (fun l last1 -> (
+
+let uu____317 = (string_of_lid l last1)
+in (FStar_String.lowercase uu____317)))
+
+
+let check_module_declaration_against_filename : FStar_Ident.lident  ->  Prims.string  ->  Prims.unit = (fun lid filename -> (
+
+let k' = (lowercase_join_longident lid true)
+in (
+
+let uu____325 = (
+
+let uu____326 = (
+
+let uu____327 = (
+
+let uu____328 = (
+
+let uu____330 = (FStar_Util.basename filename)
+in (check_and_strip_suffix uu____330))
+in (FStar_Util.must uu____328))
+in (FStar_String.lowercase uu____327))
+in (uu____326 <> k'))
+in (match (uu____325) with
+| true -> begin
+(
+
+let uu____331 = (
+
+let uu____333 = (string_of_lid lid true)
+in (uu____333)::(filename)::[])
+in (FStar_Util.fprint FStar_Util.stderr "Warning: the module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect.\n" uu____331))
+end
+| uu____334 -> begin
+()
+end))))
+
 exception Exit
-let uu___is_Exit: Prims.exn -> Prims.bool =
-  fun projectee  -> match projectee with | Exit  -> true | uu____338 -> false
-let collect_one:
-  (Prims.string* Prims.bool FStar_ST.ref) Prims.list ->
-    verify_mode ->
-      Prims.bool -> map -> Prims.string -> Prims.string Prims.list
-  =
-  fun verify_flags  ->
-    fun verify_mode  ->
-      fun is_user_provided_filename  ->
-        fun original_map  ->
-          fun filename  ->
-            let deps = FStar_Util.mk_ref [] in
-            let add_dep d =
-              let uu____373 =
-                let uu____374 =
-                  let uu____375 = FStar_ST.read deps in
-                  FStar_List.existsb (fun d'  -> d' = d) uu____375 in
-                Prims.op_Negation uu____374 in
-              if uu____373
-              then
-                let uu____381 =
-                  let uu____383 = FStar_ST.read deps in d :: uu____383 in
-                FStar_ST.write deps uu____381
-              else () in
-            let working_map = FStar_Util.smap_copy original_map in
-            let record_open let_open lid =
-              let key = lowercase_join_longident lid true in
-              let uu____410 = FStar_Util.smap_try_find working_map key in
-              match uu____410 with
-              | Some pair ->
-                  FStar_List.iter
-                    (fun f  ->
-                       let uu____430 = lowercase_module_name f in
-                       add_dep uu____430) (list_of_pair pair)
-              | None  ->
-                  let r = enter_namespace original_map working_map key in
-                  if Prims.op_Negation r
-                  then
-                    (if let_open
-                     then
-                       Prims.raise
-                         (FStar_Errors.Err
-                            "let-open only supported for modules, not namespaces")
-                     else
-                       (let uu____437 =
-                          let uu____439 = string_of_lid lid true in
-                          [uu____439] in
-                        FStar_Util.fprint FStar_Util.stderr
-                          "Warning: no modules in namespace %s and no file with that name either\n"
-                          uu____437))
-                  else () in
-            let record_module_alias ident lid =
-              let key = FStar_String.lowercase (FStar_Ident.text_of_id ident) in
-              let alias = lowercase_join_longident lid true in
-              let uu____450 = FStar_Util.smap_try_find original_map alias in
-              match uu____450 with
-              | Some deps_of_aliased_module ->
-                  FStar_Util.smap_add working_map key deps_of_aliased_module
-              | None  ->
-                  let uu____477 =
-                    let uu____478 =
-                      FStar_Util.format1
-                        "module not found in search path: %s\n" alias in
-                    FStar_Errors.Err uu____478 in
-                  Prims.raise uu____477 in
-            let record_lid lid =
-              let try_key key =
-                let uu____487 = FStar_Util.smap_try_find working_map key in
-                match uu____487 with
-                | Some pair ->
-                    FStar_List.iter
-                      (fun f  ->
-                         let uu____507 = lowercase_module_name f in
-                         add_dep uu____507) (list_of_pair pair)
-                | None  ->
-                    let uu____512 =
-                      ((FStar_List.length lid.FStar_Ident.ns) >
-                         (Prims.parse_int "0"))
-                        && (FStar_Options.debug_any ()) in
-                    if uu____512
-                    then
-                      let uu____516 =
-                        let uu____518 = string_of_lid lid false in
-                        [uu____518] in
-                      FStar_Util.fprint FStar_Util.stderr
-                        "Warning: unbound module reference %s\n" uu____516
-                    else () in
-              let uu____521 = lowercase_join_longident lid false in
-              try_key uu____521 in
-            let auto_open =
-              let uu____524 =
-                let uu____525 = FStar_Util.basename filename in
-                uu____525 = "prims.fst" in
-              if uu____524
-              then []
-              else
-                [FStar_Syntax_Const.fstar_ns_lid;
-                FStar_Syntax_Const.prims_lid] in
-            FStar_List.iter (record_open false) auto_open;
-            (let num_of_toplevelmods =
-               FStar_Util.mk_ref (Prims.parse_int "0") in
-             let rec collect_fragment uu___116_600 =
-               match uu___116_600 with
-               | FStar_Util.Inl file -> collect_file file
-               | FStar_Util.Inr decls -> collect_decls decls
-             and collect_file uu___117_613 =
-               match uu___117_613 with
-               | modul::[] -> collect_module modul
-               | modules ->
-                   (FStar_Util.fprint FStar_Util.stderr
-                      "Warning: file %s does not respect the one module per file convention\n"
-                      [filename];
-                    FStar_List.iter collect_module modules)
-             and collect_module uu___118_619 =
-               match uu___118_619 with
-               | FStar_Parser_AST.Module (lid,decls)
-                 |FStar_Parser_AST.Interface (lid,decls,_) ->
-                   (check_module_declaration_against_filename lid filename;
-                    (match verify_mode with
-                     | VerifyAll  ->
-                         let uu____629 = string_of_lid lid true in
-                         FStar_Options.add_verify_module uu____629
-                     | VerifyFigureItOut  ->
-                         if is_user_provided_filename
-                         then
-                           let uu____630 = string_of_lid lid true in
-                           FStar_Options.add_verify_module uu____630
-                         else ()
-                     | VerifyUserList  ->
-                         FStar_List.iter
-                           (fun uu____635  ->
-                              match uu____635 with
-                              | (m,r) ->
-                                  let uu____643 =
-                                    let uu____644 =
-                                      let uu____645 = string_of_lid lid true in
-                                      FStar_String.lowercase uu____645 in
-                                    (FStar_String.lowercase m) = uu____644 in
-                                  if uu____643
-                                  then FStar_ST.write r true
-                                  else ()) verify_flags);
-                    collect_decls decls)
-             and collect_decls decls =
-               FStar_List.iter
-                 (fun x  ->
-                    collect_decl x.FStar_Parser_AST.d;
-                    FStar_List.iter collect_term x.FStar_Parser_AST.attrs)
-                 decls
-             and collect_decl uu___119_653 =
-               match uu___119_653 with
-               | FStar_Parser_AST.Include lid|FStar_Parser_AST.Open lid ->
-                   record_open false lid
-               | FStar_Parser_AST.ModuleAbbrev (ident,lid) ->
-                   ((let uu____658 = lowercase_join_longident lid true in
-                     add_dep uu____658);
-                    record_module_alias ident lid)
-               | FStar_Parser_AST.TopLevelLet (uu____659,patterms) ->
-                   FStar_List.iter
-                     (fun uu____669  ->
-                        match uu____669 with
-                        | (pat,t) -> (collect_pattern pat; collect_term t))
-                     patterms
-               | FStar_Parser_AST.Main t
-                 |FStar_Parser_AST.Assume (_,t)
-                  |FStar_Parser_AST.SubEffect
-                   { FStar_Parser_AST.msource = _;
-                     FStar_Parser_AST.mdest = _;
-                     FStar_Parser_AST.lift_op =
-                       FStar_Parser_AST.NonReifiableLift t;_}
-                   |FStar_Parser_AST.SubEffect
-                    { FStar_Parser_AST.msource = _;
-                      FStar_Parser_AST.mdest = _;
-                      FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree
-                        t;_}|FStar_Parser_AST.Val (_,t)
-                   -> collect_term t
-               | FStar_Parser_AST.SubEffect
-                   { FStar_Parser_AST.msource = uu____682;
-                     FStar_Parser_AST.mdest = uu____683;
-                     FStar_Parser_AST.lift_op =
-                       FStar_Parser_AST.ReifiableLift (t0,t1);_}
-                   -> (collect_term t0; collect_term t1)
-               | FStar_Parser_AST.Tycon (uu____687,ts) ->
-                   let ts1 =
-                     FStar_List.map
-                       (fun uu____702  ->
-                          match uu____702 with | (x,doc1) -> x) ts in
-                   FStar_List.iter collect_tycon ts1
-               | FStar_Parser_AST.Exception (uu____710,t) ->
-                   FStar_Util.iter_opt t collect_term
-               | FStar_Parser_AST.NewEffect ed -> collect_effect_decl ed
-               | FStar_Parser_AST.Fsdoc _|FStar_Parser_AST.Pragma _ -> ()
-               | FStar_Parser_AST.TopLevelModule lid ->
-                   (FStar_Util.incr num_of_toplevelmods;
-                    (let uu____722 =
-                       let uu____723 = FStar_ST.read num_of_toplevelmods in
-                       uu____723 > (Prims.parse_int "1") in
-                     if uu____722
-                     then
-                       let uu____726 =
-                         let uu____727 =
-                           let uu____728 = string_of_lid lid true in
-                           FStar_Util.format1
-                             "Automatic dependency analysis demands one module per file (module %s not supported)"
-                             uu____728 in
-                         FStar_Errors.Err uu____727 in
-                       Prims.raise uu____726
-                     else ()))
-             and collect_tycon uu___120_730 =
-               match uu___120_730 with
-               | FStar_Parser_AST.TyconAbstract (uu____731,binders,k) ->
-                   (collect_binders binders;
-                    FStar_Util.iter_opt k collect_term)
-               | FStar_Parser_AST.TyconAbbrev (uu____739,binders,k,t) ->
-                   (collect_binders binders;
-                    FStar_Util.iter_opt k collect_term;
-                    collect_term t)
-               | FStar_Parser_AST.TyconRecord
-                   (uu____749,binders,k,identterms) ->
-                   (collect_binders binders;
-                    FStar_Util.iter_opt k collect_term;
-                    FStar_List.iter
-                      (fun uu____773  ->
-                         match uu____773 with
-                         | (uu____778,t,uu____780) -> collect_term t)
-                      identterms)
-               | FStar_Parser_AST.TyconVariant
-                   (uu____783,binders,k,identterms) ->
-                   (collect_binders binders;
-                    FStar_Util.iter_opt k collect_term;
-                    FStar_List.iter
-                      (fun uu____813  ->
-                         match uu____813 with
-                         | (uu____820,t,uu____822,uu____823) ->
-                             FStar_Util.iter_opt t collect_term) identterms)
-             and collect_effect_decl uu___121_828 =
-               match uu___121_828 with
-               | FStar_Parser_AST.DefineEffect (uu____829,binders,t,decls) ->
-                   (collect_binders binders;
-                    collect_term t;
-                    collect_decls decls)
-               | FStar_Parser_AST.RedefineEffect (uu____839,binders,t) ->
-                   (collect_binders binders; collect_term t)
-             and collect_binders binders =
-               FStar_List.iter collect_binder binders
-             and collect_binder uu___122_847 =
-               match uu___122_847 with
-               | { FStar_Parser_AST.b = FStar_Parser_AST.Annotated (_,t);
-                   FStar_Parser_AST.brange = _; FStar_Parser_AST.blevel = _;
-                   FStar_Parser_AST.aqual = _;_}
-                 |{ FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated (_,t);
-                    FStar_Parser_AST.brange = _; FStar_Parser_AST.blevel = _;
-                    FStar_Parser_AST.aqual = _;_}
-                  |{ FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
-                     FStar_Parser_AST.brange = _;
-                     FStar_Parser_AST.blevel = _;
-                     FStar_Parser_AST.aqual = _;_}
-                   -> collect_term t
-               | uu____860 -> ()
-             and collect_term t = collect_term' t.FStar_Parser_AST.tm
-             and collect_constant uu___123_862 =
-               match uu___123_862 with
-               | FStar_Const.Const_int (uu____863,Some (signedness,width)) ->
-                   let u =
-                     match signedness with
-                     | FStar_Const.Unsigned  -> "u"
-                     | FStar_Const.Signed  -> "" in
-                   let w =
-                     match width with
-                     | FStar_Const.Int8  -> "8"
-                     | FStar_Const.Int16  -> "16"
-                     | FStar_Const.Int32  -> "32"
-                     | FStar_Const.Int64  -> "64" in
-                   let uu____873 = FStar_Util.format2 "fstar.%sint%s" u w in
-                   add_dep uu____873
-               | uu____874 -> ()
-             and collect_term' uu___124_875 =
-               match uu___124_875 with
-               | FStar_Parser_AST.Wild  -> ()
-               | FStar_Parser_AST.Const c -> collect_constant c
-               | FStar_Parser_AST.Op (s,ts) ->
-                   (if s = "@"
-                    then
-                      (let uu____882 =
-                         let uu____883 =
-                           FStar_Ident.lid_of_path
-                             (FStar_Ident.path_of_text
-                                "FStar.List.Tot.Base.append")
-                             FStar_Range.dummyRange in
-                         FStar_Parser_AST.Name uu____883 in
-                       collect_term' uu____882)
-                    else ();
-                    FStar_List.iter collect_term ts)
-               | FStar_Parser_AST.Tvar _|FStar_Parser_AST.Uvar _ -> ()
-               | FStar_Parser_AST.Var lid
-                 |FStar_Parser_AST.Projector (lid,_)
-                  |FStar_Parser_AST.Discrim lid|FStar_Parser_AST.Name lid ->
-                   record_lid lid
-               | FStar_Parser_AST.Construct (lid,termimps) ->
-                   (if (FStar_List.length termimps) = (Prims.parse_int "1")
-                    then record_lid lid
-                    else ();
-                    FStar_List.iter
-                      (fun uu____905  ->
-                         match uu____905 with
-                         | (t,uu____909) -> collect_term t) termimps)
-               | FStar_Parser_AST.Abs (pats,t) ->
-                   (collect_patterns pats; collect_term t)
-               | FStar_Parser_AST.App (t1,t2,uu____917) ->
-                   (collect_term t1; collect_term t2)
-               | FStar_Parser_AST.Let (uu____919,patterms,t) ->
-                   (FStar_List.iter
-                      (fun uu____931  ->
-                         match uu____931 with
-                         | (pat,t1) -> (collect_pattern pat; collect_term t1))
-                      patterms;
-                    collect_term t)
-               | FStar_Parser_AST.LetOpen (lid,t) ->
-                   (record_open true lid; collect_term t)
-               | FStar_Parser_AST.Seq (t1,t2) ->
-                   (collect_term t1; collect_term t2)
-               | FStar_Parser_AST.If (t1,t2,t3) ->
-                   (collect_term t1; collect_term t2; collect_term t3)
-               | FStar_Parser_AST.Match (t,bs)|FStar_Parser_AST.TryWith
-                 (t,bs) -> (collect_term t; collect_branches bs)
-               | FStar_Parser_AST.Ascribed (t1,t2,None ) ->
-                   (collect_term t1; collect_term t2)
-               | FStar_Parser_AST.Ascribed (t1,t2,Some tac) ->
-                   (collect_term t1; collect_term t2; collect_term tac)
-               | FStar_Parser_AST.Record (t,idterms) ->
-                   (FStar_Util.iter_opt t collect_term;
-                    FStar_List.iter
-                      (fun uu____994  ->
-                         match uu____994 with
-                         | (uu____997,t1) -> collect_term t1) idterms)
-               | FStar_Parser_AST.Project (t,uu____1000) -> collect_term t
-               | FStar_Parser_AST.Product (binders,t)|FStar_Parser_AST.Sum
-                 (binders,t) -> (collect_binders binders; collect_term t)
-               | FStar_Parser_AST.QForall (binders,ts,t)
-                 |FStar_Parser_AST.QExists (binders,ts,t) ->
-                   (collect_binders binders;
-                    FStar_List.iter (FStar_List.iter collect_term) ts;
-                    collect_term t)
-               | FStar_Parser_AST.Refine (binder,t) ->
-                   (collect_binder binder; collect_term t)
-               | FStar_Parser_AST.NamedTyp (uu____1029,t) -> collect_term t
-               | FStar_Parser_AST.Paren t -> collect_term t
-               | FStar_Parser_AST.Assign (_,t)
-                 |FStar_Parser_AST.Requires (t,_)
-                  |FStar_Parser_AST.Ensures (t,_)|FStar_Parser_AST.Labeled
-                   (t,_,_) -> collect_term t
-               | FStar_Parser_AST.Attributes cattributes ->
-                   FStar_List.iter collect_term cattributes
-             and collect_patterns ps = FStar_List.iter collect_pattern ps
-             and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
-             and collect_pattern' uu___125_1045 =
-               match uu___125_1045 with
-               | FStar_Parser_AST.PatWild 
-                 |FStar_Parser_AST.PatOp _|FStar_Parser_AST.PatConst _ -> ()
-               | FStar_Parser_AST.PatApp (p,ps) ->
-                   (collect_pattern p; collect_patterns ps)
-               | FStar_Parser_AST.PatVar _
-                 |FStar_Parser_AST.PatName _|FStar_Parser_AST.PatTvar _ -> ()
-               | FStar_Parser_AST.PatList ps
-                 |FStar_Parser_AST.PatOr ps|FStar_Parser_AST.PatTuple (ps,_)
-                   -> collect_patterns ps
-               | FStar_Parser_AST.PatRecord lidpats ->
-                   FStar_List.iter
-                     (fun uu____1068  ->
-                        match uu____1068 with
-                        | (uu____1071,p) -> collect_pattern p) lidpats
-               | FStar_Parser_AST.PatAscribed (p,t) ->
-                   (collect_pattern p; collect_term t)
-             and collect_branches bs = FStar_List.iter collect_branch bs
-             and collect_branch uu____1086 =
-               match uu____1086 with
-               | (pat,t1,t2) ->
-                   (collect_pattern pat;
-                    FStar_Util.iter_opt t1 collect_term;
-                    collect_term t2) in
-             let uu____1098 = FStar_Parser_Driver.parse_file filename in
-             match uu____1098 with
-             | (ast,uu____1106) -> (collect_file ast; FStar_ST.read deps))
-let print_graph graph =
-  FStar_Util.print_endline
-    "A DOT-format graph has been dumped in the current directory as dep.graph";
-  FStar_Util.print_endline
-    "With GraphViz installed, try: fdp -Tpng -odep.png dep.graph";
-  FStar_Util.print_endline "Hint: cat dep.graph | grep -v _ | grep -v prims";
-  (let uu____1135 =
-     let uu____1136 =
-       let uu____1137 =
-         let uu____1138 =
-           let uu____1140 =
-             let uu____1142 = FStar_Util.smap_keys graph in
-             FStar_List.unique uu____1142 in
-           FStar_List.collect
-             (fun k  ->
-                let deps =
-                  let uu____1150 =
-                    let uu____1154 = FStar_Util.smap_try_find graph k in
-                    FStar_Util.must uu____1154 in
-                  Prims.fst uu____1150 in
-                let r s = FStar_Util.replace_char s '.' '_' in
-                FStar_List.map
-                  (fun dep1  ->
-                     FStar_Util.format2 "  %s -> %s" (r k) (r dep1)) deps)
-             uu____1140 in
-         FStar_String.concat "\n" uu____1138 in
-       Prims.strcat uu____1137 "\n}\n" in
-     Prims.strcat "digraph {\n" uu____1136 in
-   FStar_Util.write_file "dep.graph" uu____1135)
-let collect:
-  verify_mode ->
-    Prims.string Prims.list ->
-      ((Prims.string* Prims.string Prims.list) Prims.list* Prims.string
-        Prims.list* (Prims.string Prims.list* color) FStar_Util.smap)
-  =
-  fun verify_mode  ->
-    fun filenames  ->
-      let graph = FStar_Util.smap_create (Prims.parse_int "41") in
-      let verify_flags =
-        let uu____1216 = FStar_Options.verify_module () in
-        FStar_List.map
-          (fun f  ->
-             let uu____1222 = FStar_Util.mk_ref false in (f, uu____1222))
-          uu____1216 in
-      let m = build_map filenames in
-      let collect_one1 = collect_one verify_flags verify_mode in
-      let partial_discovery =
-        let uu____1238 =
-          (FStar_Options.verify_all ()) || (FStar_Options.extract_all ()) in
-        Prims.op_Negation uu____1238 in
-      let rec discover_one is_user_provided_filename interface_only key =
-        let uu____1249 =
-          let uu____1250 = FStar_Util.smap_try_find graph key in
-          uu____1250 = None in
-        if uu____1249
-        then
-          let uu____1265 =
-            let uu____1270 = FStar_Util.smap_try_find m key in
-            FStar_Util.must uu____1270 in
-          match uu____1265 with
-          | (intf,impl) ->
-              let intf_deps =
-                match intf with
-                | Some intf1 ->
-                    collect_one1 is_user_provided_filename m intf1
-                | None  -> [] in
-              let impl_deps =
-                match (impl, intf) with
-                | (Some impl1,Some uu____1300) when interface_only -> []
-                | (Some impl1,uu____1304) ->
-                    collect_one1 is_user_provided_filename m impl1
-                | (None ,uu____1308) -> [] in
-              let deps =
-                FStar_List.unique (FStar_List.append impl_deps intf_deps) in
-              (FStar_Util.smap_add graph key (deps, White);
-               FStar_List.iter (discover_one false partial_discovery) deps)
-        else () in
-      let discover_command_line_argument f =
-        let m1 = lowercase_module_name f in
-        let uu____1325 = is_interface f in
-        if uu____1325
-        then discover_one true true m1
-        else discover_one true false m1 in
-      FStar_List.iter discover_command_line_argument filenames;
-      (let immediate_graph = FStar_Util.smap_copy graph in
-       let topologically_sorted = FStar_Util.mk_ref [] in
-       let rec discover cycle key =
-         let uu____1351 =
-           let uu____1355 = FStar_Util.smap_try_find graph key in
-           FStar_Util.must uu____1355 in
-         match uu____1351 with
-         | (direct_deps,color) ->
-             (match color with
-              | Gray  ->
-                  (FStar_Util.print1
-                     "Warning: recursive dependency on module %s\n" key;
-                   FStar_Util.print1 "The cycle is: %s \n"
-                     (FStar_String.concat " -> " cycle);
-                   print_graph immediate_graph;
-                   FStar_Util.print_string "\n";
-                   FStar_All.exit (Prims.parse_int "1"))
-              | Black  -> direct_deps
-              | White  ->
-                  (FStar_Util.smap_add graph key (direct_deps, Gray);
-                   (let all_deps =
-                      let uu____1384 =
-                        let uu____1386 =
-                          FStar_List.map
-                            (fun dep1  ->
-                               let uu____1391 = discover (key :: cycle) dep1 in
-                               dep1 :: uu____1391) direct_deps in
-                        FStar_List.flatten uu____1386 in
-                      FStar_List.unique uu____1384 in
-                    FStar_Util.smap_add graph key (all_deps, Black);
-                    (let uu____1399 =
-                       let uu____1401 = FStar_ST.read topologically_sorted in
-                       key :: uu____1401 in
-                     FStar_ST.write topologically_sorted uu____1399);
-                    all_deps))) in
-       let discover1 = discover [] in
-       let must_find k =
-         let uu____1418 =
-           let uu____1423 = FStar_Util.smap_try_find m k in
-           FStar_Util.must uu____1423 in
-         match uu____1418 with
-         | (Some intf,Some impl) when
-             (Prims.op_Negation partial_discovery) &&
-               (let uu____1442 =
-                  FStar_List.existsML
-                    (fun f  ->
-                       let uu____1444 = lowercase_module_name f in
-                       uu____1444 = k) filenames in
-                Prims.op_Negation uu____1442)
-             -> [intf; impl]
-         | (Some intf,Some impl) when
-             FStar_List.existsML
-               (fun f  ->
-                  (is_implementation f) &&
-                    (let uu____1450 = lowercase_module_name f in
-                     uu____1450 = k)) filenames
-             -> [intf; impl]
-         | (Some intf,uu____1452) -> [intf]
-         | (None ,Some impl) -> [impl]
-         | (None ,None ) -> [] in
-       let must_find_r f =
-         let uu____1466 = must_find f in FStar_List.rev uu____1466 in
-       let by_target =
-         let uu____1473 =
-           let uu____1475 = FStar_Util.smap_keys graph in
-           FStar_List.sortWith (fun x  -> fun y  -> FStar_String.compare x y)
-             uu____1475 in
-         FStar_List.collect
-           (fun k  ->
-              let as_list = must_find k in
-              let is_interleaved =
-                (FStar_List.length as_list) = (Prims.parse_int "2") in
-              FStar_List.map
-                (fun f  ->
-                   let should_append_fsti =
-                     (is_implementation f) && is_interleaved in
-                   let suffix =
-                     if should_append_fsti then [Prims.strcat f "i"] else [] in
-                   let k1 = lowercase_module_name f in
-                   let deps =
-                     let uu____1503 = discover1 k1 in
-                     FStar_List.rev uu____1503 in
-                   let deps_as_filenames =
-                     let uu____1507 = FStar_List.collect must_find deps in
-                     FStar_List.append uu____1507 suffix in
-                   (f, deps_as_filenames)) as_list) uu____1473 in
-       let topologically_sorted1 =
-         let uu____1512 = FStar_ST.read topologically_sorted in
-         FStar_List.collect must_find_r uu____1512 in
-       FStar_List.iter
-         (fun uu____1521  ->
-            match uu____1521 with
-            | (m1,r) ->
-                let uu____1529 =
-                  (let uu____1530 = FStar_ST.read r in
-                   Prims.op_Negation uu____1530) &&
-                    (let uu____1533 = FStar_Options.interactive () in
-                     Prims.op_Negation uu____1533) in
-                if uu____1529
-                then
-                  let maybe_fst =
-                    let k = FStar_String.length m1 in
-                    let uu____1537 =
-                      (k > (Prims.parse_int "4")) &&
-                        (let uu____1541 =
-                           FStar_String.substring m1
-                             (k - (Prims.parse_int "4"))
-                             (Prims.parse_int "4") in
-                         uu____1541 = ".fst") in
-                    if uu____1537
-                    then
-                      let uu____1545 =
-                        FStar_String.substring m1 (Prims.parse_int "0")
-                          (k - (Prims.parse_int "4")) in
-                      FStar_Util.format1 " Did you mean %s ?" uu____1545
-                    else "" in
-                  let uu____1550 =
-                    let uu____1551 =
-                      FStar_Util.format3
-                        "You passed --verify_module %s but I found no file that contains [module %s] in the dependency graph.%s\n"
-                        m1 m1 maybe_fst in
-                    FStar_Errors.Err uu____1551 in
-                  Prims.raise uu____1550
-                else ()) verify_flags;
-       (by_target, topologically_sorted1, immediate_graph))
-let print_make:
-  (Prims.string* Prims.string Prims.list) Prims.list -> Prims.unit =
-  fun deps  ->
-    FStar_List.iter
-      (fun uu____1576  ->
-         match uu____1576 with
-         | (f,deps1) ->
-             let deps2 =
-               FStar_List.map
-                 (fun s  -> FStar_Util.replace_chars s ' ' "\\ ") deps1 in
-             FStar_Util.print2 "%s: %s\n" f (FStar_String.concat " " deps2))
-      deps
-let print uu____1606 =
-  match uu____1606 with
-  | (make_deps,uu____1619,graph) ->
-      let uu____1637 = FStar_Options.dep () in
-      (match uu____1637 with
-       | Some "make" -> print_make make_deps
-       | Some "graph" -> print_graph graph
-       | Some uu____1639 ->
-           Prims.raise (FStar_Errors.Err "unknown tool for --dep\n")
-       | None  -> ())
+
+
+let uu___is_Exit : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exit -> begin
+true
+end
+| uu____338 -> begin
+false
+end))
+
+
+let collect_one : (Prims.string * Prims.bool FStar_ST.ref) Prims.list  ->  verify_mode  ->  Prims.bool  ->  map  ->  Prims.string  ->  Prims.string Prims.list = (fun verify_flags verify_mode is_user_provided_filename original_map filename -> (
+
+let deps = (FStar_Util.mk_ref [])
+in (
+
+let add_dep = (fun d -> (
+
+let uu____373 = (
+
+let uu____374 = (
+
+let uu____375 = (FStar_ST.read deps)
+in (FStar_List.existsb (fun d' -> (d' = d)) uu____375))
+in (not (uu____374)))
+in (match (uu____373) with
+| true -> begin
+(
+
+let uu____381 = (
+
+let uu____383 = (FStar_ST.read deps)
+in (d)::uu____383)
+in (FStar_ST.write deps uu____381))
+end
+| uu____391 -> begin
+()
+end)))
+in (
+
+let working_map = (FStar_Util.smap_copy original_map)
+in (
+
+let record_open = (fun let_open lid -> (
+
+let key = (lowercase_join_longident lid true)
+in (
+
+let uu____410 = (FStar_Util.smap_try_find working_map key)
+in (match (uu____410) with
+| Some (pair) -> begin
+(FStar_List.iter (fun f -> (
+
+let uu____430 = (lowercase_module_name f)
+in (add_dep uu____430))) (list_of_pair pair))
+end
+| None -> begin
+(
+
+let r = (enter_namespace original_map working_map key)
+in (match ((not (r))) with
+| true -> begin
+(match (let_open) with
+| true -> begin
+(Prims.raise (FStar_Errors.Err ("let-open only supported for modules, not namespaces")))
+end
+| uu____436 -> begin
+(
+
+let uu____437 = (
+
+let uu____439 = (string_of_lid lid true)
+in (uu____439)::[])
+in (FStar_Util.fprint FStar_Util.stderr "Warning: no modules in namespace %s and no file with that name either\n" uu____437))
+end)
+end
+| uu____440 -> begin
+()
+end))
+end))))
+in (
+
+let record_module_alias = (fun ident lid -> (
+
+let key = (FStar_String.lowercase (FStar_Ident.text_of_id ident))
+in (
+
+let alias = (lowercase_join_longident lid true)
+in (
+
+let uu____450 = (FStar_Util.smap_try_find original_map alias)
+in (match (uu____450) with
+| Some (deps_of_aliased_module) -> begin
+(FStar_Util.smap_add working_map key deps_of_aliased_module)
+end
+| None -> begin
+(
+
+let uu____477 = (
+
+let uu____478 = (FStar_Util.format1 "module not found in search path: %s\n" alias)
+in FStar_Errors.Err (uu____478))
+in (Prims.raise uu____477))
+end)))))
+in (
+
+let record_lid = (fun lid -> (
+
+let try_key = (fun key -> (
+
+let uu____487 = (FStar_Util.smap_try_find working_map key)
+in (match (uu____487) with
+| Some (pair) -> begin
+(FStar_List.iter (fun f -> (
+
+let uu____507 = (lowercase_module_name f)
+in (add_dep uu____507))) (list_of_pair pair))
+end
+| None -> begin
+(
+
+let uu____512 = (((FStar_List.length lid.FStar_Ident.ns) > (Prims.parse_int "0")) && (FStar_Options.debug_any ()))
+in (match (uu____512) with
+| true -> begin
+(
+
+let uu____516 = (
+
+let uu____518 = (string_of_lid lid false)
+in (uu____518)::[])
+in (FStar_Util.fprint FStar_Util.stderr "Warning: unbound module reference %s\n" uu____516))
+end
+| uu____519 -> begin
+()
+end))
+end)))
+in (
+
+let uu____521 = (lowercase_join_longident lid false)
+in (try_key uu____521))))
+in (
+
+let auto_open = (
+
+let uu____524 = (
+
+let uu____525 = (FStar_Util.basename filename)
+in (uu____525 = "prims.fst"))
+in (match (uu____524) with
+| true -> begin
+[]
+end
+| uu____527 -> begin
+(FStar_Syntax_Const.fstar_ns_lid)::(FStar_Syntax_Const.prims_lid)::[]
+end))
+in ((FStar_List.iter (record_open false) auto_open);
+(
+
+let num_of_toplevelmods = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (
+
+let rec collect_fragment = (fun uu___116_600 -> (match (uu___116_600) with
+| FStar_Util.Inl (file) -> begin
+(collect_file file)
+end
+| FStar_Util.Inr (decls) -> begin
+(collect_decls decls)
+end))
+and collect_file = (fun uu___117_613 -> (match (uu___117_613) with
+| (modul)::[] -> begin
+(collect_module modul)
+end
+| modules -> begin
+((FStar_Util.fprint FStar_Util.stderr "Warning: file %s does not respect the one module per file convention\n" ((filename)::[]));
+(FStar_List.iter collect_module modules);
+)
+end))
+and collect_module = (fun uu___118_619 -> (match (uu___118_619) with
+| (FStar_Parser_AST.Module (lid, decls)) | (FStar_Parser_AST.Interface (lid, decls, _)) -> begin
+((check_module_declaration_against_filename lid filename);
+(match (verify_mode) with
+| VerifyAll -> begin
+(
+
+let uu____629 = (string_of_lid lid true)
+in (FStar_Options.add_verify_module uu____629))
+end
+| VerifyFigureItOut -> begin
+(match (is_user_provided_filename) with
+| true -> begin
+(
+
+let uu____630 = (string_of_lid lid true)
+in (FStar_Options.add_verify_module uu____630))
+end
+| uu____631 -> begin
+()
+end)
+end
+| VerifyUserList -> begin
+(FStar_List.iter (fun uu____635 -> (match (uu____635) with
+| (m, r) -> begin
+(
+
+let uu____643 = (
+
+let uu____644 = (
+
+let uu____645 = (string_of_lid lid true)
+in (FStar_String.lowercase uu____645))
+in ((FStar_String.lowercase m) = uu____644))
+in (match (uu____643) with
+| true -> begin
+(FStar_ST.write r true)
+end
+| uu____648 -> begin
+()
+end))
+end)) verify_flags)
+end);
+(collect_decls decls);
+)
+end))
+and collect_decls = (fun decls -> (FStar_List.iter (fun x -> ((collect_decl x.FStar_Parser_AST.d);
+(FStar_List.iter collect_term x.FStar_Parser_AST.attrs);
+)) decls))
+and collect_decl = (fun uu___119_653 -> (match (uu___119_653) with
+| (FStar_Parser_AST.Include (lid)) | (FStar_Parser_AST.Open (lid)) -> begin
+(record_open false lid)
+end
+| FStar_Parser_AST.ModuleAbbrev (ident, lid) -> begin
+((
+
+let uu____658 = (lowercase_join_longident lid true)
+in (add_dep uu____658));
+(record_module_alias ident lid);
+)
+end
+| FStar_Parser_AST.TopLevelLet (uu____659, patterms) -> begin
+(FStar_List.iter (fun uu____669 -> (match (uu____669) with
+| (pat, t) -> begin
+((collect_pattern pat);
+(collect_term t);
+)
+end)) patterms)
+end
+| (FStar_Parser_AST.Main (t)) | (FStar_Parser_AST.Assume (_, t)) | (FStar_Parser_AST.SubEffect ({FStar_Parser_AST.msource = _; FStar_Parser_AST.mdest = _; FStar_Parser_AST.lift_op = FStar_Parser_AST.NonReifiableLift (t)})) | (FStar_Parser_AST.SubEffect ({FStar_Parser_AST.msource = _; FStar_Parser_AST.mdest = _; FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree (t)})) | (FStar_Parser_AST.Val (_, t)) -> begin
+(collect_term t)
+end
+| FStar_Parser_AST.SubEffect ({FStar_Parser_AST.msource = uu____682; FStar_Parser_AST.mdest = uu____683; FStar_Parser_AST.lift_op = FStar_Parser_AST.ReifiableLift (t0, t1)}) -> begin
+((collect_term t0);
+(collect_term t1);
+)
+end
+| FStar_Parser_AST.Tycon (uu____687, ts) -> begin
+(
+
+let ts1 = (FStar_List.map (fun uu____702 -> (match (uu____702) with
+| (x, doc1) -> begin
+x
+end)) ts)
+in (FStar_List.iter collect_tycon ts1))
+end
+| FStar_Parser_AST.Exception (uu____710, t) -> begin
+(FStar_Util.iter_opt t collect_term)
+end
+| FStar_Parser_AST.NewEffect (ed) -> begin
+(collect_effect_decl ed)
+end
+| (FStar_Parser_AST.Fsdoc (_)) | (FStar_Parser_AST.Pragma (_)) -> begin
+()
+end
+| FStar_Parser_AST.TopLevelModule (lid) -> begin
+((FStar_Util.incr num_of_toplevelmods);
+(
+
+let uu____722 = (
+
+let uu____723 = (FStar_ST.read num_of_toplevelmods)
+in (uu____723 > (Prims.parse_int "1")))
+in (match (uu____722) with
+| true -> begin
+(
+
+let uu____726 = (
+
+let uu____727 = (
+
+let uu____728 = (string_of_lid lid true)
+in (FStar_Util.format1 "Automatic dependency analysis demands one module per file (module %s not supported)" uu____728))
+in FStar_Errors.Err (uu____727))
+in (Prims.raise uu____726))
+end
+| uu____729 -> begin
+()
+end));
+)
+end))
+and collect_tycon = (fun uu___120_730 -> (match (uu___120_730) with
+| FStar_Parser_AST.TyconAbstract (uu____731, binders, k) -> begin
+((collect_binders binders);
+(FStar_Util.iter_opt k collect_term);
+)
+end
+| FStar_Parser_AST.TyconAbbrev (uu____739, binders, k, t) -> begin
+((collect_binders binders);
+(FStar_Util.iter_opt k collect_term);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.TyconRecord (uu____749, binders, k, identterms) -> begin
+((collect_binders binders);
+(FStar_Util.iter_opt k collect_term);
+(FStar_List.iter (fun uu____773 -> (match (uu____773) with
+| (uu____778, t, uu____780) -> begin
+(collect_term t)
+end)) identterms);
+)
+end
+| FStar_Parser_AST.TyconVariant (uu____783, binders, k, identterms) -> begin
+((collect_binders binders);
+(FStar_Util.iter_opt k collect_term);
+(FStar_List.iter (fun uu____813 -> (match (uu____813) with
+| (uu____820, t, uu____822, uu____823) -> begin
+(FStar_Util.iter_opt t collect_term)
+end)) identterms);
+)
+end))
+and collect_effect_decl = (fun uu___121_828 -> (match (uu___121_828) with
+| FStar_Parser_AST.DefineEffect (uu____829, binders, t, decls) -> begin
+((collect_binders binders);
+(collect_term t);
+(collect_decls decls);
+)
+end
+| FStar_Parser_AST.RedefineEffect (uu____839, binders, t) -> begin
+((collect_binders binders);
+(collect_term t);
+)
+end))
+and collect_binders = (fun binders -> (FStar_List.iter collect_binder binders))
+and collect_binder = (fun uu___122_847 -> (match (uu___122_847) with
+| ({FStar_Parser_AST.b = FStar_Parser_AST.Annotated (_, t); FStar_Parser_AST.brange = _; FStar_Parser_AST.blevel = _; FStar_Parser_AST.aqual = _}) | ({FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated (_, t); FStar_Parser_AST.brange = _; FStar_Parser_AST.blevel = _; FStar_Parser_AST.aqual = _}) | ({FStar_Parser_AST.b = FStar_Parser_AST.NoName (t); FStar_Parser_AST.brange = _; FStar_Parser_AST.blevel = _; FStar_Parser_AST.aqual = _}) -> begin
+(collect_term t)
+end
+| uu____860 -> begin
+()
+end))
+and collect_term = (fun t -> (collect_term' t.FStar_Parser_AST.tm))
+and collect_constant = (fun uu___123_862 -> (match (uu___123_862) with
+| FStar_Const.Const_int (uu____863, Some (signedness, width)) -> begin
+(
+
+let u = (match (signedness) with
+| FStar_Const.Unsigned -> begin
+"u"
+end
+| FStar_Const.Signed -> begin
+""
+end)
+in (
+
+let w = (match (width) with
+| FStar_Const.Int8 -> begin
+"8"
+end
+| FStar_Const.Int16 -> begin
+"16"
+end
+| FStar_Const.Int32 -> begin
+"32"
+end
+| FStar_Const.Int64 -> begin
+"64"
+end)
+in (
+
+let uu____873 = (FStar_Util.format2 "fstar.%sint%s" u w)
+in (add_dep uu____873))))
+end
+| uu____874 -> begin
+()
+end))
+and collect_term' = (fun uu___124_875 -> (match (uu___124_875) with
+| FStar_Parser_AST.Wild -> begin
+()
+end
+| FStar_Parser_AST.Const (c) -> begin
+(collect_constant c)
+end
+| FStar_Parser_AST.Op (s, ts) -> begin
+((match ((s = "@")) with
+| true -> begin
+(
+
+let uu____882 = (
+
+let uu____883 = (FStar_Ident.lid_of_path (FStar_Ident.path_of_text "FStar.List.Tot.Base.append") FStar_Range.dummyRange)
+in FStar_Parser_AST.Name (uu____883))
+in (collect_term' uu____882))
+end
+| uu____884 -> begin
+()
+end);
+(FStar_List.iter collect_term ts);
+)
+end
+| (FStar_Parser_AST.Tvar (_)) | (FStar_Parser_AST.Uvar (_)) -> begin
+()
+end
+| (FStar_Parser_AST.Var (lid)) | (FStar_Parser_AST.Projector (lid, _)) | (FStar_Parser_AST.Discrim (lid)) | (FStar_Parser_AST.Name (lid)) -> begin
+(record_lid lid)
+end
+| FStar_Parser_AST.Construct (lid, termimps) -> begin
+((match (((FStar_List.length termimps) = (Prims.parse_int "1"))) with
+| true -> begin
+(record_lid lid)
+end
+| uu____902 -> begin
+()
+end);
+(FStar_List.iter (fun uu____905 -> (match (uu____905) with
+| (t, uu____909) -> begin
+(collect_term t)
+end)) termimps);
+)
+end
+| FStar_Parser_AST.Abs (pats, t) -> begin
+((collect_patterns pats);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.App (t1, t2, uu____917) -> begin
+((collect_term t1);
+(collect_term t2);
+)
+end
+| FStar_Parser_AST.Let (uu____919, patterms, t) -> begin
+((FStar_List.iter (fun uu____931 -> (match (uu____931) with
+| (pat, t1) -> begin
+((collect_pattern pat);
+(collect_term t1);
+)
+end)) patterms);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.LetOpen (lid, t) -> begin
+((record_open true lid);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.Seq (t1, t2) -> begin
+((collect_term t1);
+(collect_term t2);
+)
+end
+| FStar_Parser_AST.If (t1, t2, t3) -> begin
+((collect_term t1);
+(collect_term t2);
+(collect_term t3);
+)
+end
+| (FStar_Parser_AST.Match (t, bs)) | (FStar_Parser_AST.TryWith (t, bs)) -> begin
+((collect_term t);
+(collect_branches bs);
+)
+end
+| FStar_Parser_AST.Ascribed (t1, t2, None) -> begin
+((collect_term t1);
+(collect_term t2);
+)
+end
+| FStar_Parser_AST.Ascribed (t1, t2, Some (tac)) -> begin
+((collect_term t1);
+(collect_term t2);
+(collect_term tac);
+)
+end
+| FStar_Parser_AST.Record (t, idterms) -> begin
+((FStar_Util.iter_opt t collect_term);
+(FStar_List.iter (fun uu____994 -> (match (uu____994) with
+| (uu____997, t1) -> begin
+(collect_term t1)
+end)) idterms);
+)
+end
+| FStar_Parser_AST.Project (t, uu____1000) -> begin
+(collect_term t)
+end
+| (FStar_Parser_AST.Product (binders, t)) | (FStar_Parser_AST.Sum (binders, t)) -> begin
+((collect_binders binders);
+(collect_term t);
+)
+end
+| (FStar_Parser_AST.QForall (binders, ts, t)) | (FStar_Parser_AST.QExists (binders, ts, t)) -> begin
+((collect_binders binders);
+(FStar_List.iter (FStar_List.iter collect_term) ts);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.Refine (binder, t) -> begin
+((collect_binder binder);
+(collect_term t);
+)
+end
+| FStar_Parser_AST.NamedTyp (uu____1029, t) -> begin
+(collect_term t)
+end
+| FStar_Parser_AST.Paren (t) -> begin
+(collect_term t)
+end
+| (FStar_Parser_AST.Assign (_, t)) | (FStar_Parser_AST.Requires (t, _)) | (FStar_Parser_AST.Ensures (t, _)) | (FStar_Parser_AST.Labeled (t, _, _)) -> begin
+(collect_term t)
+end
+| FStar_Parser_AST.Attributes (cattributes) -> begin
+(FStar_List.iter collect_term cattributes)
+end))
+and collect_patterns = (fun ps -> (FStar_List.iter collect_pattern ps))
+and collect_pattern = (fun p -> (collect_pattern' p.FStar_Parser_AST.pat))
+and collect_pattern' = (fun uu___125_1045 -> (match (uu___125_1045) with
+| (FStar_Parser_AST.PatWild) | (FStar_Parser_AST.PatOp (_)) | (FStar_Parser_AST.PatConst (_)) -> begin
+()
+end
+| FStar_Parser_AST.PatApp (p, ps) -> begin
+((collect_pattern p);
+(collect_patterns ps);
+)
+end
+| (FStar_Parser_AST.PatVar (_)) | (FStar_Parser_AST.PatName (_)) | (FStar_Parser_AST.PatTvar (_)) -> begin
+()
+end
+| (FStar_Parser_AST.PatList (ps)) | (FStar_Parser_AST.PatOr (ps)) | (FStar_Parser_AST.PatTuple (ps, _)) -> begin
+(collect_patterns ps)
+end
+| FStar_Parser_AST.PatRecord (lidpats) -> begin
+(FStar_List.iter (fun uu____1068 -> (match (uu____1068) with
+| (uu____1071, p) -> begin
+(collect_pattern p)
+end)) lidpats)
+end
+| FStar_Parser_AST.PatAscribed (p, t) -> begin
+((collect_pattern p);
+(collect_term t);
+)
+end))
+and collect_branches = (fun bs -> (FStar_List.iter collect_branch bs))
+and collect_branch = (fun uu____1086 -> (match (uu____1086) with
+| (pat, t1, t2) -> begin
+((collect_pattern pat);
+(FStar_Util.iter_opt t1 collect_term);
+(collect_term t2);
+)
+end))
+in (
+
+let uu____1098 = (FStar_Parser_Driver.parse_file filename)
+in (match (uu____1098) with
+| (ast, uu____1106) -> begin
+((collect_file ast);
+(FStar_ST.read deps);
+)
+end))));
+)))))))))
+
+
+let print_graph = (fun graph -> ((FStar_Util.print_endline "A DOT-format graph has been dumped in the current directory as dep.graph");
+(FStar_Util.print_endline "With GraphViz installed, try: fdp -Tpng -odep.png dep.graph");
+(FStar_Util.print_endline "Hint: cat dep.graph | grep -v _ | grep -v prims");
+(
+
+let uu____1135 = (
+
+let uu____1136 = (
+
+let uu____1137 = (
+
+let uu____1138 = (
+
+let uu____1140 = (
+
+let uu____1142 = (FStar_Util.smap_keys graph)
+in (FStar_List.unique uu____1142))
+in (FStar_List.collect (fun k -> (
+
+let deps = (
+
+let uu____1150 = (
+
+let uu____1154 = (FStar_Util.smap_try_find graph k)
+in (FStar_Util.must uu____1154))
+in (Prims.fst uu____1150))
+in (
+
+let r = (fun s -> (FStar_Util.replace_char s '.' '_'))
+in (FStar_List.map (fun dep1 -> (FStar_Util.format2 "  %s -> %s" (r k) (r dep1))) deps)))) uu____1140))
+in (FStar_String.concat "\n" uu____1138))
+in (Prims.strcat uu____1137 "\n}\n"))
+in (Prims.strcat "digraph {\n" uu____1136))
+in (FStar_Util.write_file "dep.graph" uu____1135));
+))
+
+
+let collect : verify_mode  ->  Prims.string Prims.list  ->  ((Prims.string * Prims.string Prims.list) Prims.list * Prims.string Prims.list * (Prims.string Prims.list * color) FStar_Util.smap) = (fun verify_mode filenames -> (
+
+let graph = (FStar_Util.smap_create (Prims.parse_int "41"))
+in (
+
+let verify_flags = (
+
+let uu____1216 = (FStar_Options.verify_module ())
+in (FStar_List.map (fun f -> (
+
+let uu____1222 = (FStar_Util.mk_ref false)
+in ((f), (uu____1222)))) uu____1216))
+in (
+
+let m = (build_map filenames)
+in (
+
+let collect_one1 = (collect_one verify_flags verify_mode)
+in (
+
+let partial_discovery = (
+
+let uu____1238 = ((FStar_Options.verify_all ()) || (FStar_Options.extract_all ()))
+in (not (uu____1238)))
+in (
+
+let rec discover_one = (fun is_user_provided_filename interface_only key -> (
+
+let uu____1249 = (
+
+let uu____1250 = (FStar_Util.smap_try_find graph key)
+in (uu____1250 = None))
+in (match (uu____1249) with
+| true -> begin
+(
+
+let uu____1265 = (
+
+let uu____1270 = (FStar_Util.smap_try_find m key)
+in (FStar_Util.must uu____1270))
+in (match (uu____1265) with
+| (intf, impl) -> begin
+(
+
+let intf_deps = (match (intf) with
+| Some (intf1) -> begin
+(collect_one1 is_user_provided_filename m intf1)
+end
+| None -> begin
+[]
+end)
+in (
+
+let impl_deps = (match (((impl), (intf))) with
+| (Some (impl1), Some (uu____1300)) when interface_only -> begin
+[]
+end
+| (Some (impl1), uu____1304) -> begin
+(collect_one1 is_user_provided_filename m impl1)
+end
+| (None, uu____1308) -> begin
+[]
+end)
+in (
+
+let deps = (FStar_List.unique (FStar_List.append impl_deps intf_deps))
+in ((FStar_Util.smap_add graph key ((deps), (White)));
+(FStar_List.iter (discover_one false partial_discovery) deps);
+))))
+end))
+end
+| uu____1319 -> begin
+()
+end)))
+in (
+
+let discover_command_line_argument = (fun f -> (
+
+let m1 = (lowercase_module_name f)
+in (
+
+let uu____1325 = (is_interface f)
+in (match (uu____1325) with
+| true -> begin
+(discover_one true true m1)
+end
+| uu____1326 -> begin
+(discover_one true false m1)
+end))))
+in ((FStar_List.iter discover_command_line_argument filenames);
+(
+
+let immediate_graph = (FStar_Util.smap_copy graph)
+in (
+
+let topologically_sorted = (FStar_Util.mk_ref [])
+in (
+
+let rec discover = (fun cycle key -> (
+
+let uu____1351 = (
+
+let uu____1355 = (FStar_Util.smap_try_find graph key)
+in (FStar_Util.must uu____1355))
+in (match (uu____1351) with
+| (direct_deps, color) -> begin
+(match (color) with
+| Gray -> begin
+((FStar_Util.print1 "Warning: recursive dependency on module %s\n" key);
+(FStar_Util.print1 "The cycle is: %s \n" (FStar_String.concat " -> " cycle));
+(print_graph immediate_graph);
+(FStar_Util.print_string "\n");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| Black -> begin
+direct_deps
+end
+| White -> begin
+((FStar_Util.smap_add graph key ((direct_deps), (Gray)));
+(
+
+let all_deps = (
+
+let uu____1384 = (
+
+let uu____1386 = (FStar_List.map (fun dep1 -> (
+
+let uu____1391 = (discover ((key)::cycle) dep1)
+in (dep1)::uu____1391)) direct_deps)
+in (FStar_List.flatten uu____1386))
+in (FStar_List.unique uu____1384))
+in ((FStar_Util.smap_add graph key ((all_deps), (Black)));
+(
+
+let uu____1399 = (
+
+let uu____1401 = (FStar_ST.read topologically_sorted)
+in (key)::uu____1401)
+in (FStar_ST.write topologically_sorted uu____1399));
+all_deps;
+));
+)
+end)
+end)))
+in (
+
+let discover1 = (discover [])
+in (
+
+let must_find = (fun k -> (
+
+let uu____1418 = (
+
+let uu____1423 = (FStar_Util.smap_try_find m k)
+in (FStar_Util.must uu____1423))
+in (match (uu____1418) with
+| (Some (intf), Some (impl)) when ((not (partial_discovery)) && (
+
+let uu____1442 = (FStar_List.existsML (fun f -> (
+
+let uu____1444 = (lowercase_module_name f)
+in (uu____1444 = k))) filenames)
+in (not (uu____1442)))) -> begin
+(intf)::(impl)::[]
+end
+| (Some (intf), Some (impl)) when (FStar_List.existsML (fun f -> ((is_implementation f) && (
+
+let uu____1450 = (lowercase_module_name f)
+in (uu____1450 = k)))) filenames) -> begin
+(intf)::(impl)::[]
+end
+| (Some (intf), uu____1452) -> begin
+(intf)::[]
+end
+| (None, Some (impl)) -> begin
+(impl)::[]
+end
+| (None, None) -> begin
+[]
+end)))
+in (
+
+let must_find_r = (fun f -> (
+
+let uu____1466 = (must_find f)
+in (FStar_List.rev uu____1466)))
+in (
+
+let by_target = (
+
+let uu____1473 = (
+
+let uu____1475 = (FStar_Util.smap_keys graph)
+in (FStar_List.sortWith (fun x y -> (FStar_String.compare x y)) uu____1475))
+in (FStar_List.collect (fun k -> (
+
+let as_list = (must_find k)
+in (
+
+let is_interleaved = ((FStar_List.length as_list) = (Prims.parse_int "2"))
+in (FStar_List.map (fun f -> (
+
+let should_append_fsti = ((is_implementation f) && is_interleaved)
+in (
+
+let suffix = (match (should_append_fsti) with
+| true -> begin
+((Prims.strcat f "i"))::[]
+end
+| uu____1499 -> begin
+[]
+end)
+in (
+
+let k1 = (lowercase_module_name f)
+in (
+
+let deps = (
+
+let uu____1503 = (discover1 k1)
+in (FStar_List.rev uu____1503))
+in (
+
+let deps_as_filenames = (
+
+let uu____1507 = (FStar_List.collect must_find deps)
+in (FStar_List.append uu____1507 suffix))
+in ((f), (deps_as_filenames)))))))) as_list)))) uu____1473))
+in (
+
+let topologically_sorted1 = (
+
+let uu____1512 = (FStar_ST.read topologically_sorted)
+in (FStar_List.collect must_find_r uu____1512))
+in ((FStar_List.iter (fun uu____1521 -> (match (uu____1521) with
+| (m1, r) -> begin
+(
+
+let uu____1529 = ((
+
+let uu____1530 = (FStar_ST.read r)
+in (not (uu____1530))) && (
+
+let uu____1533 = (FStar_Options.interactive ())
+in (not (uu____1533))))
+in (match (uu____1529) with
+| true -> begin
+(
+
+let maybe_fst = (
+
+let k = (FStar_String.length m1)
+in (
+
+let uu____1537 = ((k > (Prims.parse_int "4")) && (
+
+let uu____1541 = (FStar_String.substring m1 (k - (Prims.parse_int "4")) (Prims.parse_int "4"))
+in (uu____1541 = ".fst")))
+in (match (uu____1537) with
+| true -> begin
+(
+
+let uu____1545 = (FStar_String.substring m1 (Prims.parse_int "0") (k - (Prims.parse_int "4")))
+in (FStar_Util.format1 " Did you mean %s ?" uu____1545))
+end
+| uu____1549 -> begin
+""
+end)))
+in (
+
+let uu____1550 = (
+
+let uu____1551 = (FStar_Util.format3 "You passed --verify_module %s but I found no file that contains [module %s] in the dependency graph.%s\n" m1 m1 maybe_fst)
+in FStar_Errors.Err (uu____1551))
+in (Prims.raise uu____1550)))
+end
+| uu____1552 -> begin
+()
+end))
+end)) verify_flags);
+((by_target), (topologically_sorted1), (immediate_graph));
+)))))))));
+)))))))))
+
+
+let print_make : (Prims.string * Prims.string Prims.list) Prims.list  ->  Prims.unit = (fun deps -> (FStar_List.iter (fun uu____1576 -> (match (uu____1576) with
+| (f, deps1) -> begin
+(
+
+let deps2 = (FStar_List.map (fun s -> (FStar_Util.replace_chars s ' ' "\\ ")) deps1)
+in (FStar_Util.print2 "%s: %s\n" f (FStar_String.concat " " deps2)))
+end)) deps))
+
+
+let print = (fun uu____1606 -> (match (uu____1606) with
+| (make_deps, uu____1619, graph) -> begin
+(
+
+let uu____1637 = (FStar_Options.dep ())
+in (match (uu____1637) with
+| Some ("make") -> begin
+(print_make make_deps)
+end
+| Some ("graph") -> begin
+(print_graph graph)
+end
+| Some (uu____1639) -> begin
+(Prims.raise (FStar_Errors.Err ("unknown tool for --dep\n")))
+end
+| None -> begin
+()
+end))
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_Driver.ml
+++ b/src/ocaml-output/FStar_Parser_Driver.ml
@@ -1,45 +1,97 @@
+
 open Prims
-let is_cache_file: Prims.string -> Prims.bool =
-  fun fn  ->
-    let uu____4 = FStar_Util.get_file_extension fn in uu____4 = ".cache"
+
+let is_cache_file : Prims.string  ->  Prims.bool = (fun fn -> (
+
+let uu____4 = (FStar_Util.get_file_extension fn)
+in (uu____4 = ".cache")))
+
 type fragment =
-  | Empty
-  | Modul of FStar_Parser_AST.modul
-  | Decls of FStar_Parser_AST.decl Prims.list
-let uu___is_Empty: fragment -> Prims.bool =
-  fun projectee  -> match projectee with | Empty  -> true | uu____15 -> false
-let uu___is_Modul: fragment -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Modul _0 -> true | uu____20 -> false
-let __proj__Modul__item___0: fragment -> FStar_Parser_AST.modul =
-  fun projectee  -> match projectee with | Modul _0 -> _0
-let uu___is_Decls: fragment -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Decls _0 -> true | uu____33 -> false
-let __proj__Decls__item___0: fragment -> FStar_Parser_AST.decl Prims.list =
-  fun projectee  -> match projectee with | Decls _0 -> _0
-let parse_fragment: FStar_Parser_ParseIt.input_frag -> fragment =
-  fun frag  ->
-    let uu____47 = FStar_Parser_ParseIt.parse (FStar_Util.Inr frag) in
-    match uu____47 with
-    | FStar_Util.Inl (FStar_Util.Inl [],uu____57) -> Empty
-    | FStar_Util.Inl (FStar_Util.Inl (modul::[]),uu____82) -> Modul modul
-    | FStar_Util.Inl (FStar_Util.Inr decls,uu____107) -> Decls decls
-    | FStar_Util.Inl (FStar_Util.Inl uu____129,uu____130) ->
-        Prims.raise
-          (FStar_Errors.Err
-             "Refusing to check more than one module at a time incrementally")
-    | FStar_Util.Inr (msg,r) -> Prims.raise (FStar_Errors.Error (msg, r))
-let parse_file:
-  FStar_Parser_ParseIt.filename ->
-    (FStar_Parser_AST.file* (Prims.string* FStar_Range.range) Prims.list)
-  =
-  fun fn  ->
-    let uu____168 = FStar_Parser_ParseIt.parse (FStar_Util.Inl fn) in
-    match uu____168 with
-    | FStar_Util.Inl (FStar_Util.Inl ast,comments) -> (ast, comments)
-    | FStar_Util.Inl (FStar_Util.Inr uu____208,uu____209) ->
-        let msg = FStar_Util.format1 "%s: expected a module\n" fn in
-        let r = FStar_Range.dummyRange in
-        Prims.raise (FStar_Errors.Error (msg, r))
-    | FStar_Util.Inr (msg,r) -> Prims.raise (FStar_Errors.Error (msg, r))
+| Empty
+| Modul of FStar_Parser_AST.modul
+| Decls of FStar_Parser_AST.decl Prims.list
+
+
+let uu___is_Empty : fragment  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Empty -> begin
+true
+end
+| uu____15 -> begin
+false
+end))
+
+
+let uu___is_Modul : fragment  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Modul (_0) -> begin
+true
+end
+| uu____20 -> begin
+false
+end))
+
+
+let __proj__Modul__item___0 : fragment  ->  FStar_Parser_AST.modul = (fun projectee -> (match (projectee) with
+| Modul (_0) -> begin
+_0
+end))
+
+
+let uu___is_Decls : fragment  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Decls (_0) -> begin
+true
+end
+| uu____33 -> begin
+false
+end))
+
+
+let __proj__Decls__item___0 : fragment  ->  FStar_Parser_AST.decl Prims.list = (fun projectee -> (match (projectee) with
+| Decls (_0) -> begin
+_0
+end))
+
+
+let parse_fragment : FStar_Parser_ParseIt.input_frag  ->  fragment = (fun frag -> (
+
+let uu____47 = (FStar_Parser_ParseIt.parse (FStar_Util.Inr (frag)))
+in (match (uu____47) with
+| FStar_Util.Inl (FStar_Util.Inl ([]), uu____57) -> begin
+Empty
+end
+| FStar_Util.Inl (FStar_Util.Inl ((modul)::[]), uu____82) -> begin
+Modul (modul)
+end
+| FStar_Util.Inl (FStar_Util.Inr (decls), uu____107) -> begin
+Decls (decls)
+end
+| FStar_Util.Inl (FStar_Util.Inl (uu____129), uu____130) -> begin
+(Prims.raise (FStar_Errors.Err ("Refusing to check more than one module at a time incrementally")))
+end
+| FStar_Util.Inr (msg, r) -> begin
+(Prims.raise (FStar_Errors.Error (((msg), (r)))))
+end)))
+
+
+let parse_file : FStar_Parser_ParseIt.filename  ->  (FStar_Parser_AST.file * (Prims.string * FStar_Range.range) Prims.list) = (fun fn -> (
+
+let uu____168 = (FStar_Parser_ParseIt.parse (FStar_Util.Inl (fn)))
+in (match (uu____168) with
+| FStar_Util.Inl (FStar_Util.Inl (ast), comments) -> begin
+((ast), (comments))
+end
+| FStar_Util.Inl (FStar_Util.Inr (uu____208), uu____209) -> begin
+(
+
+let msg = (FStar_Util.format1 "%s: expected a module\n" fn)
+in (
+
+let r = FStar_Range.dummyRange
+in (Prims.raise (FStar_Errors.Error (((msg), (r)))))))
+end
+| FStar_Util.Inr (msg, r) -> begin
+(Prims.raise (FStar_Errors.Error (((msg), (r)))))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_Interleave.ml
+++ b/src/ocaml-output/FStar_Parser_Interleave.ml
@@ -1,255 +1,292 @@
+
 open Prims
-let interleave:
-  FStar_Parser_AST.decl Prims.list ->
-    FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list
-  =
-  fun iface  ->
-    fun impl  ->
-      let id_eq_lid i l =
-        i.FStar_Ident.idText = (l.FStar_Ident.ident).FStar_Ident.idText in
-      let is_val x d =
-        match d.FStar_Parser_AST.d with
-        | FStar_Parser_AST.Val (y,uu____28) ->
-            x.FStar_Ident.idText = y.FStar_Ident.idText
-        | uu____29 -> false in
-      let is_type1 x d =
-        match d.FStar_Parser_AST.d with
-        | FStar_Parser_AST.Tycon (uu____37,tys) ->
-            FStar_All.pipe_right tys
-              (FStar_Util.for_some
-                 (fun uu____54  ->
-                    match uu____54 with
-                    | (t,uu____59) ->
-                        (FStar_Parser_AST.id_of_tycon t) =
-                          x.FStar_Ident.idText))
-        | uu____62 -> false in
-      let is_let x d =
-        match d.FStar_Parser_AST.d with
-        | FStar_Parser_AST.TopLevelLet (uu____70,defs) ->
-            let uu____78 = FStar_Parser_AST.lids_of_let defs in
-            FStar_All.pipe_right uu____78 (FStar_Util.for_some (id_eq_lid x))
-        | FStar_Parser_AST.Tycon (uu____81,tys) ->
-            let uu____91 =
-              FStar_All.pipe_right tys
-                (FStar_List.map
-                   (fun uu____101  ->
-                      match uu____101 with | (x1,uu____106) -> x1)) in
-            FStar_All.pipe_right uu____91
-              (FStar_Util.for_some
-                 (fun uu___126_110  ->
-                    match uu___126_110 with
-                    | FStar_Parser_AST.TyconAbbrev
-                        (id',uu____112,uu____113,uu____114) ->
-                        x.FStar_Ident.idText = id'.FStar_Ident.idText
-                    | uu____119 -> false))
-        | uu____120 -> false in
-      let prefix_until_let x ds =
-        FStar_All.pipe_right ds (FStar_Util.prefix_until (is_let x)) in
-      let aux_ml iface1 impl1 =
-        let rec interleave_vals vals impl2 =
-          match vals with
-          | [] -> impl2
-          | { FStar_Parser_AST.d = FStar_Parser_AST.Val (x,uu____170);
-              FStar_Parser_AST.drange = uu____171;
-              FStar_Parser_AST.doc = uu____172;
-              FStar_Parser_AST.quals = uu____173;
-              FStar_Parser_AST.attrs = uu____174;_}::remaining_vals ->
-              let d = FStar_List.hd vals in
-              let lopt = prefix_until_let x impl2 in
-              (match lopt with
-               | None  ->
-                   Prims.raise
-                     (FStar_Errors.Error
-                        ((Prims.strcat "No definition found for "
-                            x.FStar_Ident.idText),
-                          (d.FStar_Parser_AST.drange)))
-               | Some (prefix1,let_x,rest_impl) ->
-                   let impl3 =
-                     FStar_List.append prefix1
-                       (FStar_List.append [d; let_x] rest_impl) in
-                   interleave_vals remaining_vals impl3)
-          | uu____207::remaining_vals -> interleave_vals remaining_vals impl2 in
-        interleave_vals iface1 impl1 in
-      let rec aux out iface1 impl1 =
-        match iface1 with
-        | [] ->
-            let uu____230 =
-              FStar_All.pipe_right (FStar_List.rev out) FStar_List.flatten in
-            FStar_List.append uu____230 impl1
-        | d::ds ->
-            (match d.FStar_Parser_AST.d with
-             | FStar_Parser_AST.Tycon (uu____240,tys) when
-                 FStar_All.pipe_right tys
-                   (FStar_Util.for_some
-                      (fun uu___127_257  ->
-                         match uu___127_257 with
-                         | (FStar_Parser_AST.TyconAbstract
-                            uu____261,uu____262) -> true
-                         | uu____270 -> false))
-                 ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ("Interface contains an abstract 'type' declaration; use 'val' instead",
-                        (d.FStar_Parser_AST.drange)))
-             | FStar_Parser_AST.Val (x,t) ->
-                 ((let uu____278 =
-                     FStar_All.pipe_right impl1
-                       (FStar_List.tryFind
-                          (fun d1  -> (is_val x d1) || (is_type1 x d1))) in
-                   match uu____278 with
-                   | None  -> ()
-                   | Some
-                       { FStar_Parser_AST.d = FStar_Parser_AST.Val uu____283;
-                         FStar_Parser_AST.drange = r;
-                         FStar_Parser_AST.doc = uu____285;
-                         FStar_Parser_AST.quals = uu____286;
-                         FStar_Parser_AST.attrs = uu____287;_}
-                       ->
-                       let uu____291 =
-                         let uu____292 =
-                           let uu____295 =
-                             let uu____296 =
-                               FStar_Parser_AST.decl_to_string d in
-                             FStar_Util.format1
-                               "%s is repeated in the implementation"
-                               uu____296 in
-                           (uu____295, r) in
-                         FStar_Errors.Error uu____292 in
-                       Prims.raise uu____291
-                   | Some i ->
-                       let uu____298 =
-                         let uu____299 =
-                           let uu____302 =
-                             let uu____303 =
-                               FStar_Parser_AST.decl_to_string d in
-                             FStar_Util.format1
-                               "%s in the interface is implemented with a 'type'"
-                               uu____303 in
-                           (uu____302, (i.FStar_Parser_AST.drange)) in
-                         FStar_Errors.Error uu____299 in
-                       Prims.raise uu____298);
-                  (let uu____304 = prefix_until_let x iface1 in
-                   match uu____304 with
-                   | Some uu____312 ->
-                       let uu____323 =
-                         let uu____324 =
-                           let uu____327 =
-                             FStar_Util.format2
-                               "'val %s' and 'let %s' cannot both be provided in an interface"
-                               x.FStar_Ident.idText x.FStar_Ident.idText in
-                           (uu____327, (d.FStar_Parser_AST.drange)) in
-                         FStar_Errors.Error uu____324 in
-                       Prims.raise uu____323
-                   | None  ->
-                       let lopt = prefix_until_let x impl1 in
-                       (match lopt with
-                        | None  ->
-                            let uu____347 =
-                              FStar_All.pipe_right d.FStar_Parser_AST.quals
-                                (FStar_List.contains
-                                   FStar_Parser_AST.Assumption) in
-                            if uu____347
-                            then aux ([d] :: out) ds impl1
-                            else
-                              Prims.raise
-                                (FStar_Errors.Error
-                                   ((Prims.strcat "No definition found for "
-                                       x.FStar_Ident.idText),
-                                     (d.FStar_Parser_AST.drange)))
-                        | Some (prefix1,let_x,rest_impl) ->
-                            let uu____364 =
-                              FStar_All.pipe_right d.FStar_Parser_AST.quals
-                                (FStar_List.contains
-                                   FStar_Parser_AST.Assumption) in
-                            if uu____364
-                            then
-                              let uu____366 =
-                                let uu____367 =
-                                  let uu____370 =
-                                    let uu____371 =
-                                      FStar_Range.string_of_range
-                                        let_x.FStar_Parser_AST.drange in
-                                    FStar_Util.format2
-                                      "Assumed declaration %s is defined at %s"
-                                      x.FStar_Ident.idText uu____371 in
-                                  (uu____370, (d.FStar_Parser_AST.drange)) in
-                                FStar_Errors.Error uu____367 in
-                              Prims.raise uu____366
-                            else
-                              (let remaining_iface_vals =
-                                 FStar_All.pipe_right ds
-                                   (FStar_List.collect
-                                      (fun d1  ->
-                                         match d1.FStar_Parser_AST.d with
-                                         | FStar_Parser_AST.Val
-                                             (x1,uu____381) -> [x1]
-                                         | uu____382 -> [])) in
-                               let uu____383 =
-                                 FStar_All.pipe_right prefix1
-                                   (FStar_List.tryFind
-                                      (fun d1  ->
-                                         FStar_All.pipe_right
-                                           remaining_iface_vals
-                                           (FStar_Util.for_some
-                                              (fun x1  -> is_let x1 d1)))) in
-                               match uu____383 with
-                               | Some d1 ->
-                                   let uu____392 =
-                                     let uu____393 =
-                                       let uu____396 =
-                                         let uu____397 =
-                                           FStar_Parser_AST.decl_to_string d1 in
-                                         let uu____398 =
-                                           FStar_Parser_AST.decl_to_string
-                                             let_x in
-                                         FStar_Util.format2
-                                           "%s is out of order with %s"
-                                           uu____397 uu____398 in
-                                       (uu____396,
-                                         (d1.FStar_Parser_AST.drange)) in
-                                     FStar_Errors.Error uu____393 in
-                                   Prims.raise uu____392
-                               | uu____400 ->
-                                   (match let_x.FStar_Parser_AST.d with
-                                    | FStar_Parser_AST.TopLevelLet
-                                        (uu____403,defs) ->
-                                        let def_lids =
-                                          FStar_Parser_AST.lids_of_let defs in
-                                        let iface_prefix_opt =
-                                          FStar_All.pipe_right iface1
-                                            (FStar_Util.prefix_until
-                                               (fun d1  ->
-                                                  match d1.FStar_Parser_AST.d
-                                                  with
-                                                  | FStar_Parser_AST.Val
-                                                      (y,uu____429) ->
-                                                      let uu____430 =
-                                                        FStar_All.pipe_right
-                                                          def_lids
-                                                          (FStar_Util.for_some
-                                                             (id_eq_lid y)) in
-                                                      Prims.op_Negation
-                                                        uu____430
-                                                  | uu____432 -> true)) in
-                                        let uu____433 =
-                                          match iface_prefix_opt with
-                                          | None  -> (iface1, [])
-                                          | Some
-                                              (all_vals_for_defs,first_non_val,rest_iface)
-                                              ->
-                                              (all_vals_for_defs,
-                                                (first_non_val ::
-                                                rest_iface)) in
-                                        (match uu____433 with
-                                         | (all_vals_for_defs,rest_iface) ->
-                                             let hoist =
-                                               FStar_List.append prefix1
-                                                 (FStar_List.append
-                                                    all_vals_for_defs 
-                                                    [let_x]) in
-                                             aux (hoist :: out) rest_iface
-                                               rest_impl)
-                                    | uu____473 -> failwith "Impossible")))))
-             | uu____475 -> aux ([d] :: out) ds impl1) in
-      let uu____477 = FStar_Options.ml_ish () in
-      if uu____477 then aux_ml iface impl else aux [] iface impl
+
+let interleave : FStar_Parser_AST.decl Prims.list  ->  FStar_Parser_AST.decl Prims.list  ->  FStar_Parser_AST.decl Prims.list = (fun iface impl -> (
+
+let id_eq_lid = (fun i l -> (i.FStar_Ident.idText = l.FStar_Ident.ident.FStar_Ident.idText))
+in (
+
+let is_val = (fun x d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Val (y, uu____28) -> begin
+(x.FStar_Ident.idText = y.FStar_Ident.idText)
+end
+| uu____29 -> begin
+false
+end))
+in (
+
+let is_type1 = (fun x d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Tycon (uu____37, tys) -> begin
+(FStar_All.pipe_right tys (FStar_Util.for_some (fun uu____54 -> (match (uu____54) with
+| (t, uu____59) -> begin
+((FStar_Parser_AST.id_of_tycon t) = x.FStar_Ident.idText)
+end))))
+end
+| uu____62 -> begin
+false
+end))
+in (
+
+let is_let = (fun x d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.TopLevelLet (uu____70, defs) -> begin
+(
+
+let uu____78 = (FStar_Parser_AST.lids_of_let defs)
+in (FStar_All.pipe_right uu____78 (FStar_Util.for_some (id_eq_lid x))))
+end
+| FStar_Parser_AST.Tycon (uu____81, tys) -> begin
+(
+
+let uu____91 = (FStar_All.pipe_right tys (FStar_List.map (fun uu____101 -> (match (uu____101) with
+| (x1, uu____106) -> begin
+x1
+end))))
+in (FStar_All.pipe_right uu____91 (FStar_Util.for_some (fun uu___126_110 -> (match (uu___126_110) with
+| FStar_Parser_AST.TyconAbbrev (id', uu____112, uu____113, uu____114) -> begin
+(x.FStar_Ident.idText = id'.FStar_Ident.idText)
+end
+| uu____119 -> begin
+false
+end)))))
+end
+| uu____120 -> begin
+false
+end))
+in (
+
+let prefix_until_let = (fun x ds -> (FStar_All.pipe_right ds (FStar_Util.prefix_until (is_let x))))
+in (
+
+let aux_ml = (fun iface1 impl1 -> (
+
+let rec interleave_vals = (fun vals impl2 -> (match (vals) with
+| [] -> begin
+impl2
+end
+| ({FStar_Parser_AST.d = FStar_Parser_AST.Val (x, uu____170); FStar_Parser_AST.drange = uu____171; FStar_Parser_AST.doc = uu____172; FStar_Parser_AST.quals = uu____173; FStar_Parser_AST.attrs = uu____174})::remaining_vals -> begin
+(
+
+let d = (FStar_List.hd vals)
+in (
+
+let lopt = (prefix_until_let x impl2)
+in (match (lopt) with
+| None -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "No definition found for " x.FStar_Ident.idText)), (d.FStar_Parser_AST.drange)))))
+end
+| Some (prefix1, let_x, rest_impl) -> begin
+(
+
+let impl3 = (FStar_List.append prefix1 (FStar_List.append ((d)::(let_x)::[]) rest_impl))
+in (interleave_vals remaining_vals impl3))
+end)))
+end
+| (uu____207)::remaining_vals -> begin
+(interleave_vals remaining_vals impl2)
+end))
+in (interleave_vals iface1 impl1)))
+in (
+
+let rec aux = (fun out iface1 impl1 -> (match (iface1) with
+| [] -> begin
+(
+
+let uu____230 = (FStar_All.pipe_right (FStar_List.rev out) FStar_List.flatten)
+in (FStar_List.append uu____230 impl1))
+end
+| (d)::ds -> begin
+(match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Tycon (uu____240, tys) when (FStar_All.pipe_right tys (FStar_Util.for_some (fun uu___127_257 -> (match (uu___127_257) with
+| (FStar_Parser_AST.TyconAbstract (uu____261), uu____262) -> begin
+true
+end
+| uu____270 -> begin
+false
+end)))) -> begin
+(Prims.raise (FStar_Errors.Error ((("Interface contains an abstract \'type\' declaration; use \'val\' instead"), (d.FStar_Parser_AST.drange)))))
+end
+| FStar_Parser_AST.Val (x, t) -> begin
+((
+
+let uu____278 = (FStar_All.pipe_right impl1 (FStar_List.tryFind (fun d1 -> ((is_val x d1) || (is_type1 x d1)))))
+in (match (uu____278) with
+| None -> begin
+()
+end
+| Some ({FStar_Parser_AST.d = FStar_Parser_AST.Val (uu____283); FStar_Parser_AST.drange = r; FStar_Parser_AST.doc = uu____285; FStar_Parser_AST.quals = uu____286; FStar_Parser_AST.attrs = uu____287}) -> begin
+(
+
+let uu____291 = (
+
+let uu____292 = (
+
+let uu____295 = (
+
+let uu____296 = (FStar_Parser_AST.decl_to_string d)
+in (FStar_Util.format1 "%s is repeated in the implementation" uu____296))
+in ((uu____295), (r)))
+in FStar_Errors.Error (uu____292))
+in (Prims.raise uu____291))
+end
+| Some (i) -> begin
+(
+
+let uu____298 = (
+
+let uu____299 = (
+
+let uu____302 = (
+
+let uu____303 = (FStar_Parser_AST.decl_to_string d)
+in (FStar_Util.format1 "%s in the interface is implemented with a \'type\'" uu____303))
+in ((uu____302), (i.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____299))
+in (Prims.raise uu____298))
+end));
+(
+
+let uu____304 = (prefix_until_let x iface1)
+in (match (uu____304) with
+| Some (uu____312) -> begin
+(
+
+let uu____323 = (
+
+let uu____324 = (
+
+let uu____327 = (FStar_Util.format2 "\'val %s\' and \'let %s\' cannot both be provided in an interface" x.FStar_Ident.idText x.FStar_Ident.idText)
+in ((uu____327), (d.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____324))
+in (Prims.raise uu____323))
+end
+| None -> begin
+(
+
+let lopt = (prefix_until_let x impl1)
+in (match (lopt) with
+| None -> begin
+(
+
+let uu____347 = (FStar_All.pipe_right d.FStar_Parser_AST.quals (FStar_List.contains FStar_Parser_AST.Assumption))
+in (match (uu____347) with
+| true -> begin
+(aux (((d)::[])::out) ds impl1)
+end
+| uu____350 -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "No definition found for " x.FStar_Ident.idText)), (d.FStar_Parser_AST.drange)))))
+end))
+end
+| Some (prefix1, let_x, rest_impl) -> begin
+(
+
+let uu____364 = (FStar_All.pipe_right d.FStar_Parser_AST.quals (FStar_List.contains FStar_Parser_AST.Assumption))
+in (match (uu____364) with
+| true -> begin
+(
+
+let uu____366 = (
+
+let uu____367 = (
+
+let uu____370 = (
+
+let uu____371 = (FStar_Range.string_of_range let_x.FStar_Parser_AST.drange)
+in (FStar_Util.format2 "Assumed declaration %s is defined at %s" x.FStar_Ident.idText uu____371))
+in ((uu____370), (d.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____367))
+in (Prims.raise uu____366))
+end
+| uu____373 -> begin
+(
+
+let remaining_iface_vals = (FStar_All.pipe_right ds (FStar_List.collect (fun d1 -> (match (d1.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Val (x1, uu____381) -> begin
+(x1)::[]
+end
+| uu____382 -> begin
+[]
+end))))
+in (
+
+let uu____383 = (FStar_All.pipe_right prefix1 (FStar_List.tryFind (fun d1 -> (FStar_All.pipe_right remaining_iface_vals (FStar_Util.for_some (fun x1 -> (is_let x1 d1)))))))
+in (match (uu____383) with
+| Some (d1) -> begin
+(
+
+let uu____392 = (
+
+let uu____393 = (
+
+let uu____396 = (
+
+let uu____397 = (FStar_Parser_AST.decl_to_string d1)
+in (
+
+let uu____398 = (FStar_Parser_AST.decl_to_string let_x)
+in (FStar_Util.format2 "%s is out of order with %s" uu____397 uu____398)))
+in ((uu____396), (d1.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____393))
+in (Prims.raise uu____392))
+end
+| uu____400 -> begin
+(match (let_x.FStar_Parser_AST.d) with
+| FStar_Parser_AST.TopLevelLet (uu____403, defs) -> begin
+(
+
+let def_lids = (FStar_Parser_AST.lids_of_let defs)
+in (
+
+let iface_prefix_opt = (FStar_All.pipe_right iface1 (FStar_Util.prefix_until (fun d1 -> (match (d1.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Val (y, uu____429) -> begin
+(
+
+let uu____430 = (FStar_All.pipe_right def_lids (FStar_Util.for_some (id_eq_lid y)))
+in (not (uu____430)))
+end
+| uu____432 -> begin
+true
+end))))
+in (
+
+let uu____433 = (match (iface_prefix_opt) with
+| None -> begin
+((iface1), ([]))
+end
+| Some (all_vals_for_defs, first_non_val, rest_iface) -> begin
+((all_vals_for_defs), ((first_non_val)::rest_iface))
+end)
+in (match (uu____433) with
+| (all_vals_for_defs, rest_iface) -> begin
+(
+
+let hoist = (FStar_List.append prefix1 (FStar_List.append all_vals_for_defs ((let_x)::[])))
+in (aux ((hoist)::out) rest_iface rest_impl))
+end))))
+end
+| uu____473 -> begin
+(failwith "Impossible")
+end)
+end)))
+end))
+end))
+end));
+)
+end
+| uu____475 -> begin
+(aux (((d)::[])::out) ds impl1)
+end)
+end))
+in (
+
+let uu____477 = (FStar_Options.ml_ish ())
+in (match (uu____477) with
+| true -> begin
+(aux_ml iface impl)
+end
+| uu____479 -> begin
+(aux [] iface impl)
+end))))))))))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_Lexhelp.ml
+++ b/src/ocaml-output/FStar_Parser_Lexhelp.ml
@@ -1,361 +1,456 @@
+
 open Prims
-let intern_string: Prims.string -> Prims.string =
-  let strings = FStar_Util.smap_create (Prims.parse_int "100") in
-  fun s  ->
-    let uu____6 = FStar_Util.smap_try_find strings s in
-    match uu____6 with
-    | Some res -> res
-    | None  -> (FStar_Util.smap_add strings s s; s)
-let default_string_finish endm b s = FStar_Parser_Parse.STRING s
-let call_string_finish fin buf endm b =
-  let _0_27 = FStar_Bytes.close buf in fin endm b _0_27
-let add_string: FStar_Bytes.bytebuf -> Prims.string -> Prims.unit =
-  fun buf  ->
-    fun x  ->
-      let uu____76 = FStar_Bytes.string_as_unicode_bytes x in
-      FStar_Bytes.emit_bytes buf uu____76
-let add_int_char: FStar_Bytes.bytebuf -> Prims.int -> Prims.unit =
-  fun buf  ->
-    fun c  ->
-      FStar_Bytes.emit_int_as_byte buf (c mod (Prims.parse_int "256"));
-      FStar_Bytes.emit_int_as_byte buf (c / (Prims.parse_int "256"))
-let add_unichar: FStar_Bytes.bytebuf -> Prims.int -> Prims.unit =
-  fun buf  -> fun c  -> add_int_char buf c
-let add_byte_char: FStar_Bytes.bytebuf -> FStar_BaseTypes.char -> Prims.unit
-  =
-  fun buf  ->
-    fun c  ->
-      add_int_char buf
-        ((FStar_Util.int_of_char c) mod (Prims.parse_int "256"))
-let stringbuf_as_bytes: FStar_Bytes.bytebuf -> FStar_Bytes.bytes =
-  fun buf  ->
-    let bytes = FStar_Bytes.close buf in
-    let uu____100 =
-      let uu____101 = FStar_Bytes.length bytes in
-      uu____101 / (Prims.parse_int "2") in
-    FStar_Bytes.make
-      (fun i  ->
-         FStar_Bytes.get bytes (FStar_Mul.op_Star i (Prims.parse_int "2")))
-      uu____100
-let stringbuf_is_bytes: FStar_Bytes.bytebuf -> Prims.bool =
-  fun buf  ->
-    let bytes = FStar_Bytes.close buf in
-    let ok = FStar_Util.mk_ref true in
-    (let uu____114 =
-       let uu____115 =
-         let uu____116 = FStar_Bytes.length bytes in
-         uu____116 / (Prims.parse_int "2") in
-       uu____115 - (Prims.parse_int "1") in
-     FStar_Util.for_range (Prims.parse_int "0") uu____114
-       (fun i  ->
-          let uu____121 =
-            let uu____122 =
-              FStar_Bytes.get bytes
-                ((FStar_Mul.op_Star i (Prims.parse_int "2")) +
-                   (Prims.parse_int "1")) in
-            uu____122 <> (Prims.parse_int "0") in
-          if uu____121 then FStar_ST.write ok false else ()));
-    FStar_ST.read ok
-let trigraph:
-  FStar_BaseTypes.char ->
-    FStar_BaseTypes.char -> FStar_BaseTypes.char -> FStar_BaseTypes.char
-  =
-  fun c1  ->
-    fun c2  ->
-      fun c3  ->
-        let digit c =
-          (FStar_Util.int_of_char c) - (FStar_Util.int_of_char '0') in
-        FStar_Util.char_of_int
-          (((FStar_Mul.op_Star (digit c1) (Prims.parse_int "100")) +
-              (FStar_Mul.op_Star (digit c2) (Prims.parse_int "10")))
-             + (digit c3))
-let digit: FStar_BaseTypes.char -> Prims.int =
-  fun d  ->
-    let dd = FStar_Util.int_of_char d in
-    if
-      (dd >= (FStar_Util.int_of_char '0')) &&
-        (dd <= (FStar_Util.int_of_char '9'))
-    then (FStar_Util.int_of_char d) - (FStar_Util.int_of_char '0')
-    else failwith "digit"
-let hexdigit: FStar_BaseTypes.char -> Prims.int =
-  fun d  ->
-    let dd = FStar_Util.int_of_char d in
-    if
-      (dd >= (FStar_Util.int_of_char '0')) &&
-        (dd <= (FStar_Util.int_of_char '9'))
-    then digit d
-    else
-      if
-        (dd >= (FStar_Util.int_of_char 'a')) &&
-          (dd <= (FStar_Util.int_of_char 'f'))
-      then (dd - (FStar_Util.int_of_char 'a')) + (Prims.parse_int "10")
-      else
-        if
-          (dd >= (FStar_Util.int_of_char 'A')) &&
-            (dd <= (FStar_Util.int_of_char 'F'))
-        then (dd - (FStar_Util.int_of_char 'A')) + (Prims.parse_int "10")
-        else failwith "hexdigit"
-let unicodegraph_short: Prims.string -> FStar_BaseTypes.uint16 =
-  fun s  ->
-    if (FStar_String.length s) <> (Prims.parse_int "4")
-    then failwith "unicodegraph"
-    else
-      (let uu____159 =
-         let uu____160 =
-           let uu____161 =
-             let uu____162 =
-               let uu____163 =
-                 let uu____164 = FStar_Util.char_at s (Prims.parse_int "0") in
-                 hexdigit uu____164 in
-               FStar_Mul.op_Star uu____163 (Prims.parse_int "4096") in
-             let uu____165 =
-               let uu____166 =
-                 let uu____167 = FStar_Util.char_at s (Prims.parse_int "1") in
-                 hexdigit uu____167 in
-               FStar_Mul.op_Star uu____166 (Prims.parse_int "256") in
-             uu____162 + uu____165 in
-           let uu____168 =
-             let uu____169 =
-               let uu____170 = FStar_Util.char_at s (Prims.parse_int "2") in
-               hexdigit uu____170 in
-             FStar_Mul.op_Star uu____169 (Prims.parse_int "16") in
-           uu____161 + uu____168 in
-         let uu____171 =
-           let uu____172 = FStar_Util.char_at s (Prims.parse_int "3") in
-           hexdigit uu____172 in
-         uu____160 + uu____171 in
-       FStar_Util.uint16_of_int uu____159)
-let hexgraph_short: Prims.string -> FStar_BaseTypes.uint16 =
-  fun s  ->
-    if (FStar_String.length s) <> (Prims.parse_int "2")
-    then failwith "hexgraph"
-    else
-      (let uu____179 =
-         let uu____180 =
-           let uu____181 =
-             let uu____182 = FStar_Util.char_at s (Prims.parse_int "0") in
-             hexdigit uu____182 in
-           FStar_Mul.op_Star uu____181 (Prims.parse_int "16") in
-         let uu____183 =
-           let uu____184 = FStar_Util.char_at s (Prims.parse_int "1") in
-           hexdigit uu____184 in
-         uu____180 + uu____183 in
-       FStar_Util.uint16_of_int uu____179)
-let unicodegraph_long:
-  Prims.string ->
-    (FStar_BaseTypes.uint16 Prims.option* FStar_BaseTypes.uint16)
-  =
-  fun s  ->
-    if (FStar_String.length s) <> (Prims.parse_int "8")
-    then failwith "unicodegraph_long"
-    else
-      (let high =
-         let uu____201 =
-           let uu____202 =
-             let uu____203 =
-               let uu____204 =
-                 let uu____205 = FStar_Util.char_at s (Prims.parse_int "0") in
-                 hexdigit uu____205 in
-               FStar_Mul.op_Star uu____204 (Prims.parse_int "4096") in
-             let uu____206 =
-               let uu____207 =
-                 let uu____208 = FStar_Util.char_at s (Prims.parse_int "1") in
-                 hexdigit uu____208 in
-               FStar_Mul.op_Star uu____207 (Prims.parse_int "256") in
-             uu____203 + uu____206 in
-           let uu____209 =
-             let uu____210 =
-               let uu____211 = FStar_Util.char_at s (Prims.parse_int "2") in
-               hexdigit uu____211 in
-             FStar_Mul.op_Star uu____210 (Prims.parse_int "16") in
-           uu____202 + uu____209 in
-         let uu____212 =
-           let uu____213 = FStar_Util.char_at s (Prims.parse_int "3") in
-           hexdigit uu____213 in
-         uu____201 + uu____212 in
-       let low =
-         let uu____215 =
-           let uu____216 =
-             let uu____217 =
-               let uu____218 =
-                 let uu____219 = FStar_Util.char_at s (Prims.parse_int "4") in
-                 hexdigit uu____219 in
-               FStar_Mul.op_Star uu____218 (Prims.parse_int "4096") in
-             let uu____220 =
-               let uu____221 =
-                 let uu____222 = FStar_Util.char_at s (Prims.parse_int "5") in
-                 hexdigit uu____222 in
-               FStar_Mul.op_Star uu____221 (Prims.parse_int "256") in
-             uu____217 + uu____220 in
-           let uu____223 =
-             let uu____224 =
-               let uu____225 = FStar_Util.char_at s (Prims.parse_int "6") in
-               hexdigit uu____225 in
-             FStar_Mul.op_Star uu____224 (Prims.parse_int "16") in
-           uu____216 + uu____223 in
-         let uu____226 =
-           let uu____227 = FStar_Util.char_at s (Prims.parse_int "7") in
-           hexdigit uu____227 in
-         uu____215 + uu____226 in
-       if high = (Prims.parse_int "0")
-       then (None, (FStar_Util.uint16_of_int low))
-       else
-         ((Some
-             (FStar_Util.uint16_of_int
-                ((Prims.parse_int "0xD800") +
-                   (((FStar_Mul.op_Star high (Prims.parse_int "0x10000")) +
-                       (low - (Prims.parse_int "0x10000")))
-                      / (Prims.parse_int "0x400"))))),
-           (FStar_Util.uint16_of_int
-              ((Prims.parse_int "0xDF30") +
-                 (((FStar_Mul.op_Star high (Prims.parse_int "0x10000")) +
-                     (low - (Prims.parse_int "0x10000")))
-                    mod (Prims.parse_int "0x400"))))))
-let escape: FStar_Char.char -> FStar_Char.char =
-  fun c  ->
-    match c with
-    | '\\' -> '\\'
-    | '\'' -> '\''
-    | 'n' -> '\n'
-    | 't' -> '\t'
-    | 'b' -> '\b'
-    | 'r' -> '\r'
-    | c1 -> c1
+
+let intern_string : Prims.string  ->  Prims.string = (
+
+let strings = (FStar_Util.smap_create (Prims.parse_int "100"))
+in (fun s -> (
+
+let uu____6 = (FStar_Util.smap_try_find strings s)
+in (match (uu____6) with
+| Some (res) -> begin
+res
+end
+| None -> begin
+((FStar_Util.smap_add strings s s);
+s;
+)
+end))))
+
+
+let default_string_finish = (fun endm b s -> FStar_Parser_Parse.STRING (s))
+
+
+let call_string_finish = (fun fin buf endm b -> (let _0_27 = (FStar_Bytes.close buf)
+in (fin endm b _0_27)))
+
+
+let add_string : FStar_Bytes.bytebuf  ->  Prims.string  ->  Prims.unit = (fun buf x -> (
+
+let uu____76 = (FStar_Bytes.string_as_unicode_bytes x)
+in (FStar_Bytes.emit_bytes buf uu____76)))
+
+
+let add_int_char : FStar_Bytes.bytebuf  ->  Prims.int  ->  Prims.unit = (fun buf c -> ((FStar_Bytes.emit_int_as_byte buf (c mod (Prims.parse_int "256")));
+(FStar_Bytes.emit_int_as_byte buf (c / (Prims.parse_int "256")));
+))
+
+
+let add_unichar : FStar_Bytes.bytebuf  ->  Prims.int  ->  Prims.unit = (fun buf c -> (add_int_char buf c))
+
+
+let add_byte_char : FStar_Bytes.bytebuf  ->  FStar_BaseTypes.char  ->  Prims.unit = (fun buf c -> (add_int_char buf ((FStar_Util.int_of_char c) mod (Prims.parse_int "256"))))
+
+
+let stringbuf_as_bytes : FStar_Bytes.bytebuf  ->  FStar_Bytes.bytes = (fun buf -> (
+
+let bytes = (FStar_Bytes.close buf)
+in (
+
+let uu____100 = (
+
+let uu____101 = (FStar_Bytes.length bytes)
+in (uu____101 / (Prims.parse_int "2")))
+in (FStar_Bytes.make (fun i -> (FStar_Bytes.get bytes (FStar_Mul.op_Star i (Prims.parse_int "2")))) uu____100))))
+
+
+let stringbuf_is_bytes : FStar_Bytes.bytebuf  ->  Prims.bool = (fun buf -> (
+
+let bytes = (FStar_Bytes.close buf)
+in (
+
+let ok = (FStar_Util.mk_ref true)
+in ((
+
+let uu____114 = (
+
+let uu____115 = (
+
+let uu____116 = (FStar_Bytes.length bytes)
+in (uu____116 / (Prims.parse_int "2")))
+in (uu____115 - (Prims.parse_int "1")))
+in (FStar_Util.for_range (Prims.parse_int "0") uu____114 (fun i -> (
+
+let uu____121 = (
+
+let uu____122 = (FStar_Bytes.get bytes ((FStar_Mul.op_Star i (Prims.parse_int "2")) + (Prims.parse_int "1")))
+in (uu____122 <> (Prims.parse_int "0")))
+in (match (uu____121) with
+| true -> begin
+(FStar_ST.write ok false)
+end
+| uu____125 -> begin
+()
+end)))));
+(FStar_ST.read ok);
+))))
+
+
+let trigraph : FStar_BaseTypes.char  ->  FStar_BaseTypes.char  ->  FStar_BaseTypes.char  ->  FStar_BaseTypes.char = (fun c1 c2 c3 -> (
+
+let digit = (fun c -> ((FStar_Util.int_of_char c) - (FStar_Util.int_of_char '0')))
+in (FStar_Util.char_of_int (((FStar_Mul.op_Star (digit c1) (Prims.parse_int "100")) + (FStar_Mul.op_Star (digit c2) (Prims.parse_int "10"))) + (digit c3)))))
+
+
+let digit : FStar_BaseTypes.char  ->  Prims.int = (fun d -> (
+
+let dd = (FStar_Util.int_of_char d)
+in (match (((dd >= (FStar_Util.int_of_char '0')) && (dd <= (FStar_Util.int_of_char '9')))) with
+| true -> begin
+((FStar_Util.int_of_char d) - (FStar_Util.int_of_char '0'))
+end
+| uu____145 -> begin
+(failwith "digit")
+end)))
+
+
+let hexdigit : FStar_BaseTypes.char  ->  Prims.int = (fun d -> (
+
+let dd = (FStar_Util.int_of_char d)
+in (match (((dd >= (FStar_Util.int_of_char '0')) && (dd <= (FStar_Util.int_of_char '9')))) with
+| true -> begin
+(digit d)
+end
+| uu____150 -> begin
+(match (((dd >= (FStar_Util.int_of_char 'a')) && (dd <= (FStar_Util.int_of_char 'f')))) with
+| true -> begin
+((dd - (FStar_Util.int_of_char 'a')) + (Prims.parse_int "10"))
+end
+| uu____151 -> begin
+(match (((dd >= (FStar_Util.int_of_char 'A')) && (dd <= (FStar_Util.int_of_char 'F')))) with
+| true -> begin
+((dd - (FStar_Util.int_of_char 'A')) + (Prims.parse_int "10"))
+end
+| uu____152 -> begin
+(failwith "hexdigit")
+end)
+end)
+end)))
+
+
+let unicodegraph_short : Prims.string  ->  FStar_BaseTypes.uint16 = (fun s -> (match (((FStar_String.length s) <> (Prims.parse_int "4"))) with
+| true -> begin
+(failwith "unicodegraph")
+end
+| uu____158 -> begin
+(
+
+let uu____159 = (
+
+let uu____160 = (
+
+let uu____161 = (
+
+let uu____162 = (
+
+let uu____163 = (
+
+let uu____164 = (FStar_Util.char_at s (Prims.parse_int "0"))
+in (hexdigit uu____164))
+in (FStar_Mul.op_Star uu____163 (Prims.parse_int "4096")))
+in (
+
+let uu____165 = (
+
+let uu____166 = (
+
+let uu____167 = (FStar_Util.char_at s (Prims.parse_int "1"))
+in (hexdigit uu____167))
+in (FStar_Mul.op_Star uu____166 (Prims.parse_int "256")))
+in (uu____162 + uu____165)))
+in (
+
+let uu____168 = (
+
+let uu____169 = (
+
+let uu____170 = (FStar_Util.char_at s (Prims.parse_int "2"))
+in (hexdigit uu____170))
+in (FStar_Mul.op_Star uu____169 (Prims.parse_int "16")))
+in (uu____161 + uu____168)))
+in (
+
+let uu____171 = (
+
+let uu____172 = (FStar_Util.char_at s (Prims.parse_int "3"))
+in (hexdigit uu____172))
+in (uu____160 + uu____171)))
+in (FStar_Util.uint16_of_int uu____159))
+end))
+
+
+let hexgraph_short : Prims.string  ->  FStar_BaseTypes.uint16 = (fun s -> (match (((FStar_String.length s) <> (Prims.parse_int "2"))) with
+| true -> begin
+(failwith "hexgraph")
+end
+| uu____178 -> begin
+(
+
+let uu____179 = (
+
+let uu____180 = (
+
+let uu____181 = (
+
+let uu____182 = (FStar_Util.char_at s (Prims.parse_int "0"))
+in (hexdigit uu____182))
+in (FStar_Mul.op_Star uu____181 (Prims.parse_int "16")))
+in (
+
+let uu____183 = (
+
+let uu____184 = (FStar_Util.char_at s (Prims.parse_int "1"))
+in (hexdigit uu____184))
+in (uu____180 + uu____183)))
+in (FStar_Util.uint16_of_int uu____179))
+end))
+
+
+let unicodegraph_long : Prims.string  ->  (FStar_BaseTypes.uint16 Prims.option * FStar_BaseTypes.uint16) = (fun s -> (match (((FStar_String.length s) <> (Prims.parse_int "8"))) with
+| true -> begin
+(failwith "unicodegraph_long")
+end
+| uu____199 -> begin
+(
+
+let high = (
+
+let uu____201 = (
+
+let uu____202 = (
+
+let uu____203 = (
+
+let uu____204 = (
+
+let uu____205 = (FStar_Util.char_at s (Prims.parse_int "0"))
+in (hexdigit uu____205))
+in (FStar_Mul.op_Star uu____204 (Prims.parse_int "4096")))
+in (
+
+let uu____206 = (
+
+let uu____207 = (
+
+let uu____208 = (FStar_Util.char_at s (Prims.parse_int "1"))
+in (hexdigit uu____208))
+in (FStar_Mul.op_Star uu____207 (Prims.parse_int "256")))
+in (uu____203 + uu____206)))
+in (
+
+let uu____209 = (
+
+let uu____210 = (
+
+let uu____211 = (FStar_Util.char_at s (Prims.parse_int "2"))
+in (hexdigit uu____211))
+in (FStar_Mul.op_Star uu____210 (Prims.parse_int "16")))
+in (uu____202 + uu____209)))
+in (
+
+let uu____212 = (
+
+let uu____213 = (FStar_Util.char_at s (Prims.parse_int "3"))
+in (hexdigit uu____213))
+in (uu____201 + uu____212)))
+in (
+
+let low = (
+
+let uu____215 = (
+
+let uu____216 = (
+
+let uu____217 = (
+
+let uu____218 = (
+
+let uu____219 = (FStar_Util.char_at s (Prims.parse_int "4"))
+in (hexdigit uu____219))
+in (FStar_Mul.op_Star uu____218 (Prims.parse_int "4096")))
+in (
+
+let uu____220 = (
+
+let uu____221 = (
+
+let uu____222 = (FStar_Util.char_at s (Prims.parse_int "5"))
+in (hexdigit uu____222))
+in (FStar_Mul.op_Star uu____221 (Prims.parse_int "256")))
+in (uu____217 + uu____220)))
+in (
+
+let uu____223 = (
+
+let uu____224 = (
+
+let uu____225 = (FStar_Util.char_at s (Prims.parse_int "6"))
+in (hexdigit uu____225))
+in (FStar_Mul.op_Star uu____224 (Prims.parse_int "16")))
+in (uu____216 + uu____223)))
+in (
+
+let uu____226 = (
+
+let uu____227 = (FStar_Util.char_at s (Prims.parse_int "7"))
+in (hexdigit uu____227))
+in (uu____215 + uu____226)))
+in (match ((high = (Prims.parse_int "0"))) with
+| true -> begin
+((None), ((FStar_Util.uint16_of_int low)))
+end
+| uu____232 -> begin
+((Some ((FStar_Util.uint16_of_int ((Prims.parse_int "0xD800") + (((FStar_Mul.op_Star high (Prims.parse_int "0x10000")) + (low - (Prims.parse_int "0x10000"))) / (Prims.parse_int "0x400")))))), ((FStar_Util.uint16_of_int ((Prims.parse_int "0xDF30") + (((FStar_Mul.op_Star high (Prims.parse_int "0x10000")) + (low - (Prims.parse_int "0x10000"))) mod (Prims.parse_int "0x400"))))))
+end)))
+end))
+
+
+let escape : FStar_Char.char  ->  FStar_Char.char = (fun c -> (match (c) with
+| '\\' -> begin
+'\\'
+end
+| '\'' -> begin
+'\''
+end
+| 'n' -> begin
+'\n'
+end
+| 't' -> begin
+'\t'
+end
+| 'b' -> begin
+'\b'
+end
+| 'r' -> begin
+'\r'
+end
+| c1 -> begin
+c1
+end))
+
 type compatibilityMode =
-  | ALWAYS
-  | FSHARP
-let uu___is_ALWAYS: compatibilityMode -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ALWAYS  -> true | uu____241 -> false
-let uu___is_FSHARP: compatibilityMode -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FSHARP  -> true | uu____245 -> false
-let keywords:
-  (compatibilityMode* Prims.string* FStar_Parser_Parse.token) Prims.list =
-  [(ALWAYS, "abstract", FStar_Parser_Parse.ABSTRACT);
-  (ALWAYS, "attributes", FStar_Parser_Parse.ATTRIBUTES);
-  (ALWAYS, "noeq", FStar_Parser_Parse.NOEQUALITY);
-  (ALWAYS, "unopteq", FStar_Parser_Parse.UNOPTEQUALITY);
-  (ALWAYS, "and", FStar_Parser_Parse.AND);
-  (ALWAYS, "assert", FStar_Parser_Parse.ASSERT);
-  (ALWAYS, "assume", FStar_Parser_Parse.ASSUME);
-  (ALWAYS, "begin", FStar_Parser_Parse.BEGIN);
-  (ALWAYS, "by", FStar_Parser_Parse.BY);
-  (FSHARP, "default", FStar_Parser_Parse.DEFAULT);
-  (ALWAYS, "effect", FStar_Parser_Parse.EFFECT);
-  (ALWAYS, "else", FStar_Parser_Parse.ELSE);
-  (ALWAYS, "end", FStar_Parser_Parse.END);
-  (ALWAYS, "ensures", FStar_Parser_Parse.ENSURES);
-  (ALWAYS, "exception", FStar_Parser_Parse.EXCEPTION);
-  (ALWAYS, "exists", FStar_Parser_Parse.EXISTS);
-  (ALWAYS, "false", FStar_Parser_Parse.FALSE);
-  (ALWAYS, "False", FStar_Parser_Parse.L_FALSE);
-  (ALWAYS, "forall", FStar_Parser_Parse.FORALL);
-  (ALWAYS, "fun", FStar_Parser_Parse.FUN);
-  (ALWAYS, "function", FStar_Parser_Parse.FUNCTION);
-  (ALWAYS, "if", FStar_Parser_Parse.IF);
-  (ALWAYS, "in", FStar_Parser_Parse.IN);
-  (ALWAYS, "include", FStar_Parser_Parse.INCLUDE);
-  (ALWAYS, "inline", FStar_Parser_Parse.INLINE);
-  (ALWAYS, "inline_for_extraction", FStar_Parser_Parse.INLINE_FOR_EXTRACTION);
-  (ALWAYS, "irreducible", FStar_Parser_Parse.IRREDUCIBLE);
-  (ALWAYS, "let", (FStar_Parser_Parse.LET false));
-  (ALWAYS, "logic", FStar_Parser_Parse.LOGIC);
-  (ALWAYS, "match", FStar_Parser_Parse.MATCH);
-  (ALWAYS, "module", FStar_Parser_Parse.MODULE);
-  (ALWAYS, "mutable", FStar_Parser_Parse.MUTABLE);
-  (ALWAYS, "new", FStar_Parser_Parse.NEW);
-  (ALWAYS, "new_effect", FStar_Parser_Parse.NEW_EFFECT);
-  (ALWAYS, "noextract", FStar_Parser_Parse.NOEXTRACT);
-  (ALWAYS, "of", FStar_Parser_Parse.OF);
-  (ALWAYS, "open", FStar_Parser_Parse.OPEN);
-  (ALWAYS, "opaque", FStar_Parser_Parse.OPAQUE);
-  (ALWAYS, "private", FStar_Parser_Parse.PRIVATE);
-  (ALWAYS, "rec", FStar_Parser_Parse.REC);
-  (ALWAYS, "reifiable", FStar_Parser_Parse.REIFIABLE);
-  (ALWAYS, "reify", FStar_Parser_Parse.REIFY);
-  (ALWAYS, "reflectable", FStar_Parser_Parse.REFLECTABLE);
-  (ALWAYS, "requires", FStar_Parser_Parse.REQUIRES);
-  (ALWAYS, "sub_effect", FStar_Parser_Parse.SUB_EFFECT);
-  (ALWAYS, "then", FStar_Parser_Parse.THEN);
-  (ALWAYS, "total", FStar_Parser_Parse.TOTAL);
-  (ALWAYS, "true", FStar_Parser_Parse.TRUE);
-  (ALWAYS, "True", FStar_Parser_Parse.L_TRUE);
-  (ALWAYS, "try", FStar_Parser_Parse.TRY);
-  (ALWAYS, "type", FStar_Parser_Parse.TYPE);
-  (ALWAYS, "unfold", FStar_Parser_Parse.UNFOLD);
-  (ALWAYS, "unfoldable", FStar_Parser_Parse.UNFOLDABLE);
-  (ALWAYS, "val", FStar_Parser_Parse.VAL);
-  (ALWAYS, "when", FStar_Parser_Parse.WHEN);
-  (ALWAYS, "with", FStar_Parser_Parse.WITH);
-  (ALWAYS, "_", FStar_Parser_Parse.UNDERSCORE)]
-let stringKeywords: Prims.string Prims.list =
-  FStar_List.map
-    (fun uu____428  -> match uu____428 with | (uu____432,w,uu____434) -> w)
-    keywords
-let unreserve_words: Prims.string Prims.list =
-  FStar_List.choose
-    (fun uu____439  ->
-       match uu____439 with
-       | (mode,keyword,uu____446) ->
-           if mode = FSHARP then Some keyword else None) keywords
-let kwd_table: FStar_Parser_Parse.token FStar_Util.smap =
-  let tab = FStar_Util.smap_create (Prims.parse_int "1000") in
-  FStar_List.iter
-    (fun uu____456  ->
-       match uu____456 with
-       | (mode,keyword,token) -> FStar_Util.smap_add tab keyword token)
-    keywords;
-  tab
-let kwd: Prims.string -> FStar_Parser_Parse.token Prims.option =
-  fun s  -> FStar_Util.smap_try_find kwd_table s
+| ALWAYS
+| FSHARP
+
+
+let uu___is_ALWAYS : compatibilityMode  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ALWAYS -> begin
+true
+end
+| uu____241 -> begin
+false
+end))
+
+
+let uu___is_FSHARP : compatibilityMode  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FSHARP -> begin
+true
+end
+| uu____245 -> begin
+false
+end))
+
+
+let keywords : (compatibilityMode * Prims.string * FStar_Parser_Parse.token) Prims.list = (((ALWAYS), ("abstract"), (FStar_Parser_Parse.ABSTRACT)))::(((ALWAYS), ("attributes"), (FStar_Parser_Parse.ATTRIBUTES)))::(((ALWAYS), ("noeq"), (FStar_Parser_Parse.NOEQUALITY)))::(((ALWAYS), ("unopteq"), (FStar_Parser_Parse.UNOPTEQUALITY)))::(((ALWAYS), ("and"), (FStar_Parser_Parse.AND)))::(((ALWAYS), ("assert"), (FStar_Parser_Parse.ASSERT)))::(((ALWAYS), ("assume"), (FStar_Parser_Parse.ASSUME)))::(((ALWAYS), ("begin"), (FStar_Parser_Parse.BEGIN)))::(((ALWAYS), ("by"), (FStar_Parser_Parse.BY)))::(((FSHARP), ("default"), (FStar_Parser_Parse.DEFAULT)))::(((ALWAYS), ("effect"), (FStar_Parser_Parse.EFFECT)))::(((ALWAYS), ("else"), (FStar_Parser_Parse.ELSE)))::(((ALWAYS), ("end"), (FStar_Parser_Parse.END)))::(((ALWAYS), ("ensures"), (FStar_Parser_Parse.ENSURES)))::(((ALWAYS), ("exception"), (FStar_Parser_Parse.EXCEPTION)))::(((ALWAYS), ("exists"), (FStar_Parser_Parse.EXISTS)))::(((ALWAYS), ("false"), (FStar_Parser_Parse.FALSE)))::(((ALWAYS), ("False"), (FStar_Parser_Parse.L_FALSE)))::(((ALWAYS), ("forall"), (FStar_Parser_Parse.FORALL)))::(((ALWAYS), ("fun"), (FStar_Parser_Parse.FUN)))::(((ALWAYS), ("function"), (FStar_Parser_Parse.FUNCTION)))::(((ALWAYS), ("if"), (FStar_Parser_Parse.IF)))::(((ALWAYS), ("in"), (FStar_Parser_Parse.IN)))::(((ALWAYS), ("include"), (FStar_Parser_Parse.INCLUDE)))::(((ALWAYS), ("inline"), (FStar_Parser_Parse.INLINE)))::(((ALWAYS), ("inline_for_extraction"), (FStar_Parser_Parse.INLINE_FOR_EXTRACTION)))::(((ALWAYS), ("irreducible"), (FStar_Parser_Parse.IRREDUCIBLE)))::(((ALWAYS), ("let"), (FStar_Parser_Parse.LET (false))))::(((ALWAYS), ("logic"), (FStar_Parser_Parse.LOGIC)))::(((ALWAYS), ("match"), (FStar_Parser_Parse.MATCH)))::(((ALWAYS), ("module"), (FStar_Parser_Parse.MODULE)))::(((ALWAYS), ("mutable"), (FStar_Parser_Parse.MUTABLE)))::(((ALWAYS), ("new"), (FStar_Parser_Parse.NEW)))::(((ALWAYS), ("new_effect"), (FStar_Parser_Parse.NEW_EFFECT)))::(((ALWAYS), ("noextract"), (FStar_Parser_Parse.NOEXTRACT)))::(((ALWAYS), ("of"), (FStar_Parser_Parse.OF)))::(((ALWAYS), ("open"), (FStar_Parser_Parse.OPEN)))::(((ALWAYS), ("opaque"), (FStar_Parser_Parse.OPAQUE)))::(((ALWAYS), ("private"), (FStar_Parser_Parse.PRIVATE)))::(((ALWAYS), ("rec"), (FStar_Parser_Parse.REC)))::(((ALWAYS), ("reifiable"), (FStar_Parser_Parse.REIFIABLE)))::(((ALWAYS), ("reify"), (FStar_Parser_Parse.REIFY)))::(((ALWAYS), ("reflectable"), (FStar_Parser_Parse.REFLECTABLE)))::(((ALWAYS), ("requires"), (FStar_Parser_Parse.REQUIRES)))::(((ALWAYS), ("sub_effect"), (FStar_Parser_Parse.SUB_EFFECT)))::(((ALWAYS), ("then"), (FStar_Parser_Parse.THEN)))::(((ALWAYS), ("total"), (FStar_Parser_Parse.TOTAL)))::(((ALWAYS), ("true"), (FStar_Parser_Parse.TRUE)))::(((ALWAYS), ("True"), (FStar_Parser_Parse.L_TRUE)))::(((ALWAYS), ("try"), (FStar_Parser_Parse.TRY)))::(((ALWAYS), ("type"), (FStar_Parser_Parse.TYPE)))::(((ALWAYS), ("unfold"), (FStar_Parser_Parse.UNFOLD)))::(((ALWAYS), ("unfoldable"), (FStar_Parser_Parse.UNFOLDABLE)))::(((ALWAYS), ("val"), (FStar_Parser_Parse.VAL)))::(((ALWAYS), ("when"), (FStar_Parser_Parse.WHEN)))::(((ALWAYS), ("with"), (FStar_Parser_Parse.WITH)))::(((ALWAYS), ("_"), (FStar_Parser_Parse.UNDERSCORE)))::[]
+
+
+let stringKeywords : Prims.string Prims.list = (FStar_List.map (fun uu____428 -> (match (uu____428) with
+| (uu____432, w, uu____434) -> begin
+w
+end)) keywords)
+
+
+let unreserve_words : Prims.string Prims.list = (FStar_List.choose (fun uu____439 -> (match (uu____439) with
+| (mode, keyword, uu____446) -> begin
+(match ((mode = FSHARP)) with
+| true -> begin
+Some (keyword)
+end
+| uu____448 -> begin
+None
+end)
+end)) keywords)
+
+
+let kwd_table : FStar_Parser_Parse.token FStar_Util.smap = (
+
+let tab = (FStar_Util.smap_create (Prims.parse_int "1000"))
+in ((FStar_List.iter (fun uu____456 -> (match (uu____456) with
+| (mode, keyword, token) -> begin
+(FStar_Util.smap_add tab keyword token)
+end)) keywords);
+tab;
+))
+
+
+let kwd : Prims.string  ->  FStar_Parser_Parse.token Prims.option = (fun s -> (FStar_Util.smap_try_find kwd_table s))
+
 type lexargs =
-  {
-  getSourceDirectory: Prims.unit -> Prims.string;
-  filename: Prims.string;
-  contents: Prims.string;}
-let mkLexargs:
-  ((Prims.unit -> Prims.string)* Prims.string* Prims.string) -> lexargs =
-  fun uu____503  ->
-    match uu____503 with
-    | (srcdir,filename,contents) ->
-        { getSourceDirectory = srcdir; filename; contents }
-let kwd_or_id:
-  lexargs -> FStar_Range.range -> Prims.string -> FStar_Parser_Parse.token =
-  fun args  ->
-    fun r  ->
-      fun s  ->
-        let uu____525 = kwd s in
-        match uu____525 with
-        | Some v1 -> v1
-        | None  ->
-            (match s with
-             | "__SOURCE_DIRECTORY__" ->
-                 let uu____528 =
-                   let uu____529 = args.getSourceDirectory () in
-                   FStar_Bytes.string_as_unicode_bytes uu____529 in
-                 FStar_Parser_Parse.STRING uu____528
-             | "__SOURCE_FILE__" ->
-                 let uu____530 =
-                   let uu____531 = FStar_Range.file_of_range r in
-                   FStar_Bytes.string_as_unicode_bytes uu____531 in
-                 FStar_Parser_Parse.STRING uu____530
-             | "__LINE__" ->
-                 let uu____532 =
-                   let uu____535 =
-                     let uu____536 =
-                       let uu____537 = FStar_Range.start_of_range r in
-                       FStar_Range.line_of_pos uu____537 in
-                     FStar_All.pipe_left FStar_Util.string_of_int uu____536 in
-                   (uu____535, false) in
-                 FStar_Parser_Parse.INT uu____532
-             | uu____538 ->
-                 if FStar_Util.starts_with s FStar_Ident.reserved_prefix
-                 then
-                   Prims.raise
-                     (FStar_Errors.Error
-                        ((Prims.strcat FStar_Ident.reserved_prefix
-                            " is a reserved prefix for an identifier"), r))
-                 else
-                   (let uu____540 = intern_string s in
-                    FStar_Parser_Parse.IDENT uu____540))
+{getSourceDirectory : Prims.unit  ->  Prims.string; filename : Prims.string; contents : Prims.string}
+
+
+let mkLexargs : ((Prims.unit  ->  Prims.string) * Prims.string * Prims.string)  ->  lexargs = (fun uu____503 -> (match (uu____503) with
+| (srcdir, filename, contents) -> begin
+{getSourceDirectory = srcdir; filename = filename; contents = contents}
+end))
+
+
+let kwd_or_id : lexargs  ->  FStar_Range.range  ->  Prims.string  ->  FStar_Parser_Parse.token = (fun args r s -> (
+
+let uu____525 = (kwd s)
+in (match (uu____525) with
+| Some (v1) -> begin
+v1
+end
+| None -> begin
+(match (s) with
+| "__SOURCE_DIRECTORY__" -> begin
+(
+
+let uu____528 = (
+
+let uu____529 = (args.getSourceDirectory ())
+in (FStar_Bytes.string_as_unicode_bytes uu____529))
+in FStar_Parser_Parse.STRING (uu____528))
+end
+| "__SOURCE_FILE__" -> begin
+(
+
+let uu____530 = (
+
+let uu____531 = (FStar_Range.file_of_range r)
+in (FStar_Bytes.string_as_unicode_bytes uu____531))
+in FStar_Parser_Parse.STRING (uu____530))
+end
+| "__LINE__" -> begin
+(
+
+let uu____532 = (
+
+let uu____535 = (
+
+let uu____536 = (
+
+let uu____537 = (FStar_Range.start_of_range r)
+in (FStar_Range.line_of_pos uu____537))
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____536))
+in ((uu____535), (false)))
+in FStar_Parser_Parse.INT (uu____532))
+end
+| uu____538 -> begin
+(match ((FStar_Util.starts_with s FStar_Ident.reserved_prefix)) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat FStar_Ident.reserved_prefix " is a reserved prefix for an identifier")), (r)))))
+end
+| uu____539 -> begin
+(
+
+let uu____540 = (intern_string s)
+in FStar_Parser_Parse.IDENT (uu____540))
+end)
+end)
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -1,2498 +1,3743 @@
+
 open Prims
-let should_print_fs_typ_app: Prims.bool FStar_ST.ref =
-  FStar_Util.mk_ref false
-let with_fs_typ_app b printer t =
-  let b0 = FStar_ST.read should_print_fs_typ_app in
-  FStar_ST.write should_print_fs_typ_app b;
-  (let res = printer t in FStar_ST.write should_print_fs_typ_app b0; res)
-let should_unparen: Prims.bool FStar_ST.ref = FStar_Util.mk_ref true
-let rec unparen: FStar_Parser_AST.term -> FStar_Parser_AST.term =
-  fun t  ->
-    let uu____44 =
-      let uu____45 = FStar_ST.read should_unparen in
-      Prims.op_Negation uu____45 in
-    if uu____44
-    then t
-    else
-      (match t.FStar_Parser_AST.tm with
-       | FStar_Parser_AST.Paren t1 -> unparen t1
-       | uu____50 -> t)
-let str: Prims.string -> FStar_Pprint.document =
-  fun s  -> FStar_Pprint.doc_of_string s
-let default_or_map n1 f x = match x with | None  -> n1 | Some x' -> f x'
-let prefix2:
-  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document =
-  fun prefix_  ->
-    fun body  ->
-      FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "1") prefix_
-        body
-let op_Hat_Slash_Plus_Hat:
-  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document =
-  fun prefix_  -> fun body  -> prefix2 prefix_ body
-let jump2: FStar_Pprint.document -> FStar_Pprint.document =
-  fun body  ->
-    FStar_Pprint.jump (Prims.parse_int "2") (Prims.parse_int "1") body
-let infix2:
-  FStar_Pprint.document ->
-    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document
-  = FStar_Pprint.infix (Prims.parse_int "2") (Prims.parse_int "1")
-let infix0:
-  FStar_Pprint.document ->
-    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document
-  = FStar_Pprint.infix (Prims.parse_int "0") (Prims.parse_int "1")
-let break1: FStar_Pprint.document = FStar_Pprint.break_ (Prims.parse_int "1")
-let separate_break_map sep f l =
-  let uu____132 =
-    let uu____133 =
-      let uu____134 = FStar_Pprint.op_Hat_Hat sep break1 in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____134 in
-    FStar_Pprint.separate_map uu____133 f l in
-  FStar_Pprint.group uu____132
-let precede_break_separate_map prec sep f l =
-  let uu____164 =
-    let uu____165 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space in
-    let uu____166 =
-      let uu____167 = FStar_List.hd l in FStar_All.pipe_right uu____167 f in
-    FStar_Pprint.precede uu____165 uu____166 in
-  let uu____168 =
-    let uu____169 = FStar_List.tl l in
-    FStar_Pprint.concat_map
-      (fun x  ->
-         let uu____172 =
-           let uu____173 =
-             let uu____174 = f x in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____174 in
-           FStar_Pprint.op_Hat_Hat sep uu____173 in
-         FStar_Pprint.op_Hat_Hat break1 uu____172) uu____169 in
-  FStar_Pprint.op_Hat_Hat uu____164 uu____168
-let concat_break_map f l =
-  let uu____194 =
-    FStar_Pprint.concat_map
-      (fun x  ->
-         let uu____196 = f x in FStar_Pprint.op_Hat_Hat uu____196 break1) l in
-  FStar_Pprint.group uu____194
-let parens_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
-  fun contents  ->
-    FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
-      FStar_Pprint.lparen contents FStar_Pprint.rparen
-let soft_parens_with_nesting: FStar_Pprint.document -> FStar_Pprint.document
-  =
-  fun contents  ->
-    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "0")
-      FStar_Pprint.lparen contents FStar_Pprint.rparen
-let braces_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
-  fun contents  ->
-    FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-      FStar_Pprint.lbrace contents FStar_Pprint.rbrace
-let soft_braces_with_nesting: FStar_Pprint.document -> FStar_Pprint.document
-  =
-  fun contents  ->
-    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
-      FStar_Pprint.lbrace contents FStar_Pprint.rbrace
-let brackets_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
-  fun contents  ->
-    FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-      FStar_Pprint.lbracket contents FStar_Pprint.rbracket
-let soft_brackets_with_nesting:
-  FStar_Pprint.document -> FStar_Pprint.document =
-  fun contents  ->
-    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
-      FStar_Pprint.lbracket contents FStar_Pprint.rbracket
-let soft_begin_end_with_nesting:
-  FStar_Pprint.document -> FStar_Pprint.document =
-  fun contents  ->
-    let uu____218 = str "begin" in
-    let uu____219 = str "end" in
-    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
-      uu____218 contents uu____219
-let separate_map_or_flow sep f l =
-  if (FStar_List.length l) < (Prims.parse_int "10")
-  then FStar_Pprint.separate_map sep f l
-  else FStar_Pprint.flow_map sep f l
-let soft_surround_separate_map n1 b void_ opening sep closing f xs =
-  if xs = []
-  then void_
-  else
-    (let uu____299 = FStar_Pprint.separate_map sep f xs in
-     FStar_Pprint.soft_surround n1 b opening uu____299 closing)
-let doc_of_fsdoc:
-  (Prims.string* (Prims.string* Prims.string) Prims.list) ->
-    FStar_Pprint.document
-  =
-  fun uu____307  ->
-    match uu____307 with
-    | (comment,keywords1) ->
-        let uu____321 =
-          let uu____322 =
-            let uu____324 = str comment in
-            let uu____325 =
-              let uu____327 =
-                let uu____329 =
-                  FStar_Pprint.separate_map FStar_Pprint.comma
-                    (fun uu____332  ->
-                       match uu____332 with
-                       | (k,v1) ->
-                           let uu____337 =
-                             let uu____339 = str k in
-                             let uu____340 =
-                               let uu____342 =
-                                 let uu____344 = str v1 in [uu____344] in
-                               FStar_Pprint.rarrow :: uu____342 in
-                             uu____339 :: uu____340 in
-                           FStar_Pprint.concat uu____337) keywords1 in
-                [uu____329] in
-              FStar_Pprint.space :: uu____327 in
-            uu____324 :: uu____325 in
-          FStar_Pprint.concat uu____322 in
-        FStar_Pprint.group uu____321
-let is_unit: FStar_Parser_AST.term -> Prims.bool =
-  fun e  ->
-    let uu____348 =
-      let uu____349 = unparen e in uu____349.FStar_Parser_AST.tm in
-    match uu____348 with
-    | FStar_Parser_AST.Const (FStar_Const.Const_unit ) -> true
-    | uu____350 -> false
-let matches_var: FStar_Parser_AST.term -> FStar_Ident.ident -> Prims.bool =
-  fun t  ->
-    fun x  ->
-      let uu____357 =
-        let uu____358 = unparen t in uu____358.FStar_Parser_AST.tm in
-      match uu____357 with
-      | FStar_Parser_AST.Var y ->
-          x.FStar_Ident.idText = (FStar_Ident.text_of_lid y)
-      | uu____360 -> false
-let is_tuple_constructor: FStar_Ident.lident -> Prims.bool =
-  FStar_Syntax_Util.is_tuple_data_lid'
-let is_dtuple_constructor: FStar_Ident.lident -> Prims.bool =
-  FStar_Syntax_Util.is_dtuple_data_lid'
-let is_list_structure:
-  FStar_Ident.lident ->
-    FStar_Ident.lident -> FStar_Parser_AST.term -> Prims.bool
-  =
-  fun cons_lid1  ->
-    fun nil_lid1  ->
-      let rec aux e =
-        let uu____377 =
-          let uu____378 = unparen e in uu____378.FStar_Parser_AST.tm in
-        match uu____377 with
-        | FStar_Parser_AST.Construct (lid,[]) ->
-            FStar_Ident.lid_equals lid nil_lid1
-        | FStar_Parser_AST.Construct (lid,uu____386::(e2,uu____388)::[]) ->
-            (FStar_Ident.lid_equals lid cons_lid1) && (aux e2)
-        | uu____400 -> false in
-      aux
-let is_list: FStar_Parser_AST.term -> Prims.bool =
-  is_list_structure FStar_Syntax_Const.cons_lid FStar_Syntax_Const.nil_lid
-let is_lex_list: FStar_Parser_AST.term -> Prims.bool =
-  is_list_structure FStar_Syntax_Const.lexcons_lid
-    FStar_Syntax_Const.lextop_lid
-let rec extract_from_list:
-  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list =
-  fun e  ->
-    let uu____409 =
-      let uu____410 = unparen e in uu____410.FStar_Parser_AST.tm in
-    match uu____409 with
-    | FStar_Parser_AST.Construct (uu____412,[]) -> []
-    | FStar_Parser_AST.Construct
-        (uu____418,(e1,FStar_Parser_AST.Nothing )::(e2,FStar_Parser_AST.Nothing
-                                                    )::[])
-        -> let uu____430 = extract_from_list e2 in e1 :: uu____430
-    | uu____432 ->
-        let uu____433 =
-          let uu____434 = FStar_Parser_AST.term_to_string e in
-          FStar_Util.format1 "Not a list %s" uu____434 in
-        failwith uu____433
-let is_array: FStar_Parser_AST.term -> Prims.bool =
-  fun e  ->
-    let uu____439 =
-      let uu____440 = unparen e in uu____440.FStar_Parser_AST.tm in
-    match uu____439 with
-    | FStar_Parser_AST.App
-        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var lid;
-           FStar_Parser_AST.range = uu____442;
-           FStar_Parser_AST.level = uu____443;_},l,FStar_Parser_AST.Nothing
-         )
-        ->
-        (FStar_Ident.lid_equals lid FStar_Syntax_Const.array_mk_array_lid) &&
-          (is_list l)
-    | uu____445 -> false
-let rec is_ref_set: FStar_Parser_AST.term -> Prims.bool =
-  fun e  ->
-    let uu____449 =
-      let uu____450 = unparen e in uu____450.FStar_Parser_AST.tm in
-    match uu____449 with
-    | FStar_Parser_AST.Var maybe_empty_lid ->
-        FStar_Ident.lid_equals maybe_empty_lid FStar_Syntax_Const.tset_empty
-    | FStar_Parser_AST.App
-        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_singleton_lid;
-           FStar_Parser_AST.range = uu____453;
-           FStar_Parser_AST.level = uu____454;_},{
-                                                   FStar_Parser_AST.tm =
-                                                     FStar_Parser_AST.App
-                                                     ({
-                                                        FStar_Parser_AST.tm =
-                                                          FStar_Parser_AST.Var
-                                                          maybe_ref_lid;
-                                                        FStar_Parser_AST.range
-                                                          = uu____456;
-                                                        FStar_Parser_AST.level
-                                                          = uu____457;_},e1,FStar_Parser_AST.Nothing
-                                                      );
-                                                   FStar_Parser_AST.range =
-                                                     uu____459;
-                                                   FStar_Parser_AST.level =
-                                                     uu____460;_},FStar_Parser_AST.Nothing
-         )
-        ->
-        (FStar_Ident.lid_equals maybe_singleton_lid
-           FStar_Syntax_Const.tset_singleton)
-          &&
-          (FStar_Ident.lid_equals maybe_ref_lid FStar_Syntax_Const.heap_ref)
-    | FStar_Parser_AST.App
-        ({
-           FStar_Parser_AST.tm = FStar_Parser_AST.App
-             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_union_lid;
-                FStar_Parser_AST.range = uu____462;
-                FStar_Parser_AST.level = uu____463;_},e1,FStar_Parser_AST.Nothing
-              );
-           FStar_Parser_AST.range = uu____465;
-           FStar_Parser_AST.level = uu____466;_},e2,FStar_Parser_AST.Nothing
-         )
-        ->
-        ((FStar_Ident.lid_equals maybe_union_lid
-            FStar_Syntax_Const.tset_union)
-           && (is_ref_set e1))
-          && (is_ref_set e2)
-    | uu____468 -> false
-let rec extract_from_ref_set:
-  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list =
-  fun e  ->
-    let uu____473 =
-      let uu____474 = unparen e in uu____474.FStar_Parser_AST.tm in
-    match uu____473 with
-    | FStar_Parser_AST.Var uu____476 -> []
-    | FStar_Parser_AST.App
-        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____477;
-           FStar_Parser_AST.range = uu____478;
-           FStar_Parser_AST.level = uu____479;_},{
-                                                   FStar_Parser_AST.tm =
-                                                     FStar_Parser_AST.App
-                                                     ({
-                                                        FStar_Parser_AST.tm =
-                                                          FStar_Parser_AST.Var
-                                                          uu____480;
-                                                        FStar_Parser_AST.range
-                                                          = uu____481;
-                                                        FStar_Parser_AST.level
-                                                          = uu____482;_},e1,FStar_Parser_AST.Nothing
-                                                      );
-                                                   FStar_Parser_AST.range =
-                                                     uu____484;
-                                                   FStar_Parser_AST.level =
-                                                     uu____485;_},FStar_Parser_AST.Nothing
-         )
-        -> [e1]
-    | FStar_Parser_AST.App
-        ({
-           FStar_Parser_AST.tm = FStar_Parser_AST.App
-             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____486;
-                FStar_Parser_AST.range = uu____487;
-                FStar_Parser_AST.level = uu____488;_},e1,FStar_Parser_AST.Nothing
-              );
-           FStar_Parser_AST.range = uu____490;
-           FStar_Parser_AST.level = uu____491;_},e2,FStar_Parser_AST.Nothing
-         )
-        ->
-        let uu____493 = extract_from_ref_set e1 in
-        let uu____495 = extract_from_ref_set e2 in
-        FStar_List.append uu____493 uu____495
-    | uu____497 ->
-        let uu____498 =
-          let uu____499 = FStar_Parser_AST.term_to_string e in
-          FStar_Util.format1 "Not a ref set %s" uu____499 in
-        failwith uu____498
-let is_general_application: FStar_Parser_AST.term -> Prims.bool =
-  fun e  ->
-    let uu____504 = (is_array e) || (is_ref_set e) in
-    Prims.op_Negation uu____504
-let is_general_construction: FStar_Parser_AST.term -> Prims.bool =
-  fun e  ->
-    let uu____508 = (is_list e) || (is_lex_list e) in
-    Prims.op_Negation uu____508
-let is_general_prefix_op: Prims.string -> Prims.bool = fun op  -> op <> "~"
-let head_and_args:
-  FStar_Parser_AST.term ->
-    (FStar_Parser_AST.term* (FStar_Parser_AST.term* FStar_Parser_AST.imp)
-      Prims.list)
-  =
-  fun e  ->
-    let rec aux e1 acc =
-      let uu____538 =
-        let uu____539 = unparen e1 in uu____539.FStar_Parser_AST.tm in
-      match uu____538 with
-      | FStar_Parser_AST.App (head1,arg,imp) -> aux head1 ((arg, imp) :: acc)
-      | uu____550 -> (e1, acc) in
-    aux e []
+
+let should_print_fs_typ_app : Prims.bool FStar_ST.ref = (FStar_Util.mk_ref false)
+
+
+let with_fs_typ_app = (fun b printer t -> (
+
+let b0 = (FStar_ST.read should_print_fs_typ_app)
+in ((FStar_ST.write should_print_fs_typ_app b);
+(
+
+let res = (printer t)
+in ((FStar_ST.write should_print_fs_typ_app b0);
+res;
+));
+)))
+
+
+let should_unparen : Prims.bool FStar_ST.ref = (FStar_Util.mk_ref true)
+
+
+let rec unparen : FStar_Parser_AST.term  ->  FStar_Parser_AST.term = (fun t -> (
+
+let uu____44 = (
+
+let uu____45 = (FStar_ST.read should_unparen)
+in (not (uu____45)))
+in (match (uu____44) with
+| true -> begin
+t
+end
+| uu____48 -> begin
+(match (t.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Paren (t1) -> begin
+(unparen t1)
+end
+| uu____50 -> begin
+t
+end)
+end)))
+
+
+let str : Prims.string  ->  FStar_Pprint.document = (fun s -> (FStar_Pprint.doc_of_string s))
+
+
+let default_or_map = (fun n1 f x -> (match (x) with
+| None -> begin
+n1
+end
+| Some (x') -> begin
+(f x')
+end))
+
+
+let prefix2 : FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (fun prefix_ body -> (FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "1") prefix_ body))
+
+
+let op_Hat_Slash_Plus_Hat : FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (fun prefix_ body -> (prefix2 prefix_ body))
+
+
+let jump2 : FStar_Pprint.document  ->  FStar_Pprint.document = (fun body -> (FStar_Pprint.jump (Prims.parse_int "2") (Prims.parse_int "1") body))
+
+
+let infix2 : FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (FStar_Pprint.infix (Prims.parse_int "2") (Prims.parse_int "1"))
+
+
+let infix0 : FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (FStar_Pprint.infix (Prims.parse_int "0") (Prims.parse_int "1"))
+
+
+let break1 : FStar_Pprint.document = (FStar_Pprint.break_ (Prims.parse_int "1"))
+
+
+let separate_break_map = (fun sep f l -> (
+
+let uu____132 = (
+
+let uu____133 = (
+
+let uu____134 = (FStar_Pprint.op_Hat_Hat sep break1)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____134))
+in (FStar_Pprint.separate_map uu____133 f l))
+in (FStar_Pprint.group uu____132)))
+
+
+let precede_break_separate_map = (fun prec sep f l -> (
+
+let uu____164 = (
+
+let uu____165 = (FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space)
+in (
+
+let uu____166 = (
+
+let uu____167 = (FStar_List.hd l)
+in (FStar_All.pipe_right uu____167 f))
+in (FStar_Pprint.precede uu____165 uu____166)))
+in (
+
+let uu____168 = (
+
+let uu____169 = (FStar_List.tl l)
+in (FStar_Pprint.concat_map (fun x -> (
+
+let uu____172 = (
+
+let uu____173 = (
+
+let uu____174 = (f x)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____174))
+in (FStar_Pprint.op_Hat_Hat sep uu____173))
+in (FStar_Pprint.op_Hat_Hat break1 uu____172))) uu____169))
+in (FStar_Pprint.op_Hat_Hat uu____164 uu____168))))
+
+
+let concat_break_map = (fun f l -> (
+
+let uu____194 = (FStar_Pprint.concat_map (fun x -> (
+
+let uu____196 = (f x)
+in (FStar_Pprint.op_Hat_Hat uu____196 break1))) l)
+in (FStar_Pprint.group uu____194)))
+
+
+let parens_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0") FStar_Pprint.lparen contents FStar_Pprint.rparen))
+
+
+let soft_parens_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "0") FStar_Pprint.lparen contents FStar_Pprint.rparen))
+
+
+let braces_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") FStar_Pprint.lbrace contents FStar_Pprint.rbrace))
+
+
+let soft_braces_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1") FStar_Pprint.lbrace contents FStar_Pprint.rbrace))
+
+
+let brackets_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") FStar_Pprint.lbracket contents FStar_Pprint.rbracket))
+
+
+let soft_brackets_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1") FStar_Pprint.lbracket contents FStar_Pprint.rbracket))
+
+
+let soft_begin_end_with_nesting : FStar_Pprint.document  ->  FStar_Pprint.document = (fun contents -> (
+
+let uu____218 = (str "begin")
+in (
+
+let uu____219 = (str "end")
+in (FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1") uu____218 contents uu____219))))
+
+
+let separate_map_or_flow = (fun sep f l -> (match (((FStar_List.length l) < (Prims.parse_int "10"))) with
+| true -> begin
+(FStar_Pprint.separate_map sep f l)
+end
+| uu____247 -> begin
+(FStar_Pprint.flow_map sep f l)
+end))
+
+
+let soft_surround_separate_map = (fun n1 b void_ opening sep closing f xs -> (match ((xs = [])) with
+| true -> begin
+void_
+end
+| uu____298 -> begin
+(
+
+let uu____299 = (FStar_Pprint.separate_map sep f xs)
+in (FStar_Pprint.soft_surround n1 b opening uu____299 closing))
+end))
+
+
+let doc_of_fsdoc : (Prims.string * (Prims.string * Prims.string) Prims.list)  ->  FStar_Pprint.document = (fun uu____307 -> (match (uu____307) with
+| (comment, keywords1) -> begin
+(
+
+let uu____321 = (
+
+let uu____322 = (
+
+let uu____324 = (str comment)
+in (
+
+let uu____325 = (
+
+let uu____327 = (
+
+let uu____329 = (FStar_Pprint.separate_map FStar_Pprint.comma (fun uu____332 -> (match (uu____332) with
+| (k, v1) -> begin
+(
+
+let uu____337 = (
+
+let uu____339 = (str k)
+in (
+
+let uu____340 = (
+
+let uu____342 = (
+
+let uu____344 = (str v1)
+in (uu____344)::[])
+in (FStar_Pprint.rarrow)::uu____342)
+in (uu____339)::uu____340))
+in (FStar_Pprint.concat uu____337))
+end)) keywords1)
+in (uu____329)::[])
+in (FStar_Pprint.space)::uu____327)
+in (uu____324)::uu____325))
+in (FStar_Pprint.concat uu____322))
+in (FStar_Pprint.group uu____321))
+end))
+
+
+let is_unit : FStar_Parser_AST.term  ->  Prims.bool = (fun e -> (
+
+let uu____348 = (
+
+let uu____349 = (unparen e)
+in uu____349.FStar_Parser_AST.tm)
+in (match (uu____348) with
+| FStar_Parser_AST.Const (FStar_Const.Const_unit) -> begin
+true
+end
+| uu____350 -> begin
+false
+end)))
+
+
+let matches_var : FStar_Parser_AST.term  ->  FStar_Ident.ident  ->  Prims.bool = (fun t x -> (
+
+let uu____357 = (
+
+let uu____358 = (unparen t)
+in uu____358.FStar_Parser_AST.tm)
+in (match (uu____357) with
+| FStar_Parser_AST.Var (y) -> begin
+(x.FStar_Ident.idText = (FStar_Ident.text_of_lid y))
+end
+| uu____360 -> begin
+false
+end)))
+
+
+let is_tuple_constructor : FStar_Ident.lident  ->  Prims.bool = FStar_Syntax_Util.is_tuple_data_lid'
+
+
+let is_dtuple_constructor : FStar_Ident.lident  ->  Prims.bool = FStar_Syntax_Util.is_dtuple_data_lid'
+
+
+let is_list_structure : FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Parser_AST.term  ->  Prims.bool = (fun cons_lid1 nil_lid1 -> (
+
+let rec aux = (fun e -> (
+
+let uu____377 = (
+
+let uu____378 = (unparen e)
+in uu____378.FStar_Parser_AST.tm)
+in (match (uu____377) with
+| FStar_Parser_AST.Construct (lid, []) -> begin
+(FStar_Ident.lid_equals lid nil_lid1)
+end
+| FStar_Parser_AST.Construct (lid, (uu____386)::((e2, uu____388))::[]) -> begin
+((FStar_Ident.lid_equals lid cons_lid1) && (aux e2))
+end
+| uu____400 -> begin
+false
+end)))
+in aux))
+
+
+let is_list : FStar_Parser_AST.term  ->  Prims.bool = (is_list_structure FStar_Syntax_Const.cons_lid FStar_Syntax_Const.nil_lid)
+
+
+let is_lex_list : FStar_Parser_AST.term  ->  Prims.bool = (is_list_structure FStar_Syntax_Const.lexcons_lid FStar_Syntax_Const.lextop_lid)
+
+
+let rec extract_from_list : FStar_Parser_AST.term  ->  FStar_Parser_AST.term Prims.list = (fun e -> (
+
+let uu____409 = (
+
+let uu____410 = (unparen e)
+in uu____410.FStar_Parser_AST.tm)
+in (match (uu____409) with
+| FStar_Parser_AST.Construct (uu____412, []) -> begin
+[]
+end
+| FStar_Parser_AST.Construct (uu____418, ((e1, FStar_Parser_AST.Nothing))::((e2, FStar_Parser_AST.Nothing))::[]) -> begin
+(
+
+let uu____430 = (extract_from_list e2)
+in (e1)::uu____430)
+end
+| uu____432 -> begin
+(
+
+let uu____433 = (
+
+let uu____434 = (FStar_Parser_AST.term_to_string e)
+in (FStar_Util.format1 "Not a list %s" uu____434))
+in (failwith uu____433))
+end)))
+
+
+let is_array : FStar_Parser_AST.term  ->  Prims.bool = (fun e -> (
+
+let uu____439 = (
+
+let uu____440 = (unparen e)
+in uu____440.FStar_Parser_AST.tm)
+in (match (uu____439) with
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (lid); FStar_Parser_AST.range = uu____442; FStar_Parser_AST.level = uu____443}, l, FStar_Parser_AST.Nothing) -> begin
+((FStar_Ident.lid_equals lid FStar_Syntax_Const.array_mk_array_lid) && (is_list l))
+end
+| uu____445 -> begin
+false
+end)))
+
+
+let rec is_ref_set : FStar_Parser_AST.term  ->  Prims.bool = (fun e -> (
+
+let uu____449 = (
+
+let uu____450 = (unparen e)
+in uu____450.FStar_Parser_AST.tm)
+in (match (uu____449) with
+| FStar_Parser_AST.Var (maybe_empty_lid) -> begin
+(FStar_Ident.lid_equals maybe_empty_lid FStar_Syntax_Const.tset_empty)
+end
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (maybe_singleton_lid); FStar_Parser_AST.range = uu____453; FStar_Parser_AST.level = uu____454}, {FStar_Parser_AST.tm = FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (maybe_ref_lid); FStar_Parser_AST.range = uu____456; FStar_Parser_AST.level = uu____457}, e1, FStar_Parser_AST.Nothing); FStar_Parser_AST.range = uu____459; FStar_Parser_AST.level = uu____460}, FStar_Parser_AST.Nothing) -> begin
+((FStar_Ident.lid_equals maybe_singleton_lid FStar_Syntax_Const.tset_singleton) && (FStar_Ident.lid_equals maybe_ref_lid FStar_Syntax_Const.heap_ref))
+end
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (maybe_union_lid); FStar_Parser_AST.range = uu____462; FStar_Parser_AST.level = uu____463}, e1, FStar_Parser_AST.Nothing); FStar_Parser_AST.range = uu____465; FStar_Parser_AST.level = uu____466}, e2, FStar_Parser_AST.Nothing) -> begin
+(((FStar_Ident.lid_equals maybe_union_lid FStar_Syntax_Const.tset_union) && (is_ref_set e1)) && (is_ref_set e2))
+end
+| uu____468 -> begin
+false
+end)))
+
+
+let rec extract_from_ref_set : FStar_Parser_AST.term  ->  FStar_Parser_AST.term Prims.list = (fun e -> (
+
+let uu____473 = (
+
+let uu____474 = (unparen e)
+in uu____474.FStar_Parser_AST.tm)
+in (match (uu____473) with
+| FStar_Parser_AST.Var (uu____476) -> begin
+[]
+end
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (uu____477); FStar_Parser_AST.range = uu____478; FStar_Parser_AST.level = uu____479}, {FStar_Parser_AST.tm = FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (uu____480); FStar_Parser_AST.range = uu____481; FStar_Parser_AST.level = uu____482}, e1, FStar_Parser_AST.Nothing); FStar_Parser_AST.range = uu____484; FStar_Parser_AST.level = uu____485}, FStar_Parser_AST.Nothing) -> begin
+(e1)::[]
+end
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (uu____486); FStar_Parser_AST.range = uu____487; FStar_Parser_AST.level = uu____488}, e1, FStar_Parser_AST.Nothing); FStar_Parser_AST.range = uu____490; FStar_Parser_AST.level = uu____491}, e2, FStar_Parser_AST.Nothing) -> begin
+(
+
+let uu____493 = (extract_from_ref_set e1)
+in (
+
+let uu____495 = (extract_from_ref_set e2)
+in (FStar_List.append uu____493 uu____495)))
+end
+| uu____497 -> begin
+(
+
+let uu____498 = (
+
+let uu____499 = (FStar_Parser_AST.term_to_string e)
+in (FStar_Util.format1 "Not a ref set %s" uu____499))
+in (failwith uu____498))
+end)))
+
+
+let is_general_application : FStar_Parser_AST.term  ->  Prims.bool = (fun e -> (
+
+let uu____504 = ((is_array e) || (is_ref_set e))
+in (not (uu____504))))
+
+
+let is_general_construction : FStar_Parser_AST.term  ->  Prims.bool = (fun e -> (
+
+let uu____508 = ((is_list e) || (is_lex_list e))
+in (not (uu____508))))
+
+
+let is_general_prefix_op : Prims.string  ->  Prims.bool = (fun op -> (op <> "~"))
+
+
+let head_and_args : FStar_Parser_AST.term  ->  (FStar_Parser_AST.term * (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list) = (fun e -> (
+
+let rec aux = (fun e1 acc -> (
+
+let uu____538 = (
+
+let uu____539 = (unparen e1)
+in uu____539.FStar_Parser_AST.tm)
+in (match (uu____538) with
+| FStar_Parser_AST.App (head1, arg, imp) -> begin
+(aux head1 ((((arg), (imp)))::acc))
+end
+| uu____550 -> begin
+((e1), (acc))
+end)))
+in (aux e [])))
+
 type associativity =
-  | Left
-  | Right
-  | NonAssoc
-let uu___is_Left: associativity -> Prims.bool =
-  fun projectee  -> match projectee with | Left  -> true | uu____559 -> false
-let uu___is_Right: associativity -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Right  -> true | uu____563 -> false
-let uu___is_NonAssoc: associativity -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NonAssoc  -> true | uu____567 -> false
-type token = (FStar_Char.char,Prims.string) FStar_Util.either
-type associativity_level = (associativity* token Prims.list)
-let token_to_string:
-  (FStar_BaseTypes.char,Prims.string) FStar_Util.either -> Prims.string =
-  fun uu___128_577  ->
-    match uu___128_577 with
-    | FStar_Util.Inl c -> Prims.strcat (FStar_Util.string_of_char c) ".*"
-    | FStar_Util.Inr s -> s
-let matches_token:
-  Prims.string ->
-    (FStar_Char.char,Prims.string) FStar_Util.either -> Prims.bool
-  =
-  fun s  ->
-    fun uu___129_589  ->
-      match uu___129_589 with
-      | FStar_Util.Inl c ->
-          let uu____593 = FStar_String.get s (Prims.parse_int "0") in
-          uu____593 = c
-      | FStar_Util.Inr s' -> s = s'
-let matches_level s uu____611 =
-  match uu____611 with
-  | (assoc_levels,tokens) ->
-      let uu____625 = FStar_List.tryFind (matches_token s) tokens in
-      uu____625 <> None
-let opinfix4 uu____643 = (Right, [FStar_Util.Inr "**"])
-let opinfix3 uu____658 =
-  (Left, [FStar_Util.Inl '*'; FStar_Util.Inl '/'; FStar_Util.Inl '%'])
-let opinfix2 uu____677 = (Left, [FStar_Util.Inl '+'; FStar_Util.Inl '-'])
-let minus_lvl uu____694 = (Left, [FStar_Util.Inr "-"])
-let opinfix1 uu____709 = (Right, [FStar_Util.Inl '@'; FStar_Util.Inl '^'])
-let pipe_right uu____726 = (Left, [FStar_Util.Inr "|>"])
-let opinfix0d uu____741 = (Left, [FStar_Util.Inl '$'])
-let opinfix0c uu____756 =
-  (Left, [FStar_Util.Inl '='; FStar_Util.Inl '<'; FStar_Util.Inl '>'])
-let equal uu____775 = (Left, [FStar_Util.Inr "="])
-let opinfix0b uu____790 = (Left, [FStar_Util.Inl '&'])
-let opinfix0a uu____805 = (Left, [FStar_Util.Inl '|'])
-let colon_equals uu____820 = (NonAssoc, [FStar_Util.Inr ":="])
-let amp uu____835 = (Right, [FStar_Util.Inr "&"])
-let colon_colon uu____850 = (Right, [FStar_Util.Inr "::"])
-let level_associativity_spec:
-  (associativity* (FStar_Char.char,Prims.string) FStar_Util.either
-    Prims.list) Prims.list
-  =
-  [opinfix4 ();
-  opinfix3 ();
-  opinfix2 ();
-  opinfix1 ();
-  pipe_right ();
-  opinfix0d ();
-  opinfix0c ();
-  opinfix0b ();
-  opinfix0a ();
-  colon_equals ();
-  amp ();
-  colon_colon ()]
-let level_table:
-  ((Prims.int* Prims.int* Prims.int)* (FStar_Char.char,Prims.string)
-    FStar_Util.either Prims.list) Prims.list
-  =
-  let levels_from_associativity l uu___130_947 =
-    match uu___130_947 with
-    | Left  -> (l, l, (l - (Prims.parse_int "1")))
-    | Right  -> ((l - (Prims.parse_int "1")), l, l)
-    | NonAssoc  -> (l, l, l) in
-  FStar_List.mapi
-    (fun i  ->
-       fun uu____965  ->
-         match uu____965 with
-         | (assoc1,tokens) -> ((levels_from_associativity i assoc1), tokens))
-    level_associativity_spec
-let assign_levels:
-  associativity_level Prims.list ->
-    Prims.string -> (Prims.int* Prims.int* Prims.int)
-  =
-  fun token_associativity_spec  ->
-    fun s  ->
-      let uu____1007 = FStar_List.tryFind (matches_level s) level_table in
-      match uu____1007 with
-      | Some (assoc_levels,uu____1032) -> assoc_levels
-      | uu____1053 -> failwith (Prims.strcat "Unrecognized operator " s)
-let max: Prims.int -> Prims.int -> Prims.int =
-  fun k1  -> fun k2  -> if k1 > k2 then k1 else k2
-let max_level l =
-  let find_level_and_max n1 level =
-    let uu____1109 =
-      FStar_List.tryFind
-        (fun uu____1127  ->
-           match uu____1127 with
-           | (uu____1136,tokens) -> tokens = (Prims.snd level)) level_table in
-    match uu____1109 with
-    | Some ((uu____1156,l1,uu____1158),uu____1159) -> max n1 l1
-    | None  ->
-        let uu____1185 =
-          let uu____1186 =
-            let uu____1187 = FStar_List.map token_to_string (Prims.snd level) in
-            FStar_String.concat "," uu____1187 in
-          FStar_Util.format1 "Undefined associativity level %s" uu____1186 in
-        failwith uu____1185 in
-  FStar_List.fold_left find_level_and_max (Prims.parse_int "0") l
-let levels: Prims.string -> (Prims.int* Prims.int* Prims.int) =
-  assign_levels level_associativity_spec
-let operatorInfix0ad12 uu____1212 =
-  [opinfix0a ();
-  opinfix0b ();
-  opinfix0c ();
-  opinfix0d ();
-  opinfix1 ();
-  opinfix2 ()]
-let is_operatorInfix0ad12: Prims.string -> Prims.bool =
-  fun op  ->
-    let uu____1251 =
-      FStar_List.tryFind (matches_level op) (operatorInfix0ad12 ()) in
-    uu____1251 <> None
-let is_operatorInfix34: Prims.string -> Prims.bool =
-  let opinfix34 = [opinfix3 (); opinfix4 ()] in
-  fun op  ->
-    let uu____1299 = FStar_List.tryFind (matches_level op) opinfix34 in
-    uu____1299 <> None
-let comment_stack: (Prims.string* FStar_Range.range) Prims.list FStar_ST.ref
-  = FStar_Util.mk_ref []
-let with_comment printer tm tmrange =
-  let rec comments_before_pos acc print_pos lookahead_pos =
-    let uu____1367 = FStar_ST.read comment_stack in
-    match uu____1367 with
-    | [] -> (acc, false)
-    | (comment,crange)::cs ->
-        let uu____1388 = FStar_Range.range_before_pos crange print_pos in
-        if uu____1388
-        then
-          (FStar_ST.write comment_stack cs;
-           (let uu____1397 =
-              let uu____1398 =
-                let uu____1399 = str comment in
-                FStar_Pprint.op_Hat_Hat uu____1399 FStar_Pprint.hardline in
-              FStar_Pprint.op_Hat_Hat acc uu____1398 in
-            comments_before_pos uu____1397 print_pos lookahead_pos))
-        else
-          (let uu____1401 = FStar_Range.range_before_pos crange lookahead_pos in
-           (acc, uu____1401)) in
-  let uu____1402 =
-    let uu____1405 =
-      let uu____1406 = FStar_Range.start_of_range tmrange in
-      FStar_Range.end_of_line uu____1406 in
-    let uu____1407 = FStar_Range.end_of_range tmrange in
-    comments_before_pos FStar_Pprint.empty uu____1405 uu____1407 in
-  match uu____1402 with
-  | (comments,has_lookahead) ->
-      let printed_e = printer tm in
-      let comments1 =
-        if has_lookahead
-        then
-          let pos = FStar_Range.end_of_range tmrange in
-          let uu____1413 = comments_before_pos comments pos pos in
-          Prims.fst uu____1413
-        else comments in
-      let uu____1417 = FStar_Pprint.op_Hat_Hat comments1 printed_e in
-      FStar_Pprint.group uu____1417
-let rec place_comments_until_pos:
-  Prims.int ->
-    Prims.int ->
-      FStar_Range.pos -> FStar_Pprint.document -> FStar_Pprint.document
-  =
-  fun k  ->
-    fun lbegin  ->
-      fun pos_end  ->
-        fun doc1  ->
-          let uu____1430 = FStar_ST.read comment_stack in
-          match uu____1430 with
-          | (comment,crange)::cs when
-              FStar_Range.range_before_pos crange pos_end ->
-              (FStar_ST.write comment_stack cs;
-               (let lnum =
-                  let uu____1454 =
-                    let uu____1455 =
-                      let uu____1456 = FStar_Range.start_of_range crange in
-                      FStar_Range.line_of_pos uu____1456 in
-                    uu____1455 - lbegin in
-                  max k uu____1454 in
-                let doc2 =
-                  let uu____1458 =
-                    let uu____1459 =
-                      FStar_Pprint.repeat lnum FStar_Pprint.hardline in
-                    let uu____1460 = str comment in
-                    FStar_Pprint.op_Hat_Hat uu____1459 uu____1460 in
-                  FStar_Pprint.op_Hat_Hat doc1 uu____1458 in
-                let uu____1461 =
-                  let uu____1462 = FStar_Range.end_of_range crange in
-                  FStar_Range.line_of_pos uu____1462 in
-                place_comments_until_pos (Prims.parse_int "1") uu____1461
-                  pos_end doc2))
-          | uu____1463 ->
-              let lnum =
-                let uu____1468 =
-                  let uu____1469 = FStar_Range.line_of_pos pos_end in
-                  uu____1469 - lbegin in
-                max (Prims.parse_int "1") uu____1468 in
-              let uu____1470 = FStar_Pprint.repeat lnum FStar_Pprint.hardline in
-              FStar_Pprint.op_Hat_Hat doc1 uu____1470
-let separate_map_with_comments prefix1 sep f xs extract_range =
-  let fold_fun uu____1519 x =
-    match uu____1519 with
-    | (last_line,doc1) ->
-        let r = extract_range x in
-        let doc2 =
-          let uu____1529 = FStar_Range.start_of_range r in
-          place_comments_until_pos (Prims.parse_int "1") last_line uu____1529
-            doc1 in
-        let uu____1530 =
-          let uu____1531 = FStar_Range.end_of_range r in
-          FStar_Range.line_of_pos uu____1531 in
-        let uu____1532 =
-          let uu____1533 =
-            let uu____1534 = f x in FStar_Pprint.op_Hat_Hat sep uu____1534 in
-          FStar_Pprint.op_Hat_Hat doc2 uu____1533 in
-        (uu____1530, uu____1532) in
-  let uu____1535 =
-    let uu____1539 = FStar_List.hd xs in
-    let uu____1540 = FStar_List.tl xs in (uu____1539, uu____1540) in
-  match uu____1535 with
-  | (x,xs1) ->
-      let init1 =
-        let uu____1550 =
-          let uu____1551 =
-            let uu____1552 = extract_range x in
-            FStar_Range.end_of_range uu____1552 in
-          FStar_Range.line_of_pos uu____1551 in
-        let uu____1553 =
-          let uu____1554 = f x in FStar_Pprint.op_Hat_Hat prefix1 uu____1554 in
-        (uu____1550, uu____1553) in
-      let uu____1555 = FStar_List.fold_left fold_fun init1 xs1 in
-      Prims.snd uu____1555
-let rec p_decl: FStar_Parser_AST.decl -> FStar_Pprint.document =
-  fun d  ->
-    let uu____1801 =
-      let uu____1802 = FStar_Pprint.optional p_fsdoc d.FStar_Parser_AST.doc in
-      let uu____1803 =
-        let uu____1804 = p_attributes d.FStar_Parser_AST.attrs in
-        let uu____1805 =
-          let uu____1806 = p_qualifiers d.FStar_Parser_AST.quals in
-          let uu____1807 =
-            let uu____1808 = p_rawDecl d in
-            FStar_Pprint.op_Hat_Hat
-              (if d.FStar_Parser_AST.quals = []
-               then FStar_Pprint.empty
-               else break1) uu____1808 in
-          FStar_Pprint.op_Hat_Hat uu____1806 uu____1807 in
-        FStar_Pprint.op_Hat_Hat uu____1804 uu____1805 in
-      FStar_Pprint.op_Hat_Hat uu____1802 uu____1803 in
-    FStar_Pprint.group uu____1801
-and p_attributes: FStar_Parser_AST.attributes_ -> FStar_Pprint.document =
-  fun attrs  ->
-    let uu____1811 =
-      let uu____1812 = str "@" in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____1812 in
-    let uu____1813 =
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.rbracket FStar_Pprint.hardline in
-    soft_surround_separate_map (Prims.parse_int "0") (Prims.parse_int "2")
-      FStar_Pprint.empty uu____1811 FStar_Pprint.space uu____1813
-      p_atomicTerm attrs
-and p_fsdoc: FStar_Parser_AST.fsdoc -> FStar_Pprint.document =
-  fun uu____1814  ->
-    match uu____1814 with
-    | (doc1,kwd_args) ->
-        let kwd_args_doc =
-          match kwd_args with
-          | [] -> FStar_Pprint.empty
-          | kwd_args1 ->
-              let process_kwd_arg uu____1835 =
-                match uu____1835 with
-                | (kwd1,arg) ->
-                    let uu____1840 = str "@" in
-                    let uu____1841 =
-                      let uu____1842 = str kwd1 in
-                      let uu____1843 =
-                        let uu____1844 = str arg in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1844 in
-                      FStar_Pprint.op_Hat_Hat uu____1842 uu____1843 in
-                    FStar_Pprint.op_Hat_Hat uu____1840 uu____1841 in
-              let uu____1845 =
-                let uu____1846 =
-                  FStar_Pprint.separate_map FStar_Pprint.hardline
-                    process_kwd_arg kwd_args1 in
-                FStar_Pprint.op_Hat_Hat uu____1846 FStar_Pprint.hardline in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____1845 in
-        let uu____1849 =
-          let uu____1850 =
-            let uu____1851 =
-              let uu____1852 =
-                let uu____1853 = str doc1 in
-                let uu____1854 =
-                  let uu____1855 =
-                    let uu____1856 =
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen
-                        FStar_Pprint.hardline in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1856 in
-                  FStar_Pprint.op_Hat_Hat kwd_args_doc uu____1855 in
-                FStar_Pprint.op_Hat_Hat uu____1853 uu____1854 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1852 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1851 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____1850 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____1849
-and p_rawDecl: FStar_Parser_AST.decl -> FStar_Pprint.document =
-  fun d  ->
-    match d.FStar_Parser_AST.d with
-    | FStar_Parser_AST.Open uid ->
-        let uu____1859 =
-          let uu____1860 = str "open" in
-          let uu____1861 = p_quident uid in
-          FStar_Pprint.op_Hat_Slash_Hat uu____1860 uu____1861 in
-        FStar_Pprint.group uu____1859
-    | FStar_Parser_AST.Include uid ->
-        let uu____1863 =
-          let uu____1864 = str "include" in
-          let uu____1865 = p_quident uid in
-          FStar_Pprint.op_Hat_Slash_Hat uu____1864 uu____1865 in
-        FStar_Pprint.group uu____1863
-    | FStar_Parser_AST.ModuleAbbrev (uid1,uid2) ->
-        let uu____1868 =
-          let uu____1869 = str "module" in
-          let uu____1870 =
-            let uu____1871 =
-              let uu____1872 = p_uident uid1 in
-              let uu____1873 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                  FStar_Pprint.equals in
-              FStar_Pprint.op_Hat_Hat uu____1872 uu____1873 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1871 in
-          FStar_Pprint.op_Hat_Hat uu____1869 uu____1870 in
-        let uu____1874 = p_quident uid2 in
-        op_Hat_Slash_Plus_Hat uu____1868 uu____1874
-    | FStar_Parser_AST.TopLevelModule uid ->
-        let uu____1876 =
-          let uu____1877 = str "module" in
-          let uu____1878 =
-            let uu____1879 = p_quident uid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1879 in
-          FStar_Pprint.op_Hat_Hat uu____1877 uu____1878 in
-        FStar_Pprint.group uu____1876
-    | FStar_Parser_AST.Tycon
-        (true ,(FStar_Parser_AST.TyconAbbrev (uid,tpars,None ,t),None )::[])
-        ->
-        let effect_prefix_doc =
-          let uu____1898 = str "effect" in
-          let uu____1899 =
-            let uu____1900 = p_uident uid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1900 in
-          FStar_Pprint.op_Hat_Hat uu____1898 uu____1899 in
-        let uu____1901 =
-          let uu____1902 = p_typars tpars in
-          FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-            effect_prefix_doc uu____1902 FStar_Pprint.equals in
-        let uu____1903 = p_typ t in
-        op_Hat_Slash_Plus_Hat uu____1901 uu____1903
-    | FStar_Parser_AST.Tycon (false ,tcdefs) ->
-        let uu____1913 = str "type" in
-        let uu____1914 = str "and" in
-        precede_break_separate_map uu____1913 uu____1914 p_fsdocTypeDeclPairs
-          tcdefs
-    | FStar_Parser_AST.TopLevelLet (q,lbs) ->
-        let let_doc =
-          let uu____1927 = str "let" in
-          let uu____1928 =
-            let uu____1929 = p_letqualifier q in
-            FStar_Pprint.op_Hat_Hat uu____1929 FStar_Pprint.space in
-          FStar_Pprint.op_Hat_Hat uu____1927 uu____1928 in
-        let uu____1930 =
-          let uu____1931 = str "and" in
-          FStar_Pprint.op_Hat_Hat uu____1931 FStar_Pprint.space in
-        separate_map_with_comments let_doc uu____1930 p_letbinding lbs
-          (fun uu____1934  ->
-             match uu____1934 with
-             | (p,t) ->
-                 FStar_Range.union_ranges p.FStar_Parser_AST.prange
-                   t.FStar_Parser_AST.range)
-    | FStar_Parser_AST.Val (lid,t) ->
-        let uu____1941 =
-          let uu____1942 = str "val" in
-          let uu____1943 =
-            let uu____1944 =
-              let uu____1945 = p_lident lid in
-              let uu____1946 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
-              FStar_Pprint.op_Hat_Hat uu____1945 uu____1946 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1944 in
-          FStar_Pprint.op_Hat_Hat uu____1942 uu____1943 in
-        let uu____1947 = p_typ t in
-        op_Hat_Slash_Plus_Hat uu____1941 uu____1947
-    | FStar_Parser_AST.Assume (id,t) ->
-        let decl_keyword =
-          let uu____1951 =
-            let uu____1952 =
-              FStar_Util.char_at id.FStar_Ident.idText (Prims.parse_int "0") in
-            FStar_All.pipe_right uu____1952 FStar_Util.is_upper in
-          if uu____1951
-          then FStar_Pprint.empty
-          else
-            (let uu____1954 = str "val" in
-             FStar_Pprint.op_Hat_Hat uu____1954 FStar_Pprint.space) in
-        let uu____1955 =
-          let uu____1956 =
-            let uu____1957 = p_ident id in
-            let uu____1958 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
-            FStar_Pprint.op_Hat_Hat uu____1957 uu____1958 in
-          FStar_Pprint.op_Hat_Hat decl_keyword uu____1956 in
-        let uu____1959 = p_typ t in
-        op_Hat_Slash_Plus_Hat uu____1955 uu____1959
-    | FStar_Parser_AST.Exception (uid,t_opt) ->
-        let uu____1964 = str "exception" in
-        let uu____1965 =
-          let uu____1966 =
-            let uu____1967 = p_uident uid in
-            let uu____1968 =
-              FStar_Pprint.optional
-                (fun t  ->
-                   let uu____1970 = str "of" in
-                   let uu____1971 = p_typ t in
-                   op_Hat_Slash_Plus_Hat uu____1970 uu____1971) t_opt in
-            FStar_Pprint.op_Hat_Hat uu____1967 uu____1968 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1966 in
-        FStar_Pprint.op_Hat_Hat uu____1964 uu____1965
-    | FStar_Parser_AST.NewEffect ne ->
-        let uu____1973 = str "new_effect" in
-        let uu____1974 =
-          let uu____1975 = p_newEffect ne in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1975 in
-        FStar_Pprint.op_Hat_Hat uu____1973 uu____1974
-    | FStar_Parser_AST.SubEffect se ->
-        let uu____1977 = str "sub_effect" in
-        let uu____1978 =
-          let uu____1979 = p_subEffect se in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1979 in
-        FStar_Pprint.op_Hat_Hat uu____1977 uu____1978
-    | FStar_Parser_AST.Pragma p -> p_pragma p
-    | FStar_Parser_AST.Fsdoc doc1 ->
-        let uu____1982 = p_fsdoc doc1 in
-        FStar_Pprint.op_Hat_Hat uu____1982 FStar_Pprint.hardline
-    | FStar_Parser_AST.Main uu____1983 ->
-        failwith "*Main declaration* : Is that really still in use ??"
-    | FStar_Parser_AST.Tycon (true ,uu____1984) ->
-        failwith
-          "Effect abbreviation is expected to be defined by an abbreviation"
-and p_pragma: FStar_Parser_AST.pragma -> FStar_Pprint.document =
-  fun uu___131_1993  ->
-    match uu___131_1993 with
-    | FStar_Parser_AST.SetOptions s ->
-        let uu____1995 = str "#set-options" in
-        let uu____1996 =
-          let uu____1997 =
-            let uu____1998 = str s in FStar_Pprint.dquotes uu____1998 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1997 in
-        FStar_Pprint.op_Hat_Hat uu____1995 uu____1996
-    | FStar_Parser_AST.ResetOptions s_opt ->
-        let uu____2001 = str "#reset-options" in
-        let uu____2002 =
-          FStar_Pprint.optional
-            (fun s  ->
-               let uu____2004 =
-                 let uu____2005 = str s in FStar_Pprint.dquotes uu____2005 in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2004) s_opt in
-        FStar_Pprint.op_Hat_Hat uu____2001 uu____2002
-    | FStar_Parser_AST.LightOff  ->
-        (FStar_ST.write should_print_fs_typ_app true; str "#light \"off\"")
-and p_typars: FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document =
-  fun bs  -> p_binders true bs
-and p_fsdocTypeDeclPairs:
-  (FStar_Parser_AST.tycon* FStar_Parser_AST.fsdoc Prims.option) ->
-    FStar_Pprint.document
-  =
-  fun uu____2011  ->
-    match uu____2011 with
-    | (typedecl,fsdoc_opt) ->
-        let uu____2019 = FStar_Pprint.optional p_fsdoc fsdoc_opt in
-        let uu____2020 = p_typeDecl typedecl in
-        FStar_Pprint.op_Hat_Hat uu____2019 uu____2020
-and p_typeDecl: FStar_Parser_AST.tycon -> FStar_Pprint.document =
-  fun uu___132_2021  ->
-    match uu___132_2021 with
-    | FStar_Parser_AST.TyconAbstract (lid,bs,typ_opt) ->
-        let empty' uu____2032 = FStar_Pprint.empty in
-        p_typeDeclPrefix lid bs typ_opt empty'
-    | FStar_Parser_AST.TyconAbbrev (lid,bs,typ_opt,t) ->
-        let f uu____2044 =
-          let uu____2045 = p_typ t in prefix2 FStar_Pprint.equals uu____2045 in
-        p_typeDeclPrefix lid bs typ_opt f
-    | FStar_Parser_AST.TyconRecord (lid,bs,typ_opt,record_field_decls) ->
-        let p_recordFieldAndComments uu____2071 =
-          match uu____2071 with
-          | (lid1,t,doc_opt) ->
-              let uu____2081 =
-                FStar_Range.extend_to_end_of_line t.FStar_Parser_AST.range in
-              with_comment p_recordFieldDecl (lid1, t, doc_opt) uu____2081 in
-        let p_fields uu____2090 =
-          let uu____2091 =
-            let uu____2092 =
-              let uu____2093 =
-                let uu____2094 =
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-                FStar_Pprint.separate_map uu____2094 p_recordFieldAndComments
-                  record_field_decls in
-              braces_with_nesting uu____2093 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2092 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____2091 in
-        p_typeDeclPrefix lid bs typ_opt p_fields
-    | FStar_Parser_AST.TyconVariant (lid,bs,typ_opt,ct_decls) ->
-        let p_constructorBranchAndComments uu____2130 =
-          match uu____2130 with
-          | (uid,t_opt,doc_opt,use_of) ->
-              let range =
-                let uu____2146 =
-                  let uu____2147 =
-                    FStar_Util.map_opt t_opt
-                      (fun t  -> t.FStar_Parser_AST.range) in
-                  FStar_Util.dflt uid.FStar_Ident.idRange uu____2147 in
-                FStar_Range.extend_to_end_of_line uu____2146 in
-              let p_constructorBranch decl =
-                let uu____2166 =
-                  let uu____2167 =
-                    let uu____2168 = p_constructorDecl decl in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2168 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____2167 in
-                FStar_Pprint.group uu____2166 in
-              with_comment p_constructorBranch (uid, t_opt, doc_opt, use_of)
-                range in
-        let datacon_doc uu____2180 =
-          let uu____2181 =
-            FStar_Pprint.separate_map break1 p_constructorBranchAndComments
-              ct_decls in
-          FStar_Pprint.group uu____2181 in
-        p_typeDeclPrefix lid bs typ_opt
-          (fun uu____2188  ->
-             let uu____2189 = datacon_doc () in
-             prefix2 FStar_Pprint.equals uu____2189)
-and p_typeDeclPrefix:
-  FStar_Ident.ident ->
-    FStar_Parser_AST.binder Prims.list ->
-      FStar_Parser_AST.knd Prims.option ->
-        (Prims.unit -> FStar_Pprint.document) -> FStar_Pprint.document
-  =
-  fun lid  ->
-    fun bs  ->
-      fun typ_opt  ->
-        fun cont  ->
-          if (bs = []) && (typ_opt = None)
-          then
-            let uu____2200 = p_ident lid in
-            let uu____2201 =
-              let uu____2202 = cont () in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2202 in
-            FStar_Pprint.op_Hat_Hat uu____2200 uu____2201
-          else
-            (let binders_doc =
-               let uu____2205 = p_typars bs in
-               let uu____2206 =
-                 FStar_Pprint.optional
-                   (fun t  ->
-                      let uu____2208 =
-                        let uu____2209 =
-                          let uu____2210 = p_typ t in
-                          FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                            uu____2210 in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2209 in
-                      FStar_Pprint.op_Hat_Hat break1 uu____2208) typ_opt in
-               FStar_Pprint.op_Hat_Hat uu____2205 uu____2206 in
-             let uu____2211 = p_ident lid in
-             let uu____2212 = cont () in
-             FStar_Pprint.surround (Prims.parse_int "2")
-               (Prims.parse_int "1") uu____2211 binders_doc uu____2212)
-and p_recordFieldDecl:
-  (FStar_Ident.ident* FStar_Parser_AST.term* FStar_Parser_AST.fsdoc
-    Prims.option) -> FStar_Pprint.document
-  =
-  fun uu____2213  ->
-    match uu____2213 with
-    | (lid,t,doc_opt) ->
-        let uu____2223 =
-          let uu____2224 = FStar_Pprint.optional p_fsdoc doc_opt in
-          let uu____2225 =
-            let uu____2226 = p_lident lid in
-            let uu____2227 =
-              let uu____2228 = p_typ t in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2228 in
-            FStar_Pprint.op_Hat_Hat uu____2226 uu____2227 in
-          FStar_Pprint.op_Hat_Hat uu____2224 uu____2225 in
-        FStar_Pprint.group uu____2223
-and p_constructorDecl:
-  (FStar_Ident.ident* FStar_Parser_AST.term Prims.option*
-    FStar_Parser_AST.fsdoc Prims.option* Prims.bool) -> FStar_Pprint.document
-  =
-  fun uu____2229  ->
-    match uu____2229 with
-    | (uid,t_opt,doc_opt,use_of) ->
-        let sep = if use_of then str "of" else FStar_Pprint.colon in
-        let uid_doc = p_uident uid in
-        let uu____2247 = FStar_Pprint.optional p_fsdoc doc_opt in
-        let uu____2248 =
-          let uu____2249 = FStar_Pprint.break_ (Prims.parse_int "0") in
-          let uu____2250 =
-            default_or_map uid_doc
-              (fun t  ->
-                 let uu____2252 =
-                   let uu____2253 =
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space sep in
-                   FStar_Pprint.op_Hat_Hat uid_doc uu____2253 in
-                 let uu____2254 = p_typ t in
-                 op_Hat_Slash_Plus_Hat uu____2252 uu____2254) t_opt in
-          FStar_Pprint.op_Hat_Hat uu____2249 uu____2250 in
-        FStar_Pprint.op_Hat_Hat uu____2247 uu____2248
-and p_letbinding:
-  (FStar_Parser_AST.pattern* FStar_Parser_AST.term) -> FStar_Pprint.document
-  =
-  fun uu____2255  ->
-    match uu____2255 with
-    | (pat,e) ->
-        let pat_doc =
-          let uu____2261 =
-            match pat.FStar_Parser_AST.pat with
-            | FStar_Parser_AST.PatAscribed (pat1,t) ->
-                let uu____2268 =
-                  let uu____2269 =
-                    let uu____2270 =
-                      let uu____2271 =
-                        let uu____2272 = p_tmArrow p_tmNoEq t in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2272 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2271 in
-                    FStar_Pprint.group uu____2270 in
-                  FStar_Pprint.op_Hat_Hat break1 uu____2269 in
-                (pat1, uu____2268)
-            | uu____2273 -> (pat, FStar_Pprint.empty) in
-          match uu____2261 with
-          | (pat1,ascr_doc) ->
-              (match pat1.FStar_Parser_AST.pat with
-               | FStar_Parser_AST.PatApp
-                   ({
-                      FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                        (x,uu____2277);
-                      FStar_Parser_AST.prange = uu____2278;_},pats)
-                   ->
-                   let uu____2284 = p_lident x in
-                   let uu____2285 =
-                     let uu____2286 =
-                       FStar_Pprint.separate_map break1 p_atomicPattern pats in
-                     FStar_Pprint.op_Hat_Hat uu____2286 ascr_doc in
-                   FStar_Pprint.surround (Prims.parse_int "2")
-                     (Prims.parse_int "1") uu____2284 uu____2285
-                     FStar_Pprint.equals
-               | uu____2287 ->
-                   let uu____2288 =
-                     let uu____2289 = p_tuplePattern pat1 in
-                     let uu____2290 =
-                       FStar_Pprint.op_Hat_Slash_Hat ascr_doc
-                         FStar_Pprint.equals in
-                     FStar_Pprint.op_Hat_Hat uu____2289 uu____2290 in
-                   FStar_Pprint.group uu____2288) in
-        let uu____2291 = p_term e in prefix2 pat_doc uu____2291
-and p_newEffect: FStar_Parser_AST.effect_decl -> FStar_Pprint.document =
-  fun uu___133_2292  ->
-    match uu___133_2292 with
-    | FStar_Parser_AST.RedefineEffect (lid,bs,t) ->
-        p_effectRedefinition lid bs t
-    | FStar_Parser_AST.DefineEffect (lid,bs,t,eff_decls) ->
-        p_effectDefinition lid bs t eff_decls
-and p_effectRedefinition:
-  FStar_Ident.ident ->
-    FStar_Parser_AST.binder Prims.list ->
-      FStar_Parser_AST.term -> FStar_Pprint.document
-  =
-  fun uid  ->
-    fun bs  ->
-      fun t  ->
-        let uu____2310 = p_uident uid in
-        let uu____2311 = p_binders true bs in
-        let uu____2312 =
-          let uu____2313 = p_simpleTerm t in
-          prefix2 FStar_Pprint.equals uu____2313 in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-          uu____2310 uu____2311 uu____2312
-and p_effectDefinition:
-  FStar_Ident.ident ->
-    FStar_Parser_AST.binder Prims.list ->
-      FStar_Parser_AST.term ->
-        FStar_Parser_AST.decl Prims.list -> FStar_Pprint.document
-  =
-  fun uid  ->
-    fun bs  ->
-      fun t  ->
-        fun eff_decls  ->
-          let uu____2320 =
-            let uu____2321 =
-              let uu____2322 =
-                let uu____2323 = p_uident uid in
-                let uu____2324 = p_binders true bs in
-                let uu____2325 =
-                  let uu____2326 = p_typ t in
-                  prefix2 FStar_Pprint.colon uu____2326 in
-                FStar_Pprint.surround (Prims.parse_int "2")
-                  (Prims.parse_int "1") uu____2323 uu____2324 uu____2325 in
-              FStar_Pprint.group uu____2322 in
-            let uu____2327 =
-              let uu____2328 = str "with" in
-              let uu____2329 =
-                separate_break_map FStar_Pprint.semi p_effectDecl eff_decls in
-              prefix2 uu____2328 uu____2329 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2321 uu____2327 in
-          braces_with_nesting uu____2320
-and p_effectDecl: FStar_Parser_AST.decl -> FStar_Pprint.document =
-  fun d  ->
-    match d.FStar_Parser_AST.d with
-    | FStar_Parser_AST.Tycon
-        (false ,(FStar_Parser_AST.TyconAbbrev (lid,[],None ,e),None )::[]) ->
-        let uu____2346 =
-          let uu____2347 = p_lident lid in
-          let uu____2348 =
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals in
-          FStar_Pprint.op_Hat_Hat uu____2347 uu____2348 in
-        let uu____2349 = p_simpleTerm e in prefix2 uu____2346 uu____2349
-    | uu____2350 ->
-        let uu____2351 =
-          let uu____2352 = FStar_Parser_AST.decl_to_string d in
-          FStar_Util.format1
-            "Not a declaration of an effect member... or at least I hope so : %s"
-            uu____2352 in
-        failwith uu____2351
-and p_subEffect: FStar_Parser_AST.lift -> FStar_Pprint.document =
-  fun lift  ->
-    let lift_op_doc =
-      let lifts =
-        match lift.FStar_Parser_AST.lift_op with
-        | FStar_Parser_AST.NonReifiableLift t -> [("lift_wp", t)]
-        | FStar_Parser_AST.ReifiableLift (t1,t2) ->
-            [("lif_wp", t1); ("lift", t2)]
-        | FStar_Parser_AST.LiftForFree t -> [("lift", t)] in
-      let p_lift uu____2385 =
-        match uu____2385 with
-        | (kwd1,t) ->
-            let uu____2390 =
-              let uu____2391 = str kwd1 in
-              let uu____2392 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                  FStar_Pprint.equals in
-              FStar_Pprint.op_Hat_Hat uu____2391 uu____2392 in
-            let uu____2393 = p_simpleTerm t in prefix2 uu____2390 uu____2393 in
-      separate_break_map FStar_Pprint.semi p_lift lifts in
-    let uu____2396 =
-      let uu____2397 =
-        let uu____2398 = p_quident lift.FStar_Parser_AST.msource in
-        let uu____2399 =
-          let uu____2400 = str "~>" in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2400 in
-        FStar_Pprint.op_Hat_Hat uu____2398 uu____2399 in
-      let uu____2401 = p_quident lift.FStar_Parser_AST.mdest in
-      prefix2 uu____2397 uu____2401 in
-    let uu____2402 =
-      let uu____2403 = braces_with_nesting lift_op_doc in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2403 in
-    FStar_Pprint.op_Hat_Hat uu____2396 uu____2402
-and p_qualifier: FStar_Parser_AST.qualifier -> FStar_Pprint.document =
-  fun uu___134_2404  ->
-    match uu___134_2404 with
-    | FStar_Parser_AST.Private  -> str "private"
-    | FStar_Parser_AST.Abstract  -> str "abstract"
-    | FStar_Parser_AST.Noeq  -> str "noeq"
-    | FStar_Parser_AST.Unopteq  -> str "unopteq"
-    | FStar_Parser_AST.Assumption  -> str "assume"
-    | FStar_Parser_AST.DefaultEffect  -> str "default"
-    | FStar_Parser_AST.TotalEffect  -> str "total"
-    | FStar_Parser_AST.Effect_qual  -> FStar_Pprint.empty
-    | FStar_Parser_AST.New  -> str "new"
-    | FStar_Parser_AST.Inline  -> str "inline"
-    | FStar_Parser_AST.Visible  -> FStar_Pprint.empty
-    | FStar_Parser_AST.Unfold_for_unification_and_vcgen  -> str "unfold"
-    | FStar_Parser_AST.Inline_for_extraction  -> str "inline_for_extraction"
-    | FStar_Parser_AST.Irreducible  -> str "irreducible"
-    | FStar_Parser_AST.NoExtract  -> str "noextract"
-    | FStar_Parser_AST.Reifiable  -> str "reifiable"
-    | FStar_Parser_AST.Reflectable  -> str "reflectable"
-    | FStar_Parser_AST.Opaque  -> str "opaque"
-    | FStar_Parser_AST.Logic  -> str "logic"
-and p_qualifiers: FStar_Parser_AST.qualifiers -> FStar_Pprint.document =
-  fun qs  ->
-    let uu____2406 = FStar_Pprint.separate_map break1 p_qualifier qs in
-    FStar_Pprint.group uu____2406
-and p_letqualifier: FStar_Parser_AST.let_qualifier -> FStar_Pprint.document =
-  fun uu___135_2407  ->
-    match uu___135_2407 with
-    | FStar_Parser_AST.Rec  ->
-        let uu____2408 = str "rec" in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2408
-    | FStar_Parser_AST.Mutable  ->
-        let uu____2409 = str "mutable" in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2409
-    | FStar_Parser_AST.NoLetQualifier  -> FStar_Pprint.empty
-and p_aqual: FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document =
-  fun uu___136_2410  ->
-    match uu___136_2410 with
-    | FStar_Parser_AST.Implicit  -> str "#"
-    | FStar_Parser_AST.Equality  -> str "$"
-and p_disjunctivePattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatOr pats ->
-        let uu____2414 =
-          let uu____2415 =
-            let uu____2416 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space in
-            FStar_Pprint.op_Hat_Hat break1 uu____2416 in
-          FStar_Pprint.separate_map uu____2415 p_tuplePattern pats in
-        FStar_Pprint.group uu____2414
-    | uu____2417 -> p_tuplePattern p
-and p_tuplePattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatTuple (pats,false ) ->
-        let uu____2422 =
-          let uu____2423 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          FStar_Pprint.separate_map uu____2423 p_constructorPattern pats in
-        FStar_Pprint.group uu____2422
-    | uu____2424 -> p_constructorPattern p
-and p_constructorPattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName maybe_cons_lid;
-           FStar_Parser_AST.prange = uu____2427;_},hd1::tl1::[])
-        when
-        FStar_Ident.lid_equals maybe_cons_lid FStar_Syntax_Const.cons_lid ->
-        let uu____2431 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon in
-        let uu____2432 = p_constructorPattern hd1 in
-        let uu____2433 = p_constructorPattern tl1 in
-        infix0 uu____2431 uu____2432 uu____2433
-    | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uid;
-           FStar_Parser_AST.prange = uu____2435;_},pats)
-        ->
-        let uu____2439 = p_quident uid in
-        let uu____2440 =
-          FStar_Pprint.separate_map break1 p_atomicPattern pats in
-        prefix2 uu____2439 uu____2440
-    | uu____2441 -> p_atomicPattern p
-and p_atomicPattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatAscribed (pat,t) ->
-        let uu____2445 =
-          let uu____2448 =
-            let uu____2449 = unparen t in uu____2449.FStar_Parser_AST.tm in
-          ((pat.FStar_Parser_AST.pat), uu____2448) in
-        (match uu____2445 with
-         | (FStar_Parser_AST.PatVar (lid,aqual),FStar_Parser_AST.Refine
-            ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid',t1);
-               FStar_Parser_AST.brange = uu____2454;
-               FStar_Parser_AST.blevel = uu____2455;
-               FStar_Parser_AST.aqual = uu____2456;_},phi))
-             when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-             let uu____2460 =
-               let uu____2461 = p_ident lid in
-               p_refinement aqual uu____2461 t1 phi in
-             soft_parens_with_nesting uu____2460
-         | (FStar_Parser_AST.PatWild ,FStar_Parser_AST.Refine
-            ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-               FStar_Parser_AST.brange = uu____2463;
-               FStar_Parser_AST.blevel = uu____2464;
-               FStar_Parser_AST.aqual = uu____2465;_},phi))
-             ->
-             let uu____2467 =
-               p_refinement None FStar_Pprint.underscore t1 phi in
-             soft_parens_with_nesting uu____2467
-         | uu____2468 ->
-             let uu____2471 =
-               let uu____2472 = p_tuplePattern pat in
-               let uu____2473 =
-                 let uu____2474 = FStar_Pprint.break_ (Prims.parse_int "0") in
-                 let uu____2475 =
-                   let uu____2476 = p_typ t in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2476 in
-                 FStar_Pprint.op_Hat_Hat uu____2474 uu____2475 in
-               FStar_Pprint.op_Hat_Hat uu____2472 uu____2473 in
-             soft_parens_with_nesting uu____2471)
-    | FStar_Parser_AST.PatList pats ->
-        let uu____2479 =
-          separate_break_map FStar_Pprint.semi p_tuplePattern pats in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
-          FStar_Pprint.lbracket uu____2479 FStar_Pprint.rbracket
-    | FStar_Parser_AST.PatRecord pats ->
-        let p_recordFieldPat uu____2489 =
-          match uu____2489 with
-          | (lid,pat) ->
-              let uu____2494 = p_qlident lid in
-              let uu____2495 = p_tuplePattern pat in
-              infix2 FStar_Pprint.equals uu____2494 uu____2495 in
-        let uu____2496 =
-          separate_break_map FStar_Pprint.semi p_recordFieldPat pats in
-        soft_braces_with_nesting uu____2496
-    | FStar_Parser_AST.PatTuple (pats,true ) ->
-        let uu____2502 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
-        let uu____2503 =
-          separate_break_map FStar_Pprint.comma p_constructorPattern pats in
-        let uu____2504 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-          uu____2502 uu____2503 uu____2504
-    | FStar_Parser_AST.PatTvar (tv,arg_qualifier_opt) -> p_tvar tv
-    | FStar_Parser_AST.PatOp op ->
-        let uu____2511 =
-          let uu____2512 =
-            let uu____2513 = str op in
-            let uu____2514 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
-            FStar_Pprint.op_Hat_Hat uu____2513 uu____2514 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2512 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2511
-    | FStar_Parser_AST.PatWild  -> FStar_Pprint.underscore
-    | FStar_Parser_AST.PatConst c -> p_constant c
-    | FStar_Parser_AST.PatVar (lid,aqual) ->
-        let uu____2520 = FStar_Pprint.optional p_aqual aqual in
-        let uu____2521 = p_lident lid in
-        FStar_Pprint.op_Hat_Hat uu____2520 uu____2521
-    | FStar_Parser_AST.PatName uid -> p_quident uid
-    | FStar_Parser_AST.PatOr uu____2523 -> failwith "Inner or pattern !"
-    | FStar_Parser_AST.PatApp
-      ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName _;
-         FStar_Parser_AST.prange = _;_},_)|FStar_Parser_AST.PatTuple
-      (_,false ) ->
-        let uu____2531 = p_tuplePattern p in
-        soft_parens_with_nesting uu____2531
-    | uu____2532 ->
-        let uu____2533 =
-          let uu____2534 = FStar_Parser_AST.pat_to_string p in
-          FStar_Util.format1 "Invalid pattern %s" uu____2534 in
-        failwith uu____2533
-and p_binder: Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document
-  =
-  fun is_atomic  ->
-    fun b  ->
-      match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Variable lid ->
-          let uu____2538 =
-            FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-          let uu____2539 = p_lident lid in
-          FStar_Pprint.op_Hat_Hat uu____2538 uu____2539
-      | FStar_Parser_AST.TVariable lid -> p_lident lid
-      | FStar_Parser_AST.Annotated (lid,t) ->
-          let doc1 =
-            let uu____2544 =
-              let uu____2545 = unparen t in uu____2545.FStar_Parser_AST.tm in
-            match uu____2544 with
-            | FStar_Parser_AST.Refine
-                ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid',t1);
-                   FStar_Parser_AST.brange = uu____2548;
-                   FStar_Parser_AST.blevel = uu____2549;
-                   FStar_Parser_AST.aqual = uu____2550;_},phi)
-                when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-                let uu____2552 = p_ident lid in
-                p_refinement b.FStar_Parser_AST.aqual uu____2552 t1 phi
-            | uu____2553 ->
-                let uu____2554 =
-                  FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-                let uu____2555 =
-                  let uu____2556 = p_lident lid in
-                  let uu____2557 =
-                    let uu____2558 =
-                      let uu____2559 =
-                        FStar_Pprint.break_ (Prims.parse_int "0") in
-                      let uu____2560 = p_tmFormula t in
-                      FStar_Pprint.op_Hat_Hat uu____2559 uu____2560 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2558 in
-                  FStar_Pprint.op_Hat_Hat uu____2556 uu____2557 in
-                FStar_Pprint.op_Hat_Hat uu____2554 uu____2555 in
-          if is_atomic
-          then
-            let uu____2561 =
-              let uu____2562 =
-                FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2562 in
-            FStar_Pprint.group uu____2561
-          else FStar_Pprint.group doc1
-      | FStar_Parser_AST.TAnnotated uu____2564 ->
-          failwith "Is this still used ?"
-      | FStar_Parser_AST.NoName t ->
-          let uu____2568 =
-            let uu____2569 = unparen t in uu____2569.FStar_Parser_AST.tm in
-          (match uu____2568 with
-           | FStar_Parser_AST.Refine
-               ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-                  FStar_Parser_AST.brange = uu____2571;
-                  FStar_Parser_AST.blevel = uu____2572;
-                  FStar_Parser_AST.aqual = uu____2573;_},phi)
-               ->
-               if is_atomic
-               then
-                 let uu____2575 =
-                   let uu____2576 =
-                     let uu____2577 =
-                       p_refinement b.FStar_Parser_AST.aqual
-                         FStar_Pprint.underscore t1 phi in
-                     FStar_Pprint.op_Hat_Hat uu____2577 FStar_Pprint.rparen in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2576 in
-                 FStar_Pprint.group uu____2575
-               else
-                 (let uu____2579 =
-                    p_refinement b.FStar_Parser_AST.aqual
-                      FStar_Pprint.underscore t1 phi in
-                  FStar_Pprint.group uu____2579)
-           | uu____2580 -> if is_atomic then p_atomicTerm t else p_appTerm t)
-and p_refinement:
-  FStar_Parser_AST.arg_qualifier Prims.option ->
-    FStar_Pprint.document ->
-      FStar_Parser_AST.term -> FStar_Parser_AST.term -> FStar_Pprint.document
-  =
-  fun aqual_opt  ->
-    fun binder  ->
-      fun t  ->
-        fun phi  ->
-          let uu____2587 = FStar_Pprint.optional p_aqual aqual_opt in
-          let uu____2588 =
-            let uu____2589 =
-              let uu____2590 =
-                let uu____2591 = p_appTerm t in
-                let uu____2592 =
-                  let uu____2593 = p_noSeqTerm phi in
-                  soft_braces_with_nesting uu____2593 in
-                FStar_Pprint.op_Hat_Hat uu____2591 uu____2592 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2590 in
-            FStar_Pprint.op_Hat_Hat binder uu____2589 in
-          FStar_Pprint.op_Hat_Hat uu____2587 uu____2588
-and p_binders:
-  Prims.bool -> FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document =
-  fun is_atomic  ->
-    fun bs  -> FStar_Pprint.separate_map break1 (p_binder is_atomic) bs
-and p_qlident: FStar_Ident.lid -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_lid lid)
-and p_quident: FStar_Ident.lid -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_lid lid)
-and p_ident: FStar_Ident.ident -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_id lid)
-and p_lident: FStar_Ident.ident -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_id lid)
-and p_uident: FStar_Ident.ident -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_id lid)
-and p_tvar: FStar_Ident.ident -> FStar_Pprint.document =
-  fun lid  -> str (FStar_Ident.text_of_id lid)
-and p_lidentOrUnderscore: FStar_Ident.ident -> FStar_Pprint.document =
-  fun id  ->
-    if
-      FStar_Util.starts_with FStar_Ident.reserved_prefix
-        id.FStar_Ident.idText
-    then FStar_Pprint.underscore
-    else p_lident id
-and p_term: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2606 =
-      let uu____2607 = unparen e in uu____2607.FStar_Parser_AST.tm in
-    match uu____2606 with
-    | FStar_Parser_AST.Seq (e1,e2) ->
-        let uu____2610 =
-          let uu____2611 =
-            let uu____2612 = p_noSeqTerm e1 in
-            FStar_Pprint.op_Hat_Hat uu____2612 FStar_Pprint.semi in
-          FStar_Pprint.group uu____2611 in
-        let uu____2613 = p_term e2 in
-        FStar_Pprint.op_Hat_Slash_Hat uu____2610 uu____2613
-    | uu____2614 ->
-        let uu____2615 = p_noSeqTerm e in FStar_Pprint.group uu____2615
-and p_noSeqTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  -> with_comment p_noSeqTerm' e e.FStar_Parser_AST.range
-and p_noSeqTerm': FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2618 =
-      let uu____2619 = unparen e in uu____2619.FStar_Parser_AST.tm in
-    match uu____2618 with
-    | FStar_Parser_AST.Ascribed (e1,t,None ) ->
-        let uu____2623 =
-          let uu____2624 = p_tmIff e1 in
-          let uu____2625 =
-            let uu____2626 =
-              let uu____2627 = p_typ t in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____2627 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____2626 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2624 uu____2625 in
-        FStar_Pprint.group uu____2623
-    | FStar_Parser_AST.Ascribed (e1,t,Some tac) ->
-        let uu____2632 =
-          let uu____2633 = p_tmIff e1 in
-          let uu____2634 =
-            let uu____2635 =
-              let uu____2636 =
-                let uu____2637 = p_typ t in
-                let uu____2638 =
-                  let uu____2639 = str "by" in
-                  let uu____2640 = p_typ tac in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____2639 uu____2640 in
-                FStar_Pprint.op_Hat_Slash_Hat uu____2637 uu____2638 in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____2636 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____2635 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2633 uu____2634 in
-        FStar_Pprint.group uu____2632
-    | FStar_Parser_AST.Op (op,e1::e2::e3::[]) when op = ".()<-" ->
-        let uu____2646 =
-          let uu____2647 =
-            let uu____2648 =
-              let uu____2649 = p_atomicTermNotQUident e1 in
-              let uu____2650 =
-                let uu____2651 =
-                  let uu____2652 =
-                    let uu____2653 = p_term e2 in
-                    soft_parens_with_nesting uu____2653 in
-                  let uu____2654 =
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                      FStar_Pprint.larrow in
-                  FStar_Pprint.op_Hat_Hat uu____2652 uu____2654 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____2651 in
-              FStar_Pprint.op_Hat_Hat uu____2649 uu____2650 in
-            FStar_Pprint.group uu____2648 in
-          let uu____2655 =
-            let uu____2656 = p_noSeqTerm e3 in jump2 uu____2656 in
-          FStar_Pprint.op_Hat_Hat uu____2647 uu____2655 in
-        FStar_Pprint.group uu____2646
-    | FStar_Parser_AST.Op (op,e1::e2::e3::[]) when op = ".[]<-" ->
-        let uu____2662 =
-          let uu____2663 =
-            let uu____2664 =
-              let uu____2665 = p_atomicTermNotQUident e1 in
-              let uu____2666 =
-                let uu____2667 =
-                  let uu____2668 =
-                    let uu____2669 = p_term e2 in
-                    soft_brackets_with_nesting uu____2669 in
-                  let uu____2670 =
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                      FStar_Pprint.larrow in
-                  FStar_Pprint.op_Hat_Hat uu____2668 uu____2670 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____2667 in
-              FStar_Pprint.op_Hat_Hat uu____2665 uu____2666 in
-            FStar_Pprint.group uu____2664 in
-          let uu____2671 =
-            let uu____2672 = p_noSeqTerm e3 in jump2 uu____2672 in
-          FStar_Pprint.op_Hat_Hat uu____2663 uu____2671 in
-        FStar_Pprint.group uu____2662
-    | FStar_Parser_AST.Requires (e1,wtf) ->
-        let uu____2678 =
-          let uu____2679 = str "requires" in
-          let uu____2680 = p_typ e1 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2679 uu____2680 in
-        FStar_Pprint.group uu____2678
-    | FStar_Parser_AST.Ensures (e1,wtf) ->
-        let uu____2686 =
-          let uu____2687 = str "ensures" in
-          let uu____2688 = p_typ e1 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2687 uu____2688 in
-        FStar_Pprint.group uu____2686
-    | FStar_Parser_AST.Attributes es ->
-        let uu____2691 =
-          let uu____2692 = str "attributes" in
-          let uu____2693 = FStar_Pprint.separate_map break1 p_atomicTerm es in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2692 uu____2693 in
-        FStar_Pprint.group uu____2691
-    | FStar_Parser_AST.If (e1,e2,e3) ->
-        let uu____2697 = is_unit e3 in
-        if uu____2697
-        then
-          let uu____2698 =
-            let uu____2699 =
-              let uu____2700 = str "if" in
-              let uu____2701 = p_noSeqTerm e1 in
-              op_Hat_Slash_Plus_Hat uu____2700 uu____2701 in
-            let uu____2702 =
-              let uu____2703 = str "then" in
-              let uu____2704 = p_noSeqTerm e2 in
-              op_Hat_Slash_Plus_Hat uu____2703 uu____2704 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2699 uu____2702 in
-          FStar_Pprint.group uu____2698
-        else
-          (let e2_doc =
-             let uu____2707 =
-               let uu____2708 = unparen e2 in uu____2708.FStar_Parser_AST.tm in
-             match uu____2707 with
-             | FStar_Parser_AST.If (uu____2709,uu____2710,e31) when
-                 is_unit e31 ->
-                 let uu____2712 = p_noSeqTerm e2 in
-                 soft_parens_with_nesting uu____2712
-             | uu____2713 -> p_noSeqTerm e2 in
-           let uu____2714 =
-             let uu____2715 =
-               let uu____2716 = str "if" in
-               let uu____2717 = p_noSeqTerm e1 in
-               op_Hat_Slash_Plus_Hat uu____2716 uu____2717 in
-             let uu____2718 =
-               let uu____2719 =
-                 let uu____2720 = str "then" in
-                 op_Hat_Slash_Plus_Hat uu____2720 e2_doc in
-               let uu____2721 =
-                 let uu____2722 = str "else" in
-                 let uu____2723 = p_noSeqTerm e3 in
-                 op_Hat_Slash_Plus_Hat uu____2722 uu____2723 in
-               FStar_Pprint.op_Hat_Slash_Hat uu____2719 uu____2721 in
-             FStar_Pprint.op_Hat_Slash_Hat uu____2715 uu____2718 in
-           FStar_Pprint.group uu____2714)
-    | FStar_Parser_AST.TryWith (e1,branches) ->
-        let uu____2736 =
-          let uu____2737 =
-            let uu____2738 = str "try" in
-            let uu____2739 = p_noSeqTerm e1 in prefix2 uu____2738 uu____2739 in
-          let uu____2740 =
-            let uu____2741 = str "with" in
-            let uu____2742 =
-              FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch
-                branches in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2741 uu____2742 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2737 uu____2740 in
-        FStar_Pprint.group uu____2736
-    | FStar_Parser_AST.Match (e1,branches) ->
-        let uu____2759 =
-          let uu____2760 =
-            let uu____2761 = str "match" in
-            let uu____2762 = p_noSeqTerm e1 in
-            let uu____2763 = str "with" in
-            FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-              uu____2761 uu____2762 uu____2763 in
-          let uu____2764 =
-            FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch
-              branches in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2760 uu____2764 in
-        FStar_Pprint.group uu____2759
-    | FStar_Parser_AST.LetOpen (uid,e1) ->
-        let uu____2771 =
-          let uu____2772 =
-            let uu____2773 = str "let open" in
-            let uu____2774 = p_quident uid in
-            let uu____2775 = str "in" in
-            FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-              uu____2773 uu____2774 uu____2775 in
-          let uu____2776 = p_term e1 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2772 uu____2776 in
-        FStar_Pprint.group uu____2771
-    | FStar_Parser_AST.Let (q,lbs,e1) ->
-        let let_doc =
-          let uu____2787 = str "let" in
-          let uu____2788 = p_letqualifier q in
-          FStar_Pprint.op_Hat_Hat uu____2787 uu____2788 in
-        let uu____2789 =
-          let uu____2790 =
-            let uu____2791 =
-              let uu____2792 = str "and" in
-              precede_break_separate_map let_doc uu____2792 p_letbinding lbs in
-            let uu____2795 = str "in" in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2791 uu____2795 in
-          FStar_Pprint.group uu____2790 in
-        let uu____2796 = p_term e1 in
-        FStar_Pprint.op_Hat_Slash_Hat uu____2789 uu____2796
-    | FStar_Parser_AST.Abs
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x,typ_opt);
-           FStar_Parser_AST.prange = uu____2799;_}::[],{
-                                                         FStar_Parser_AST.tm
-                                                           =
-                                                           FStar_Parser_AST.Match
-                                                           (maybe_x,branches);
-                                                         FStar_Parser_AST.range
-                                                           = uu____2802;
-                                                         FStar_Parser_AST.level
-                                                           = uu____2803;_})
-        when matches_var maybe_x x ->
-        let uu____2817 =
-          let uu____2818 = str "function" in
-          let uu____2819 =
-            FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch
-              branches in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2818 uu____2819 in
-        FStar_Pprint.group uu____2817
-    | FStar_Parser_AST.Assign (id,e1) ->
-        let uu____2826 =
-          let uu____2827 = p_lident id in
-          let uu____2828 =
-            let uu____2829 = p_noSeqTerm e1 in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.larrow uu____2829 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____2827 uu____2828 in
-        FStar_Pprint.group uu____2826
-    | uu____2830 -> p_typ e
-and p_typ: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  -> with_comment p_typ' e e.FStar_Parser_AST.range
-and p_typ': FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2833 =
-      let uu____2834 = unparen e in uu____2834.FStar_Parser_AST.tm in
-    match uu____2833 with
-    | FStar_Parser_AST.QForall (bs,trigger,e1)|FStar_Parser_AST.QExists
-      (bs,trigger,e1) ->
-        let uu____2850 =
-          let uu____2851 =
-            let uu____2852 = p_quantifier e in
-            FStar_Pprint.op_Hat_Hat uu____2852 FStar_Pprint.space in
-          let uu____2853 = p_binders true bs in
-          FStar_Pprint.soft_surround (Prims.parse_int "2")
-            (Prims.parse_int "0") uu____2851 uu____2853 FStar_Pprint.dot in
-        let uu____2854 =
-          let uu____2855 = p_trigger trigger in
-          let uu____2856 = p_noSeqTerm e1 in
-          FStar_Pprint.op_Hat_Hat uu____2855 uu____2856 in
-        prefix2 uu____2850 uu____2854
-    | uu____2857 -> p_simpleTerm e
-and p_quantifier: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2859 =
-      let uu____2860 = unparen e in uu____2860.FStar_Parser_AST.tm in
-    match uu____2859 with
-    | FStar_Parser_AST.QForall uu____2861 -> str "forall"
-    | FStar_Parser_AST.QExists uu____2868 -> str "exists"
-    | uu____2875 ->
-        failwith "Imposible : p_quantifier called on a non-quantifier term"
-and p_trigger:
-  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document =
-  fun uu___137_2876  ->
-    match uu___137_2876 with
-    | [] -> FStar_Pprint.empty
-    | pats ->
-        let uu____2883 =
-          let uu____2884 =
-            let uu____2885 = str "pattern" in
-            let uu____2886 =
-              let uu____2887 =
-                let uu____2888 = p_disjunctivePats pats in jump2 uu____2888 in
-              let uu____2889 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace break1 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____2887 uu____2889 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2885 uu____2886 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2884 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____2883
-and p_disjunctivePats:
-  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document =
-  fun pats  ->
-    let uu____2893 = str "\\/" in
-    FStar_Pprint.separate_map uu____2893 p_conjunctivePats pats
-and p_conjunctivePats:
-  FStar_Parser_AST.term Prims.list -> FStar_Pprint.document =
-  fun pats  ->
-    let uu____2897 =
-      FStar_Pprint.separate_map FStar_Pprint.semi p_appTerm pats in
-    FStar_Pprint.group uu____2897
-and p_simpleTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2899 =
-      let uu____2900 = unparen e in uu____2900.FStar_Parser_AST.tm in
-    match uu____2899 with
-    | FStar_Parser_AST.Abs (pats,e1) ->
-        let uu____2905 =
-          let uu____2906 = str "fun" in
-          let uu____2907 =
-            let uu____2908 =
-              FStar_Pprint.separate_map break1 p_atomicPattern pats in
-            FStar_Pprint.op_Hat_Slash_Hat uu____2908 FStar_Pprint.rarrow in
-          op_Hat_Slash_Plus_Hat uu____2906 uu____2907 in
-        let uu____2909 = p_term e1 in
-        op_Hat_Slash_Plus_Hat uu____2905 uu____2909
-    | uu____2910 -> p_tmIff e
-and p_maybeFocusArrow: Prims.bool -> FStar_Pprint.document =
-  fun b  -> if b then str "~>" else FStar_Pprint.rarrow
-and p_patternBranch:
-  (FStar_Parser_AST.pattern* FStar_Parser_AST.term Prims.option*
-    FStar_Parser_AST.term) -> FStar_Pprint.document
-  =
-  fun uu____2913  ->
-    match uu____2913 with
-    | (pat,when_opt,e) ->
-        let maybe_paren =
-          let uu____2926 =
-            let uu____2927 = unparen e in uu____2927.FStar_Parser_AST.tm in
-          match uu____2926 with
-          | FStar_Parser_AST.Match _|FStar_Parser_AST.TryWith _ ->
-              soft_begin_end_with_nesting
-          | FStar_Parser_AST.Abs
-              ({
-                 FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                   (x,uu____2933);
-                 FStar_Parser_AST.prange = uu____2934;_}::[],{
-                                                               FStar_Parser_AST.tm
-                                                                 =
-                                                                 FStar_Parser_AST.Match
-                                                                 (maybe_x,uu____2936);
-                                                               FStar_Parser_AST.range
-                                                                 = uu____2937;
-                                                               FStar_Parser_AST.level
-                                                                 = uu____2938;_})
-              when matches_var maybe_x x -> soft_begin_end_with_nesting
-          | uu____2952 -> (fun x  -> x) in
-        let uu____2954 =
-          let uu____2955 =
-            let uu____2956 =
-              let uu____2957 =
-                let uu____2958 =
-                  let uu____2959 = p_disjunctivePattern pat in
-                  let uu____2960 =
-                    let uu____2961 = p_maybeWhen when_opt in
-                    FStar_Pprint.op_Hat_Hat uu____2961 FStar_Pprint.rarrow in
-                  op_Hat_Slash_Plus_Hat uu____2959 uu____2960 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2958 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____2957 in
-            FStar_Pprint.group uu____2956 in
-          let uu____2962 =
-            let uu____2963 = p_term e in maybe_paren uu____2963 in
-          op_Hat_Slash_Plus_Hat uu____2955 uu____2962 in
-        FStar_Pprint.group uu____2954
-and p_maybeWhen: FStar_Parser_AST.term Prims.option -> FStar_Pprint.document
-  =
-  fun uu___138_2964  ->
-    match uu___138_2964 with
-    | None  -> FStar_Pprint.empty
-    | Some e ->
-        let uu____2967 = str "when" in
-        let uu____2968 =
-          let uu____2969 = p_tmFormula e in
-          FStar_Pprint.op_Hat_Hat uu____2969 FStar_Pprint.space in
-        op_Hat_Slash_Plus_Hat uu____2967 uu____2968
-and p_tmIff: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2971 =
-      let uu____2972 = unparen e in uu____2972.FStar_Parser_AST.tm in
-    match uu____2971 with
-    | FStar_Parser_AST.Op ("<==>",e1::e2::[]) ->
-        let uu____2976 = str "<==>" in
-        let uu____2977 = p_tmImplies e1 in
-        let uu____2978 = p_tmIff e2 in
-        infix0 uu____2976 uu____2977 uu____2978
-    | uu____2979 -> p_tmImplies e
-and p_tmImplies: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____2981 =
-      let uu____2982 = unparen e in uu____2982.FStar_Parser_AST.tm in
-    match uu____2981 with
-    | FStar_Parser_AST.Op ("==>",e1::e2::[]) ->
-        let uu____2986 = str "==>" in
-        let uu____2987 = p_tmArrow p_tmFormula e1 in
-        let uu____2988 = p_tmImplies e2 in
-        infix0 uu____2986 uu____2987 uu____2988
-    | uu____2989 -> p_tmArrow p_tmFormula e
-and p_tmArrow:
-  (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document
-  =
-  fun p_Tm  ->
-    fun e  ->
-      let uu____2994 =
-        let uu____2995 = unparen e in uu____2995.FStar_Parser_AST.tm in
-      match uu____2994 with
-      | FStar_Parser_AST.Product (bs,tgt) ->
-          let uu____3000 =
-            let uu____3001 =
-              FStar_Pprint.concat_map
-                (fun b  ->
-                   let uu____3003 = p_binder false b in
-                   let uu____3004 =
-                     let uu____3005 =
-                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1 in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3005 in
-                   FStar_Pprint.op_Hat_Hat uu____3003 uu____3004) bs in
-            let uu____3006 = p_tmArrow p_Tm tgt in
-            FStar_Pprint.op_Hat_Hat uu____3001 uu____3006 in
-          FStar_Pprint.group uu____3000
-      | uu____3007 -> p_Tm e
-and p_tmFormula: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3009 =
-      let uu____3010 = unparen e in uu____3010.FStar_Parser_AST.tm in
-    match uu____3009 with
-    | FStar_Parser_AST.Op ("\\/",e1::e2::[]) ->
-        let uu____3014 = str "\\/" in
-        let uu____3015 = p_tmFormula e1 in
-        let uu____3016 = p_tmConjunction e2 in
-        infix0 uu____3014 uu____3015 uu____3016
-    | uu____3017 -> p_tmConjunction e
-and p_tmConjunction: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3019 =
-      let uu____3020 = unparen e in uu____3020.FStar_Parser_AST.tm in
-    match uu____3019 with
-    | FStar_Parser_AST.Op ("/\\",e1::e2::[]) ->
-        let uu____3024 = str "/\\" in
-        let uu____3025 = p_tmConjunction e1 in
-        let uu____3026 = p_tmTuple e2 in
-        infix0 uu____3024 uu____3025 uu____3026
-    | uu____3027 -> p_tmTuple e
-and p_tmTuple: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  -> with_comment p_tmTuple' e e.FStar_Parser_AST.range
-and p_tmTuple': FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3030 =
-      let uu____3031 = unparen e in uu____3031.FStar_Parser_AST.tm in
-    match uu____3030 with
-    | FStar_Parser_AST.Construct (lid,args) when is_tuple_constructor lid ->
-        let uu____3040 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-        FStar_Pprint.separate_map uu____3040
-          (fun uu____3043  ->
-             match uu____3043 with | (e1,uu____3047) -> p_tmEq e1) args
-    | uu____3048 -> p_tmEq e
-and paren_if:
-  Prims.int -> Prims.int -> FStar_Pprint.document -> FStar_Pprint.document =
-  fun curr  ->
-    fun mine  ->
-      fun doc1  ->
-        if mine <= curr
-        then doc1
-        else
-          (let uu____3053 =
-             let uu____3054 =
-               FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3054 in
-           FStar_Pprint.group uu____3053)
-and p_tmEq: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let n1 =
-      max_level
-        (FStar_List.append [colon_equals (); pipe_right ()]
-           (operatorInfix0ad12 ())) in
-    p_tmEq' n1 e
-and p_tmEq': Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun curr  ->
-    fun e  ->
-      let uu____3079 =
-        let uu____3080 = unparen e in uu____3080.FStar_Parser_AST.tm in
-      match uu____3079 with
-      | FStar_Parser_AST.Op (op,e1::e2::[]) when
-          ((is_operatorInfix0ad12 op) || (op = "=")) || (op = "|>") ->
-          let uu____3085 = levels op in
-          (match uu____3085 with
-           | (left1,mine,right1) ->
-               let uu____3092 =
-                 let uu____3093 = str op in
-                 let uu____3094 = p_tmEq' left1 e1 in
-                 let uu____3095 = p_tmEq' right1 e2 in
-                 infix0 uu____3093 uu____3094 uu____3095 in
-               paren_if curr mine uu____3092)
-      | FStar_Parser_AST.Op (":=",e1::e2::[]) ->
-          let uu____3099 =
-            let uu____3100 = p_tmEq e1 in
-            let uu____3101 =
-              let uu____3102 =
-                let uu____3103 =
-                  let uu____3104 = p_tmEq e2 in
-                  op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____3104 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____3103 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3102 in
-            FStar_Pprint.op_Hat_Hat uu____3100 uu____3101 in
-          FStar_Pprint.group uu____3099
-      | uu____3105 -> p_tmNoEq e
-and p_tmNoEq: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let n1 = max_level [colon_colon (); amp (); opinfix3 (); opinfix4 ()] in
-    p_tmNoEq' n1 e
-and p_tmNoEq': Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun curr  ->
-    fun e  ->
-      let uu____3135 =
-        let uu____3136 = unparen e in uu____3136.FStar_Parser_AST.tm in
-      match uu____3135 with
-      | FStar_Parser_AST.Construct (lid,(e1,uu____3139)::(e2,uu____3141)::[])
-          when
-          (FStar_Ident.lid_equals lid FStar_Syntax_Const.cons_lid) &&
-            (let uu____3151 = is_list e in Prims.op_Negation uu____3151)
-          ->
-          let op = "::" in
-          let uu____3153 = levels op in
-          (match uu____3153 with
-           | (left1,mine,right1) ->
-               let uu____3160 =
-                 let uu____3161 = str op in
-                 let uu____3162 = p_tmNoEq' left1 e1 in
-                 let uu____3163 = p_tmNoEq' right1 e2 in
-                 infix0 uu____3161 uu____3162 uu____3163 in
-               paren_if curr mine uu____3160)
-      | FStar_Parser_AST.Sum (binders,res) ->
-          let op = "&" in
-          let uu____3169 = levels op in
-          (match uu____3169 with
-           | (left1,mine,right1) ->
-               let p_dsumfst b =
-                 let uu____3180 = p_binder false b in
-                 let uu____3181 =
-                   let uu____3182 =
-                     let uu____3183 = str "&" in
-                     FStar_Pprint.op_Hat_Hat uu____3183 break1 in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3182 in
-                 FStar_Pprint.op_Hat_Hat uu____3180 uu____3181 in
-               let uu____3184 =
-                 let uu____3185 = FStar_Pprint.concat_map p_dsumfst binders in
-                 let uu____3186 = p_tmNoEq' right1 res in
-                 FStar_Pprint.op_Hat_Hat uu____3185 uu____3186 in
-               paren_if curr mine uu____3184)
-      | FStar_Parser_AST.Op (op,e1::e2::[]) when is_operatorInfix34 op ->
-          let uu____3191 = levels op in
-          (match uu____3191 with
-           | (left1,mine,right1) ->
-               let uu____3198 =
-                 let uu____3199 = str op in
-                 let uu____3200 = p_tmNoEq' left1 e1 in
-                 let uu____3201 = p_tmNoEq' right1 e2 in
-                 infix0 uu____3199 uu____3200 uu____3201 in
-               paren_if curr mine uu____3198)
-      | FStar_Parser_AST.Op ("-",e1::[]) ->
-          let uu____3204 = levels "-" in
-          (match uu____3204 with
-           | (left1,mine,right1) ->
-               let uu____3211 = p_tmNoEq' mine e1 in
-               FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____3211)
-      | FStar_Parser_AST.NamedTyp (lid,e1) ->
-          let uu____3214 =
-            let uu____3215 = p_lidentOrUnderscore lid in
-            let uu____3216 =
-              let uu____3217 = p_appTerm e1 in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____3217 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____3215 uu____3216 in
-          FStar_Pprint.group uu____3214
-      | FStar_Parser_AST.Refine (b,phi) -> p_refinedBinder b phi
-      | FStar_Parser_AST.Record (with_opt,record_fields) ->
-          let uu____3230 =
-            let uu____3231 =
-              default_or_map FStar_Pprint.empty p_with_clause with_opt in
-            let uu____3232 =
-              let uu____3233 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-              FStar_Pprint.separate_map uu____3233 p_simpleDef record_fields in
-            FStar_Pprint.op_Hat_Hat uu____3231 uu____3232 in
-          braces_with_nesting uu____3230
-      | FStar_Parser_AST.Op ("~",e1::[]) ->
-          let uu____3238 =
-            let uu____3239 = str "~" in
-            let uu____3240 = p_atomicTerm e1 in
-            FStar_Pprint.op_Hat_Hat uu____3239 uu____3240 in
-          FStar_Pprint.group uu____3238
-      | uu____3241 -> p_appTerm e
-and p_with_clause: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3243 = p_appTerm e in
-    let uu____3244 =
-      let uu____3245 =
-        let uu____3246 = str "with" in
-        FStar_Pprint.op_Hat_Hat uu____3246 break1 in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3245 in
-    FStar_Pprint.op_Hat_Hat uu____3243 uu____3244
-and p_refinedBinder:
-  FStar_Parser_AST.binder -> FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun b  ->
-    fun phi  ->
-      match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Annotated (lid,t) ->
-          let uu____3251 =
-            let uu____3252 = p_lident lid in
-            p_refinement b.FStar_Parser_AST.aqual uu____3252 t phi in
-          soft_parens_with_nesting uu____3251
-      | FStar_Parser_AST.TAnnotated uu____3253 ->
-          failwith "Is this still used ?"
-      | FStar_Parser_AST.Variable _
-        |FStar_Parser_AST.TVariable _|FStar_Parser_AST.NoName _ ->
-          let uu____3259 =
-            let uu____3260 = FStar_Parser_AST.binder_to_string b in
-            FStar_Util.format1
-              "Imposible : a refined binder ought to be annotated %s"
-              uu____3260 in
-          failwith uu____3259
-and p_simpleDef:
-  (FStar_Ident.lid* FStar_Parser_AST.term) -> FStar_Pprint.document =
-  fun uu____3261  ->
-    match uu____3261 with
-    | (lid,e) ->
-        let uu____3266 =
-          let uu____3267 = p_qlident lid in
-          let uu____3268 =
-            let uu____3269 = p_tmIff e in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____3269 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3267 uu____3268 in
-        FStar_Pprint.group uu____3266
-and p_appTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3271 =
-      let uu____3272 = unparen e in uu____3272.FStar_Parser_AST.tm in
-    match uu____3271 with
-    | FStar_Parser_AST.App uu____3273 when is_general_application e ->
-        let uu____3277 = head_and_args e in
-        (match uu____3277 with
-         | (head1,args) ->
-             let uu____3291 =
-               let uu____3297 = FStar_ST.read should_print_fs_typ_app in
-               if uu____3297
-               then
-                 let uu____3305 =
-                   FStar_Util.take
-                     (fun uu____3316  ->
-                        match uu____3316 with
-                        | (uu____3319,aq) -> aq = FStar_Parser_AST.FsTypApp)
-                     args in
-                 match uu____3305 with
-                 | (fs_typ_args,args1) ->
-                     let uu____3340 =
-                       let uu____3341 = p_indexingTerm head1 in
-                       let uu____3342 =
-                         let uu____3343 =
-                           FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-                         soft_surround_separate_map (Prims.parse_int "2")
-                           (Prims.parse_int "0") FStar_Pprint.empty
-                           FStar_Pprint.langle uu____3343 FStar_Pprint.rangle
-                           p_fsTypArg fs_typ_args in
-                       FStar_Pprint.op_Hat_Hat uu____3341 uu____3342 in
-                     (uu____3340, args1)
-               else
-                 (let uu____3350 = p_indexingTerm head1 in (uu____3350, args)) in
-             (match uu____3291 with
-              | (head_doc,args1) ->
-                  let uu____3362 =
-                    let uu____3363 =
-                      FStar_Pprint.op_Hat_Hat head_doc FStar_Pprint.space in
-                    soft_surround_separate_map (Prims.parse_int "2")
-                      (Prims.parse_int "0") head_doc uu____3363 break1
-                      FStar_Pprint.empty p_argTerm args1 in
-                  FStar_Pprint.group uu____3362))
-    | FStar_Parser_AST.Construct (lid,args) when
-        (is_general_construction e) &&
-          (Prims.op_Negation (is_dtuple_constructor lid))
-        ->
-        (match args with
-         | [] -> p_quident lid
-         | arg::[] ->
-             let uu____3383 =
-               let uu____3384 = p_quident lid in
-               let uu____3385 = p_argTerm arg in
-               FStar_Pprint.op_Hat_Slash_Hat uu____3384 uu____3385 in
-             FStar_Pprint.group uu____3383
-         | hd1::tl1 ->
-             let uu____3395 =
-               let uu____3396 =
-                 let uu____3397 =
-                   let uu____3398 = p_quident lid in
-                   let uu____3399 = p_argTerm hd1 in
-                   prefix2 uu____3398 uu____3399 in
-                 FStar_Pprint.group uu____3397 in
-               let uu____3400 =
-                 let uu____3401 =
-                   FStar_Pprint.separate_map break1 p_argTerm tl1 in
-                 jump2 uu____3401 in
-               FStar_Pprint.op_Hat_Hat uu____3396 uu____3400 in
-             FStar_Pprint.group uu____3395)
-    | uu____3404 -> p_indexingTerm e
-and p_argTerm:
-  (FStar_Parser_AST.term* FStar_Parser_AST.imp) -> FStar_Pprint.document =
-  fun arg_imp  ->
-    match arg_imp with
-    | ({ FStar_Parser_AST.tm = FStar_Parser_AST.Uvar uu____3408;
-         FStar_Parser_AST.range = uu____3409;
-         FStar_Parser_AST.level = uu____3410;_},FStar_Parser_AST.UnivApp
-       ) -> p_univar (Prims.fst arg_imp)
-    | (u,FStar_Parser_AST.UnivApp ) -> p_universe u
-    | (e,FStar_Parser_AST.FsTypApp ) ->
-        (FStar_Util.print_warning
-           "Unexpected FsTypApp, output might not be formatted correctly.\n";
-         (let uu____3414 = p_indexingTerm e in
-          FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-            FStar_Pprint.langle uu____3414 FStar_Pprint.rangle))
-    | (e,FStar_Parser_AST.Hash ) ->
-        let uu____3416 = str "#" in
-        let uu____3417 = p_indexingTerm e in
-        FStar_Pprint.op_Hat_Hat uu____3416 uu____3417
-    | (e,FStar_Parser_AST.Nothing ) -> p_indexingTerm e
-and p_fsTypArg:
-  (FStar_Parser_AST.term* FStar_Parser_AST.imp) -> FStar_Pprint.document =
-  fun uu____3419  ->
-    match uu____3419 with | (e,uu____3423) -> p_indexingTerm e
-and p_indexingTerm_aux:
-  (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document
-  =
-  fun exit1  ->
-    fun e  ->
-      let uu____3428 =
-        let uu____3429 = unparen e in uu____3429.FStar_Parser_AST.tm in
-      match uu____3428 with
-      | FStar_Parser_AST.Op (".()",e1::e2::[]) ->
-          let uu____3433 =
-            let uu____3434 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
-            let uu____3435 =
-              let uu____3436 =
-                let uu____3437 = p_term e2 in
-                soft_parens_with_nesting uu____3437 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3436 in
-            FStar_Pprint.op_Hat_Hat uu____3434 uu____3435 in
-          FStar_Pprint.group uu____3433
-      | FStar_Parser_AST.Op (".[]",e1::e2::[]) ->
-          let uu____3441 =
-            let uu____3442 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
-            let uu____3443 =
-              let uu____3444 =
-                let uu____3445 = p_term e2 in
-                soft_brackets_with_nesting uu____3445 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3444 in
-            FStar_Pprint.op_Hat_Hat uu____3442 uu____3443 in
-          FStar_Pprint.group uu____3441
-      | uu____3446 -> exit1 e
-and p_indexingTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  -> p_indexingTerm_aux p_atomicTerm e
-and p_atomicTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3449 =
-      let uu____3450 = unparen e in uu____3450.FStar_Parser_AST.tm in
-    match uu____3449 with
-    | FStar_Parser_AST.LetOpen (lid,e1) ->
-        let uu____3453 = p_quident lid in
-        let uu____3454 =
-          let uu____3455 =
-            let uu____3456 = p_term e1 in soft_parens_with_nesting uu____3456 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3455 in
-        FStar_Pprint.op_Hat_Hat uu____3453 uu____3454
-    | FStar_Parser_AST.Name lid -> p_quident lid
-    | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____3461 = str op in
-        let uu____3462 = p_atomicTerm e1 in
-        FStar_Pprint.op_Hat_Hat uu____3461 uu____3462
-    | uu____3463 -> p_atomicTermNotQUident e
-and p_atomicTermNotQUident: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3465 =
-      let uu____3466 = unparen e in uu____3466.FStar_Parser_AST.tm in
-    match uu____3465 with
-    | FStar_Parser_AST.Wild  -> FStar_Pprint.underscore
-    | FStar_Parser_AST.Var lid when
-        FStar_Ident.lid_equals lid FStar_Syntax_Const.assert_lid ->
-        str "assert"
-    | FStar_Parser_AST.Tvar tv -> p_tvar tv
-    | FStar_Parser_AST.Const c -> p_constant c
-    | FStar_Parser_AST.Name lid when
-        FStar_Ident.lid_equals lid FStar_Syntax_Const.true_lid -> str "True"
-    | FStar_Parser_AST.Name lid when
-        FStar_Ident.lid_equals lid FStar_Syntax_Const.false_lid ->
-        str "False"
-    | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____3475 = str op in
-        let uu____3476 = p_atomicTermNotQUident e1 in
-        FStar_Pprint.op_Hat_Hat uu____3475 uu____3476
-    | FStar_Parser_AST.Op (op,[]) ->
-        let uu____3479 =
-          let uu____3480 =
-            let uu____3481 = str op in
-            let uu____3482 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
-            FStar_Pprint.op_Hat_Hat uu____3481 uu____3482 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3480 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3479
-    | FStar_Parser_AST.Construct (lid,args) when is_dtuple_constructor lid ->
-        let uu____3491 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
-        let uu____3492 =
-          let uu____3493 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          let uu____3494 = FStar_List.map Prims.fst args in
-          FStar_Pprint.separate_map uu____3493 p_tmEq uu____3494 in
-        let uu____3498 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-          uu____3491 uu____3492 uu____3498
-    | FStar_Parser_AST.Project (e1,lid) ->
-        let uu____3501 =
-          let uu____3502 = p_atomicTermNotQUident e1 in
-          let uu____3503 =
-            let uu____3504 = p_qlident lid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3504 in
-          FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "0")
-            uu____3502 uu____3503 in
-        FStar_Pprint.group uu____3501
-    | uu____3505 -> p_projectionLHS e
-and p_projectionLHS: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  ->
-    let uu____3507 =
-      let uu____3508 = unparen e in uu____3508.FStar_Parser_AST.tm in
-    match uu____3507 with
-    | FStar_Parser_AST.Var lid -> p_qlident lid
-    | FStar_Parser_AST.Projector (constr_lid,field_lid) ->
-        let uu____3512 = p_quident constr_lid in
-        let uu____3513 =
-          let uu____3514 =
-            let uu____3515 = p_lident field_lid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3515 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____3514 in
-        FStar_Pprint.op_Hat_Hat uu____3512 uu____3513
-    | FStar_Parser_AST.Discrim constr_lid ->
-        let uu____3517 = p_quident constr_lid in
-        FStar_Pprint.op_Hat_Hat uu____3517 FStar_Pprint.qmark
-    | FStar_Parser_AST.Paren e1 ->
-        let uu____3519 = p_term e1 in soft_parens_with_nesting uu____3519
-    | uu____3520 when is_array e ->
-        let es = extract_from_list e in
-        let uu____3523 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar in
-        let uu____3524 =
-          let uu____3525 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          separate_map_or_flow uu____3525 p_noSeqTerm es in
-        let uu____3526 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
-          uu____3523 uu____3524 uu____3526
-    | uu____3527 when is_list e ->
-        let uu____3528 =
-          let uu____3529 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          let uu____3530 = extract_from_list e in
-          separate_map_or_flow uu____3529 p_noSeqTerm uu____3530 in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
-          FStar_Pprint.lbracket uu____3528 FStar_Pprint.rbracket
-    | uu____3532 when is_lex_list e ->
-        let uu____3533 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket in
-        let uu____3534 =
-          let uu____3535 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          let uu____3536 = extract_from_list e in
-          separate_map_or_flow uu____3535 p_noSeqTerm uu____3536 in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-          uu____3533 uu____3534 FStar_Pprint.rbracket
-    | uu____3538 when is_ref_set e ->
-        let es = extract_from_ref_set e in
-        let uu____3541 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace in
-        let uu____3542 =
-          let uu____3543 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          separate_map_or_flow uu____3543 p_appTerm es in
-        FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
-          uu____3541 uu____3542 FStar_Pprint.rbrace
-    | FStar_Parser_AST.Wild 
-      |FStar_Parser_AST.Const _
-       |FStar_Parser_AST.Op _
-        |FStar_Parser_AST.Tvar _
-         |FStar_Parser_AST.Uvar _
-          |FStar_Parser_AST.Var _
-           |FStar_Parser_AST.Name _
-            |FStar_Parser_AST.Construct _
-             |FStar_Parser_AST.Abs _
-              |FStar_Parser_AST.App _
-               |FStar_Parser_AST.Let _
-                |FStar_Parser_AST.LetOpen _
-                 |FStar_Parser_AST.Seq _
-                  |FStar_Parser_AST.If _
-                   |FStar_Parser_AST.Match _
-                    |FStar_Parser_AST.TryWith _
-                     |FStar_Parser_AST.Ascribed _
-                      |FStar_Parser_AST.Record _
-                       |FStar_Parser_AST.Project _
-                        |FStar_Parser_AST.Product _
-                         |FStar_Parser_AST.Sum _
-                          |FStar_Parser_AST.QForall _
-                           |FStar_Parser_AST.QExists _
-                            |FStar_Parser_AST.Refine _
-                             |FStar_Parser_AST.NamedTyp _
-                              |FStar_Parser_AST.Requires _
-                               |FStar_Parser_AST.Ensures _
-                                |FStar_Parser_AST.Assign _
-                                 |FStar_Parser_AST.Attributes _
-        -> let uu____3572 = p_term e in soft_parens_with_nesting uu____3572
-    | FStar_Parser_AST.Labeled uu____3573 -> failwith "Not valid in universe"
-and p_constant: FStar_Const.sconst -> FStar_Pprint.document =
-  fun uu___141_3577  ->
-    match uu___141_3577 with
-    | FStar_Const.Const_effect  -> str "Effect"
-    | FStar_Const.Const_unit  -> str "()"
-    | FStar_Const.Const_bool b -> FStar_Pprint.doc_of_bool b
-    | FStar_Const.Const_float x -> str (FStar_Util.string_of_float x)
-    | FStar_Const.Const_char x ->
-        let uu____3581 = FStar_Pprint.doc_of_char x in
-        FStar_Pprint.squotes uu____3581
-    | FStar_Const.Const_string (bytes,uu____3583) ->
-        let uu____3586 = str (FStar_Util.string_of_bytes bytes) in
-        FStar_Pprint.dquotes uu____3586
-    | FStar_Const.Const_bytearray (bytes,uu____3588) ->
-        let uu____3591 =
-          let uu____3592 = str (FStar_Util.string_of_bytes bytes) in
-          FStar_Pprint.dquotes uu____3592 in
-        let uu____3593 = str "B" in
-        FStar_Pprint.op_Hat_Hat uu____3591 uu____3593
-    | FStar_Const.Const_int (repr,sign_width_opt) ->
-        let signedness uu___139_3605 =
-          match uu___139_3605 with
-          | FStar_Const.Unsigned  -> str "u"
-          | FStar_Const.Signed  -> FStar_Pprint.empty in
-        let width uu___140_3609 =
-          match uu___140_3609 with
-          | FStar_Const.Int8  -> str "y"
-          | FStar_Const.Int16  -> str "s"
-          | FStar_Const.Int32  -> str "l"
-          | FStar_Const.Int64  -> str "L" in
-        let ending =
-          default_or_map FStar_Pprint.empty
-            (fun uu____3613  ->
-               match uu____3613 with
-               | (s,w) ->
-                   let uu____3618 = signedness s in
-                   let uu____3619 = width w in
-                   FStar_Pprint.op_Hat_Hat uu____3618 uu____3619)
-            sign_width_opt in
-        let uu____3620 = str repr in
-        FStar_Pprint.op_Hat_Hat uu____3620 ending
-    | FStar_Const.Const_range r ->
-        let uu____3622 = FStar_Range.string_of_range r in str uu____3622
-    | FStar_Const.Const_reify  -> str "reify"
-    | FStar_Const.Const_reflect lid ->
-        let uu____3624 = p_quident lid in
-        let uu____3625 =
-          let uu____3626 =
-            let uu____3627 = str "reflect" in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3627 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____3626 in
-        FStar_Pprint.op_Hat_Hat uu____3624 uu____3625
-and p_universe: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun u  ->
-    let uu____3629 = str "u#" in
-    let uu____3630 = p_atomicUniverse u in
-    FStar_Pprint.op_Hat_Hat uu____3629 uu____3630
-and p_universeFrom: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun u  ->
-    let uu____3632 =
-      let uu____3633 = unparen u in uu____3633.FStar_Parser_AST.tm in
-    match uu____3632 with
-    | FStar_Parser_AST.Op ("+",u1::u2::[]) ->
-        let uu____3637 =
-          let uu____3638 = p_universeFrom u1 in
-          let uu____3639 =
-            let uu____3640 = p_universeFrom u2 in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____3640 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3638 uu____3639 in
-        FStar_Pprint.group uu____3637
-    | FStar_Parser_AST.App uu____3641 ->
-        let uu____3645 = head_and_args u in
-        (match uu____3645 with
-         | (head1,args) ->
-             let uu____3659 =
-               let uu____3660 = unparen head1 in
-               uu____3660.FStar_Parser_AST.tm in
-             (match uu____3659 with
-              | FStar_Parser_AST.Var maybe_max_lid when
-                  FStar_Ident.lid_equals maybe_max_lid
-                    FStar_Syntax_Const.max_lid
-                  ->
-                  let uu____3662 =
-                    let uu____3663 = p_qlident FStar_Syntax_Const.max_lid in
-                    let uu____3664 =
-                      FStar_Pprint.separate_map FStar_Pprint.space
-                        (fun uu____3667  ->
-                           match uu____3667 with
-                           | (u1,uu____3671) -> p_atomicUniverse u1) args in
-                    op_Hat_Slash_Plus_Hat uu____3663 uu____3664 in
-                  FStar_Pprint.group uu____3662
-              | uu____3672 ->
-                  let uu____3673 =
-                    let uu____3674 = FStar_Parser_AST.term_to_string u in
-                    FStar_Util.format1 "Invalid term in universe context %s"
-                      uu____3674 in
-                  failwith uu____3673))
-    | uu____3675 -> p_atomicUniverse u
-and p_atomicUniverse: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun u  ->
-    let uu____3677 =
-      let uu____3678 = unparen u in uu____3678.FStar_Parser_AST.tm in
-    match uu____3677 with
-    | FStar_Parser_AST.Wild  -> FStar_Pprint.underscore
-    | FStar_Parser_AST.Const (FStar_Const.Const_int (r,sw)) ->
-        p_constant (FStar_Const.Const_int (r, sw))
-    | FStar_Parser_AST.Uvar uu____3690 -> p_univar u
-    | FStar_Parser_AST.Paren u1 ->
-        let uu____3692 = p_universeFrom u1 in
-        soft_parens_with_nesting uu____3692
-    | FStar_Parser_AST.Op ("+",_::_::[])|FStar_Parser_AST.App _ ->
-        let uu____3697 = p_universeFrom u in
-        soft_parens_with_nesting uu____3697
-    | uu____3698 ->
-        let uu____3699 =
-          let uu____3700 = FStar_Parser_AST.term_to_string u in
-          FStar_Util.format1 "Invalid term in universe context %s" uu____3700 in
-        failwith uu____3699
-and p_univar: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun u  ->
-    let uu____3702 =
-      let uu____3703 = unparen u in uu____3703.FStar_Parser_AST.tm in
-    match uu____3702 with
-    | FStar_Parser_AST.Uvar id -> str (FStar_Ident.text_of_id id)
-    | uu____3705 ->
-        let uu____3706 =
-          let uu____3707 = FStar_Parser_AST.term_to_string u in
-          FStar_Util.format1 "Not a universe variable %s" uu____3707 in
-        failwith uu____3706
-let term_to_document: FStar_Parser_AST.term -> FStar_Pprint.document =
-  fun e  -> p_term e
-let decl_to_document: FStar_Parser_AST.decl -> FStar_Pprint.document =
-  fun e  -> p_decl e
-let modul_to_document: FStar_Parser_AST.modul -> FStar_Pprint.document =
-  fun m  ->
-    FStar_ST.write should_print_fs_typ_app false;
-    (let res =
-       match m with
-       | FStar_Parser_AST.Module (_,decls)|FStar_Parser_AST.Interface
-         (_,decls,_) ->
-           let uu____3729 =
-             FStar_All.pipe_right decls (FStar_List.map decl_to_document) in
-           FStar_All.pipe_right uu____3729
-             (FStar_Pprint.separate FStar_Pprint.hardline) in
-     FStar_ST.write should_print_fs_typ_app false; res)
-let comments_to_document:
-  (Prims.string* FStar_Range.range) Prims.list -> FStar_Pprint.document =
-  fun comments  ->
-    FStar_Pprint.separate_map FStar_Pprint.hardline
-      (fun uu____3748  ->
-         match uu____3748 with | (comment,range) -> str comment) comments
-let modul_with_comments_to_document:
-  FStar_Parser_AST.modul ->
-    (Prims.string* FStar_Range.range) Prims.list ->
-      (FStar_Pprint.document* (Prims.string* FStar_Range.range) Prims.list)
-  =
-  fun m  ->
-    fun comments  ->
-      let decls =
-        match m with
-        | FStar_Parser_AST.Module (_,decls)|FStar_Parser_AST.Interface
-          (_,decls,_) -> decls in
-      FStar_ST.write should_print_fs_typ_app false;
-      (match decls with
-       | [] -> (FStar_Pprint.empty, comments)
-       | d::ds ->
-           let uu____3795 =
-             match ds with
-             | {
-                 FStar_Parser_AST.d = FStar_Parser_AST.Pragma
-                   (FStar_Parser_AST.LightOff );
-                 FStar_Parser_AST.drange = uu____3802;
-                 FStar_Parser_AST.doc = uu____3803;
-                 FStar_Parser_AST.quals = uu____3804;
-                 FStar_Parser_AST.attrs = uu____3805;_}::uu____3806 ->
-                 let d0 = FStar_List.hd ds in
-                 let uu____3810 =
-                   let uu____3812 =
-                     let uu____3814 = FStar_List.tl ds in d :: uu____3814 in
-                   d0 :: uu____3812 in
-                 (uu____3810, (d0.FStar_Parser_AST.drange))
-             | uu____3817 -> ((d :: ds), (d.FStar_Parser_AST.drange)) in
-           (match uu____3795 with
-            | (decls1,first_range) ->
-                let extract_decl_range d1 = d1.FStar_Parser_AST.drange in
-                (FStar_ST.write comment_stack comments;
-                 (let initial_comment =
-                    let uu____3840 = FStar_Range.start_of_range first_range in
-                    place_comments_until_pos (Prims.parse_int "0")
-                      (Prims.parse_int "1") uu____3840 FStar_Pprint.empty in
-                  let doc1 =
-                    separate_map_with_comments FStar_Pprint.empty
-                      FStar_Pprint.empty decl_to_document decls1
-                      extract_decl_range in
-                  let comments1 = FStar_ST.read comment_stack in
-                  FStar_ST.write comment_stack [];
-                  FStar_ST.write should_print_fs_typ_app false;
-                  (let uu____3862 =
-                     FStar_Pprint.op_Hat_Hat initial_comment doc1 in
-                   (uu____3862, comments1))))))
+| Left
+| Right
+| NonAssoc
+
+
+let uu___is_Left : associativity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Left -> begin
+true
+end
+| uu____559 -> begin
+false
+end))
+
+
+let uu___is_Right : associativity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Right -> begin
+true
+end
+| uu____563 -> begin
+false
+end))
+
+
+let uu___is_NonAssoc : associativity  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NonAssoc -> begin
+true
+end
+| uu____567 -> begin
+false
+end))
+
+
+type token =
+(FStar_Char.char, Prims.string) FStar_Util.either
+
+
+type associativity_level =
+(associativity * token Prims.list)
+
+
+let token_to_string : (FStar_BaseTypes.char, Prims.string) FStar_Util.either  ->  Prims.string = (fun uu___128_577 -> (match (uu___128_577) with
+| FStar_Util.Inl (c) -> begin
+(Prims.strcat (FStar_Util.string_of_char c) ".*")
+end
+| FStar_Util.Inr (s) -> begin
+s
+end))
+
+
+let matches_token : Prims.string  ->  (FStar_Char.char, Prims.string) FStar_Util.either  ->  Prims.bool = (fun s uu___129_589 -> (match (uu___129_589) with
+| FStar_Util.Inl (c) -> begin
+(
+
+let uu____593 = (FStar_String.get s (Prims.parse_int "0"))
+in (uu____593 = c))
+end
+| FStar_Util.Inr (s') -> begin
+(s = s')
+end))
+
+
+let matches_level = (fun s uu____611 -> (match (uu____611) with
+| (assoc_levels, tokens) -> begin
+(
+
+let uu____625 = (FStar_List.tryFind (matches_token s) tokens)
+in (uu____625 <> None))
+end))
+
+
+let opinfix4 = (fun uu____643 -> ((Right), ((FStar_Util.Inr ("**"))::[])))
+
+
+let opinfix3 = (fun uu____658 -> ((Left), ((FStar_Util.Inl ('*'))::(FStar_Util.Inl ('/'))::(FStar_Util.Inl ('%'))::[])))
+
+
+let opinfix2 = (fun uu____677 -> ((Left), ((FStar_Util.Inl ('+'))::(FStar_Util.Inl ('-'))::[])))
+
+
+let minus_lvl = (fun uu____694 -> ((Left), ((FStar_Util.Inr ("-"))::[])))
+
+
+let opinfix1 = (fun uu____709 -> ((Right), ((FStar_Util.Inl ('@'))::(FStar_Util.Inl ('^'))::[])))
+
+
+let pipe_right = (fun uu____726 -> ((Left), ((FStar_Util.Inr ("|>"))::[])))
+
+
+let opinfix0d = (fun uu____741 -> ((Left), ((FStar_Util.Inl ('$'))::[])))
+
+
+let opinfix0c = (fun uu____756 -> ((Left), ((FStar_Util.Inl ('='))::(FStar_Util.Inl ('<'))::(FStar_Util.Inl ('>'))::[])))
+
+
+let equal = (fun uu____775 -> ((Left), ((FStar_Util.Inr ("="))::[])))
+
+
+let opinfix0b = (fun uu____790 -> ((Left), ((FStar_Util.Inl ('&'))::[])))
+
+
+let opinfix0a = (fun uu____805 -> ((Left), ((FStar_Util.Inl ('|'))::[])))
+
+
+let colon_equals = (fun uu____820 -> ((NonAssoc), ((FStar_Util.Inr (":="))::[])))
+
+
+let amp = (fun uu____835 -> ((Right), ((FStar_Util.Inr ("&"))::[])))
+
+
+let colon_colon = (fun uu____850 -> ((Right), ((FStar_Util.Inr ("::"))::[])))
+
+
+let level_associativity_spec : (associativity * (FStar_Char.char, Prims.string) FStar_Util.either Prims.list) Prims.list = ((opinfix4 ()))::((opinfix3 ()))::((opinfix2 ()))::((opinfix1 ()))::((pipe_right ()))::((opinfix0d ()))::((opinfix0c ()))::((opinfix0b ()))::((opinfix0a ()))::((colon_equals ()))::((amp ()))::((colon_colon ()))::[]
+
+
+let level_table : ((Prims.int * Prims.int * Prims.int) * (FStar_Char.char, Prims.string) FStar_Util.either Prims.list) Prims.list = (
+
+let levels_from_associativity = (fun l uu___130_947 -> (match (uu___130_947) with
+| Left -> begin
+((l), (l), ((l - (Prims.parse_int "1"))))
+end
+| Right -> begin
+(((l - (Prims.parse_int "1"))), (l), (l))
+end
+| NonAssoc -> begin
+((l), (l), (l))
+end))
+in (FStar_List.mapi (fun i uu____965 -> (match (uu____965) with
+| (assoc1, tokens) -> begin
+(((levels_from_associativity i assoc1)), (tokens))
+end)) level_associativity_spec))
+
+
+let assign_levels : associativity_level Prims.list  ->  Prims.string  ->  (Prims.int * Prims.int * Prims.int) = (fun token_associativity_spec s -> (
+
+let uu____1007 = (FStar_List.tryFind (matches_level s) level_table)
+in (match (uu____1007) with
+| Some (assoc_levels, uu____1032) -> begin
+assoc_levels
+end
+| uu____1053 -> begin
+(failwith (Prims.strcat "Unrecognized operator " s))
+end)))
+
+
+let max : Prims.int  ->  Prims.int  ->  Prims.int = (fun k1 k2 -> (match ((k1 > k2)) with
+| true -> begin
+k1
+end
+| uu____1072 -> begin
+k2
+end))
+
+
+let max_level = (fun l -> (
+
+let find_level_and_max = (fun n1 level -> (
+
+let uu____1109 = (FStar_List.tryFind (fun uu____1127 -> (match (uu____1127) with
+| (uu____1136, tokens) -> begin
+(tokens = (Prims.snd level))
+end)) level_table)
+in (match (uu____1109) with
+| Some ((uu____1156, l1, uu____1158), uu____1159) -> begin
+(max n1 l1)
+end
+| None -> begin
+(
+
+let uu____1185 = (
+
+let uu____1186 = (
+
+let uu____1187 = (FStar_List.map token_to_string (Prims.snd level))
+in (FStar_String.concat "," uu____1187))
+in (FStar_Util.format1 "Undefined associativity level %s" uu____1186))
+in (failwith uu____1185))
+end)))
+in (FStar_List.fold_left find_level_and_max (Prims.parse_int "0") l)))
+
+
+let levels : Prims.string  ->  (Prims.int * Prims.int * Prims.int) = (assign_levels level_associativity_spec)
+
+
+let operatorInfix0ad12 = (fun uu____1212 -> ((opinfix0a ()))::((opinfix0b ()))::((opinfix0c ()))::((opinfix0d ()))::((opinfix1 ()))::((opinfix2 ()))::[])
+
+
+let is_operatorInfix0ad12 : Prims.string  ->  Prims.bool = (fun op -> (
+
+let uu____1251 = (FStar_List.tryFind (matches_level op) (operatorInfix0ad12 ()))
+in (uu____1251 <> None)))
+
+
+let is_operatorInfix34 : Prims.string  ->  Prims.bool = (
+
+let opinfix34 = ((opinfix3 ()))::((opinfix4 ()))::[]
+in (fun op -> (
+
+let uu____1299 = (FStar_List.tryFind (matches_level op) opinfix34)
+in (uu____1299 <> None))))
+
+
+let comment_stack : (Prims.string * FStar_Range.range) Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let with_comment = (fun printer tm tmrange -> (
+
+let rec comments_before_pos = (fun acc print_pos lookahead_pos -> (
+
+let uu____1367 = (FStar_ST.read comment_stack)
+in (match (uu____1367) with
+| [] -> begin
+((acc), (false))
+end
+| ((comment, crange))::cs -> begin
+(
+
+let uu____1388 = (FStar_Range.range_before_pos crange print_pos)
+in (match (uu____1388) with
+| true -> begin
+((FStar_ST.write comment_stack cs);
+(
+
+let uu____1397 = (
+
+let uu____1398 = (
+
+let uu____1399 = (str comment)
+in (FStar_Pprint.op_Hat_Hat uu____1399 FStar_Pprint.hardline))
+in (FStar_Pprint.op_Hat_Hat acc uu____1398))
+in (comments_before_pos uu____1397 print_pos lookahead_pos));
+)
+end
+| uu____1400 -> begin
+(
+
+let uu____1401 = (FStar_Range.range_before_pos crange lookahead_pos)
+in ((acc), (uu____1401)))
+end))
+end)))
+in (
+
+let uu____1402 = (
+
+let uu____1405 = (
+
+let uu____1406 = (FStar_Range.start_of_range tmrange)
+in (FStar_Range.end_of_line uu____1406))
+in (
+
+let uu____1407 = (FStar_Range.end_of_range tmrange)
+in (comments_before_pos FStar_Pprint.empty uu____1405 uu____1407)))
+in (match (uu____1402) with
+| (comments, has_lookahead) -> begin
+(
+
+let printed_e = (printer tm)
+in (
+
+let comments1 = (match (has_lookahead) with
+| true -> begin
+(
+
+let pos = (FStar_Range.end_of_range tmrange)
+in (
+
+let uu____1413 = (comments_before_pos comments pos pos)
+in (Prims.fst uu____1413)))
+end
+| uu____1416 -> begin
+comments
+end)
+in (
+
+let uu____1417 = (FStar_Pprint.op_Hat_Hat comments1 printed_e)
+in (FStar_Pprint.group uu____1417))))
+end))))
+
+
+let rec place_comments_until_pos : Prims.int  ->  Prims.int  ->  FStar_Range.pos  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (fun k lbegin pos_end doc1 -> (
+
+let uu____1430 = (FStar_ST.read comment_stack)
+in (match (uu____1430) with
+| ((comment, crange))::cs when (FStar_Range.range_before_pos crange pos_end) -> begin
+((FStar_ST.write comment_stack cs);
+(
+
+let lnum = (
+
+let uu____1454 = (
+
+let uu____1455 = (
+
+let uu____1456 = (FStar_Range.start_of_range crange)
+in (FStar_Range.line_of_pos uu____1456))
+in (uu____1455 - lbegin))
+in (max k uu____1454))
+in (
+
+let doc2 = (
+
+let uu____1458 = (
+
+let uu____1459 = (FStar_Pprint.repeat lnum FStar_Pprint.hardline)
+in (
+
+let uu____1460 = (str comment)
+in (FStar_Pprint.op_Hat_Hat uu____1459 uu____1460)))
+in (FStar_Pprint.op_Hat_Hat doc1 uu____1458))
+in (
+
+let uu____1461 = (
+
+let uu____1462 = (FStar_Range.end_of_range crange)
+in (FStar_Range.line_of_pos uu____1462))
+in (place_comments_until_pos (Prims.parse_int "1") uu____1461 pos_end doc2))));
+)
+end
+| uu____1463 -> begin
+(
+
+let lnum = (
+
+let uu____1468 = (
+
+let uu____1469 = (FStar_Range.line_of_pos pos_end)
+in (uu____1469 - lbegin))
+in (max (Prims.parse_int "1") uu____1468))
+in (
+
+let uu____1470 = (FStar_Pprint.repeat lnum FStar_Pprint.hardline)
+in (FStar_Pprint.op_Hat_Hat doc1 uu____1470)))
+end)))
+
+
+let separate_map_with_comments = (fun prefix1 sep f xs extract_range -> (
+
+let fold_fun = (fun uu____1519 x -> (match (uu____1519) with
+| (last_line, doc1) -> begin
+(
+
+let r = (extract_range x)
+in (
+
+let doc2 = (
+
+let uu____1529 = (FStar_Range.start_of_range r)
+in (place_comments_until_pos (Prims.parse_int "1") last_line uu____1529 doc1))
+in (
+
+let uu____1530 = (
+
+let uu____1531 = (FStar_Range.end_of_range r)
+in (FStar_Range.line_of_pos uu____1531))
+in (
+
+let uu____1532 = (
+
+let uu____1533 = (
+
+let uu____1534 = (f x)
+in (FStar_Pprint.op_Hat_Hat sep uu____1534))
+in (FStar_Pprint.op_Hat_Hat doc2 uu____1533))
+in ((uu____1530), (uu____1532))))))
+end))
+in (
+
+let uu____1535 = (
+
+let uu____1539 = (FStar_List.hd xs)
+in (
+
+let uu____1540 = (FStar_List.tl xs)
+in ((uu____1539), (uu____1540))))
+in (match (uu____1535) with
+| (x, xs1) -> begin
+(
+
+let init1 = (
+
+let uu____1550 = (
+
+let uu____1551 = (
+
+let uu____1552 = (extract_range x)
+in (FStar_Range.end_of_range uu____1552))
+in (FStar_Range.line_of_pos uu____1551))
+in (
+
+let uu____1553 = (
+
+let uu____1554 = (f x)
+in (FStar_Pprint.op_Hat_Hat prefix1 uu____1554))
+in ((uu____1550), (uu____1553))))
+in (
+
+let uu____1555 = (FStar_List.fold_left fold_fun init1 xs1)
+in (Prims.snd uu____1555)))
+end))))
+
+
+let rec p_decl : FStar_Parser_AST.decl  ->  FStar_Pprint.document = (fun d -> (
+
+let uu____1801 = (
+
+let uu____1802 = (FStar_Pprint.optional p_fsdoc d.FStar_Parser_AST.doc)
+in (
+
+let uu____1803 = (
+
+let uu____1804 = (p_attributes d.FStar_Parser_AST.attrs)
+in (
+
+let uu____1805 = (
+
+let uu____1806 = (p_qualifiers d.FStar_Parser_AST.quals)
+in (
+
+let uu____1807 = (
+
+let uu____1808 = (p_rawDecl d)
+in (FStar_Pprint.op_Hat_Hat (match ((d.FStar_Parser_AST.quals = [])) with
+| true -> begin
+FStar_Pprint.empty
+end
+| uu____1809 -> begin
+break1
+end) uu____1808))
+in (FStar_Pprint.op_Hat_Hat uu____1806 uu____1807)))
+in (FStar_Pprint.op_Hat_Hat uu____1804 uu____1805)))
+in (FStar_Pprint.op_Hat_Hat uu____1802 uu____1803)))
+in (FStar_Pprint.group uu____1801)))
+and p_attributes : FStar_Parser_AST.attributes_  ->  FStar_Pprint.document = (fun attrs -> (
+
+let uu____1811 = (
+
+let uu____1812 = (str "@")
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____1812))
+in (
+
+let uu____1813 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.rbracket FStar_Pprint.hardline)
+in (soft_surround_separate_map (Prims.parse_int "0") (Prims.parse_int "2") FStar_Pprint.empty uu____1811 FStar_Pprint.space uu____1813 p_atomicTerm attrs))))
+and p_fsdoc : FStar_Syntax_Syntax.fsdoc  ->  FStar_Pprint.document = (fun uu____1814 -> (match (uu____1814) with
+| (doc1, kwd_args) -> begin
+(
+
+let kwd_args_doc = (match (kwd_args) with
+| [] -> begin
+FStar_Pprint.empty
+end
+| kwd_args1 -> begin
+(
+
+let process_kwd_arg = (fun uu____1835 -> (match (uu____1835) with
+| (kwd1, arg) -> begin
+(
+
+let uu____1840 = (str "@")
+in (
+
+let uu____1841 = (
+
+let uu____1842 = (str kwd1)
+in (
+
+let uu____1843 = (
+
+let uu____1844 = (str arg)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1844))
+in (FStar_Pprint.op_Hat_Hat uu____1842 uu____1843)))
+in (FStar_Pprint.op_Hat_Hat uu____1840 uu____1841)))
+end))
+in (
+
+let uu____1845 = (
+
+let uu____1846 = (FStar_Pprint.separate_map FStar_Pprint.hardline process_kwd_arg kwd_args1)
+in (FStar_Pprint.op_Hat_Hat uu____1846 FStar_Pprint.hardline))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____1845)))
+end)
+in (
+
+let uu____1849 = (
+
+let uu____1850 = (
+
+let uu____1851 = (
+
+let uu____1852 = (
+
+let uu____1853 = (str doc1)
+in (
+
+let uu____1854 = (
+
+let uu____1855 = (
+
+let uu____1856 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen FStar_Pprint.hardline)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1856))
+in (FStar_Pprint.op_Hat_Hat kwd_args_doc uu____1855))
+in (FStar_Pprint.op_Hat_Hat uu____1853 uu____1854)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1852))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____1851))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____1850))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____1849)))
+end))
+and p_rawDecl : FStar_Parser_AST.decl  ->  FStar_Pprint.document = (fun d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Open (uid) -> begin
+(
+
+let uu____1859 = (
+
+let uu____1860 = (str "open")
+in (
+
+let uu____1861 = (p_quident uid)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____1860 uu____1861)))
+in (FStar_Pprint.group uu____1859))
+end
+| FStar_Parser_AST.Include (uid) -> begin
+(
+
+let uu____1863 = (
+
+let uu____1864 = (str "include")
+in (
+
+let uu____1865 = (p_quident uid)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____1864 uu____1865)))
+in (FStar_Pprint.group uu____1863))
+end
+| FStar_Parser_AST.ModuleAbbrev (uid1, uid2) -> begin
+(
+
+let uu____1868 = (
+
+let uu____1869 = (str "module")
+in (
+
+let uu____1870 = (
+
+let uu____1871 = (
+
+let uu____1872 = (p_uident uid1)
+in (
+
+let uu____1873 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals)
+in (FStar_Pprint.op_Hat_Hat uu____1872 uu____1873)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1871))
+in (FStar_Pprint.op_Hat_Hat uu____1869 uu____1870)))
+in (
+
+let uu____1874 = (p_quident uid2)
+in (op_Hat_Slash_Plus_Hat uu____1868 uu____1874)))
+end
+| FStar_Parser_AST.TopLevelModule (uid) -> begin
+(
+
+let uu____1876 = (
+
+let uu____1877 = (str "module")
+in (
+
+let uu____1878 = (
+
+let uu____1879 = (p_quident uid)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1879))
+in (FStar_Pprint.op_Hat_Hat uu____1877 uu____1878)))
+in (FStar_Pprint.group uu____1876))
+end
+| FStar_Parser_AST.Tycon (true, ((FStar_Parser_AST.TyconAbbrev (uid, tpars, None, t), None))::[]) -> begin
+(
+
+let effect_prefix_doc = (
+
+let uu____1898 = (str "effect")
+in (
+
+let uu____1899 = (
+
+let uu____1900 = (p_uident uid)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1900))
+in (FStar_Pprint.op_Hat_Hat uu____1898 uu____1899)))
+in (
+
+let uu____1901 = (
+
+let uu____1902 = (p_typars tpars)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") effect_prefix_doc uu____1902 FStar_Pprint.equals))
+in (
+
+let uu____1903 = (p_typ t)
+in (op_Hat_Slash_Plus_Hat uu____1901 uu____1903))))
+end
+| FStar_Parser_AST.Tycon (false, tcdefs) -> begin
+(
+
+let uu____1913 = (str "type")
+in (
+
+let uu____1914 = (str "and")
+in (precede_break_separate_map uu____1913 uu____1914 p_fsdocTypeDeclPairs tcdefs)))
+end
+| FStar_Parser_AST.TopLevelLet (q, lbs) -> begin
+(
+
+let let_doc = (
+
+let uu____1927 = (str "let")
+in (
+
+let uu____1928 = (
+
+let uu____1929 = (p_letqualifier q)
+in (FStar_Pprint.op_Hat_Hat uu____1929 FStar_Pprint.space))
+in (FStar_Pprint.op_Hat_Hat uu____1927 uu____1928)))
+in (
+
+let uu____1930 = (
+
+let uu____1931 = (str "and")
+in (FStar_Pprint.op_Hat_Hat uu____1931 FStar_Pprint.space))
+in (separate_map_with_comments let_doc uu____1930 p_letbinding lbs (fun uu____1934 -> (match (uu____1934) with
+| (p, t) -> begin
+(FStar_Range.union_ranges p.FStar_Parser_AST.prange t.FStar_Parser_AST.range)
+end)))))
+end
+| FStar_Parser_AST.Val (lid, t) -> begin
+(
+
+let uu____1941 = (
+
+let uu____1942 = (str "val")
+in (
+
+let uu____1943 = (
+
+let uu____1944 = (
+
+let uu____1945 = (p_lident lid)
+in (
+
+let uu____1946 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon)
+in (FStar_Pprint.op_Hat_Hat uu____1945 uu____1946)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1944))
+in (FStar_Pprint.op_Hat_Hat uu____1942 uu____1943)))
+in (
+
+let uu____1947 = (p_typ t)
+in (op_Hat_Slash_Plus_Hat uu____1941 uu____1947)))
+end
+| FStar_Parser_AST.Assume (id, t) -> begin
+(
+
+let decl_keyword = (
+
+let uu____1951 = (
+
+let uu____1952 = (FStar_Util.char_at id.FStar_Ident.idText (Prims.parse_int "0"))
+in (FStar_All.pipe_right uu____1952 FStar_Util.is_upper))
+in (match (uu____1951) with
+| true -> begin
+FStar_Pprint.empty
+end
+| uu____1953 -> begin
+(
+
+let uu____1954 = (str "val")
+in (FStar_Pprint.op_Hat_Hat uu____1954 FStar_Pprint.space))
+end))
+in (
+
+let uu____1955 = (
+
+let uu____1956 = (
+
+let uu____1957 = (p_ident id)
+in (
+
+let uu____1958 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon)
+in (FStar_Pprint.op_Hat_Hat uu____1957 uu____1958)))
+in (FStar_Pprint.op_Hat_Hat decl_keyword uu____1956))
+in (
+
+let uu____1959 = (p_typ t)
+in (op_Hat_Slash_Plus_Hat uu____1955 uu____1959))))
+end
+| FStar_Parser_AST.Exception (uid, t_opt) -> begin
+(
+
+let uu____1964 = (str "exception")
+in (
+
+let uu____1965 = (
+
+let uu____1966 = (
+
+let uu____1967 = (p_uident uid)
+in (
+
+let uu____1968 = (FStar_Pprint.optional (fun t -> (
+
+let uu____1970 = (str "of")
+in (
+
+let uu____1971 = (p_typ t)
+in (op_Hat_Slash_Plus_Hat uu____1970 uu____1971)))) t_opt)
+in (FStar_Pprint.op_Hat_Hat uu____1967 uu____1968)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1966))
+in (FStar_Pprint.op_Hat_Hat uu____1964 uu____1965)))
+end
+| FStar_Parser_AST.NewEffect (ne) -> begin
+(
+
+let uu____1973 = (str "new_effect")
+in (
+
+let uu____1974 = (
+
+let uu____1975 = (p_newEffect ne)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1975))
+in (FStar_Pprint.op_Hat_Hat uu____1973 uu____1974)))
+end
+| FStar_Parser_AST.SubEffect (se) -> begin
+(
+
+let uu____1977 = (str "sub_effect")
+in (
+
+let uu____1978 = (
+
+let uu____1979 = (p_subEffect se)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1979))
+in (FStar_Pprint.op_Hat_Hat uu____1977 uu____1978)))
+end
+| FStar_Parser_AST.Pragma (p) -> begin
+(p_pragma p)
+end
+| FStar_Parser_AST.Fsdoc (doc1) -> begin
+(
+
+let uu____1982 = (p_fsdoc doc1)
+in (FStar_Pprint.op_Hat_Hat uu____1982 FStar_Pprint.hardline))
+end
+| FStar_Parser_AST.Main (uu____1983) -> begin
+(failwith "*Main declaration* : Is that really still in use ??")
+end
+| FStar_Parser_AST.Tycon (true, uu____1984) -> begin
+(failwith "Effect abbreviation is expected to be defined by an abbreviation")
+end))
+and p_pragma : FStar_Parser_AST.pragma  ->  FStar_Pprint.document = (fun uu___131_1993 -> (match (uu___131_1993) with
+| FStar_Parser_AST.SetOptions (s) -> begin
+(
+
+let uu____1995 = (str "#set-options")
+in (
+
+let uu____1996 = (
+
+let uu____1997 = (
+
+let uu____1998 = (str s)
+in (FStar_Pprint.dquotes uu____1998))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____1997))
+in (FStar_Pprint.op_Hat_Hat uu____1995 uu____1996)))
+end
+| FStar_Parser_AST.ResetOptions (s_opt) -> begin
+(
+
+let uu____2001 = (str "#reset-options")
+in (
+
+let uu____2002 = (FStar_Pprint.optional (fun s -> (
+
+let uu____2004 = (
+
+let uu____2005 = (str s)
+in (FStar_Pprint.dquotes uu____2005))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2004))) s_opt)
+in (FStar_Pprint.op_Hat_Hat uu____2001 uu____2002)))
+end
+| FStar_Parser_AST.LightOff -> begin
+((FStar_ST.write should_print_fs_typ_app true);
+(str "#light \"off\"");
+)
+end))
+and p_typars : FStar_Parser_AST.binder Prims.list  ->  FStar_Pprint.document = (fun bs -> (p_binders true bs))
+and p_fsdocTypeDeclPairs : (FStar_Parser_AST.tycon * FStar_Syntax_Syntax.fsdoc Prims.option)  ->  FStar_Pprint.document = (fun uu____2011 -> (match (uu____2011) with
+| (typedecl, fsdoc_opt) -> begin
+(
+
+let uu____2019 = (FStar_Pprint.optional p_fsdoc fsdoc_opt)
+in (
+
+let uu____2020 = (p_typeDecl typedecl)
+in (FStar_Pprint.op_Hat_Hat uu____2019 uu____2020)))
+end))
+and p_typeDecl : FStar_Parser_AST.tycon  ->  FStar_Pprint.document = (fun uu___132_2021 -> (match (uu___132_2021) with
+| FStar_Parser_AST.TyconAbstract (lid, bs, typ_opt) -> begin
+(
+
+let empty' = (fun uu____2032 -> FStar_Pprint.empty)
+in (p_typeDeclPrefix lid bs typ_opt empty'))
+end
+| FStar_Parser_AST.TyconAbbrev (lid, bs, typ_opt, t) -> begin
+(
+
+let f = (fun uu____2044 -> (
+
+let uu____2045 = (p_typ t)
+in (prefix2 FStar_Pprint.equals uu____2045)))
+in (p_typeDeclPrefix lid bs typ_opt f))
+end
+| FStar_Parser_AST.TyconRecord (lid, bs, typ_opt, record_field_decls) -> begin
+(
+
+let p_recordFieldAndComments = (fun uu____2071 -> (match (uu____2071) with
+| (lid1, t, doc_opt) -> begin
+(
+
+let uu____2081 = (FStar_Range.extend_to_end_of_line t.FStar_Parser_AST.range)
+in (with_comment p_recordFieldDecl ((lid1), (t), (doc_opt)) uu____2081))
+end))
+in (
+
+let p_fields = (fun uu____2090 -> (
+
+let uu____2091 = (
+
+let uu____2092 = (
+
+let uu____2093 = (
+
+let uu____2094 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1)
+in (FStar_Pprint.separate_map uu____2094 p_recordFieldAndComments record_field_decls))
+in (braces_with_nesting uu____2093))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2092))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____2091)))
+in (p_typeDeclPrefix lid bs typ_opt p_fields)))
+end
+| FStar_Parser_AST.TyconVariant (lid, bs, typ_opt, ct_decls) -> begin
+(
+
+let p_constructorBranchAndComments = (fun uu____2130 -> (match (uu____2130) with
+| (uid, t_opt, doc_opt, use_of) -> begin
+(
+
+let range = (
+
+let uu____2146 = (
+
+let uu____2147 = (FStar_Util.map_opt t_opt (fun t -> t.FStar_Parser_AST.range))
+in (FStar_Util.dflt uid.FStar_Ident.idRange uu____2147))
+in (FStar_Range.extend_to_end_of_line uu____2146))
+in (
+
+let p_constructorBranch = (fun decl -> (
+
+let uu____2166 = (
+
+let uu____2167 = (
+
+let uu____2168 = (p_constructorDecl decl)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2168))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____2167))
+in (FStar_Pprint.group uu____2166)))
+in (with_comment p_constructorBranch ((uid), (t_opt), (doc_opt), (use_of)) range)))
+end))
+in (
+
+let datacon_doc = (fun uu____2180 -> (
+
+let uu____2181 = (FStar_Pprint.separate_map break1 p_constructorBranchAndComments ct_decls)
+in (FStar_Pprint.group uu____2181)))
+in (p_typeDeclPrefix lid bs typ_opt (fun uu____2188 -> (
+
+let uu____2189 = (datacon_doc ())
+in (prefix2 FStar_Pprint.equals uu____2189))))))
+end))
+and p_typeDeclPrefix : FStar_Ident.ident  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.knd Prims.option  ->  (Prims.unit  ->  FStar_Pprint.document)  ->  FStar_Pprint.document = (fun lid bs typ_opt cont -> (match (((bs = []) && (typ_opt = None))) with
+| true -> begin
+(
+
+let uu____2200 = (p_ident lid)
+in (
+
+let uu____2201 = (
+
+let uu____2202 = (cont ())
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2202))
+in (FStar_Pprint.op_Hat_Hat uu____2200 uu____2201)))
+end
+| uu____2203 -> begin
+(
+
+let binders_doc = (
+
+let uu____2205 = (p_typars bs)
+in (
+
+let uu____2206 = (FStar_Pprint.optional (fun t -> (
+
+let uu____2208 = (
+
+let uu____2209 = (
+
+let uu____2210 = (p_typ t)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2210))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2209))
+in (FStar_Pprint.op_Hat_Hat break1 uu____2208))) typ_opt)
+in (FStar_Pprint.op_Hat_Hat uu____2205 uu____2206)))
+in (
+
+let uu____2211 = (p_ident lid)
+in (
+
+let uu____2212 = (cont ())
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2211 binders_doc uu____2212))))
+end))
+and p_recordFieldDecl : (FStar_Ident.ident * FStar_Parser_AST.term * FStar_Syntax_Syntax.fsdoc Prims.option)  ->  FStar_Pprint.document = (fun uu____2213 -> (match (uu____2213) with
+| (lid, t, doc_opt) -> begin
+(
+
+let uu____2223 = (
+
+let uu____2224 = (FStar_Pprint.optional p_fsdoc doc_opt)
+in (
+
+let uu____2225 = (
+
+let uu____2226 = (p_lident lid)
+in (
+
+let uu____2227 = (
+
+let uu____2228 = (p_typ t)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2228))
+in (FStar_Pprint.op_Hat_Hat uu____2226 uu____2227)))
+in (FStar_Pprint.op_Hat_Hat uu____2224 uu____2225)))
+in (FStar_Pprint.group uu____2223))
+end))
+and p_constructorDecl : (FStar_Ident.ident * FStar_Parser_AST.term Prims.option * FStar_Syntax_Syntax.fsdoc Prims.option * Prims.bool)  ->  FStar_Pprint.document = (fun uu____2229 -> (match (uu____2229) with
+| (uid, t_opt, doc_opt, use_of) -> begin
+(
+
+let sep = (match (use_of) with
+| true -> begin
+(str "of")
+end
+| uu____2245 -> begin
+FStar_Pprint.colon
+end)
+in (
+
+let uid_doc = (p_uident uid)
+in (
+
+let uu____2247 = (FStar_Pprint.optional p_fsdoc doc_opt)
+in (
+
+let uu____2248 = (
+
+let uu____2249 = (FStar_Pprint.break_ (Prims.parse_int "0"))
+in (
+
+let uu____2250 = (default_or_map uid_doc (fun t -> (
+
+let uu____2252 = (
+
+let uu____2253 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space sep)
+in (FStar_Pprint.op_Hat_Hat uid_doc uu____2253))
+in (
+
+let uu____2254 = (p_typ t)
+in (op_Hat_Slash_Plus_Hat uu____2252 uu____2254)))) t_opt)
+in (FStar_Pprint.op_Hat_Hat uu____2249 uu____2250)))
+in (FStar_Pprint.op_Hat_Hat uu____2247 uu____2248)))))
+end))
+and p_letbinding : (FStar_Parser_AST.pattern * FStar_Parser_AST.term)  ->  FStar_Pprint.document = (fun uu____2255 -> (match (uu____2255) with
+| (pat, e) -> begin
+(
+
+let pat_doc = (
+
+let uu____2261 = (match (pat.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (pat1, t) -> begin
+(
+
+let uu____2268 = (
+
+let uu____2269 = (
+
+let uu____2270 = (
+
+let uu____2271 = (
+
+let uu____2272 = (p_tmArrow p_tmNoEq t)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2272))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2271))
+in (FStar_Pprint.group uu____2270))
+in (FStar_Pprint.op_Hat_Hat break1 uu____2269))
+in ((pat1), (uu____2268)))
+end
+| uu____2273 -> begin
+((pat), (FStar_Pprint.empty))
+end)
+in (match (uu____2261) with
+| (pat1, ascr_doc) -> begin
+(match (pat1.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, uu____2277); FStar_Parser_AST.prange = uu____2278}, pats) -> begin
+(
+
+let uu____2284 = (p_lident x)
+in (
+
+let uu____2285 = (
+
+let uu____2286 = (FStar_Pprint.separate_map break1 p_atomicPattern pats)
+in (FStar_Pprint.op_Hat_Hat uu____2286 ascr_doc))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2284 uu____2285 FStar_Pprint.equals)))
+end
+| uu____2287 -> begin
+(
+
+let uu____2288 = (
+
+let uu____2289 = (p_tuplePattern pat1)
+in (
+
+let uu____2290 = (FStar_Pprint.op_Hat_Slash_Hat ascr_doc FStar_Pprint.equals)
+in (FStar_Pprint.op_Hat_Hat uu____2289 uu____2290)))
+in (FStar_Pprint.group uu____2288))
+end)
+end))
+in (
+
+let uu____2291 = (p_term e)
+in (prefix2 pat_doc uu____2291)))
+end))
+and p_newEffect : FStar_Parser_AST.effect_decl  ->  FStar_Pprint.document = (fun uu___133_2292 -> (match (uu___133_2292) with
+| FStar_Parser_AST.RedefineEffect (lid, bs, t) -> begin
+(p_effectRedefinition lid bs t)
+end
+| FStar_Parser_AST.DefineEffect (lid, bs, t, eff_decls) -> begin
+(p_effectDefinition lid bs t eff_decls)
+end))
+and p_effectRedefinition : FStar_Ident.ident  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun uid bs t -> (
+
+let uu____2310 = (p_uident uid)
+in (
+
+let uu____2311 = (p_binders true bs)
+in (
+
+let uu____2312 = (
+
+let uu____2313 = (p_simpleTerm t)
+in (prefix2 FStar_Pprint.equals uu____2313))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2310 uu____2311 uu____2312)))))
+and p_effectDefinition : FStar_Ident.ident  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.term  ->  FStar_Parser_AST.decl Prims.list  ->  FStar_Pprint.document = (fun uid bs t eff_decls -> (
+
+let uu____2320 = (
+
+let uu____2321 = (
+
+let uu____2322 = (
+
+let uu____2323 = (p_uident uid)
+in (
+
+let uu____2324 = (p_binders true bs)
+in (
+
+let uu____2325 = (
+
+let uu____2326 = (p_typ t)
+in (prefix2 FStar_Pprint.colon uu____2326))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2323 uu____2324 uu____2325))))
+in (FStar_Pprint.group uu____2322))
+in (
+
+let uu____2327 = (
+
+let uu____2328 = (str "with")
+in (
+
+let uu____2329 = (separate_break_map FStar_Pprint.semi p_effectDecl eff_decls)
+in (prefix2 uu____2328 uu____2329)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2321 uu____2327)))
+in (braces_with_nesting uu____2320)))
+and p_effectDecl : FStar_Parser_AST.decl  ->  FStar_Pprint.document = (fun d -> (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Tycon (false, ((FStar_Parser_AST.TyconAbbrev (lid, [], None, e), None))::[]) -> begin
+(
+
+let uu____2346 = (
+
+let uu____2347 = (p_lident lid)
+in (
+
+let uu____2348 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals)
+in (FStar_Pprint.op_Hat_Hat uu____2347 uu____2348)))
+in (
+
+let uu____2349 = (p_simpleTerm e)
+in (prefix2 uu____2346 uu____2349)))
+end
+| uu____2350 -> begin
+(
+
+let uu____2351 = (
+
+let uu____2352 = (FStar_Parser_AST.decl_to_string d)
+in (FStar_Util.format1 "Not a declaration of an effect member... or at least I hope so : %s" uu____2352))
+in (failwith uu____2351))
+end))
+and p_subEffect : FStar_Parser_AST.lift  ->  FStar_Pprint.document = (fun lift -> (
+
+let lift_op_doc = (
+
+let lifts = (match (lift.FStar_Parser_AST.lift_op) with
+| FStar_Parser_AST.NonReifiableLift (t) -> begin
+((("lift_wp"), (t)))::[]
+end
+| FStar_Parser_AST.ReifiableLift (t1, t2) -> begin
+((("lif_wp"), (t1)))::((("lift"), (t2)))::[]
+end
+| FStar_Parser_AST.LiftForFree (t) -> begin
+((("lift"), (t)))::[]
+end)
+in (
+
+let p_lift = (fun uu____2385 -> (match (uu____2385) with
+| (kwd1, t) -> begin
+(
+
+let uu____2390 = (
+
+let uu____2391 = (str kwd1)
+in (
+
+let uu____2392 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals)
+in (FStar_Pprint.op_Hat_Hat uu____2391 uu____2392)))
+in (
+
+let uu____2393 = (p_simpleTerm t)
+in (prefix2 uu____2390 uu____2393)))
+end))
+in (separate_break_map FStar_Pprint.semi p_lift lifts)))
+in (
+
+let uu____2396 = (
+
+let uu____2397 = (
+
+let uu____2398 = (p_quident lift.FStar_Parser_AST.msource)
+in (
+
+let uu____2399 = (
+
+let uu____2400 = (str "~>")
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2400))
+in (FStar_Pprint.op_Hat_Hat uu____2398 uu____2399)))
+in (
+
+let uu____2401 = (p_quident lift.FStar_Parser_AST.mdest)
+in (prefix2 uu____2397 uu____2401)))
+in (
+
+let uu____2402 = (
+
+let uu____2403 = (braces_with_nesting lift_op_doc)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2403))
+in (FStar_Pprint.op_Hat_Hat uu____2396 uu____2402)))))
+and p_qualifier : FStar_Parser_AST.qualifier  ->  FStar_Pprint.document = (fun uu___134_2404 -> (match (uu___134_2404) with
+| FStar_Parser_AST.Private -> begin
+(str "private")
+end
+| FStar_Parser_AST.Abstract -> begin
+(str "abstract")
+end
+| FStar_Parser_AST.Noeq -> begin
+(str "noeq")
+end
+| FStar_Parser_AST.Unopteq -> begin
+(str "unopteq")
+end
+| FStar_Parser_AST.Assumption -> begin
+(str "assume")
+end
+| FStar_Parser_AST.DefaultEffect -> begin
+(str "default")
+end
+| FStar_Parser_AST.TotalEffect -> begin
+(str "total")
+end
+| FStar_Parser_AST.Effect_qual -> begin
+FStar_Pprint.empty
+end
+| FStar_Parser_AST.New -> begin
+(str "new")
+end
+| FStar_Parser_AST.Inline -> begin
+(str "inline")
+end
+| FStar_Parser_AST.Visible -> begin
+FStar_Pprint.empty
+end
+| FStar_Parser_AST.Unfold_for_unification_and_vcgen -> begin
+(str "unfold")
+end
+| FStar_Parser_AST.Inline_for_extraction -> begin
+(str "inline_for_extraction")
+end
+| FStar_Parser_AST.Irreducible -> begin
+(str "irreducible")
+end
+| FStar_Parser_AST.NoExtract -> begin
+(str "noextract")
+end
+| FStar_Parser_AST.Reifiable -> begin
+(str "reifiable")
+end
+| FStar_Parser_AST.Reflectable -> begin
+(str "reflectable")
+end
+| FStar_Parser_AST.Opaque -> begin
+(str "opaque")
+end
+| FStar_Parser_AST.Logic -> begin
+(str "logic")
+end))
+and p_qualifiers : FStar_Parser_AST.qualifiers  ->  FStar_Pprint.document = (fun qs -> (
+
+let uu____2406 = (FStar_Pprint.separate_map break1 p_qualifier qs)
+in (FStar_Pprint.group uu____2406)))
+and p_letqualifier : FStar_Parser_AST.let_qualifier  ->  FStar_Pprint.document = (fun uu___135_2407 -> (match (uu___135_2407) with
+| FStar_Parser_AST.Rec -> begin
+(
+
+let uu____2408 = (str "rec")
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2408))
+end
+| FStar_Parser_AST.Mutable -> begin
+(
+
+let uu____2409 = (str "mutable")
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2409))
+end
+| FStar_Parser_AST.NoLetQualifier -> begin
+FStar_Pprint.empty
+end))
+and p_aqual : FStar_Parser_AST.arg_qualifier  ->  FStar_Pprint.document = (fun uu___136_2410 -> (match (uu___136_2410) with
+| FStar_Parser_AST.Implicit -> begin
+(str "#")
+end
+| FStar_Parser_AST.Equality -> begin
+(str "$")
+end))
+and p_disjunctivePattern : FStar_Parser_AST.pattern  ->  FStar_Pprint.document = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatOr (pats) -> begin
+(
+
+let uu____2414 = (
+
+let uu____2415 = (
+
+let uu____2416 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space)
+in (FStar_Pprint.op_Hat_Hat break1 uu____2416))
+in (FStar_Pprint.separate_map uu____2415 p_tuplePattern pats))
+in (FStar_Pprint.group uu____2414))
+end
+| uu____2417 -> begin
+(p_tuplePattern p)
+end))
+and p_tuplePattern : FStar_Parser_AST.pattern  ->  FStar_Pprint.document = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatTuple (pats, false) -> begin
+(
+
+let uu____2422 = (
+
+let uu____2423 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1)
+in (FStar_Pprint.separate_map uu____2423 p_constructorPattern pats))
+in (FStar_Pprint.group uu____2422))
+end
+| uu____2424 -> begin
+(p_constructorPattern p)
+end))
+and p_constructorPattern : FStar_Parser_AST.pattern  ->  FStar_Pprint.document = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatName (maybe_cons_lid); FStar_Parser_AST.prange = uu____2427}, (hd1)::(tl1)::[]) when (FStar_Ident.lid_equals maybe_cons_lid FStar_Syntax_Const.cons_lid) -> begin
+(
+
+let uu____2431 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon)
+in (
+
+let uu____2432 = (p_constructorPattern hd1)
+in (
+
+let uu____2433 = (p_constructorPattern tl1)
+in (infix0 uu____2431 uu____2432 uu____2433))))
+end
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatName (uid); FStar_Parser_AST.prange = uu____2435}, pats) -> begin
+(
+
+let uu____2439 = (p_quident uid)
+in (
+
+let uu____2440 = (FStar_Pprint.separate_map break1 p_atomicPattern pats)
+in (prefix2 uu____2439 uu____2440)))
+end
+| uu____2441 -> begin
+(p_atomicPattern p)
+end))
+and p_atomicPattern : FStar_Parser_AST.pattern  ->  FStar_Pprint.document = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (pat, t) -> begin
+(
+
+let uu____2445 = (
+
+let uu____2448 = (
+
+let uu____2449 = (unparen t)
+in uu____2449.FStar_Parser_AST.tm)
+in ((pat.FStar_Parser_AST.pat), (uu____2448)))
+in (match (uu____2445) with
+| (FStar_Parser_AST.PatVar (lid, aqual), FStar_Parser_AST.Refine ({FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1); FStar_Parser_AST.brange = uu____2454; FStar_Parser_AST.blevel = uu____2455; FStar_Parser_AST.aqual = uu____2456}, phi)) when (lid.FStar_Ident.idText = lid'.FStar_Ident.idText) -> begin
+(
+
+let uu____2460 = (
+
+let uu____2461 = (p_ident lid)
+in (p_refinement aqual uu____2461 t1 phi))
+in (soft_parens_with_nesting uu____2460))
+end
+| (FStar_Parser_AST.PatWild, FStar_Parser_AST.Refine ({FStar_Parser_AST.b = FStar_Parser_AST.NoName (t1); FStar_Parser_AST.brange = uu____2463; FStar_Parser_AST.blevel = uu____2464; FStar_Parser_AST.aqual = uu____2465}, phi)) -> begin
+(
+
+let uu____2467 = (p_refinement None FStar_Pprint.underscore t1 phi)
+in (soft_parens_with_nesting uu____2467))
+end
+| uu____2468 -> begin
+(
+
+let uu____2471 = (
+
+let uu____2472 = (p_tuplePattern pat)
+in (
+
+let uu____2473 = (
+
+let uu____2474 = (FStar_Pprint.break_ (Prims.parse_int "0"))
+in (
+
+let uu____2475 = (
+
+let uu____2476 = (p_typ t)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2476))
+in (FStar_Pprint.op_Hat_Hat uu____2474 uu____2475)))
+in (FStar_Pprint.op_Hat_Hat uu____2472 uu____2473)))
+in (soft_parens_with_nesting uu____2471))
+end))
+end
+| FStar_Parser_AST.PatList (pats) -> begin
+(
+
+let uu____2479 = (separate_break_map FStar_Pprint.semi p_tuplePattern pats)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0") FStar_Pprint.lbracket uu____2479 FStar_Pprint.rbracket))
+end
+| FStar_Parser_AST.PatRecord (pats) -> begin
+(
+
+let p_recordFieldPat = (fun uu____2489 -> (match (uu____2489) with
+| (lid, pat) -> begin
+(
+
+let uu____2494 = (p_qlident lid)
+in (
+
+let uu____2495 = (p_tuplePattern pat)
+in (infix2 FStar_Pprint.equals uu____2494 uu____2495)))
+end))
+in (
+
+let uu____2496 = (separate_break_map FStar_Pprint.semi p_recordFieldPat pats)
+in (soft_braces_with_nesting uu____2496)))
+end
+| FStar_Parser_AST.PatTuple (pats, true) -> begin
+(
+
+let uu____2502 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar)
+in (
+
+let uu____2503 = (separate_break_map FStar_Pprint.comma p_constructorPattern pats)
+in (
+
+let uu____2504 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2502 uu____2503 uu____2504))))
+end
+| FStar_Parser_AST.PatTvar (tv, arg_qualifier_opt) -> begin
+(p_tvar tv)
+end
+| FStar_Parser_AST.PatOp (op) -> begin
+(
+
+let uu____2511 = (
+
+let uu____2512 = (
+
+let uu____2513 = (str op)
+in (
+
+let uu____2514 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen)
+in (FStar_Pprint.op_Hat_Hat uu____2513 uu____2514)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2512))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2511))
+end
+| FStar_Parser_AST.PatWild -> begin
+FStar_Pprint.underscore
+end
+| FStar_Parser_AST.PatConst (c) -> begin
+(p_constant c)
+end
+| FStar_Parser_AST.PatVar (lid, aqual) -> begin
+(
+
+let uu____2520 = (FStar_Pprint.optional p_aqual aqual)
+in (
+
+let uu____2521 = (p_lident lid)
+in (FStar_Pprint.op_Hat_Hat uu____2520 uu____2521)))
+end
+| FStar_Parser_AST.PatName (uid) -> begin
+(p_quident uid)
+end
+| FStar_Parser_AST.PatOr (uu____2523) -> begin
+(failwith "Inner or pattern !")
+end
+| (FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatName (_); FStar_Parser_AST.prange = _}, _)) | (FStar_Parser_AST.PatTuple (_, false)) -> begin
+(
+
+let uu____2531 = (p_tuplePattern p)
+in (soft_parens_with_nesting uu____2531))
+end
+| uu____2532 -> begin
+(
+
+let uu____2533 = (
+
+let uu____2534 = (FStar_Parser_AST.pat_to_string p)
+in (FStar_Util.format1 "Invalid pattern %s" uu____2534))
+in (failwith uu____2533))
+end))
+and p_binder : Prims.bool  ->  FStar_Parser_AST.binder  ->  FStar_Pprint.document = (fun is_atomic b -> (match (b.FStar_Parser_AST.b) with
+| FStar_Parser_AST.Variable (lid) -> begin
+(
+
+let uu____2538 = (FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual)
+in (
+
+let uu____2539 = (p_lident lid)
+in (FStar_Pprint.op_Hat_Hat uu____2538 uu____2539)))
+end
+| FStar_Parser_AST.TVariable (lid) -> begin
+(p_lident lid)
+end
+| FStar_Parser_AST.Annotated (lid, t) -> begin
+(
+
+let doc1 = (
+
+let uu____2544 = (
+
+let uu____2545 = (unparen t)
+in uu____2545.FStar_Parser_AST.tm)
+in (match (uu____2544) with
+| FStar_Parser_AST.Refine ({FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1); FStar_Parser_AST.brange = uu____2548; FStar_Parser_AST.blevel = uu____2549; FStar_Parser_AST.aqual = uu____2550}, phi) when (lid.FStar_Ident.idText = lid'.FStar_Ident.idText) -> begin
+(
+
+let uu____2552 = (p_ident lid)
+in (p_refinement b.FStar_Parser_AST.aqual uu____2552 t1 phi))
+end
+| uu____2553 -> begin
+(
+
+let uu____2554 = (FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual)
+in (
+
+let uu____2555 = (
+
+let uu____2556 = (p_lident lid)
+in (
+
+let uu____2557 = (
+
+let uu____2558 = (
+
+let uu____2559 = (FStar_Pprint.break_ (Prims.parse_int "0"))
+in (
+
+let uu____2560 = (p_tmFormula t)
+in (FStar_Pprint.op_Hat_Hat uu____2559 uu____2560)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2558))
+in (FStar_Pprint.op_Hat_Hat uu____2556 uu____2557)))
+in (FStar_Pprint.op_Hat_Hat uu____2554 uu____2555)))
+end))
+in (match (is_atomic) with
+| true -> begin
+(
+
+let uu____2561 = (
+
+let uu____2562 = (FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2562))
+in (FStar_Pprint.group uu____2561))
+end
+| uu____2563 -> begin
+(FStar_Pprint.group doc1)
+end))
+end
+| FStar_Parser_AST.TAnnotated (uu____2564) -> begin
+(failwith "Is this still used ?")
+end
+| FStar_Parser_AST.NoName (t) -> begin
+(
+
+let uu____2568 = (
+
+let uu____2569 = (unparen t)
+in uu____2569.FStar_Parser_AST.tm)
+in (match (uu____2568) with
+| FStar_Parser_AST.Refine ({FStar_Parser_AST.b = FStar_Parser_AST.NoName (t1); FStar_Parser_AST.brange = uu____2571; FStar_Parser_AST.blevel = uu____2572; FStar_Parser_AST.aqual = uu____2573}, phi) -> begin
+(match (is_atomic) with
+| true -> begin
+(
+
+let uu____2575 = (
+
+let uu____2576 = (
+
+let uu____2577 = (p_refinement b.FStar_Parser_AST.aqual FStar_Pprint.underscore t1 phi)
+in (FStar_Pprint.op_Hat_Hat uu____2577 FStar_Pprint.rparen))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____2576))
+in (FStar_Pprint.group uu____2575))
+end
+| uu____2578 -> begin
+(
+
+let uu____2579 = (p_refinement b.FStar_Parser_AST.aqual FStar_Pprint.underscore t1 phi)
+in (FStar_Pprint.group uu____2579))
+end)
+end
+| uu____2580 -> begin
+(match (is_atomic) with
+| true -> begin
+(p_atomicTerm t)
+end
+| uu____2581 -> begin
+(p_appTerm t)
+end)
+end))
+end))
+and p_refinement : FStar_Parser_AST.arg_qualifier Prims.option  ->  FStar_Pprint.document  ->  FStar_Parser_AST.term  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun aqual_opt binder t phi -> (
+
+let uu____2587 = (FStar_Pprint.optional p_aqual aqual_opt)
+in (
+
+let uu____2588 = (
+
+let uu____2589 = (
+
+let uu____2590 = (
+
+let uu____2591 = (p_appTerm t)
+in (
+
+let uu____2592 = (
+
+let uu____2593 = (p_noSeqTerm phi)
+in (soft_braces_with_nesting uu____2593))
+in (FStar_Pprint.op_Hat_Hat uu____2591 uu____2592)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2590))
+in (FStar_Pprint.op_Hat_Hat binder uu____2589))
+in (FStar_Pprint.op_Hat_Hat uu____2587 uu____2588))))
+and p_binders : Prims.bool  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Pprint.document = (fun is_atomic bs -> (FStar_Pprint.separate_map break1 (p_binder is_atomic) bs))
+and p_qlident : FStar_Ident.lid  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_lid lid)))
+and p_quident : FStar_Ident.lid  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_lid lid)))
+and p_ident : FStar_Ident.ident  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_id lid)))
+and p_lident : FStar_Ident.ident  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_id lid)))
+and p_uident : FStar_Ident.ident  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_id lid)))
+and p_tvar : FStar_Ident.ident  ->  FStar_Pprint.document = (fun lid -> (str (FStar_Ident.text_of_id lid)))
+and p_lidentOrUnderscore : FStar_Ident.ident  ->  FStar_Pprint.document = (fun id -> (match ((FStar_Util.starts_with FStar_Ident.reserved_prefix id.FStar_Ident.idText)) with
+| true -> begin
+FStar_Pprint.underscore
+end
+| uu____2604 -> begin
+(p_lident id)
+end))
+and p_term : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2606 = (
+
+let uu____2607 = (unparen e)
+in uu____2607.FStar_Parser_AST.tm)
+in (match (uu____2606) with
+| FStar_Parser_AST.Seq (e1, e2) -> begin
+(
+
+let uu____2610 = (
+
+let uu____2611 = (
+
+let uu____2612 = (p_noSeqTerm e1)
+in (FStar_Pprint.op_Hat_Hat uu____2612 FStar_Pprint.semi))
+in (FStar_Pprint.group uu____2611))
+in (
+
+let uu____2613 = (p_term e2)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2610 uu____2613)))
+end
+| uu____2614 -> begin
+(
+
+let uu____2615 = (p_noSeqTerm e)
+in (FStar_Pprint.group uu____2615))
+end)))
+and p_noSeqTerm : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (with_comment p_noSeqTerm' e e.FStar_Parser_AST.range))
+and p_noSeqTerm' : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2618 = (
+
+let uu____2619 = (unparen e)
+in uu____2619.FStar_Parser_AST.tm)
+in (match (uu____2618) with
+| FStar_Parser_AST.Ascribed (e1, t, None) -> begin
+(
+
+let uu____2623 = (
+
+let uu____2624 = (p_tmIff e1)
+in (
+
+let uu____2625 = (
+
+let uu____2626 = (
+
+let uu____2627 = (p_typ t)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____2627))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____2626))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2624 uu____2625)))
+in (FStar_Pprint.group uu____2623))
+end
+| FStar_Parser_AST.Ascribed (e1, t, Some (tac)) -> begin
+(
+
+let uu____2632 = (
+
+let uu____2633 = (p_tmIff e1)
+in (
+
+let uu____2634 = (
+
+let uu____2635 = (
+
+let uu____2636 = (
+
+let uu____2637 = (p_typ t)
+in (
+
+let uu____2638 = (
+
+let uu____2639 = (str "by")
+in (
+
+let uu____2640 = (p_typ tac)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2639 uu____2640)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2637 uu____2638)))
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____2636))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____2635))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2633 uu____2634)))
+in (FStar_Pprint.group uu____2632))
+end
+| FStar_Parser_AST.Op (op, (e1)::(e2)::(e3)::[]) when (op = ".()<-") -> begin
+(
+
+let uu____2646 = (
+
+let uu____2647 = (
+
+let uu____2648 = (
+
+let uu____2649 = (p_atomicTermNotQUident e1)
+in (
+
+let uu____2650 = (
+
+let uu____2651 = (
+
+let uu____2652 = (
+
+let uu____2653 = (p_term e2)
+in (soft_parens_with_nesting uu____2653))
+in (
+
+let uu____2654 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.larrow)
+in (FStar_Pprint.op_Hat_Hat uu____2652 uu____2654)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____2651))
+in (FStar_Pprint.op_Hat_Hat uu____2649 uu____2650)))
+in (FStar_Pprint.group uu____2648))
+in (
+
+let uu____2655 = (
+
+let uu____2656 = (p_noSeqTerm e3)
+in (jump2 uu____2656))
+in (FStar_Pprint.op_Hat_Hat uu____2647 uu____2655)))
+in (FStar_Pprint.group uu____2646))
+end
+| FStar_Parser_AST.Op (op, (e1)::(e2)::(e3)::[]) when (op = ".[]<-") -> begin
+(
+
+let uu____2662 = (
+
+let uu____2663 = (
+
+let uu____2664 = (
+
+let uu____2665 = (p_atomicTermNotQUident e1)
+in (
+
+let uu____2666 = (
+
+let uu____2667 = (
+
+let uu____2668 = (
+
+let uu____2669 = (p_term e2)
+in (soft_brackets_with_nesting uu____2669))
+in (
+
+let uu____2670 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.larrow)
+in (FStar_Pprint.op_Hat_Hat uu____2668 uu____2670)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____2667))
+in (FStar_Pprint.op_Hat_Hat uu____2665 uu____2666)))
+in (FStar_Pprint.group uu____2664))
+in (
+
+let uu____2671 = (
+
+let uu____2672 = (p_noSeqTerm e3)
+in (jump2 uu____2672))
+in (FStar_Pprint.op_Hat_Hat uu____2663 uu____2671)))
+in (FStar_Pprint.group uu____2662))
+end
+| FStar_Parser_AST.Requires (e1, wtf) -> begin
+(
+
+let uu____2678 = (
+
+let uu____2679 = (str "requires")
+in (
+
+let uu____2680 = (p_typ e1)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2679 uu____2680)))
+in (FStar_Pprint.group uu____2678))
+end
+| FStar_Parser_AST.Ensures (e1, wtf) -> begin
+(
+
+let uu____2686 = (
+
+let uu____2687 = (str "ensures")
+in (
+
+let uu____2688 = (p_typ e1)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2687 uu____2688)))
+in (FStar_Pprint.group uu____2686))
+end
+| FStar_Parser_AST.Attributes (es) -> begin
+(
+
+let uu____2691 = (
+
+let uu____2692 = (str "attributes")
+in (
+
+let uu____2693 = (FStar_Pprint.separate_map break1 p_atomicTerm es)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2692 uu____2693)))
+in (FStar_Pprint.group uu____2691))
+end
+| FStar_Parser_AST.If (e1, e2, e3) -> begin
+(
+
+let uu____2697 = (is_unit e3)
+in (match (uu____2697) with
+| true -> begin
+(
+
+let uu____2698 = (
+
+let uu____2699 = (
+
+let uu____2700 = (str "if")
+in (
+
+let uu____2701 = (p_noSeqTerm e1)
+in (op_Hat_Slash_Plus_Hat uu____2700 uu____2701)))
+in (
+
+let uu____2702 = (
+
+let uu____2703 = (str "then")
+in (
+
+let uu____2704 = (p_noSeqTerm e2)
+in (op_Hat_Slash_Plus_Hat uu____2703 uu____2704)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2699 uu____2702)))
+in (FStar_Pprint.group uu____2698))
+end
+| uu____2705 -> begin
+(
+
+let e2_doc = (
+
+let uu____2707 = (
+
+let uu____2708 = (unparen e2)
+in uu____2708.FStar_Parser_AST.tm)
+in (match (uu____2707) with
+| FStar_Parser_AST.If (uu____2709, uu____2710, e31) when (is_unit e31) -> begin
+(
+
+let uu____2712 = (p_noSeqTerm e2)
+in (soft_parens_with_nesting uu____2712))
+end
+| uu____2713 -> begin
+(p_noSeqTerm e2)
+end))
+in (
+
+let uu____2714 = (
+
+let uu____2715 = (
+
+let uu____2716 = (str "if")
+in (
+
+let uu____2717 = (p_noSeqTerm e1)
+in (op_Hat_Slash_Plus_Hat uu____2716 uu____2717)))
+in (
+
+let uu____2718 = (
+
+let uu____2719 = (
+
+let uu____2720 = (str "then")
+in (op_Hat_Slash_Plus_Hat uu____2720 e2_doc))
+in (
+
+let uu____2721 = (
+
+let uu____2722 = (str "else")
+in (
+
+let uu____2723 = (p_noSeqTerm e3)
+in (op_Hat_Slash_Plus_Hat uu____2722 uu____2723)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2719 uu____2721)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2715 uu____2718)))
+in (FStar_Pprint.group uu____2714)))
+end))
+end
+| FStar_Parser_AST.TryWith (e1, branches) -> begin
+(
+
+let uu____2736 = (
+
+let uu____2737 = (
+
+let uu____2738 = (str "try")
+in (
+
+let uu____2739 = (p_noSeqTerm e1)
+in (prefix2 uu____2738 uu____2739)))
+in (
+
+let uu____2740 = (
+
+let uu____2741 = (str "with")
+in (
+
+let uu____2742 = (FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch branches)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2741 uu____2742)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2737 uu____2740)))
+in (FStar_Pprint.group uu____2736))
+end
+| FStar_Parser_AST.Match (e1, branches) -> begin
+(
+
+let uu____2759 = (
+
+let uu____2760 = (
+
+let uu____2761 = (str "match")
+in (
+
+let uu____2762 = (p_noSeqTerm e1)
+in (
+
+let uu____2763 = (str "with")
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2761 uu____2762 uu____2763))))
+in (
+
+let uu____2764 = (FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch branches)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2760 uu____2764)))
+in (FStar_Pprint.group uu____2759))
+end
+| FStar_Parser_AST.LetOpen (uid, e1) -> begin
+(
+
+let uu____2771 = (
+
+let uu____2772 = (
+
+let uu____2773 = (str "let open")
+in (
+
+let uu____2774 = (p_quident uid)
+in (
+
+let uu____2775 = (str "in")
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____2773 uu____2774 uu____2775))))
+in (
+
+let uu____2776 = (p_term e1)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2772 uu____2776)))
+in (FStar_Pprint.group uu____2771))
+end
+| FStar_Parser_AST.Let (q, lbs, e1) -> begin
+(
+
+let let_doc = (
+
+let uu____2787 = (str "let")
+in (
+
+let uu____2788 = (p_letqualifier q)
+in (FStar_Pprint.op_Hat_Hat uu____2787 uu____2788)))
+in (
+
+let uu____2789 = (
+
+let uu____2790 = (
+
+let uu____2791 = (
+
+let uu____2792 = (str "and")
+in (precede_break_separate_map let_doc uu____2792 p_letbinding lbs))
+in (
+
+let uu____2795 = (str "in")
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2791 uu____2795)))
+in (FStar_Pprint.group uu____2790))
+in (
+
+let uu____2796 = (p_term e1)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2789 uu____2796))))
+end
+| FStar_Parser_AST.Abs (({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, typ_opt); FStar_Parser_AST.prange = uu____2799})::[], {FStar_Parser_AST.tm = FStar_Parser_AST.Match (maybe_x, branches); FStar_Parser_AST.range = uu____2802; FStar_Parser_AST.level = uu____2803}) when (matches_var maybe_x x) -> begin
+(
+
+let uu____2817 = (
+
+let uu____2818 = (str "function")
+in (
+
+let uu____2819 = (FStar_Pprint.separate_map FStar_Pprint.hardline p_patternBranch branches)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2818 uu____2819)))
+in (FStar_Pprint.group uu____2817))
+end
+| FStar_Parser_AST.Assign (id, e1) -> begin
+(
+
+let uu____2826 = (
+
+let uu____2827 = (p_lident id)
+in (
+
+let uu____2828 = (
+
+let uu____2829 = (p_noSeqTerm e1)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.larrow uu____2829))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2827 uu____2828)))
+in (FStar_Pprint.group uu____2826))
+end
+| uu____2830 -> begin
+(p_typ e)
+end)))
+and p_typ : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (with_comment p_typ' e e.FStar_Parser_AST.range))
+and p_typ' : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2833 = (
+
+let uu____2834 = (unparen e)
+in uu____2834.FStar_Parser_AST.tm)
+in (match (uu____2833) with
+| (FStar_Parser_AST.QForall (bs, trigger, e1)) | (FStar_Parser_AST.QExists (bs, trigger, e1)) -> begin
+(
+
+let uu____2850 = (
+
+let uu____2851 = (
+
+let uu____2852 = (p_quantifier e)
+in (FStar_Pprint.op_Hat_Hat uu____2852 FStar_Pprint.space))
+in (
+
+let uu____2853 = (p_binders true bs)
+in (FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "0") uu____2851 uu____2853 FStar_Pprint.dot)))
+in (
+
+let uu____2854 = (
+
+let uu____2855 = (p_trigger trigger)
+in (
+
+let uu____2856 = (p_noSeqTerm e1)
+in (FStar_Pprint.op_Hat_Hat uu____2855 uu____2856)))
+in (prefix2 uu____2850 uu____2854)))
+end
+| uu____2857 -> begin
+(p_simpleTerm e)
+end)))
+and p_quantifier : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2859 = (
+
+let uu____2860 = (unparen e)
+in uu____2860.FStar_Parser_AST.tm)
+in (match (uu____2859) with
+| FStar_Parser_AST.QForall (uu____2861) -> begin
+(str "forall")
+end
+| FStar_Parser_AST.QExists (uu____2868) -> begin
+(str "exists")
+end
+| uu____2875 -> begin
+(failwith "Imposible : p_quantifier called on a non-quantifier term")
+end)))
+and p_trigger : FStar_Parser_AST.term Prims.list Prims.list  ->  FStar_Pprint.document = (fun uu___137_2876 -> (match (uu___137_2876) with
+| [] -> begin
+FStar_Pprint.empty
+end
+| pats -> begin
+(
+
+let uu____2883 = (
+
+let uu____2884 = (
+
+let uu____2885 = (str "pattern")
+in (
+
+let uu____2886 = (
+
+let uu____2887 = (
+
+let uu____2888 = (p_disjunctivePats pats)
+in (jump2 uu____2888))
+in (
+
+let uu____2889 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace break1)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2887 uu____2889)))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2885 uu____2886)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____2884))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____2883))
+end))
+and p_disjunctivePats : FStar_Parser_AST.term Prims.list Prims.list  ->  FStar_Pprint.document = (fun pats -> (
+
+let uu____2893 = (str "\\/")
+in (FStar_Pprint.separate_map uu____2893 p_conjunctivePats pats)))
+and p_conjunctivePats : FStar_Parser_AST.term Prims.list  ->  FStar_Pprint.document = (fun pats -> (
+
+let uu____2897 = (FStar_Pprint.separate_map FStar_Pprint.semi p_appTerm pats)
+in (FStar_Pprint.group uu____2897)))
+and p_simpleTerm : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2899 = (
+
+let uu____2900 = (unparen e)
+in uu____2900.FStar_Parser_AST.tm)
+in (match (uu____2899) with
+| FStar_Parser_AST.Abs (pats, e1) -> begin
+(
+
+let uu____2905 = (
+
+let uu____2906 = (str "fun")
+in (
+
+let uu____2907 = (
+
+let uu____2908 = (FStar_Pprint.separate_map break1 p_atomicPattern pats)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____2908 FStar_Pprint.rarrow))
+in (op_Hat_Slash_Plus_Hat uu____2906 uu____2907)))
+in (
+
+let uu____2909 = (p_term e1)
+in (op_Hat_Slash_Plus_Hat uu____2905 uu____2909)))
+end
+| uu____2910 -> begin
+(p_tmIff e)
+end)))
+and p_maybeFocusArrow : Prims.bool  ->  FStar_Pprint.document = (fun b -> (match (b) with
+| true -> begin
+(str "~>")
+end
+| uu____2912 -> begin
+FStar_Pprint.rarrow
+end))
+and p_patternBranch : (FStar_Parser_AST.pattern * FStar_Parser_AST.term Prims.option * FStar_Parser_AST.term)  ->  FStar_Pprint.document = (fun uu____2913 -> (match (uu____2913) with
+| (pat, when_opt, e) -> begin
+(
+
+let maybe_paren = (
+
+let uu____2926 = (
+
+let uu____2927 = (unparen e)
+in uu____2927.FStar_Parser_AST.tm)
+in (match (uu____2926) with
+| (FStar_Parser_AST.Match (_)) | (FStar_Parser_AST.TryWith (_)) -> begin
+soft_begin_end_with_nesting
+end
+| FStar_Parser_AST.Abs (({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, uu____2933); FStar_Parser_AST.prange = uu____2934})::[], {FStar_Parser_AST.tm = FStar_Parser_AST.Match (maybe_x, uu____2936); FStar_Parser_AST.range = uu____2937; FStar_Parser_AST.level = uu____2938}) when (matches_var maybe_x x) -> begin
+soft_begin_end_with_nesting
+end
+| uu____2952 -> begin
+(fun x -> x)
+end))
+in (
+
+let uu____2954 = (
+
+let uu____2955 = (
+
+let uu____2956 = (
+
+let uu____2957 = (
+
+let uu____2958 = (
+
+let uu____2959 = (p_disjunctivePattern pat)
+in (
+
+let uu____2960 = (
+
+let uu____2961 = (p_maybeWhen when_opt)
+in (FStar_Pprint.op_Hat_Hat uu____2961 FStar_Pprint.rarrow))
+in (op_Hat_Slash_Plus_Hat uu____2959 uu____2960)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____2958))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____2957))
+in (FStar_Pprint.group uu____2956))
+in (
+
+let uu____2962 = (
+
+let uu____2963 = (p_term e)
+in (maybe_paren uu____2963))
+in (op_Hat_Slash_Plus_Hat uu____2955 uu____2962)))
+in (FStar_Pprint.group uu____2954)))
+end))
+and p_maybeWhen : FStar_Parser_AST.term Prims.option  ->  FStar_Pprint.document = (fun uu___138_2964 -> (match (uu___138_2964) with
+| None -> begin
+FStar_Pprint.empty
+end
+| Some (e) -> begin
+(
+
+let uu____2967 = (str "when")
+in (
+
+let uu____2968 = (
+
+let uu____2969 = (p_tmFormula e)
+in (FStar_Pprint.op_Hat_Hat uu____2969 FStar_Pprint.space))
+in (op_Hat_Slash_Plus_Hat uu____2967 uu____2968)))
+end))
+and p_tmIff : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2971 = (
+
+let uu____2972 = (unparen e)
+in uu____2972.FStar_Parser_AST.tm)
+in (match (uu____2971) with
+| FStar_Parser_AST.Op ("<==>", (e1)::(e2)::[]) -> begin
+(
+
+let uu____2976 = (str "<==>")
+in (
+
+let uu____2977 = (p_tmImplies e1)
+in (
+
+let uu____2978 = (p_tmIff e2)
+in (infix0 uu____2976 uu____2977 uu____2978))))
+end
+| uu____2979 -> begin
+(p_tmImplies e)
+end)))
+and p_tmImplies : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____2981 = (
+
+let uu____2982 = (unparen e)
+in uu____2982.FStar_Parser_AST.tm)
+in (match (uu____2981) with
+| FStar_Parser_AST.Op ("==>", (e1)::(e2)::[]) -> begin
+(
+
+let uu____2986 = (str "==>")
+in (
+
+let uu____2987 = (p_tmArrow p_tmFormula e1)
+in (
+
+let uu____2988 = (p_tmImplies e2)
+in (infix0 uu____2986 uu____2987 uu____2988))))
+end
+| uu____2989 -> begin
+(p_tmArrow p_tmFormula e)
+end)))
+and p_tmArrow : (FStar_Parser_AST.term  ->  FStar_Pprint.document)  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun p_Tm e -> (
+
+let uu____2994 = (
+
+let uu____2995 = (unparen e)
+in uu____2995.FStar_Parser_AST.tm)
+in (match (uu____2994) with
+| FStar_Parser_AST.Product (bs, tgt) -> begin
+(
+
+let uu____3000 = (
+
+let uu____3001 = (FStar_Pprint.concat_map (fun b -> (
+
+let uu____3003 = (p_binder false b)
+in (
+
+let uu____3004 = (
+
+let uu____3005 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3005))
+in (FStar_Pprint.op_Hat_Hat uu____3003 uu____3004)))) bs)
+in (
+
+let uu____3006 = (p_tmArrow p_Tm tgt)
+in (FStar_Pprint.op_Hat_Hat uu____3001 uu____3006)))
+in (FStar_Pprint.group uu____3000))
+end
+| uu____3007 -> begin
+(p_Tm e)
+end)))
+and p_tmFormula : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3009 = (
+
+let uu____3010 = (unparen e)
+in uu____3010.FStar_Parser_AST.tm)
+in (match (uu____3009) with
+| FStar_Parser_AST.Op ("\\/", (e1)::(e2)::[]) -> begin
+(
+
+let uu____3014 = (str "\\/")
+in (
+
+let uu____3015 = (p_tmFormula e1)
+in (
+
+let uu____3016 = (p_tmConjunction e2)
+in (infix0 uu____3014 uu____3015 uu____3016))))
+end
+| uu____3017 -> begin
+(p_tmConjunction e)
+end)))
+and p_tmConjunction : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3019 = (
+
+let uu____3020 = (unparen e)
+in uu____3020.FStar_Parser_AST.tm)
+in (match (uu____3019) with
+| FStar_Parser_AST.Op ("/\\", (e1)::(e2)::[]) -> begin
+(
+
+let uu____3024 = (str "/\\")
+in (
+
+let uu____3025 = (p_tmConjunction e1)
+in (
+
+let uu____3026 = (p_tmTuple e2)
+in (infix0 uu____3024 uu____3025 uu____3026))))
+end
+| uu____3027 -> begin
+(p_tmTuple e)
+end)))
+and p_tmTuple : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (with_comment p_tmTuple' e e.FStar_Parser_AST.range))
+and p_tmTuple' : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3030 = (
+
+let uu____3031 = (unparen e)
+in uu____3031.FStar_Parser_AST.tm)
+in (match (uu____3030) with
+| FStar_Parser_AST.Construct (lid, args) when (is_tuple_constructor lid) -> begin
+(
+
+let uu____3040 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1)
+in (FStar_Pprint.separate_map uu____3040 (fun uu____3043 -> (match (uu____3043) with
+| (e1, uu____3047) -> begin
+(p_tmEq e1)
+end)) args))
+end
+| uu____3048 -> begin
+(p_tmEq e)
+end)))
+and paren_if : Prims.int  ->  Prims.int  ->  FStar_Pprint.document  ->  FStar_Pprint.document = (fun curr mine doc1 -> (match ((mine <= curr)) with
+| true -> begin
+doc1
+end
+| uu____3052 -> begin
+(
+
+let uu____3053 = (
+
+let uu____3054 = (FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3054))
+in (FStar_Pprint.group uu____3053))
+end))
+and p_tmEq : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let n1 = (max_level (FStar_List.append (((colon_equals ()))::((pipe_right ()))::[]) (operatorInfix0ad12 ())))
+in (p_tmEq' n1 e)))
+and p_tmEq' : Prims.int  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun curr e -> (
+
+let uu____3079 = (
+
+let uu____3080 = (unparen e)
+in uu____3080.FStar_Parser_AST.tm)
+in (match (uu____3079) with
+| FStar_Parser_AST.Op (op, (e1)::(e2)::[]) when (((is_operatorInfix0ad12 op) || (op = "=")) || (op = "|>")) -> begin
+(
+
+let uu____3085 = (levels op)
+in (match (uu____3085) with
+| (left1, mine, right1) -> begin
+(
+
+let uu____3092 = (
+
+let uu____3093 = (str op)
+in (
+
+let uu____3094 = (p_tmEq' left1 e1)
+in (
+
+let uu____3095 = (p_tmEq' right1 e2)
+in (infix0 uu____3093 uu____3094 uu____3095))))
+in (paren_if curr mine uu____3092))
+end))
+end
+| FStar_Parser_AST.Op (":=", (e1)::(e2)::[]) -> begin
+(
+
+let uu____3099 = (
+
+let uu____3100 = (p_tmEq e1)
+in (
+
+let uu____3101 = (
+
+let uu____3102 = (
+
+let uu____3103 = (
+
+let uu____3104 = (p_tmEq e2)
+in (op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____3104))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____3103))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3102))
+in (FStar_Pprint.op_Hat_Hat uu____3100 uu____3101)))
+in (FStar_Pprint.group uu____3099))
+end
+| uu____3105 -> begin
+(p_tmNoEq e)
+end)))
+and p_tmNoEq : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let n1 = (max_level (((colon_colon ()))::((amp ()))::((opinfix3 ()))::((opinfix4 ()))::[]))
+in (p_tmNoEq' n1 e)))
+and p_tmNoEq' : Prims.int  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun curr e -> (
+
+let uu____3135 = (
+
+let uu____3136 = (unparen e)
+in uu____3136.FStar_Parser_AST.tm)
+in (match (uu____3135) with
+| FStar_Parser_AST.Construct (lid, ((e1, uu____3139))::((e2, uu____3141))::[]) when ((FStar_Ident.lid_equals lid FStar_Syntax_Const.cons_lid) && (
+
+let uu____3151 = (is_list e)
+in (not (uu____3151)))) -> begin
+(
+
+let op = "::"
+in (
+
+let uu____3153 = (levels op)
+in (match (uu____3153) with
+| (left1, mine, right1) -> begin
+(
+
+let uu____3160 = (
+
+let uu____3161 = (str op)
+in (
+
+let uu____3162 = (p_tmNoEq' left1 e1)
+in (
+
+let uu____3163 = (p_tmNoEq' right1 e2)
+in (infix0 uu____3161 uu____3162 uu____3163))))
+in (paren_if curr mine uu____3160))
+end)))
+end
+| FStar_Parser_AST.Sum (binders, res) -> begin
+(
+
+let op = "&"
+in (
+
+let uu____3169 = (levels op)
+in (match (uu____3169) with
+| (left1, mine, right1) -> begin
+(
+
+let p_dsumfst = (fun b -> (
+
+let uu____3180 = (p_binder false b)
+in (
+
+let uu____3181 = (
+
+let uu____3182 = (
+
+let uu____3183 = (str "&")
+in (FStar_Pprint.op_Hat_Hat uu____3183 break1))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3182))
+in (FStar_Pprint.op_Hat_Hat uu____3180 uu____3181))))
+in (
+
+let uu____3184 = (
+
+let uu____3185 = (FStar_Pprint.concat_map p_dsumfst binders)
+in (
+
+let uu____3186 = (p_tmNoEq' right1 res)
+in (FStar_Pprint.op_Hat_Hat uu____3185 uu____3186)))
+in (paren_if curr mine uu____3184)))
+end)))
+end
+| FStar_Parser_AST.Op (op, (e1)::(e2)::[]) when (is_operatorInfix34 op) -> begin
+(
+
+let uu____3191 = (levels op)
+in (match (uu____3191) with
+| (left1, mine, right1) -> begin
+(
+
+let uu____3198 = (
+
+let uu____3199 = (str op)
+in (
+
+let uu____3200 = (p_tmNoEq' left1 e1)
+in (
+
+let uu____3201 = (p_tmNoEq' right1 e2)
+in (infix0 uu____3199 uu____3200 uu____3201))))
+in (paren_if curr mine uu____3198))
+end))
+end
+| FStar_Parser_AST.Op ("-", (e1)::[]) -> begin
+(
+
+let uu____3204 = (levels "-")
+in (match (uu____3204) with
+| (left1, mine, right1) -> begin
+(
+
+let uu____3211 = (p_tmNoEq' mine e1)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____3211))
+end))
+end
+| FStar_Parser_AST.NamedTyp (lid, e1) -> begin
+(
+
+let uu____3214 = (
+
+let uu____3215 = (p_lidentOrUnderscore lid)
+in (
+
+let uu____3216 = (
+
+let uu____3217 = (p_appTerm e1)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____3217))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____3215 uu____3216)))
+in (FStar_Pprint.group uu____3214))
+end
+| FStar_Parser_AST.Refine (b, phi) -> begin
+(p_refinedBinder b phi)
+end
+| FStar_Parser_AST.Record (with_opt, record_fields) -> begin
+(
+
+let uu____3230 = (
+
+let uu____3231 = (default_or_map FStar_Pprint.empty p_with_clause with_opt)
+in (
+
+let uu____3232 = (
+
+let uu____3233 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1)
+in (FStar_Pprint.separate_map uu____3233 p_simpleDef record_fields))
+in (FStar_Pprint.op_Hat_Hat uu____3231 uu____3232)))
+in (braces_with_nesting uu____3230))
+end
+| FStar_Parser_AST.Op ("~", (e1)::[]) -> begin
+(
+
+let uu____3238 = (
+
+let uu____3239 = (str "~")
+in (
+
+let uu____3240 = (p_atomicTerm e1)
+in (FStar_Pprint.op_Hat_Hat uu____3239 uu____3240)))
+in (FStar_Pprint.group uu____3238))
+end
+| uu____3241 -> begin
+(p_appTerm e)
+end)))
+and p_with_clause : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3243 = (p_appTerm e)
+in (
+
+let uu____3244 = (
+
+let uu____3245 = (
+
+let uu____3246 = (str "with")
+in (FStar_Pprint.op_Hat_Hat uu____3246 break1))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3245))
+in (FStar_Pprint.op_Hat_Hat uu____3243 uu____3244))))
+and p_refinedBinder : FStar_Parser_AST.binder  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun b phi -> (match (b.FStar_Parser_AST.b) with
+| FStar_Parser_AST.Annotated (lid, t) -> begin
+(
+
+let uu____3251 = (
+
+let uu____3252 = (p_lident lid)
+in (p_refinement b.FStar_Parser_AST.aqual uu____3252 t phi))
+in (soft_parens_with_nesting uu____3251))
+end
+| FStar_Parser_AST.TAnnotated (uu____3253) -> begin
+(failwith "Is this still used ?")
+end
+| (FStar_Parser_AST.Variable (_)) | (FStar_Parser_AST.TVariable (_)) | (FStar_Parser_AST.NoName (_)) -> begin
+(
+
+let uu____3259 = (
+
+let uu____3260 = (FStar_Parser_AST.binder_to_string b)
+in (FStar_Util.format1 "Imposible : a refined binder ought to be annotated %s" uu____3260))
+in (failwith uu____3259))
+end))
+and p_simpleDef : (FStar_Ident.lid * FStar_Parser_AST.term)  ->  FStar_Pprint.document = (fun uu____3261 -> (match (uu____3261) with
+| (lid, e) -> begin
+(
+
+let uu____3266 = (
+
+let uu____3267 = (p_qlident lid)
+in (
+
+let uu____3268 = (
+
+let uu____3269 = (p_tmIff e)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____3269))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____3267 uu____3268)))
+in (FStar_Pprint.group uu____3266))
+end))
+and p_appTerm : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3271 = (
+
+let uu____3272 = (unparen e)
+in uu____3272.FStar_Parser_AST.tm)
+in (match (uu____3271) with
+| FStar_Parser_AST.App (uu____3273) when (is_general_application e) -> begin
+(
+
+let uu____3277 = (head_and_args e)
+in (match (uu____3277) with
+| (head1, args) -> begin
+(
+
+let uu____3291 = (
+
+let uu____3297 = (FStar_ST.read should_print_fs_typ_app)
+in (match (uu____3297) with
+| true -> begin
+(
+
+let uu____3305 = (FStar_Util.take (fun uu____3316 -> (match (uu____3316) with
+| (uu____3319, aq) -> begin
+(aq = FStar_Parser_AST.FsTypApp)
+end)) args)
+in (match (uu____3305) with
+| (fs_typ_args, args1) -> begin
+(
+
+let uu____3340 = (
+
+let uu____3341 = (p_indexingTerm head1)
+in (
+
+let uu____3342 = (
+
+let uu____3343 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1)
+in (soft_surround_separate_map (Prims.parse_int "2") (Prims.parse_int "0") FStar_Pprint.empty FStar_Pprint.langle uu____3343 FStar_Pprint.rangle p_fsTypArg fs_typ_args))
+in (FStar_Pprint.op_Hat_Hat uu____3341 uu____3342)))
+in ((uu____3340), (args1)))
+end))
+end
+| uu____3349 -> begin
+(
+
+let uu____3350 = (p_indexingTerm head1)
+in ((uu____3350), (args)))
+end))
+in (match (uu____3291) with
+| (head_doc, args1) -> begin
+(
+
+let uu____3362 = (
+
+let uu____3363 = (FStar_Pprint.op_Hat_Hat head_doc FStar_Pprint.space)
+in (soft_surround_separate_map (Prims.parse_int "2") (Prims.parse_int "0") head_doc uu____3363 break1 FStar_Pprint.empty p_argTerm args1))
+in (FStar_Pprint.group uu____3362))
+end))
+end))
+end
+| FStar_Parser_AST.Construct (lid, args) when ((is_general_construction e) && (not ((is_dtuple_constructor lid)))) -> begin
+(match (args) with
+| [] -> begin
+(p_quident lid)
+end
+| (arg)::[] -> begin
+(
+
+let uu____3383 = (
+
+let uu____3384 = (p_quident lid)
+in (
+
+let uu____3385 = (p_argTerm arg)
+in (FStar_Pprint.op_Hat_Slash_Hat uu____3384 uu____3385)))
+in (FStar_Pprint.group uu____3383))
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____3395 = (
+
+let uu____3396 = (
+
+let uu____3397 = (
+
+let uu____3398 = (p_quident lid)
+in (
+
+let uu____3399 = (p_argTerm hd1)
+in (prefix2 uu____3398 uu____3399)))
+in (FStar_Pprint.group uu____3397))
+in (
+
+let uu____3400 = (
+
+let uu____3401 = (FStar_Pprint.separate_map break1 p_argTerm tl1)
+in (jump2 uu____3401))
+in (FStar_Pprint.op_Hat_Hat uu____3396 uu____3400)))
+in (FStar_Pprint.group uu____3395))
+end)
+end
+| uu____3404 -> begin
+(p_indexingTerm e)
+end)))
+and p_argTerm : (FStar_Parser_AST.term * FStar_Parser_AST.imp)  ->  FStar_Pprint.document = (fun arg_imp -> (match (arg_imp) with
+| ({FStar_Parser_AST.tm = FStar_Parser_AST.Uvar (uu____3408); FStar_Parser_AST.range = uu____3409; FStar_Parser_AST.level = uu____3410}, FStar_Parser_AST.UnivApp) -> begin
+(p_univar (Prims.fst arg_imp))
+end
+| (u, FStar_Parser_AST.UnivApp) -> begin
+(p_universe u)
+end
+| (e, FStar_Parser_AST.FsTypApp) -> begin
+((FStar_Util.print_warning "Unexpected FsTypApp, output might not be formatted correctly.\n");
+(
+
+let uu____3414 = (p_indexingTerm e)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") FStar_Pprint.langle uu____3414 FStar_Pprint.rangle));
+)
+end
+| (e, FStar_Parser_AST.Hash) -> begin
+(
+
+let uu____3416 = (str "#")
+in (
+
+let uu____3417 = (p_indexingTerm e)
+in (FStar_Pprint.op_Hat_Hat uu____3416 uu____3417)))
+end
+| (e, FStar_Parser_AST.Nothing) -> begin
+(p_indexingTerm e)
+end))
+and p_fsTypArg : (FStar_Parser_AST.term * FStar_Parser_AST.imp)  ->  FStar_Pprint.document = (fun uu____3419 -> (match (uu____3419) with
+| (e, uu____3423) -> begin
+(p_indexingTerm e)
+end))
+and p_indexingTerm_aux : (FStar_Parser_AST.term  ->  FStar_Pprint.document)  ->  FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun exit1 e -> (
+
+let uu____3428 = (
+
+let uu____3429 = (unparen e)
+in uu____3429.FStar_Parser_AST.tm)
+in (match (uu____3428) with
+| FStar_Parser_AST.Op (".()", (e1)::(e2)::[]) -> begin
+(
+
+let uu____3433 = (
+
+let uu____3434 = (p_indexingTerm_aux p_atomicTermNotQUident e1)
+in (
+
+let uu____3435 = (
+
+let uu____3436 = (
+
+let uu____3437 = (p_term e2)
+in (soft_parens_with_nesting uu____3437))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3436))
+in (FStar_Pprint.op_Hat_Hat uu____3434 uu____3435)))
+in (FStar_Pprint.group uu____3433))
+end
+| FStar_Parser_AST.Op (".[]", (e1)::(e2)::[]) -> begin
+(
+
+let uu____3441 = (
+
+let uu____3442 = (p_indexingTerm_aux p_atomicTermNotQUident e1)
+in (
+
+let uu____3443 = (
+
+let uu____3444 = (
+
+let uu____3445 = (p_term e2)
+in (soft_brackets_with_nesting uu____3445))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3444))
+in (FStar_Pprint.op_Hat_Hat uu____3442 uu____3443)))
+in (FStar_Pprint.group uu____3441))
+end
+| uu____3446 -> begin
+(exit1 e)
+end)))
+and p_indexingTerm : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (p_indexingTerm_aux p_atomicTerm e))
+and p_atomicTerm : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3449 = (
+
+let uu____3450 = (unparen e)
+in uu____3450.FStar_Parser_AST.tm)
+in (match (uu____3449) with
+| FStar_Parser_AST.LetOpen (lid, e1) -> begin
+(
+
+let uu____3453 = (p_quident lid)
+in (
+
+let uu____3454 = (
+
+let uu____3455 = (
+
+let uu____3456 = (p_term e1)
+in (soft_parens_with_nesting uu____3456))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3455))
+in (FStar_Pprint.op_Hat_Hat uu____3453 uu____3454)))
+end
+| FStar_Parser_AST.Name (lid) -> begin
+(p_quident lid)
+end
+| FStar_Parser_AST.Op (op, (e1)::[]) when (is_general_prefix_op op) -> begin
+(
+
+let uu____3461 = (str op)
+in (
+
+let uu____3462 = (p_atomicTerm e1)
+in (FStar_Pprint.op_Hat_Hat uu____3461 uu____3462)))
+end
+| uu____3463 -> begin
+(p_atomicTermNotQUident e)
+end)))
+and p_atomicTermNotQUident : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3465 = (
+
+let uu____3466 = (unparen e)
+in uu____3466.FStar_Parser_AST.tm)
+in (match (uu____3465) with
+| FStar_Parser_AST.Wild -> begin
+FStar_Pprint.underscore
+end
+| FStar_Parser_AST.Var (lid) when (FStar_Ident.lid_equals lid FStar_Syntax_Const.assert_lid) -> begin
+(str "assert")
+end
+| FStar_Parser_AST.Tvar (tv) -> begin
+(p_tvar tv)
+end
+| FStar_Parser_AST.Const (c) -> begin
+(p_constant c)
+end
+| FStar_Parser_AST.Name (lid) when (FStar_Ident.lid_equals lid FStar_Syntax_Const.true_lid) -> begin
+(str "True")
+end
+| FStar_Parser_AST.Name (lid) when (FStar_Ident.lid_equals lid FStar_Syntax_Const.false_lid) -> begin
+(str "False")
+end
+| FStar_Parser_AST.Op (op, (e1)::[]) when (is_general_prefix_op op) -> begin
+(
+
+let uu____3475 = (str op)
+in (
+
+let uu____3476 = (p_atomicTermNotQUident e1)
+in (FStar_Pprint.op_Hat_Hat uu____3475 uu____3476)))
+end
+| FStar_Parser_AST.Op (op, []) -> begin
+(
+
+let uu____3479 = (
+
+let uu____3480 = (
+
+let uu____3481 = (str op)
+in (
+
+let uu____3482 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen)
+in (FStar_Pprint.op_Hat_Hat uu____3481 uu____3482)))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3480))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3479))
+end
+| FStar_Parser_AST.Construct (lid, args) when (is_dtuple_constructor lid) -> begin
+(
+
+let uu____3491 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar)
+in (
+
+let uu____3492 = (
+
+let uu____3493 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1)
+in (
+
+let uu____3494 = (FStar_List.map Prims.fst args)
+in (FStar_Pprint.separate_map uu____3493 p_tmEq uu____3494)))
+in (
+
+let uu____3498 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____3491 uu____3492 uu____3498))))
+end
+| FStar_Parser_AST.Project (e1, lid) -> begin
+(
+
+let uu____3501 = (
+
+let uu____3502 = (p_atomicTermNotQUident e1)
+in (
+
+let uu____3503 = (
+
+let uu____3504 = (p_qlident lid)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3504))
+in (FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "0") uu____3502 uu____3503)))
+in (FStar_Pprint.group uu____3501))
+end
+| uu____3505 -> begin
+(p_projectionLHS e)
+end)))
+and p_projectionLHS : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (
+
+let uu____3507 = (
+
+let uu____3508 = (unparen e)
+in uu____3508.FStar_Parser_AST.tm)
+in (match (uu____3507) with
+| FStar_Parser_AST.Var (lid) -> begin
+(p_qlident lid)
+end
+| FStar_Parser_AST.Projector (constr_lid, field_lid) -> begin
+(
+
+let uu____3512 = (p_quident constr_lid)
+in (
+
+let uu____3513 = (
+
+let uu____3514 = (
+
+let uu____3515 = (p_lident field_lid)
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3515))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____3514))
+in (FStar_Pprint.op_Hat_Hat uu____3512 uu____3513)))
+end
+| FStar_Parser_AST.Discrim (constr_lid) -> begin
+(
+
+let uu____3517 = (p_quident constr_lid)
+in (FStar_Pprint.op_Hat_Hat uu____3517 FStar_Pprint.qmark))
+end
+| FStar_Parser_AST.Paren (e1) -> begin
+(
+
+let uu____3519 = (p_term e1)
+in (soft_parens_with_nesting uu____3519))
+end
+| uu____3520 when (is_array e) -> begin
+(
+
+let es = (extract_from_list e)
+in (
+
+let uu____3523 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar)
+in (
+
+let uu____3524 = (
+
+let uu____3525 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1)
+in (separate_map_or_flow uu____3525 p_noSeqTerm es))
+in (
+
+let uu____3526 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket)
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0") uu____3523 uu____3524 uu____3526)))))
+end
+| uu____3527 when (is_list e) -> begin
+(
+
+let uu____3528 = (
+
+let uu____3529 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1)
+in (
+
+let uu____3530 = (extract_from_list e)
+in (separate_map_or_flow uu____3529 p_noSeqTerm uu____3530)))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0") FStar_Pprint.lbracket uu____3528 FStar_Pprint.rbracket))
+end
+| uu____3532 when (is_lex_list e) -> begin
+(
+
+let uu____3533 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket)
+in (
+
+let uu____3534 = (
+
+let uu____3535 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1)
+in (
+
+let uu____3536 = (extract_from_list e)
+in (separate_map_or_flow uu____3535 p_noSeqTerm uu____3536)))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1") uu____3533 uu____3534 FStar_Pprint.rbracket)))
+end
+| uu____3538 when (is_ref_set e) -> begin
+(
+
+let es = (extract_from_ref_set e)
+in (
+
+let uu____3541 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace)
+in (
+
+let uu____3542 = (
+
+let uu____3543 = (FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1)
+in (separate_map_or_flow uu____3543 p_appTerm es))
+in (FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0") uu____3541 uu____3542 FStar_Pprint.rbrace))))
+end
+| (FStar_Parser_AST.Wild) | (FStar_Parser_AST.Const (_)) | (FStar_Parser_AST.Op (_)) | (FStar_Parser_AST.Tvar (_)) | (FStar_Parser_AST.Uvar (_)) | (FStar_Parser_AST.Var (_)) | (FStar_Parser_AST.Name (_)) | (FStar_Parser_AST.Construct (_)) | (FStar_Parser_AST.Abs (_)) | (FStar_Parser_AST.App (_)) | (FStar_Parser_AST.Let (_)) | (FStar_Parser_AST.LetOpen (_)) | (FStar_Parser_AST.Seq (_)) | (FStar_Parser_AST.If (_)) | (FStar_Parser_AST.Match (_)) | (FStar_Parser_AST.TryWith (_)) | (FStar_Parser_AST.Ascribed (_)) | (FStar_Parser_AST.Record (_)) | (FStar_Parser_AST.Project (_)) | (FStar_Parser_AST.Product (_)) | (FStar_Parser_AST.Sum (_)) | (FStar_Parser_AST.QForall (_)) | (FStar_Parser_AST.QExists (_)) | (FStar_Parser_AST.Refine (_)) | (FStar_Parser_AST.NamedTyp (_)) | (FStar_Parser_AST.Requires (_)) | (FStar_Parser_AST.Ensures (_)) | (FStar_Parser_AST.Assign (_)) | (FStar_Parser_AST.Attributes (_)) -> begin
+(
+
+let uu____3572 = (p_term e)
+in (soft_parens_with_nesting uu____3572))
+end
+| FStar_Parser_AST.Labeled (uu____3573) -> begin
+(failwith "Not valid in universe")
+end)))
+and p_constant : FStar_Const.sconst  ->  FStar_Pprint.document = (fun uu___141_3577 -> (match (uu___141_3577) with
+| FStar_Const.Const_effect -> begin
+(str "Effect")
+end
+| FStar_Const.Const_unit -> begin
+(str "()")
+end
+| FStar_Const.Const_bool (b) -> begin
+(FStar_Pprint.doc_of_bool b)
+end
+| FStar_Const.Const_float (x) -> begin
+(str (FStar_Util.string_of_float x))
+end
+| FStar_Const.Const_char (x) -> begin
+(
+
+let uu____3581 = (FStar_Pprint.doc_of_char x)
+in (FStar_Pprint.squotes uu____3581))
+end
+| FStar_Const.Const_string (bytes, uu____3583) -> begin
+(
+
+let uu____3586 = (str (FStar_Util.string_of_bytes bytes))
+in (FStar_Pprint.dquotes uu____3586))
+end
+| FStar_Const.Const_bytearray (bytes, uu____3588) -> begin
+(
+
+let uu____3591 = (
+
+let uu____3592 = (str (FStar_Util.string_of_bytes bytes))
+in (FStar_Pprint.dquotes uu____3592))
+in (
+
+let uu____3593 = (str "B")
+in (FStar_Pprint.op_Hat_Hat uu____3591 uu____3593)))
+end
+| FStar_Const.Const_int (repr, sign_width_opt) -> begin
+(
+
+let signedness = (fun uu___139_3605 -> (match (uu___139_3605) with
+| FStar_Const.Unsigned -> begin
+(str "u")
+end
+| FStar_Const.Signed -> begin
+FStar_Pprint.empty
+end))
+in (
+
+let width = (fun uu___140_3609 -> (match (uu___140_3609) with
+| FStar_Const.Int8 -> begin
+(str "y")
+end
+| FStar_Const.Int16 -> begin
+(str "s")
+end
+| FStar_Const.Int32 -> begin
+(str "l")
+end
+| FStar_Const.Int64 -> begin
+(str "L")
+end))
+in (
+
+let ending = (default_or_map FStar_Pprint.empty (fun uu____3613 -> (match (uu____3613) with
+| (s, w) -> begin
+(
+
+let uu____3618 = (signedness s)
+in (
+
+let uu____3619 = (width w)
+in (FStar_Pprint.op_Hat_Hat uu____3618 uu____3619)))
+end)) sign_width_opt)
+in (
+
+let uu____3620 = (str repr)
+in (FStar_Pprint.op_Hat_Hat uu____3620 ending)))))
+end
+| FStar_Const.Const_range (r) -> begin
+(
+
+let uu____3622 = (FStar_Range.string_of_range r)
+in (str uu____3622))
+end
+| FStar_Const.Const_reify -> begin
+(str "reify")
+end
+| FStar_Const.Const_reflect (lid) -> begin
+(
+
+let uu____3624 = (p_quident lid)
+in (
+
+let uu____3625 = (
+
+let uu____3626 = (
+
+let uu____3627 = (str "reflect")
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____3627))
+in (FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____3626))
+in (FStar_Pprint.op_Hat_Hat uu____3624 uu____3625)))
+end))
+and p_universe : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun u -> (
+
+let uu____3629 = (str "u#")
+in (
+
+let uu____3630 = (p_atomicUniverse u)
+in (FStar_Pprint.op_Hat_Hat uu____3629 uu____3630))))
+and p_universeFrom : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun u -> (
+
+let uu____3632 = (
+
+let uu____3633 = (unparen u)
+in uu____3633.FStar_Parser_AST.tm)
+in (match (uu____3632) with
+| FStar_Parser_AST.Op ("+", (u1)::(u2)::[]) -> begin
+(
+
+let uu____3637 = (
+
+let uu____3638 = (p_universeFrom u1)
+in (
+
+let uu____3639 = (
+
+let uu____3640 = (p_universeFrom u2)
+in (FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____3640))
+in (FStar_Pprint.op_Hat_Slash_Hat uu____3638 uu____3639)))
+in (FStar_Pprint.group uu____3637))
+end
+| FStar_Parser_AST.App (uu____3641) -> begin
+(
+
+let uu____3645 = (head_and_args u)
+in (match (uu____3645) with
+| (head1, args) -> begin
+(
+
+let uu____3659 = (
+
+let uu____3660 = (unparen head1)
+in uu____3660.FStar_Parser_AST.tm)
+in (match (uu____3659) with
+| FStar_Parser_AST.Var (maybe_max_lid) when (FStar_Ident.lid_equals maybe_max_lid FStar_Syntax_Const.max_lid) -> begin
+(
+
+let uu____3662 = (
+
+let uu____3663 = (p_qlident FStar_Syntax_Const.max_lid)
+in (
+
+let uu____3664 = (FStar_Pprint.separate_map FStar_Pprint.space (fun uu____3667 -> (match (uu____3667) with
+| (u1, uu____3671) -> begin
+(p_atomicUniverse u1)
+end)) args)
+in (op_Hat_Slash_Plus_Hat uu____3663 uu____3664)))
+in (FStar_Pprint.group uu____3662))
+end
+| uu____3672 -> begin
+(
+
+let uu____3673 = (
+
+let uu____3674 = (FStar_Parser_AST.term_to_string u)
+in (FStar_Util.format1 "Invalid term in universe context %s" uu____3674))
+in (failwith uu____3673))
+end))
+end))
+end
+| uu____3675 -> begin
+(p_atomicUniverse u)
+end)))
+and p_atomicUniverse : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun u -> (
+
+let uu____3677 = (
+
+let uu____3678 = (unparen u)
+in uu____3678.FStar_Parser_AST.tm)
+in (match (uu____3677) with
+| FStar_Parser_AST.Wild -> begin
+FStar_Pprint.underscore
+end
+| FStar_Parser_AST.Const (FStar_Const.Const_int (r, sw)) -> begin
+(p_constant (FStar_Const.Const_int (((r), (sw)))))
+end
+| FStar_Parser_AST.Uvar (uu____3690) -> begin
+(p_univar u)
+end
+| FStar_Parser_AST.Paren (u1) -> begin
+(
+
+let uu____3692 = (p_universeFrom u1)
+in (soft_parens_with_nesting uu____3692))
+end
+| (FStar_Parser_AST.Op ("+", (_)::(_)::[])) | (FStar_Parser_AST.App (_)) -> begin
+(
+
+let uu____3697 = (p_universeFrom u)
+in (soft_parens_with_nesting uu____3697))
+end
+| uu____3698 -> begin
+(
+
+let uu____3699 = (
+
+let uu____3700 = (FStar_Parser_AST.term_to_string u)
+in (FStar_Util.format1 "Invalid term in universe context %s" uu____3700))
+in (failwith uu____3699))
+end)))
+and p_univar : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun u -> (
+
+let uu____3702 = (
+
+let uu____3703 = (unparen u)
+in uu____3703.FStar_Parser_AST.tm)
+in (match (uu____3702) with
+| FStar_Parser_AST.Uvar (id) -> begin
+(str (FStar_Ident.text_of_id id))
+end
+| uu____3705 -> begin
+(
+
+let uu____3706 = (
+
+let uu____3707 = (FStar_Parser_AST.term_to_string u)
+in (FStar_Util.format1 "Not a universe variable %s" uu____3707))
+in (failwith uu____3706))
+end)))
+
+
+let term_to_document : FStar_Parser_AST.term  ->  FStar_Pprint.document = (fun e -> (p_term e))
+
+
+let decl_to_document : FStar_Parser_AST.decl  ->  FStar_Pprint.document = (fun e -> (p_decl e))
+
+
+let modul_to_document : FStar_Parser_AST.modul  ->  FStar_Pprint.document = (fun m -> ((FStar_ST.write should_print_fs_typ_app false);
+(
+
+let res = (match (m) with
+| (FStar_Parser_AST.Module (_, decls)) | (FStar_Parser_AST.Interface (_, decls, _)) -> begin
+(
+
+let uu____3729 = (FStar_All.pipe_right decls (FStar_List.map decl_to_document))
+in (FStar_All.pipe_right uu____3729 (FStar_Pprint.separate FStar_Pprint.hardline)))
+end)
+in ((FStar_ST.write should_print_fs_typ_app false);
+res;
+));
+))
+
+
+let comments_to_document : (Prims.string * FStar_Range.range) Prims.list  ->  FStar_Pprint.document = (fun comments -> (FStar_Pprint.separate_map FStar_Pprint.hardline (fun uu____3748 -> (match (uu____3748) with
+| (comment, range) -> begin
+(str comment)
+end)) comments))
+
+
+let modul_with_comments_to_document : FStar_Parser_AST.modul  ->  (Prims.string * FStar_Range.range) Prims.list  ->  (FStar_Pprint.document * (Prims.string * FStar_Range.range) Prims.list) = (fun m comments -> (
+
+let decls = (match (m) with
+| (FStar_Parser_AST.Module (_, decls)) | (FStar_Parser_AST.Interface (_, decls, _)) -> begin
+decls
+end)
+in ((FStar_ST.write should_print_fs_typ_app false);
+(match (decls) with
+| [] -> begin
+((FStar_Pprint.empty), (comments))
+end
+| (d)::ds -> begin
+(
+
+let uu____3795 = (match (ds) with
+| ({FStar_Parser_AST.d = FStar_Parser_AST.Pragma (FStar_Parser_AST.LightOff); FStar_Parser_AST.drange = uu____3802; FStar_Parser_AST.doc = uu____3803; FStar_Parser_AST.quals = uu____3804; FStar_Parser_AST.attrs = uu____3805})::uu____3806 -> begin
+(
+
+let d0 = (FStar_List.hd ds)
+in (
+
+let uu____3810 = (
+
+let uu____3812 = (
+
+let uu____3814 = (FStar_List.tl ds)
+in (d)::uu____3814)
+in (d0)::uu____3812)
+in ((uu____3810), (d0.FStar_Parser_AST.drange))))
+end
+| uu____3817 -> begin
+(((d)::ds), (d.FStar_Parser_AST.drange))
+end)
+in (match (uu____3795) with
+| (decls1, first_range) -> begin
+(
+
+let extract_decl_range = (fun d1 -> d1.FStar_Parser_AST.drange)
+in ((FStar_ST.write comment_stack comments);
+(
+
+let initial_comment = (
+
+let uu____3840 = (FStar_Range.start_of_range first_range)
+in (place_comments_until_pos (Prims.parse_int "0") (Prims.parse_int "1") uu____3840 FStar_Pprint.empty))
+in (
+
+let doc1 = (separate_map_with_comments FStar_Pprint.empty FStar_Pprint.empty decl_to_document decls1 extract_decl_range)
+in (
+
+let comments1 = (FStar_ST.read comment_stack)
+in ((FStar_ST.write comment_stack []);
+(FStar_ST.write should_print_fs_typ_app false);
+(
+
+let uu____3862 = (FStar_Pprint.op_Hat_Hat initial_comment doc1)
+in ((uu____3862), (comments1)));
+))));
+))
+end))
+end);
+)))
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -1,7620 +1,8362 @@
+
 open Prims
-let add_fuel x tl1 =
-  let uu____16 = FStar_Options.unthrottle_inductives () in
-  if uu____16 then tl1 else x :: tl1
-let withenv c uu____39 = match uu____39 with | (a,b) -> (a, b, c)
-let vargs args =
-  FStar_List.filter
-    (fun uu___111_74  ->
-       match uu___111_74 with
-       | (FStar_Util.Inl uu____79,uu____80) -> false
-       | uu____83 -> true) args
-let subst_lcomp_opt s l =
-  match l with
-  | Some (FStar_Util.Inl l1) ->
-      let uu____114 =
-        let uu____117 =
-          let uu____118 =
-            let uu____121 = l1.FStar_Syntax_Syntax.comp () in
-            FStar_Syntax_Subst.subst_comp s uu____121 in
-          FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____118 in
-        FStar_Util.Inl uu____117 in
-      Some uu____114
-  | uu____126 -> l
-let escape: Prims.string -> Prims.string =
-  fun s  -> FStar_Util.replace_char s '\'' '_'
-let mk_term_projector_name:
-  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> Prims.string =
-  fun lid  ->
-    fun a  ->
-      let a1 =
-        let uu___135_140 = a in
-        let uu____141 =
-          FStar_Syntax_Util.unmangle_field_name a.FStar_Syntax_Syntax.ppname in
-        {
-          FStar_Syntax_Syntax.ppname = uu____141;
-          FStar_Syntax_Syntax.index =
-            (uu___135_140.FStar_Syntax_Syntax.index);
-          FStar_Syntax_Syntax.sort = (uu___135_140.FStar_Syntax_Syntax.sort)
-        } in
-      let uu____142 =
-        FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (a1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText in
-      FStar_All.pipe_left escape uu____142
-let primitive_projector_by_pos:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident -> Prims.int -> Prims.string
-  =
-  fun env  ->
-    fun lid  ->
-      fun i  ->
-        let fail uu____155 =
-          let uu____156 =
-            FStar_Util.format2
-              "Projector %s on data constructor %s not found"
-              (Prims.string_of_int i) lid.FStar_Ident.str in
-          failwith uu____156 in
-        let uu____157 = FStar_TypeChecker_Env.lookup_datacon env lid in
-        match uu____157 with
-        | (uu____160,t) ->
-            let uu____162 =
-              let uu____163 = FStar_Syntax_Subst.compress t in
-              uu____163.FStar_Syntax_Syntax.n in
-            (match uu____162 with
-             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                 let uu____178 = FStar_Syntax_Subst.open_comp bs c in
-                 (match uu____178 with
-                  | (binders,uu____182) ->
-                      if
-                        (i < (Prims.parse_int "0")) ||
-                          (i >= (FStar_List.length binders))
-                      then fail ()
-                      else
-                        (let b = FStar_List.nth binders i in
-                         mk_term_projector_name lid (Prims.fst b)))
-             | uu____193 -> fail ())
-let mk_term_projector_name_by_pos:
-  FStar_Ident.lident -> Prims.int -> Prims.string =
-  fun lid  ->
-    fun i  ->
-      let uu____200 =
-        FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (Prims.string_of_int i) in
-      FStar_All.pipe_left escape uu____200
-let mk_term_projector:
-  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term
-  =
-  fun lid  ->
-    fun a  ->
-      let uu____207 =
-        let uu____210 = mk_term_projector_name lid a in
-        (uu____210,
-          (FStar_SMTEncoding_Term.Arrow
-             (FStar_SMTEncoding_Term.Term_sort,
-               FStar_SMTEncoding_Term.Term_sort))) in
-      FStar_SMTEncoding_Util.mkFreeV uu____207
-let mk_term_projector_by_pos:
-  FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term =
-  fun lid  ->
-    fun i  ->
-      let uu____217 =
-        let uu____220 = mk_term_projector_name_by_pos lid i in
-        (uu____220,
-          (FStar_SMTEncoding_Term.Arrow
-             (FStar_SMTEncoding_Term.Term_sort,
-               FStar_SMTEncoding_Term.Term_sort))) in
-      FStar_SMTEncoding_Util.mkFreeV uu____217
-let mk_data_tester env l x =
-  FStar_SMTEncoding_Term.mk_tester (escape l.FStar_Ident.str) x
+
+let add_fuel = (fun x tl1 -> (
+
+let uu____16 = (FStar_Options.unthrottle_inductives ())
+in (match (uu____16) with
+| true -> begin
+tl1
+end
+| uu____18 -> begin
+(x)::tl1
+end)))
+
+
+let withenv = (fun c uu____39 -> (match (uu____39) with
+| (a, b) -> begin
+((a), (b), (c))
+end))
+
+
+let vargs = (fun args -> (FStar_List.filter (fun uu___111_74 -> (match (uu___111_74) with
+| (FStar_Util.Inl (uu____79), uu____80) -> begin
+false
+end
+| uu____83 -> begin
+true
+end)) args))
+
+
+let subst_lcomp_opt = (fun s l -> (match (l) with
+| Some (FStar_Util.Inl (l1)) -> begin
+(
+
+let uu____114 = (
+
+let uu____117 = (
+
+let uu____118 = (
+
+let uu____121 = (l1.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Subst.subst_comp s uu____121))
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____118))
+in FStar_Util.Inl (uu____117))
+in Some (uu____114))
+end
+| uu____126 -> begin
+l
+end))
+
+
+let escape : Prims.string  ->  Prims.string = (fun s -> (FStar_Util.replace_char s '\'' '_'))
+
+
+let mk_term_projector_name : FStar_Ident.lident  ->  FStar_Syntax_Syntax.bv  ->  Prims.string = (fun lid a -> (
+
+let a1 = (
+
+let uu___135_140 = a
+in (
+
+let uu____141 = (FStar_Syntax_Util.unmangle_field_name a.FStar_Syntax_Syntax.ppname)
+in {FStar_Syntax_Syntax.ppname = uu____141; FStar_Syntax_Syntax.index = uu___135_140.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu___135_140.FStar_Syntax_Syntax.sort}))
+in (
+
+let uu____142 = (FStar_Util.format2 "%s_%s" lid.FStar_Ident.str a1.FStar_Syntax_Syntax.ppname.FStar_Ident.idText)
+in (FStar_All.pipe_left escape uu____142))))
+
+
+let primitive_projector_by_pos : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  Prims.int  ->  Prims.string = (fun env lid i -> (
+
+let fail = (fun uu____155 -> (
+
+let uu____156 = (FStar_Util.format2 "Projector %s on data constructor %s not found" (Prims.string_of_int i) lid.FStar_Ident.str)
+in (failwith uu____156)))
+in (
+
+let uu____157 = (FStar_TypeChecker_Env.lookup_datacon env lid)
+in (match (uu____157) with
+| (uu____160, t) -> begin
+(
+
+let uu____162 = (
+
+let uu____163 = (FStar_Syntax_Subst.compress t)
+in uu____163.FStar_Syntax_Syntax.n)
+in (match (uu____162) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____178 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____178) with
+| (binders, uu____182) -> begin
+(match (((i < (Prims.parse_int "0")) || (i >= (FStar_List.length binders)))) with
+| true -> begin
+(fail ())
+end
+| uu____187 -> begin
+(
+
+let b = (FStar_List.nth binders i)
+in (mk_term_projector_name lid (Prims.fst b)))
+end)
+end))
+end
+| uu____193 -> begin
+(fail ())
+end))
+end))))
+
+
+let mk_term_projector_name_by_pos : FStar_Ident.lident  ->  Prims.int  ->  Prims.string = (fun lid i -> (
+
+let uu____200 = (FStar_Util.format2 "%s_%s" lid.FStar_Ident.str (Prims.string_of_int i))
+in (FStar_All.pipe_left escape uu____200)))
+
+
+let mk_term_projector : FStar_Ident.lident  ->  FStar_Syntax_Syntax.bv  ->  FStar_SMTEncoding_Term.term = (fun lid a -> (
+
+let uu____207 = (
+
+let uu____210 = (mk_term_projector_name lid a)
+in ((uu____210), (FStar_SMTEncoding_Term.Arrow (((FStar_SMTEncoding_Term.Term_sort), (FStar_SMTEncoding_Term.Term_sort))))))
+in (FStar_SMTEncoding_Util.mkFreeV uu____207)))
+
+
+let mk_term_projector_by_pos : FStar_Ident.lident  ->  Prims.int  ->  FStar_SMTEncoding_Term.term = (fun lid i -> (
+
+let uu____217 = (
+
+let uu____220 = (mk_term_projector_name_by_pos lid i)
+in ((uu____220), (FStar_SMTEncoding_Term.Arrow (((FStar_SMTEncoding_Term.Term_sort), (FStar_SMTEncoding_Term.Term_sort))))))
+in (FStar_SMTEncoding_Util.mkFreeV uu____217)))
+
+
+let mk_data_tester = (fun env l x -> (FStar_SMTEncoding_Term.mk_tester (escape l.FStar_Ident.str) x))
+
 type varops_t =
-  {
-  push: Prims.unit -> Prims.unit;
-  pop: Prims.unit -> Prims.unit;
-  mark: Prims.unit -> Prims.unit;
-  reset_mark: Prims.unit -> Prims.unit;
-  commit_mark: Prims.unit -> Prims.unit;
-  new_var: FStar_Ident.ident -> Prims.int -> Prims.string;
-  new_fvar: FStar_Ident.lident -> Prims.string;
-  fresh: Prims.string -> Prims.string;
-  string_const: Prims.string -> FStar_SMTEncoding_Term.term;
-  next_id: Prims.unit -> Prims.int;
-  mk_unique: Prims.string -> Prims.string;}
-let varops: varops_t =
-  let initial_ctr = Prims.parse_int "100" in
-  let ctr = FStar_Util.mk_ref initial_ctr in
-  let new_scope uu____410 =
-    let uu____411 = FStar_Util.smap_create (Prims.parse_int "100") in
-    let uu____413 = FStar_Util.smap_create (Prims.parse_int "100") in
-    (uu____411, uu____413) in
-  let scopes =
-    let uu____424 = let uu____430 = new_scope () in [uu____430] in
-    FStar_Util.mk_ref uu____424 in
-  let mk_unique y =
-    let y1 = escape y in
-    let y2 =
-      let uu____455 =
-        let uu____457 = FStar_ST.read scopes in
-        FStar_Util.find_map uu____457
-          (fun uu____474  ->
-             match uu____474 with
-             | (names1,uu____481) -> FStar_Util.smap_try_find names1 y1) in
-      match uu____455 with
-      | None  -> y1
-      | Some uu____486 ->
-          (FStar_Util.incr ctr;
-           (let uu____491 =
-              let uu____492 =
-                let uu____493 = FStar_ST.read ctr in
-                Prims.string_of_int uu____493 in
-              Prims.strcat "__" uu____492 in
-            Prims.strcat y1 uu____491)) in
-    let top_scope =
-      let uu____498 =
-        let uu____503 = FStar_ST.read scopes in FStar_List.hd uu____503 in
-      FStar_All.pipe_left Prims.fst uu____498 in
-    FStar_Util.smap_add top_scope y2 true; y2 in
-  let new_var pp rn =
-    FStar_All.pipe_left mk_unique
-      (Prims.strcat pp.FStar_Ident.idText
-         (Prims.strcat "__" (Prims.string_of_int rn))) in
-  let new_fvar lid = mk_unique lid.FStar_Ident.str in
-  let next_id1 uu____542 = FStar_Util.incr ctr; FStar_ST.read ctr in
-  let fresh1 pfx =
-    let uu____553 =
-      let uu____554 = next_id1 () in
-      FStar_All.pipe_left Prims.string_of_int uu____554 in
-    FStar_Util.format2 "%s_%s" pfx uu____553 in
-  let string_const s =
-    let uu____559 =
-      let uu____561 = FStar_ST.read scopes in
-      FStar_Util.find_map uu____561
-        (fun uu____578  ->
-           match uu____578 with
-           | (uu____584,strings) -> FStar_Util.smap_try_find strings s) in
-    match uu____559 with
-    | Some f -> f
-    | None  ->
-        let id = next_id1 () in
-        let f =
-          let uu____593 = FStar_SMTEncoding_Util.mk_String_const id in
-          FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____593 in
-        let top_scope =
-          let uu____596 =
-            let uu____601 = FStar_ST.read scopes in FStar_List.hd uu____601 in
-          FStar_All.pipe_left Prims.snd uu____596 in
-        (FStar_Util.smap_add top_scope s f; f) in
-  let push1 uu____629 =
-    let uu____630 =
-      let uu____636 = new_scope () in
-      let uu____641 = FStar_ST.read scopes in uu____636 :: uu____641 in
-    FStar_ST.write scopes uu____630 in
-  let pop1 uu____668 =
-    let uu____669 =
-      let uu____675 = FStar_ST.read scopes in FStar_List.tl uu____675 in
-    FStar_ST.write scopes uu____669 in
-  let mark1 uu____702 = push1 () in
-  let reset_mark1 uu____706 = pop1 () in
-  let commit_mark1 uu____710 =
-    let uu____711 = FStar_ST.read scopes in
-    match uu____711 with
-    | (hd1,hd2)::(next1,next2)::tl1 ->
-        (FStar_Util.smap_fold hd1
-           (fun key  ->
-              fun value  -> fun v1  -> FStar_Util.smap_add next1 key value)
-           ();
-         FStar_Util.smap_fold hd2
-           (fun key  ->
-              fun value  -> fun v1  -> FStar_Util.smap_add next2 key value)
-           ();
-         FStar_ST.write scopes ((next1, next2) :: tl1))
-    | uu____771 -> failwith "Impossible" in
-  {
-    push = push1;
-    pop = pop1;
-    mark = mark1;
-    reset_mark = reset_mark1;
-    commit_mark = commit_mark1;
-    new_var;
-    new_fvar;
-    fresh = fresh1;
-    string_const;
-    next_id = next_id1;
-    mk_unique
-  }
-let unmangle: FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.bv =
-  fun x  ->
-    let uu___136_780 = x in
-    let uu____781 =
-      FStar_Syntax_Util.unmangle_field_name x.FStar_Syntax_Syntax.ppname in
-    {
-      FStar_Syntax_Syntax.ppname = uu____781;
-      FStar_Syntax_Syntax.index = (uu___136_780.FStar_Syntax_Syntax.index);
-      FStar_Syntax_Syntax.sort = (uu___136_780.FStar_Syntax_Syntax.sort)
-    }
+{push : Prims.unit  ->  Prims.unit; pop : Prims.unit  ->  Prims.unit; mark : Prims.unit  ->  Prims.unit; reset_mark : Prims.unit  ->  Prims.unit; commit_mark : Prims.unit  ->  Prims.unit; new_var : FStar_Ident.ident  ->  Prims.int  ->  Prims.string; new_fvar : FStar_Ident.lident  ->  Prims.string; fresh : Prims.string  ->  Prims.string; string_const : Prims.string  ->  FStar_SMTEncoding_Term.term; next_id : Prims.unit  ->  Prims.int; mk_unique : Prims.string  ->  Prims.string}
+
+
+let varops : varops_t = (
+
+let initial_ctr = (Prims.parse_int "100")
+in (
+
+let ctr = (FStar_Util.mk_ref initial_ctr)
+in (
+
+let new_scope = (fun uu____410 -> (
+
+let uu____411 = (FStar_Util.smap_create (Prims.parse_int "100"))
+in (
+
+let uu____413 = (FStar_Util.smap_create (Prims.parse_int "100"))
+in ((uu____411), (uu____413)))))
+in (
+
+let scopes = (
+
+let uu____424 = (
+
+let uu____430 = (new_scope ())
+in (uu____430)::[])
+in (FStar_Util.mk_ref uu____424))
+in (
+
+let mk_unique = (fun y -> (
+
+let y1 = (escape y)
+in (
+
+let y2 = (
+
+let uu____455 = (
+
+let uu____457 = (FStar_ST.read scopes)
+in (FStar_Util.find_map uu____457 (fun uu____474 -> (match (uu____474) with
+| (names1, uu____481) -> begin
+(FStar_Util.smap_try_find names1 y1)
+end))))
+in (match (uu____455) with
+| None -> begin
+y1
+end
+| Some (uu____486) -> begin
+((FStar_Util.incr ctr);
+(
+
+let uu____491 = (
+
+let uu____492 = (
+
+let uu____493 = (FStar_ST.read ctr)
+in (Prims.string_of_int uu____493))
+in (Prims.strcat "__" uu____492))
+in (Prims.strcat y1 uu____491));
+)
+end))
+in (
+
+let top_scope = (
+
+let uu____498 = (
+
+let uu____503 = (FStar_ST.read scopes)
+in (FStar_List.hd uu____503))
+in (FStar_All.pipe_left Prims.fst uu____498))
+in ((FStar_Util.smap_add top_scope y2 true);
+y2;
+)))))
+in (
+
+let new_var = (fun pp rn -> (FStar_All.pipe_left mk_unique (Prims.strcat pp.FStar_Ident.idText (Prims.strcat "__" (Prims.string_of_int rn)))))
+in (
+
+let new_fvar = (fun lid -> (mk_unique lid.FStar_Ident.str))
+in (
+
+let next_id1 = (fun uu____542 -> ((FStar_Util.incr ctr);
+(FStar_ST.read ctr);
+))
+in (
+
+let fresh1 = (fun pfx -> (
+
+let uu____553 = (
+
+let uu____554 = (next_id1 ())
+in (FStar_All.pipe_left Prims.string_of_int uu____554))
+in (FStar_Util.format2 "%s_%s" pfx uu____553)))
+in (
+
+let string_const = (fun s -> (
+
+let uu____559 = (
+
+let uu____561 = (FStar_ST.read scopes)
+in (FStar_Util.find_map uu____561 (fun uu____578 -> (match (uu____578) with
+| (uu____584, strings) -> begin
+(FStar_Util.smap_try_find strings s)
+end))))
+in (match (uu____559) with
+| Some (f) -> begin
+f
+end
+| None -> begin
+(
+
+let id = (next_id1 ())
+in (
+
+let f = (
+
+let uu____593 = (FStar_SMTEncoding_Util.mk_String_const id)
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____593))
+in (
+
+let top_scope = (
+
+let uu____596 = (
+
+let uu____601 = (FStar_ST.read scopes)
+in (FStar_List.hd uu____601))
+in (FStar_All.pipe_left Prims.snd uu____596))
+in ((FStar_Util.smap_add top_scope s f);
+f;
+))))
+end)))
+in (
+
+let push1 = (fun uu____629 -> (
+
+let uu____630 = (
+
+let uu____636 = (new_scope ())
+in (
+
+let uu____641 = (FStar_ST.read scopes)
+in (uu____636)::uu____641))
+in (FStar_ST.write scopes uu____630)))
+in (
+
+let pop1 = (fun uu____668 -> (
+
+let uu____669 = (
+
+let uu____675 = (FStar_ST.read scopes)
+in (FStar_List.tl uu____675))
+in (FStar_ST.write scopes uu____669)))
+in (
+
+let mark1 = (fun uu____702 -> (push1 ()))
+in (
+
+let reset_mark1 = (fun uu____706 -> (pop1 ()))
+in (
+
+let commit_mark1 = (fun uu____710 -> (
+
+let uu____711 = (FStar_ST.read scopes)
+in (match (uu____711) with
+| ((hd1, hd2))::((next1, next2))::tl1 -> begin
+((FStar_Util.smap_fold hd1 (fun key value v1 -> (FStar_Util.smap_add next1 key value)) ());
+(FStar_Util.smap_fold hd2 (fun key value v1 -> (FStar_Util.smap_add next2 key value)) ());
+(FStar_ST.write scopes ((((next1), (next2)))::tl1));
+)
+end
+| uu____771 -> begin
+(failwith "Impossible")
+end)))
+in {push = push1; pop = pop1; mark = mark1; reset_mark = reset_mark1; commit_mark = commit_mark1; new_var = new_var; new_fvar = new_fvar; fresh = fresh1; string_const = string_const; next_id = next_id1; mk_unique = mk_unique})))))))))))))))
+
+
+let unmangle : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.bv = (fun x -> (
+
+let uu___136_780 = x
+in (
+
+let uu____781 = (FStar_Syntax_Util.unmangle_field_name x.FStar_Syntax_Syntax.ppname)
+in {FStar_Syntax_Syntax.ppname = uu____781; FStar_Syntax_Syntax.index = uu___136_780.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu___136_780.FStar_Syntax_Syntax.sort})))
+
 type binding =
-  | Binding_var of (FStar_Syntax_Syntax.bv* FStar_SMTEncoding_Term.term)
-  | Binding_fvar of (FStar_Ident.lident* Prims.string*
-  FStar_SMTEncoding_Term.term Prims.option* FStar_SMTEncoding_Term.term
-  Prims.option)
-let uu___is_Binding_var: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_var _0 -> true | uu____802 -> false
-let __proj__Binding_var__item___0:
-  binding -> (FStar_Syntax_Syntax.bv* FStar_SMTEncoding_Term.term) =
-  fun projectee  -> match projectee with | Binding_var _0 -> _0
-let uu___is_Binding_fvar: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_fvar _0 -> true | uu____826 -> false
-let __proj__Binding_fvar__item___0:
-  binding ->
-    (FStar_Ident.lident* Prims.string* FStar_SMTEncoding_Term.term
-      Prims.option* FStar_SMTEncoding_Term.term Prims.option)
-  = fun projectee  -> match projectee with | Binding_fvar _0 -> _0
-let binder_of_eithervar v1 = (v1, None)
+| Binding_var of (FStar_Syntax_Syntax.bv * FStar_SMTEncoding_Term.term)
+| Binding_fvar of (FStar_Ident.lident * Prims.string * FStar_SMTEncoding_Term.term Prims.option * FStar_SMTEncoding_Term.term Prims.option)
+
+
+let uu___is_Binding_var : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_var (_0) -> begin
+true
+end
+| uu____802 -> begin
+false
+end))
+
+
+let __proj__Binding_var__item___0 : binding  ->  (FStar_Syntax_Syntax.bv * FStar_SMTEncoding_Term.term) = (fun projectee -> (match (projectee) with
+| Binding_var (_0) -> begin
+_0
+end))
+
+
+let uu___is_Binding_fvar : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_fvar (_0) -> begin
+true
+end
+| uu____826 -> begin
+false
+end))
+
+
+let __proj__Binding_fvar__item___0 : binding  ->  (FStar_Ident.lident * Prims.string * FStar_SMTEncoding_Term.term Prims.option * FStar_SMTEncoding_Term.term Prims.option) = (fun projectee -> (match (projectee) with
+| Binding_fvar (_0) -> begin
+_0
+end))
+
+
+let binder_of_eithervar = (fun v1 -> ((v1), (None)))
+
 type env_t =
-  {
-  bindings: binding Prims.list;
-  depth: Prims.int;
-  tcenv: FStar_TypeChecker_Env.env;
-  warn: Prims.bool;
-  cache:
-    (Prims.string* FStar_SMTEncoding_Term.sort Prims.list*
-      FStar_SMTEncoding_Term.decl Prims.list) FStar_Util.smap;
-  nolabels: Prims.bool;
-  use_zfuel_name: Prims.bool;
-  encode_non_total_function_typ: Prims.bool;}
-let print_env: env_t -> Prims.string =
-  fun e  ->
-    let uu____945 =
-      FStar_All.pipe_right e.bindings
-        (FStar_List.map
-           (fun uu___112_949  ->
-              match uu___112_949 with
-              | Binding_var (x,uu____951) ->
-                  FStar_Syntax_Print.bv_to_string x
-              | Binding_fvar (l,uu____953,uu____954,uu____955) ->
-                  FStar_Syntax_Print.lid_to_string l)) in
-    FStar_All.pipe_right uu____945 (FStar_String.concat ", ")
-let lookup_binding env f = FStar_Util.find_map env.bindings f
-let caption_t: env_t -> FStar_Syntax_Syntax.term -> Prims.string Prims.option
-  =
-  fun env  ->
-    fun t  ->
-      let uu____988 = FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
-      if uu____988
-      then
-        let uu____990 = FStar_Syntax_Print.term_to_string t in Some uu____990
-      else None
-let fresh_fvar:
-  Prims.string ->
-    FStar_SMTEncoding_Term.sort ->
-      (Prims.string* FStar_SMTEncoding_Term.term)
-  =
-  fun x  ->
-    fun s  ->
-      let xsym = varops.fresh x in
-      let uu____1001 = FStar_SMTEncoding_Util.mkFreeV (xsym, s) in
-      (xsym, uu____1001)
-let gen_term_var:
-  env_t ->
-    FStar_Syntax_Syntax.bv ->
-      (Prims.string* FStar_SMTEncoding_Term.term* env_t)
-  =
-  fun env  ->
-    fun x  ->
-      let ysym = Prims.strcat "@x" (Prims.string_of_int env.depth) in
-      let y =
-        FStar_SMTEncoding_Util.mkFreeV
-          (ysym, FStar_SMTEncoding_Term.Term_sort) in
-      (ysym, y,
-        (let uu___137_1013 = env in
-         {
-           bindings = ((Binding_var (x, y)) :: (env.bindings));
-           depth = (env.depth + (Prims.parse_int "1"));
-           tcenv = (uu___137_1013.tcenv);
-           warn = (uu___137_1013.warn);
-           cache = (uu___137_1013.cache);
-           nolabels = (uu___137_1013.nolabels);
-           use_zfuel_name = (uu___137_1013.use_zfuel_name);
-           encode_non_total_function_typ =
-             (uu___137_1013.encode_non_total_function_typ)
-         }))
-let new_term_constant:
-  env_t ->
-    FStar_Syntax_Syntax.bv ->
-      (Prims.string* FStar_SMTEncoding_Term.term* env_t)
-  =
-  fun env  ->
-    fun x  ->
-      let ysym =
-        varops.new_var x.FStar_Syntax_Syntax.ppname
-          x.FStar_Syntax_Syntax.index in
-      let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
-      (ysym, y,
-        (let uu___138_1026 = env in
-         {
-           bindings = ((Binding_var (x, y)) :: (env.bindings));
-           depth = (uu___138_1026.depth);
-           tcenv = (uu___138_1026.tcenv);
-           warn = (uu___138_1026.warn);
-           cache = (uu___138_1026.cache);
-           nolabels = (uu___138_1026.nolabels);
-           use_zfuel_name = (uu___138_1026.use_zfuel_name);
-           encode_non_total_function_typ =
-             (uu___138_1026.encode_non_total_function_typ)
-         }))
-let new_term_constant_from_string:
-  env_t ->
-    FStar_Syntax_Syntax.bv ->
-      Prims.string -> (Prims.string* FStar_SMTEncoding_Term.term* env_t)
-  =
-  fun env  ->
-    fun x  ->
-      fun str  ->
-        let ysym = varops.mk_unique str in
-        let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
-        (ysym, y,
-          (let uu___139_1042 = env in
-           {
-             bindings = ((Binding_var (x, y)) :: (env.bindings));
-             depth = (uu___139_1042.depth);
-             tcenv = (uu___139_1042.tcenv);
-             warn = (uu___139_1042.warn);
-             cache = (uu___139_1042.cache);
-             nolabels = (uu___139_1042.nolabels);
-             use_zfuel_name = (uu___139_1042.use_zfuel_name);
-             encode_non_total_function_typ =
-               (uu___139_1042.encode_non_total_function_typ)
-           }))
-let push_term_var:
-  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term -> env_t =
-  fun env  ->
-    fun x  ->
-      fun t  ->
-        let uu___140_1052 = env in
-        {
-          bindings = ((Binding_var (x, t)) :: (env.bindings));
-          depth = (uu___140_1052.depth);
-          tcenv = (uu___140_1052.tcenv);
-          warn = (uu___140_1052.warn);
-          cache = (uu___140_1052.cache);
-          nolabels = (uu___140_1052.nolabels);
-          use_zfuel_name = (uu___140_1052.use_zfuel_name);
-          encode_non_total_function_typ =
-            (uu___140_1052.encode_non_total_function_typ)
-        }
-let lookup_term_var:
-  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term =
-  fun env  ->
-    fun a  ->
-      let aux a' =
-        lookup_binding env
-          (fun uu___113_1068  ->
-             match uu___113_1068 with
-             | Binding_var (b,t) when FStar_Syntax_Syntax.bv_eq b a' ->
-                 Some (b, t)
-             | uu____1076 -> None) in
-      let uu____1079 = aux a in
-      match uu____1079 with
-      | None  ->
-          let a2 = unmangle a in
-          let uu____1086 = aux a2 in
-          (match uu____1086 with
-           | None  ->
-               let uu____1092 =
-                 let uu____1093 = FStar_Syntax_Print.bv_to_string a2 in
-                 let uu____1094 = print_env env in
-                 FStar_Util.format2
-                   "Bound term variable not found (after unmangling): %s in environment: %s"
-                   uu____1093 uu____1094 in
-               failwith uu____1092
-           | Some (b,t) -> t)
-      | Some (b,t) -> t
-let new_term_constant_and_tok_from_lid:
-  env_t -> FStar_Ident.lident -> (Prims.string* Prims.string* env_t) =
-  fun env  ->
-    fun x  ->
-      let fname = varops.new_fvar x in
-      let ftok = Prims.strcat fname "@tok" in
-      let uu____1114 =
-        let uu___141_1115 = env in
-        let uu____1116 =
-          let uu____1118 =
-            let uu____1119 =
-              let uu____1126 =
-                let uu____1128 = FStar_SMTEncoding_Util.mkApp (ftok, []) in
-                FStar_All.pipe_left (fun _0_29  -> Some _0_29) uu____1128 in
-              (x, fname, uu____1126, None) in
-            Binding_fvar uu____1119 in
-          uu____1118 :: (env.bindings) in
-        {
-          bindings = uu____1116;
-          depth = (uu___141_1115.depth);
-          tcenv = (uu___141_1115.tcenv);
-          warn = (uu___141_1115.warn);
-          cache = (uu___141_1115.cache);
-          nolabels = (uu___141_1115.nolabels);
-          use_zfuel_name = (uu___141_1115.use_zfuel_name);
-          encode_non_total_function_typ =
-            (uu___141_1115.encode_non_total_function_typ)
-        } in
-      (fname, ftok, uu____1114)
-let try_lookup_lid:
-  env_t ->
-    FStar_Ident.lident ->
-      (Prims.string* FStar_SMTEncoding_Term.term Prims.option*
-        FStar_SMTEncoding_Term.term Prims.option) Prims.option
-  =
-  fun env  ->
-    fun a  ->
-      lookup_binding env
-        (fun uu___114_1150  ->
-           match uu___114_1150 with
-           | Binding_fvar (b,t1,t2,t3) when FStar_Ident.lid_equals b a ->
-               Some (t1, t2, t3)
-           | uu____1172 -> None)
-let contains_name: env_t -> Prims.string -> Prims.bool =
-  fun env  ->
-    fun s  ->
-      let uu____1184 =
-        lookup_binding env
-          (fun uu___115_1186  ->
-             match uu___115_1186 with
-             | Binding_fvar (b,t1,t2,t3) when b.FStar_Ident.str = s ->
-                 Some ()
-             | uu____1196 -> None) in
-      FStar_All.pipe_right uu____1184 FStar_Option.isSome
-let lookup_lid:
-  env_t ->
-    FStar_Ident.lident ->
-      (Prims.string* FStar_SMTEncoding_Term.term Prims.option*
-        FStar_SMTEncoding_Term.term Prims.option)
-  =
-  fun env  ->
-    fun a  ->
-      let uu____1209 = try_lookup_lid env a in
-      match uu____1209 with
-      | None  ->
-          let uu____1226 =
-            let uu____1227 = FStar_Syntax_Print.lid_to_string a in
-            FStar_Util.format1 "Name not found: %s" uu____1227 in
-          failwith uu____1226
-      | Some s -> s
-let push_free_var:
-  env_t ->
-    FStar_Ident.lident ->
-      Prims.string -> FStar_SMTEncoding_Term.term Prims.option -> env_t
-  =
-  fun env  ->
-    fun x  ->
-      fun fname  ->
-        fun ftok  ->
-          let uu___142_1258 = env in
-          {
-            bindings = ((Binding_fvar (x, fname, ftok, None)) ::
-              (env.bindings));
-            depth = (uu___142_1258.depth);
-            tcenv = (uu___142_1258.tcenv);
-            warn = (uu___142_1258.warn);
-            cache = (uu___142_1258.cache);
-            nolabels = (uu___142_1258.nolabels);
-            use_zfuel_name = (uu___142_1258.use_zfuel_name);
-            encode_non_total_function_typ =
-              (uu___142_1258.encode_non_total_function_typ)
-          }
-let push_zfuel_name: env_t -> FStar_Ident.lident -> Prims.string -> env_t =
-  fun env  ->
-    fun x  ->
-      fun f  ->
-        let uu____1270 = lookup_lid env x in
-        match uu____1270 with
-        | (t1,t2,uu____1278) ->
-            let t3 =
-              let uu____1284 =
-                let uu____1288 =
-                  let uu____1290 = FStar_SMTEncoding_Util.mkApp ("ZFuel", []) in
-                  [uu____1290] in
-                (f, uu____1288) in
-              FStar_SMTEncoding_Util.mkApp uu____1284 in
-            let uu___143_1293 = env in
-            {
-              bindings = ((Binding_fvar (x, t1, t2, (Some t3))) ::
-                (env.bindings));
-              depth = (uu___143_1293.depth);
-              tcenv = (uu___143_1293.tcenv);
-              warn = (uu___143_1293.warn);
-              cache = (uu___143_1293.cache);
-              nolabels = (uu___143_1293.nolabels);
-              use_zfuel_name = (uu___143_1293.use_zfuel_name);
-              encode_non_total_function_typ =
-                (uu___143_1293.encode_non_total_function_typ)
-            }
-let try_lookup_free_var:
-  env_t -> FStar_Ident.lident -> FStar_SMTEncoding_Term.term Prims.option =
-  fun env  ->
-    fun l  ->
-      let uu____1303 = try_lookup_lid env l in
-      match uu____1303 with
-      | None  -> None
-      | Some (name,sym,zf_opt) ->
-          (match zf_opt with
-           | Some f when env.use_zfuel_name -> Some f
-           | uu____1330 ->
-               (match sym with
-                | Some t ->
-                    (match t.FStar_SMTEncoding_Term.tm with
-                     | FStar_SMTEncoding_Term.App (uu____1335,fuel::[]) ->
-                         let uu____1338 =
-                           let uu____1339 =
-                             let uu____1340 =
-                               FStar_SMTEncoding_Term.fv_of_term fuel in
-                             FStar_All.pipe_right uu____1340 Prims.fst in
-                           FStar_Util.starts_with uu____1339 "fuel" in
-                         if uu____1338
-                         then
-                           let uu____1342 =
-                             let uu____1343 =
-                               FStar_SMTEncoding_Util.mkFreeV
-                                 (name, FStar_SMTEncoding_Term.Term_sort) in
-                             FStar_SMTEncoding_Term.mk_ApplyTF uu____1343
-                               fuel in
-                           FStar_All.pipe_left (fun _0_30  -> Some _0_30)
-                             uu____1342
-                         else Some t
-                     | uu____1346 -> Some t)
-                | uu____1347 -> None))
-let lookup_free_var env a =
-  let uu____1365 = try_lookup_free_var env a.FStar_Syntax_Syntax.v in
-  match uu____1365 with
-  | Some t -> t
-  | None  ->
-      let uu____1368 =
-        let uu____1369 =
-          FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v in
-        FStar_Util.format1 "Name not found: %s" uu____1369 in
-      failwith uu____1368
-let lookup_free_var_name env a =
-  let uu____1386 = lookup_lid env a.FStar_Syntax_Syntax.v in
-  match uu____1386 with | (x,uu____1393,uu____1394) -> x
-let lookup_free_var_sym env a =
-  let uu____1418 = lookup_lid env a.FStar_Syntax_Syntax.v in
-  match uu____1418 with
-  | (name,sym,zf_opt) ->
-      (match zf_opt with
-       | Some
-           { FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (g,zf);
-             FStar_SMTEncoding_Term.freevars = uu____1439;
-             FStar_SMTEncoding_Term.rng = uu____1440;_}
-           when env.use_zfuel_name -> (g, zf)
-       | uu____1448 ->
-           (match sym with
-            | None  -> ((FStar_SMTEncoding_Term.Var name), [])
-            | Some sym1 ->
-                (match sym1.FStar_SMTEncoding_Term.tm with
-                 | FStar_SMTEncoding_Term.App (g,fuel::[]) -> (g, [fuel])
-                 | uu____1462 -> ((FStar_SMTEncoding_Term.Var name), []))))
-let tok_of_name:
-  env_t -> Prims.string -> FStar_SMTEncoding_Term.term Prims.option =
-  fun env  ->
-    fun nm  ->
-      FStar_Util.find_map env.bindings
-        (fun uu___116_1471  ->
-           match uu___116_1471 with
-           | Binding_fvar (uu____1473,nm',tok,uu____1476) when nm = nm' ->
-               tok
-           | uu____1481 -> None)
-let mkForall_fuel' n1 uu____1498 =
-  match uu____1498 with
-  | (pats,vars,body) ->
-      let fallback uu____1514 =
-        FStar_SMTEncoding_Util.mkForall (pats, vars, body) in
-      let uu____1517 = FStar_Options.unthrottle_inductives () in
-      if uu____1517
-      then fallback ()
-      else
-        (let uu____1519 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
-         match uu____1519 with
-         | (fsym,fterm) ->
-             let add_fuel1 tms =
-               FStar_All.pipe_right tms
-                 (FStar_List.map
-                    (fun p  ->
-                       match p.FStar_SMTEncoding_Term.tm with
-                       | FStar_SMTEncoding_Term.App
-                           (FStar_SMTEncoding_Term.Var "HasType",args) ->
-                           FStar_SMTEncoding_Util.mkApp
-                             ("HasTypeFuel", (fterm :: args))
-                       | uu____1538 -> p)) in
-             let pats1 = FStar_List.map add_fuel1 pats in
-             let body1 =
-               match body.FStar_SMTEncoding_Term.tm with
-               | FStar_SMTEncoding_Term.App
-                   (FStar_SMTEncoding_Term.Imp ,guard::body'::[]) ->
-                   let guard1 =
-                     match guard.FStar_SMTEncoding_Term.tm with
-                     | FStar_SMTEncoding_Term.App
-                         (FStar_SMTEncoding_Term.And ,guards) ->
-                         let uu____1552 = add_fuel1 guards in
-                         FStar_SMTEncoding_Util.mk_and_l uu____1552
-                     | uu____1554 ->
-                         let uu____1555 = add_fuel1 [guard] in
-                         FStar_All.pipe_right uu____1555 FStar_List.hd in
-                   FStar_SMTEncoding_Util.mkImp (guard1, body')
-               | uu____1558 -> body in
-             let vars1 = (fsym, FStar_SMTEncoding_Term.Fuel_sort) :: vars in
-             FStar_SMTEncoding_Util.mkForall (pats1, vars1, body1))
-let mkForall_fuel:
-  (FStar_SMTEncoding_Term.pat Prims.list Prims.list*
-    FStar_SMTEncoding_Term.fvs* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = mkForall_fuel' (Prims.parse_int "1")
-let head_normal: env_t -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_arrow _
-        |FStar_Syntax_Syntax.Tm_refine _
-         |FStar_Syntax_Syntax.Tm_bvar _
-          |FStar_Syntax_Syntax.Tm_uvar _
-           |FStar_Syntax_Syntax.Tm_abs _|FStar_Syntax_Syntax.Tm_constant _
-          -> true
-      | FStar_Syntax_Syntax.Tm_fvar fv|FStar_Syntax_Syntax.Tm_app
-        ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-           FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-           FStar_Syntax_Syntax.vars = _;_},_)
-          ->
-          let uu____1602 =
-            FStar_TypeChecker_Env.lookup_definition
-              [FStar_TypeChecker_Env.Eager_unfolding_only] env.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_All.pipe_right uu____1602 FStar_Option.isNone
-      | uu____1615 -> false
-let head_redex: env_t -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let uu____1622 =
-        let uu____1623 = FStar_Syntax_Util.un_uinst t in
-        uu____1623.FStar_Syntax_Syntax.n in
-      match uu____1622 with
-      | FStar_Syntax_Syntax.Tm_abs
-          (uu____1626,uu____1627,Some (FStar_Util.Inr (l,flags))) ->
-          ((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) ||
-             (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GTot_lid))
-            ||
-            (FStar_List.existsb
-               (fun uu___117_1656  ->
-                  match uu___117_1656 with
-                  | FStar_Syntax_Syntax.TOTAL  -> true
-                  | uu____1657 -> false) flags)
-      | FStar_Syntax_Syntax.Tm_abs
-          (uu____1658,uu____1659,Some (FStar_Util.Inl lc)) ->
-          FStar_Syntax_Util.is_tot_or_gtot_lcomp lc
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____1686 =
-            FStar_TypeChecker_Env.lookup_definition
-              [FStar_TypeChecker_Env.Eager_unfolding_only] env.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_All.pipe_right uu____1686 FStar_Option.isSome
-      | uu____1699 -> false
-let whnf: env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun env  ->
-    fun t  ->
-      let uu____1706 = head_normal env t in
-      if uu____1706
-      then t
-      else
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.WHNF;
-          FStar_TypeChecker_Normalize.Exclude
-            FStar_TypeChecker_Normalize.Zeta;
-          FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t
-let norm: env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun env  ->
-    fun t  ->
-      FStar_TypeChecker_Normalize.normalize
-        [FStar_TypeChecker_Normalize.Beta;
-        FStar_TypeChecker_Normalize.Exclude FStar_TypeChecker_Normalize.Zeta;
-        FStar_TypeChecker_Normalize.Eager_unfolding;
-        FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t
-let trivial_post: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  ->
-    let uu____1717 =
-      let uu____1721 = FStar_Syntax_Syntax.null_binder t in [uu____1721] in
-    let uu____1722 =
-      FStar_Syntax_Syntax.fvar FStar_Syntax_Const.true_lid
-        FStar_Syntax_Syntax.Delta_constant None in
-    FStar_Syntax_Util.abs uu____1717 uu____1722 None
-let mk_Apply:
-  FStar_SMTEncoding_Term.term ->
-    (Prims.string* FStar_SMTEncoding_Term.sort) Prims.list ->
-      FStar_SMTEncoding_Term.term
-  =
-  fun e  ->
-    fun vars  ->
-      FStar_All.pipe_right vars
-        (FStar_List.fold_left
-           (fun out  ->
-              fun var  ->
-                match Prims.snd var with
-                | FStar_SMTEncoding_Term.Fuel_sort  ->
-                    let uu____1749 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Term.mk_ApplyTF out uu____1749
-                | s ->
-                    let uu____1752 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Util.mk_ApplyTT out uu____1752) e)
-let mk_Apply_args:
-  FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term
-  =
-  fun e  ->
-    fun args  ->
-      FStar_All.pipe_right args
-        (FStar_List.fold_left FStar_SMTEncoding_Util.mk_ApplyTT e)
-let is_app: FStar_SMTEncoding_Term.op -> Prims.bool =
-  fun uu___118_1764  ->
-    match uu___118_1764 with
-    | FStar_SMTEncoding_Term.Var "ApplyTT"|FStar_SMTEncoding_Term.Var
-      "ApplyTF" -> true
-    | uu____1765 -> false
-let is_eta:
-  env_t ->
-    FStar_SMTEncoding_Term.fv Prims.list ->
-      FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term Prims.option
-  =
-  fun env  ->
-    fun vars  ->
-      fun t  ->
-        let rec aux t1 xs =
-          match ((t1.FStar_SMTEncoding_Term.tm), xs) with
-          | (FStar_SMTEncoding_Term.App
-             (app,f::{
-                       FStar_SMTEncoding_Term.tm =
-                         FStar_SMTEncoding_Term.FreeV y;
-                       FStar_SMTEncoding_Term.freevars = uu____1793;
-                       FStar_SMTEncoding_Term.rng = uu____1794;_}::[]),x::xs1)
-              when (is_app app) && (FStar_SMTEncoding_Term.fv_eq x y) ->
-              aux f xs1
-          | (FStar_SMTEncoding_Term.App
-             (FStar_SMTEncoding_Term.Var f,args),uu____1808) ->
-              let uu____1813 =
-                ((FStar_List.length args) = (FStar_List.length vars)) &&
-                  (FStar_List.forall2
-                     (fun a  ->
-                        fun v1  ->
-                          match a.FStar_SMTEncoding_Term.tm with
-                          | FStar_SMTEncoding_Term.FreeV fv ->
-                              FStar_SMTEncoding_Term.fv_eq fv v1
-                          | uu____1823 -> false) args vars) in
-              if uu____1813 then tok_of_name env f else None
-          | (uu____1826,[]) ->
-              let fvs = FStar_SMTEncoding_Term.free_variables t1 in
-              let uu____1829 =
-                FStar_All.pipe_right fvs
-                  (FStar_List.for_all
-                     (fun fv  ->
-                        let uu____1831 =
-                          FStar_Util.for_some
-                            (FStar_SMTEncoding_Term.fv_eq fv) vars in
-                        Prims.op_Negation uu____1831)) in
-              if uu____1829 then Some t1 else None
-          | uu____1834 -> None in
-        aux t (FStar_List.rev vars)
-let reify_body:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      let tm = FStar_Syntax_Util.mk_reify t in
-      let tm' =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.Reify;
-          FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.EraseUniverses;
-          FStar_TypeChecker_Normalize.AllowUnboundUniverses] env tm in
-      (let uu____1849 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "SMTEncodingReify") in
-       if uu____1849
-       then
-         let uu____1850 = FStar_Syntax_Print.term_to_string tm in
-         let uu____1851 = FStar_Syntax_Print.term_to_string tm' in
-         FStar_Util.print2 "Reified body %s \nto %s\n" uu____1850 uu____1851
-       else ());
-      tm'
-type label = (FStar_SMTEncoding_Term.fv* Prims.string* FStar_Range.range)
-type labels = label Prims.list
+{bindings : binding Prims.list; depth : Prims.int; tcenv : FStar_TypeChecker_Env.env; warn : Prims.bool; cache : (Prims.string * FStar_SMTEncoding_Term.sort Prims.list * FStar_SMTEncoding_Term.decl Prims.list) FStar_Util.smap; nolabels : Prims.bool; use_zfuel_name : Prims.bool; encode_non_total_function_typ : Prims.bool}
+
+
+let print_env : env_t  ->  Prims.string = (fun e -> (
+
+let uu____945 = (FStar_All.pipe_right e.bindings (FStar_List.map (fun uu___112_949 -> (match (uu___112_949) with
+| Binding_var (x, uu____951) -> begin
+(FStar_Syntax_Print.bv_to_string x)
+end
+| Binding_fvar (l, uu____953, uu____954, uu____955) -> begin
+(FStar_Syntax_Print.lid_to_string l)
+end))))
+in (FStar_All.pipe_right uu____945 (FStar_String.concat ", "))))
+
+
+let lookup_binding = (fun env f -> (FStar_Util.find_map env.bindings f))
+
+
+let caption_t : env_t  ->  FStar_Syntax_Syntax.term  ->  Prims.string Prims.option = (fun env t -> (
+
+let uu____988 = (FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low)
+in (match (uu____988) with
+| true -> begin
+(
+
+let uu____990 = (FStar_Syntax_Print.term_to_string t)
+in Some (uu____990))
+end
+| uu____991 -> begin
+None
+end)))
+
+
+let fresh_fvar : Prims.string  ->  FStar_SMTEncoding_Term.sort  ->  (Prims.string * FStar_SMTEncoding_Term.term) = (fun x s -> (
+
+let xsym = (varops.fresh x)
+in (
+
+let uu____1001 = (FStar_SMTEncoding_Util.mkFreeV ((xsym), (s)))
+in ((xsym), (uu____1001)))))
+
+
+let gen_term_var : env_t  ->  FStar_Syntax_Syntax.bv  ->  (Prims.string * FStar_SMTEncoding_Term.term * env_t) = (fun env x -> (
+
+let ysym = (Prims.strcat "@x" (Prims.string_of_int env.depth))
+in (
+
+let y = (FStar_SMTEncoding_Util.mkFreeV ((ysym), (FStar_SMTEncoding_Term.Term_sort)))
+in ((ysym), (y), ((
+
+let uu___137_1013 = env
+in {bindings = (Binding_var (((x), (y))))::env.bindings; depth = (env.depth + (Prims.parse_int "1")); tcenv = uu___137_1013.tcenv; warn = uu___137_1013.warn; cache = uu___137_1013.cache; nolabels = uu___137_1013.nolabels; use_zfuel_name = uu___137_1013.use_zfuel_name; encode_non_total_function_typ = uu___137_1013.encode_non_total_function_typ}))))))
+
+
+let new_term_constant : env_t  ->  FStar_Syntax_Syntax.bv  ->  (Prims.string * FStar_SMTEncoding_Term.term * env_t) = (fun env x -> (
+
+let ysym = (varops.new_var x.FStar_Syntax_Syntax.ppname x.FStar_Syntax_Syntax.index)
+in (
+
+let y = (FStar_SMTEncoding_Util.mkApp ((ysym), ([])))
+in ((ysym), (y), ((
+
+let uu___138_1026 = env
+in {bindings = (Binding_var (((x), (y))))::env.bindings; depth = uu___138_1026.depth; tcenv = uu___138_1026.tcenv; warn = uu___138_1026.warn; cache = uu___138_1026.cache; nolabels = uu___138_1026.nolabels; use_zfuel_name = uu___138_1026.use_zfuel_name; encode_non_total_function_typ = uu___138_1026.encode_non_total_function_typ}))))))
+
+
+let new_term_constant_from_string : env_t  ->  FStar_Syntax_Syntax.bv  ->  Prims.string  ->  (Prims.string * FStar_SMTEncoding_Term.term * env_t) = (fun env x str -> (
+
+let ysym = (varops.mk_unique str)
+in (
+
+let y = (FStar_SMTEncoding_Util.mkApp ((ysym), ([])))
+in ((ysym), (y), ((
+
+let uu___139_1042 = env
+in {bindings = (Binding_var (((x), (y))))::env.bindings; depth = uu___139_1042.depth; tcenv = uu___139_1042.tcenv; warn = uu___139_1042.warn; cache = uu___139_1042.cache; nolabels = uu___139_1042.nolabels; use_zfuel_name = uu___139_1042.use_zfuel_name; encode_non_total_function_typ = uu___139_1042.encode_non_total_function_typ}))))))
+
+
+let push_term_var : env_t  ->  FStar_Syntax_Syntax.bv  ->  FStar_SMTEncoding_Term.term  ->  env_t = (fun env x t -> (
+
+let uu___140_1052 = env
+in {bindings = (Binding_var (((x), (t))))::env.bindings; depth = uu___140_1052.depth; tcenv = uu___140_1052.tcenv; warn = uu___140_1052.warn; cache = uu___140_1052.cache; nolabels = uu___140_1052.nolabels; use_zfuel_name = uu___140_1052.use_zfuel_name; encode_non_total_function_typ = uu___140_1052.encode_non_total_function_typ}))
+
+
+let lookup_term_var : env_t  ->  FStar_Syntax_Syntax.bv  ->  FStar_SMTEncoding_Term.term = (fun env a -> (
+
+let aux = (fun a' -> (lookup_binding env (fun uu___113_1068 -> (match (uu___113_1068) with
+| Binding_var (b, t) when (FStar_Syntax_Syntax.bv_eq b a') -> begin
+Some (((b), (t)))
+end
+| uu____1076 -> begin
+None
+end))))
+in (
+
+let uu____1079 = (aux a)
+in (match (uu____1079) with
+| None -> begin
+(
+
+let a2 = (unmangle a)
+in (
+
+let uu____1086 = (aux a2)
+in (match (uu____1086) with
+| None -> begin
+(
+
+let uu____1092 = (
+
+let uu____1093 = (FStar_Syntax_Print.bv_to_string a2)
+in (
+
+let uu____1094 = (print_env env)
+in (FStar_Util.format2 "Bound term variable not found (after unmangling): %s in environment: %s" uu____1093 uu____1094)))
+in (failwith uu____1092))
+end
+| Some (b, t) -> begin
+t
+end)))
+end
+| Some (b, t) -> begin
+t
+end))))
+
+
+let new_term_constant_and_tok_from_lid : env_t  ->  FStar_Ident.lident  ->  (Prims.string * Prims.string * env_t) = (fun env x -> (
+
+let fname = (varops.new_fvar x)
+in (
+
+let ftok = (Prims.strcat fname "@tok")
+in (
+
+let uu____1114 = (
+
+let uu___141_1115 = env
+in (
+
+let uu____1116 = (
+
+let uu____1118 = (
+
+let uu____1119 = (
+
+let uu____1126 = (
+
+let uu____1128 = (FStar_SMTEncoding_Util.mkApp ((ftok), ([])))
+in (FStar_All.pipe_left (fun _0_29 -> Some (_0_29)) uu____1128))
+in ((x), (fname), (uu____1126), (None)))
+in Binding_fvar (uu____1119))
+in (uu____1118)::env.bindings)
+in {bindings = uu____1116; depth = uu___141_1115.depth; tcenv = uu___141_1115.tcenv; warn = uu___141_1115.warn; cache = uu___141_1115.cache; nolabels = uu___141_1115.nolabels; use_zfuel_name = uu___141_1115.use_zfuel_name; encode_non_total_function_typ = uu___141_1115.encode_non_total_function_typ}))
+in ((fname), (ftok), (uu____1114))))))
+
+
+let try_lookup_lid : env_t  ->  FStar_Ident.lident  ->  (Prims.string * FStar_SMTEncoding_Term.term Prims.option * FStar_SMTEncoding_Term.term Prims.option) Prims.option = (fun env a -> (lookup_binding env (fun uu___114_1150 -> (match (uu___114_1150) with
+| Binding_fvar (b, t1, t2, t3) when (FStar_Ident.lid_equals b a) -> begin
+Some (((t1), (t2), (t3)))
+end
+| uu____1172 -> begin
+None
+end))))
+
+
+let contains_name : env_t  ->  Prims.string  ->  Prims.bool = (fun env s -> (
+
+let uu____1184 = (lookup_binding env (fun uu___115_1186 -> (match (uu___115_1186) with
+| Binding_fvar (b, t1, t2, t3) when (b.FStar_Ident.str = s) -> begin
+Some (())
+end
+| uu____1196 -> begin
+None
+end)))
+in (FStar_All.pipe_right uu____1184 FStar_Option.isSome)))
+
+
+let lookup_lid : env_t  ->  FStar_Ident.lident  ->  (Prims.string * FStar_SMTEncoding_Term.term Prims.option * FStar_SMTEncoding_Term.term Prims.option) = (fun env a -> (
+
+let uu____1209 = (try_lookup_lid env a)
+in (match (uu____1209) with
+| None -> begin
+(
+
+let uu____1226 = (
+
+let uu____1227 = (FStar_Syntax_Print.lid_to_string a)
+in (FStar_Util.format1 "Name not found: %s" uu____1227))
+in (failwith uu____1226))
+end
+| Some (s) -> begin
+s
+end)))
+
+
+let push_free_var : env_t  ->  FStar_Ident.lident  ->  Prims.string  ->  FStar_SMTEncoding_Term.term Prims.option  ->  env_t = (fun env x fname ftok -> (
+
+let uu___142_1258 = env
+in {bindings = (Binding_fvar (((x), (fname), (ftok), (None))))::env.bindings; depth = uu___142_1258.depth; tcenv = uu___142_1258.tcenv; warn = uu___142_1258.warn; cache = uu___142_1258.cache; nolabels = uu___142_1258.nolabels; use_zfuel_name = uu___142_1258.use_zfuel_name; encode_non_total_function_typ = uu___142_1258.encode_non_total_function_typ}))
+
+
+let push_zfuel_name : env_t  ->  FStar_Ident.lident  ->  Prims.string  ->  env_t = (fun env x f -> (
+
+let uu____1270 = (lookup_lid env x)
+in (match (uu____1270) with
+| (t1, t2, uu____1278) -> begin
+(
+
+let t3 = (
+
+let uu____1284 = (
+
+let uu____1288 = (
+
+let uu____1290 = (FStar_SMTEncoding_Util.mkApp (("ZFuel"), ([])))
+in (uu____1290)::[])
+in ((f), (uu____1288)))
+in (FStar_SMTEncoding_Util.mkApp uu____1284))
+in (
+
+let uu___143_1293 = env
+in {bindings = (Binding_fvar (((x), (t1), (t2), (Some (t3)))))::env.bindings; depth = uu___143_1293.depth; tcenv = uu___143_1293.tcenv; warn = uu___143_1293.warn; cache = uu___143_1293.cache; nolabels = uu___143_1293.nolabels; use_zfuel_name = uu___143_1293.use_zfuel_name; encode_non_total_function_typ = uu___143_1293.encode_non_total_function_typ}))
+end)))
+
+
+let try_lookup_free_var : env_t  ->  FStar_Ident.lident  ->  FStar_SMTEncoding_Term.term Prims.option = (fun env l -> (
+
+let uu____1303 = (try_lookup_lid env l)
+in (match (uu____1303) with
+| None -> begin
+None
+end
+| Some (name, sym, zf_opt) -> begin
+(match (zf_opt) with
+| Some (f) when env.use_zfuel_name -> begin
+Some (f)
+end
+| uu____1330 -> begin
+(match (sym) with
+| Some (t) -> begin
+(match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (uu____1335, (fuel)::[]) -> begin
+(
+
+let uu____1338 = (
+
+let uu____1339 = (
+
+let uu____1340 = (FStar_SMTEncoding_Term.fv_of_term fuel)
+in (FStar_All.pipe_right uu____1340 Prims.fst))
+in (FStar_Util.starts_with uu____1339 "fuel"))
+in (match (uu____1338) with
+| true -> begin
+(
+
+let uu____1342 = (
+
+let uu____1343 = (FStar_SMTEncoding_Util.mkFreeV ((name), (FStar_SMTEncoding_Term.Term_sort)))
+in (FStar_SMTEncoding_Term.mk_ApplyTF uu____1343 fuel))
+in (FStar_All.pipe_left (fun _0_30 -> Some (_0_30)) uu____1342))
+end
+| uu____1345 -> begin
+Some (t)
+end))
+end
+| uu____1346 -> begin
+Some (t)
+end)
+end
+| uu____1347 -> begin
+None
+end)
+end)
+end)))
+
+
+let lookup_free_var = (fun env a -> (
+
+let uu____1365 = (try_lookup_free_var env a.FStar_Syntax_Syntax.v)
+in (match (uu____1365) with
+| Some (t) -> begin
+t
+end
+| None -> begin
+(
+
+let uu____1368 = (
+
+let uu____1369 = (FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v)
+in (FStar_Util.format1 "Name not found: %s" uu____1369))
+in (failwith uu____1368))
+end)))
+
+
+let lookup_free_var_name = (fun env a -> (
+
+let uu____1386 = (lookup_lid env a.FStar_Syntax_Syntax.v)
+in (match (uu____1386) with
+| (x, uu____1393, uu____1394) -> begin
+x
+end)))
+
+
+let lookup_free_var_sym = (fun env a -> (
+
+let uu____1418 = (lookup_lid env a.FStar_Syntax_Syntax.v)
+in (match (uu____1418) with
+| (name, sym, zf_opt) -> begin
+(match (zf_opt) with
+| Some ({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (g, zf); FStar_SMTEncoding_Term.freevars = uu____1439; FStar_SMTEncoding_Term.rng = uu____1440}) when env.use_zfuel_name -> begin
+((g), (zf))
+end
+| uu____1448 -> begin
+(match (sym) with
+| None -> begin
+((FStar_SMTEncoding_Term.Var (name)), ([]))
+end
+| Some (sym1) -> begin
+(match (sym1.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (g, (fuel)::[]) -> begin
+((g), ((fuel)::[]))
+end
+| uu____1462 -> begin
+((FStar_SMTEncoding_Term.Var (name)), ([]))
+end)
+end)
+end)
+end)))
+
+
+let tok_of_name : env_t  ->  Prims.string  ->  FStar_SMTEncoding_Term.term Prims.option = (fun env nm -> (FStar_Util.find_map env.bindings (fun uu___116_1471 -> (match (uu___116_1471) with
+| Binding_fvar (uu____1473, nm', tok, uu____1476) when (nm = nm') -> begin
+tok
+end
+| uu____1481 -> begin
+None
+end))))
+
+
+let mkForall_fuel' = (fun n1 uu____1498 -> (match (uu____1498) with
+| (pats, vars, body) -> begin
+(
+
+let fallback = (fun uu____1514 -> (FStar_SMTEncoding_Util.mkForall ((pats), (vars), (body))))
+in (
+
+let uu____1517 = (FStar_Options.unthrottle_inductives ())
+in (match (uu____1517) with
+| true -> begin
+(fallback ())
+end
+| uu____1518 -> begin
+(
+
+let uu____1519 = (fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort)
+in (match (uu____1519) with
+| (fsym, fterm) -> begin
+(
+
+let add_fuel1 = (fun tms -> (FStar_All.pipe_right tms (FStar_List.map (fun p -> (match (p.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var ("HasType"), args) -> begin
+(FStar_SMTEncoding_Util.mkApp (("HasTypeFuel"), ((fterm)::args)))
+end
+| uu____1538 -> begin
+p
+end)))))
+in (
+
+let pats1 = (FStar_List.map add_fuel1 pats)
+in (
+
+let body1 = (match (body.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (guard)::(body')::[]) -> begin
+(
+
+let guard1 = (match (guard.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And, guards) -> begin
+(
+
+let uu____1552 = (add_fuel1 guards)
+in (FStar_SMTEncoding_Util.mk_and_l uu____1552))
+end
+| uu____1554 -> begin
+(
+
+let uu____1555 = (add_fuel1 ((guard)::[]))
+in (FStar_All.pipe_right uu____1555 FStar_List.hd))
+end)
+in (FStar_SMTEncoding_Util.mkImp ((guard1), (body'))))
+end
+| uu____1558 -> begin
+body
+end)
+in (
+
+let vars1 = (((fsym), (FStar_SMTEncoding_Term.Fuel_sort)))::vars
+in (FStar_SMTEncoding_Util.mkForall ((pats1), (vars1), (body1)))))))
+end))
+end)))
+end))
+
+
+let mkForall_fuel : (FStar_SMTEncoding_Term.pat Prims.list Prims.list * FStar_SMTEncoding_Term.fvs * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (mkForall_fuel' (Prims.parse_int "1"))
+
+
+let head_normal : env_t  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let t1 = (FStar_Syntax_Util.unmeta t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_refine (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) -> begin
+true
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) -> begin
+(
+
+let uu____1602 = (FStar_TypeChecker_Env.lookup_definition ((FStar_TypeChecker_Env.Eager_unfolding_only)::[]) env.tcenv fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_All.pipe_right uu____1602 FStar_Option.isNone))
+end
+| uu____1615 -> begin
+false
+end)))
+
+
+let head_redex : env_t  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let uu____1622 = (
+
+let uu____1623 = (FStar_Syntax_Util.un_uinst t)
+in uu____1623.FStar_Syntax_Syntax.n)
+in (match (uu____1622) with
+| FStar_Syntax_Syntax.Tm_abs (uu____1626, uu____1627, Some (FStar_Util.Inr (l, flags))) -> begin
+(((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) || (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GTot_lid)) || (FStar_List.existsb (fun uu___117_1656 -> (match (uu___117_1656) with
+| FStar_Syntax_Syntax.TOTAL -> begin
+true
+end
+| uu____1657 -> begin
+false
+end)) flags))
+end
+| FStar_Syntax_Syntax.Tm_abs (uu____1658, uu____1659, Some (FStar_Util.Inl (lc))) -> begin
+(FStar_Syntax_Util.is_tot_or_gtot_lcomp lc)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____1686 = (FStar_TypeChecker_Env.lookup_definition ((FStar_TypeChecker_Env.Eager_unfolding_only)::[]) env.tcenv fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_All.pipe_right uu____1686 FStar_Option.isSome))
+end
+| uu____1699 -> begin
+false
+end)))
+
+
+let whnf : env_t  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let uu____1706 = (head_normal env t)
+in (match (uu____1706) with
+| true -> begin
+t
+end
+| uu____1707 -> begin
+(FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Zeta))::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv t)
+end)))
+
+
+let norm : env_t  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Zeta))::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv t))
+
+
+let trivial_post : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (
+
+let uu____1717 = (
+
+let uu____1721 = (FStar_Syntax_Syntax.null_binder t)
+in (uu____1721)::[])
+in (
+
+let uu____1722 = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.true_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Util.abs uu____1717 uu____1722 None))))
+
+
+let mk_Apply : FStar_SMTEncoding_Term.term  ->  (Prims.string * FStar_SMTEncoding_Term.sort) Prims.list  ->  FStar_SMTEncoding_Term.term = (fun e vars -> (FStar_All.pipe_right vars (FStar_List.fold_left (fun out var -> (match ((Prims.snd var)) with
+| FStar_SMTEncoding_Term.Fuel_sort -> begin
+(
+
+let uu____1749 = (FStar_SMTEncoding_Util.mkFreeV var)
+in (FStar_SMTEncoding_Term.mk_ApplyTF out uu____1749))
+end
+| s -> begin
+(
+
+let uu____1752 = (FStar_SMTEncoding_Util.mkFreeV var)
+in (FStar_SMTEncoding_Util.mk_ApplyTT out uu____1752))
+end)) e)))
+
+
+let mk_Apply_args : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term Prims.list  ->  FStar_SMTEncoding_Term.term = (fun e args -> (FStar_All.pipe_right args (FStar_List.fold_left FStar_SMTEncoding_Util.mk_ApplyTT e)))
+
+
+let is_app : FStar_SMTEncoding_Term.op  ->  Prims.bool = (fun uu___118_1764 -> (match (uu___118_1764) with
+| (FStar_SMTEncoding_Term.Var ("ApplyTT")) | (FStar_SMTEncoding_Term.Var ("ApplyTF")) -> begin
+true
+end
+| uu____1765 -> begin
+false
+end))
+
+
+let is_eta : env_t  ->  FStar_SMTEncoding_Term.fv Prims.list  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term Prims.option = (fun env vars t -> (
+
+let rec aux = (fun t1 xs -> (match (((t1.FStar_SMTEncoding_Term.tm), (xs))) with
+| (FStar_SMTEncoding_Term.App (app, (f)::({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV (y); FStar_SMTEncoding_Term.freevars = uu____1793; FStar_SMTEncoding_Term.rng = uu____1794})::[]), (x)::xs1) when ((is_app app) && (FStar_SMTEncoding_Term.fv_eq x y)) -> begin
+(aux f xs1)
+end
+| (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var (f), args), uu____1808) -> begin
+(
+
+let uu____1813 = (((FStar_List.length args) = (FStar_List.length vars)) && (FStar_List.forall2 (fun a v1 -> (match (a.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.FreeV (fv) -> begin
+(FStar_SMTEncoding_Term.fv_eq fv v1)
+end
+| uu____1823 -> begin
+false
+end)) args vars))
+in (match (uu____1813) with
+| true -> begin
+(tok_of_name env f)
+end
+| uu____1825 -> begin
+None
+end))
+end
+| (uu____1826, []) -> begin
+(
+
+let fvs = (FStar_SMTEncoding_Term.free_variables t1)
+in (
+
+let uu____1829 = (FStar_All.pipe_right fvs (FStar_List.for_all (fun fv -> (
+
+let uu____1831 = (FStar_Util.for_some (FStar_SMTEncoding_Term.fv_eq fv) vars)
+in (not (uu____1831))))))
+in (match (uu____1829) with
+| true -> begin
+Some (t1)
+end
+| uu____1833 -> begin
+None
+end)))
+end
+| uu____1834 -> begin
+None
+end))
+in (aux t (FStar_List.rev vars))))
+
+
+let reify_body : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let tm = (FStar_Syntax_Util.mk_reify t)
+in (
+
+let tm' = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Reify)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env tm)
+in ((
+
+let uu____1849 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("SMTEncodingReify")))
+in (match (uu____1849) with
+| true -> begin
+(
+
+let uu____1850 = (FStar_Syntax_Print.term_to_string tm)
+in (
+
+let uu____1851 = (FStar_Syntax_Print.term_to_string tm')
+in (FStar_Util.print2 "Reified body %s \nto %s\n" uu____1850 uu____1851)))
+end
+| uu____1852 -> begin
+()
+end));
+tm';
+))))
+
+
+type label =
+(FStar_SMTEncoding_Term.fv * Prims.string * FStar_Range.range)
+
+
+type labels =
+label Prims.list
+
 type pattern =
-  {
-  pat_vars: (FStar_Syntax_Syntax.bv* FStar_SMTEncoding_Term.fv) Prims.list;
-  pat_term:
-    Prims.unit ->
-      (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t);
-  guard: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term;
-  projections:
-    FStar_SMTEncoding_Term.term ->
-      (FStar_Syntax_Syntax.bv* FStar_SMTEncoding_Term.term) Prims.list;}
+{pat_vars : (FStar_Syntax_Syntax.bv * FStar_SMTEncoding_Term.fv) Prims.list; pat_term : Prims.unit  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t); guard : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term; projections : FStar_SMTEncoding_Term.term  ->  (FStar_Syntax_Syntax.bv * FStar_SMTEncoding_Term.term) Prims.list}
+
 exception Let_rec_unencodeable
-let uu___is_Let_rec_unencodeable: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Let_rec_unencodeable  -> true
-    | uu____1933 -> false
-let encode_const: FStar_Const.sconst -> FStar_SMTEncoding_Term.term =
-  fun uu___119_1936  ->
-    match uu___119_1936 with
-    | FStar_Const.Const_unit  -> FStar_SMTEncoding_Term.mk_Term_unit
-    | FStar_Const.Const_bool (true ) ->
-        FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue
-    | FStar_Const.Const_bool (false ) ->
-        FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkFalse
-    | FStar_Const.Const_char c ->
-        let uu____1938 =
-          let uu____1942 =
-            let uu____1944 =
-              let uu____1945 =
-                FStar_SMTEncoding_Util.mkInteger' (FStar_Util.int_of_char c) in
-              FStar_SMTEncoding_Term.boxInt uu____1945 in
-            [uu____1944] in
-          ("FStar.Char.Char", uu____1942) in
-        FStar_SMTEncoding_Util.mkApp uu____1938
-    | FStar_Const.Const_int (i,None ) ->
-        let uu____1953 = FStar_SMTEncoding_Util.mkInteger i in
-        FStar_SMTEncoding_Term.boxInt uu____1953
-    | FStar_Const.Const_int (i,Some uu____1955) ->
-        failwith "Machine integers should be desugared"
-    | FStar_Const.Const_string (bytes,uu____1964) ->
-        let uu____1967 = FStar_All.pipe_left FStar_Util.string_of_bytes bytes in
-        varops.string_const uu____1967
-    | FStar_Const.Const_range r -> FStar_SMTEncoding_Term.mk_Range_const
-    | FStar_Const.Const_effect  -> FStar_SMTEncoding_Term.mk_Term_type
-    | c ->
-        let uu____1971 =
-          let uu____1972 = FStar_Syntax_Print.const_to_string c in
-          FStar_Util.format1 "Unhandled constant: %s" uu____1972 in
-        failwith uu____1971
-let as_function_typ:
-  env_t ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t0  ->
-      let rec aux norm1 t =
-        let t1 = FStar_Syntax_Subst.compress t in
-        match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_arrow uu____1991 -> t1
-        | FStar_Syntax_Syntax.Tm_refine uu____1999 ->
-            let uu____2004 = FStar_Syntax_Util.unrefine t1 in
-            aux true uu____2004
-        | uu____2005 ->
-            if norm1
-            then let uu____2006 = whnf env t1 in aux false uu____2006
-            else
-              (let uu____2008 =
-                 let uu____2009 =
-                   FStar_Range.string_of_range t0.FStar_Syntax_Syntax.pos in
-                 let uu____2010 = FStar_Syntax_Print.term_to_string t0 in
-                 FStar_Util.format2 "(%s) Expected a function typ; got %s"
-                   uu____2009 uu____2010 in
-               failwith uu____2008) in
-      aux true t0
-let curried_arrow_formals_comp:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.comp)
-  =
-  fun k  ->
-    let k1 = FStar_Syntax_Subst.compress k in
-    match k1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        FStar_Syntax_Subst.open_comp bs c
-    | uu____2031 ->
-        let uu____2032 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____2032)
-let rec encode_binders:
-  FStar_SMTEncoding_Term.term Prims.option ->
-    FStar_Syntax_Syntax.binders ->
-      env_t ->
-        (FStar_SMTEncoding_Term.fv Prims.list* FStar_SMTEncoding_Term.term
-          Prims.list* env_t* FStar_SMTEncoding_Term.decls_t*
-          FStar_Syntax_Syntax.bv Prims.list)
-  =
-  fun fuel_opt  ->
-    fun bs  ->
-      fun env  ->
-        (let uu____2175 =
-           FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
-         if uu____2175
-         then
-           let uu____2176 = FStar_Syntax_Print.binders_to_string ", " bs in
-           FStar_Util.print1 "Encoding binders %s\n" uu____2176
-         else ());
-        (let uu____2178 =
-           FStar_All.pipe_right bs
-             (FStar_List.fold_left
-                (fun uu____2214  ->
-                   fun b  ->
-                     match uu____2214 with
-                     | (vars,guards,env1,decls,names1) ->
-                         let uu____2257 =
-                           let x = unmangle (Prims.fst b) in
-                           let uu____2266 = gen_term_var env1 x in
-                           match uu____2266 with
-                           | (xxsym,xx,env') ->
-                               let uu____2280 =
-                                 let uu____2283 =
-                                   norm env1 x.FStar_Syntax_Syntax.sort in
-                                 encode_term_pred fuel_opt uu____2283 env1 xx in
-                               (match uu____2280 with
-                                | (guard_x_t,decls') ->
-                                    ((xxsym,
-                                       FStar_SMTEncoding_Term.Term_sort),
-                                      guard_x_t, env', decls', x)) in
-                         (match uu____2257 with
-                          | (v1,g,env2,decls',n1) ->
-                              ((v1 :: vars), (g :: guards), env2,
-                                (FStar_List.append decls decls'), (n1 ::
-                                names1)))) ([], [], env, [], [])) in
-         match uu____2178 with
-         | (vars,guards,env1,decls,names1) ->
-             ((FStar_List.rev vars), (FStar_List.rev guards), env1, decls,
-               (FStar_List.rev names1)))
-and encode_term_pred:
-  FStar_SMTEncoding_Term.term Prims.option ->
-    FStar_Syntax_Syntax.typ ->
-      env_t ->
-        FStar_SMTEncoding_Term.term ->
-          (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun fuel_opt  ->
-    fun t  ->
-      fun env  ->
-        fun e  ->
-          let uu____2371 = encode_term t env in
-          match uu____2371 with
-          | (t1,decls) ->
-              let uu____2378 =
-                FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1 in
-              (uu____2378, decls)
-and encode_term_pred':
-  FStar_SMTEncoding_Term.term Prims.option ->
-    FStar_Syntax_Syntax.typ ->
-      env_t ->
-        FStar_SMTEncoding_Term.term ->
-          (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun fuel_opt  ->
-    fun t  ->
-      fun env  ->
-        fun e  ->
-          let uu____2386 = encode_term t env in
-          match uu____2386 with
-          | (t1,decls) ->
-              (match fuel_opt with
-               | None  ->
-                   let uu____2395 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1 in
-                   (uu____2395, decls)
-               | Some f ->
-                   let uu____2397 =
-                     FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1 in
-                   (uu____2397, decls))
-and encode_term:
-  FStar_Syntax_Syntax.typ ->
-    env_t -> (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun t  ->
-    fun env  ->
-      let t0 = FStar_Syntax_Subst.compress t in
-      (let uu____2404 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
-           (FStar_Options.Other "SMTEncoding") in
-       if uu____2404
-       then
-         let uu____2405 = FStar_Syntax_Print.tag_of_term t in
-         let uu____2406 = FStar_Syntax_Print.tag_of_term t0 in
-         let uu____2407 = FStar_Syntax_Print.term_to_string t0 in
-         FStar_Util.print3 "(%s) (%s)   %s\n" uu____2405 uu____2406
-           uu____2407
-       else ());
-      (match t0.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed _|FStar_Syntax_Syntax.Tm_unknown  ->
-           let uu____2412 =
-             let uu____2413 =
-               FStar_All.pipe_left FStar_Range.string_of_range
-                 t.FStar_Syntax_Syntax.pos in
-             let uu____2414 = FStar_Syntax_Print.tag_of_term t0 in
-             let uu____2415 = FStar_Syntax_Print.term_to_string t0 in
-             let uu____2416 = FStar_Syntax_Print.term_to_string t in
-             FStar_Util.format4 "(%s) Impossible: %s\n%s\n%s\n" uu____2413
-               uu____2414 uu____2415 uu____2416 in
-           failwith uu____2412
-       | FStar_Syntax_Syntax.Tm_bvar x ->
-           let uu____2420 =
-             let uu____2421 = FStar_Syntax_Print.bv_to_string x in
-             FStar_Util.format1 "Impossible: locally nameless; got %s"
-               uu____2421 in
-           failwith uu____2420
-       | FStar_Syntax_Syntax.Tm_ascribed (t1,k,uu____2426) ->
-           encode_term t1 env
-       | FStar_Syntax_Syntax.Tm_meta (t1,uu____2456) -> encode_term t1 env
-       | FStar_Syntax_Syntax.Tm_name x ->
-           let t1 = lookup_term_var env x in (t1, [])
-       | FStar_Syntax_Syntax.Tm_fvar v1 ->
-           let uu____2465 =
-             lookup_free_var env v1.FStar_Syntax_Syntax.fv_name in
-           (uu____2465, [])
-       | FStar_Syntax_Syntax.Tm_type uu____2471 ->
-           (FStar_SMTEncoding_Term.mk_Term_type, [])
-       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____2474) -> encode_term t1 env
-       | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____2480 = encode_const c in (uu____2480, [])
-       | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-           let uu____2494 = FStar_Syntax_Subst.open_comp binders c in
-           (match uu____2494 with
-            | (binders1,res) ->
-                let uu____2501 =
-                  (env.encode_non_total_function_typ &&
-                     (FStar_Syntax_Util.is_pure_or_ghost_comp res))
-                    || (FStar_Syntax_Util.is_tot_or_gtot_comp res) in
-                if uu____2501
-                then
-                  let uu____2504 = encode_binders None binders1 env in
-                  (match uu____2504 with
-                   | (vars,guards,env',decls,uu____2519) ->
-                       let fsym =
-                         let uu____2529 = varops.fresh "f" in
-                         (uu____2529, FStar_SMTEncoding_Term.Term_sort) in
-                       let f = FStar_SMTEncoding_Util.mkFreeV fsym in
-                       let app = mk_Apply f vars in
-                       let uu____2532 =
-                         FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
-                           (let uu___144_2536 = env.tcenv in
-                            {
-                              FStar_TypeChecker_Env.solver =
-                                (uu___144_2536.FStar_TypeChecker_Env.solver);
-                              FStar_TypeChecker_Env.range =
-                                (uu___144_2536.FStar_TypeChecker_Env.range);
-                              FStar_TypeChecker_Env.curmodule =
-                                (uu___144_2536.FStar_TypeChecker_Env.curmodule);
-                              FStar_TypeChecker_Env.gamma =
-                                (uu___144_2536.FStar_TypeChecker_Env.gamma);
-                              FStar_TypeChecker_Env.gamma_cache =
-                                (uu___144_2536.FStar_TypeChecker_Env.gamma_cache);
-                              FStar_TypeChecker_Env.modules =
-                                (uu___144_2536.FStar_TypeChecker_Env.modules);
-                              FStar_TypeChecker_Env.expected_typ =
-                                (uu___144_2536.FStar_TypeChecker_Env.expected_typ);
-                              FStar_TypeChecker_Env.sigtab =
-                                (uu___144_2536.FStar_TypeChecker_Env.sigtab);
-                              FStar_TypeChecker_Env.is_pattern =
-                                (uu___144_2536.FStar_TypeChecker_Env.is_pattern);
-                              FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___144_2536.FStar_TypeChecker_Env.instantiate_imp);
-                              FStar_TypeChecker_Env.effects =
-                                (uu___144_2536.FStar_TypeChecker_Env.effects);
-                              FStar_TypeChecker_Env.generalize =
-                                (uu___144_2536.FStar_TypeChecker_Env.generalize);
-                              FStar_TypeChecker_Env.letrecs =
-                                (uu___144_2536.FStar_TypeChecker_Env.letrecs);
-                              FStar_TypeChecker_Env.top_level =
-                                (uu___144_2536.FStar_TypeChecker_Env.top_level);
-                              FStar_TypeChecker_Env.check_uvars =
-                                (uu___144_2536.FStar_TypeChecker_Env.check_uvars);
-                              FStar_TypeChecker_Env.use_eq =
-                                (uu___144_2536.FStar_TypeChecker_Env.use_eq);
-                              FStar_TypeChecker_Env.is_iface =
-                                (uu___144_2536.FStar_TypeChecker_Env.is_iface);
-                              FStar_TypeChecker_Env.admit =
-                                (uu___144_2536.FStar_TypeChecker_Env.admit);
-                              FStar_TypeChecker_Env.lax = true;
-                              FStar_TypeChecker_Env.lax_universes =
-                                (uu___144_2536.FStar_TypeChecker_Env.lax_universes);
-                              FStar_TypeChecker_Env.type_of =
-                                (uu___144_2536.FStar_TypeChecker_Env.type_of);
-                              FStar_TypeChecker_Env.universe_of =
-                                (uu___144_2536.FStar_TypeChecker_Env.universe_of);
-                              FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___144_2536.FStar_TypeChecker_Env.use_bv_sorts);
-                              FStar_TypeChecker_Env.qname_and_index =
-                                (uu___144_2536.FStar_TypeChecker_Env.qname_and_index)
-                            }) res in
-                       (match uu____2532 with
-                        | (pre_opt,res_t) ->
-                            let uu____2543 =
-                              encode_term_pred None res_t env' app in
-                            (match uu____2543 with
-                             | (res_pred,decls') ->
-                                 let uu____2550 =
-                                   match pre_opt with
-                                   | None  ->
-                                       let uu____2557 =
-                                         FStar_SMTEncoding_Util.mk_and_l
-                                           guards in
-                                       (uu____2557, [])
-                                   | Some pre ->
-                                       let uu____2560 =
-                                         encode_formula pre env' in
-                                       (match uu____2560 with
-                                        | (guard,decls0) ->
-                                            let uu____2568 =
-                                              FStar_SMTEncoding_Util.mk_and_l
-                                                (guard :: guards) in
-                                            (uu____2568, decls0)) in
-                                 (match uu____2550 with
-                                  | (guards1,guard_decls) ->
-                                      let t_interp =
-                                        let uu____2576 =
-                                          let uu____2582 =
-                                            FStar_SMTEncoding_Util.mkImp
-                                              (guards1, res_pred) in
-                                          ([[app]], vars, uu____2582) in
-                                        FStar_SMTEncoding_Util.mkForall
-                                          uu____2576 in
-                                      let cvars =
-                                        let uu____2592 =
-                                          FStar_SMTEncoding_Term.free_variables
-                                            t_interp in
-                                        FStar_All.pipe_right uu____2592
-                                          (FStar_List.filter
-                                             (fun uu____2598  ->
-                                                match uu____2598 with
-                                                | (x,uu____2602) ->
-                                                    x <> (Prims.fst fsym))) in
-                                      let tkey =
-                                        FStar_SMTEncoding_Util.mkForall
-                                          ([], (fsym :: cvars), t_interp) in
-                                      let tkey_hash =
-                                        FStar_SMTEncoding_Term.hash_of_term
-                                          tkey in
-                                      let uu____2613 =
-                                        FStar_Util.smap_try_find env.cache
-                                          tkey_hash in
-                                      (match uu____2613 with
-                                       | Some (t',sorts,uu____2629) ->
-                                           let uu____2639 =
-                                             let uu____2640 =
-                                               let uu____2644 =
-                                                 FStar_All.pipe_right cvars
-                                                   (FStar_List.map
-                                                      FStar_SMTEncoding_Util.mkFreeV) in
-                                               (t', uu____2644) in
-                                             FStar_SMTEncoding_Util.mkApp
-                                               uu____2640 in
-                                           (uu____2639, [])
-                                       | None  ->
-                                           let tsym =
-                                             let uu____2660 =
-                                               let uu____2661 =
-                                                 FStar_Util.digest_of_string
-                                                   tkey_hash in
-                                               Prims.strcat "Tm_arrow_"
-                                                 uu____2661 in
-                                             varops.mk_unique uu____2660 in
-                                           let cvar_sorts =
-                                             FStar_List.map Prims.snd cvars in
-                                           let caption =
-                                             let uu____2668 =
-                                               FStar_Options.log_queries () in
-                                             if uu____2668
-                                             then
-                                               let uu____2670 =
-                                                 FStar_TypeChecker_Normalize.term_to_string
-                                                   env.tcenv t0 in
-                                               Some uu____2670
-                                             else None in
-                                           let tdecl =
-                                             FStar_SMTEncoding_Term.DeclFun
-                                               (tsym, cvar_sorts,
-                                                 FStar_SMTEncoding_Term.Term_sort,
-                                                 caption) in
-                                           let t1 =
-                                             let uu____2676 =
-                                               let uu____2680 =
-                                                 FStar_List.map
-                                                   FStar_SMTEncoding_Util.mkFreeV
-                                                   cvars in
-                                               (tsym, uu____2680) in
-                                             FStar_SMTEncoding_Util.mkApp
-                                               uu____2676 in
-                                           let t_has_kind =
-                                             FStar_SMTEncoding_Term.mk_HasType
-                                               t1
-                                               FStar_SMTEncoding_Term.mk_Term_type in
-                                           let k_assumption =
-                                             let a_name =
-                                               Some
-                                                 (Prims.strcat "kinding_"
-                                                    tsym) in
-                                             let uu____2689 =
-                                               let uu____2694 =
-                                                 FStar_SMTEncoding_Util.mkForall
-                                                   ([[t_has_kind]], cvars,
-                                                     t_has_kind) in
-                                               (uu____2694, a_name, a_name) in
-                                             FStar_SMTEncoding_Term.Assume
-                                               uu____2689 in
-                                           let f_has_t =
-                                             FStar_SMTEncoding_Term.mk_HasType
-                                               f t1 in
-                                           let f_has_t_z =
-                                             FStar_SMTEncoding_Term.mk_HasTypeZ
-                                               f t1 in
-                                           let pre_typing =
-                                             let a_name =
-                                               Some
-                                                 (Prims.strcat "pre_typing_"
-                                                    tsym) in
-                                             let uu____2709 =
-                                               let uu____2714 =
-                                                 let uu____2715 =
-                                                   let uu____2721 =
-                                                     let uu____2722 =
-                                                       let uu____2725 =
-                                                         let uu____2726 =
-                                                           FStar_SMTEncoding_Term.mk_PreType
-                                                             f in
-                                                         FStar_SMTEncoding_Term.mk_tester
-                                                           "Tm_arrow"
-                                                           uu____2726 in
-                                                       (f_has_t, uu____2725) in
-                                                     FStar_SMTEncoding_Util.mkImp
-                                                       uu____2722 in
-                                                   ([[f_has_t]], (fsym ::
-                                                     cvars), uu____2721) in
-                                                 mkForall_fuel uu____2715 in
-                                               (uu____2714,
-                                                 (Some
-                                                    "pre-typing for functions"),
-                                                 a_name) in
-                                             FStar_SMTEncoding_Term.Assume
-                                               uu____2709 in
-                                           let t_interp1 =
-                                             let a_name =
-                                               Some
-                                                 (Prims.strcat
-                                                    "interpretation_" tsym) in
-                                             let uu____2741 =
-                                               let uu____2746 =
-                                                 let uu____2747 =
-                                                   let uu____2753 =
-                                                     FStar_SMTEncoding_Util.mkIff
-                                                       (f_has_t_z, t_interp) in
-                                                   ([[f_has_t_z]], (fsym ::
-                                                     cvars), uu____2753) in
-                                                 FStar_SMTEncoding_Util.mkForall
-                                                   uu____2747 in
-                                               (uu____2746, a_name, a_name) in
-                                             FStar_SMTEncoding_Term.Assume
-                                               uu____2741 in
-                                           let t_decls =
-                                             FStar_List.append (tdecl ::
-                                               decls)
-                                               (FStar_List.append decls'
-                                                  (FStar_List.append
-                                                     guard_decls
-                                                     [k_assumption;
-                                                     pre_typing;
-                                                     t_interp1])) in
-                                           (FStar_Util.smap_add env.cache
-                                              tkey_hash
-                                              (tsym, cvar_sorts, t_decls);
-                                            (t1, t_decls)))))))
-                else
-                  (let tsym = varops.fresh "Non_total_Tm_arrow" in
-                   let tdecl =
-                     FStar_SMTEncoding_Term.DeclFun
-                       (tsym, [], FStar_SMTEncoding_Term.Term_sort, None) in
-                   let t1 = FStar_SMTEncoding_Util.mkApp (tsym, []) in
-                   let t_kinding =
-                     let a_name =
-                       Some (Prims.strcat "non_total_function_typing_" tsym) in
-                     let uu____2786 =
-                       let uu____2791 =
-                         FStar_SMTEncoding_Term.mk_HasType t1
-                           FStar_SMTEncoding_Term.mk_Term_type in
-                       (uu____2791, (Some "Typing for non-total arrows"),
-                         a_name) in
-                     FStar_SMTEncoding_Term.Assume uu____2786 in
-                   let fsym = ("f", FStar_SMTEncoding_Term.Term_sort) in
-                   let f = FStar_SMTEncoding_Util.mkFreeV fsym in
-                   let f_has_t = FStar_SMTEncoding_Term.mk_HasType f t1 in
-                   let t_interp =
-                     let a_name = Some (Prims.strcat "pre_typing_" tsym) in
-                     let uu____2802 =
-                       let uu____2807 =
-                         let uu____2808 =
-                           let uu____2814 =
-                             let uu____2815 =
-                               let uu____2818 =
-                                 let uu____2819 =
-                                   FStar_SMTEncoding_Term.mk_PreType f in
-                                 FStar_SMTEncoding_Term.mk_tester "Tm_arrow"
-                                   uu____2819 in
-                               (f_has_t, uu____2818) in
-                             FStar_SMTEncoding_Util.mkImp uu____2815 in
-                           ([[f_has_t]], [fsym], uu____2814) in
-                         mkForall_fuel uu____2808 in
-                       (uu____2807, a_name, a_name) in
-                     FStar_SMTEncoding_Term.Assume uu____2802 in
-                   (t1, [tdecl; t_kinding; t_interp])))
-       | FStar_Syntax_Syntax.Tm_refine uu____2834 ->
-           let uu____2839 =
-             let uu____2842 =
-               FStar_TypeChecker_Normalize.normalize_refinement
-                 [FStar_TypeChecker_Normalize.WHNF;
-                 FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t0 in
-             match uu____2842 with
-             | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine (x,f);
-                 FStar_Syntax_Syntax.tk = uu____2847;
-                 FStar_Syntax_Syntax.pos = uu____2848;
-                 FStar_Syntax_Syntax.vars = uu____2849;_} ->
-                 let uu____2856 = FStar_Syntax_Subst.open_term [(x, None)] f in
-                 (match uu____2856 with
-                  | (b,f1) ->
-                      let uu____2870 =
-                        let uu____2871 = FStar_List.hd b in
-                        Prims.fst uu____2871 in
-                      (uu____2870, f1))
-             | uu____2876 -> failwith "impossible" in
-           (match uu____2839 with
-            | (x,f) ->
-                let uu____2883 = encode_term x.FStar_Syntax_Syntax.sort env in
-                (match uu____2883 with
-                 | (base_t,decls) ->
-                     let uu____2890 = gen_term_var env x in
-                     (match uu____2890 with
-                      | (x1,xtm,env') ->
-                          let uu____2899 = encode_formula f env' in
-                          (match uu____2899 with
-                           | (refinement,decls') ->
-                               let uu____2906 =
-                                 fresh_fvar "f"
-                                   FStar_SMTEncoding_Term.Fuel_sort in
-                               (match uu____2906 with
-                                | (fsym,fterm) ->
-                                    let encoding =
-                                      let uu____2914 =
-                                        let uu____2917 =
-                                          FStar_SMTEncoding_Term.mk_HasTypeWithFuel
-                                            (Some fterm) xtm base_t in
-                                        (uu____2917, refinement) in
-                                      FStar_SMTEncoding_Util.mkAnd uu____2914 in
-                                    let cvars =
-                                      let uu____2922 =
-                                        FStar_SMTEncoding_Term.free_variables
-                                          encoding in
-                                      FStar_All.pipe_right uu____2922
-                                        (FStar_List.filter
-                                           (fun uu____2928  ->
-                                              match uu____2928 with
-                                              | (y,uu____2932) ->
-                                                  (y <> x1) && (y <> fsym))) in
-                                    let xfv =
-                                      (x1, FStar_SMTEncoding_Term.Term_sort) in
-                                    let ffv =
-                                      (fsym,
-                                        FStar_SMTEncoding_Term.Fuel_sort) in
-                                    let tkey =
-                                      FStar_SMTEncoding_Util.mkForall
-                                        ([], (ffv :: xfv :: cvars), encoding) in
-                                    let tkey_hash =
-                                      FStar_SMTEncoding_Term.hash_of_term
-                                        tkey in
-                                    let uu____2951 =
-                                      FStar_Util.smap_try_find env.cache
-                                        tkey_hash in
-                                    (match uu____2951 with
-                                     | Some (t1,uu____2966,uu____2967) ->
-                                         let uu____2977 =
-                                           let uu____2978 =
-                                             let uu____2982 =
-                                               FStar_All.pipe_right cvars
-                                                 (FStar_List.map
-                                                    FStar_SMTEncoding_Util.mkFreeV) in
-                                             (t1, uu____2982) in
-                                           FStar_SMTEncoding_Util.mkApp
-                                             uu____2978 in
-                                         (uu____2977, [])
-                                     | None  ->
-                                         let tsym =
-                                           let uu____2998 =
-                                             let uu____2999 =
-                                               FStar_Util.digest_of_string
-                                                 tkey_hash in
-                                             Prims.strcat "Tm_refine_"
-                                               uu____2999 in
-                                           varops.mk_unique uu____2998 in
-                                         let cvar_sorts =
-                                           FStar_List.map Prims.snd cvars in
-                                         let tdecl =
-                                           FStar_SMTEncoding_Term.DeclFun
-                                             (tsym, cvar_sorts,
-                                               FStar_SMTEncoding_Term.Term_sort,
-                                               None) in
-                                         let t1 =
-                                           let uu____3008 =
-                                             let uu____3012 =
-                                               FStar_List.map
-                                                 FStar_SMTEncoding_Util.mkFreeV
-                                                 cvars in
-                                             (tsym, uu____3012) in
-                                           FStar_SMTEncoding_Util.mkApp
-                                             uu____3008 in
-                                         let x_has_t =
-                                           FStar_SMTEncoding_Term.mk_HasTypeWithFuel
-                                             (Some fterm) xtm t1 in
-                                         let t_has_kind =
-                                           FStar_SMTEncoding_Term.mk_HasType
-                                             t1
-                                             FStar_SMTEncoding_Term.mk_Term_type in
-                                         let t_haseq_base =
-                                           FStar_SMTEncoding_Term.mk_haseq
-                                             base_t in
-                                         let t_haseq_ref =
-                                           FStar_SMTEncoding_Term.mk_haseq t1 in
-                                         let t_haseq1 =
-                                           let uu____3022 =
-                                             let uu____3027 =
-                                               let uu____3028 =
-                                                 let uu____3034 =
-                                                   FStar_SMTEncoding_Util.mkIff
-                                                     (t_haseq_ref,
-                                                       t_haseq_base) in
-                                                 ([[t_haseq_ref]], cvars,
-                                                   uu____3034) in
-                                               FStar_SMTEncoding_Util.mkForall
-                                                 uu____3028 in
-                                             (uu____3027,
-                                               (Some
-                                                  (Prims.strcat "haseq for "
-                                                     tsym)),
-                                               (Some
-                                                  (Prims.strcat "haseq" tsym))) in
-                                           FStar_SMTEncoding_Term.Assume
-                                             uu____3022 in
-                                         let t_kinding =
-                                           let uu____3045 =
-                                             let uu____3050 =
-                                               FStar_SMTEncoding_Util.mkForall
-                                                 ([[t_has_kind]], cvars,
-                                                   t_has_kind) in
-                                             (uu____3050,
-                                               (Some "refinement kinding"),
-                                               (Some
-                                                  (Prims.strcat
-                                                     "refinement_kinding_"
-                                                     tsym))) in
-                                           FStar_SMTEncoding_Term.Assume
-                                             uu____3045 in
-                                         let t_interp =
-                                           let uu____3061 =
-                                             let uu____3066 =
-                                               let uu____3067 =
-                                                 let uu____3073 =
-                                                   FStar_SMTEncoding_Util.mkIff
-                                                     (x_has_t, encoding) in
-                                                 ([[x_has_t]], (ffv :: xfv ::
-                                                   cvars), uu____3073) in
-                                               FStar_SMTEncoding_Util.mkForall
-                                                 uu____3067 in
-                                             let uu____3085 =
-                                               let uu____3087 =
-                                                 FStar_Syntax_Print.term_to_string
-                                                   t0 in
-                                               Some uu____3087 in
-                                             (uu____3066, uu____3085,
-                                               (Some
-                                                  (Prims.strcat
-                                                     "refinement_interpretation_"
-                                                     tsym))) in
-                                           FStar_SMTEncoding_Term.Assume
-                                             uu____3061 in
-                                         let t_decls =
-                                           FStar_List.append decls
-                                             (FStar_List.append decls'
-                                                [tdecl;
-                                                t_kinding;
-                                                t_interp;
-                                                t_haseq1]) in
-                                         (FStar_Util.smap_add env.cache
-                                            tkey_hash
-                                            (tsym, cvar_sorts, t_decls);
-                                          (t1, t_decls))))))))
-       | FStar_Syntax_Syntax.Tm_uvar (uv,k) ->
-           let ttm =
-             let uu____3116 = FStar_Unionfind.uvar_id uv in
-             FStar_SMTEncoding_Util.mk_Term_uvar uu____3116 in
-           let uu____3120 = encode_term_pred None k env ttm in
-           (match uu____3120 with
-            | (t_has_k,decls) ->
-                let d =
-                  let uu____3128 =
-                    let uu____3133 =
-                      let uu____3135 =
-                        let uu____3136 =
-                          let uu____3137 =
-                            let uu____3138 = FStar_Unionfind.uvar_id uv in
-                            FStar_All.pipe_left FStar_Util.string_of_int
-                              uu____3138 in
-                          FStar_Util.format1 "uvar_typing_%s" uu____3137 in
-                        varops.mk_unique uu____3136 in
-                      Some uu____3135 in
-                    (t_has_k, (Some "Uvar typing"), uu____3133) in
-                  FStar_SMTEncoding_Term.Assume uu____3128 in
-                (ttm, (FStar_List.append decls [d])))
-       | FStar_Syntax_Syntax.Tm_app uu____3145 ->
-           let uu____3155 = FStar_Syntax_Util.head_and_args t0 in
-           (match uu____3155 with
-            | (head1,args_e) ->
-                let uu____3183 =
-                  let uu____3191 =
-                    let uu____3192 = FStar_Syntax_Subst.compress head1 in
-                    uu____3192.FStar_Syntax_Syntax.n in
-                  (uu____3191, args_e) in
-                (match uu____3183 with
-                 | (uu____3202,uu____3203) when head_redex env head1 ->
-                     let uu____3214 = whnf env t in
-                     encode_term uu____3214 env
-                 | (FStar_Syntax_Syntax.Tm_uinst
-                    ({
-                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                       FStar_Syntax_Syntax.tk = _;
-                       FStar_Syntax_Syntax.pos = _;
-                       FStar_Syntax_Syntax.vars = _;_},_),_::(v1,_)::
-                    (v2,_)::[])
-                   |(FStar_Syntax_Syntax.Tm_fvar fv,_::(v1,_)::(v2,_)::[])
-                     when
-                     FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Syntax_Const.lexcons_lid
-                     ->
-                     let uu____3288 = encode_term v1 env in
-                     (match uu____3288 with
-                      | (v11,decls1) ->
-                          let uu____3295 = encode_term v2 env in
-                          (match uu____3295 with
-                           | (v21,decls2) ->
-                               let uu____3302 =
-                                 FStar_SMTEncoding_Util.mk_LexCons v11 v21 in
-                               (uu____3302,
-                                 (FStar_List.append decls1 decls2))))
-                 | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
-                    ),uu____3304) ->
-                     let e0 =
-                       let uu____3318 =
-                         let uu____3321 =
-                           let uu____3322 =
-                             let uu____3332 =
-                               let uu____3338 = FStar_List.hd args_e in
-                               [uu____3338] in
-                             (head1, uu____3332) in
-                           FStar_Syntax_Syntax.Tm_app uu____3322 in
-                         FStar_Syntax_Syntax.mk uu____3321 in
-                       uu____3318 None head1.FStar_Syntax_Syntax.pos in
-                     ((let uu____3371 =
-                         FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug env.tcenv)
-                           (FStar_Options.Other "SMTEncodingReify") in
-                       if uu____3371
-                       then
-                         let uu____3372 =
-                           FStar_Syntax_Print.term_to_string e0 in
-                         FStar_Util.print1 "Trying to normalize %s\n"
-                           uu____3372
-                       else ());
-                      (let e01 =
-                         FStar_TypeChecker_Normalize.normalize
-                           [FStar_TypeChecker_Normalize.Beta;
-                           FStar_TypeChecker_Normalize.Reify;
-                           FStar_TypeChecker_Normalize.Eager_unfolding;
-                           FStar_TypeChecker_Normalize.EraseUniverses;
-                           FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                           env.tcenv e0 in
-                       (let uu____3376 =
-                          FStar_All.pipe_left
-                            (FStar_TypeChecker_Env.debug env.tcenv)
-                            (FStar_Options.Other "SMTEncodingReify") in
-                        if uu____3376
-                        then
-                          let uu____3377 =
-                            FStar_Syntax_Print.term_to_string e01 in
-                          FStar_Util.print1 "Result of normalization %s\n"
-                            uu____3377
-                        else ());
-                       (let e02 =
-                          let uu____3380 =
-                            let uu____3381 =
-                              let uu____3382 =
-                                FStar_Syntax_Subst.compress e01 in
-                              uu____3382.FStar_Syntax_Syntax.n in
-                            match uu____3381 with
-                            | FStar_Syntax_Syntax.Tm_app uu____3385 -> false
-                            | uu____3395 -> true in
-                          if uu____3380
-                          then e01
-                          else
-                            (let uu____3397 =
-                               FStar_Syntax_Util.head_and_args e01 in
-                             match uu____3397 with
-                             | (head2,args) ->
-                                 let uu____3423 =
-                                   let uu____3424 =
-                                     let uu____3425 =
-                                       FStar_Syntax_Subst.compress head2 in
-                                     uu____3425.FStar_Syntax_Syntax.n in
-                                   match uu____3424 with
-                                   | FStar_Syntax_Syntax.Tm_constant
-                                       (FStar_Const.Const_reify ) -> true
-                                   | uu____3428 -> false in
-                                 if uu____3423
-                                 then
-                                   (match args with
-                                    | x::[] -> Prims.fst x
-                                    | uu____3444 ->
-                                        failwith
-                                          "Impossible : Reify applied to multiple arguments after normalization.")
-                                 else e01) in
-                        let e =
-                          match args_e with
-                          | uu____3452::[] -> e02
-                          | uu____3465 ->
-                              let uu____3471 =
-                                let uu____3474 =
-                                  let uu____3475 =
-                                    let uu____3485 = FStar_List.tl args_e in
-                                    (e02, uu____3485) in
-                                  FStar_Syntax_Syntax.Tm_app uu____3475 in
-                                FStar_Syntax_Syntax.mk uu____3474 in
-                              uu____3471 None t0.FStar_Syntax_Syntax.pos in
-                        encode_term e env)))
-                 | (FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_reflect
-                    uu____3508),(arg,uu____3510)::[]) -> encode_term arg env
-                 | uu____3528 ->
-                     let uu____3536 = encode_args args_e env in
-                     (match uu____3536 with
-                      | (args,decls) ->
-                          let encode_partial_app ht_opt =
-                            let uu____3569 = encode_term head1 env in
-                            match uu____3569 with
-                            | (head2,decls') ->
-                                let app_tm = mk_Apply_args head2 args in
-                                (match ht_opt with
-                                 | None  ->
-                                     (app_tm,
-                                       (FStar_List.append decls decls'))
-                                 | Some (formals,c) ->
-                                     let uu____3608 =
-                                       FStar_Util.first_N
-                                         (FStar_List.length args_e) formals in
-                                     (match uu____3608 with
-                                      | (formals1,rest) ->
-                                          let subst1 =
-                                            FStar_List.map2
-                                              (fun uu____3650  ->
-                                                 fun uu____3651  ->
-                                                   match (uu____3650,
-                                                           uu____3651)
-                                                   with
-                                                   | ((bv,uu____3665),
-                                                      (a,uu____3667)) ->
-                                                       FStar_Syntax_Syntax.NT
-                                                         (bv, a)) formals1
-                                              args_e in
-                                          let ty =
-                                            let uu____3681 =
-                                              FStar_Syntax_Util.arrow rest c in
-                                            FStar_All.pipe_right uu____3681
-                                              (FStar_Syntax_Subst.subst
-                                                 subst1) in
-                                          let uu____3686 =
-                                            encode_term_pred None ty env
-                                              app_tm in
-                                          (match uu____3686 with
-                                           | (has_type,decls'') ->
-                                               let cvars =
-                                                 FStar_SMTEncoding_Term.free_variables
-                                                   has_type in
-                                               let e_typing =
-                                                 let uu____3696 =
-                                                   let uu____3701 =
-                                                     FStar_SMTEncoding_Util.mkForall
-                                                       ([[has_type]], cvars,
-                                                         has_type) in
-                                                   let uu____3706 =
-                                                     let uu____3708 =
-                                                       let uu____3709 =
-                                                         let uu____3710 =
-                                                           let uu____3711 =
-                                                             FStar_SMTEncoding_Term.hash_of_term
-                                                               app_tm in
-                                                           FStar_Util.digest_of_string
-                                                             uu____3711 in
-                                                         Prims.strcat
-                                                           "partial_app_typing_"
-                                                           uu____3710 in
-                                                       varops.mk_unique
-                                                         uu____3709 in
-                                                     Some uu____3708 in
-                                                   (uu____3701,
-                                                     (Some
-                                                        "Partial app typing"),
-                                                     uu____3706) in
-                                                 FStar_SMTEncoding_Term.Assume
-                                                   uu____3696 in
-                                               (app_tm,
-                                                 (FStar_List.append decls
-                                                    (FStar_List.append decls'
-                                                       (FStar_List.append
-                                                          decls'' [e_typing]))))))) in
-                          let encode_full_app fv =
-                            let uu____3729 = lookup_free_var_sym env fv in
-                            match uu____3729 with
-                            | (fname,fuel_args) ->
-                                let tm =
-                                  FStar_SMTEncoding_Util.mkApp'
-                                    (fname,
-                                      (FStar_List.append fuel_args args)) in
-                                (tm, decls) in
-                          let head2 = FStar_Syntax_Subst.compress head1 in
-                          let head_type =
-                            match head2.FStar_Syntax_Syntax.n with
-                            | FStar_Syntax_Syntax.Tm_uinst
-                              ({
-                                 FStar_Syntax_Syntax.n =
-                                   FStar_Syntax_Syntax.Tm_name x;
-                                 FStar_Syntax_Syntax.tk = _;
-                                 FStar_Syntax_Syntax.pos = _;
-                                 FStar_Syntax_Syntax.vars = _;_},_)
-                              |FStar_Syntax_Syntax.Tm_name x ->
-                                Some (x.FStar_Syntax_Syntax.sort)
-                            | FStar_Syntax_Syntax.Tm_uinst
-                              ({
-                                 FStar_Syntax_Syntax.n =
-                                   FStar_Syntax_Syntax.Tm_fvar fv;
-                                 FStar_Syntax_Syntax.tk = _;
-                                 FStar_Syntax_Syntax.pos = _;
-                                 FStar_Syntax_Syntax.vars = _;_},_)
-                              |FStar_Syntax_Syntax.Tm_fvar fv ->
-                                let uu____3767 =
-                                  let uu____3768 =
-                                    let uu____3771 =
-                                      FStar_TypeChecker_Env.lookup_lid
-                                        env.tcenv
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                    FStar_All.pipe_right uu____3771 Prims.fst in
-                                  FStar_All.pipe_right uu____3768 Prims.snd in
-                                Some uu____3767
-                            | FStar_Syntax_Syntax.Tm_ascribed
-                                (uu____3790,(FStar_Util.Inl t1,uu____3792),uu____3793)
-                                -> Some t1
-                            | FStar_Syntax_Syntax.Tm_ascribed
-                                (uu____3831,(FStar_Util.Inr c,uu____3833),uu____3834)
-                                -> Some (FStar_Syntax_Util.comp_result c)
-                            | uu____3872 -> None in
-                          (match head_type with
-                           | None  -> encode_partial_app None
-                           | Some head_type1 ->
-                               let head_type2 =
-                                 let uu____3892 =
-                                   FStar_TypeChecker_Normalize.normalize_refinement
-                                     [FStar_TypeChecker_Normalize.WHNF;
-                                     FStar_TypeChecker_Normalize.EraseUniverses]
-                                     env.tcenv head_type1 in
-                                 FStar_All.pipe_left
-                                   FStar_Syntax_Util.unrefine uu____3892 in
-                               let uu____3893 =
-                                 curried_arrow_formals_comp head_type2 in
-                               (match uu____3893 with
-                                | (formals,c) ->
-                                    (match head2.FStar_Syntax_Syntax.n with
-                                     | FStar_Syntax_Syntax.Tm_uinst
-                                       ({
-                                          FStar_Syntax_Syntax.n =
-                                            FStar_Syntax_Syntax.Tm_fvar fv;
-                                          FStar_Syntax_Syntax.tk = _;
-                                          FStar_Syntax_Syntax.pos = _;
-                                          FStar_Syntax_Syntax.vars = _;_},_)
-                                       |FStar_Syntax_Syntax.Tm_fvar fv when
-                                         (FStar_List.length formals) =
-                                           (FStar_List.length args)
-                                         ->
-                                         encode_full_app
-                                           fv.FStar_Syntax_Syntax.fv_name
-                                     | uu____3918 ->
-                                         if
-                                           (FStar_List.length formals) >
-                                             (FStar_List.length args)
-                                         then
-                                           encode_partial_app
-                                             (Some (formals, c))
-                                         else encode_partial_app None))))))
-       | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-           let uu____3963 = FStar_Syntax_Subst.open_term' bs body in
-           (match uu____3963 with
-            | (bs1,body1,opening) ->
-                let fallback uu____3978 =
-                  let f = varops.fresh "Tm_abs" in
-                  let decl =
-                    FStar_SMTEncoding_Term.DeclFun
-                      (f, [], FStar_SMTEncoding_Term.Term_sort,
-                        (Some "Imprecise function encoding")) in
-                  let uu____3983 =
-                    FStar_SMTEncoding_Util.mkFreeV
-                      (f, FStar_SMTEncoding_Term.Term_sort) in
-                  (uu____3983, [decl]) in
-                let is_impure lc =
-                  match lc with
-                  | FStar_Util.Inl lc1 ->
-                      let uu____3994 =
-                        FStar_Syntax_Util.is_pure_or_ghost_lcomp lc1 in
-                      Prims.op_Negation uu____3994
-                  | FStar_Util.Inr (eff,uu____3996) ->
-                      let uu____4002 =
-                        FStar_TypeChecker_Util.is_pure_or_ghost_effect
-                          env.tcenv eff in
-                      FStar_All.pipe_right uu____4002 Prims.op_Negation in
-                let reify_comp_and_body env1 c body2 =
-                  let reified_body = reify_body env1.tcenv body2 in
-                  let c1 =
-                    match c with
-                    | FStar_Util.Inl lc ->
-                        let typ =
-                          let uu____4047 = lc.FStar_Syntax_Syntax.comp () in
-                          FStar_TypeChecker_Env.reify_comp
-                            (let uu___145_4048 = env1.tcenv in
-                             {
-                               FStar_TypeChecker_Env.solver =
-                                 (uu___145_4048.FStar_TypeChecker_Env.solver);
-                               FStar_TypeChecker_Env.range =
-                                 (uu___145_4048.FStar_TypeChecker_Env.range);
-                               FStar_TypeChecker_Env.curmodule =
-                                 (uu___145_4048.FStar_TypeChecker_Env.curmodule);
-                               FStar_TypeChecker_Env.gamma =
-                                 (uu___145_4048.FStar_TypeChecker_Env.gamma);
-                               FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___145_4048.FStar_TypeChecker_Env.gamma_cache);
-                               FStar_TypeChecker_Env.modules =
-                                 (uu___145_4048.FStar_TypeChecker_Env.modules);
-                               FStar_TypeChecker_Env.expected_typ =
-                                 (uu___145_4048.FStar_TypeChecker_Env.expected_typ);
-                               FStar_TypeChecker_Env.sigtab =
-                                 (uu___145_4048.FStar_TypeChecker_Env.sigtab);
-                               FStar_TypeChecker_Env.is_pattern =
-                                 (uu___145_4048.FStar_TypeChecker_Env.is_pattern);
-                               FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___145_4048.FStar_TypeChecker_Env.instantiate_imp);
-                               FStar_TypeChecker_Env.effects =
-                                 (uu___145_4048.FStar_TypeChecker_Env.effects);
-                               FStar_TypeChecker_Env.generalize =
-                                 (uu___145_4048.FStar_TypeChecker_Env.generalize);
-                               FStar_TypeChecker_Env.letrecs =
-                                 (uu___145_4048.FStar_TypeChecker_Env.letrecs);
-                               FStar_TypeChecker_Env.top_level =
-                                 (uu___145_4048.FStar_TypeChecker_Env.top_level);
-                               FStar_TypeChecker_Env.check_uvars =
-                                 (uu___145_4048.FStar_TypeChecker_Env.check_uvars);
-                               FStar_TypeChecker_Env.use_eq =
-                                 (uu___145_4048.FStar_TypeChecker_Env.use_eq);
-                               FStar_TypeChecker_Env.is_iface =
-                                 (uu___145_4048.FStar_TypeChecker_Env.is_iface);
-                               FStar_TypeChecker_Env.admit =
-                                 (uu___145_4048.FStar_TypeChecker_Env.admit);
-                               FStar_TypeChecker_Env.lax = true;
-                               FStar_TypeChecker_Env.lax_universes =
-                                 (uu___145_4048.FStar_TypeChecker_Env.lax_universes);
-                               FStar_TypeChecker_Env.type_of =
-                                 (uu___145_4048.FStar_TypeChecker_Env.type_of);
-                               FStar_TypeChecker_Env.universe_of =
-                                 (uu___145_4048.FStar_TypeChecker_Env.universe_of);
-                               FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___145_4048.FStar_TypeChecker_Env.use_bv_sorts);
-                               FStar_TypeChecker_Env.qname_and_index =
-                                 (uu___145_4048.FStar_TypeChecker_Env.qname_and_index)
-                             }) uu____4047 FStar_Syntax_Syntax.U_unknown in
-                        let uu____4049 =
-                          let uu____4050 = FStar_Syntax_Syntax.mk_Total typ in
-                          FStar_Syntax_Util.lcomp_of_comp uu____4050 in
-                        FStar_Util.Inl uu____4049
-                    | FStar_Util.Inr (eff_name,uu____4057) -> c in
-                  (c1, reified_body) in
-                let codomain_eff lc =
-                  match lc with
-                  | FStar_Util.Inl lc1 ->
-                      let uu____4088 =
-                        let uu____4089 = lc1.FStar_Syntax_Syntax.comp () in
-                        FStar_Syntax_Subst.subst_comp opening uu____4089 in
-                      FStar_All.pipe_right uu____4088
-                        (fun _0_31  -> Some _0_31)
-                  | FStar_Util.Inr (eff,flags) ->
-                      let new_uvar1 uu____4101 =
-                        let uu____4102 =
-                          FStar_TypeChecker_Rel.new_uvar
-                            FStar_Range.dummyRange []
-                            FStar_Syntax_Util.ktype0 in
-                        FStar_All.pipe_right uu____4102 Prims.fst in
-                      if
-                        FStar_Ident.lid_equals eff
-                          FStar_Syntax_Const.effect_Tot_lid
-                      then
-                        let uu____4110 =
-                          let uu____4111 = new_uvar1 () in
-                          FStar_Syntax_Syntax.mk_Total uu____4111 in
-                        FStar_All.pipe_right uu____4110
-                          (fun _0_32  -> Some _0_32)
-                      else
-                        if
-                          FStar_Ident.lid_equals eff
-                            FStar_Syntax_Const.effect_GTot_lid
-                        then
-                          (let uu____4115 =
-                             let uu____4116 = new_uvar1 () in
-                             FStar_Syntax_Syntax.mk_GTotal uu____4116 in
-                           FStar_All.pipe_right uu____4115
-                             (fun _0_33  -> Some _0_33))
-                        else None in
-                (match lopt with
-                 | None  ->
-                     ((let uu____4127 =
-                         let uu____4128 =
-                           FStar_Syntax_Print.term_to_string t0 in
-                         FStar_Util.format1
-                           "Losing precision when encoding a function literal: %s\n(Unnannotated abstraction in the compiler ?)"
-                           uu____4128 in
-                       FStar_Errors.warn t0.FStar_Syntax_Syntax.pos
-                         uu____4127);
-                      fallback ())
-                 | Some lc ->
-                     let lc1 = lc in
-                     let uu____4143 =
-                       (is_impure lc1) &&
-                         (let uu____4144 =
-                            FStar_TypeChecker_Env.is_reifiable env.tcenv lc1 in
-                          Prims.op_Negation uu____4144) in
-                     if uu____4143
-                     then fallback ()
-                     else
-                       (let uu____4148 = encode_binders None bs1 env in
-                        match uu____4148 with
-                        | (vars,guards,envbody,decls,uu____4163) ->
-                            let uu____4170 =
-                              let uu____4178 =
-                                FStar_TypeChecker_Env.is_reifiable env.tcenv
-                                  lc1 in
-                              if uu____4178
-                              then reify_comp_and_body envbody lc1 body1
-                              else (lc1, body1) in
-                            (match uu____4170 with
-                             | (lc2,body2) ->
-                                 let uu____4203 = encode_term body2 envbody in
-                                 (match uu____4203 with
-                                  | (body3,decls') ->
-                                      let key_body =
-                                        let uu____4211 =
-                                          let uu____4217 =
-                                            let uu____4218 =
-                                              let uu____4221 =
-                                                FStar_SMTEncoding_Util.mk_and_l
-                                                  guards in
-                                              (uu____4221, body3) in
-                                            FStar_SMTEncoding_Util.mkImp
-                                              uu____4218 in
-                                          ([], vars, uu____4217) in
-                                        FStar_SMTEncoding_Util.mkForall
-                                          uu____4211 in
-                                      let cvars =
-                                        FStar_SMTEncoding_Term.free_variables
-                                          key_body in
-                                      let tkey =
-                                        FStar_SMTEncoding_Util.mkForall
-                                          ([], cvars, key_body) in
-                                      let tkey_hash =
-                                        FStar_SMTEncoding_Term.hash_of_term
-                                          tkey in
-                                      let uu____4232 =
-                                        FStar_Util.smap_try_find env.cache
-                                          tkey_hash in
-                                      (match uu____4232 with
-                                       | Some (t1,uu____4247,uu____4248) ->
-                                           let uu____4258 =
-                                             let uu____4259 =
-                                               let uu____4263 =
-                                                 FStar_List.map
-                                                   FStar_SMTEncoding_Util.mkFreeV
-                                                   cvars in
-                                               (t1, uu____4263) in
-                                             FStar_SMTEncoding_Util.mkApp
-                                               uu____4259 in
-                                           (uu____4258, [])
-                                       | None  ->
-                                           let uu____4274 =
-                                             is_eta env vars body3 in
-                                           (match uu____4274 with
-                                            | Some t1 -> (t1, [])
-                                            | None  ->
-                                                let cvar_sorts =
-                                                  FStar_List.map Prims.snd
-                                                    cvars in
-                                                let fsym =
-                                                  let uu____4285 =
-                                                    let uu____4286 =
-                                                      FStar_Util.digest_of_string
-                                                        tkey_hash in
-                                                    Prims.strcat "Tm_abs_"
-                                                      uu____4286 in
-                                                  varops.mk_unique uu____4285 in
-                                                let fdecl =
-                                                  FStar_SMTEncoding_Term.DeclFun
-                                                    (fsym, cvar_sorts,
-                                                      FStar_SMTEncoding_Term.Term_sort,
-                                                      None) in
-                                                let f =
-                                                  let uu____4291 =
-                                                    let uu____4295 =
-                                                      FStar_List.map
-                                                        FStar_SMTEncoding_Util.mkFreeV
-                                                        cvars in
-                                                    (fsym, uu____4295) in
-                                                  FStar_SMTEncoding_Util.mkApp
-                                                    uu____4291 in
-                                                let app = mk_Apply f vars in
-                                                let typing_f =
-                                                  let uu____4303 =
-                                                    codomain_eff lc2 in
-                                                  match uu____4303 with
-                                                  | None  -> []
-                                                  | Some c ->
-                                                      let tfun =
-                                                        FStar_Syntax_Util.arrow
-                                                          bs1 c in
-                                                      let uu____4310 =
-                                                        encode_term_pred None
-                                                          tfun env f in
-                                                      (match uu____4310 with
-                                                       | (f_has_t,decls'') ->
-                                                           let a_name =
-                                                             Some
-                                                               (Prims.strcat
-                                                                  "typing_"
-                                                                  fsym) in
-                                                           let uu____4318 =
-                                                             let uu____4320 =
-                                                               let uu____4321
-                                                                 =
-                                                                 let uu____4326
-                                                                   =
-                                                                   FStar_SMTEncoding_Util.mkForall
-                                                                    ([[f]],
-                                                                    cvars,
-                                                                    f_has_t) in
-                                                                 (uu____4326,
-                                                                   a_name,
-                                                                   a_name) in
-                                                               FStar_SMTEncoding_Term.Assume
-                                                                 uu____4321 in
-                                                             [uu____4320] in
-                                                           FStar_List.append
-                                                             decls''
-                                                             uu____4318) in
-                                                let interp_f =
-                                                  let a_name =
-                                                    Some
-                                                      (Prims.strcat
-                                                         "interpretation_"
-                                                         fsym) in
-                                                  let uu____4336 =
-                                                    let uu____4341 =
-                                                      let uu____4342 =
-                                                        let uu____4348 =
-                                                          FStar_SMTEncoding_Util.mkEq
-                                                            (app, body3) in
-                                                        ([[app]],
-                                                          (FStar_List.append
-                                                             vars cvars),
-                                                          uu____4348) in
-                                                      FStar_SMTEncoding_Util.mkForall
-                                                        uu____4342 in
-                                                    (uu____4341, a_name,
-                                                      a_name) in
-                                                  FStar_SMTEncoding_Term.Assume
-                                                    uu____4336 in
-                                                let f_decls =
-                                                  FStar_List.append decls
-                                                    (FStar_List.append decls'
-                                                       (FStar_List.append
-                                                          (fdecl :: typing_f)
-                                                          [interp_f])) in
-                                                (FStar_Util.smap_add
-                                                   env.cache tkey_hash
-                                                   (fsym, cvar_sorts,
-                                                     f_decls);
-                                                 (f, f_decls)))))))))
-       | FStar_Syntax_Syntax.Tm_let
-           ((uu____4367,{
-                          FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                            uu____4368;
-                          FStar_Syntax_Syntax.lbunivs = uu____4369;
-                          FStar_Syntax_Syntax.lbtyp = uu____4370;
-                          FStar_Syntax_Syntax.lbeff = uu____4371;
-                          FStar_Syntax_Syntax.lbdef = uu____4372;_}::uu____4373),uu____4374)
-           -> failwith "Impossible: already handled by encoding of Sig_let"
-       | FStar_Syntax_Syntax.Tm_let
-           ((false
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-                FStar_Syntax_Syntax.lbunivs = uu____4392;
-                FStar_Syntax_Syntax.lbtyp = t1;
-                FStar_Syntax_Syntax.lbeff = uu____4394;
-                FStar_Syntax_Syntax.lbdef = e1;_}::[]),e2)
-           -> encode_let x t1 e1 e2 env encode_term
-       | FStar_Syntax_Syntax.Tm_let uu____4410 ->
-           (FStar_Errors.diag t0.FStar_Syntax_Syntax.pos
-              "Non-top-level recursive functions are not yet fully encoded to the SMT solver; you may not be able to prove some facts";
-            (let e = varops.fresh "let-rec" in
-             let decl_e =
-               FStar_SMTEncoding_Term.DeclFun
-                 (e, [], FStar_SMTEncoding_Term.Term_sort, None) in
-             let uu____4423 =
-               FStar_SMTEncoding_Util.mkFreeV
-                 (e, FStar_SMTEncoding_Term.Term_sort) in
-             (uu____4423, [decl_e])))
-       | FStar_Syntax_Syntax.Tm_match (e,pats) ->
-           encode_match e pats FStar_SMTEncoding_Term.mk_Term_unit env
-             encode_term)
-and encode_let:
-  FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term ->
-          env_t ->
-            (FStar_Syntax_Syntax.term ->
-               env_t ->
-                 (FStar_SMTEncoding_Term.term*
-                   FStar_SMTEncoding_Term.decls_t))
-              ->
-              (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun x  ->
-    fun t1  ->
-      fun e1  ->
-        fun e2  ->
-          fun env  ->
-            fun encode_body  ->
-              let uu____4465 = encode_term e1 env in
-              match uu____4465 with
-              | (ee1,decls1) ->
-                  let uu____4472 =
-                    FStar_Syntax_Subst.open_term [(x, None)] e2 in
-                  (match uu____4472 with
-                   | (xs,e21) ->
-                       let uu____4486 = FStar_List.hd xs in
-                       (match uu____4486 with
-                        | (x1,uu____4494) ->
-                            let env' = push_term_var env x1 ee1 in
-                            let uu____4496 = encode_body e21 env' in
-                            (match uu____4496 with
-                             | (ee2,decls2) ->
-                                 (ee2, (FStar_List.append decls1 decls2)))))
-and encode_match:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.branch Prims.list ->
-      FStar_SMTEncoding_Term.term ->
-        env_t ->
-          (FStar_Syntax_Syntax.term ->
-             env_t ->
-               (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t))
-            -> (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun e  ->
-    fun pats  ->
-      fun default_case  ->
-        fun env  ->
-          fun encode_br  ->
-            let uu____4518 =
-              let uu____4522 =
-                let uu____4523 =
-                  (FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown)
-                    None FStar_Range.dummyRange in
-                FStar_Syntax_Syntax.null_bv uu____4523 in
-              gen_term_var env uu____4522 in
-            match uu____4518 with
-            | (scrsym,scr',env1) ->
-                let uu____4537 = encode_term e env1 in
-                (match uu____4537 with
-                 | (scr,decls) ->
-                     let uu____4544 =
-                       let encode_branch b uu____4560 =
-                         match uu____4560 with
-                         | (else_case,decls1) ->
-                             let uu____4571 =
-                               FStar_Syntax_Subst.open_branch b in
-                             (match uu____4571 with
-                              | (p,w,br) ->
-                                  let patterns = encode_pat env1 p in
-                                  FStar_List.fold_right
-                                    (fun uu____4601  ->
-                                       fun uu____4602  ->
-                                         match (uu____4601, uu____4602) with
-                                         | ((env0,pattern),(else_case1,decls2))
-                                             ->
-                                             let guard = pattern.guard scr' in
-                                             let projections =
-                                               pattern.projections scr' in
-                                             let env2 =
-                                               FStar_All.pipe_right
-                                                 projections
-                                                 (FStar_List.fold_left
-                                                    (fun env2  ->
-                                                       fun uu____4639  ->
-                                                         match uu____4639
-                                                         with
-                                                         | (x,t) ->
-                                                             push_term_var
-                                                               env2 x t) env1) in
-                                             let uu____4644 =
-                                               match w with
-                                               | None  -> (guard, [])
-                                               | Some w1 ->
-                                                   let uu____4659 =
-                                                     encode_term w1 env2 in
-                                                   (match uu____4659 with
-                                                    | (w2,decls21) ->
-                                                        let uu____4667 =
-                                                          let uu____4668 =
-                                                            let uu____4671 =
-                                                              let uu____4672
-                                                                =
-                                                                let uu____4675
-                                                                  =
-                                                                  FStar_SMTEncoding_Term.boxBool
-                                                                    FStar_SMTEncoding_Util.mkTrue in
-                                                                (w2,
-                                                                  uu____4675) in
-                                                              FStar_SMTEncoding_Util.mkEq
-                                                                uu____4672 in
-                                                            (guard,
-                                                              uu____4671) in
-                                                          FStar_SMTEncoding_Util.mkAnd
-                                                            uu____4668 in
-                                                        (uu____4667, decls21)) in
-                                             (match uu____4644 with
-                                              | (guard1,decls21) ->
-                                                  let uu____4683 =
-                                                    encode_br br env2 in
-                                                  (match uu____4683 with
-                                                   | (br1,decls3) ->
-                                                       let uu____4691 =
-                                                         FStar_SMTEncoding_Util.mkITE
-                                                           (guard1, br1,
-                                                             else_case1) in
-                                                       (uu____4691,
-                                                         (FStar_List.append
-                                                            decls2
-                                                            (FStar_List.append
-                                                               decls21 decls3))))))
-                                    patterns (else_case, decls1)) in
-                       FStar_List.fold_right encode_branch pats
-                         (default_case, decls) in
-                     (match uu____4544 with
-                      | (match_tm,decls1) ->
-                          let uu____4703 =
-                            FStar_SMTEncoding_Term.mkLet'
-                              ([((scrsym, FStar_SMTEncoding_Term.Term_sort),
-                                  scr)], match_tm) FStar_Range.dummyRange in
-                          (uu____4703, decls1)))
-and encode_pat:
-  env_t -> FStar_Syntax_Syntax.pat -> (env_t* pattern) Prims.list =
-  fun env  ->
-    fun pat  ->
-      match pat.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_disj ps ->
-          FStar_List.map (encode_one_pat env) ps
-      | uu____4734 -> let uu____4735 = encode_one_pat env pat in [uu____4735]
-and encode_one_pat: env_t -> FStar_Syntax_Syntax.pat -> (env_t* pattern) =
-  fun env  ->
-    fun pat  ->
-      (let uu____4747 =
-         FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
-       if uu____4747
-       then
-         let uu____4748 = FStar_Syntax_Print.pat_to_string pat in
-         FStar_Util.print1 "Encoding pattern %s\n" uu____4748
-       else ());
-      (let uu____4750 = FStar_TypeChecker_Util.decorated_pattern_as_term pat in
-       match uu____4750 with
-       | (vars,pat_term) ->
-           let uu____4760 =
-             FStar_All.pipe_right vars
-               (FStar_List.fold_left
-                  (fun uu____4783  ->
-                     fun v1  ->
-                       match uu____4783 with
-                       | (env1,vars1) ->
-                           let uu____4811 = gen_term_var env1 v1 in
-                           (match uu____4811 with
-                            | (xx,uu____4823,env2) ->
-                                (env2,
-                                  ((v1,
-                                     (xx, FStar_SMTEncoding_Term.Term_sort))
-                                  :: vars1)))) (env, [])) in
-           (match uu____4760 with
-            | (env1,vars1) ->
-                let rec mk_guard pat1 scrutinee =
-                  match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_disj uu____4870 ->
-                      failwith "Impossible"
-                  | FStar_Syntax_Syntax.Pat_var _
-                    |FStar_Syntax_Syntax.Pat_wild _
-                     |FStar_Syntax_Syntax.Pat_dot_term _ ->
-                      FStar_SMTEncoding_Util.mkTrue
-                  | FStar_Syntax_Syntax.Pat_constant c ->
-                      let uu____4878 =
-                        let uu____4881 = encode_const c in
-                        (scrutinee, uu____4881) in
-                      FStar_SMTEncoding_Util.mkEq uu____4878
-                  | FStar_Syntax_Syntax.Pat_cons (f,args) ->
-                      let is_f =
-                        let tc_name =
-                          FStar_TypeChecker_Env.typ_of_datacon env1.tcenv
-                            (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                        let uu____4900 =
-                          FStar_TypeChecker_Env.datacons_of_typ env1.tcenv
-                            tc_name in
-                        match uu____4900 with
-                        | (uu____4904,uu____4905::[]) ->
-                            FStar_SMTEncoding_Util.mkTrue
-                        | uu____4907 ->
-                            mk_data_tester env1
-                              (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                              scrutinee in
-                      let sub_term_guards =
-                        FStar_All.pipe_right args
-                          (FStar_List.mapi
-                             (fun i  ->
-                                fun uu____4928  ->
-                                  match uu____4928 with
-                                  | (arg,uu____4934) ->
-                                      let proj =
-                                        primitive_projector_by_pos env1.tcenv
-                                          (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i in
-                                      let uu____4944 =
-                                        FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee]) in
-                                      mk_guard arg uu____4944)) in
-                      FStar_SMTEncoding_Util.mk_and_l (is_f ::
-                        sub_term_guards) in
-                let rec mk_projections pat1 scrutinee =
-                  match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_disj uu____4963 ->
-                      failwith "Impossible"
-                  | FStar_Syntax_Syntax.Pat_dot_term (x,_)
-                    |FStar_Syntax_Syntax.Pat_var x
-                     |FStar_Syntax_Syntax.Pat_wild x -> [(x, scrutinee)]
-                  | FStar_Syntax_Syntax.Pat_constant uu____4978 -> []
-                  | FStar_Syntax_Syntax.Pat_cons (f,args) ->
-                      let uu____4993 =
-                        FStar_All.pipe_right args
-                          (FStar_List.mapi
-                             (fun i  ->
-                                fun uu____5015  ->
-                                  match uu____5015 with
-                                  | (arg,uu____5024) ->
-                                      let proj =
-                                        primitive_projector_by_pos env1.tcenv
-                                          (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i in
-                                      let uu____5034 =
-                                        FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee]) in
-                                      mk_projections arg uu____5034)) in
-                      FStar_All.pipe_right uu____4993 FStar_List.flatten in
-                let pat_term1 uu____5050 = encode_term pat_term env1 in
-                let pattern =
-                  {
-                    pat_vars = vars1;
-                    pat_term = pat_term1;
-                    guard = (mk_guard pat);
-                    projections = (mk_projections pat)
-                  } in
-                (env1, pattern)))
-and encode_args:
-  FStar_Syntax_Syntax.args ->
-    env_t ->
-      (FStar_SMTEncoding_Term.term Prims.list*
-        FStar_SMTEncoding_Term.decls_t)
-  =
-  fun l  ->
-    fun env  ->
-      let uu____5057 =
-        FStar_All.pipe_right l
-          (FStar_List.fold_left
-             (fun uu____5072  ->
-                fun uu____5073  ->
-                  match (uu____5072, uu____5073) with
-                  | ((tms,decls),(t,uu____5093)) ->
-                      let uu____5104 = encode_term t env in
-                      (match uu____5104 with
-                       | (t1,decls') ->
-                           ((t1 :: tms), (FStar_List.append decls decls'))))
-             ([], [])) in
-      match uu____5057 with | (l1,decls) -> ((FStar_List.rev l1), decls)
-and encode_function_type_as_formula:
-  FStar_SMTEncoding_Term.term Prims.option ->
-    FStar_Syntax_Syntax.term Prims.option ->
-      FStar_Syntax_Syntax.typ ->
-        env_t ->
-          (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun induction_on  ->
-    fun new_pats  ->
-      fun t  ->
-        fun env  ->
-          let list_elements1 e =
-            let uu____5142 = FStar_Syntax_Util.list_elements e in
-            match uu____5142 with
-            | Some l -> l
-            | None  ->
-                (FStar_Errors.warn e.FStar_Syntax_Syntax.pos
-                   "SMT pattern is not a list literal; ignoring the pattern";
-                 []) in
-          let one_pat p =
-            let uu____5160 =
-              let uu____5170 = FStar_Syntax_Util.unmeta p in
-              FStar_All.pipe_right uu____5170 FStar_Syntax_Util.head_and_args in
-            match uu____5160 with
-            | (head1,args) ->
-                let uu____5201 =
-                  let uu____5209 =
-                    let uu____5210 = FStar_Syntax_Util.un_uinst head1 in
-                    uu____5210.FStar_Syntax_Syntax.n in
-                  (uu____5209, args) in
-                (match uu____5201 with
-                 | (FStar_Syntax_Syntax.Tm_fvar
-                    fv,(uu____5224,uu____5225)::(e,uu____5227)::[]) when
-                     FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Syntax_Const.smtpat_lid
-                     -> (e, None)
-                 | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____5258)::[]) when
-                     FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Syntax_Const.smtpatT_lid
-                     -> (e, None)
-                 | uu____5279 -> failwith "Unexpected pattern term") in
-          let lemma_pats p =
-            let elts = list_elements1 p in
-            let smt_pat_or t1 =
-              let uu____5312 =
-                let uu____5322 = FStar_Syntax_Util.unmeta t1 in
-                FStar_All.pipe_right uu____5322
-                  FStar_Syntax_Util.head_and_args in
-              match uu____5312 with
-              | (head1,args) ->
-                  let uu____5351 =
-                    let uu____5359 =
-                      let uu____5360 = FStar_Syntax_Util.un_uinst head1 in
-                      uu____5360.FStar_Syntax_Syntax.n in
-                    (uu____5359, args) in
-                  (match uu____5351 with
-                   | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____5373)::[]) when
-                       FStar_Syntax_Syntax.fv_eq_lid fv
-                         FStar_Syntax_Const.smtpatOr_lid
-                       -> Some e
-                   | uu____5393 -> None) in
-            match elts with
-            | t1::[] ->
-                let uu____5411 = smt_pat_or t1 in
-                (match uu____5411 with
-                 | Some e ->
-                     let uu____5427 = list_elements1 e in
-                     FStar_All.pipe_right uu____5427
-                       (FStar_List.map
-                          (fun branch1  ->
-                             let uu____5444 = list_elements1 branch1 in
-                             FStar_All.pipe_right uu____5444
-                               (FStar_List.map one_pat)))
-                 | uu____5458 ->
-                     let uu____5462 =
-                       FStar_All.pipe_right elts (FStar_List.map one_pat) in
-                     [uu____5462])
-            | uu____5493 ->
-                let uu____5495 =
-                  FStar_All.pipe_right elts (FStar_List.map one_pat) in
-                [uu____5495] in
-          let uu____5526 =
-            let uu____5542 =
-              let uu____5543 = FStar_Syntax_Subst.compress t in
-              uu____5543.FStar_Syntax_Syntax.n in
-            match uu____5542 with
-            | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-                let uu____5573 = FStar_Syntax_Subst.open_comp binders c in
-                (match uu____5573 with
-                 | (binders1,c1) ->
-                     (match c1.FStar_Syntax_Syntax.n with
-                      | FStar_Syntax_Syntax.Comp
-                          { FStar_Syntax_Syntax.comp_univs = uu____5608;
-                            FStar_Syntax_Syntax.effect_name = uu____5609;
-                            FStar_Syntax_Syntax.result_typ = uu____5610;
-                            FStar_Syntax_Syntax.effect_args =
-                              (pre,uu____5612)::(post,uu____5614)::(pats,uu____5616)::[];
-                            FStar_Syntax_Syntax.flags = uu____5617;_}
-                          ->
-                          let pats' =
-                            match new_pats with
-                            | Some new_pats' -> new_pats'
-                            | None  -> pats in
-                          let uu____5651 = lemma_pats pats' in
-                          (binders1, pre, post, uu____5651)
-                      | uu____5670 -> failwith "impos"))
-            | uu____5686 -> failwith "Impos" in
-          match uu____5526 with
-          | (binders,pre,post,patterns) ->
-              let uu____5730 = encode_binders None binders env in
-              (match uu____5730 with
-               | (vars,guards,env1,decls,uu____5745) ->
-                   let uu____5752 =
-                     let uu____5759 =
-                       FStar_All.pipe_right patterns
-                         (FStar_List.map
-                            (fun branch1  ->
-                               let uu____5790 =
-                                 let uu____5795 =
-                                   FStar_All.pipe_right branch1
-                                     (FStar_List.map
-                                        (fun uu____5811  ->
-                                           match uu____5811 with
-                                           | (t1,uu____5818) ->
-                                               encode_term t1
-                                                 (let uu___146_5821 = env1 in
-                                                  {
-                                                    bindings =
-                                                      (uu___146_5821.bindings);
-                                                    depth =
-                                                      (uu___146_5821.depth);
-                                                    tcenv =
-                                                      (uu___146_5821.tcenv);
-                                                    warn =
-                                                      (uu___146_5821.warn);
-                                                    cache =
-                                                      (uu___146_5821.cache);
-                                                    nolabels =
-                                                      (uu___146_5821.nolabels);
-                                                    use_zfuel_name = true;
-                                                    encode_non_total_function_typ
-                                                      =
-                                                      (uu___146_5821.encode_non_total_function_typ)
-                                                  }))) in
-                                 FStar_All.pipe_right uu____5795
-                                   FStar_List.unzip in
-                               match uu____5790 with
-                               | (pats,decls1) -> (pats, decls1))) in
-                     FStar_All.pipe_right uu____5759 FStar_List.unzip in
-                   (match uu____5752 with
-                    | (pats,decls') ->
-                        let decls'1 = FStar_List.flatten decls' in
-                        let pats1 =
-                          match induction_on with
-                          | None  -> pats
-                          | Some e ->
-                              (match vars with
-                               | [] -> pats
-                               | l::[] ->
-                                   FStar_All.pipe_right pats
-                                     (FStar_List.map
-                                        (fun p  ->
-                                           let uu____5885 =
-                                             let uu____5886 =
-                                               FStar_SMTEncoding_Util.mkFreeV
-                                                 l in
-                                             FStar_SMTEncoding_Util.mk_Precedes
-                                               uu____5886 e in
-                                           uu____5885 :: p))
-                               | uu____5887 ->
-                                   let rec aux tl1 vars1 =
-                                     match vars1 with
-                                     | [] ->
-                                         FStar_All.pipe_right pats
-                                           (FStar_List.map
-                                              (fun p  ->
-                                                 let uu____5916 =
-                                                   FStar_SMTEncoding_Util.mk_Precedes
-                                                     tl1 e in
-                                                 uu____5916 :: p))
-                                     | (x,FStar_SMTEncoding_Term.Term_sort )::vars2
-                                         ->
-                                         let uu____5924 =
-                                           let uu____5925 =
-                                             FStar_SMTEncoding_Util.mkFreeV
-                                               (x,
-                                                 FStar_SMTEncoding_Term.Term_sort) in
-                                           FStar_SMTEncoding_Util.mk_LexCons
-                                             uu____5925 tl1 in
-                                         aux uu____5924 vars2
-                                     | uu____5926 -> pats in
-                                   let uu____5930 =
-                                     FStar_SMTEncoding_Util.mkFreeV
-                                       ("Prims.LexTop",
-                                         FStar_SMTEncoding_Term.Term_sort) in
-                                   aux uu____5930 vars) in
-                        let env2 =
-                          let uu___147_5932 = env1 in
-                          {
-                            bindings = (uu___147_5932.bindings);
-                            depth = (uu___147_5932.depth);
-                            tcenv = (uu___147_5932.tcenv);
-                            warn = (uu___147_5932.warn);
-                            cache = (uu___147_5932.cache);
-                            nolabels = true;
-                            use_zfuel_name = (uu___147_5932.use_zfuel_name);
-                            encode_non_total_function_typ =
-                              (uu___147_5932.encode_non_total_function_typ)
-                          } in
-                        let uu____5933 =
-                          let uu____5936 = FStar_Syntax_Util.unmeta pre in
-                          encode_formula uu____5936 env2 in
-                        (match uu____5933 with
-                         | (pre1,decls'') ->
-                             let uu____5941 =
-                               let uu____5944 = FStar_Syntax_Util.unmeta post in
-                               encode_formula uu____5944 env2 in
-                             (match uu____5941 with
-                              | (post1,decls''') ->
-                                  let decls1 =
-                                    FStar_List.append decls
-                                      (FStar_List.append
-                                         (FStar_List.flatten decls'1)
-                                         (FStar_List.append decls'' decls''')) in
-                                  let uu____5951 =
-                                    let uu____5952 =
-                                      let uu____5958 =
-                                        let uu____5959 =
-                                          let uu____5962 =
-                                            FStar_SMTEncoding_Util.mk_and_l
-                                              (pre1 :: guards) in
-                                          (uu____5962, post1) in
-                                        FStar_SMTEncoding_Util.mkImp
-                                          uu____5959 in
-                                      (pats1, vars, uu____5958) in
-                                    FStar_SMTEncoding_Util.mkForall
-                                      uu____5952 in
-                                  (uu____5951, decls1)))))
-and encode_formula:
-  FStar_Syntax_Syntax.typ ->
-    env_t -> (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decls_t)
-  =
-  fun phi  ->
-    fun env  ->
-      let debug1 phi1 =
-        let uu____5975 =
-          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
-            (FStar_Options.Other "SMTEncoding") in
-        if uu____5975
-        then
-          let uu____5976 = FStar_Syntax_Print.tag_of_term phi1 in
-          let uu____5977 = FStar_Syntax_Print.term_to_string phi1 in
-          FStar_Util.print2 "Formula (%s)  %s\n" uu____5976 uu____5977
-        else () in
-      let enc f r l =
-        let uu____6004 =
-          FStar_Util.fold_map
-            (fun decls  ->
-               fun x  ->
-                 let uu____6017 = encode_term (Prims.fst x) env in
-                 match uu____6017 with
-                 | (t,decls') -> ((FStar_List.append decls decls'), t)) [] l in
-        match uu____6004 with
-        | (decls,args) ->
-            let uu____6034 =
-              let uu___148_6035 = f args in
-              {
-                FStar_SMTEncoding_Term.tm =
-                  (uu___148_6035.FStar_SMTEncoding_Term.tm);
-                FStar_SMTEncoding_Term.freevars =
-                  (uu___148_6035.FStar_SMTEncoding_Term.freevars);
-                FStar_SMTEncoding_Term.rng = r
-              } in
-            (uu____6034, decls) in
-      let const_op f r uu____6054 = let uu____6057 = f r in (uu____6057, []) in
-      let un_op f l =
-        let uu____6073 = FStar_List.hd l in FStar_All.pipe_left f uu____6073 in
-      let bin_op f uu___120_6086 =
-        match uu___120_6086 with
-        | t1::t2::[] -> f (t1, t2)
-        | uu____6094 -> failwith "Impossible" in
-      let enc_prop_c f r l =
-        let uu____6121 =
-          FStar_Util.fold_map
-            (fun decls  ->
-               fun uu____6130  ->
-                 match uu____6130 with
-                 | (t,uu____6138) ->
-                     let uu____6139 = encode_formula t env in
-                     (match uu____6139 with
-                      | (phi1,decls') ->
-                          ((FStar_List.append decls decls'), phi1))) [] l in
-        match uu____6121 with
-        | (decls,phis) ->
-            let uu____6156 =
-              let uu___149_6157 = f phis in
-              {
-                FStar_SMTEncoding_Term.tm =
-                  (uu___149_6157.FStar_SMTEncoding_Term.tm);
-                FStar_SMTEncoding_Term.freevars =
-                  (uu___149_6157.FStar_SMTEncoding_Term.freevars);
-                FStar_SMTEncoding_Term.rng = r
-              } in
-            (uu____6156, decls) in
-      let eq_op r uu___121_6173 =
-        match uu___121_6173 with
-        | _::e1::e2::[]|_::_::e1::e2::[] ->
-            let uu____6233 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
-            uu____6233 r [e1; e2]
-        | l ->
-            let uu____6253 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
-            uu____6253 r l in
-      let mk_imp1 r uu___122_6272 =
-        match uu___122_6272 with
-        | (lhs,uu____6276)::(rhs,uu____6278)::[] ->
-            let uu____6299 = encode_formula rhs env in
-            (match uu____6299 with
-             | (l1,decls1) ->
-                 (match l1.FStar_SMTEncoding_Term.tm with
-                  | FStar_SMTEncoding_Term.App
-                      (FStar_SMTEncoding_Term.TrueOp ,uu____6308) ->
-                      (l1, decls1)
-                  | uu____6311 ->
-                      let uu____6312 = encode_formula lhs env in
-                      (match uu____6312 with
-                       | (l2,decls2) ->
-                           let uu____6319 =
-                             FStar_SMTEncoding_Term.mkImp (l2, l1) r in
-                           (uu____6319, (FStar_List.append decls1 decls2)))))
-        | uu____6321 -> failwith "impossible" in
-      let mk_ite r uu___123_6336 =
-        match uu___123_6336 with
-        | (guard,uu____6340)::(_then,uu____6342)::(_else,uu____6344)::[] ->
-            let uu____6373 = encode_formula guard env in
-            (match uu____6373 with
-             | (g,decls1) ->
-                 let uu____6380 = encode_formula _then env in
-                 (match uu____6380 with
-                  | (t,decls2) ->
-                      let uu____6387 = encode_formula _else env in
-                      (match uu____6387 with
-                       | (e,decls3) ->
-                           let res = FStar_SMTEncoding_Term.mkITE (g, t, e) r in
-                           (res,
-                             (FStar_List.append decls1
-                                (FStar_List.append decls2 decls3))))))
-        | uu____6396 -> failwith "impossible" in
-      let unboxInt_l f l =
-        let uu____6415 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l in
-        f uu____6415 in
-      let connectives =
-        let uu____6427 =
-          let uu____6436 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd) in
-          (FStar_Syntax_Const.and_lid, uu____6436) in
-        let uu____6449 =
-          let uu____6459 =
-            let uu____6468 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr) in
-            (FStar_Syntax_Const.or_lid, uu____6468) in
-          let uu____6481 =
-            let uu____6491 =
-              let uu____6501 =
-                let uu____6510 =
-                  enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff) in
-                (FStar_Syntax_Const.iff_lid, uu____6510) in
-              let uu____6523 =
-                let uu____6533 =
-                  let uu____6543 =
-                    let uu____6552 =
-                      enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot) in
-                    (FStar_Syntax_Const.not_lid, uu____6552) in
-                  [uu____6543;
-                  (FStar_Syntax_Const.eq2_lid, eq_op);
-                  (FStar_Syntax_Const.eq3_lid, eq_op);
-                  (FStar_Syntax_Const.true_lid,
-                    (const_op FStar_SMTEncoding_Term.mkTrue));
-                  (FStar_Syntax_Const.false_lid,
-                    (const_op FStar_SMTEncoding_Term.mkFalse))] in
-                (FStar_Syntax_Const.ite_lid, mk_ite) :: uu____6533 in
-              uu____6501 :: uu____6523 in
-            (FStar_Syntax_Const.imp_lid, mk_imp1) :: uu____6491 in
-          uu____6459 :: uu____6481 in
-        uu____6427 :: uu____6449 in
-      let rec fallback phi1 =
-        match phi1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_meta
-            (phi',FStar_Syntax_Syntax.Meta_labeled (msg,r,b)) ->
-            let uu____6714 = encode_formula phi' env in
-            (match uu____6714 with
-             | (phi2,decls) ->
-                 let uu____6721 =
-                   FStar_SMTEncoding_Term.mk
-                     (FStar_SMTEncoding_Term.Labeled (phi2, msg, r)) r in
-                 (uu____6721, decls))
-        | FStar_Syntax_Syntax.Tm_meta uu____6722 ->
-            let uu____6727 = FStar_Syntax_Util.unmeta phi1 in
-            encode_formula uu____6727 env
-        | FStar_Syntax_Syntax.Tm_match (e,pats) ->
-            let uu____6756 =
-              encode_match e pats FStar_SMTEncoding_Util.mkFalse env
-                encode_formula in
-            (match uu____6756 with | (t,decls) -> (t, decls))
-        | FStar_Syntax_Syntax.Tm_let
-            ((false
-              ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-                 FStar_Syntax_Syntax.lbunivs = uu____6764;
-                 FStar_Syntax_Syntax.lbtyp = t1;
-                 FStar_Syntax_Syntax.lbeff = uu____6766;
-                 FStar_Syntax_Syntax.lbdef = e1;_}::[]),e2)
-            ->
-            let uu____6782 = encode_let x t1 e1 e2 env encode_formula in
-            (match uu____6782 with | (t,decls) -> (t, decls))
-        | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-            let head2 = FStar_Syntax_Util.un_uinst head1 in
-            (match ((head2.FStar_Syntax_Syntax.n), args) with
-             | (FStar_Syntax_Syntax.Tm_fvar
-                fv,uu____6814::(x,uu____6816)::(t,uu____6818)::[]) when
-                 FStar_Syntax_Syntax.fv_eq_lid fv
-                   FStar_Syntax_Const.has_type_lid
-                 ->
-                 let uu____6852 = encode_term x env in
-                 (match uu____6852 with
-                  | (x1,decls) ->
-                      let uu____6859 = encode_term t env in
-                      (match uu____6859 with
-                       | (t1,decls') ->
-                           let uu____6866 =
-                             FStar_SMTEncoding_Term.mk_HasType x1 t1 in
-                           (uu____6866, (FStar_List.append decls decls'))))
-             | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(r,uu____6870)::(msg,uu____6872)::(phi2,uu____6874)::[])
-                 when
-                 FStar_Syntax_Syntax.fv_eq_lid fv
-                   FStar_Syntax_Const.labeled_lid
-                 ->
-                 let uu____6908 =
-                   let uu____6911 =
-                     let uu____6912 = FStar_Syntax_Subst.compress r in
-                     uu____6912.FStar_Syntax_Syntax.n in
-                   let uu____6915 =
-                     let uu____6916 = FStar_Syntax_Subst.compress msg in
-                     uu____6916.FStar_Syntax_Syntax.n in
-                   (uu____6911, uu____6915) in
-                 (match uu____6908 with
-                  | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-                     r1),FStar_Syntax_Syntax.Tm_constant
-                     (FStar_Const.Const_string (s,uu____6923))) ->
-                      let phi3 =
-                        (FStar_Syntax_Syntax.mk
-                           (FStar_Syntax_Syntax.Tm_meta
-                              (phi2,
-                                (FStar_Syntax_Syntax.Meta_labeled
-                                   ((FStar_Util.string_of_unicode s), r1,
-                                     false))))) None r1 in
-                      fallback phi3
-                  | uu____6939 -> fallback phi2)
-             | uu____6942 when head_redex env head2 ->
-                 let uu____6950 = whnf env phi1 in
-                 encode_formula uu____6950 env
-             | uu____6951 ->
-                 let uu____6959 = encode_term phi1 env in
-                 (match uu____6959 with
-                  | (tt,decls) ->
-                      let uu____6966 =
-                        FStar_SMTEncoding_Term.mk_Valid
-                          (let uu___150_6967 = tt in
-                           {
-                             FStar_SMTEncoding_Term.tm =
-                               (uu___150_6967.FStar_SMTEncoding_Term.tm);
-                             FStar_SMTEncoding_Term.freevars =
-                               (uu___150_6967.FStar_SMTEncoding_Term.freevars);
-                             FStar_SMTEncoding_Term.rng =
-                               (phi1.FStar_Syntax_Syntax.pos)
-                           }) in
-                      (uu____6966, decls)))
-        | uu____6970 ->
-            let uu____6971 = encode_term phi1 env in
-            (match uu____6971 with
-             | (tt,decls) ->
-                 let uu____6978 =
-                   FStar_SMTEncoding_Term.mk_Valid
-                     (let uu___151_6979 = tt in
-                      {
-                        FStar_SMTEncoding_Term.tm =
-                          (uu___151_6979.FStar_SMTEncoding_Term.tm);
-                        FStar_SMTEncoding_Term.freevars =
-                          (uu___151_6979.FStar_SMTEncoding_Term.freevars);
-                        FStar_SMTEncoding_Term.rng =
-                          (phi1.FStar_Syntax_Syntax.pos)
-                      }) in
-                 (uu____6978, decls)) in
-      let encode_q_body env1 bs ps body =
-        let uu____7006 = encode_binders None bs env1 in
-        match uu____7006 with
-        | (vars,guards,env2,decls,uu____7028) ->
-            let uu____7035 =
-              let uu____7042 =
-                FStar_All.pipe_right ps
-                  (FStar_List.map
-                     (fun p  ->
-                        let uu____7065 =
-                          let uu____7070 =
-                            FStar_All.pipe_right p
-                              (FStar_List.map
-                                 (fun uu____7084  ->
-                                    match uu____7084 with
-                                    | (t,uu____7090) ->
-                                        encode_term t
-                                          (let uu___152_7091 = env2 in
-                                           {
-                                             bindings =
-                                               (uu___152_7091.bindings);
-                                             depth = (uu___152_7091.depth);
-                                             tcenv = (uu___152_7091.tcenv);
-                                             warn = (uu___152_7091.warn);
-                                             cache = (uu___152_7091.cache);
-                                             nolabels =
-                                               (uu___152_7091.nolabels);
-                                             use_zfuel_name = true;
-                                             encode_non_total_function_typ =
-                                               (uu___152_7091.encode_non_total_function_typ)
-                                           }))) in
-                          FStar_All.pipe_right uu____7070 FStar_List.unzip in
-                        match uu____7065 with
-                        | (p1,decls1) -> (p1, (FStar_List.flatten decls1)))) in
-              FStar_All.pipe_right uu____7042 FStar_List.unzip in
-            (match uu____7035 with
-             | (pats,decls') ->
-                 let uu____7143 = encode_formula body env2 in
-                 (match uu____7143 with
-                  | (body1,decls'') ->
-                      let guards1 =
-                        match pats with
-                        | ({
-                             FStar_SMTEncoding_Term.tm =
-                               FStar_SMTEncoding_Term.App
-                               (FStar_SMTEncoding_Term.Var gf,p::[]);
-                             FStar_SMTEncoding_Term.freevars = uu____7162;
-                             FStar_SMTEncoding_Term.rng = uu____7163;_}::[])::[]
-                            when
-                            (FStar_Ident.text_of_lid
-                               FStar_Syntax_Const.guard_free)
-                              = gf
-                            -> []
-                        | uu____7171 -> guards in
-                      let uu____7174 =
-                        FStar_SMTEncoding_Util.mk_and_l guards1 in
-                      (vars, pats, uu____7174, body1,
-                        (FStar_List.append decls
-                           (FStar_List.append (FStar_List.flatten decls')
-                              decls''))))) in
-      debug1 phi;
-      (let phi1 = FStar_Syntax_Util.unascribe phi in
-       let check_pattern_vars vars pats =
-         let pats1 =
-           FStar_All.pipe_right pats
-             (FStar_List.map
-                (fun uu____7208  ->
-                   match uu____7208 with
-                   | (x,uu____7212) ->
-                       FStar_TypeChecker_Normalize.normalize
-                         [FStar_TypeChecker_Normalize.Beta;
-                         FStar_TypeChecker_Normalize.AllowUnboundUniverses;
-                         FStar_TypeChecker_Normalize.EraseUniverses]
-                         env.tcenv x)) in
-         match pats1 with
-         | [] -> ()
-         | hd1::tl1 ->
-             let pat_vars =
-               let uu____7218 = FStar_Syntax_Free.names hd1 in
-               FStar_List.fold_left
-                 (fun out  ->
-                    fun x  ->
-                      let uu____7224 = FStar_Syntax_Free.names x in
-                      FStar_Util.set_union out uu____7224) uu____7218 tl1 in
-             let uu____7226 =
-               FStar_All.pipe_right vars
-                 (FStar_Util.find_opt
-                    (fun uu____7238  ->
-                       match uu____7238 with
-                       | (b,uu____7242) ->
-                           let uu____7243 = FStar_Util.set_mem b pat_vars in
-                           Prims.op_Negation uu____7243)) in
-             (match uu____7226 with
-              | None  -> ()
-              | Some (x,uu____7247) ->
-                  let pos =
-                    FStar_List.fold_left
-                      (fun out  ->
-                         fun t  ->
-                           FStar_Range.union_ranges out
-                             t.FStar_Syntax_Syntax.pos)
-                      hd1.FStar_Syntax_Syntax.pos tl1 in
-                  let uu____7257 =
-                    let uu____7258 = FStar_Syntax_Print.bv_to_string x in
-                    FStar_Util.format1
-                      "SMT pattern misses at least one bound variable: %s"
-                      uu____7258 in
-                  FStar_Errors.warn pos uu____7257) in
-       let uu____7259 = FStar_Syntax_Util.destruct_typ_as_formula phi1 in
-       match uu____7259 with
-       | None  -> fallback phi1
-       | Some (FStar_Syntax_Util.BaseConn (op,arms)) ->
-           let uu____7265 =
-             FStar_All.pipe_right connectives
-               (FStar_List.tryFind
-                  (fun uu____7301  ->
-                     match uu____7301 with
-                     | (l,uu____7311) -> FStar_Ident.lid_equals op l)) in
-           (match uu____7265 with
-            | None  -> fallback phi1
-            | Some (uu____7334,f) -> f phi1.FStar_Syntax_Syntax.pos arms)
-       | Some (FStar_Syntax_Util.QAll (vars,pats,body)) ->
-           (FStar_All.pipe_right pats
-              (FStar_List.iter (check_pattern_vars vars));
-            (let uu____7363 = encode_q_body env vars pats body in
-             match uu____7363 with
-             | (vars1,pats1,guard,body1,decls) ->
-                 let tm =
-                   let uu____7389 =
-                     let uu____7395 =
-                       FStar_SMTEncoding_Util.mkImp (guard, body1) in
-                     (pats1, vars1, uu____7395) in
-                   FStar_SMTEncoding_Term.mkForall uu____7389
-                     phi1.FStar_Syntax_Syntax.pos in
-                 (tm, decls)))
-       | Some (FStar_Syntax_Util.QEx (vars,pats,body)) ->
-           (FStar_All.pipe_right pats
-              (FStar_List.iter (check_pattern_vars vars));
-            (let uu____7407 = encode_q_body env vars pats body in
-             match uu____7407 with
-             | (vars1,pats1,guard,body1,decls) ->
-                 let uu____7432 =
-                   let uu____7433 =
-                     let uu____7439 =
-                       FStar_SMTEncoding_Util.mkAnd (guard, body1) in
-                     (pats1, vars1, uu____7439) in
-                   FStar_SMTEncoding_Term.mkExists uu____7433
-                     phi1.FStar_Syntax_Syntax.pos in
-                 (uu____7432, decls))))
+
+
+let uu___is_Let_rec_unencodeable : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Let_rec_unencodeable -> begin
+true
+end
+| uu____1933 -> begin
+false
+end))
+
+
+let encode_const : FStar_Const.sconst  ->  FStar_SMTEncoding_Term.term = (fun uu___119_1936 -> (match (uu___119_1936) with
+| FStar_Const.Const_unit -> begin
+FStar_SMTEncoding_Term.mk_Term_unit
+end
+| FStar_Const.Const_bool (true) -> begin
+(FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue)
+end
+| FStar_Const.Const_bool (false) -> begin
+(FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkFalse)
+end
+| FStar_Const.Const_char (c) -> begin
+(
+
+let uu____1938 = (
+
+let uu____1942 = (
+
+let uu____1944 = (
+
+let uu____1945 = (FStar_SMTEncoding_Util.mkInteger' (FStar_Util.int_of_char c))
+in (FStar_SMTEncoding_Term.boxInt uu____1945))
+in (uu____1944)::[])
+in (("FStar.Char.Char"), (uu____1942)))
+in (FStar_SMTEncoding_Util.mkApp uu____1938))
+end
+| FStar_Const.Const_int (i, None) -> begin
+(
+
+let uu____1953 = (FStar_SMTEncoding_Util.mkInteger i)
+in (FStar_SMTEncoding_Term.boxInt uu____1953))
+end
+| FStar_Const.Const_int (i, Some (uu____1955)) -> begin
+(failwith "Machine integers should be desugared")
+end
+| FStar_Const.Const_string (bytes, uu____1964) -> begin
+(
+
+let uu____1967 = (FStar_All.pipe_left FStar_Util.string_of_bytes bytes)
+in (varops.string_const uu____1967))
+end
+| FStar_Const.Const_range (r) -> begin
+FStar_SMTEncoding_Term.mk_Range_const
+end
+| FStar_Const.Const_effect -> begin
+FStar_SMTEncoding_Term.mk_Term_type
+end
+| c -> begin
+(
+
+let uu____1971 = (
+
+let uu____1972 = (FStar_Syntax_Print.const_to_string c)
+in (FStar_Util.format1 "Unhandled constant: %s" uu____1972))
+in (failwith uu____1971))
+end))
+
+
+let as_function_typ : env_t  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term = (fun env t0 -> (
+
+let rec aux = (fun norm1 t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____1991) -> begin
+t1
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____1999) -> begin
+(
+
+let uu____2004 = (FStar_Syntax_Util.unrefine t1)
+in (aux true uu____2004))
+end
+| uu____2005 -> begin
+(match (norm1) with
+| true -> begin
+(
+
+let uu____2006 = (whnf env t1)
+in (aux false uu____2006))
+end
+| uu____2007 -> begin
+(
+
+let uu____2008 = (
+
+let uu____2009 = (FStar_Range.string_of_range t0.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2010 = (FStar_Syntax_Print.term_to_string t0)
+in (FStar_Util.format2 "(%s) Expected a function typ; got %s" uu____2009 uu____2010)))
+in (failwith uu____2008))
+end)
+end)))
+in (aux true t0)))
+
+
+let curried_arrow_formals_comp : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp) = (fun k -> (
+
+let k1 = (FStar_Syntax_Subst.compress k)
+in (match (k1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(FStar_Syntax_Subst.open_comp bs c)
+end
+| uu____2031 -> begin
+(
+
+let uu____2032 = (FStar_Syntax_Syntax.mk_Total k1)
+in (([]), (uu____2032)))
+end)))
+
+
+let rec encode_binders : FStar_SMTEncoding_Term.term Prims.option  ->  FStar_Syntax_Syntax.binders  ->  env_t  ->  (FStar_SMTEncoding_Term.fv Prims.list * FStar_SMTEncoding_Term.term Prims.list * env_t * FStar_SMTEncoding_Term.decls_t * FStar_Syntax_Syntax.bv Prims.list) = (fun fuel_opt bs env -> ((
+
+let uu____2175 = (FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low)
+in (match (uu____2175) with
+| true -> begin
+(
+
+let uu____2176 = (FStar_Syntax_Print.binders_to_string ", " bs)
+in (FStar_Util.print1 "Encoding binders %s\n" uu____2176))
+end
+| uu____2177 -> begin
+()
+end));
+(
+
+let uu____2178 = (FStar_All.pipe_right bs (FStar_List.fold_left (fun uu____2214 b -> (match (uu____2214) with
+| (vars, guards, env1, decls, names1) -> begin
+(
+
+let uu____2257 = (
+
+let x = (unmangle (Prims.fst b))
+in (
+
+let uu____2266 = (gen_term_var env1 x)
+in (match (uu____2266) with
+| (xxsym, xx, env') -> begin
+(
+
+let uu____2280 = (
+
+let uu____2283 = (norm env1 x.FStar_Syntax_Syntax.sort)
+in (encode_term_pred fuel_opt uu____2283 env1 xx))
+in (match (uu____2280) with
+| (guard_x_t, decls') -> begin
+((((xxsym), (FStar_SMTEncoding_Term.Term_sort))), (guard_x_t), (env'), (decls'), (x))
+end))
+end)))
+in (match (uu____2257) with
+| (v1, g, env2, decls', n1) -> begin
+(((v1)::vars), ((g)::guards), (env2), ((FStar_List.append decls decls')), ((n1)::names1))
+end))
+end)) (([]), ([]), (env), ([]), ([]))))
+in (match (uu____2178) with
+| (vars, guards, env1, decls, names1) -> begin
+(((FStar_List.rev vars)), ((FStar_List.rev guards)), (env1), (decls), ((FStar_List.rev names1)))
+end));
+))
+and encode_term_pred : FStar_SMTEncoding_Term.term Prims.option  ->  FStar_Syntax_Syntax.typ  ->  env_t  ->  FStar_SMTEncoding_Term.term  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun fuel_opt t env e -> (
+
+let uu____2371 = (encode_term t env)
+in (match (uu____2371) with
+| (t1, decls) -> begin
+(
+
+let uu____2378 = (FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1)
+in ((uu____2378), (decls)))
+end)))
+and encode_term_pred' : FStar_SMTEncoding_Term.term Prims.option  ->  FStar_Syntax_Syntax.typ  ->  env_t  ->  FStar_SMTEncoding_Term.term  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun fuel_opt t env e -> (
+
+let uu____2386 = (encode_term t env)
+in (match (uu____2386) with
+| (t1, decls) -> begin
+(match (fuel_opt) with
+| None -> begin
+(
+
+let uu____2395 = (FStar_SMTEncoding_Term.mk_HasTypeZ e t1)
+in ((uu____2395), (decls)))
+end
+| Some (f) -> begin
+(
+
+let uu____2397 = (FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1)
+in ((uu____2397), (decls)))
+end)
+end)))
+and encode_term : FStar_Syntax_Syntax.typ  ->  env_t  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun t env -> (
+
+let t0 = (FStar_Syntax_Subst.compress t)
+in ((
+
+let uu____2404 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____2404) with
+| true -> begin
+(
+
+let uu____2405 = (FStar_Syntax_Print.tag_of_term t)
+in (
+
+let uu____2406 = (FStar_Syntax_Print.tag_of_term t0)
+in (
+
+let uu____2407 = (FStar_Syntax_Print.term_to_string t0)
+in (FStar_Util.print3 "(%s) (%s)   %s\n" uu____2405 uu____2406 uu____2407))))
+end
+| uu____2408 -> begin
+()
+end));
+(match (t0.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+(
+
+let uu____2412 = (
+
+let uu____2413 = (FStar_All.pipe_left FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2414 = (FStar_Syntax_Print.tag_of_term t0)
+in (
+
+let uu____2415 = (FStar_Syntax_Print.term_to_string t0)
+in (
+
+let uu____2416 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format4 "(%s) Impossible: %s\n%s\n%s\n" uu____2413 uu____2414 uu____2415 uu____2416)))))
+in (failwith uu____2412))
+end
+| FStar_Syntax_Syntax.Tm_bvar (x) -> begin
+(
+
+let uu____2420 = (
+
+let uu____2421 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format1 "Impossible: locally nameless; got %s" uu____2421))
+in (failwith uu____2420))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t1, k, uu____2426) -> begin
+(encode_term t1 env)
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, uu____2456) -> begin
+(encode_term t1 env)
+end
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+(
+
+let t1 = (lookup_term_var env x)
+in ((t1), ([])))
+end
+| FStar_Syntax_Syntax.Tm_fvar (v1) -> begin
+(
+
+let uu____2465 = (lookup_free_var env v1.FStar_Syntax_Syntax.fv_name)
+in ((uu____2465), ([])))
+end
+| FStar_Syntax_Syntax.Tm_type (uu____2471) -> begin
+((FStar_SMTEncoding_Term.mk_Term_type), ([]))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, uu____2474) -> begin
+(encode_term t1 env)
+end
+| FStar_Syntax_Syntax.Tm_constant (c) -> begin
+(
+
+let uu____2480 = (encode_const c)
+in ((uu____2480), ([])))
+end
+| FStar_Syntax_Syntax.Tm_arrow (binders, c) -> begin
+(
+
+let uu____2494 = (FStar_Syntax_Subst.open_comp binders c)
+in (match (uu____2494) with
+| (binders1, res) -> begin
+(
+
+let uu____2501 = ((env.encode_non_total_function_typ && (FStar_Syntax_Util.is_pure_or_ghost_comp res)) || (FStar_Syntax_Util.is_tot_or_gtot_comp res))
+in (match (uu____2501) with
+| true -> begin
+(
+
+let uu____2504 = (encode_binders None binders1 env)
+in (match (uu____2504) with
+| (vars, guards, env', decls, uu____2519) -> begin
+(
+
+let fsym = (
+
+let uu____2529 = (varops.fresh "f")
+in ((uu____2529), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let f = (FStar_SMTEncoding_Util.mkFreeV fsym)
+in (
+
+let app = (mk_Apply f vars)
+in (
+
+let uu____2532 = (FStar_TypeChecker_Util.pure_or_ghost_pre_and_post (
+
+let uu___144_2536 = env.tcenv
+in {FStar_TypeChecker_Env.solver = uu___144_2536.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___144_2536.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___144_2536.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___144_2536.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___144_2536.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___144_2536.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___144_2536.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___144_2536.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___144_2536.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___144_2536.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___144_2536.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___144_2536.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___144_2536.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___144_2536.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___144_2536.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___144_2536.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___144_2536.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___144_2536.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___144_2536.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___144_2536.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___144_2536.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___144_2536.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___144_2536.FStar_TypeChecker_Env.qname_and_index}) res)
+in (match (uu____2532) with
+| (pre_opt, res_t) -> begin
+(
+
+let uu____2543 = (encode_term_pred None res_t env' app)
+in (match (uu____2543) with
+| (res_pred, decls') -> begin
+(
+
+let uu____2550 = (match (pre_opt) with
+| None -> begin
+(
+
+let uu____2557 = (FStar_SMTEncoding_Util.mk_and_l guards)
+in ((uu____2557), ([])))
+end
+| Some (pre) -> begin
+(
+
+let uu____2560 = (encode_formula pre env')
+in (match (uu____2560) with
+| (guard, decls0) -> begin
+(
+
+let uu____2568 = (FStar_SMTEncoding_Util.mk_and_l ((guard)::guards))
+in ((uu____2568), (decls0)))
+end))
+end)
+in (match (uu____2550) with
+| (guards1, guard_decls) -> begin
+(
+
+let t_interp = (
+
+let uu____2576 = (
+
+let uu____2582 = (FStar_SMTEncoding_Util.mkImp ((guards1), (res_pred)))
+in ((((app)::[])::[]), (vars), (uu____2582)))
+in (FStar_SMTEncoding_Util.mkForall uu____2576))
+in (
+
+let cvars = (
+
+let uu____2592 = (FStar_SMTEncoding_Term.free_variables t_interp)
+in (FStar_All.pipe_right uu____2592 (FStar_List.filter (fun uu____2598 -> (match (uu____2598) with
+| (x, uu____2602) -> begin
+(x <> (Prims.fst fsym))
+end)))))
+in (
+
+let tkey = (FStar_SMTEncoding_Util.mkForall (([]), ((fsym)::cvars), (t_interp)))
+in (
+
+let tkey_hash = (FStar_SMTEncoding_Term.hash_of_term tkey)
+in (
+
+let uu____2613 = (FStar_Util.smap_try_find env.cache tkey_hash)
+in (match (uu____2613) with
+| Some (t', sorts, uu____2629) -> begin
+(
+
+let uu____2639 = (
+
+let uu____2640 = (
+
+let uu____2644 = (FStar_All.pipe_right cvars (FStar_List.map FStar_SMTEncoding_Util.mkFreeV))
+in ((t'), (uu____2644)))
+in (FStar_SMTEncoding_Util.mkApp uu____2640))
+in ((uu____2639), ([])))
+end
+| None -> begin
+(
+
+let tsym = (
+
+let uu____2660 = (
+
+let uu____2661 = (FStar_Util.digest_of_string tkey_hash)
+in (Prims.strcat "Tm_arrow_" uu____2661))
+in (varops.mk_unique uu____2660))
+in (
+
+let cvar_sorts = (FStar_List.map Prims.snd cvars)
+in (
+
+let caption = (
+
+let uu____2668 = (FStar_Options.log_queries ())
+in (match (uu____2668) with
+| true -> begin
+(
+
+let uu____2670 = (FStar_TypeChecker_Normalize.term_to_string env.tcenv t0)
+in Some (uu____2670))
+end
+| uu____2671 -> begin
+None
+end))
+in (
+
+let tdecl = FStar_SMTEncoding_Term.DeclFun (((tsym), (cvar_sorts), (FStar_SMTEncoding_Term.Term_sort), (caption)))
+in (
+
+let t1 = (
+
+let uu____2676 = (
+
+let uu____2680 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV cvars)
+in ((tsym), (uu____2680)))
+in (FStar_SMTEncoding_Util.mkApp uu____2676))
+in (
+
+let t_has_kind = (FStar_SMTEncoding_Term.mk_HasType t1 FStar_SMTEncoding_Term.mk_Term_type)
+in (
+
+let k_assumption = (
+
+let a_name = Some ((Prims.strcat "kinding_" tsym))
+in (
+
+let uu____2689 = (
+
+let uu____2694 = (FStar_SMTEncoding_Util.mkForall ((((t_has_kind)::[])::[]), (cvars), (t_has_kind)))
+in ((uu____2694), (a_name), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____2689)))
+in (
+
+let f_has_t = (FStar_SMTEncoding_Term.mk_HasType f t1)
+in (
+
+let f_has_t_z = (FStar_SMTEncoding_Term.mk_HasTypeZ f t1)
+in (
+
+let pre_typing = (
+
+let a_name = Some ((Prims.strcat "pre_typing_" tsym))
+in (
+
+let uu____2709 = (
+
+let uu____2714 = (
+
+let uu____2715 = (
+
+let uu____2721 = (
+
+let uu____2722 = (
+
+let uu____2725 = (
+
+let uu____2726 = (FStar_SMTEncoding_Term.mk_PreType f)
+in (FStar_SMTEncoding_Term.mk_tester "Tm_arrow" uu____2726))
+in ((f_has_t), (uu____2725)))
+in (FStar_SMTEncoding_Util.mkImp uu____2722))
+in ((((f_has_t)::[])::[]), ((fsym)::cvars), (uu____2721)))
+in (mkForall_fuel uu____2715))
+in ((uu____2714), (Some ("pre-typing for functions")), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____2709)))
+in (
+
+let t_interp1 = (
+
+let a_name = Some ((Prims.strcat "interpretation_" tsym))
+in (
+
+let uu____2741 = (
+
+let uu____2746 = (
+
+let uu____2747 = (
+
+let uu____2753 = (FStar_SMTEncoding_Util.mkIff ((f_has_t_z), (t_interp)))
+in ((((f_has_t_z)::[])::[]), ((fsym)::cvars), (uu____2753)))
+in (FStar_SMTEncoding_Util.mkForall uu____2747))
+in ((uu____2746), (a_name), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____2741)))
+in (
+
+let t_decls = (FStar_List.append ((tdecl)::decls) (FStar_List.append decls' (FStar_List.append guard_decls ((k_assumption)::(pre_typing)::(t_interp1)::[]))))
+in ((FStar_Util.smap_add env.cache tkey_hash ((tsym), (cvar_sorts), (t_decls)));
+((t1), (t_decls));
+)))))))))))))
+end))))))
+end))
+end))
+end)))))
+end))
+end
+| uu____2776 -> begin
+(
+
+let tsym = (varops.fresh "Non_total_Tm_arrow")
+in (
+
+let tdecl = FStar_SMTEncoding_Term.DeclFun (((tsym), ([]), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let t1 = (FStar_SMTEncoding_Util.mkApp ((tsym), ([])))
+in (
+
+let t_kinding = (
+
+let a_name = Some ((Prims.strcat "non_total_function_typing_" tsym))
+in (
+
+let uu____2786 = (
+
+let uu____2791 = (FStar_SMTEncoding_Term.mk_HasType t1 FStar_SMTEncoding_Term.mk_Term_type)
+in ((uu____2791), (Some ("Typing for non-total arrows")), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____2786)))
+in (
+
+let fsym = (("f"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let f = (FStar_SMTEncoding_Util.mkFreeV fsym)
+in (
+
+let f_has_t = (FStar_SMTEncoding_Term.mk_HasType f t1)
+in (
+
+let t_interp = (
+
+let a_name = Some ((Prims.strcat "pre_typing_" tsym))
+in (
+
+let uu____2802 = (
+
+let uu____2807 = (
+
+let uu____2808 = (
+
+let uu____2814 = (
+
+let uu____2815 = (
+
+let uu____2818 = (
+
+let uu____2819 = (FStar_SMTEncoding_Term.mk_PreType f)
+in (FStar_SMTEncoding_Term.mk_tester "Tm_arrow" uu____2819))
+in ((f_has_t), (uu____2818)))
+in (FStar_SMTEncoding_Util.mkImp uu____2815))
+in ((((f_has_t)::[])::[]), ((fsym)::[]), (uu____2814)))
+in (mkForall_fuel uu____2808))
+in ((uu____2807), (a_name), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____2802)))
+in ((t1), ((tdecl)::(t_kinding)::(t_interp)::[]))))))))))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____2834) -> begin
+(
+
+let uu____2839 = (
+
+let uu____2842 = (FStar_TypeChecker_Normalize.normalize_refinement ((FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv t0)
+in (match (uu____2842) with
+| {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine (x, f); FStar_Syntax_Syntax.tk = uu____2847; FStar_Syntax_Syntax.pos = uu____2848; FStar_Syntax_Syntax.vars = uu____2849} -> begin
+(
+
+let uu____2856 = (FStar_Syntax_Subst.open_term ((((x), (None)))::[]) f)
+in (match (uu____2856) with
+| (b, f1) -> begin
+(
+
+let uu____2870 = (
+
+let uu____2871 = (FStar_List.hd b)
+in (Prims.fst uu____2871))
+in ((uu____2870), (f1)))
+end))
+end
+| uu____2876 -> begin
+(failwith "impossible")
+end))
+in (match (uu____2839) with
+| (x, f) -> begin
+(
+
+let uu____2883 = (encode_term x.FStar_Syntax_Syntax.sort env)
+in (match (uu____2883) with
+| (base_t, decls) -> begin
+(
+
+let uu____2890 = (gen_term_var env x)
+in (match (uu____2890) with
+| (x1, xtm, env') -> begin
+(
+
+let uu____2899 = (encode_formula f env')
+in (match (uu____2899) with
+| (refinement, decls') -> begin
+(
+
+let uu____2906 = (fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort)
+in (match (uu____2906) with
+| (fsym, fterm) -> begin
+(
+
+let encoding = (
+
+let uu____2914 = (
+
+let uu____2917 = (FStar_SMTEncoding_Term.mk_HasTypeWithFuel (Some (fterm)) xtm base_t)
+in ((uu____2917), (refinement)))
+in (FStar_SMTEncoding_Util.mkAnd uu____2914))
+in (
+
+let cvars = (
+
+let uu____2922 = (FStar_SMTEncoding_Term.free_variables encoding)
+in (FStar_All.pipe_right uu____2922 (FStar_List.filter (fun uu____2928 -> (match (uu____2928) with
+| (y, uu____2932) -> begin
+((y <> x1) && (y <> fsym))
+end)))))
+in (
+
+let xfv = ((x1), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let ffv = ((fsym), (FStar_SMTEncoding_Term.Fuel_sort))
+in (
+
+let tkey = (FStar_SMTEncoding_Util.mkForall (([]), ((ffv)::(xfv)::cvars), (encoding)))
+in (
+
+let tkey_hash = (FStar_SMTEncoding_Term.hash_of_term tkey)
+in (
+
+let uu____2951 = (FStar_Util.smap_try_find env.cache tkey_hash)
+in (match (uu____2951) with
+| Some (t1, uu____2966, uu____2967) -> begin
+(
+
+let uu____2977 = (
+
+let uu____2978 = (
+
+let uu____2982 = (FStar_All.pipe_right cvars (FStar_List.map FStar_SMTEncoding_Util.mkFreeV))
+in ((t1), (uu____2982)))
+in (FStar_SMTEncoding_Util.mkApp uu____2978))
+in ((uu____2977), ([])))
+end
+| None -> begin
+(
+
+let tsym = (
+
+let uu____2998 = (
+
+let uu____2999 = (FStar_Util.digest_of_string tkey_hash)
+in (Prims.strcat "Tm_refine_" uu____2999))
+in (varops.mk_unique uu____2998))
+in (
+
+let cvar_sorts = (FStar_List.map Prims.snd cvars)
+in (
+
+let tdecl = FStar_SMTEncoding_Term.DeclFun (((tsym), (cvar_sorts), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let t1 = (
+
+let uu____3008 = (
+
+let uu____3012 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV cvars)
+in ((tsym), (uu____3012)))
+in (FStar_SMTEncoding_Util.mkApp uu____3008))
+in (
+
+let x_has_t = (FStar_SMTEncoding_Term.mk_HasTypeWithFuel (Some (fterm)) xtm t1)
+in (
+
+let t_has_kind = (FStar_SMTEncoding_Term.mk_HasType t1 FStar_SMTEncoding_Term.mk_Term_type)
+in (
+
+let t_haseq_base = (FStar_SMTEncoding_Term.mk_haseq base_t)
+in (
+
+let t_haseq_ref = (FStar_SMTEncoding_Term.mk_haseq t1)
+in (
+
+let t_haseq1 = (
+
+let uu____3022 = (
+
+let uu____3027 = (
+
+let uu____3028 = (
+
+let uu____3034 = (FStar_SMTEncoding_Util.mkIff ((t_haseq_ref), (t_haseq_base)))
+in ((((t_haseq_ref)::[])::[]), (cvars), (uu____3034)))
+in (FStar_SMTEncoding_Util.mkForall uu____3028))
+in ((uu____3027), (Some ((Prims.strcat "haseq for " tsym))), (Some ((Prims.strcat "haseq" tsym)))))
+in FStar_SMTEncoding_Term.Assume (uu____3022))
+in (
+
+let t_kinding = (
+
+let uu____3045 = (
+
+let uu____3050 = (FStar_SMTEncoding_Util.mkForall ((((t_has_kind)::[])::[]), (cvars), (t_has_kind)))
+in ((uu____3050), (Some ("refinement kinding")), (Some ((Prims.strcat "refinement_kinding_" tsym)))))
+in FStar_SMTEncoding_Term.Assume (uu____3045))
+in (
+
+let t_interp = (
+
+let uu____3061 = (
+
+let uu____3066 = (
+
+let uu____3067 = (
+
+let uu____3073 = (FStar_SMTEncoding_Util.mkIff ((x_has_t), (encoding)))
+in ((((x_has_t)::[])::[]), ((ffv)::(xfv)::cvars), (uu____3073)))
+in (FStar_SMTEncoding_Util.mkForall uu____3067))
+in (
+
+let uu____3085 = (
+
+let uu____3087 = (FStar_Syntax_Print.term_to_string t0)
+in Some (uu____3087))
+in ((uu____3066), (uu____3085), (Some ((Prims.strcat "refinement_interpretation_" tsym))))))
+in FStar_SMTEncoding_Term.Assume (uu____3061))
+in (
+
+let t_decls = (FStar_List.append decls (FStar_List.append decls' ((tdecl)::(t_kinding)::(t_interp)::(t_haseq1)::[])))
+in ((FStar_Util.smap_add env.cache tkey_hash ((tsym), (cvar_sorts), (t_decls)));
+((t1), (t_decls));
+)))))))))))))
+end))))))))
+end))
+end))
+end))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_uvar (uv, k) -> begin
+(
+
+let ttm = (
+
+let uu____3116 = (FStar_Unionfind.uvar_id uv)
+in (FStar_SMTEncoding_Util.mk_Term_uvar uu____3116))
+in (
+
+let uu____3120 = (encode_term_pred None k env ttm)
+in (match (uu____3120) with
+| (t_has_k, decls) -> begin
+(
+
+let d = (
+
+let uu____3128 = (
+
+let uu____3133 = (
+
+let uu____3135 = (
+
+let uu____3136 = (
+
+let uu____3137 = (
+
+let uu____3138 = (FStar_Unionfind.uvar_id uv)
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____3138))
+in (FStar_Util.format1 "uvar_typing_%s" uu____3137))
+in (varops.mk_unique uu____3136))
+in Some (uu____3135))
+in ((t_has_k), (Some ("Uvar typing")), (uu____3133)))
+in FStar_SMTEncoding_Term.Assume (uu____3128))
+in ((ttm), ((FStar_List.append decls ((d)::[])))))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_app (uu____3145) -> begin
+(
+
+let uu____3155 = (FStar_Syntax_Util.head_and_args t0)
+in (match (uu____3155) with
+| (head1, args_e) -> begin
+(
+
+let uu____3183 = (
+
+let uu____3191 = (
+
+let uu____3192 = (FStar_Syntax_Subst.compress head1)
+in uu____3192.FStar_Syntax_Syntax.n)
+in ((uu____3191), (args_e)))
+in (match (uu____3183) with
+| (uu____3202, uu____3203) when (head_redex env head1) -> begin
+(
+
+let uu____3214 = (whnf env t)
+in (encode_term uu____3214 env))
+end
+| ((FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), (_)::((v1, _))::((v2, _))::[])) | ((FStar_Syntax_Syntax.Tm_fvar (fv), (_)::((v1, _))::((v2, _))::[])) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.lexcons_lid) -> begin
+(
+
+let uu____3288 = (encode_term v1 env)
+in (match (uu____3288) with
+| (v11, decls1) -> begin
+(
+
+let uu____3295 = (encode_term v2 env)
+in (match (uu____3295) with
+| (v21, decls2) -> begin
+(
+
+let uu____3302 = (FStar_SMTEncoding_Util.mk_LexCons v11 v21)
+in ((uu____3302), ((FStar_List.append decls1 decls2))))
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify), uu____3304) -> begin
+(
+
+let e0 = (
+
+let uu____3318 = (
+
+let uu____3321 = (
+
+let uu____3322 = (
+
+let uu____3332 = (
+
+let uu____3338 = (FStar_List.hd args_e)
+in (uu____3338)::[])
+in ((head1), (uu____3332)))
+in FStar_Syntax_Syntax.Tm_app (uu____3322))
+in (FStar_Syntax_Syntax.mk uu____3321))
+in (uu____3318 None head1.FStar_Syntax_Syntax.pos))
+in ((
+
+let uu____3371 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv) (FStar_Options.Other ("SMTEncodingReify")))
+in (match (uu____3371) with
+| true -> begin
+(
+
+let uu____3372 = (FStar_Syntax_Print.term_to_string e0)
+in (FStar_Util.print1 "Trying to normalize %s\n" uu____3372))
+end
+| uu____3373 -> begin
+()
+end));
+(
+
+let e01 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Reify)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env.tcenv e0)
+in ((
+
+let uu____3376 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv) (FStar_Options.Other ("SMTEncodingReify")))
+in (match (uu____3376) with
+| true -> begin
+(
+
+let uu____3377 = (FStar_Syntax_Print.term_to_string e01)
+in (FStar_Util.print1 "Result of normalization %s\n" uu____3377))
+end
+| uu____3378 -> begin
+()
+end));
+(
+
+let e02 = (
+
+let uu____3380 = (
+
+let uu____3381 = (
+
+let uu____3382 = (FStar_Syntax_Subst.compress e01)
+in uu____3382.FStar_Syntax_Syntax.n)
+in (match (uu____3381) with
+| FStar_Syntax_Syntax.Tm_app (uu____3385) -> begin
+false
+end
+| uu____3395 -> begin
+true
+end))
+in (match (uu____3380) with
+| true -> begin
+e01
+end
+| uu____3396 -> begin
+(
+
+let uu____3397 = (FStar_Syntax_Util.head_and_args e01)
+in (match (uu____3397) with
+| (head2, args) -> begin
+(
+
+let uu____3423 = (
+
+let uu____3424 = (
+
+let uu____3425 = (FStar_Syntax_Subst.compress head2)
+in uu____3425.FStar_Syntax_Syntax.n)
+in (match (uu____3424) with
+| FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) -> begin
+true
+end
+| uu____3428 -> begin
+false
+end))
+in (match (uu____3423) with
+| true -> begin
+(match (args) with
+| (x)::[] -> begin
+(Prims.fst x)
+end
+| uu____3444 -> begin
+(failwith "Impossible : Reify applied to multiple arguments after normalization.")
+end)
+end
+| uu____3450 -> begin
+e01
+end))
+end))
+end))
+in (
+
+let e = (match (args_e) with
+| (uu____3452)::[] -> begin
+e02
+end
+| uu____3465 -> begin
+(
+
+let uu____3471 = (
+
+let uu____3474 = (
+
+let uu____3475 = (
+
+let uu____3485 = (FStar_List.tl args_e)
+in ((e02), (uu____3485)))
+in FStar_Syntax_Syntax.Tm_app (uu____3475))
+in (FStar_Syntax_Syntax.mk uu____3474))
+in (uu____3471 None t0.FStar_Syntax_Syntax.pos))
+end)
+in (encode_term e env)));
+));
+))
+end
+| (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (uu____3508)), ((arg, uu____3510))::[]) -> begin
+(encode_term arg env)
+end
+| uu____3528 -> begin
+(
+
+let uu____3536 = (encode_args args_e env)
+in (match (uu____3536) with
+| (args, decls) -> begin
+(
+
+let encode_partial_app = (fun ht_opt -> (
+
+let uu____3569 = (encode_term head1 env)
+in (match (uu____3569) with
+| (head2, decls') -> begin
+(
+
+let app_tm = (mk_Apply_args head2 args)
+in (match (ht_opt) with
+| None -> begin
+((app_tm), ((FStar_List.append decls decls')))
+end
+| Some (formals, c) -> begin
+(
+
+let uu____3608 = (FStar_Util.first_N (FStar_List.length args_e) formals)
+in (match (uu____3608) with
+| (formals1, rest) -> begin
+(
+
+let subst1 = (FStar_List.map2 (fun uu____3650 uu____3651 -> (match (((uu____3650), (uu____3651))) with
+| ((bv, uu____3665), (a, uu____3667)) -> begin
+FStar_Syntax_Syntax.NT (((bv), (a)))
+end)) formals1 args_e)
+in (
+
+let ty = (
+
+let uu____3681 = (FStar_Syntax_Util.arrow rest c)
+in (FStar_All.pipe_right uu____3681 (FStar_Syntax_Subst.subst subst1)))
+in (
+
+let uu____3686 = (encode_term_pred None ty env app_tm)
+in (match (uu____3686) with
+| (has_type, decls'') -> begin
+(
+
+let cvars = (FStar_SMTEncoding_Term.free_variables has_type)
+in (
+
+let e_typing = (
+
+let uu____3696 = (
+
+let uu____3701 = (FStar_SMTEncoding_Util.mkForall ((((has_type)::[])::[]), (cvars), (has_type)))
+in (
+
+let uu____3706 = (
+
+let uu____3708 = (
+
+let uu____3709 = (
+
+let uu____3710 = (
+
+let uu____3711 = (FStar_SMTEncoding_Term.hash_of_term app_tm)
+in (FStar_Util.digest_of_string uu____3711))
+in (Prims.strcat "partial_app_typing_" uu____3710))
+in (varops.mk_unique uu____3709))
+in Some (uu____3708))
+in ((uu____3701), (Some ("Partial app typing")), (uu____3706))))
+in FStar_SMTEncoding_Term.Assume (uu____3696))
+in ((app_tm), ((FStar_List.append decls (FStar_List.append decls' (FStar_List.append decls'' ((e_typing)::[]))))))))
+end))))
+end))
+end))
+end)))
+in (
+
+let encode_full_app = (fun fv -> (
+
+let uu____3729 = (lookup_free_var_sym env fv)
+in (match (uu____3729) with
+| (fname, fuel_args) -> begin
+(
+
+let tm = (FStar_SMTEncoding_Util.mkApp' ((fname), ((FStar_List.append fuel_args args))))
+in ((tm), (decls)))
+end)))
+in (
+
+let head2 = (FStar_Syntax_Subst.compress head1)
+in (
+
+let head_type = (match (head2.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_name (x); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) | (FStar_Syntax_Syntax.Tm_name (x)) -> begin
+Some (x.FStar_Syntax_Syntax.sort)
+end
+| (FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) | (FStar_Syntax_Syntax.Tm_fvar (fv)) -> begin
+(
+
+let uu____3767 = (
+
+let uu____3768 = (
+
+let uu____3771 = (FStar_TypeChecker_Env.lookup_lid env.tcenv fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_All.pipe_right uu____3771 Prims.fst))
+in (FStar_All.pipe_right uu____3768 Prims.snd))
+in Some (uu____3767))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____3790, (FStar_Util.Inl (t1), uu____3792), uu____3793) -> begin
+Some (t1)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____3831, (FStar_Util.Inr (c), uu____3833), uu____3834) -> begin
+Some ((FStar_Syntax_Util.comp_result c))
+end
+| uu____3872 -> begin
+None
+end)
+in (match (head_type) with
+| None -> begin
+(encode_partial_app None)
+end
+| Some (head_type1) -> begin
+(
+
+let head_type2 = (
+
+let uu____3892 = (FStar_TypeChecker_Normalize.normalize_refinement ((FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv head_type1)
+in (FStar_All.pipe_left FStar_Syntax_Util.unrefine uu____3892))
+in (
+
+let uu____3893 = (curried_arrow_formals_comp head_type2)
+in (match (uu____3893) with
+| (formals, c) -> begin
+(match (head2.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) | (FStar_Syntax_Syntax.Tm_fvar (fv)) when ((FStar_List.length formals) = (FStar_List.length args)) -> begin
+(encode_full_app fv.FStar_Syntax_Syntax.fv_name)
+end
+| uu____3918 -> begin
+(match (((FStar_List.length formals) > (FStar_List.length args))) with
+| true -> begin
+(encode_partial_app (Some (((formals), (c)))))
+end
+| uu____3930 -> begin
+(encode_partial_app None)
+end)
+end)
+end)))
+end)))))
+end))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) -> begin
+(
+
+let uu____3963 = (FStar_Syntax_Subst.open_term' bs body)
+in (match (uu____3963) with
+| (bs1, body1, opening) -> begin
+(
+
+let fallback = (fun uu____3978 -> (
+
+let f = (varops.fresh "Tm_abs")
+in (
+
+let decl = FStar_SMTEncoding_Term.DeclFun (((f), ([]), (FStar_SMTEncoding_Term.Term_sort), (Some ("Imprecise function encoding"))))
+in (
+
+let uu____3983 = (FStar_SMTEncoding_Util.mkFreeV ((f), (FStar_SMTEncoding_Term.Term_sort)))
+in ((uu____3983), ((decl)::[]))))))
+in (
+
+let is_impure = (fun lc -> (match (lc) with
+| FStar_Util.Inl (lc1) -> begin
+(
+
+let uu____3994 = (FStar_Syntax_Util.is_pure_or_ghost_lcomp lc1)
+in (not (uu____3994)))
+end
+| FStar_Util.Inr (eff, uu____3996) -> begin
+(
+
+let uu____4002 = (FStar_TypeChecker_Util.is_pure_or_ghost_effect env.tcenv eff)
+in (FStar_All.pipe_right uu____4002 Prims.op_Negation))
+end))
+in (
+
+let reify_comp_and_body = (fun env1 c body2 -> (
+
+let reified_body = (reify_body env1.tcenv body2)
+in (
+
+let c1 = (match (c) with
+| FStar_Util.Inl (lc) -> begin
+(
+
+let typ = (
+
+let uu____4047 = (lc.FStar_Syntax_Syntax.comp ())
+in (FStar_TypeChecker_Env.reify_comp (
+
+let uu___145_4048 = env1.tcenv
+in {FStar_TypeChecker_Env.solver = uu___145_4048.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___145_4048.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___145_4048.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___145_4048.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___145_4048.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___145_4048.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___145_4048.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___145_4048.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___145_4048.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___145_4048.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___145_4048.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___145_4048.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___145_4048.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___145_4048.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___145_4048.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___145_4048.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___145_4048.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___145_4048.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___145_4048.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___145_4048.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___145_4048.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___145_4048.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___145_4048.FStar_TypeChecker_Env.qname_and_index}) uu____4047 FStar_Syntax_Syntax.U_unknown))
+in (
+
+let uu____4049 = (
+
+let uu____4050 = (FStar_Syntax_Syntax.mk_Total typ)
+in (FStar_Syntax_Util.lcomp_of_comp uu____4050))
+in FStar_Util.Inl (uu____4049)))
+end
+| FStar_Util.Inr (eff_name, uu____4057) -> begin
+c
+end)
+in ((c1), (reified_body)))))
+in (
+
+let codomain_eff = (fun lc -> (match (lc) with
+| FStar_Util.Inl (lc1) -> begin
+(
+
+let uu____4088 = (
+
+let uu____4089 = (lc1.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Subst.subst_comp opening uu____4089))
+in (FStar_All.pipe_right uu____4088 (fun _0_31 -> Some (_0_31))))
+end
+| FStar_Util.Inr (eff, flags) -> begin
+(
+
+let new_uvar1 = (fun uu____4101 -> (
+
+let uu____4102 = (FStar_TypeChecker_Rel.new_uvar FStar_Range.dummyRange [] FStar_Syntax_Util.ktype0)
+in (FStar_All.pipe_right uu____4102 Prims.fst)))
+in (match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_Tot_lid)) with
+| true -> begin
+(
+
+let uu____4110 = (
+
+let uu____4111 = (new_uvar1 ())
+in (FStar_Syntax_Syntax.mk_Total uu____4111))
+in (FStar_All.pipe_right uu____4110 (fun _0_32 -> Some (_0_32))))
+end
+| uu____4113 -> begin
+(match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_GTot_lid)) with
+| true -> begin
+(
+
+let uu____4115 = (
+
+let uu____4116 = (new_uvar1 ())
+in (FStar_Syntax_Syntax.mk_GTotal uu____4116))
+in (FStar_All.pipe_right uu____4115 (fun _0_33 -> Some (_0_33))))
+end
+| uu____4118 -> begin
+None
+end)
+end))
+end))
+in (match (lopt) with
+| None -> begin
+((
+
+let uu____4127 = (
+
+let uu____4128 = (FStar_Syntax_Print.term_to_string t0)
+in (FStar_Util.format1 "Losing precision when encoding a function literal: %s\n(Unnannotated abstraction in the compiler ?)" uu____4128))
+in (FStar_Errors.warn t0.FStar_Syntax_Syntax.pos uu____4127));
+(fallback ());
+)
+end
+| Some (lc) -> begin
+(
+
+let lc1 = lc
+in (
+
+let uu____4143 = ((is_impure lc1) && (
+
+let uu____4144 = (FStar_TypeChecker_Env.is_reifiable env.tcenv lc1)
+in (not (uu____4144))))
+in (match (uu____4143) with
+| true -> begin
+(fallback ())
+end
+| uu____4147 -> begin
+(
+
+let uu____4148 = (encode_binders None bs1 env)
+in (match (uu____4148) with
+| (vars, guards, envbody, decls, uu____4163) -> begin
+(
+
+let uu____4170 = (
+
+let uu____4178 = (FStar_TypeChecker_Env.is_reifiable env.tcenv lc1)
+in (match (uu____4178) with
+| true -> begin
+(reify_comp_and_body envbody lc1 body1)
+end
+| uu____4186 -> begin
+((lc1), (body1))
+end))
+in (match (uu____4170) with
+| (lc2, body2) -> begin
+(
+
+let uu____4203 = (encode_term body2 envbody)
+in (match (uu____4203) with
+| (body3, decls') -> begin
+(
+
+let key_body = (
+
+let uu____4211 = (
+
+let uu____4217 = (
+
+let uu____4218 = (
+
+let uu____4221 = (FStar_SMTEncoding_Util.mk_and_l guards)
+in ((uu____4221), (body3)))
+in (FStar_SMTEncoding_Util.mkImp uu____4218))
+in (([]), (vars), (uu____4217)))
+in (FStar_SMTEncoding_Util.mkForall uu____4211))
+in (
+
+let cvars = (FStar_SMTEncoding_Term.free_variables key_body)
+in (
+
+let tkey = (FStar_SMTEncoding_Util.mkForall (([]), (cvars), (key_body)))
+in (
+
+let tkey_hash = (FStar_SMTEncoding_Term.hash_of_term tkey)
+in (
+
+let uu____4232 = (FStar_Util.smap_try_find env.cache tkey_hash)
+in (match (uu____4232) with
+| Some (t1, uu____4247, uu____4248) -> begin
+(
+
+let uu____4258 = (
+
+let uu____4259 = (
+
+let uu____4263 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV cvars)
+in ((t1), (uu____4263)))
+in (FStar_SMTEncoding_Util.mkApp uu____4259))
+in ((uu____4258), ([])))
+end
+| None -> begin
+(
+
+let uu____4274 = (is_eta env vars body3)
+in (match (uu____4274) with
+| Some (t1) -> begin
+((t1), ([]))
+end
+| None -> begin
+(
+
+let cvar_sorts = (FStar_List.map Prims.snd cvars)
+in (
+
+let fsym = (
+
+let uu____4285 = (
+
+let uu____4286 = (FStar_Util.digest_of_string tkey_hash)
+in (Prims.strcat "Tm_abs_" uu____4286))
+in (varops.mk_unique uu____4285))
+in (
+
+let fdecl = FStar_SMTEncoding_Term.DeclFun (((fsym), (cvar_sorts), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let f = (
+
+let uu____4291 = (
+
+let uu____4295 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV cvars)
+in ((fsym), (uu____4295)))
+in (FStar_SMTEncoding_Util.mkApp uu____4291))
+in (
+
+let app = (mk_Apply f vars)
+in (
+
+let typing_f = (
+
+let uu____4303 = (codomain_eff lc2)
+in (match (uu____4303) with
+| None -> begin
+[]
+end
+| Some (c) -> begin
+(
+
+let tfun = (FStar_Syntax_Util.arrow bs1 c)
+in (
+
+let uu____4310 = (encode_term_pred None tfun env f)
+in (match (uu____4310) with
+| (f_has_t, decls'') -> begin
+(
+
+let a_name = Some ((Prims.strcat "typing_" fsym))
+in (
+
+let uu____4318 = (
+
+let uu____4320 = (
+
+let uu____4321 = (
+
+let uu____4326 = (FStar_SMTEncoding_Util.mkForall ((((f)::[])::[]), (cvars), (f_has_t)))
+in ((uu____4326), (a_name), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____4321))
+in (uu____4320)::[])
+in (FStar_List.append decls'' uu____4318)))
+end)))
+end))
+in (
+
+let interp_f = (
+
+let a_name = Some ((Prims.strcat "interpretation_" fsym))
+in (
+
+let uu____4336 = (
+
+let uu____4341 = (
+
+let uu____4342 = (
+
+let uu____4348 = (FStar_SMTEncoding_Util.mkEq ((app), (body3)))
+in ((((app)::[])::[]), ((FStar_List.append vars cvars)), (uu____4348)))
+in (FStar_SMTEncoding_Util.mkForall uu____4342))
+in ((uu____4341), (a_name), (a_name)))
+in FStar_SMTEncoding_Term.Assume (uu____4336)))
+in (
+
+let f_decls = (FStar_List.append decls (FStar_List.append decls' (FStar_List.append ((fdecl)::typing_f) ((interp_f)::[]))))
+in ((FStar_Util.smap_add env.cache tkey_hash ((fsym), (cvar_sorts), (f_decls)));
+((f), (f_decls));
+)))))))))
+end))
+end))))))
+end))
+end))
+end))
+end)))
+end)))))
+end))
+end
+| FStar_Syntax_Syntax.Tm_let ((uu____4367, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (uu____4368); FStar_Syntax_Syntax.lbunivs = uu____4369; FStar_Syntax_Syntax.lbtyp = uu____4370; FStar_Syntax_Syntax.lbeff = uu____4371; FStar_Syntax_Syntax.lbdef = uu____4372})::uu____4373), uu____4374) -> begin
+(failwith "Impossible: already handled by encoding of Sig_let")
+end
+| FStar_Syntax_Syntax.Tm_let ((false, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inl (x); FStar_Syntax_Syntax.lbunivs = uu____4392; FStar_Syntax_Syntax.lbtyp = t1; FStar_Syntax_Syntax.lbeff = uu____4394; FStar_Syntax_Syntax.lbdef = e1})::[]), e2) -> begin
+(encode_let x t1 e1 e2 env encode_term)
+end
+| FStar_Syntax_Syntax.Tm_let (uu____4410) -> begin
+((FStar_Errors.diag t0.FStar_Syntax_Syntax.pos "Non-top-level recursive functions are not yet fully encoded to the SMT solver; you may not be able to prove some facts");
+(
+
+let e = (varops.fresh "let-rec")
+in (
+
+let decl_e = FStar_SMTEncoding_Term.DeclFun (((e), ([]), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let uu____4423 = (FStar_SMTEncoding_Util.mkFreeV ((e), (FStar_SMTEncoding_Term.Term_sort)))
+in ((uu____4423), ((decl_e)::[])))));
+)
+end
+| FStar_Syntax_Syntax.Tm_match (e, pats) -> begin
+(encode_match e pats FStar_SMTEncoding_Term.mk_Term_unit env encode_term)
+end);
+)))
+and encode_let : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  env_t  ->  (FStar_Syntax_Syntax.term  ->  env_t  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t))  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun x t1 e1 e2 env encode_body -> (
+
+let uu____4465 = (encode_term e1 env)
+in (match (uu____4465) with
+| (ee1, decls1) -> begin
+(
+
+let uu____4472 = (FStar_Syntax_Subst.open_term ((((x), (None)))::[]) e2)
+in (match (uu____4472) with
+| (xs, e21) -> begin
+(
+
+let uu____4486 = (FStar_List.hd xs)
+in (match (uu____4486) with
+| (x1, uu____4494) -> begin
+(
+
+let env' = (push_term_var env x1 ee1)
+in (
+
+let uu____4496 = (encode_body e21 env')
+in (match (uu____4496) with
+| (ee2, decls2) -> begin
+((ee2), ((FStar_List.append decls1 decls2)))
+end)))
+end))
+end))
+end)))
+and encode_match : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.branch Prims.list  ->  FStar_SMTEncoding_Term.term  ->  env_t  ->  (FStar_Syntax_Syntax.term  ->  env_t  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t))  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun e pats default_case env encode_br -> (
+
+let uu____4518 = (
+
+let uu____4522 = (
+
+let uu____4523 = ((FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown) None FStar_Range.dummyRange)
+in (FStar_Syntax_Syntax.null_bv uu____4523))
+in (gen_term_var env uu____4522))
+in (match (uu____4518) with
+| (scrsym, scr', env1) -> begin
+(
+
+let uu____4537 = (encode_term e env1)
+in (match (uu____4537) with
+| (scr, decls) -> begin
+(
+
+let uu____4544 = (
+
+let encode_branch = (fun b uu____4560 -> (match (uu____4560) with
+| (else_case, decls1) -> begin
+(
+
+let uu____4571 = (FStar_Syntax_Subst.open_branch b)
+in (match (uu____4571) with
+| (p, w, br) -> begin
+(
+
+let patterns = (encode_pat env1 p)
+in (FStar_List.fold_right (fun uu____4601 uu____4602 -> (match (((uu____4601), (uu____4602))) with
+| ((env0, pattern), (else_case1, decls2)) -> begin
+(
+
+let guard = (pattern.guard scr')
+in (
+
+let projections = (pattern.projections scr')
+in (
+
+let env2 = (FStar_All.pipe_right projections (FStar_List.fold_left (fun env2 uu____4639 -> (match (uu____4639) with
+| (x, t) -> begin
+(push_term_var env2 x t)
+end)) env1))
+in (
+
+let uu____4644 = (match (w) with
+| None -> begin
+((guard), ([]))
+end
+| Some (w1) -> begin
+(
+
+let uu____4659 = (encode_term w1 env2)
+in (match (uu____4659) with
+| (w2, decls21) -> begin
+(
+
+let uu____4667 = (
+
+let uu____4668 = (
+
+let uu____4671 = (
+
+let uu____4672 = (
+
+let uu____4675 = (FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue)
+in ((w2), (uu____4675)))
+in (FStar_SMTEncoding_Util.mkEq uu____4672))
+in ((guard), (uu____4671)))
+in (FStar_SMTEncoding_Util.mkAnd uu____4668))
+in ((uu____4667), (decls21)))
+end))
+end)
+in (match (uu____4644) with
+| (guard1, decls21) -> begin
+(
+
+let uu____4683 = (encode_br br env2)
+in (match (uu____4683) with
+| (br1, decls3) -> begin
+(
+
+let uu____4691 = (FStar_SMTEncoding_Util.mkITE ((guard1), (br1), (else_case1)))
+in ((uu____4691), ((FStar_List.append decls2 (FStar_List.append decls21 decls3)))))
+end))
+end)))))
+end)) patterns ((else_case), (decls1))))
+end))
+end))
+in (FStar_List.fold_right encode_branch pats ((default_case), (decls))))
+in (match (uu____4544) with
+| (match_tm, decls1) -> begin
+(
+
+let uu____4703 = (FStar_SMTEncoding_Term.mkLet' (((((((scrsym), (FStar_SMTEncoding_Term.Term_sort))), (scr)))::[]), (match_tm)) FStar_Range.dummyRange)
+in ((uu____4703), (decls1)))
+end))
+end))
+end)))
+and encode_pat : env_t  ->  FStar_Syntax_Syntax.pat  ->  (env_t * pattern) Prims.list = (fun env pat -> (match (pat.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (ps) -> begin
+(FStar_List.map (encode_one_pat env) ps)
+end
+| uu____4734 -> begin
+(
+
+let uu____4735 = (encode_one_pat env pat)
+in (uu____4735)::[])
+end))
+and encode_one_pat : env_t  ->  FStar_Syntax_Syntax.pat  ->  (env_t * pattern) = (fun env pat -> ((
+
+let uu____4747 = (FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low)
+in (match (uu____4747) with
+| true -> begin
+(
+
+let uu____4748 = (FStar_Syntax_Print.pat_to_string pat)
+in (FStar_Util.print1 "Encoding pattern %s\n" uu____4748))
+end
+| uu____4749 -> begin
+()
+end));
+(
+
+let uu____4750 = (FStar_TypeChecker_Util.decorated_pattern_as_term pat)
+in (match (uu____4750) with
+| (vars, pat_term) -> begin
+(
+
+let uu____4760 = (FStar_All.pipe_right vars (FStar_List.fold_left (fun uu____4783 v1 -> (match (uu____4783) with
+| (env1, vars1) -> begin
+(
+
+let uu____4811 = (gen_term_var env1 v1)
+in (match (uu____4811) with
+| (xx, uu____4823, env2) -> begin
+((env2), ((((v1), (((xx), (FStar_SMTEncoding_Term.Term_sort)))))::vars1))
+end))
+end)) ((env), ([]))))
+in (match (uu____4760) with
+| (env1, vars1) -> begin
+(
+
+let rec mk_guard = (fun pat1 scrutinee -> (match (pat1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (uu____4870) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Pat_var (_)) | (FStar_Syntax_Syntax.Pat_wild (_)) | (FStar_Syntax_Syntax.Pat_dot_term (_)) -> begin
+FStar_SMTEncoding_Util.mkTrue
+end
+| FStar_Syntax_Syntax.Pat_constant (c) -> begin
+(
+
+let uu____4878 = (
+
+let uu____4881 = (encode_const c)
+in ((scrutinee), (uu____4881)))
+in (FStar_SMTEncoding_Util.mkEq uu____4878))
+end
+| FStar_Syntax_Syntax.Pat_cons (f, args) -> begin
+(
+
+let is_f = (
+
+let tc_name = (FStar_TypeChecker_Env.typ_of_datacon env1.tcenv f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (
+
+let uu____4900 = (FStar_TypeChecker_Env.datacons_of_typ env1.tcenv tc_name)
+in (match (uu____4900) with
+| (uu____4904, (uu____4905)::[]) -> begin
+FStar_SMTEncoding_Util.mkTrue
+end
+| uu____4907 -> begin
+(mk_data_tester env1 f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v scrutinee)
+end)))
+in (
+
+let sub_term_guards = (FStar_All.pipe_right args (FStar_List.mapi (fun i uu____4928 -> (match (uu____4928) with
+| (arg, uu____4934) -> begin
+(
+
+let proj = (primitive_projector_by_pos env1.tcenv f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v i)
+in (
+
+let uu____4944 = (FStar_SMTEncoding_Util.mkApp ((proj), ((scrutinee)::[])))
+in (mk_guard arg uu____4944)))
+end))))
+in (FStar_SMTEncoding_Util.mk_and_l ((is_f)::sub_term_guards))))
+end))
+in (
+
+let rec mk_projections = (fun pat1 scrutinee -> (match (pat1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (uu____4963) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Pat_dot_term (x, _)) | (FStar_Syntax_Syntax.Pat_var (x)) | (FStar_Syntax_Syntax.Pat_wild (x)) -> begin
+(((x), (scrutinee)))::[]
+end
+| FStar_Syntax_Syntax.Pat_constant (uu____4978) -> begin
+[]
+end
+| FStar_Syntax_Syntax.Pat_cons (f, args) -> begin
+(
+
+let uu____4993 = (FStar_All.pipe_right args (FStar_List.mapi (fun i uu____5015 -> (match (uu____5015) with
+| (arg, uu____5024) -> begin
+(
+
+let proj = (primitive_projector_by_pos env1.tcenv f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v i)
+in (
+
+let uu____5034 = (FStar_SMTEncoding_Util.mkApp ((proj), ((scrutinee)::[])))
+in (mk_projections arg uu____5034)))
+end))))
+in (FStar_All.pipe_right uu____4993 FStar_List.flatten))
+end))
+in (
+
+let pat_term1 = (fun uu____5050 -> (encode_term pat_term env1))
+in (
+
+let pattern = {pat_vars = vars1; pat_term = pat_term1; guard = (mk_guard pat); projections = (mk_projections pat)}
+in ((env1), (pattern))))))
+end))
+end));
+))
+and encode_args : FStar_Syntax_Syntax.args  ->  env_t  ->  (FStar_SMTEncoding_Term.term Prims.list * FStar_SMTEncoding_Term.decls_t) = (fun l env -> (
+
+let uu____5057 = (FStar_All.pipe_right l (FStar_List.fold_left (fun uu____5072 uu____5073 -> (match (((uu____5072), (uu____5073))) with
+| ((tms, decls), (t, uu____5093)) -> begin
+(
+
+let uu____5104 = (encode_term t env)
+in (match (uu____5104) with
+| (t1, decls') -> begin
+(((t1)::tms), ((FStar_List.append decls decls')))
+end))
+end)) (([]), ([]))))
+in (match (uu____5057) with
+| (l1, decls) -> begin
+(((FStar_List.rev l1)), (decls))
+end)))
+and encode_function_type_as_formula : FStar_SMTEncoding_Term.term Prims.option  ->  FStar_Syntax_Syntax.term Prims.option  ->  FStar_Syntax_Syntax.typ  ->  env_t  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun induction_on new_pats t env -> (
+
+let list_elements1 = (fun e -> (
+
+let uu____5142 = (FStar_Syntax_Util.list_elements e)
+in (match (uu____5142) with
+| Some (l) -> begin
+l
+end
+| None -> begin
+((FStar_Errors.warn e.FStar_Syntax_Syntax.pos "SMT pattern is not a list literal; ignoring the pattern");
+[];
+)
+end)))
+in (
+
+let one_pat = (fun p -> (
+
+let uu____5160 = (
+
+let uu____5170 = (FStar_Syntax_Util.unmeta p)
+in (FStar_All.pipe_right uu____5170 FStar_Syntax_Util.head_and_args))
+in (match (uu____5160) with
+| (head1, args) -> begin
+(
+
+let uu____5201 = (
+
+let uu____5209 = (
+
+let uu____5210 = (FStar_Syntax_Util.un_uinst head1)
+in uu____5210.FStar_Syntax_Syntax.n)
+in ((uu____5209), (args)))
+in (match (uu____5201) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((uu____5224, uu____5225))::((e, uu____5227))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.smtpat_lid) -> begin
+((e), (None))
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((e, uu____5258))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.smtpatT_lid) -> begin
+((e), (None))
+end
+| uu____5279 -> begin
+(failwith "Unexpected pattern term")
+end))
+end)))
+in (
+
+let lemma_pats = (fun p -> (
+
+let elts = (list_elements1 p)
+in (
+
+let smt_pat_or = (fun t1 -> (
+
+let uu____5312 = (
+
+let uu____5322 = (FStar_Syntax_Util.unmeta t1)
+in (FStar_All.pipe_right uu____5322 FStar_Syntax_Util.head_and_args))
+in (match (uu____5312) with
+| (head1, args) -> begin
+(
+
+let uu____5351 = (
+
+let uu____5359 = (
+
+let uu____5360 = (FStar_Syntax_Util.un_uinst head1)
+in uu____5360.FStar_Syntax_Syntax.n)
+in ((uu____5359), (args)))
+in (match (uu____5351) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((e, uu____5373))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.smtpatOr_lid) -> begin
+Some (e)
+end
+| uu____5393 -> begin
+None
+end))
+end)))
+in (match (elts) with
+| (t1)::[] -> begin
+(
+
+let uu____5411 = (smt_pat_or t1)
+in (match (uu____5411) with
+| Some (e) -> begin
+(
+
+let uu____5427 = (list_elements1 e)
+in (FStar_All.pipe_right uu____5427 (FStar_List.map (fun branch1 -> (
+
+let uu____5444 = (list_elements1 branch1)
+in (FStar_All.pipe_right uu____5444 (FStar_List.map one_pat)))))))
+end
+| uu____5458 -> begin
+(
+
+let uu____5462 = (FStar_All.pipe_right elts (FStar_List.map one_pat))
+in (uu____5462)::[])
+end))
+end
+| uu____5493 -> begin
+(
+
+let uu____5495 = (FStar_All.pipe_right elts (FStar_List.map one_pat))
+in (uu____5495)::[])
+end))))
+in (
+
+let uu____5526 = (
+
+let uu____5542 = (
+
+let uu____5543 = (FStar_Syntax_Subst.compress t)
+in uu____5543.FStar_Syntax_Syntax.n)
+in (match (uu____5542) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, c) -> begin
+(
+
+let uu____5573 = (FStar_Syntax_Subst.open_comp binders c)
+in (match (uu____5573) with
+| (binders1, c1) -> begin
+(match (c1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp ({FStar_Syntax_Syntax.comp_univs = uu____5608; FStar_Syntax_Syntax.effect_name = uu____5609; FStar_Syntax_Syntax.result_typ = uu____5610; FStar_Syntax_Syntax.effect_args = ((pre, uu____5612))::((post, uu____5614))::((pats, uu____5616))::[]; FStar_Syntax_Syntax.flags = uu____5617}) -> begin
+(
+
+let pats' = (match (new_pats) with
+| Some (new_pats') -> begin
+new_pats'
+end
+| None -> begin
+pats
+end)
+in (
+
+let uu____5651 = (lemma_pats pats')
+in ((binders1), (pre), (post), (uu____5651))))
+end
+| uu____5670 -> begin
+(failwith "impos")
+end)
+end))
+end
+| uu____5686 -> begin
+(failwith "Impos")
+end))
+in (match (uu____5526) with
+| (binders, pre, post, patterns) -> begin
+(
+
+let uu____5730 = (encode_binders None binders env)
+in (match (uu____5730) with
+| (vars, guards, env1, decls, uu____5745) -> begin
+(
+
+let uu____5752 = (
+
+let uu____5759 = (FStar_All.pipe_right patterns (FStar_List.map (fun branch1 -> (
+
+let uu____5790 = (
+
+let uu____5795 = (FStar_All.pipe_right branch1 (FStar_List.map (fun uu____5811 -> (match (uu____5811) with
+| (t1, uu____5818) -> begin
+(encode_term t1 (
+
+let uu___146_5821 = env1
+in {bindings = uu___146_5821.bindings; depth = uu___146_5821.depth; tcenv = uu___146_5821.tcenv; warn = uu___146_5821.warn; cache = uu___146_5821.cache; nolabels = uu___146_5821.nolabels; use_zfuel_name = true; encode_non_total_function_typ = uu___146_5821.encode_non_total_function_typ}))
+end))))
+in (FStar_All.pipe_right uu____5795 FStar_List.unzip))
+in (match (uu____5790) with
+| (pats, decls1) -> begin
+((pats), (decls1))
+end)))))
+in (FStar_All.pipe_right uu____5759 FStar_List.unzip))
+in (match (uu____5752) with
+| (pats, decls') -> begin
+(
+
+let decls'1 = (FStar_List.flatten decls')
+in (
+
+let pats1 = (match (induction_on) with
+| None -> begin
+pats
+end
+| Some (e) -> begin
+(match (vars) with
+| [] -> begin
+pats
+end
+| (l)::[] -> begin
+(FStar_All.pipe_right pats (FStar_List.map (fun p -> (
+
+let uu____5885 = (
+
+let uu____5886 = (FStar_SMTEncoding_Util.mkFreeV l)
+in (FStar_SMTEncoding_Util.mk_Precedes uu____5886 e))
+in (uu____5885)::p))))
+end
+| uu____5887 -> begin
+(
+
+let rec aux = (fun tl1 vars1 -> (match (vars1) with
+| [] -> begin
+(FStar_All.pipe_right pats (FStar_List.map (fun p -> (
+
+let uu____5916 = (FStar_SMTEncoding_Util.mk_Precedes tl1 e)
+in (uu____5916)::p))))
+end
+| ((x, FStar_SMTEncoding_Term.Term_sort))::vars2 -> begin
+(
+
+let uu____5924 = (
+
+let uu____5925 = (FStar_SMTEncoding_Util.mkFreeV ((x), (FStar_SMTEncoding_Term.Term_sort)))
+in (FStar_SMTEncoding_Util.mk_LexCons uu____5925 tl1))
+in (aux uu____5924 vars2))
+end
+| uu____5926 -> begin
+pats
+end))
+in (
+
+let uu____5930 = (FStar_SMTEncoding_Util.mkFreeV (("Prims.LexTop"), (FStar_SMTEncoding_Term.Term_sort)))
+in (aux uu____5930 vars)))
+end)
+end)
+in (
+
+let env2 = (
+
+let uu___147_5932 = env1
+in {bindings = uu___147_5932.bindings; depth = uu___147_5932.depth; tcenv = uu___147_5932.tcenv; warn = uu___147_5932.warn; cache = uu___147_5932.cache; nolabels = true; use_zfuel_name = uu___147_5932.use_zfuel_name; encode_non_total_function_typ = uu___147_5932.encode_non_total_function_typ})
+in (
+
+let uu____5933 = (
+
+let uu____5936 = (FStar_Syntax_Util.unmeta pre)
+in (encode_formula uu____5936 env2))
+in (match (uu____5933) with
+| (pre1, decls'') -> begin
+(
+
+let uu____5941 = (
+
+let uu____5944 = (FStar_Syntax_Util.unmeta post)
+in (encode_formula uu____5944 env2))
+in (match (uu____5941) with
+| (post1, decls''') -> begin
+(
+
+let decls1 = (FStar_List.append decls (FStar_List.append (FStar_List.flatten decls'1) (FStar_List.append decls'' decls''')))
+in (
+
+let uu____5951 = (
+
+let uu____5952 = (
+
+let uu____5958 = (
+
+let uu____5959 = (
+
+let uu____5962 = (FStar_SMTEncoding_Util.mk_and_l ((pre1)::guards))
+in ((uu____5962), (post1)))
+in (FStar_SMTEncoding_Util.mkImp uu____5959))
+in ((pats1), (vars), (uu____5958)))
+in (FStar_SMTEncoding_Util.mkForall uu____5952))
+in ((uu____5951), (decls1))))
+end))
+end)))))
+end))
+end))
+end))))))
+and encode_formula : FStar_Syntax_Syntax.typ  ->  env_t  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t) = (fun phi env -> (
+
+let debug1 = (fun phi1 -> (
+
+let uu____5975 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____5975) with
+| true -> begin
+(
+
+let uu____5976 = (FStar_Syntax_Print.tag_of_term phi1)
+in (
+
+let uu____5977 = (FStar_Syntax_Print.term_to_string phi1)
+in (FStar_Util.print2 "Formula (%s)  %s\n" uu____5976 uu____5977)))
+end
+| uu____5978 -> begin
+()
+end)))
+in (
+
+let enc = (fun f r l -> (
+
+let uu____6004 = (FStar_Util.fold_map (fun decls x -> (
+
+let uu____6017 = (encode_term (Prims.fst x) env)
+in (match (uu____6017) with
+| (t, decls') -> begin
+(((FStar_List.append decls decls')), (t))
+end))) [] l)
+in (match (uu____6004) with
+| (decls, args) -> begin
+(
+
+let uu____6034 = (
+
+let uu___148_6035 = (f args)
+in {FStar_SMTEncoding_Term.tm = uu___148_6035.FStar_SMTEncoding_Term.tm; FStar_SMTEncoding_Term.freevars = uu___148_6035.FStar_SMTEncoding_Term.freevars; FStar_SMTEncoding_Term.rng = r})
+in ((uu____6034), (decls)))
+end)))
+in (
+
+let const_op = (fun f r uu____6054 -> (
+
+let uu____6057 = (f r)
+in ((uu____6057), ([]))))
+in (
+
+let un_op = (fun f l -> (
+
+let uu____6073 = (FStar_List.hd l)
+in (FStar_All.pipe_left f uu____6073)))
+in (
+
+let bin_op = (fun f uu___120_6086 -> (match (uu___120_6086) with
+| (t1)::(t2)::[] -> begin
+(f ((t1), (t2)))
+end
+| uu____6094 -> begin
+(failwith "Impossible")
+end))
+in (
+
+let enc_prop_c = (fun f r l -> (
+
+let uu____6121 = (FStar_Util.fold_map (fun decls uu____6130 -> (match (uu____6130) with
+| (t, uu____6138) -> begin
+(
+
+let uu____6139 = (encode_formula t env)
+in (match (uu____6139) with
+| (phi1, decls') -> begin
+(((FStar_List.append decls decls')), (phi1))
+end))
+end)) [] l)
+in (match (uu____6121) with
+| (decls, phis) -> begin
+(
+
+let uu____6156 = (
+
+let uu___149_6157 = (f phis)
+in {FStar_SMTEncoding_Term.tm = uu___149_6157.FStar_SMTEncoding_Term.tm; FStar_SMTEncoding_Term.freevars = uu___149_6157.FStar_SMTEncoding_Term.freevars; FStar_SMTEncoding_Term.rng = r})
+in ((uu____6156), (decls)))
+end)))
+in (
+
+let eq_op = (fun r uu___121_6173 -> (match (uu___121_6173) with
+| ((_)::(e1)::(e2)::[]) | ((_)::(_)::(e1)::(e2)::[]) -> begin
+(
+
+let uu____6233 = (enc (bin_op FStar_SMTEncoding_Util.mkEq))
+in (uu____6233 r ((e1)::(e2)::[])))
+end
+| l -> begin
+(
+
+let uu____6253 = (enc (bin_op FStar_SMTEncoding_Util.mkEq))
+in (uu____6253 r l))
+end))
+in (
+
+let mk_imp1 = (fun r uu___122_6272 -> (match (uu___122_6272) with
+| ((lhs, uu____6276))::((rhs, uu____6278))::[] -> begin
+(
+
+let uu____6299 = (encode_formula rhs env)
+in (match (uu____6299) with
+| (l1, decls1) -> begin
+(match (l1.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.TrueOp, uu____6308) -> begin
+((l1), (decls1))
+end
+| uu____6311 -> begin
+(
+
+let uu____6312 = (encode_formula lhs env)
+in (match (uu____6312) with
+| (l2, decls2) -> begin
+(
+
+let uu____6319 = (FStar_SMTEncoding_Term.mkImp ((l2), (l1)) r)
+in ((uu____6319), ((FStar_List.append decls1 decls2))))
+end))
+end)
+end))
+end
+| uu____6321 -> begin
+(failwith "impossible")
+end))
+in (
+
+let mk_ite = (fun r uu___123_6336 -> (match (uu___123_6336) with
+| ((guard, uu____6340))::((_then, uu____6342))::((_else, uu____6344))::[] -> begin
+(
+
+let uu____6373 = (encode_formula guard env)
+in (match (uu____6373) with
+| (g, decls1) -> begin
+(
+
+let uu____6380 = (encode_formula _then env)
+in (match (uu____6380) with
+| (t, decls2) -> begin
+(
+
+let uu____6387 = (encode_formula _else env)
+in (match (uu____6387) with
+| (e, decls3) -> begin
+(
+
+let res = (FStar_SMTEncoding_Term.mkITE ((g), (t), (e)) r)
+in ((res), ((FStar_List.append decls1 (FStar_List.append decls2 decls3)))))
+end))
+end))
+end))
+end
+| uu____6396 -> begin
+(failwith "impossible")
+end))
+in (
+
+let unboxInt_l = (fun f l -> (
+
+let uu____6415 = (FStar_List.map FStar_SMTEncoding_Term.unboxInt l)
+in (f uu____6415)))
+in (
+
+let connectives = (
+
+let uu____6427 = (
+
+let uu____6436 = (enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd))
+in ((FStar_Syntax_Const.and_lid), (uu____6436)))
+in (
+
+let uu____6449 = (
+
+let uu____6459 = (
+
+let uu____6468 = (enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr))
+in ((FStar_Syntax_Const.or_lid), (uu____6468)))
+in (
+
+let uu____6481 = (
+
+let uu____6491 = (
+
+let uu____6501 = (
+
+let uu____6510 = (enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff))
+in ((FStar_Syntax_Const.iff_lid), (uu____6510)))
+in (
+
+let uu____6523 = (
+
+let uu____6533 = (
+
+let uu____6543 = (
+
+let uu____6552 = (enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot))
+in ((FStar_Syntax_Const.not_lid), (uu____6552)))
+in (uu____6543)::(((FStar_Syntax_Const.eq2_lid), (eq_op)))::(((FStar_Syntax_Const.eq3_lid), (eq_op)))::(((FStar_Syntax_Const.true_lid), ((const_op FStar_SMTEncoding_Term.mkTrue))))::(((FStar_Syntax_Const.false_lid), ((const_op FStar_SMTEncoding_Term.mkFalse))))::[])
+in (((FStar_Syntax_Const.ite_lid), (mk_ite)))::uu____6533)
+in (uu____6501)::uu____6523))
+in (((FStar_Syntax_Const.imp_lid), (mk_imp1)))::uu____6491)
+in (uu____6459)::uu____6481))
+in (uu____6427)::uu____6449))
+in (
+
+let rec fallback = (fun phi1 -> (match (phi1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_meta (phi', FStar_Syntax_Syntax.Meta_labeled (msg, r, b)) -> begin
+(
+
+let uu____6714 = (encode_formula phi' env)
+in (match (uu____6714) with
+| (phi2, decls) -> begin
+(
+
+let uu____6721 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.Labeled (((phi2), (msg), (r)))) r)
+in ((uu____6721), (decls)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (uu____6722) -> begin
+(
+
+let uu____6727 = (FStar_Syntax_Util.unmeta phi1)
+in (encode_formula uu____6727 env))
+end
+| FStar_Syntax_Syntax.Tm_match (e, pats) -> begin
+(
+
+let uu____6756 = (encode_match e pats FStar_SMTEncoding_Util.mkFalse env encode_formula)
+in (match (uu____6756) with
+| (t, decls) -> begin
+((t), (decls))
+end))
+end
+| FStar_Syntax_Syntax.Tm_let ((false, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inl (x); FStar_Syntax_Syntax.lbunivs = uu____6764; FStar_Syntax_Syntax.lbtyp = t1; FStar_Syntax_Syntax.lbeff = uu____6766; FStar_Syntax_Syntax.lbdef = e1})::[]), e2) -> begin
+(
+
+let uu____6782 = (encode_let x t1 e1 e2 env encode_formula)
+in (match (uu____6782) with
+| (t, decls) -> begin
+((t), (decls))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let head2 = (FStar_Syntax_Util.un_uinst head1)
+in (match (((head2.FStar_Syntax_Syntax.n), (args))) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____6814)::((x, uu____6816))::((t, uu____6818))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.has_type_lid) -> begin
+(
+
+let uu____6852 = (encode_term x env)
+in (match (uu____6852) with
+| (x1, decls) -> begin
+(
+
+let uu____6859 = (encode_term t env)
+in (match (uu____6859) with
+| (t1, decls') -> begin
+(
+
+let uu____6866 = (FStar_SMTEncoding_Term.mk_HasType x1 t1)
+in ((uu____6866), ((FStar_List.append decls decls'))))
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((r, uu____6870))::((msg, uu____6872))::((phi2, uu____6874))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.labeled_lid) -> begin
+(
+
+let uu____6908 = (
+
+let uu____6911 = (
+
+let uu____6912 = (FStar_Syntax_Subst.compress r)
+in uu____6912.FStar_Syntax_Syntax.n)
+in (
+
+let uu____6915 = (
+
+let uu____6916 = (FStar_Syntax_Subst.compress msg)
+in uu____6916.FStar_Syntax_Syntax.n)
+in ((uu____6911), (uu____6915))))
+in (match (uu____6908) with
+| (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range (r1)), FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (s, uu____6923))) -> begin
+(
+
+let phi3 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((phi2), (FStar_Syntax_Syntax.Meta_labeled ((((FStar_Util.string_of_unicode s)), (r1), (false)))))))) None r1)
+in (fallback phi3))
+end
+| uu____6939 -> begin
+(fallback phi2)
+end))
+end
+| uu____6942 when (head_redex env head2) -> begin
+(
+
+let uu____6950 = (whnf env phi1)
+in (encode_formula uu____6950 env))
+end
+| uu____6951 -> begin
+(
+
+let uu____6959 = (encode_term phi1 env)
+in (match (uu____6959) with
+| (tt, decls) -> begin
+(
+
+let uu____6966 = (FStar_SMTEncoding_Term.mk_Valid (
+
+let uu___150_6967 = tt
+in {FStar_SMTEncoding_Term.tm = uu___150_6967.FStar_SMTEncoding_Term.tm; FStar_SMTEncoding_Term.freevars = uu___150_6967.FStar_SMTEncoding_Term.freevars; FStar_SMTEncoding_Term.rng = phi1.FStar_Syntax_Syntax.pos}))
+in ((uu____6966), (decls)))
+end))
+end))
+end
+| uu____6970 -> begin
+(
+
+let uu____6971 = (encode_term phi1 env)
+in (match (uu____6971) with
+| (tt, decls) -> begin
+(
+
+let uu____6978 = (FStar_SMTEncoding_Term.mk_Valid (
+
+let uu___151_6979 = tt
+in {FStar_SMTEncoding_Term.tm = uu___151_6979.FStar_SMTEncoding_Term.tm; FStar_SMTEncoding_Term.freevars = uu___151_6979.FStar_SMTEncoding_Term.freevars; FStar_SMTEncoding_Term.rng = phi1.FStar_Syntax_Syntax.pos}))
+in ((uu____6978), (decls)))
+end))
+end))
+in (
+
+let encode_q_body = (fun env1 bs ps body -> (
+
+let uu____7006 = (encode_binders None bs env1)
+in (match (uu____7006) with
+| (vars, guards, env2, decls, uu____7028) -> begin
+(
+
+let uu____7035 = (
+
+let uu____7042 = (FStar_All.pipe_right ps (FStar_List.map (fun p -> (
+
+let uu____7065 = (
+
+let uu____7070 = (FStar_All.pipe_right p (FStar_List.map (fun uu____7084 -> (match (uu____7084) with
+| (t, uu____7090) -> begin
+(encode_term t (
+
+let uu___152_7091 = env2
+in {bindings = uu___152_7091.bindings; depth = uu___152_7091.depth; tcenv = uu___152_7091.tcenv; warn = uu___152_7091.warn; cache = uu___152_7091.cache; nolabels = uu___152_7091.nolabels; use_zfuel_name = true; encode_non_total_function_typ = uu___152_7091.encode_non_total_function_typ}))
+end))))
+in (FStar_All.pipe_right uu____7070 FStar_List.unzip))
+in (match (uu____7065) with
+| (p1, decls1) -> begin
+((p1), ((FStar_List.flatten decls1)))
+end)))))
+in (FStar_All.pipe_right uu____7042 FStar_List.unzip))
+in (match (uu____7035) with
+| (pats, decls') -> begin
+(
+
+let uu____7143 = (encode_formula body env2)
+in (match (uu____7143) with
+| (body1, decls'') -> begin
+(
+
+let guards1 = (match (pats) with
+| (({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var (gf), (p)::[]); FStar_SMTEncoding_Term.freevars = uu____7162; FStar_SMTEncoding_Term.rng = uu____7163})::[])::[] when ((FStar_Ident.text_of_lid FStar_Syntax_Const.guard_free) = gf) -> begin
+[]
+end
+| uu____7171 -> begin
+guards
+end)
+in (
+
+let uu____7174 = (FStar_SMTEncoding_Util.mk_and_l guards1)
+in ((vars), (pats), (uu____7174), (body1), ((FStar_List.append decls (FStar_List.append (FStar_List.flatten decls') decls''))))))
+end))
+end))
+end)))
+in ((debug1 phi);
+(
+
+let phi1 = (FStar_Syntax_Util.unascribe phi)
+in (
+
+let check_pattern_vars = (fun vars pats -> (
+
+let pats1 = (FStar_All.pipe_right pats (FStar_List.map (fun uu____7208 -> (match (uu____7208) with
+| (x, uu____7212) -> begin
+(FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv x)
+end))))
+in (match (pats1) with
+| [] -> begin
+()
+end
+| (hd1)::tl1 -> begin
+(
+
+let pat_vars = (
+
+let uu____7218 = (FStar_Syntax_Free.names hd1)
+in (FStar_List.fold_left (fun out x -> (
+
+let uu____7224 = (FStar_Syntax_Free.names x)
+in (FStar_Util.set_union out uu____7224))) uu____7218 tl1))
+in (
+
+let uu____7226 = (FStar_All.pipe_right vars (FStar_Util.find_opt (fun uu____7238 -> (match (uu____7238) with
+| (b, uu____7242) -> begin
+(
+
+let uu____7243 = (FStar_Util.set_mem b pat_vars)
+in (not (uu____7243)))
+end))))
+in (match (uu____7226) with
+| None -> begin
+()
+end
+| Some (x, uu____7247) -> begin
+(
+
+let pos = (FStar_List.fold_left (fun out t -> (FStar_Range.union_ranges out t.FStar_Syntax_Syntax.pos)) hd1.FStar_Syntax_Syntax.pos tl1)
+in (
+
+let uu____7257 = (
+
+let uu____7258 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format1 "SMT pattern misses at least one bound variable: %s" uu____7258))
+in (FStar_Errors.warn pos uu____7257)))
+end)))
+end)))
+in (
+
+let uu____7259 = (FStar_Syntax_Util.destruct_typ_as_formula phi1)
+in (match (uu____7259) with
+| None -> begin
+(fallback phi1)
+end
+| Some (FStar_Syntax_Util.BaseConn (op, arms)) -> begin
+(
+
+let uu____7265 = (FStar_All.pipe_right connectives (FStar_List.tryFind (fun uu____7301 -> (match (uu____7301) with
+| (l, uu____7311) -> begin
+(FStar_Ident.lid_equals op l)
+end))))
+in (match (uu____7265) with
+| None -> begin
+(fallback phi1)
+end
+| Some (uu____7334, f) -> begin
+(f phi1.FStar_Syntax_Syntax.pos arms)
+end))
+end
+| Some (FStar_Syntax_Util.QAll (vars, pats, body)) -> begin
+((FStar_All.pipe_right pats (FStar_List.iter (check_pattern_vars vars)));
+(
+
+let uu____7363 = (encode_q_body env vars pats body)
+in (match (uu____7363) with
+| (vars1, pats1, guard, body1, decls) -> begin
+(
+
+let tm = (
+
+let uu____7389 = (
+
+let uu____7395 = (FStar_SMTEncoding_Util.mkImp ((guard), (body1)))
+in ((pats1), (vars1), (uu____7395)))
+in (FStar_SMTEncoding_Term.mkForall uu____7389 phi1.FStar_Syntax_Syntax.pos))
+in ((tm), (decls)))
+end));
+)
+end
+| Some (FStar_Syntax_Util.QEx (vars, pats, body)) -> begin
+((FStar_All.pipe_right pats (FStar_List.iter (check_pattern_vars vars)));
+(
+
+let uu____7407 = (encode_q_body env vars pats body)
+in (match (uu____7407) with
+| (vars1, pats1, guard, body1, decls) -> begin
+(
+
+let uu____7432 = (
+
+let uu____7433 = (
+
+let uu____7439 = (FStar_SMTEncoding_Util.mkAnd ((guard), (body1)))
+in ((pats1), (vars1), (uu____7439)))
+in (FStar_SMTEncoding_Term.mkExists uu____7433 phi1.FStar_Syntax_Syntax.pos))
+in ((uu____7432), (decls)))
+end));
+)
+end))));
+)))))))))))))))
+
 type prims_t =
-  {
-  mk:
-    FStar_Ident.lident ->
-      Prims.string ->
-        (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.decl Prims.list);
-  is: FStar_Ident.lident -> Prims.bool;}
-let prims: prims_t =
-  let uu____7488 = fresh_fvar "a" FStar_SMTEncoding_Term.Term_sort in
-  match uu____7488 with
-  | (asym,a) ->
-      let uu____7493 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
-      (match uu____7493 with
-       | (xsym,x) ->
-           let uu____7498 = fresh_fvar "y" FStar_SMTEncoding_Term.Term_sort in
-           (match uu____7498 with
-            | (ysym,y) ->
-                let quant vars body x1 =
-                  let xname_decl =
-                    let uu____7528 =
-                      let uu____7534 =
-                        FStar_All.pipe_right vars (FStar_List.map Prims.snd) in
-                      (x1, uu____7534, FStar_SMTEncoding_Term.Term_sort,
-                        None) in
-                    FStar_SMTEncoding_Term.DeclFun uu____7528 in
-                  let xtok = Prims.strcat x1 "@tok" in
-                  let xtok_decl =
-                    FStar_SMTEncoding_Term.DeclFun
-                      (xtok, [], FStar_SMTEncoding_Term.Term_sort, None) in
-                  let xapp =
-                    let uu____7549 =
-                      let uu____7553 =
-                        FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars in
-                      (x1, uu____7553) in
-                    FStar_SMTEncoding_Util.mkApp uu____7549 in
-                  let xtok1 = FStar_SMTEncoding_Util.mkApp (xtok, []) in
-                  let xtok_app = mk_Apply xtok1 vars in
-                  let uu____7561 =
-                    let uu____7563 =
-                      let uu____7565 =
-                        let uu____7567 =
-                          let uu____7568 =
-                            let uu____7573 =
-                              let uu____7574 =
-                                let uu____7580 =
-                                  FStar_SMTEncoding_Util.mkEq (xapp, body) in
-                                ([[xapp]], vars, uu____7580) in
-                              FStar_SMTEncoding_Util.mkForall uu____7574 in
-                            (uu____7573, None,
-                              (Some (Prims.strcat "primitive_" x1))) in
-                          FStar_SMTEncoding_Term.Assume uu____7568 in
-                        let uu____7590 =
-                          let uu____7592 =
-                            let uu____7593 =
-                              let uu____7598 =
-                                let uu____7599 =
-                                  let uu____7605 =
-                                    FStar_SMTEncoding_Util.mkEq
-                                      (xtok_app, xapp) in
-                                  ([[xtok_app]], vars, uu____7605) in
-                                FStar_SMTEncoding_Util.mkForall uu____7599 in
-                              (uu____7598,
-                                (Some "Name-token correspondence"),
-                                (Some
-                                   (Prims.strcat "token_correspondence_" x1))) in
-                            FStar_SMTEncoding_Term.Assume uu____7593 in
-                          [uu____7592] in
-                        uu____7567 :: uu____7590 in
-                      xtok_decl :: uu____7565 in
-                    xname_decl :: uu____7563 in
-                  (xtok1, uu____7561) in
-                let axy =
-                  [(asym, FStar_SMTEncoding_Term.Term_sort);
-                  (xsym, FStar_SMTEncoding_Term.Term_sort);
-                  (ysym, FStar_SMTEncoding_Term.Term_sort)] in
-                let xy =
-                  [(xsym, FStar_SMTEncoding_Term.Term_sort);
-                  (ysym, FStar_SMTEncoding_Term.Term_sort)] in
-                let qx = [(xsym, FStar_SMTEncoding_Term.Term_sort)] in
-                let prims1 =
-                  let uu____7655 =
-                    let uu____7663 =
-                      let uu____7669 =
-                        let uu____7670 = FStar_SMTEncoding_Util.mkEq (x, y) in
-                        FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                          uu____7670 in
-                      quant axy uu____7669 in
-                    (FStar_Syntax_Const.op_Eq, uu____7663) in
-                  let uu____7676 =
-                    let uu____7685 =
-                      let uu____7693 =
-                        let uu____7699 =
-                          let uu____7700 =
-                            let uu____7701 =
-                              FStar_SMTEncoding_Util.mkEq (x, y) in
-                            FStar_SMTEncoding_Util.mkNot uu____7701 in
-                          FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                            uu____7700 in
-                        quant axy uu____7699 in
-                      (FStar_Syntax_Const.op_notEq, uu____7693) in
-                    let uu____7707 =
-                      let uu____7716 =
-                        let uu____7724 =
-                          let uu____7730 =
-                            let uu____7731 =
-                              let uu____7732 =
-                                let uu____7735 =
-                                  FStar_SMTEncoding_Term.unboxInt x in
-                                let uu____7736 =
-                                  FStar_SMTEncoding_Term.unboxInt y in
-                                (uu____7735, uu____7736) in
-                              FStar_SMTEncoding_Util.mkLT uu____7732 in
-                            FStar_All.pipe_left
-                              FStar_SMTEncoding_Term.boxBool uu____7731 in
-                          quant xy uu____7730 in
-                        (FStar_Syntax_Const.op_LT, uu____7724) in
-                      let uu____7742 =
-                        let uu____7751 =
-                          let uu____7759 =
-                            let uu____7765 =
-                              let uu____7766 =
-                                let uu____7767 =
-                                  let uu____7770 =
-                                    FStar_SMTEncoding_Term.unboxInt x in
-                                  let uu____7771 =
-                                    FStar_SMTEncoding_Term.unboxInt y in
-                                  (uu____7770, uu____7771) in
-                                FStar_SMTEncoding_Util.mkLTE uu____7767 in
-                              FStar_All.pipe_left
-                                FStar_SMTEncoding_Term.boxBool uu____7766 in
-                            quant xy uu____7765 in
-                          (FStar_Syntax_Const.op_LTE, uu____7759) in
-                        let uu____7777 =
-                          let uu____7786 =
-                            let uu____7794 =
-                              let uu____7800 =
-                                let uu____7801 =
-                                  let uu____7802 =
-                                    let uu____7805 =
-                                      FStar_SMTEncoding_Term.unboxInt x in
-                                    let uu____7806 =
-                                      FStar_SMTEncoding_Term.unboxInt y in
-                                    (uu____7805, uu____7806) in
-                                  FStar_SMTEncoding_Util.mkGT uu____7802 in
-                                FStar_All.pipe_left
-                                  FStar_SMTEncoding_Term.boxBool uu____7801 in
-                              quant xy uu____7800 in
-                            (FStar_Syntax_Const.op_GT, uu____7794) in
-                          let uu____7812 =
-                            let uu____7821 =
-                              let uu____7829 =
-                                let uu____7835 =
-                                  let uu____7836 =
-                                    let uu____7837 =
-                                      let uu____7840 =
-                                        FStar_SMTEncoding_Term.unboxInt x in
-                                      let uu____7841 =
-                                        FStar_SMTEncoding_Term.unboxInt y in
-                                      (uu____7840, uu____7841) in
-                                    FStar_SMTEncoding_Util.mkGTE uu____7837 in
-                                  FStar_All.pipe_left
-                                    FStar_SMTEncoding_Term.boxBool uu____7836 in
-                                quant xy uu____7835 in
-                              (FStar_Syntax_Const.op_GTE, uu____7829) in
-                            let uu____7847 =
-                              let uu____7856 =
-                                let uu____7864 =
-                                  let uu____7870 =
-                                    let uu____7871 =
-                                      let uu____7872 =
-                                        let uu____7875 =
-                                          FStar_SMTEncoding_Term.unboxInt x in
-                                        let uu____7876 =
-                                          FStar_SMTEncoding_Term.unboxInt y in
-                                        (uu____7875, uu____7876) in
-                                      FStar_SMTEncoding_Util.mkSub uu____7872 in
-                                    FStar_All.pipe_left
-                                      FStar_SMTEncoding_Term.boxInt
-                                      uu____7871 in
-                                  quant xy uu____7870 in
-                                (FStar_Syntax_Const.op_Subtraction,
-                                  uu____7864) in
-                              let uu____7882 =
-                                let uu____7891 =
-                                  let uu____7899 =
-                                    let uu____7905 =
-                                      let uu____7906 =
-                                        let uu____7907 =
-                                          FStar_SMTEncoding_Term.unboxInt x in
-                                        FStar_SMTEncoding_Util.mkMinus
-                                          uu____7907 in
-                                      FStar_All.pipe_left
-                                        FStar_SMTEncoding_Term.boxInt
-                                        uu____7906 in
-                                    quant qx uu____7905 in
-                                  (FStar_Syntax_Const.op_Minus, uu____7899) in
-                                let uu____7913 =
-                                  let uu____7922 =
-                                    let uu____7930 =
-                                      let uu____7936 =
-                                        let uu____7937 =
-                                          let uu____7938 =
-                                            let uu____7941 =
-                                              FStar_SMTEncoding_Term.unboxInt
-                                                x in
-                                            let uu____7942 =
-                                              FStar_SMTEncoding_Term.unboxInt
-                                                y in
-                                            (uu____7941, uu____7942) in
-                                          FStar_SMTEncoding_Util.mkAdd
-                                            uu____7938 in
-                                        FStar_All.pipe_left
-                                          FStar_SMTEncoding_Term.boxInt
-                                          uu____7937 in
-                                      quant xy uu____7936 in
-                                    (FStar_Syntax_Const.op_Addition,
-                                      uu____7930) in
-                                  let uu____7948 =
-                                    let uu____7957 =
-                                      let uu____7965 =
-                                        let uu____7971 =
-                                          let uu____7972 =
-                                            let uu____7973 =
-                                              let uu____7976 =
-                                                FStar_SMTEncoding_Term.unboxInt
-                                                  x in
-                                              let uu____7977 =
-                                                FStar_SMTEncoding_Term.unboxInt
-                                                  y in
-                                              (uu____7976, uu____7977) in
-                                            FStar_SMTEncoding_Util.mkMul
-                                              uu____7973 in
-                                          FStar_All.pipe_left
-                                            FStar_SMTEncoding_Term.boxInt
-                                            uu____7972 in
-                                        quant xy uu____7971 in
-                                      (FStar_Syntax_Const.op_Multiply,
-                                        uu____7965) in
-                                    let uu____7983 =
-                                      let uu____7992 =
-                                        let uu____8000 =
-                                          let uu____8006 =
-                                            let uu____8007 =
-                                              let uu____8008 =
-                                                let uu____8011 =
-                                                  FStar_SMTEncoding_Term.unboxInt
-                                                    x in
-                                                let uu____8012 =
-                                                  FStar_SMTEncoding_Term.unboxInt
-                                                    y in
-                                                (uu____8011, uu____8012) in
-                                              FStar_SMTEncoding_Util.mkDiv
-                                                uu____8008 in
-                                            FStar_All.pipe_left
-                                              FStar_SMTEncoding_Term.boxInt
-                                              uu____8007 in
-                                          quant xy uu____8006 in
-                                        (FStar_Syntax_Const.op_Division,
-                                          uu____8000) in
-                                      let uu____8018 =
-                                        let uu____8027 =
-                                          let uu____8035 =
-                                            let uu____8041 =
-                                              let uu____8042 =
-                                                let uu____8043 =
-                                                  let uu____8046 =
-                                                    FStar_SMTEncoding_Term.unboxInt
-                                                      x in
-                                                  let uu____8047 =
-                                                    FStar_SMTEncoding_Term.unboxInt
-                                                      y in
-                                                  (uu____8046, uu____8047) in
-                                                FStar_SMTEncoding_Util.mkMod
-                                                  uu____8043 in
-                                              FStar_All.pipe_left
-                                                FStar_SMTEncoding_Term.boxInt
-                                                uu____8042 in
-                                            quant xy uu____8041 in
-                                          (FStar_Syntax_Const.op_Modulus,
-                                            uu____8035) in
-                                        let uu____8053 =
-                                          let uu____8062 =
-                                            let uu____8070 =
-                                              let uu____8076 =
-                                                let uu____8077 =
-                                                  let uu____8078 =
-                                                    let uu____8081 =
-                                                      FStar_SMTEncoding_Term.unboxBool
-                                                        x in
-                                                    let uu____8082 =
-                                                      FStar_SMTEncoding_Term.unboxBool
-                                                        y in
-                                                    (uu____8081, uu____8082) in
-                                                  FStar_SMTEncoding_Util.mkAnd
-                                                    uu____8078 in
-                                                FStar_All.pipe_left
-                                                  FStar_SMTEncoding_Term.boxBool
-                                                  uu____8077 in
-                                              quant xy uu____8076 in
-                                            (FStar_Syntax_Const.op_And,
-                                              uu____8070) in
-                                          let uu____8088 =
-                                            let uu____8097 =
-                                              let uu____8105 =
-                                                let uu____8111 =
-                                                  let uu____8112 =
-                                                    let uu____8113 =
-                                                      let uu____8116 =
-                                                        FStar_SMTEncoding_Term.unboxBool
-                                                          x in
-                                                      let uu____8117 =
-                                                        FStar_SMTEncoding_Term.unboxBool
-                                                          y in
-                                                      (uu____8116,
-                                                        uu____8117) in
-                                                    FStar_SMTEncoding_Util.mkOr
-                                                      uu____8113 in
-                                                  FStar_All.pipe_left
-                                                    FStar_SMTEncoding_Term.boxBool
-                                                    uu____8112 in
-                                                quant xy uu____8111 in
-                                              (FStar_Syntax_Const.op_Or,
-                                                uu____8105) in
-                                            let uu____8123 =
-                                              let uu____8132 =
-                                                let uu____8140 =
-                                                  let uu____8146 =
-                                                    let uu____8147 =
-                                                      let uu____8148 =
-                                                        FStar_SMTEncoding_Term.unboxBool
-                                                          x in
-                                                      FStar_SMTEncoding_Util.mkNot
-                                                        uu____8148 in
-                                                    FStar_All.pipe_left
-                                                      FStar_SMTEncoding_Term.boxBool
-                                                      uu____8147 in
-                                                  quant qx uu____8146 in
-                                                (FStar_Syntax_Const.op_Negation,
-                                                  uu____8140) in
-                                              [uu____8132] in
-                                            uu____8097 :: uu____8123 in
-                                          uu____8062 :: uu____8088 in
-                                        uu____8027 :: uu____8053 in
-                                      uu____7992 :: uu____8018 in
-                                    uu____7957 :: uu____7983 in
-                                  uu____7922 :: uu____7948 in
-                                uu____7891 :: uu____7913 in
-                              uu____7856 :: uu____7882 in
-                            uu____7821 :: uu____7847 in
-                          uu____7786 :: uu____7812 in
-                        uu____7751 :: uu____7777 in
-                      uu____7716 :: uu____7742 in
-                    uu____7685 :: uu____7707 in
-                  uu____7655 :: uu____7676 in
-                let mk1 l v1 =
-                  let uu____8276 =
-                    let uu____8281 =
-                      FStar_All.pipe_right prims1
-                        (FStar_List.find
-                           (fun uu____8313  ->
-                              match uu____8313 with
-                              | (l',uu____8322) ->
-                                  FStar_Ident.lid_equals l l')) in
-                    FStar_All.pipe_right uu____8281
-                      (FStar_Option.map
-                         (fun uu____8355  ->
-                            match uu____8355 with | (uu____8366,b) -> b v1)) in
-                  FStar_All.pipe_right uu____8276 FStar_Option.get in
-                let is l =
-                  FStar_All.pipe_right prims1
-                    (FStar_Util.for_some
-                       (fun uu____8407  ->
-                          match uu____8407 with
-                          | (l',uu____8416) -> FStar_Ident.lid_equals l l')) in
-                { mk = mk1; is }))
-let pretype_axiom:
-  FStar_SMTEncoding_Term.term ->
-    (Prims.string* FStar_SMTEncoding_Term.sort) Prims.list ->
-      FStar_SMTEncoding_Term.decl
-  =
-  fun tapp  ->
-    fun vars  ->
-      let uu____8439 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
-      match uu____8439 with
-      | (xxsym,xx) ->
-          let uu____8444 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
-          (match uu____8444 with
-           | (ffsym,ff) ->
-               let xx_has_type =
-                 FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp in
-               let tapp_hash = FStar_SMTEncoding_Term.hash_of_term tapp in
-               let uu____8451 =
-                 let uu____8456 =
-                   let uu____8457 =
-                     let uu____8463 =
-                       let uu____8464 =
-                         let uu____8467 =
-                           let uu____8468 =
-                             let uu____8471 =
-                               FStar_SMTEncoding_Util.mkApp ("PreType", [xx]) in
-                             (tapp, uu____8471) in
-                           FStar_SMTEncoding_Util.mkEq uu____8468 in
-                         (xx_has_type, uu____8467) in
-                       FStar_SMTEncoding_Util.mkImp uu____8464 in
-                     ([[xx_has_type]],
-                       ((xxsym, FStar_SMTEncoding_Term.Term_sort) ::
-                       (ffsym, FStar_SMTEncoding_Term.Fuel_sort) :: vars),
-                       uu____8463) in
-                   FStar_SMTEncoding_Util.mkForall uu____8457 in
-                 let uu____8484 =
-                   let uu____8486 =
-                     let uu____8487 =
-                       let uu____8488 = FStar_Util.digest_of_string tapp_hash in
-                       Prims.strcat "pretyping_" uu____8488 in
-                     varops.mk_unique uu____8487 in
-                   Some uu____8486 in
-                 (uu____8456, (Some "pretyping"), uu____8484) in
-               FStar_SMTEncoding_Term.Assume uu____8451)
-let primitive_type_axioms:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident ->
-      Prims.string ->
-        FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.decl Prims.list
-  =
-  let xx = ("x", FStar_SMTEncoding_Term.Term_sort) in
-  let x = FStar_SMTEncoding_Util.mkFreeV xx in
-  let yy = ("y", FStar_SMTEncoding_Term.Term_sort) in
-  let y = FStar_SMTEncoding_Util.mkFreeV yy in
-  let mk_unit env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
-    let uu____8519 =
-      let uu____8520 =
-        let uu____8525 =
-          FStar_SMTEncoding_Term.mk_HasType
-            FStar_SMTEncoding_Term.mk_Term_unit tt in
-        (uu____8525, (Some "unit typing"), (Some "unit_typing")) in
-      FStar_SMTEncoding_Term.Assume uu____8520 in
-    let uu____8528 =
-      let uu____8530 =
-        let uu____8531 =
-          let uu____8536 =
-            let uu____8537 =
-              let uu____8543 =
-                let uu____8544 =
-                  let uu____8547 =
-                    FStar_SMTEncoding_Util.mkEq
-                      (x, FStar_SMTEncoding_Term.mk_Term_unit) in
-                  (typing_pred, uu____8547) in
-                FStar_SMTEncoding_Util.mkImp uu____8544 in
-              ([[typing_pred]], [xx], uu____8543) in
-            mkForall_fuel uu____8537 in
-          (uu____8536, (Some "unit inversion"), (Some "unit_inversion")) in
-        FStar_SMTEncoding_Term.Assume uu____8531 in
-      [uu____8530] in
-    uu____8519 :: uu____8528 in
-  let mk_bool env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
-    let bb = ("b", FStar_SMTEncoding_Term.Bool_sort) in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let uu____8576 =
-      let uu____8577 =
-        let uu____8582 =
-          let uu____8583 =
-            let uu____8589 =
-              let uu____8592 =
-                let uu____8594 = FStar_SMTEncoding_Term.boxBool b in
-                [uu____8594] in
-              [uu____8592] in
-            let uu____8597 =
-              let uu____8598 = FStar_SMTEncoding_Term.boxBool b in
-              FStar_SMTEncoding_Term.mk_HasType uu____8598 tt in
-            (uu____8589, [bb], uu____8597) in
-          FStar_SMTEncoding_Util.mkForall uu____8583 in
-        (uu____8582, (Some "bool typing"), (Some "bool_typing")) in
-      FStar_SMTEncoding_Term.Assume uu____8577 in
-    let uu____8610 =
-      let uu____8612 =
-        let uu____8613 =
-          let uu____8618 =
-            let uu____8619 =
-              let uu____8625 =
-                let uu____8626 =
-                  let uu____8629 =
-                    FStar_SMTEncoding_Term.mk_tester "BoxBool" x in
-                  (typing_pred, uu____8629) in
-                FStar_SMTEncoding_Util.mkImp uu____8626 in
-              ([[typing_pred]], [xx], uu____8625) in
-            mkForall_fuel uu____8619 in
-          (uu____8618, (Some "bool inversion"), (Some "bool_inversion")) in
-        FStar_SMTEncoding_Term.Assume uu____8613 in
-      [uu____8612] in
-    uu____8576 :: uu____8610 in
-  let mk_int env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
-    let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt in
-    let aa = ("a", FStar_SMTEncoding_Term.Int_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let bb = ("b", FStar_SMTEncoding_Term.Int_sort) in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let precedes =
-      let uu____8664 =
-        let uu____8665 =
-          let uu____8669 =
-            let uu____8671 =
-              let uu____8673 =
-                let uu____8675 = FStar_SMTEncoding_Term.boxInt a in
-                let uu____8676 =
-                  let uu____8678 = FStar_SMTEncoding_Term.boxInt b in
-                  [uu____8678] in
-                uu____8675 :: uu____8676 in
-              tt :: uu____8673 in
-            tt :: uu____8671 in
-          ("Prims.Precedes", uu____8669) in
-        FStar_SMTEncoding_Util.mkApp uu____8665 in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____8664 in
-    let precedes_y_x =
-      let uu____8681 = FStar_SMTEncoding_Util.mkApp ("Precedes", [y; x]) in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____8681 in
-    let uu____8683 =
-      let uu____8684 =
-        let uu____8689 =
-          let uu____8690 =
-            let uu____8696 =
-              let uu____8699 =
-                let uu____8701 = FStar_SMTEncoding_Term.boxInt b in
-                [uu____8701] in
-              [uu____8699] in
-            let uu____8704 =
-              let uu____8705 = FStar_SMTEncoding_Term.boxInt b in
-              FStar_SMTEncoding_Term.mk_HasType uu____8705 tt in
-            (uu____8696, [bb], uu____8704) in
-          FStar_SMTEncoding_Util.mkForall uu____8690 in
-        (uu____8689, (Some "int typing"), (Some "int_typing")) in
-      FStar_SMTEncoding_Term.Assume uu____8684 in
-    let uu____8717 =
-      let uu____8719 =
-        let uu____8720 =
-          let uu____8725 =
-            let uu____8726 =
-              let uu____8732 =
-                let uu____8733 =
-                  let uu____8736 =
-                    FStar_SMTEncoding_Term.mk_tester "BoxInt" x in
-                  (typing_pred, uu____8736) in
-                FStar_SMTEncoding_Util.mkImp uu____8733 in
-              ([[typing_pred]], [xx], uu____8732) in
-            mkForall_fuel uu____8726 in
-          (uu____8725, (Some "int inversion"), (Some "int_inversion")) in
-        FStar_SMTEncoding_Term.Assume uu____8720 in
-      let uu____8750 =
-        let uu____8752 =
-          let uu____8753 =
-            let uu____8758 =
-              let uu____8759 =
-                let uu____8765 =
-                  let uu____8766 =
-                    let uu____8769 =
-                      let uu____8770 =
-                        let uu____8772 =
-                          let uu____8774 =
-                            let uu____8776 =
-                              let uu____8777 =
-                                let uu____8780 =
-                                  FStar_SMTEncoding_Term.unboxInt x in
-                                let uu____8781 =
-                                  FStar_SMTEncoding_Util.mkInteger'
-                                    (Prims.parse_int "0") in
-                                (uu____8780, uu____8781) in
-                              FStar_SMTEncoding_Util.mkGT uu____8777 in
-                            let uu____8782 =
-                              let uu____8784 =
-                                let uu____8785 =
-                                  let uu____8788 =
-                                    FStar_SMTEncoding_Term.unboxInt y in
-                                  let uu____8789 =
-                                    FStar_SMTEncoding_Util.mkInteger'
-                                      (Prims.parse_int "0") in
-                                  (uu____8788, uu____8789) in
-                                FStar_SMTEncoding_Util.mkGTE uu____8785 in
-                              let uu____8790 =
-                                let uu____8792 =
-                                  let uu____8793 =
-                                    let uu____8796 =
-                                      FStar_SMTEncoding_Term.unboxInt y in
-                                    let uu____8797 =
-                                      FStar_SMTEncoding_Term.unboxInt x in
-                                    (uu____8796, uu____8797) in
-                                  FStar_SMTEncoding_Util.mkLT uu____8793 in
-                                [uu____8792] in
-                              uu____8784 :: uu____8790 in
-                            uu____8776 :: uu____8782 in
-                          typing_pred_y :: uu____8774 in
-                        typing_pred :: uu____8772 in
-                      FStar_SMTEncoding_Util.mk_and_l uu____8770 in
-                    (uu____8769, precedes_y_x) in
-                  FStar_SMTEncoding_Util.mkImp uu____8766 in
-                ([[typing_pred; typing_pred_y; precedes_y_x]], [xx; yy],
-                  uu____8765) in
-              mkForall_fuel uu____8759 in
-            (uu____8758, (Some "well-founded ordering on nat (alt)"),
-              (Some "well-founded-ordering-on-nat")) in
-          FStar_SMTEncoding_Term.Assume uu____8753 in
-        [uu____8752] in
-      uu____8719 :: uu____8750 in
-    uu____8683 :: uu____8717 in
-  let mk_str env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
-    let bb = ("b", FStar_SMTEncoding_Term.String_sort) in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let uu____8828 =
-      let uu____8829 =
-        let uu____8834 =
-          let uu____8835 =
-            let uu____8841 =
-              let uu____8844 =
-                let uu____8846 = FStar_SMTEncoding_Term.boxString b in
-                [uu____8846] in
-              [uu____8844] in
-            let uu____8849 =
-              let uu____8850 = FStar_SMTEncoding_Term.boxString b in
-              FStar_SMTEncoding_Term.mk_HasType uu____8850 tt in
-            (uu____8841, [bb], uu____8849) in
-          FStar_SMTEncoding_Util.mkForall uu____8835 in
-        (uu____8834, (Some "string typing"), (Some "string_typing")) in
-      FStar_SMTEncoding_Term.Assume uu____8829 in
-    let uu____8862 =
-      let uu____8864 =
-        let uu____8865 =
-          let uu____8870 =
-            let uu____8871 =
-              let uu____8877 =
-                let uu____8878 =
-                  let uu____8881 =
-                    FStar_SMTEncoding_Term.mk_tester "BoxString" x in
-                  (typing_pred, uu____8881) in
-                FStar_SMTEncoding_Util.mkImp uu____8878 in
-              ([[typing_pred]], [xx], uu____8877) in
-            mkForall_fuel uu____8871 in
-          (uu____8870, (Some "string inversion"), (Some "string_inversion")) in
-        FStar_SMTEncoding_Term.Assume uu____8865 in
-      [uu____8864] in
-    uu____8828 :: uu____8862 in
-  let mk_ref1 env reft_name uu____8904 =
-    let r = ("r", FStar_SMTEncoding_Term.Ref_sort) in
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let refa =
-      let uu____8915 =
-        let uu____8919 =
-          let uu____8921 = FStar_SMTEncoding_Util.mkFreeV aa in [uu____8921] in
-        (reft_name, uu____8919) in
-      FStar_SMTEncoding_Util.mkApp uu____8915 in
-    let refb =
-      let uu____8924 =
-        let uu____8928 =
-          let uu____8930 = FStar_SMTEncoding_Util.mkFreeV bb in [uu____8930] in
-        (reft_name, uu____8928) in
-      FStar_SMTEncoding_Util.mkApp uu____8924 in
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x refa in
-    let typing_pred_b = FStar_SMTEncoding_Term.mk_HasType x refb in
-    let uu____8934 =
-      let uu____8935 =
-        let uu____8940 =
-          let uu____8941 =
-            let uu____8947 =
-              let uu____8948 =
-                let uu____8951 = FStar_SMTEncoding_Term.mk_tester "BoxRef" x in
-                (typing_pred, uu____8951) in
-              FStar_SMTEncoding_Util.mkImp uu____8948 in
-            ([[typing_pred]], [xx; aa], uu____8947) in
-          mkForall_fuel uu____8941 in
-        (uu____8940, (Some "ref inversion"), (Some "ref_inversion")) in
-      FStar_SMTEncoding_Term.Assume uu____8935 in
-    let uu____8967 =
-      let uu____8969 =
-        let uu____8970 =
-          let uu____8975 =
-            let uu____8976 =
-              let uu____8982 =
-                let uu____8983 =
-                  let uu____8986 =
-                    FStar_SMTEncoding_Util.mkAnd (typing_pred, typing_pred_b) in
-                  let uu____8987 =
-                    let uu____8988 =
-                      let uu____8991 = FStar_SMTEncoding_Util.mkFreeV aa in
-                      let uu____8992 = FStar_SMTEncoding_Util.mkFreeV bb in
-                      (uu____8991, uu____8992) in
-                    FStar_SMTEncoding_Util.mkEq uu____8988 in
-                  (uu____8986, uu____8987) in
-                FStar_SMTEncoding_Util.mkImp uu____8983 in
-              ([[typing_pred; typing_pred_b]], [xx; aa; bb], uu____8982) in
-            mkForall_fuel' (Prims.parse_int "2") uu____8976 in
-          (uu____8975, (Some "ref typing is injective"),
-            (Some "ref_injectivity")) in
-        FStar_SMTEncoding_Term.Assume uu____8970 in
-      [uu____8969] in
-    uu____8934 :: uu____8967 in
-  let mk_true_interp env nm true_tm =
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [true_tm]) in
-    [FStar_SMTEncoding_Term.Assume
-       (valid, (Some "True interpretation"), (Some "true_interp"))] in
-  let mk_false_interp env nm false_tm =
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [false_tm]) in
-    let uu____9036 =
-      let uu____9037 =
-        let uu____9042 =
-          FStar_SMTEncoding_Util.mkIff
-            (FStar_SMTEncoding_Util.mkFalse, valid) in
-        (uu____9042, (Some "False interpretation"), (Some "false_interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9037 in
-    [uu____9036] in
-  let mk_and_interp env conj uu____9054 =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let valid =
-      let uu____9064 =
-        let uu____9068 =
-          let uu____9070 = FStar_SMTEncoding_Util.mkApp (conj, [a; b]) in
-          [uu____9070] in
-        ("Valid", uu____9068) in
-      FStar_SMTEncoding_Util.mkApp uu____9064 in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____9077 =
-      let uu____9078 =
-        let uu____9083 =
-          let uu____9084 =
-            let uu____9090 =
-              let uu____9091 =
-                let uu____9094 =
-                  FStar_SMTEncoding_Util.mkAnd (valid_a, valid_b) in
-                (uu____9094, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9091 in
-            ([[valid]], [aa; bb], uu____9090) in
-          FStar_SMTEncoding_Util.mkForall uu____9084 in
-        (uu____9083, (Some "/\\ interpretation"), (Some "l_and-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9078 in
-    [uu____9077] in
-  let mk_or_interp env disj uu____9119 =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let valid =
-      let uu____9129 =
-        let uu____9133 =
-          let uu____9135 = FStar_SMTEncoding_Util.mkApp (disj, [a; b]) in
-          [uu____9135] in
-        ("Valid", uu____9133) in
-      FStar_SMTEncoding_Util.mkApp uu____9129 in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____9142 =
-      let uu____9143 =
-        let uu____9148 =
-          let uu____9149 =
-            let uu____9155 =
-              let uu____9156 =
-                let uu____9159 =
-                  FStar_SMTEncoding_Util.mkOr (valid_a, valid_b) in
-                (uu____9159, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9156 in
-            ([[valid]], [aa; bb], uu____9155) in
-          FStar_SMTEncoding_Util.mkForall uu____9149 in
-        (uu____9148, (Some "\\/ interpretation"), (Some "l_or-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9143 in
-    [uu____9142] in
-  let mk_eq2_interp env eq2 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
-    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
-    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
-    let valid =
-      let uu____9198 =
-        let uu____9202 =
-          let uu____9204 = FStar_SMTEncoding_Util.mkApp (eq2, [a; x1; y1]) in
-          [uu____9204] in
-        ("Valid", uu____9202) in
-      FStar_SMTEncoding_Util.mkApp uu____9198 in
-    let uu____9207 =
-      let uu____9208 =
-        let uu____9213 =
-          let uu____9214 =
-            let uu____9220 =
-              let uu____9221 =
-                let uu____9224 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
-                (uu____9224, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9221 in
-            ([[valid]], [aa; xx1; yy1], uu____9220) in
-          FStar_SMTEncoding_Util.mkForall uu____9214 in
-        (uu____9213, (Some "Eq2 interpretation"), (Some "eq2-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9208 in
-    [uu____9207] in
-  let mk_eq3_interp env eq3 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
-    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
-    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
-    let valid =
-      let uu____9269 =
-        let uu____9273 =
-          let uu____9275 = FStar_SMTEncoding_Util.mkApp (eq3, [a; b; x1; y1]) in
-          [uu____9275] in
-        ("Valid", uu____9273) in
-      FStar_SMTEncoding_Util.mkApp uu____9269 in
-    let uu____9278 =
-      let uu____9279 =
-        let uu____9284 =
-          let uu____9285 =
-            let uu____9291 =
-              let uu____9292 =
-                let uu____9295 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
-                (uu____9295, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9292 in
-            ([[valid]], [aa; bb; xx1; yy1], uu____9291) in
-          FStar_SMTEncoding_Util.mkForall uu____9285 in
-        (uu____9284, (Some "Eq3 interpretation"), (Some "eq3-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9279 in
-    [uu____9278] in
-  let mk_imp_interp env imp tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let valid =
-      let uu____9334 =
-        let uu____9338 =
-          let uu____9340 = FStar_SMTEncoding_Util.mkApp (imp, [a; b]) in
-          [uu____9340] in
-        ("Valid", uu____9338) in
-      FStar_SMTEncoding_Util.mkApp uu____9334 in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____9347 =
-      let uu____9348 =
-        let uu____9353 =
-          let uu____9354 =
-            let uu____9360 =
-              let uu____9361 =
-                let uu____9364 =
-                  FStar_SMTEncoding_Util.mkImp (valid_a, valid_b) in
-                (uu____9364, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9361 in
-            ([[valid]], [aa; bb], uu____9360) in
-          FStar_SMTEncoding_Util.mkForall uu____9354 in
-        (uu____9353, (Some "==> interpretation"), (Some "l_imp-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9348 in
-    [uu____9347] in
-  let mk_iff_interp env iff tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let valid =
-      let uu____9399 =
-        let uu____9403 =
-          let uu____9405 = FStar_SMTEncoding_Util.mkApp (iff, [a; b]) in
-          [uu____9405] in
-        ("Valid", uu____9403) in
-      FStar_SMTEncoding_Util.mkApp uu____9399 in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____9412 =
-      let uu____9413 =
-        let uu____9418 =
-          let uu____9419 =
-            let uu____9425 =
-              let uu____9426 =
-                let uu____9429 =
-                  FStar_SMTEncoding_Util.mkIff (valid_a, valid_b) in
-                (uu____9429, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9426 in
-            ([[valid]], [aa; bb], uu____9425) in
-          FStar_SMTEncoding_Util.mkForall uu____9419 in
-        (uu____9418, (Some "<==> interpretation"), (Some "l_iff-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9413 in
-    [uu____9412] in
-  let mk_not_interp env l_not tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let valid =
-      let uu____9460 =
-        let uu____9464 =
-          let uu____9466 = FStar_SMTEncoding_Util.mkApp (l_not, [a]) in
-          [uu____9466] in
-        ("Valid", uu____9464) in
-      FStar_SMTEncoding_Util.mkApp uu____9460 in
-    let not_valid_a =
-      let uu____9470 = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu____9470 in
-    let uu____9472 =
-      let uu____9473 =
-        let uu____9478 =
-          let uu____9479 =
-            let uu____9485 =
-              FStar_SMTEncoding_Util.mkIff (not_valid_a, valid) in
-            ([[valid]], [aa], uu____9485) in
-          FStar_SMTEncoding_Util.mkForall uu____9479 in
-        (uu____9478, (Some "not interpretation"), (Some "l_not-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9473 in
-    [uu____9472] in
-  let mk_forall_interp env for_all1 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
-    let valid =
-      let uu____9522 =
-        let uu____9526 =
-          let uu____9528 = FStar_SMTEncoding_Util.mkApp (for_all1, [a; b]) in
-          [uu____9528] in
-        ("Valid", uu____9526) in
-      FStar_SMTEncoding_Util.mkApp uu____9522 in
-    let valid_b_x =
-      let uu____9532 =
-        let uu____9536 =
-          let uu____9538 = FStar_SMTEncoding_Util.mk_ApplyTT b x1 in
-          [uu____9538] in
-        ("Valid", uu____9536) in
-      FStar_SMTEncoding_Util.mkApp uu____9532 in
-    let uu____9540 =
-      let uu____9541 =
-        let uu____9546 =
-          let uu____9547 =
-            let uu____9553 =
-              let uu____9554 =
-                let uu____9557 =
-                  let uu____9558 =
-                    let uu____9564 =
-                      let uu____9567 =
-                        let uu____9569 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
-                        [uu____9569] in
-                      [uu____9567] in
-                    let uu____9572 =
-                      let uu____9573 =
-                        let uu____9576 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
-                        (uu____9576, valid_b_x) in
-                      FStar_SMTEncoding_Util.mkImp uu____9573 in
-                    (uu____9564, [xx1], uu____9572) in
-                  FStar_SMTEncoding_Util.mkForall uu____9558 in
-                (uu____9557, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9554 in
-            ([[valid]], [aa; bb], uu____9553) in
-          FStar_SMTEncoding_Util.mkForall uu____9547 in
-        (uu____9546, (Some "forall interpretation"), (Some "forall-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9541 in
-    [uu____9540] in
-  let mk_exists_interp env for_some1 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
-    let valid =
-      let uu____9624 =
-        let uu____9628 =
-          let uu____9630 = FStar_SMTEncoding_Util.mkApp (for_some1, [a; b]) in
-          [uu____9630] in
-        ("Valid", uu____9628) in
-      FStar_SMTEncoding_Util.mkApp uu____9624 in
-    let valid_b_x =
-      let uu____9634 =
-        let uu____9638 =
-          let uu____9640 = FStar_SMTEncoding_Util.mk_ApplyTT b x1 in
-          [uu____9640] in
-        ("Valid", uu____9638) in
-      FStar_SMTEncoding_Util.mkApp uu____9634 in
-    let uu____9642 =
-      let uu____9643 =
-        let uu____9648 =
-          let uu____9649 =
-            let uu____9655 =
-              let uu____9656 =
-                let uu____9659 =
-                  let uu____9660 =
-                    let uu____9666 =
-                      let uu____9669 =
-                        let uu____9671 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
-                        [uu____9671] in
-                      [uu____9669] in
-                    let uu____9674 =
-                      let uu____9675 =
-                        let uu____9678 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
-                        (uu____9678, valid_b_x) in
-                      FStar_SMTEncoding_Util.mkImp uu____9675 in
-                    (uu____9666, [xx1], uu____9674) in
-                  FStar_SMTEncoding_Util.mkExists uu____9660 in
-                (uu____9659, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____9656 in
-            ([[valid]], [aa; bb], uu____9655) in
-          FStar_SMTEncoding_Util.mkForall uu____9649 in
-        (uu____9648, (Some "exists interpretation"), (Some "exists-interp")) in
-      FStar_SMTEncoding_Term.Assume uu____9643 in
-    [uu____9642] in
-  let mk_range_interp env range tt =
-    let range_ty = FStar_SMTEncoding_Util.mkApp (range, []) in
-    let uu____9715 =
-      let uu____9716 =
-        let uu____9721 =
-          FStar_SMTEncoding_Term.mk_HasTypeZ
-            FStar_SMTEncoding_Term.mk_Range_const range_ty in
-        let uu____9722 =
-          let uu____9724 = varops.mk_unique "typing_range_const" in
-          Some uu____9724 in
-        (uu____9721, (Some "Range_const typing"), uu____9722) in
-      FStar_SMTEncoding_Term.Assume uu____9716 in
-    [uu____9715] in
-  let prims1 =
-    [(FStar_Syntax_Const.unit_lid, mk_unit);
-    (FStar_Syntax_Const.bool_lid, mk_bool);
-    (FStar_Syntax_Const.int_lid, mk_int);
-    (FStar_Syntax_Const.string_lid, mk_str);
-    (FStar_Syntax_Const.ref_lid, mk_ref1);
-    (FStar_Syntax_Const.true_lid, mk_true_interp);
-    (FStar_Syntax_Const.false_lid, mk_false_interp);
-    (FStar_Syntax_Const.and_lid, mk_and_interp);
-    (FStar_Syntax_Const.or_lid, mk_or_interp);
-    (FStar_Syntax_Const.eq2_lid, mk_eq2_interp);
-    (FStar_Syntax_Const.eq3_lid, mk_eq3_interp);
-    (FStar_Syntax_Const.imp_lid, mk_imp_interp);
-    (FStar_Syntax_Const.iff_lid, mk_iff_interp);
-    (FStar_Syntax_Const.not_lid, mk_not_interp);
-    (FStar_Syntax_Const.forall_lid, mk_forall_interp);
-    (FStar_Syntax_Const.exists_lid, mk_exists_interp);
-    (FStar_Syntax_Const.range_lid, mk_range_interp)] in
-  fun env  ->
-    fun t  ->
-      fun s  ->
-        fun tt  ->
-          let uu____9987 =
-            FStar_Util.find_opt
-              (fun uu____10005  ->
-                 match uu____10005 with
-                 | (l,uu____10015) -> FStar_Ident.lid_equals l t) prims1 in
-          match uu____9987 with
-          | None  -> []
-          | Some (uu____10037,f) -> f env s tt
-let encode_smt_lemma:
-  env_t ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.typ -> FStar_SMTEncoding_Term.decl Prims.list
-  =
-  fun env  ->
-    fun fv  ->
-      fun t  ->
-        let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        let uu____10074 = encode_function_type_as_formula None None t env in
-        match uu____10074 with
-        | (form,decls) ->
-            FStar_List.append decls
-              [FStar_SMTEncoding_Term.Assume
-                 (form, (Some (Prims.strcat "Lemma: " lid.FStar_Ident.str)),
-                   (Some (Prims.strcat "lemma_" lid.FStar_Ident.str)))]
-let encode_free_var:
-  env_t ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.qualifier Prims.list ->
-            (FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun fv  ->
-      fun tt  ->
-        fun t_norm  ->
-          fun quals  ->
-            let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            let uu____10107 =
-              (let uu____10108 =
-                 (FStar_Syntax_Util.is_pure_or_ghost_function t_norm) ||
-                   (FStar_TypeChecker_Env.is_reifiable_function env.tcenv
-                      t_norm) in
-               FStar_All.pipe_left Prims.op_Negation uu____10108) ||
-                (FStar_Syntax_Util.is_lemma t_norm) in
-            if uu____10107
-            then
-              let uu____10112 = new_term_constant_and_tok_from_lid env lid in
-              match uu____10112 with
-              | (vname,vtok,env1) ->
-                  let arg_sorts =
-                    let uu____10124 =
-                      let uu____10125 = FStar_Syntax_Subst.compress t_norm in
-                      uu____10125.FStar_Syntax_Syntax.n in
-                    match uu____10124 with
-                    | FStar_Syntax_Syntax.Tm_arrow (binders,uu____10130) ->
-                        FStar_All.pipe_right binders
-                          (FStar_List.map
-                             (fun uu____10147  ->
-                                FStar_SMTEncoding_Term.Term_sort))
-                    | uu____10150 -> [] in
-                  let d =
-                    FStar_SMTEncoding_Term.DeclFun
-                      (vname, arg_sorts, FStar_SMTEncoding_Term.Term_sort,
-                        (Some
-                           "Uninterpreted function symbol for impure function")) in
-                  let dd =
-                    FStar_SMTEncoding_Term.DeclFun
-                      (vtok, [], FStar_SMTEncoding_Term.Term_sort,
-                        (Some "Uninterpreted name for impure function")) in
-                  ([d; dd], env1)
-            else
-              (let uu____10159 = prims.is lid in
-               if uu____10159
-               then
-                 let vname = varops.new_fvar lid in
-                 let uu____10164 = prims.mk lid vname in
-                 match uu____10164 with
-                 | (tok,definition) ->
-                     let env1 = push_free_var env lid vname (Some tok) in
-                     (definition, env1)
-               else
-                 (let encode_non_total_function_typ =
-                    lid.FStar_Ident.nsstr <> "Prims" in
-                  let uu____10179 =
-                    let uu____10185 = curried_arrow_formals_comp t_norm in
-                    match uu____10185 with
-                    | (args,comp) ->
-                        let comp1 =
-                          let uu____10196 =
-                            FStar_TypeChecker_Env.is_reifiable_comp env.tcenv
-                              comp in
-                          if uu____10196
-                          then
-                            let uu____10197 =
-                              FStar_TypeChecker_Env.reify_comp
-                                (let uu___153_10198 = env.tcenv in
-                                 {
-                                   FStar_TypeChecker_Env.solver =
-                                     (uu___153_10198.FStar_TypeChecker_Env.solver);
-                                   FStar_TypeChecker_Env.range =
-                                     (uu___153_10198.FStar_TypeChecker_Env.range);
-                                   FStar_TypeChecker_Env.curmodule =
-                                     (uu___153_10198.FStar_TypeChecker_Env.curmodule);
-                                   FStar_TypeChecker_Env.gamma =
-                                     (uu___153_10198.FStar_TypeChecker_Env.gamma);
-                                   FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___153_10198.FStar_TypeChecker_Env.gamma_cache);
-                                   FStar_TypeChecker_Env.modules =
-                                     (uu___153_10198.FStar_TypeChecker_Env.modules);
-                                   FStar_TypeChecker_Env.expected_typ =
-                                     (uu___153_10198.FStar_TypeChecker_Env.expected_typ);
-                                   FStar_TypeChecker_Env.sigtab =
-                                     (uu___153_10198.FStar_TypeChecker_Env.sigtab);
-                                   FStar_TypeChecker_Env.is_pattern =
-                                     (uu___153_10198.FStar_TypeChecker_Env.is_pattern);
-                                   FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___153_10198.FStar_TypeChecker_Env.instantiate_imp);
-                                   FStar_TypeChecker_Env.effects =
-                                     (uu___153_10198.FStar_TypeChecker_Env.effects);
-                                   FStar_TypeChecker_Env.generalize =
-                                     (uu___153_10198.FStar_TypeChecker_Env.generalize);
-                                   FStar_TypeChecker_Env.letrecs =
-                                     (uu___153_10198.FStar_TypeChecker_Env.letrecs);
-                                   FStar_TypeChecker_Env.top_level =
-                                     (uu___153_10198.FStar_TypeChecker_Env.top_level);
-                                   FStar_TypeChecker_Env.check_uvars =
-                                     (uu___153_10198.FStar_TypeChecker_Env.check_uvars);
-                                   FStar_TypeChecker_Env.use_eq =
-                                     (uu___153_10198.FStar_TypeChecker_Env.use_eq);
-                                   FStar_TypeChecker_Env.is_iface =
-                                     (uu___153_10198.FStar_TypeChecker_Env.is_iface);
-                                   FStar_TypeChecker_Env.admit =
-                                     (uu___153_10198.FStar_TypeChecker_Env.admit);
-                                   FStar_TypeChecker_Env.lax = true;
-                                   FStar_TypeChecker_Env.lax_universes =
-                                     (uu___153_10198.FStar_TypeChecker_Env.lax_universes);
-                                   FStar_TypeChecker_Env.type_of =
-                                     (uu___153_10198.FStar_TypeChecker_Env.type_of);
-                                   FStar_TypeChecker_Env.universe_of =
-                                     (uu___153_10198.FStar_TypeChecker_Env.universe_of);
-                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___153_10198.FStar_TypeChecker_Env.use_bv_sorts);
-                                   FStar_TypeChecker_Env.qname_and_index =
-                                     (uu___153_10198.FStar_TypeChecker_Env.qname_and_index)
-                                 }) comp FStar_Syntax_Syntax.U_unknown in
-                            FStar_Syntax_Syntax.mk_Total uu____10197
-                          else comp in
-                        if encode_non_total_function_typ
-                        then
-                          let uu____10205 =
-                            FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
-                              env.tcenv comp1 in
-                          (args, uu____10205)
-                        else
-                          (args,
-                            (None, (FStar_Syntax_Util.comp_result comp1))) in
-                  match uu____10179 with
-                  | (formals,(pre_opt,res_t)) ->
-                      let uu____10232 =
-                        new_term_constant_and_tok_from_lid env lid in
-                      (match uu____10232 with
-                       | (vname,vtok,env1) ->
-                           let vtok_tm =
-                             match formals with
-                             | [] ->
-                                 FStar_SMTEncoding_Util.mkFreeV
-                                   (vname, FStar_SMTEncoding_Term.Term_sort)
-                             | uu____10245 ->
-                                 FStar_SMTEncoding_Util.mkApp (vtok, []) in
-                           let mk_disc_proj_axioms guard encoded_res_t vapp
-                             vars =
-                             FStar_All.pipe_right quals
-                               (FStar_List.collect
-                                  (fun uu___124_10269  ->
-                                     match uu___124_10269 with
-                                     | FStar_Syntax_Syntax.Discriminator d ->
-                                         let uu____10272 =
-                                           FStar_Util.prefix vars in
-                                         (match uu____10272 with
-                                          | (uu____10283,(xxsym,uu____10285))
-                                              ->
-                                              let xx =
-                                                FStar_SMTEncoding_Util.mkFreeV
-                                                  (xxsym,
-                                                    FStar_SMTEncoding_Term.Term_sort) in
-                                              let uu____10295 =
-                                                let uu____10296 =
-                                                  let uu____10301 =
-                                                    let uu____10302 =
-                                                      let uu____10308 =
-                                                        let uu____10309 =
-                                                          let uu____10312 =
-                                                            let uu____10313 =
-                                                              FStar_SMTEncoding_Term.mk_tester
-                                                                (escape
-                                                                   d.FStar_Ident.str)
-                                                                xx in
-                                                            FStar_All.pipe_left
-                                                              FStar_SMTEncoding_Term.boxBool
-                                                              uu____10313 in
-                                                          (vapp, uu____10312) in
-                                                        FStar_SMTEncoding_Util.mkEq
-                                                          uu____10309 in
-                                                      ([[vapp]], vars,
-                                                        uu____10308) in
-                                                    FStar_SMTEncoding_Util.mkForall
-                                                      uu____10302 in
-                                                  (uu____10301,
-                                                    (Some
-                                                       "Discriminator equation"),
-                                                    (Some
-                                                       (Prims.strcat
-                                                          "disc_equation_"
-                                                          (escape
-                                                             d.FStar_Ident.str)))) in
-                                                FStar_SMTEncoding_Term.Assume
-                                                  uu____10296 in
-                                              [uu____10295])
-                                     | FStar_Syntax_Syntax.Projector 
-                                         (d,f) ->
-                                         let uu____10325 =
-                                           FStar_Util.prefix vars in
-                                         (match uu____10325 with
-                                          | (uu____10336,(xxsym,uu____10338))
-                                              ->
-                                              let xx =
-                                                FStar_SMTEncoding_Util.mkFreeV
-                                                  (xxsym,
-                                                    FStar_SMTEncoding_Term.Term_sort) in
-                                              let f1 =
-                                                {
-                                                  FStar_Syntax_Syntax.ppname
-                                                    = f;
-                                                  FStar_Syntax_Syntax.index =
-                                                    (Prims.parse_int "0");
-                                                  FStar_Syntax_Syntax.sort =
-                                                    FStar_Syntax_Syntax.tun
-                                                } in
-                                              let tp_name =
-                                                mk_term_projector_name d f1 in
-                                              let prim_app =
-                                                FStar_SMTEncoding_Util.mkApp
-                                                  (tp_name, [xx]) in
-                                              let uu____10352 =
-                                                let uu____10353 =
-                                                  let uu____10358 =
-                                                    let uu____10359 =
-                                                      let uu____10365 =
-                                                        FStar_SMTEncoding_Util.mkEq
-                                                          (vapp, prim_app) in
-                                                      ([[vapp]], vars,
-                                                        uu____10365) in
-                                                    FStar_SMTEncoding_Util.mkForall
-                                                      uu____10359 in
-                                                  (uu____10358,
-                                                    (Some
-                                                       "Projector equation"),
-                                                    (Some
-                                                       (Prims.strcat
-                                                          "proj_equation_"
-                                                          tp_name))) in
-                                                FStar_SMTEncoding_Term.Assume
-                                                  uu____10353 in
-                                              [uu____10352])
-                                     | uu____10375 -> [])) in
-                           let uu____10376 = encode_binders None formals env1 in
-                           (match uu____10376 with
-                            | (vars,guards,env',decls1,uu____10392) ->
-                                let uu____10399 =
-                                  match pre_opt with
-                                  | None  ->
-                                      let uu____10404 =
-                                        FStar_SMTEncoding_Util.mk_and_l
-                                          guards in
-                                      (uu____10404, decls1)
-                                  | Some p ->
-                                      let uu____10406 = encode_formula p env' in
-                                      (match uu____10406 with
-                                       | (g,ds) ->
-                                           let uu____10413 =
-                                             FStar_SMTEncoding_Util.mk_and_l
-                                               (g :: guards) in
-                                           (uu____10413,
-                                             (FStar_List.append decls1 ds))) in
-                                (match uu____10399 with
-                                 | (guard,decls11) ->
-                                     let vtok_app = mk_Apply vtok_tm vars in
-                                     let vapp =
-                                       let uu____10422 =
-                                         let uu____10426 =
-                                           FStar_List.map
-                                             FStar_SMTEncoding_Util.mkFreeV
-                                             vars in
-                                         (vname, uu____10426) in
-                                       FStar_SMTEncoding_Util.mkApp
-                                         uu____10422 in
-                                     let uu____10431 =
-                                       let vname_decl =
-                                         let uu____10436 =
-                                           let uu____10442 =
-                                             FStar_All.pipe_right formals
-                                               (FStar_List.map
-                                                  (fun uu____10447  ->
-                                                     FStar_SMTEncoding_Term.Term_sort)) in
-                                           (vname, uu____10442,
-                                             FStar_SMTEncoding_Term.Term_sort,
-                                             None) in
-                                         FStar_SMTEncoding_Term.DeclFun
-                                           uu____10436 in
-                                       let uu____10452 =
-                                         let env2 =
-                                           let uu___154_10456 = env1 in
-                                           {
-                                             bindings =
-                                               (uu___154_10456.bindings);
-                                             depth = (uu___154_10456.depth);
-                                             tcenv = (uu___154_10456.tcenv);
-                                             warn = (uu___154_10456.warn);
-                                             cache = (uu___154_10456.cache);
-                                             nolabels =
-                                               (uu___154_10456.nolabels);
-                                             use_zfuel_name =
-                                               (uu___154_10456.use_zfuel_name);
-                                             encode_non_total_function_typ
-                                           } in
-                                         let uu____10457 =
-                                           let uu____10458 =
-                                             head_normal env2 tt in
-                                           Prims.op_Negation uu____10458 in
-                                         if uu____10457
-                                         then
-                                           encode_term_pred None tt env2
-                                             vtok_tm
-                                         else
-                                           encode_term_pred None t_norm env2
-                                             vtok_tm in
-                                       match uu____10452 with
-                                       | (tok_typing,decls2) ->
-                                           let tok_typing1 =
-                                             FStar_SMTEncoding_Term.Assume
-                                               (tok_typing,
-                                                 (Some
-                                                    "function token typing"),
-                                                 (Some
-                                                    (Prims.strcat
-                                                       "function_token_typing_"
-                                                       vname))) in
-                                           let uu____10470 =
-                                             match formals with
-                                             | [] ->
-                                                 let uu____10479 =
-                                                   let uu____10480 =
-                                                     let uu____10482 =
-                                                       FStar_SMTEncoding_Util.mkFreeV
-                                                         (vname,
-                                                           FStar_SMTEncoding_Term.Term_sort) in
-                                                     FStar_All.pipe_left
-                                                       (fun _0_34  ->
-                                                          Some _0_34)
-                                                       uu____10482 in
-                                                   push_free_var env1 lid
-                                                     vname uu____10480 in
-                                                 ((FStar_List.append decls2
-                                                     [tok_typing1]),
-                                                   uu____10479)
-                                             | uu____10485 ->
-                                                 let vtok_decl =
-                                                   FStar_SMTEncoding_Term.DeclFun
-                                                     (vtok, [],
-                                                       FStar_SMTEncoding_Term.Term_sort,
-                                                       None) in
-                                                 let vtok_fresh =
-                                                   let uu____10490 =
-                                                     varops.next_id () in
-                                                   FStar_SMTEncoding_Term.fresh_token
-                                                     (vtok,
-                                                       FStar_SMTEncoding_Term.Term_sort)
-                                                     uu____10490 in
-                                                 let name_tok_corr =
-                                                   let uu____10492 =
-                                                     let uu____10497 =
-                                                       let uu____10498 =
-                                                         let uu____10504 =
-                                                           FStar_SMTEncoding_Util.mkEq
-                                                             (vtok_app, vapp) in
-                                                         ([[vtok_app];
-                                                          [vapp]], vars,
-                                                           uu____10504) in
-                                                       FStar_SMTEncoding_Util.mkForall
-                                                         uu____10498 in
-                                                     (uu____10497,
-                                                       (Some
-                                                          "Name-token correspondence"),
-                                                       (Some
-                                                          (Prims.strcat
-                                                             "token_correspondence_"
-                                                             vname))) in
-                                                   FStar_SMTEncoding_Term.Assume
-                                                     uu____10492 in
-                                                 ((FStar_List.append decls2
-                                                     [vtok_decl;
-                                                     vtok_fresh;
-                                                     name_tok_corr;
-                                                     tok_typing1]), env1) in
-                                           (match uu____10470 with
-                                            | (tok_decl,env2) ->
-                                                ((vname_decl :: tok_decl),
-                                                  env2)) in
-                                     (match uu____10431 with
-                                      | (decls2,env2) ->
-                                          let uu____10529 =
-                                            let res_t1 =
-                                              FStar_Syntax_Subst.compress
-                                                res_t in
-                                            let uu____10534 =
-                                              encode_term res_t1 env' in
-                                            match uu____10534 with
-                                            | (encoded_res_t,decls) ->
-                                                let uu____10542 =
-                                                  FStar_SMTEncoding_Term.mk_HasType
-                                                    vapp encoded_res_t in
-                                                (encoded_res_t, uu____10542,
-                                                  decls) in
-                                          (match uu____10529 with
-                                           | (encoded_res_t,ty_pred,decls3)
-                                               ->
-                                               let typingAx =
-                                                 let uu____10550 =
-                                                   let uu____10555 =
-                                                     let uu____10556 =
-                                                       let uu____10562 =
-                                                         FStar_SMTEncoding_Util.mkImp
-                                                           (guard, ty_pred) in
-                                                       ([[vapp]], vars,
-                                                         uu____10562) in
-                                                     FStar_SMTEncoding_Util.mkForall
-                                                       uu____10556 in
-                                                   (uu____10555,
-                                                     (Some "free var typing"),
-                                                     (Some
-                                                        (Prims.strcat
-                                                           "typing_" vname))) in
-                                                 FStar_SMTEncoding_Term.Assume
-                                                   uu____10550 in
-                                               let freshness =
-                                                 let uu____10572 =
-                                                   FStar_All.pipe_right quals
-                                                     (FStar_List.contains
-                                                        FStar_Syntax_Syntax.New) in
-                                                 if uu____10572
-                                                 then
-                                                   let uu____10575 =
-                                                     let uu____10576 =
-                                                       let uu____10582 =
-                                                         FStar_All.pipe_right
-                                                           vars
-                                                           (FStar_List.map
-                                                              Prims.snd) in
-                                                       let uu____10588 =
-                                                         varops.next_id () in
-                                                       (vname, uu____10582,
-                                                         FStar_SMTEncoding_Term.Term_sort,
-                                                         uu____10588) in
-                                                     FStar_SMTEncoding_Term.fresh_constructor
-                                                       uu____10576 in
-                                                   let uu____10590 =
-                                                     let uu____10592 =
-                                                       pretype_axiom vapp
-                                                         vars in
-                                                     [uu____10592] in
-                                                   uu____10575 :: uu____10590
-                                                 else [] in
-                                               let g =
-                                                 let uu____10596 =
-                                                   let uu____10598 =
-                                                     let uu____10600 =
-                                                       let uu____10602 =
-                                                         let uu____10604 =
-                                                           mk_disc_proj_axioms
-                                                             guard
-                                                             encoded_res_t
-                                                             vapp vars in
-                                                         typingAx ::
-                                                           uu____10604 in
-                                                       FStar_List.append
-                                                         freshness
-                                                         uu____10602 in
-                                                     FStar_List.append decls3
-                                                       uu____10600 in
-                                                   FStar_List.append decls2
-                                                     uu____10598 in
-                                                 FStar_List.append decls11
-                                                   uu____10596 in
-                                               (g, env2))))))))
-let declare_top_level_let:
-  env_t ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term ->
-          ((Prims.string* FStar_SMTEncoding_Term.term Prims.option)*
-            FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun x  ->
-      fun t  ->
-        fun t_norm  ->
-          let uu____10626 =
-            try_lookup_lid env
-              (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          match uu____10626 with
-          | None  ->
-              let uu____10649 = encode_free_var env x t t_norm [] in
-              (match uu____10649 with
-               | (decls,env1) ->
-                   let uu____10664 =
-                     lookup_lid env1
-                       (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                   (match uu____10664 with
-                    | (n1,x',uu____10683) -> ((n1, x'), decls, env1)))
-          | Some (n1,x1,uu____10695) -> ((n1, x1), [], env)
-let encode_top_level_val:
-  env_t ->
-    FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.qualifier Prims.list ->
-          (FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun lid  ->
-      fun t  ->
-        fun quals  ->
-          let tt = norm env t in
-          let uu____10728 = encode_free_var env lid t tt quals in
-          match uu____10728 with
-          | (decls,env1) ->
-              let uu____10739 = FStar_Syntax_Util.is_smt_lemma t in
-              if uu____10739
-              then
-                let uu____10743 =
-                  let uu____10745 = encode_smt_lemma env1 lid tt in
-                  FStar_List.append decls uu____10745 in
-                (uu____10743, env1)
-              else (decls, env1)
-let encode_top_level_vals:
-  env_t ->
-    FStar_Syntax_Syntax.letbinding Prims.list ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        (FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun bindings  ->
-      fun quals  ->
-        FStar_All.pipe_right bindings
-          (FStar_List.fold_left
-             (fun uu____10773  ->
-                fun lb  ->
-                  match uu____10773 with
-                  | (decls,env1) ->
-                      let uu____10785 =
-                        let uu____10789 =
-                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                        encode_top_level_val env1 uu____10789
-                          lb.FStar_Syntax_Syntax.lbtyp quals in
-                      (match uu____10785 with
-                       | (decls',env2) ->
-                           ((FStar_List.append decls decls'), env2)))
-             ([], env))
-let is_tactic: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let fstar_tactics_tactic_lid =
-      FStar_Syntax_Const.p2l ["FStar"; "Tactics"; "tactic"] in
-    let uu____10803 = FStar_Syntax_Util.head_and_args t in
-    match uu____10803 with
-    | (hd1,args) ->
-        let uu____10829 =
-          let uu____10830 = FStar_Syntax_Util.un_uinst hd1 in
-          uu____10830.FStar_Syntax_Syntax.n in
-        (match uu____10829 with
-         | FStar_Syntax_Syntax.Tm_fvar fv when
-             FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_tactic_lid ->
-             true
-         | FStar_Syntax_Syntax.Tm_arrow (uu____10834,c) ->
-             let effect_name = FStar_Syntax_Util.comp_effect_name c in
-             FStar_Util.starts_with "FStar.Tactics"
-               effect_name.FStar_Ident.str
-         | uu____10847 -> false)
-let encode_top_level_let:
-  env_t ->
-    (Prims.bool* FStar_Syntax_Syntax.letbinding Prims.list) ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        (FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun uu____10862  ->
-      fun quals  ->
-        match uu____10862 with
-        | (is_rec,bindings) ->
-            let eta_expand1 binders formals body t =
-              let nbinders = FStar_List.length binders in
-              let uu____10911 = FStar_Util.first_N nbinders formals in
-              match uu____10911 with
-              | (formals1,extra_formals) ->
-                  let subst1 =
-                    FStar_List.map2
-                      (fun uu____10951  ->
-                         fun uu____10952  ->
-                           match (uu____10951, uu____10952) with
-                           | ((formal,uu____10962),(binder,uu____10964)) ->
-                               let uu____10969 =
-                                 let uu____10974 =
-                                   FStar_Syntax_Syntax.bv_to_name binder in
-                                 (formal, uu____10974) in
-                               FStar_Syntax_Syntax.NT uu____10969) formals1
-                      binders in
-                  let extra_formals1 =
-                    let uu____10979 =
-                      FStar_All.pipe_right extra_formals
-                        (FStar_List.map
-                           (fun uu____10993  ->
-                              match uu____10993 with
-                              | (x,i) ->
-                                  let uu____11000 =
-                                    let uu___155_11001 = x in
-                                    let uu____11002 =
-                                      FStar_Syntax_Subst.subst subst1
-                                        x.FStar_Syntax_Syntax.sort in
-                                    {
-                                      FStar_Syntax_Syntax.ppname =
-                                        (uu___155_11001.FStar_Syntax_Syntax.ppname);
-                                      FStar_Syntax_Syntax.index =
-                                        (uu___155_11001.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = uu____11002
-                                    } in
-                                  (uu____11000, i))) in
-                    FStar_All.pipe_right uu____10979
-                      FStar_Syntax_Util.name_binders in
-                  let body1 =
-                    let uu____11014 =
-                      let uu____11016 =
-                        let uu____11017 = FStar_Syntax_Subst.subst subst1 t in
-                        uu____11017.FStar_Syntax_Syntax.n in
-                      FStar_All.pipe_left (fun _0_35  -> Some _0_35)
-                        uu____11016 in
-                    let uu____11021 =
-                      let uu____11022 = FStar_Syntax_Subst.compress body in
-                      let uu____11023 =
-                        let uu____11024 =
-                          FStar_Syntax_Util.args_of_binders extra_formals1 in
-                        FStar_All.pipe_left Prims.snd uu____11024 in
-                      FStar_Syntax_Syntax.extend_app_n uu____11022
-                        uu____11023 in
-                    uu____11021 uu____11014 body.FStar_Syntax_Syntax.pos in
-                  ((FStar_List.append binders extra_formals1), body1) in
-            let destruct_bound_function flid t_norm e =
-              let get_result_type c =
-                let uu____11066 =
-                  FStar_TypeChecker_Env.is_reifiable_comp env.tcenv c in
-                if uu____11066
-                then
-                  FStar_TypeChecker_Env.reify_comp
-                    (let uu___156_11067 = env.tcenv in
-                     {
-                       FStar_TypeChecker_Env.solver =
-                         (uu___156_11067.FStar_TypeChecker_Env.solver);
-                       FStar_TypeChecker_Env.range =
-                         (uu___156_11067.FStar_TypeChecker_Env.range);
-                       FStar_TypeChecker_Env.curmodule =
-                         (uu___156_11067.FStar_TypeChecker_Env.curmodule);
-                       FStar_TypeChecker_Env.gamma =
-                         (uu___156_11067.FStar_TypeChecker_Env.gamma);
-                       FStar_TypeChecker_Env.gamma_cache =
-                         (uu___156_11067.FStar_TypeChecker_Env.gamma_cache);
-                       FStar_TypeChecker_Env.modules =
-                         (uu___156_11067.FStar_TypeChecker_Env.modules);
-                       FStar_TypeChecker_Env.expected_typ =
-                         (uu___156_11067.FStar_TypeChecker_Env.expected_typ);
-                       FStar_TypeChecker_Env.sigtab =
-                         (uu___156_11067.FStar_TypeChecker_Env.sigtab);
-                       FStar_TypeChecker_Env.is_pattern =
-                         (uu___156_11067.FStar_TypeChecker_Env.is_pattern);
-                       FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___156_11067.FStar_TypeChecker_Env.instantiate_imp);
-                       FStar_TypeChecker_Env.effects =
-                         (uu___156_11067.FStar_TypeChecker_Env.effects);
-                       FStar_TypeChecker_Env.generalize =
-                         (uu___156_11067.FStar_TypeChecker_Env.generalize);
-                       FStar_TypeChecker_Env.letrecs =
-                         (uu___156_11067.FStar_TypeChecker_Env.letrecs);
-                       FStar_TypeChecker_Env.top_level =
-                         (uu___156_11067.FStar_TypeChecker_Env.top_level);
-                       FStar_TypeChecker_Env.check_uvars =
-                         (uu___156_11067.FStar_TypeChecker_Env.check_uvars);
-                       FStar_TypeChecker_Env.use_eq =
-                         (uu___156_11067.FStar_TypeChecker_Env.use_eq);
-                       FStar_TypeChecker_Env.is_iface =
-                         (uu___156_11067.FStar_TypeChecker_Env.is_iface);
-                       FStar_TypeChecker_Env.admit =
-                         (uu___156_11067.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax = true;
-                       FStar_TypeChecker_Env.lax_universes =
-                         (uu___156_11067.FStar_TypeChecker_Env.lax_universes);
-                       FStar_TypeChecker_Env.type_of =
-                         (uu___156_11067.FStar_TypeChecker_Env.type_of);
-                       FStar_TypeChecker_Env.universe_of =
-                         (uu___156_11067.FStar_TypeChecker_Env.universe_of);
-                       FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___156_11067.FStar_TypeChecker_Env.use_bv_sorts);
-                       FStar_TypeChecker_Env.qname_and_index =
-                         (uu___156_11067.FStar_TypeChecker_Env.qname_and_index)
-                     }) c FStar_Syntax_Syntax.U_unknown
-                else FStar_Syntax_Util.comp_result c in
-              let rec aux norm1 t_norm1 =
-                let uu____11088 = FStar_Syntax_Util.abs_formals e in
-                match uu____11088 with
-                | (binders,body,lopt) ->
-                    (match binders with
-                     | uu____11137::uu____11138 ->
-                         let uu____11146 =
-                           let uu____11147 =
-                             FStar_Syntax_Subst.compress t_norm1 in
-                           uu____11147.FStar_Syntax_Syntax.n in
-                         (match uu____11146 with
-                          | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
-                              let uu____11174 =
-                                FStar_Syntax_Subst.open_comp formals c in
-                              (match uu____11174 with
-                               | (formals1,c1) ->
-                                   let nformals = FStar_List.length formals1 in
-                                   let nbinders = FStar_List.length binders in
-                                   let tres = get_result_type c1 in
-                                   let uu____11200 =
-                                     (nformals < nbinders) &&
-                                       (FStar_Syntax_Util.is_total_comp c1) in
-                                   if uu____11200
-                                   then
-                                     let uu____11218 =
-                                       FStar_Util.first_N nformals binders in
-                                     (match uu____11218 with
-                                      | (bs0,rest) ->
-                                          let c2 =
-                                            let subst1 =
-                                              FStar_List.map2
-                                                (fun uu____11264  ->
-                                                   fun uu____11265  ->
-                                                     match (uu____11264,
-                                                             uu____11265)
-                                                     with
-                                                     | ((x,uu____11275),
-                                                        (b,uu____11277)) ->
-                                                         let uu____11282 =
-                                                           let uu____11287 =
-                                                             FStar_Syntax_Syntax.bv_to_name
-                                                               b in
-                                                           (x, uu____11287) in
-                                                         FStar_Syntax_Syntax.NT
-                                                           uu____11282)
-                                                formals1 bs0 in
-                                            FStar_Syntax_Subst.subst_comp
-                                              subst1 c1 in
-                                          let body1 =
-                                            FStar_Syntax_Util.abs rest body
-                                              lopt in
-                                          let uu____11289 =
-                                            let uu____11300 =
-                                              get_result_type c2 in
-                                            (bs0, body1, bs0, uu____11300) in
-                                          (uu____11289, false))
-                                   else
-                                     if nformals > nbinders
-                                     then
-                                       (let uu____11335 =
-                                          eta_expand1 binders formals1 body
-                                            tres in
-                                        match uu____11335 with
-                                        | (binders1,body1) ->
-                                            ((binders1, body1, formals1,
-                                               tres), false))
-                                     else
-                                       ((binders, body, formals1, tres),
-                                         false))
-                          | FStar_Syntax_Syntax.Tm_refine (x,uu____11387) ->
-                              let uu____11392 =
-                                let uu____11403 =
-                                  aux norm1 x.FStar_Syntax_Syntax.sort in
-                                Prims.fst uu____11403 in
-                              (uu____11392, true)
-                          | uu____11436 when Prims.op_Negation norm1 ->
-                              let t_norm2 =
-                                FStar_TypeChecker_Normalize.normalize
-                                  [FStar_TypeChecker_Normalize.AllowUnboundUniverses;
-                                  FStar_TypeChecker_Normalize.Beta;
-                                  FStar_TypeChecker_Normalize.WHNF;
-                                  FStar_TypeChecker_Normalize.Exclude
-                                    FStar_TypeChecker_Normalize.Zeta;
-                                  FStar_TypeChecker_Normalize.UnfoldUntil
-                                    FStar_Syntax_Syntax.Delta_constant;
-                                  FStar_TypeChecker_Normalize.EraseUniverses]
-                                  env.tcenv t_norm1 in
-                              aux true t_norm2
-                          | uu____11438 ->
-                              let uu____11439 =
-                                let uu____11440 =
-                                  FStar_Syntax_Print.term_to_string e in
-                                let uu____11441 =
-                                  FStar_Syntax_Print.term_to_string t_norm1 in
-                                FStar_Util.format3
-                                  "Impossible! let-bound lambda %s = %s has a type that's not a function: %s\n"
-                                  flid.FStar_Ident.str uu____11440
-                                  uu____11441 in
-                              failwith uu____11439)
-                     | uu____11454 ->
-                         let uu____11455 =
-                           let uu____11456 =
-                             FStar_Syntax_Subst.compress t_norm1 in
-                           uu____11456.FStar_Syntax_Syntax.n in
-                         (match uu____11455 with
-                          | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
-                              let uu____11483 =
-                                FStar_Syntax_Subst.open_comp formals c in
-                              (match uu____11483 with
-                               | (formals1,c1) ->
-                                   let tres = get_result_type c1 in
-                                   let uu____11501 =
-                                     eta_expand1 [] formals1 e tres in
-                                   (match uu____11501 with
-                                    | (binders1,body1) ->
-                                        ((binders1, body1, formals1, tres),
-                                          false)))
-                          | uu____11549 -> (([], e, [], t_norm1), false))) in
-              aux false t_norm in
-            (try
-               let uu____11577 =
-                 FStar_All.pipe_right bindings
-                   (FStar_Util.for_all
-                      (fun lb  ->
-                         (FStar_Syntax_Util.is_lemma
-                            lb.FStar_Syntax_Syntax.lbtyp)
-                           || (is_tactic lb.FStar_Syntax_Syntax.lbtyp))) in
-               if uu____11577
-               then encode_top_level_vals env bindings quals
-               else
-                 (let uu____11584 =
-                    FStar_All.pipe_right bindings
-                      (FStar_List.fold_left
-                         (fun uu____11625  ->
-                            fun lb  ->
-                              match uu____11625 with
-                              | (toks,typs,decls,env1) ->
-                                  ((let uu____11676 =
-                                      FStar_Syntax_Util.is_lemma
-                                        lb.FStar_Syntax_Syntax.lbtyp in
-                                    if uu____11676
-                                    then Prims.raise Let_rec_unencodeable
-                                    else ());
-                                   (let t_norm =
-                                      whnf env1 lb.FStar_Syntax_Syntax.lbtyp in
-                                    let uu____11679 =
-                                      let uu____11687 =
-                                        FStar_Util.right
-                                          lb.FStar_Syntax_Syntax.lbname in
-                                      declare_top_level_let env1 uu____11687
-                                        lb.FStar_Syntax_Syntax.lbtyp t_norm in
-                                    match uu____11679 with
-                                    | (tok,decl,env2) ->
-                                        let uu____11712 =
-                                          let uu____11719 =
-                                            let uu____11725 =
-                                              FStar_Util.right
-                                                lb.FStar_Syntax_Syntax.lbname in
-                                            (uu____11725, tok) in
-                                          uu____11719 :: toks in
-                                        (uu____11712, (t_norm :: typs), (decl
-                                          :: decls), env2))))
-                         ([], [], [], env)) in
-                  match uu____11584 with
-                  | (toks,typs,decls,env1) ->
-                      let toks1 = FStar_List.rev toks in
-                      let decls1 =
-                        FStar_All.pipe_right (FStar_List.rev decls)
-                          FStar_List.flatten in
-                      let typs1 = FStar_List.rev typs in
-                      let mk_app1 curry f ftok vars =
-                        match vars with
-                        | [] ->
-                            FStar_SMTEncoding_Util.mkFreeV
-                              (f, FStar_SMTEncoding_Term.Term_sort)
-                        | uu____11827 ->
-                            if curry
-                            then
-                              (match ftok with
-                               | Some ftok1 -> mk_Apply ftok1 vars
-                               | None  ->
-                                   let uu____11832 =
-                                     FStar_SMTEncoding_Util.mkFreeV
-                                       (f, FStar_SMTEncoding_Term.Term_sort) in
-                                   mk_Apply uu____11832 vars)
-                            else
-                              (let uu____11834 =
-                                 let uu____11838 =
-                                   FStar_List.map
-                                     FStar_SMTEncoding_Util.mkFreeV vars in
-                                 (f, uu____11838) in
-                               FStar_SMTEncoding_Util.mkApp uu____11834) in
-                      let uu____11843 =
-                        (FStar_All.pipe_right quals
-                           (FStar_Util.for_some
-                              (fun uu___125_11845  ->
-                                 match uu___125_11845 with
-                                 | FStar_Syntax_Syntax.HasMaskedEffect  ->
-                                     true
-                                 | uu____11846 -> false)))
-                          ||
-                          (FStar_All.pipe_right typs1
-                             (FStar_Util.for_some
-                                (fun t  ->
-                                   let uu____11849 =
-                                     (FStar_Syntax_Util.is_pure_or_ghost_function
-                                        t)
-                                       ||
-                                       (FStar_TypeChecker_Env.is_reifiable_function
-                                          env1.tcenv t) in
-                                   FStar_All.pipe_left Prims.op_Negation
-                                     uu____11849))) in
-                      if uu____11843
-                      then (decls1, env1)
-                      else
-                        if Prims.op_Negation is_rec
-                        then
-                          (match (bindings, typs1, toks1) with
-                           | ({ FStar_Syntax_Syntax.lbname = uu____11869;
-                                FStar_Syntax_Syntax.lbunivs = uvs;
-                                FStar_Syntax_Syntax.lbtyp = uu____11871;
-                                FStar_Syntax_Syntax.lbeff = uu____11872;
-                                FStar_Syntax_Syntax.lbdef = e;_}::[],t_norm::[],
-                              (flid_fv,(f,ftok))::[]) ->
-                               let flid =
-                                 (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               let uu____11913 =
-                                 FStar_Syntax_Subst.univ_var_opening uvs in
-                               (match uu____11913 with
-                                | (univ_subst,univ_vars1) ->
-                                    let env' =
-                                      let uu___159_11928 = env1 in
-                                      let uu____11929 =
-                                        FStar_TypeChecker_Env.push_univ_vars
-                                          env1.tcenv univ_vars1 in
-                                      {
-                                        bindings = (uu___159_11928.bindings);
-                                        depth = (uu___159_11928.depth);
-                                        tcenv = uu____11929;
-                                        warn = (uu___159_11928.warn);
-                                        cache = (uu___159_11928.cache);
-                                        nolabels = (uu___159_11928.nolabels);
-                                        use_zfuel_name =
-                                          (uu___159_11928.use_zfuel_name);
-                                        encode_non_total_function_typ =
-                                          (uu___159_11928.encode_non_total_function_typ)
-                                      } in
-                                    let t_norm1 =
-                                      FStar_Syntax_Subst.subst univ_subst
-                                        t_norm in
-                                    let e1 =
-                                      let uu____11932 =
-                                        FStar_Syntax_Subst.subst univ_subst e in
-                                      FStar_Syntax_Subst.compress uu____11932 in
-                                    let uu____11933 =
-                                      destruct_bound_function flid t_norm1 e1 in
-                                    (match uu____11933 with
-                                     | ((binders,body,uu____11945,uu____11946),curry)
-                                         ->
-                                         ((let uu____11953 =
-                                             FStar_All.pipe_left
-                                               (FStar_TypeChecker_Env.debug
-                                                  env1.tcenv)
-                                               (FStar_Options.Other
-                                                  "SMTEncoding") in
-                                           if uu____11953
-                                           then
-                                             let uu____11954 =
-                                               FStar_Syntax_Print.binders_to_string
-                                                 ", " binders in
-                                             let uu____11955 =
-                                               FStar_Syntax_Print.term_to_string
-                                                 body in
-                                             FStar_Util.print2
-                                               "Encoding let : binders=[%s], body=%s\n"
-                                               uu____11954 uu____11955
-                                           else ());
-                                          (let uu____11957 =
-                                             encode_binders None binders env' in
-                                           match uu____11957 with
-                                           | (vars,guards,env'1,binder_decls,uu____11973)
-                                               ->
-                                               let body1 =
-                                                 let uu____11981 =
-                                                   FStar_TypeChecker_Env.is_reifiable_function
-                                                     env'1.tcenv t_norm1 in
-                                                 if uu____11981
-                                                 then
-                                                   reify_body env'1.tcenv
-                                                     body
-                                                 else body in
-                                               let app =
-                                                 mk_app1 curry f ftok vars in
-                                               let uu____11984 =
-                                                 let uu____11989 =
-                                                   FStar_All.pipe_right quals
-                                                     (FStar_List.contains
-                                                        FStar_Syntax_Syntax.Logic) in
-                                                 if uu____11989
-                                                 then
-                                                   let uu____11995 =
-                                                     FStar_SMTEncoding_Term.mk_Valid
-                                                       app in
-                                                   let uu____11996 =
-                                                     encode_formula body1
-                                                       env'1 in
-                                                   (uu____11995, uu____11996)
-                                                 else
-                                                   (let uu____12002 =
-                                                      encode_term body1 env'1 in
-                                                    (app, uu____12002)) in
-                                               (match uu____11984 with
-                                                | (app1,(body2,decls2)) ->
-                                                    let eqn =
-                                                      let uu____12016 =
-                                                        let uu____12021 =
-                                                          let uu____12022 =
-                                                            let uu____12028 =
-                                                              FStar_SMTEncoding_Util.mkEq
-                                                                (app1, body2) in
-                                                            ([[app1]], vars,
-                                                              uu____12028) in
-                                                          FStar_SMTEncoding_Util.mkForall
-                                                            uu____12022 in
-                                                        let uu____12034 =
-                                                          let uu____12036 =
-                                                            FStar_Util.format1
-                                                              "Equation for %s"
-                                                              flid.FStar_Ident.str in
-                                                          Some uu____12036 in
-                                                        (uu____12021,
-                                                          uu____12034,
-                                                          (Some
-                                                             (Prims.strcat
-                                                                "equation_" f))) in
-                                                      FStar_SMTEncoding_Term.Assume
-                                                        uu____12016 in
-                                                    let uu____12039 =
-                                                      let uu____12041 =
-                                                        let uu____12043 =
-                                                          let uu____12045 =
-                                                            let uu____12047 =
-                                                              primitive_type_axioms
-                                                                env1.tcenv
-                                                                flid f app1 in
-                                                            FStar_List.append
-                                                              [eqn]
-                                                              uu____12047 in
-                                                          FStar_List.append
-                                                            decls2
-                                                            uu____12045 in
-                                                        FStar_List.append
-                                                          binder_decls
-                                                          uu____12043 in
-                                                      FStar_List.append
-                                                        decls1 uu____12041 in
-                                                    (uu____12039, env1))))))
-                           | uu____12050 -> failwith "Impossible")
-                        else
-                          (let fuel =
-                             let uu____12069 = varops.fresh "fuel" in
-                             (uu____12069, FStar_SMTEncoding_Term.Fuel_sort) in
-                           let fuel_tm = FStar_SMTEncoding_Util.mkFreeV fuel in
-                           let env0 = env1 in
-                           let uu____12072 =
-                             FStar_All.pipe_right toks1
-                               (FStar_List.fold_left
-                                  (fun uu____12111  ->
-                                     fun uu____12112  ->
-                                       match (uu____12111, uu____12112) with
-                                       | ((gtoks,env2),(flid_fv,(f,ftok))) ->
-                                           let flid =
-                                             (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                           let g =
-                                             let uu____12194 =
-                                               FStar_Ident.lid_add_suffix
-                                                 flid "fuel_instrumented" in
-                                             varops.new_fvar uu____12194 in
-                                           let gtok =
-                                             let uu____12196 =
-                                               FStar_Ident.lid_add_suffix
-                                                 flid
-                                                 "fuel_instrumented_token" in
-                                             varops.new_fvar uu____12196 in
-                                           let env3 =
-                                             let uu____12198 =
-                                               let uu____12200 =
-                                                 FStar_SMTEncoding_Util.mkApp
-                                                   (g, [fuel_tm]) in
-                                               FStar_All.pipe_left
-                                                 (fun _0_36  -> Some _0_36)
-                                                 uu____12200 in
-                                             push_free_var env2 flid gtok
-                                               uu____12198 in
-                                           (((flid, f, ftok, g, gtok) ::
-                                             gtoks), env3)) ([], env1)) in
-                           match uu____12072 with
-                           | (gtoks,env2) ->
-                               let gtoks1 = FStar_List.rev gtoks in
-                               let encode_one_binding env01 uu____12284
-                                 t_norm uu____12286 =
-                                 match (uu____12284, uu____12286) with
-                                 | ((flid,f,ftok,g,gtok),{
-                                                           FStar_Syntax_Syntax.lbname
-                                                             = lbn;
-                                                           FStar_Syntax_Syntax.lbunivs
-                                                             = uvs;
-                                                           FStar_Syntax_Syntax.lbtyp
-                                                             = uu____12311;
-                                                           FStar_Syntax_Syntax.lbeff
-                                                             = uu____12312;
-                                                           FStar_Syntax_Syntax.lbdef
-                                                             = e;_})
-                                     ->
-                                     let uu____12329 =
-                                       FStar_Syntax_Subst.univ_var_opening
-                                         uvs in
-                                     (match uu____12329 with
-                                      | (univ_subst,univ_vars1) ->
-                                          let env' =
-                                            let uu___160_12346 = env2 in
-                                            let uu____12347 =
-                                              FStar_TypeChecker_Env.push_univ_vars
-                                                env2.tcenv univ_vars1 in
-                                            {
-                                              bindings =
-                                                (uu___160_12346.bindings);
-                                              depth = (uu___160_12346.depth);
-                                              tcenv = uu____12347;
-                                              warn = (uu___160_12346.warn);
-                                              cache = (uu___160_12346.cache);
-                                              nolabels =
-                                                (uu___160_12346.nolabels);
-                                              use_zfuel_name =
-                                                (uu___160_12346.use_zfuel_name);
-                                              encode_non_total_function_typ =
-                                                (uu___160_12346.encode_non_total_function_typ)
-                                            } in
-                                          let t_norm1 =
-                                            FStar_Syntax_Subst.subst
-                                              univ_subst t_norm in
-                                          let e1 =
-                                            FStar_Syntax_Subst.subst
-                                              univ_subst e in
-                                          ((let uu____12351 =
-                                              FStar_All.pipe_left
-                                                (FStar_TypeChecker_Env.debug
-                                                   env01.tcenv)
-                                                (FStar_Options.Other
-                                                   "SMTEncoding") in
-                                            if uu____12351
-                                            then
-                                              let uu____12352 =
-                                                FStar_Syntax_Print.lbname_to_string
-                                                  lbn in
-                                              let uu____12353 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  t_norm1 in
-                                              let uu____12354 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  e1 in
-                                              FStar_Util.print3
-                                                "Encoding let rec %s : %s = %s\n"
-                                                uu____12352 uu____12353
-                                                uu____12354
-                                            else ());
-                                           (let uu____12356 =
-                                              destruct_bound_function flid
-                                                t_norm1 e1 in
-                                            match uu____12356 with
-                                            | ((binders,body,formals,tres),curry)
-                                                ->
-                                                ((let uu____12378 =
-                                                    FStar_All.pipe_left
-                                                      (FStar_TypeChecker_Env.debug
-                                                         env01.tcenv)
-                                                      (FStar_Options.Other
-                                                         "SMTEncoding") in
-                                                  if uu____12378
-                                                  then
-                                                    let uu____12379 =
-                                                      FStar_Syntax_Print.binders_to_string
-                                                        ", " binders in
-                                                    let uu____12380 =
-                                                      FStar_Syntax_Print.term_to_string
-                                                        body in
-                                                    let uu____12381 =
-                                                      FStar_Syntax_Print.binders_to_string
-                                                        ", " formals in
-                                                    let uu____12382 =
-                                                      FStar_Syntax_Print.term_to_string
-                                                        tres in
-                                                    FStar_Util.print4
-                                                      "Encoding let rec: binders=[%s], body=%s, formals=[%s], tres=%s\n"
-                                                      uu____12379 uu____12380
-                                                      uu____12381 uu____12382
-                                                  else ());
-                                                 if curry
-                                                 then
-                                                   failwith
-                                                     "Unexpected type of let rec in SMT Encoding; expected it to be annotated with an arrow type"
-                                                 else ();
-                                                 (let uu____12386 =
-                                                    encode_binders None
-                                                      binders env' in
-                                                  match uu____12386 with
-                                                  | (vars,guards,env'1,binder_decls,uu____12404)
-                                                      ->
-                                                      let decl_g =
-                                                        let uu____12412 =
-                                                          let uu____12418 =
-                                                            let uu____12420 =
-                                                              FStar_List.map
-                                                                Prims.snd
-                                                                vars in
-                                                            FStar_SMTEncoding_Term.Fuel_sort
-                                                              :: uu____12420 in
-                                                          (g, uu____12418,
-                                                            FStar_SMTEncoding_Term.Term_sort,
-                                                            (Some
-                                                               "Fuel-instrumented function name")) in
-                                                        FStar_SMTEncoding_Term.DeclFun
-                                                          uu____12412 in
-                                                      let env02 =
-                                                        push_zfuel_name env01
-                                                          flid g in
-                                                      let decl_g_tok =
-                                                        FStar_SMTEncoding_Term.DeclFun
-                                                          (gtok, [],
-                                                            FStar_SMTEncoding_Term.Term_sort,
-                                                            (Some
-                                                               "Token for fuel-instrumented partial applications")) in
-                                                      let vars_tm =
-                                                        FStar_List.map
-                                                          FStar_SMTEncoding_Util.mkFreeV
-                                                          vars in
-                                                      let app =
-                                                        let uu____12435 =
-                                                          let uu____12439 =
-                                                            FStar_List.map
-                                                              FStar_SMTEncoding_Util.mkFreeV
-                                                              vars in
-                                                          (f, uu____12439) in
-                                                        FStar_SMTEncoding_Util.mkApp
-                                                          uu____12435 in
-                                                      let gsapp =
-                                                        let uu____12445 =
-                                                          let uu____12449 =
-                                                            let uu____12451 =
-                                                              FStar_SMTEncoding_Util.mkApp
-                                                                ("SFuel",
-                                                                  [fuel_tm]) in
-                                                            uu____12451 ::
-                                                              vars_tm in
-                                                          (g, uu____12449) in
-                                                        FStar_SMTEncoding_Util.mkApp
-                                                          uu____12445 in
-                                                      let gmax =
-                                                        let uu____12455 =
-                                                          let uu____12459 =
-                                                            let uu____12461 =
-                                                              FStar_SMTEncoding_Util.mkApp
-                                                                ("MaxFuel",
-                                                                  []) in
-                                                            uu____12461 ::
-                                                              vars_tm in
-                                                          (g, uu____12459) in
-                                                        FStar_SMTEncoding_Util.mkApp
-                                                          uu____12455 in
-                                                      let body1 =
-                                                        let uu____12465 =
-                                                          FStar_TypeChecker_Env.is_reifiable_function
-                                                            env'1.tcenv
-                                                            t_norm1 in
-                                                        if uu____12465
-                                                        then
-                                                          reify_body
-                                                            env'1.tcenv body
-                                                        else body in
-                                                      let uu____12467 =
-                                                        encode_term body1
-                                                          env'1 in
-                                                      (match uu____12467 with
-                                                       | (body_tm,decls2) ->
-                                                           let eqn_g =
-                                                             let uu____12478
-                                                               =
-                                                               let uu____12483
-                                                                 =
-                                                                 let uu____12484
-                                                                   =
-                                                                   let uu____12492
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    (gsapp,
-                                                                    body_tm) in
-                                                                   ([[gsapp]],
-                                                                    (Some
-                                                                    (Prims.parse_int
-                                                                    "0")),
-                                                                    (fuel ::
-                                                                    vars),
-                                                                    uu____12492) in
-                                                                 FStar_SMTEncoding_Util.mkForall'
-                                                                   uu____12484 in
-                                                               let uu____12503
-                                                                 =
-                                                                 let uu____12505
-                                                                   =
-                                                                   FStar_Util.format1
-                                                                    "Equation for fuel-instrumented recursive function: %s"
-                                                                    flid.FStar_Ident.str in
-                                                                 Some
-                                                                   uu____12505 in
-                                                               (uu____12483,
-                                                                 uu____12503,
-                                                                 (Some
-                                                                    (
-                                                                    Prims.strcat
-                                                                    "equation_with_fuel_"
-                                                                    g))) in
-                                                             FStar_SMTEncoding_Term.Assume
-                                                               uu____12478 in
-                                                           let eqn_f =
-                                                             let uu____12509
-                                                               =
-                                                               let uu____12514
-                                                                 =
-                                                                 let uu____12515
-                                                                   =
-                                                                   let uu____12521
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    (app,
-                                                                    gmax) in
-                                                                   ([[app]],
-                                                                    vars,
-                                                                    uu____12521) in
-                                                                 FStar_SMTEncoding_Util.mkForall
-                                                                   uu____12515 in
-                                                               (uu____12514,
-                                                                 (Some
-                                                                    "Correspondence of recursive function to instrumented version"),
-                                                                 (Some
-                                                                    (
-                                                                    Prims.strcat
-                                                                    "fuel_correspondence_"
-                                                                    g))) in
-                                                             FStar_SMTEncoding_Term.Assume
-                                                               uu____12509 in
-                                                           let eqn_g' =
-                                                             let uu____12530
-                                                               =
-                                                               let uu____12535
-                                                                 =
-                                                                 let uu____12536
-                                                                   =
-                                                                   let uu____12542
-                                                                    =
-                                                                    let uu____12543
-                                                                    =
-                                                                    let uu____12546
-                                                                    =
-                                                                    let uu____12547
-                                                                    =
-                                                                    let uu____12551
-                                                                    =
-                                                                    let uu____12553
-                                                                    =
-                                                                    FStar_SMTEncoding_Term.n_fuel
-                                                                    (Prims.parse_int
-                                                                    "0") in
-                                                                    uu____12553
-                                                                    ::
-                                                                    vars_tm in
-                                                                    (g,
-                                                                    uu____12551) in
-                                                                    FStar_SMTEncoding_Util.mkApp
-                                                                    uu____12547 in
-                                                                    (gsapp,
-                                                                    uu____12546) in
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    uu____12543 in
-                                                                   ([[gsapp]],
-                                                                    (fuel ::
-                                                                    vars),
-                                                                    uu____12542) in
-                                                                 FStar_SMTEncoding_Util.mkForall
-                                                                   uu____12536 in
-                                                               (uu____12535,
-                                                                 (Some
-                                                                    "Fuel irrelevance"),
-                                                                 (Some
-                                                                    (
-                                                                    Prims.strcat
-                                                                    "fuel_irrelevance_"
-                                                                    g))) in
-                                                             FStar_SMTEncoding_Term.Assume
-                                                               uu____12530 in
-                                                           let uu____12566 =
-                                                             let uu____12571
-                                                               =
-                                                               encode_binders
-                                                                 None formals
-                                                                 env02 in
-                                                             match uu____12571
-                                                             with
-                                                             | (vars1,v_guards,env3,binder_decls1,uu____12588)
-                                                                 ->
-                                                                 let vars_tm1
-                                                                   =
-                                                                   FStar_List.map
-                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    vars1 in
-                                                                 let gapp =
-                                                                   FStar_SMTEncoding_Util.mkApp
-                                                                    (g,
-                                                                    (fuel_tm
-                                                                    ::
-                                                                    vars_tm1)) in
-                                                                 let tok_corr
-                                                                   =
-                                                                   let tok_app
-                                                                    =
-                                                                    let uu____12603
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    (gtok,
-                                                                    FStar_SMTEncoding_Term.Term_sort) in
-                                                                    mk_Apply
-                                                                    uu____12603
-                                                                    (fuel ::
-                                                                    vars1) in
-                                                                   let uu____12606
-                                                                    =
-                                                                    let uu____12611
-                                                                    =
-                                                                    let uu____12612
-                                                                    =
-                                                                    let uu____12618
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    (tok_app,
-                                                                    gapp) in
-                                                                    ([
-                                                                    [tok_app]],
-                                                                    (fuel ::
-                                                                    vars1),
-                                                                    uu____12618) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____12612 in
-                                                                    (uu____12611,
-                                                                    (Some
-                                                                    "Fuel token correspondence"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "fuel_token_correspondence_"
-                                                                    gtok))) in
-                                                                   FStar_SMTEncoding_Term.Assume
-                                                                    uu____12606 in
-                                                                 let uu____12630
-                                                                   =
-                                                                   let uu____12634
-                                                                    =
-                                                                    encode_term_pred
-                                                                    None tres
-                                                                    env3 gapp in
-                                                                   match uu____12634
-                                                                   with
-                                                                   | 
-                                                                   (g_typing,d3)
-                                                                    ->
-                                                                    let uu____12642
-                                                                    =
-                                                                    let uu____12644
-                                                                    =
-                                                                    let uu____12645
-                                                                    =
-                                                                    let uu____12650
-                                                                    =
-                                                                    let uu____12651
-                                                                    =
-                                                                    let uu____12657
-                                                                    =
-                                                                    let uu____12658
-                                                                    =
-                                                                    let uu____12661
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_and_l
-                                                                    v_guards in
-                                                                    (uu____12661,
-                                                                    g_typing) in
-                                                                    FStar_SMTEncoding_Util.mkImp
-                                                                    uu____12658 in
-                                                                    ([[gapp]],
-                                                                    (fuel ::
-                                                                    vars1),
-                                                                    uu____12657) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____12651 in
-                                                                    (uu____12650,
-                                                                    (Some
-                                                                    "Typing correspondence of token to term"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "token_correspondence_"
-                                                                    g))) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____12645 in
-                                                                    [uu____12644] in
-                                                                    (d3,
-                                                                    uu____12642) in
-                                                                 (match uu____12630
-                                                                  with
-                                                                  | (aux_decls,typing_corr)
-                                                                    ->
-                                                                    ((FStar_List.append
-                                                                    binder_decls1
-                                                                    aux_decls),
-                                                                    (FStar_List.append
-                                                                    typing_corr
-                                                                    [tok_corr]))) in
-                                                           (match uu____12566
-                                                            with
-                                                            | (aux_decls,g_typing)
-                                                                ->
-                                                                ((FStar_List.append
-                                                                    binder_decls
-                                                                    (
-                                                                    FStar_List.append
-                                                                    decls2
-                                                                    (FStar_List.append
-                                                                    aux_decls
-                                                                    [decl_g;
-                                                                    decl_g_tok]))),
-                                                                  (FStar_List.append
-                                                                    [eqn_g;
-                                                                    eqn_g';
-                                                                    eqn_f]
-                                                                    g_typing),
-                                                                  env02)))))))) in
-                               let uu____12697 =
-                                 let uu____12704 =
-                                   FStar_List.zip3 gtoks1 typs1 bindings in
-                                 FStar_List.fold_left
-                                   (fun uu____12736  ->
-                                      fun uu____12737  ->
-                                        match (uu____12736, uu____12737) with
-                                        | ((decls2,eqns,env01),(gtok,ty,lb))
-                                            ->
-                                            let uu____12813 =
-                                              encode_one_binding env01 gtok
-                                                ty lb in
-                                            (match uu____12813 with
-                                             | (decls',eqns',env02) ->
-                                                 ((decls' :: decls2),
-                                                   (FStar_List.append eqns'
-                                                      eqns), env02)))
-                                   ([decls1], [], env0) uu____12704 in
-                               (match uu____12697 with
-                                | (decls2,eqns,env01) ->
-                                    let uu____12853 =
-                                      let isDeclFun uu___126_12861 =
-                                        match uu___126_12861 with
-                                        | FStar_SMTEncoding_Term.DeclFun
-                                            uu____12862 -> true
-                                        | uu____12868 -> false in
-                                      let uu____12869 =
-                                        FStar_All.pipe_right decls2
-                                          FStar_List.flatten in
-                                      FStar_All.pipe_right uu____12869
-                                        (FStar_List.partition isDeclFun) in
-                                    (match uu____12853 with
-                                     | (prefix_decls,rest) ->
-                                         let eqns1 = FStar_List.rev eqns in
-                                         ((FStar_List.append prefix_decls
-                                             (FStar_List.append rest eqns1)),
-                                           env01)))))
-             with
-             | Let_rec_unencodeable  ->
-                 let msg =
-                   let uu____12896 =
-                     FStar_All.pipe_right bindings
-                       (FStar_List.map
-                          (fun lb  ->
-                             FStar_Syntax_Print.lbname_to_string
-                               lb.FStar_Syntax_Syntax.lbname)) in
-                   FStar_All.pipe_right uu____12896
-                     (FStar_String.concat " and ") in
-                 let decl =
-                   FStar_SMTEncoding_Term.Caption
-                     (Prims.strcat "let rec unencodeable: Skipping: " msg) in
-                 ([decl], env))
-let rec encode_sigelt:
-  env_t ->
-    FStar_Syntax_Syntax.sigelt -> (FStar_SMTEncoding_Term.decls_t* env_t)
-  =
-  fun env  ->
-    fun se  ->
-      (let uu____12929 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
-           (FStar_Options.Other "SMTEncoding") in
-       if uu____12929
-       then
-         let uu____12930 = FStar_Syntax_Print.sigelt_to_string se in
-         FStar_All.pipe_left (FStar_Util.print1 ">>>>Encoding [%s]\n")
-           uu____12930
-       else ());
-      (let nm =
-         let uu____12933 = FStar_Syntax_Util.lid_of_sigelt se in
-         match uu____12933 with | None  -> "" | Some l -> l.FStar_Ident.str in
-       let uu____12936 = encode_sigelt' env se in
-       match uu____12936 with
-       | (g,e) ->
-           (match g with
-            | [] ->
-                let uu____12945 =
-                  let uu____12947 =
-                    let uu____12948 = FStar_Util.format1 "<Skipped %s/>" nm in
-                    FStar_SMTEncoding_Term.Caption uu____12948 in
-                  [uu____12947] in
-                (uu____12945, e)
-            | uu____12950 ->
-                let uu____12951 =
-                  let uu____12953 =
-                    let uu____12955 =
-                      let uu____12956 =
-                        FStar_Util.format1 "<Start encoding %s>" nm in
-                      FStar_SMTEncoding_Term.Caption uu____12956 in
-                    uu____12955 :: g in
-                  let uu____12957 =
-                    let uu____12959 =
-                      let uu____12960 =
-                        FStar_Util.format1 "</end encoding %s>" nm in
-                      FStar_SMTEncoding_Term.Caption uu____12960 in
-                    [uu____12959] in
-                  FStar_List.append uu____12953 uu____12957 in
-                (uu____12951, e)))
-and encode_sigelt':
-  env_t ->
-    FStar_Syntax_Syntax.sigelt -> (FStar_SMTEncoding_Term.decls_t* env_t)
-  =
-  fun env  ->
-    fun se  ->
-      match se with
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____12968 ->
-          failwith "impossible -- removed by tc.fs"
-      | FStar_Syntax_Syntax.Sig_pragma _
-        |FStar_Syntax_Syntax.Sig_main _
-         |FStar_Syntax_Syntax.Sig_effect_abbrev _
-          |FStar_Syntax_Syntax.Sig_sub_effect _ -> ([], env)
-      | FStar_Syntax_Syntax.Sig_new_effect (ed,uu____12979) ->
-          let uu____12980 =
-            let uu____12981 =
-              FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers
-                (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
-            FStar_All.pipe_right uu____12981 Prims.op_Negation in
-          if uu____12980
-          then ([], env)
-          else
-            (let close_effect_params tm =
-               match ed.FStar_Syntax_Syntax.binders with
-               | [] -> tm
-               | uu____13001 ->
-                   let uu____13002 =
-                     let uu____13005 =
-                       let uu____13006 =
-                         let uu____13021 =
-                           FStar_All.pipe_left (fun _0_37  -> Some _0_37)
-                             (FStar_Util.Inr
-                                (FStar_Syntax_Const.effect_Tot_lid,
-                                  [FStar_Syntax_Syntax.TOTAL])) in
-                         ((ed.FStar_Syntax_Syntax.binders), tm, uu____13021) in
-                       FStar_Syntax_Syntax.Tm_abs uu____13006 in
-                     FStar_Syntax_Syntax.mk uu____13005 in
-                   uu____13002 None tm.FStar_Syntax_Syntax.pos in
-             let encode_action env1 a =
-               let uu____13074 =
-                 new_term_constant_and_tok_from_lid env1
-                   a.FStar_Syntax_Syntax.action_name in
-               match uu____13074 with
-               | (aname,atok,env2) ->
-                   let uu____13084 =
-                     FStar_Syntax_Util.arrow_formals_comp
-                       a.FStar_Syntax_Syntax.action_typ in
-                   (match uu____13084 with
-                    | (formals,uu____13094) ->
-                        let uu____13101 =
-                          let uu____13104 =
-                            close_effect_params
-                              a.FStar_Syntax_Syntax.action_defn in
-                          encode_term uu____13104 env2 in
-                        (match uu____13101 with
-                         | (tm,decls) ->
-                             let a_decls =
-                               let uu____13112 =
-                                 let uu____13113 =
-                                   let uu____13119 =
-                                     FStar_All.pipe_right formals
-                                       (FStar_List.map
-                                          (fun uu____13127  ->
-                                             FStar_SMTEncoding_Term.Term_sort)) in
-                                   (aname, uu____13119,
-                                     FStar_SMTEncoding_Term.Term_sort,
-                                     (Some "Action")) in
-                                 FStar_SMTEncoding_Term.DeclFun uu____13113 in
-                               [uu____13112;
-                               FStar_SMTEncoding_Term.DeclFun
-                                 (atok, [], FStar_SMTEncoding_Term.Term_sort,
-                                   (Some "Action token"))] in
-                             let uu____13134 =
-                               let aux uu____13163 uu____13164 =
-                                 match (uu____13163, uu____13164) with
-                                 | ((bv,uu____13191),(env3,acc_sorts,acc)) ->
-                                     let uu____13212 = gen_term_var env3 bv in
-                                     (match uu____13212 with
-                                      | (xxsym,xx,env4) ->
-                                          (env4,
-                                            ((xxsym,
-                                               FStar_SMTEncoding_Term.Term_sort)
-                                            :: acc_sorts), (xx :: acc))) in
-                               FStar_List.fold_right aux formals
-                                 (env2, [], []) in
-                             (match uu____13134 with
-                              | (uu____13250,xs_sorts,xs) ->
-                                  let app =
-                                    FStar_SMTEncoding_Util.mkApp (aname, xs) in
-                                  let a_eq =
-                                    let uu____13264 =
-                                      let uu____13269 =
-                                        let uu____13270 =
-                                          let uu____13276 =
-                                            let uu____13277 =
-                                              let uu____13280 =
-                                                mk_Apply tm xs_sorts in
-                                              (app, uu____13280) in
-                                            FStar_SMTEncoding_Util.mkEq
-                                              uu____13277 in
-                                          ([[app]], xs_sorts, uu____13276) in
-                                        FStar_SMTEncoding_Util.mkForall
-                                          uu____13270 in
-                                      (uu____13269, (Some "Action equality"),
-                                        (Some
-                                           (Prims.strcat aname "_equality"))) in
-                                    FStar_SMTEncoding_Term.Assume uu____13264 in
-                                  let tok_correspondence =
-                                    let tok_term =
-                                      FStar_SMTEncoding_Util.mkFreeV
-                                        (atok,
-                                          FStar_SMTEncoding_Term.Term_sort) in
-                                    let tok_app = mk_Apply tok_term xs_sorts in
-                                    let uu____13293 =
-                                      let uu____13298 =
-                                        let uu____13299 =
-                                          let uu____13305 =
-                                            FStar_SMTEncoding_Util.mkEq
-                                              (tok_app, app) in
-                                          ([[tok_app]], xs_sorts,
-                                            uu____13305) in
-                                        FStar_SMTEncoding_Util.mkForall
-                                          uu____13299 in
-                                      (uu____13298,
-                                        (Some "Action token correspondence"),
-                                        (Some
-                                           (Prims.strcat aname
-                                              "_token_correspondence"))) in
-                                    FStar_SMTEncoding_Term.Assume uu____13293 in
-                                  (env2,
-                                    (FStar_List.append decls
-                                       (FStar_List.append a_decls
-                                          [a_eq; tok_correspondence])))))) in
-             let uu____13316 =
-               FStar_Util.fold_map encode_action env
-                 ed.FStar_Syntax_Syntax.actions in
-             match uu____13316 with
-             | (env1,decls2) -> ((FStar_List.flatten decls2), env1))
-      | FStar_Syntax_Syntax.Sig_declare_typ
-          (lid,uu____13332,uu____13333,uu____13334,uu____13335) when
-          FStar_Ident.lid_equals lid FStar_Syntax_Const.precedes_lid ->
-          let uu____13338 = new_term_constant_and_tok_from_lid env lid in
-          (match uu____13338 with | (tname,ttok,env1) -> ([], env1))
-      | FStar_Syntax_Syntax.Sig_declare_typ
-          (lid,uu____13349,t,quals,uu____13352) ->
-          let will_encode_definition =
-            let uu____13356 =
-              FStar_All.pipe_right quals
-                (FStar_Util.for_some
-                   (fun uu___127_13358  ->
-                      match uu___127_13358 with
-                      | FStar_Syntax_Syntax.Assumption 
-                        |FStar_Syntax_Syntax.Projector _
-                         |FStar_Syntax_Syntax.Discriminator _
-                          |FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____13361 -> false)) in
-            Prims.op_Negation uu____13356 in
-          if will_encode_definition
-          then ([], env)
-          else
-            (let fv =
-               FStar_Syntax_Syntax.lid_as_fv lid
-                 FStar_Syntax_Syntax.Delta_constant None in
-             let uu____13367 = encode_top_level_val env fv t quals in
-             match uu____13367 with
-             | (decls,env1) ->
-                 let tname = lid.FStar_Ident.str in
-                 let tsym =
-                   FStar_SMTEncoding_Util.mkFreeV
-                     (tname, FStar_SMTEncoding_Term.Term_sort) in
-                 let uu____13379 =
-                   let uu____13381 =
-                     primitive_type_axioms env1.tcenv lid tname tsym in
-                   FStar_List.append decls uu____13381 in
-                 (uu____13379, env1))
-      | FStar_Syntax_Syntax.Sig_assume (l,f,uu____13386,uu____13387) ->
-          let uu____13390 = encode_formula f env in
-          (match uu____13390 with
-           | (f1,decls) ->
-               let g =
-                 let uu____13399 =
-                   let uu____13400 =
-                     let uu____13405 =
-                       let uu____13407 =
-                         let uu____13408 = FStar_Syntax_Print.lid_to_string l in
-                         FStar_Util.format1 "Assumption: %s" uu____13408 in
-                       Some uu____13407 in
-                     let uu____13409 =
-                       let uu____13411 =
-                         varops.mk_unique
-                           (Prims.strcat "assumption_" l.FStar_Ident.str) in
-                       Some uu____13411 in
-                     (f1, uu____13405, uu____13409) in
-                   FStar_SMTEncoding_Term.Assume uu____13400 in
-                 [uu____13399] in
-               ((FStar_List.append decls g), env))
-      | FStar_Syntax_Syntax.Sig_let (lbs,r,uu____13417,quals,uu____13419)
-          when
-          FStar_All.pipe_right quals
-            (FStar_List.contains FStar_Syntax_Syntax.Irreducible)
-          ->
-          let uu____13427 =
-            FStar_Util.fold_map
-              (fun env1  ->
-                 fun lb  ->
-                   let lid =
-                     let uu____13434 =
-                       let uu____13439 =
-                         FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                       uu____13439.FStar_Syntax_Syntax.fv_name in
-                     uu____13434.FStar_Syntax_Syntax.v in
-                   let uu____13443 =
-                     let uu____13444 =
-                       FStar_TypeChecker_Env.try_lookup_val_decl env1.tcenv
-                         lid in
-                     FStar_All.pipe_left FStar_Option.isNone uu____13444 in
-                   if uu____13443
-                   then
-                     let val_decl =
-                       FStar_Syntax_Syntax.Sig_declare_typ
-                         (lid, (lb.FStar_Syntax_Syntax.lbunivs),
-                           (lb.FStar_Syntax_Syntax.lbtyp), quals, r) in
-                     let uu____13463 = encode_sigelt' env1 val_decl in
-                     match uu____13463 with | (decls,env2) -> (env2, decls)
-                   else (env1, [])) env (Prims.snd lbs) in
-          (match uu____13427 with
-           | (env1,decls) -> ((FStar_List.flatten decls), env1))
-      | FStar_Syntax_Syntax.Sig_let
-          ((uu____13480,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t1;
-                          FStar_Syntax_Syntax.lbunivs = uu____13482;
-                          FStar_Syntax_Syntax.lbtyp = uu____13483;
-                          FStar_Syntax_Syntax.lbeff = uu____13484;
-                          FStar_Syntax_Syntax.lbdef = uu____13485;_}::[]),uu____13486,uu____13487,uu____13488,uu____13489)
-          when FStar_Syntax_Syntax.fv_eq_lid b2t1 FStar_Syntax_Const.b2t_lid
-          ->
-          let uu____13505 =
-            new_term_constant_and_tok_from_lid env
-              (b2t1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____13505 with
-           | (tname,ttok,env1) ->
-               let xx = ("x", FStar_SMTEncoding_Term.Term_sort) in
-               let x = FStar_SMTEncoding_Util.mkFreeV xx in
-               let valid_b2t_x =
-                 let uu____13523 =
-                   let uu____13527 =
-                     let uu____13529 =
-                       FStar_SMTEncoding_Util.mkApp ("Prims.b2t", [x]) in
-                     [uu____13529] in
-                   ("Valid", uu____13527) in
-                 FStar_SMTEncoding_Util.mkApp uu____13523 in
-               let decls =
-                 let uu____13534 =
-                   let uu____13536 =
-                     let uu____13537 =
-                       let uu____13542 =
-                         let uu____13543 =
-                           let uu____13549 =
-                             let uu____13550 =
-                               let uu____13553 =
-                                 FStar_SMTEncoding_Util.mkApp
-                                   ("BoxBool_proj_0", [x]) in
-                               (valid_b2t_x, uu____13553) in
-                             FStar_SMTEncoding_Util.mkEq uu____13550 in
-                           ([[valid_b2t_x]], [xx], uu____13549) in
-                         FStar_SMTEncoding_Util.mkForall uu____13543 in
-                       (uu____13542, (Some "b2t def"), (Some "b2t_def")) in
-                     FStar_SMTEncoding_Term.Assume uu____13537 in
-                   [uu____13536] in
-                 (FStar_SMTEncoding_Term.DeclFun
-                    (tname, [FStar_SMTEncoding_Term.Term_sort],
-                      FStar_SMTEncoding_Term.Term_sort, None))
-                   :: uu____13534 in
-               (decls, env1))
-      | FStar_Syntax_Syntax.Sig_let
-          (uu____13571,uu____13572,uu____13573,quals,uu____13575) when
-          FStar_All.pipe_right quals
-            (FStar_Util.for_some
-               (fun uu___128_13583  ->
-                  match uu___128_13583 with
-                  | FStar_Syntax_Syntax.Discriminator uu____13584 -> true
-                  | uu____13585 -> false))
-          -> ([], env)
-      | FStar_Syntax_Syntax.Sig_let
-          (uu____13587,uu____13588,lids,quals,uu____13591) when
-          (FStar_All.pipe_right lids
-             (FStar_Util.for_some
-                (fun l  ->
-                   let uu____13600 =
-                     let uu____13601 = FStar_List.hd l.FStar_Ident.ns in
-                     uu____13601.FStar_Ident.idText in
-                   uu____13600 = "Prims")))
-            &&
-            (FStar_All.pipe_right quals
-               (FStar_Util.for_some
-                  (fun uu___129_13603  ->
-                     match uu___129_13603 with
-                     | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen 
-                         -> true
-                     | uu____13604 -> false)))
-          -> ([], env)
-      | FStar_Syntax_Syntax.Sig_let
-          ((false ,lb::[]),uu____13607,uu____13608,quals,uu____13610) when
-          FStar_All.pipe_right quals
-            (FStar_Util.for_some
-               (fun uu___130_13622  ->
-                  match uu___130_13622 with
-                  | FStar_Syntax_Syntax.Projector uu____13623 -> true
-                  | uu____13626 -> false))
-          ->
-          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-          let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          let uu____13633 = try_lookup_free_var env l in
-          (match uu____13633 with
-           | Some uu____13637 -> ([], env)
-           | None  ->
-               let se1 =
-                 FStar_Syntax_Syntax.Sig_declare_typ
-                   (l, (lb.FStar_Syntax_Syntax.lbunivs),
-                     (lb.FStar_Syntax_Syntax.lbtyp), quals,
-                     (FStar_Ident.range_of_lid l)) in
-               encode_sigelt env se1)
-      | FStar_Syntax_Syntax.Sig_let
-          ((is_rec,bindings),uu____13646,uu____13647,quals,uu____13649) ->
-          encode_top_level_let env (is_rec, bindings) quals
-      | FStar_Syntax_Syntax.Sig_bundle
-          (ses,uu____13663,uu____13664,uu____13665) ->
-          let uu____13672 = encode_signature env ses in
-          (match uu____13672 with
-           | (g,env1) ->
-               let uu____13682 =
-                 FStar_All.pipe_right g
-                   (FStar_List.partition
-                      (fun uu___131_13692  ->
-                         match uu___131_13692 with
-                         | FStar_SMTEncoding_Term.Assume
-                             (uu____13693,Some "inversion axiom",uu____13694)
-                             -> false
-                         | uu____13698 -> true)) in
-               (match uu____13682 with
-                | (g',inversions) ->
-                    let uu____13707 =
-                      FStar_All.pipe_right g'
-                        (FStar_List.partition
-                           (fun uu___132_13717  ->
-                              match uu___132_13717 with
-                              | FStar_SMTEncoding_Term.DeclFun uu____13718 ->
-                                  true
-                              | uu____13724 -> false)) in
-                    (match uu____13707 with
-                     | (decls,rest) ->
-                         ((FStar_List.append decls
-                             (FStar_List.append rest inversions)), env1))))
-      | FStar_Syntax_Syntax.Sig_inductive_typ
-          (t,uu____13735,tps,k,uu____13738,datas,quals,uu____13741) ->
-          let is_logical =
-            FStar_All.pipe_right quals
-              (FStar_Util.for_some
-                 (fun uu___133_13750  ->
-                    match uu___133_13750 with
-                    | FStar_Syntax_Syntax.Logic 
-                      |FStar_Syntax_Syntax.Assumption  -> true
-                    | uu____13751 -> false)) in
-          let constructor_or_logic_type_decl c =
-            if is_logical
-            then
-              let uu____13758 = c in
-              match uu____13758 with
-              | (name,args,uu____13762,uu____13763,uu____13764) ->
-                  let uu____13767 =
-                    let uu____13768 =
-                      let uu____13774 =
-                        FStar_All.pipe_right args
-                          (FStar_List.map
-                             (fun uu____13781  ->
-                                match uu____13781 with
-                                | (uu____13785,sort,uu____13787) -> sort)) in
-                      (name, uu____13774, FStar_SMTEncoding_Term.Term_sort,
-                        None) in
-                    FStar_SMTEncoding_Term.DeclFun uu____13768 in
-                  [uu____13767]
-            else FStar_SMTEncoding_Term.constructor_to_decl c in
-          let inversion_axioms tapp vars =
-            let uu____13805 =
-              FStar_All.pipe_right datas
-                (FStar_Util.for_some
-                   (fun l  ->
-                      let uu____13808 =
-                        FStar_TypeChecker_Env.try_lookup_lid env.tcenv l in
-                      FStar_All.pipe_right uu____13808 FStar_Option.isNone)) in
-            if uu____13805
-            then []
-            else
-              (let uu____13825 =
-                 fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
-               match uu____13825 with
-               | (xxsym,xx) ->
-                   let uu____13831 =
-                     FStar_All.pipe_right datas
-                       (FStar_List.fold_left
-                          (fun uu____13842  ->
-                             fun l  ->
-                               match uu____13842 with
-                               | (out,decls) ->
-                                   let uu____13854 =
-                                     FStar_TypeChecker_Env.lookup_datacon
-                                       env.tcenv l in
-                                   (match uu____13854 with
-                                    | (uu____13860,data_t) ->
-                                        let uu____13862 =
-                                          FStar_Syntax_Util.arrow_formals
-                                            data_t in
-                                        (match uu____13862 with
-                                         | (args,res) ->
-                                             let indices =
-                                               let uu____13891 =
-                                                 let uu____13892 =
-                                                   FStar_Syntax_Subst.compress
-                                                     res in
-                                                 uu____13892.FStar_Syntax_Syntax.n in
-                                               match uu____13891 with
-                                               | FStar_Syntax_Syntax.Tm_app
-                                                   (uu____13900,indices) ->
-                                                   indices
-                                               | uu____13916 -> [] in
-                                             let env1 =
-                                               FStar_All.pipe_right args
-                                                 (FStar_List.fold_left
-                                                    (fun env1  ->
-                                                       fun uu____13928  ->
-                                                         match uu____13928
-                                                         with
-                                                         | (x,uu____13932) ->
-                                                             let uu____13933
-                                                               =
-                                                               let uu____13934
-                                                                 =
-                                                                 let uu____13938
-                                                                   =
-                                                                   mk_term_projector_name
-                                                                    l x in
-                                                                 (uu____13938,
-                                                                   [xx]) in
-                                                               FStar_SMTEncoding_Util.mkApp
-                                                                 uu____13934 in
-                                                             push_term_var
-                                                               env1 x
-                                                               uu____13933)
-                                                    env) in
-                                             let uu____13940 =
-                                               encode_args indices env1 in
-                                             (match uu____13940 with
-                                              | (indices1,decls') ->
-                                                  (if
-                                                     (FStar_List.length
-                                                        indices1)
-                                                       <>
-                                                       (FStar_List.length
-                                                          vars)
-                                                   then failwith "Impossible"
-                                                   else ();
-                                                   (let eqs =
-                                                      let uu____13960 =
-                                                        FStar_List.map2
-                                                          (fun v1  ->
-                                                             fun a  ->
-                                                               let uu____13968
-                                                                 =
-                                                                 let uu____13971
-                                                                   =
-                                                                   FStar_SMTEncoding_Util.mkFreeV
-                                                                    v1 in
-                                                                 (uu____13971,
-                                                                   a) in
-                                                               FStar_SMTEncoding_Util.mkEq
-                                                                 uu____13968)
-                                                          vars indices1 in
-                                                      FStar_All.pipe_right
-                                                        uu____13960
-                                                        FStar_SMTEncoding_Util.mk_and_l in
-                                                    let uu____13973 =
-                                                      let uu____13974 =
-                                                        let uu____13977 =
-                                                          let uu____13978 =
-                                                            let uu____13981 =
-                                                              mk_data_tester
-                                                                env1 l xx in
-                                                            (uu____13981,
-                                                              eqs) in
-                                                          FStar_SMTEncoding_Util.mkAnd
-                                                            uu____13978 in
-                                                        (out, uu____13977) in
-                                                      FStar_SMTEncoding_Util.mkOr
-                                                        uu____13974 in
-                                                    (uu____13973,
-                                                      (FStar_List.append
-                                                         decls decls'))))))))
-                          (FStar_SMTEncoding_Util.mkFalse, [])) in
-                   (match uu____13831 with
-                    | (data_ax,decls) ->
-                        let uu____13989 =
-                          fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
-                        (match uu____13989 with
-                         | (ffsym,ff) ->
-                             let fuel_guarded_inversion =
-                               let xx_has_type_sfuel =
-                                 if
-                                   (FStar_List.length datas) >
-                                     (Prims.parse_int "1")
-                                 then
-                                   let uu____14000 =
-                                     FStar_SMTEncoding_Util.mkApp
-                                       ("SFuel", [ff]) in
-                                   FStar_SMTEncoding_Term.mk_HasTypeFuel
-                                     uu____14000 xx tapp
-                                 else
-                                   FStar_SMTEncoding_Term.mk_HasTypeFuel ff
-                                     xx tapp in
-                               let uu____14003 =
-                                 let uu____14008 =
-                                   let uu____14009 =
-                                     let uu____14015 =
-                                       add_fuel
-                                         (ffsym,
-                                           FStar_SMTEncoding_Term.Fuel_sort)
-                                         ((xxsym,
-                                            FStar_SMTEncoding_Term.Term_sort)
-                                         :: vars) in
-                                     let uu____14023 =
-                                       FStar_SMTEncoding_Util.mkImp
-                                         (xx_has_type_sfuel, data_ax) in
-                                     ([[xx_has_type_sfuel]], uu____14015,
-                                       uu____14023) in
-                                   FStar_SMTEncoding_Util.mkForall
-                                     uu____14009 in
-                                 let uu____14031 =
-                                   let uu____14033 =
-                                     varops.mk_unique
-                                       (Prims.strcat
-                                          "fuel_guarded_inversion_"
-                                          t.FStar_Ident.str) in
-                                   Some uu____14033 in
-                                 (uu____14008, (Some "inversion axiom"),
-                                   uu____14031) in
-                               FStar_SMTEncoding_Term.Assume uu____14003 in
-                             let pattern_guarded_inversion =
-                               let uu____14038 =
-                                 (contains_name env "Prims.inversion") &&
-                                   ((FStar_List.length datas) >
-                                      (Prims.parse_int "1")) in
-                               if uu____14038
-                               then
-                                 let xx_has_type_fuel =
-                                   FStar_SMTEncoding_Term.mk_HasTypeFuel ff
-                                     xx tapp in
-                                 let pattern_guard =
-                                   FStar_SMTEncoding_Util.mkApp
-                                     ("Prims.inversion", [tapp]) in
-                                 let uu____14046 =
-                                   let uu____14047 =
-                                     let uu____14052 =
-                                       let uu____14053 =
-                                         let uu____14059 =
-                                           add_fuel
-                                             (ffsym,
-                                               FStar_SMTEncoding_Term.Fuel_sort)
-                                             ((xxsym,
-                                                FStar_SMTEncoding_Term.Term_sort)
-                                             :: vars) in
-                                         let uu____14067 =
-                                           FStar_SMTEncoding_Util.mkImp
-                                             (xx_has_type_fuel, data_ax) in
-                                         ([[xx_has_type_fuel; pattern_guard]],
-                                           uu____14059, uu____14067) in
-                                       FStar_SMTEncoding_Util.mkForall
-                                         uu____14053 in
-                                     let uu____14075 =
-                                       let uu____14077 =
-                                         varops.mk_unique
-                                           (Prims.strcat
-                                              "pattern_guarded_inversion_"
-                                              t.FStar_Ident.str) in
-                                       Some uu____14077 in
-                                     (uu____14052, (Some "inversion axiom"),
-                                       uu____14075) in
-                                   FStar_SMTEncoding_Term.Assume uu____14047 in
-                                 [uu____14046]
-                               else [] in
-                             FStar_List.append decls
-                               (FStar_List.append [fuel_guarded_inversion]
-                                  pattern_guarded_inversion)))) in
-          let uu____14081 =
-            let uu____14089 =
-              let uu____14090 = FStar_Syntax_Subst.compress k in
-              uu____14090.FStar_Syntax_Syntax.n in
-            match uu____14089 with
-            | FStar_Syntax_Syntax.Tm_arrow (formals,kres) ->
-                ((FStar_List.append tps formals),
-                  (FStar_Syntax_Util.comp_result kres))
-            | uu____14119 -> (tps, k) in
-          (match uu____14081 with
-           | (formals,res) ->
-               let uu____14134 = FStar_Syntax_Subst.open_term formals res in
-               (match uu____14134 with
-                | (formals1,res1) ->
-                    let uu____14141 = encode_binders None formals1 env in
-                    (match uu____14141 with
-                     | (vars,guards,env',binder_decls,uu____14156) ->
-                         let uu____14163 =
-                           new_term_constant_and_tok_from_lid env t in
-                         (match uu____14163 with
-                          | (tname,ttok,env1) ->
-                              let ttok_tm =
-                                FStar_SMTEncoding_Util.mkApp (ttok, []) in
-                              let guard =
-                                FStar_SMTEncoding_Util.mk_and_l guards in
-                              let tapp =
-                                let uu____14176 =
-                                  let uu____14180 =
-                                    FStar_List.map
-                                      FStar_SMTEncoding_Util.mkFreeV vars in
-                                  (tname, uu____14180) in
-                                FStar_SMTEncoding_Util.mkApp uu____14176 in
-                              let uu____14185 =
-                                let tname_decl =
-                                  let uu____14191 =
-                                    let uu____14192 =
-                                      FStar_All.pipe_right vars
-                                        (FStar_List.map
-                                           (fun uu____14207  ->
-                                              match uu____14207 with
-                                              | (n1,s) ->
-                                                  ((Prims.strcat tname n1),
-                                                    s, false))) in
-                                    let uu____14215 = varops.next_id () in
-                                    (tname, uu____14192,
-                                      FStar_SMTEncoding_Term.Term_sort,
-                                      uu____14215, false) in
-                                  constructor_or_logic_type_decl uu____14191 in
-                                let uu____14220 =
-                                  match vars with
-                                  | [] ->
-                                      let uu____14227 =
-                                        let uu____14228 =
-                                          let uu____14230 =
-                                            FStar_SMTEncoding_Util.mkApp
-                                              (tname, []) in
-                                          FStar_All.pipe_left
-                                            (fun _0_38  -> Some _0_38)
-                                            uu____14230 in
-                                        push_free_var env1 t tname
-                                          uu____14228 in
-                                      ([], uu____14227)
-                                  | uu____14234 ->
-                                      let ttok_decl =
-                                        FStar_SMTEncoding_Term.DeclFun
-                                          (ttok, [],
-                                            FStar_SMTEncoding_Term.Term_sort,
-                                            (Some "token")) in
-                                      let ttok_fresh =
-                                        let uu____14240 = varops.next_id () in
-                                        FStar_SMTEncoding_Term.fresh_token
-                                          (ttok,
-                                            FStar_SMTEncoding_Term.Term_sort)
-                                          uu____14240 in
-                                      let ttok_app = mk_Apply ttok_tm vars in
-                                      let pats = [[ttok_app]; [tapp]] in
-                                      let name_tok_corr =
-                                        let uu____14249 =
-                                          let uu____14254 =
-                                            let uu____14255 =
-                                              let uu____14263 =
-                                                FStar_SMTEncoding_Util.mkEq
-                                                  (ttok_app, tapp) in
-                                              (pats, None, vars, uu____14263) in
-                                            FStar_SMTEncoding_Util.mkForall'
-                                              uu____14255 in
-                                          (uu____14254,
-                                            (Some "name-token correspondence"),
-                                            (Some
-                                               (Prims.strcat
-                                                  "token_correspondence_"
-                                                  ttok))) in
-                                        FStar_SMTEncoding_Term.Assume
-                                          uu____14249 in
-                                      ([ttok_decl; ttok_fresh; name_tok_corr],
-                                        env1) in
-                                match uu____14220 with
-                                | (tok_decls,env2) ->
-                                    ((FStar_List.append tname_decl tok_decls),
-                                      env2) in
-                              (match uu____14185 with
-                               | (decls,env2) ->
-                                   let kindingAx =
-                                     let uu____14287 =
-                                       encode_term_pred None res1 env' tapp in
-                                     match uu____14287 with
-                                     | (k1,decls1) ->
-                                         let karr =
-                                           if
-                                             (FStar_List.length formals1) >
-                                               (Prims.parse_int "0")
-                                           then
-                                             let uu____14301 =
-                                               let uu____14302 =
-                                                 let uu____14307 =
-                                                   let uu____14308 =
-                                                     FStar_SMTEncoding_Term.mk_PreType
-                                                       ttok_tm in
-                                                   FStar_SMTEncoding_Term.mk_tester
-                                                     "Tm_arrow" uu____14308 in
-                                                 (uu____14307,
-                                                   (Some "kinding"),
-                                                   (Some
-                                                      (Prims.strcat
-                                                         "pre_kinding_" ttok))) in
-                                               FStar_SMTEncoding_Term.Assume
-                                                 uu____14302 in
-                                             [uu____14301]
-                                           else [] in
-                                         let uu____14312 =
-                                           let uu____14314 =
-                                             let uu____14316 =
-                                               let uu____14317 =
-                                                 let uu____14322 =
-                                                   let uu____14323 =
-                                                     let uu____14329 =
-                                                       FStar_SMTEncoding_Util.mkImp
-                                                         (guard, k1) in
-                                                     ([[tapp]], vars,
-                                                       uu____14329) in
-                                                   FStar_SMTEncoding_Util.mkForall
-                                                     uu____14323 in
-                                                 (uu____14322, None,
-                                                   (Some
-                                                      (Prims.strcat
-                                                         "kinding_" ttok))) in
-                                               FStar_SMTEncoding_Term.Assume
-                                                 uu____14317 in
-                                             [uu____14316] in
-                                           FStar_List.append karr uu____14314 in
-                                         FStar_List.append decls1 uu____14312 in
-                                   let aux =
-                                     let uu____14339 =
-                                       let uu____14341 =
-                                         inversion_axioms tapp vars in
-                                       let uu____14343 =
-                                         let uu____14345 =
-                                           pretype_axiom tapp vars in
-                                         [uu____14345] in
-                                       FStar_List.append uu____14341
-                                         uu____14343 in
-                                     FStar_List.append kindingAx uu____14339 in
-                                   let g =
-                                     FStar_List.append decls
-                                       (FStar_List.append binder_decls aux) in
-                                   (g, env2))))))
-      | FStar_Syntax_Syntax.Sig_datacon
-          (d,uu____14350,uu____14351,uu____14352,uu____14353,uu____14354,uu____14355,uu____14356)
-          when FStar_Ident.lid_equals d FStar_Syntax_Const.lexcons_lid ->
-          ([], env)
-      | FStar_Syntax_Syntax.Sig_datacon
-          (d,uu____14363,t,uu____14365,n_tps,quals,uu____14368,drange) ->
-          let uu____14374 = new_term_constant_and_tok_from_lid env d in
-          (match uu____14374 with
-           | (ddconstrsym,ddtok,env1) ->
-               let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, []) in
-               let uu____14385 = FStar_Syntax_Util.arrow_formals t in
-               (match uu____14385 with
-                | (formals,t_res) ->
-                    let uu____14407 =
-                      fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
-                    (match uu____14407 with
-                     | (fuel_var,fuel_tm) ->
-                         let s_fuel_tm =
-                           FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm]) in
-                         let uu____14416 =
-                           encode_binders (Some fuel_tm) formals env1 in
-                         (match uu____14416 with
-                          | (vars,guards,env',binder_decls,names1) ->
-                              let fields =
-                                FStar_All.pipe_right names1
-                                  (FStar_List.mapi
-                                     (fun n1  ->
-                                        fun x  ->
-                                          let projectible = true in
-                                          let uu____14454 =
-                                            mk_term_projector_name d x in
-                                          (uu____14454,
-                                            FStar_SMTEncoding_Term.Term_sort,
-                                            projectible))) in
-                              let datacons =
-                                let uu____14456 =
-                                  let uu____14466 = varops.next_id () in
-                                  (ddconstrsym, fields,
-                                    FStar_SMTEncoding_Term.Term_sort,
-                                    uu____14466, true) in
-                                FStar_All.pipe_right uu____14456
-                                  FStar_SMTEncoding_Term.constructor_to_decl in
-                              let app = mk_Apply ddtok_tm vars in
-                              let guard =
-                                FStar_SMTEncoding_Util.mk_and_l guards in
-                              let xvars =
-                                FStar_List.map FStar_SMTEncoding_Util.mkFreeV
-                                  vars in
-                              let dapp =
-                                FStar_SMTEncoding_Util.mkApp
-                                  (ddconstrsym, xvars) in
-                              let uu____14488 =
-                                encode_term_pred None t env1 ddtok_tm in
-                              (match uu____14488 with
-                               | (tok_typing,decls3) ->
-                                   let uu____14495 =
-                                     encode_binders (Some fuel_tm) formals
-                                       env1 in
-                                   (match uu____14495 with
-                                    | (vars',guards',env'',decls_formals,uu____14510)
-                                        ->
-                                        let uu____14517 =
-                                          let xvars1 =
-                                            FStar_List.map
-                                              FStar_SMTEncoding_Util.mkFreeV
-                                              vars' in
-                                          let dapp1 =
-                                            FStar_SMTEncoding_Util.mkApp
-                                              (ddconstrsym, xvars1) in
-                                          encode_term_pred (Some fuel_tm)
-                                            t_res env'' dapp1 in
-                                        (match uu____14517 with
-                                         | (ty_pred',decls_pred) ->
-                                             let guard' =
-                                               FStar_SMTEncoding_Util.mk_and_l
-                                                 guards' in
-                                             let proxy_fresh =
-                                               match formals with
-                                               | [] -> []
-                                               | uu____14536 ->
-                                                   let uu____14540 =
-                                                     let uu____14541 =
-                                                       varops.next_id () in
-                                                     FStar_SMTEncoding_Term.fresh_token
-                                                       (ddtok,
-                                                         FStar_SMTEncoding_Term.Term_sort)
-                                                       uu____14541 in
-                                                   [uu____14540] in
-                                             let encode_elim uu____14548 =
-                                               let uu____14549 =
-                                                 FStar_Syntax_Util.head_and_args
-                                                   t_res in
-                                               match uu____14549 with
-                                               | (head1,args) ->
-                                                   let uu____14578 =
-                                                     let uu____14579 =
-                                                       FStar_Syntax_Subst.compress
-                                                         head1 in
-                                                     uu____14579.FStar_Syntax_Syntax.n in
-                                                   (match uu____14578 with
-                                                    | FStar_Syntax_Syntax.Tm_uinst
-                                                      ({
-                                                         FStar_Syntax_Syntax.n
-                                                           =
-                                                           FStar_Syntax_Syntax.Tm_fvar
-                                                           fv;
-                                                         FStar_Syntax_Syntax.tk
-                                                           = _;
-                                                         FStar_Syntax_Syntax.pos
-                                                           = _;
-                                                         FStar_Syntax_Syntax.vars
-                                                           = _;_},_)
-                                                      |FStar_Syntax_Syntax.Tm_fvar
-                                                      fv ->
-                                                        let encoded_head =
-                                                          lookup_free_var_name
-                                                            env'
-                                                            fv.FStar_Syntax_Syntax.fv_name in
-                                                        let uu____14597 =
-                                                          encode_args args
-                                                            env' in
-                                                        (match uu____14597
-                                                         with
-                                                         | (encoded_args,arg_decls)
-                                                             ->
-                                                             let guards_for_parameter
-                                                               arg xv =
-                                                               let fv1 =
-                                                                 match 
-                                                                   arg.FStar_SMTEncoding_Term.tm
-                                                                 with
-                                                                 | FStar_SMTEncoding_Term.FreeV
-                                                                    fv1 ->
-                                                                    fv1
-                                                                 | uu____14623
-                                                                    ->
-                                                                    failwith
-                                                                    "Impossible: parameter must be a variable" in
-                                                               let guards1 =
-                                                                 FStar_All.pipe_right
-                                                                   guards
-                                                                   (FStar_List.collect
-                                                                    (fun g 
-                                                                    ->
-                                                                    let uu____14631
-                                                                    =
-                                                                    let uu____14632
-                                                                    =
-                                                                    FStar_SMTEncoding_Term.free_variables
-                                                                    g in
-                                                                    FStar_List.contains
-                                                                    fv1
-                                                                    uu____14632 in
-                                                                    if
-                                                                    uu____14631
-                                                                    then
-                                                                    let uu____14639
-                                                                    =
-                                                                    FStar_SMTEncoding_Term.subst
-                                                                    g fv1 xv in
-                                                                    [uu____14639]
-                                                                    else [])) in
-                                                               FStar_SMTEncoding_Util.mk_and_l
-                                                                 guards1 in
-                                                             let uu____14641
-                                                               =
-                                                               FStar_List.fold_left
-                                                                 (fun
-                                                                    uu____14654
-                                                                     ->
-                                                                    fun arg 
-                                                                    ->
-                                                                    match uu____14654
-                                                                    with
-                                                                    | 
-                                                                    (env2,arg_vars,eqns_or_guards,i)
-                                                                    ->
-                                                                    let uu____14676
-                                                                    =
-                                                                    let uu____14680
-                                                                    =
-                                                                    FStar_Syntax_Syntax.new_bv
-                                                                    None
-                                                                    FStar_Syntax_Syntax.tun in
-                                                                    gen_term_var
-                                                                    env2
-                                                                    uu____14680 in
-                                                                    (match uu____14676
-                                                                    with
-                                                                    | 
-                                                                    (uu____14687,xv,env3)
-                                                                    ->
-                                                                    let eqns
-                                                                    =
-                                                                    if
-                                                                    i < n_tps
-                                                                    then
-                                                                    let uu____14693
-                                                                    =
-                                                                    guards_for_parameter
-                                                                    arg xv in
-                                                                    uu____14693
-                                                                    ::
-                                                                    eqns_or_guards
-                                                                    else
-                                                                    (let uu____14695
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    (arg, xv) in
-                                                                    uu____14695
-                                                                    ::
-                                                                    eqns_or_guards) in
-                                                                    (env3,
-                                                                    (xv ::
-                                                                    arg_vars),
-                                                                    eqns,
-                                                                    (i +
-                                                                    (Prims.parse_int
-                                                                    "1")))))
-                                                                 (env', [],
-                                                                   [],
-                                                                   (Prims.parse_int
-                                                                    "0"))
-                                                                 encoded_args in
-                                                             (match uu____14641
-                                                              with
-                                                              | (uu____14703,arg_vars,elim_eqns_or_guards,uu____14706)
-                                                                  ->
-                                                                  let arg_vars1
-                                                                    =
-                                                                    FStar_List.rev
-                                                                    arg_vars in
-                                                                  let ty =
-                                                                    FStar_SMTEncoding_Util.mkApp
-                                                                    (encoded_head,
-                                                                    arg_vars1) in
-                                                                  let xvars1
-                                                                    =
-                                                                    FStar_List.map
-                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    vars in
-                                                                  let dapp1 =
-                                                                    FStar_SMTEncoding_Util.mkApp
-                                                                    (ddconstrsym,
-                                                                    xvars1) in
-                                                                  let ty_pred
-                                                                    =
-                                                                    FStar_SMTEncoding_Term.mk_HasTypeWithFuel
-                                                                    (Some
-                                                                    s_fuel_tm)
-                                                                    dapp1 ty in
-                                                                  let arg_binders
-                                                                    =
-                                                                    FStar_List.map
-                                                                    FStar_SMTEncoding_Term.fv_of_term
-                                                                    arg_vars1 in
-                                                                  let typing_inversion
-                                                                    =
-                                                                    let uu____14725
-                                                                    =
-                                                                    let uu____14730
-                                                                    =
-                                                                    let uu____14731
-                                                                    =
-                                                                    let uu____14737
-                                                                    =
-                                                                    add_fuel
-                                                                    (fuel_var,
-                                                                    FStar_SMTEncoding_Term.Fuel_sort)
-                                                                    (FStar_List.append
-                                                                    vars
-                                                                    arg_binders) in
-                                                                    let uu____14743
-                                                                    =
-                                                                    let uu____14744
-                                                                    =
-                                                                    let uu____14747
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_and_l
-                                                                    (FStar_List.append
-                                                                    elim_eqns_or_guards
-                                                                    guards) in
-                                                                    (ty_pred,
-                                                                    uu____14747) in
-                                                                    FStar_SMTEncoding_Util.mkImp
-                                                                    uu____14744 in
-                                                                    ([
-                                                                    [ty_pred]],
-                                                                    uu____14737,
-                                                                    uu____14743) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____14731 in
-                                                                    (uu____14730,
-                                                                    (Some
-                                                                    "data constructor typing elim"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "data_elim_"
-                                                                    ddconstrsym))) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____14725 in
-                                                                  let subterm_ordering
-                                                                    =
-                                                                    if
-                                                                    FStar_Ident.lid_equals
-                                                                    d
-                                                                    FStar_Syntax_Const.lextop_lid
-                                                                    then
-                                                                    let x =
-                                                                    let uu____14761
-                                                                    =
-                                                                    varops.fresh
-                                                                    "x" in
-                                                                    (uu____14761,
-                                                                    FStar_SMTEncoding_Term.Term_sort) in
-                                                                    let xtm =
-                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    x in
-                                                                    let uu____14763
-                                                                    =
-                                                                    let uu____14768
-                                                                    =
-                                                                    let uu____14769
-                                                                    =
-                                                                    let uu____14775
-                                                                    =
-                                                                    let uu____14778
-                                                                    =
-                                                                    let uu____14780
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1 in
-                                                                    [uu____14780] in
-                                                                    [uu____14778] in
-                                                                    let uu____14783
-                                                                    =
-                                                                    let uu____14784
-                                                                    =
-                                                                    let uu____14787
-                                                                    =
-                                                                    FStar_SMTEncoding_Term.mk_tester
-                                                                    "LexCons"
-                                                                    xtm in
-                                                                    let uu____14788
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1 in
-                                                                    (uu____14787,
-                                                                    uu____14788) in
-                                                                    FStar_SMTEncoding_Util.mkImp
-                                                                    uu____14784 in
-                                                                    (uu____14775,
-                                                                    [x],
-                                                                    uu____14783) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____14769 in
-                                                                    let uu____14798
-                                                                    =
-                                                                    let uu____14800
-                                                                    =
-                                                                    varops.mk_unique
-                                                                    "lextop" in
-                                                                    Some
-                                                                    uu____14800 in
-                                                                    (uu____14768,
-                                                                    (Some
-                                                                    "lextop is top"),
-                                                                    uu____14798) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____14763
-                                                                    else
-                                                                    (let prec
-                                                                    =
-                                                                    let uu____14806
-                                                                    =
-                                                                    FStar_All.pipe_right
-                                                                    vars
-                                                                    (FStar_List.mapi
-                                                                    (fun i 
-                                                                    ->
-                                                                    fun v1 
-                                                                    ->
-                                                                    if
-                                                                    i < n_tps
-                                                                    then []
-                                                                    else
-                                                                    (let uu____14821
-                                                                    =
-                                                                    let uu____14822
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    v1 in
-                                                                    FStar_SMTEncoding_Util.mk_Precedes
-                                                                    uu____14822
-                                                                    dapp1 in
-                                                                    [uu____14821]))) in
-                                                                    FStar_All.pipe_right
-                                                                    uu____14806
-                                                                    FStar_List.flatten in
-                                                                    let uu____14826
-                                                                    =
-                                                                    let uu____14831
-                                                                    =
-                                                                    let uu____14832
-                                                                    =
-                                                                    let uu____14838
-                                                                    =
-                                                                    add_fuel
-                                                                    (fuel_var,
-                                                                    FStar_SMTEncoding_Term.Fuel_sort)
-                                                                    (FStar_List.append
-                                                                    vars
-                                                                    arg_binders) in
-                                                                    let uu____14844
-                                                                    =
-                                                                    let uu____14845
-                                                                    =
-                                                                    let uu____14848
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_and_l
-                                                                    prec in
-                                                                    (ty_pred,
-                                                                    uu____14848) in
-                                                                    FStar_SMTEncoding_Util.mkImp
-                                                                    uu____14845 in
-                                                                    ([
-                                                                    [ty_pred]],
-                                                                    uu____14838,
-                                                                    uu____14844) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____14832 in
-                                                                    (uu____14831,
-                                                                    (Some
-                                                                    "subterm ordering"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "subterm_ordering_"
-                                                                    ddconstrsym))) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____14826) in
-                                                                  (arg_decls,
-                                                                    [typing_inversion;
-                                                                    subterm_ordering])))
-                                                    | uu____14859 ->
-                                                        ((let uu____14861 =
-                                                            let uu____14862 =
-                                                              FStar_Syntax_Print.lid_to_string
-                                                                d in
-                                                            let uu____14863 =
-                                                              FStar_Syntax_Print.term_to_string
-                                                                head1 in
-                                                            FStar_Util.format2
-                                                              "Constructor %s builds an unexpected type %s\n"
-                                                              uu____14862
-                                                              uu____14863 in
-                                                          FStar_Errors.warn
-                                                            drange
-                                                            uu____14861);
-                                                         ([], []))) in
-                                             let uu____14866 = encode_elim () in
-                                             (match uu____14866 with
-                                              | (decls2,elim) ->
-                                                  let g =
-                                                    let uu____14878 =
-                                                      let uu____14880 =
-                                                        let uu____14882 =
-                                                          let uu____14884 =
-                                                            let uu____14886 =
-                                                              let uu____14887
-                                                                =
-                                                                let uu____14893
-                                                                  =
-                                                                  let uu____14895
-                                                                    =
-                                                                    let uu____14896
-                                                                    =
-                                                                    FStar_Syntax_Print.lid_to_string
-                                                                    d in
-                                                                    FStar_Util.format1
-                                                                    "data constructor proxy: %s"
-                                                                    uu____14896 in
-                                                                  Some
-                                                                    uu____14895 in
-                                                                (ddtok, [],
-                                                                  FStar_SMTEncoding_Term.Term_sort,
-                                                                  uu____14893) in
-                                                              FStar_SMTEncoding_Term.DeclFun
-                                                                uu____14887 in
-                                                            [uu____14886] in
-                                                          let uu____14899 =
-                                                            let uu____14901 =
-                                                              let uu____14903
-                                                                =
-                                                                let uu____14905
-                                                                  =
-                                                                  let uu____14907
-                                                                    =
-                                                                    let uu____14909
-                                                                    =
-                                                                    let uu____14911
-                                                                    =
-                                                                    let uu____14912
-                                                                    =
-                                                                    let uu____14917
-                                                                    =
-                                                                    let uu____14918
-                                                                    =
-                                                                    let uu____14924
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
-                                                                    (app,
-                                                                    dapp) in
-                                                                    ([[app]],
-                                                                    vars,
-                                                                    uu____14924) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____14918 in
-                                                                    (uu____14917,
-                                                                    (Some
-                                                                    "equality for proxy"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "equality_tok_"
-                                                                    ddtok))) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____14912 in
-                                                                    let uu____14932
-                                                                    =
-                                                                    let uu____14934
-                                                                    =
-                                                                    let uu____14935
-                                                                    =
-                                                                    let uu____14940
-                                                                    =
-                                                                    let uu____14941
-                                                                    =
-                                                                    let uu____14947
-                                                                    =
-                                                                    add_fuel
-                                                                    (fuel_var,
-                                                                    FStar_SMTEncoding_Term.Fuel_sort)
-                                                                    vars' in
-                                                                    let uu____14953
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkImp
-                                                                    (guard',
-                                                                    ty_pred') in
-                                                                    ([
-                                                                    [ty_pred']],
-                                                                    uu____14947,
-                                                                    uu____14953) in
-                                                                    FStar_SMTEncoding_Util.mkForall
-                                                                    uu____14941 in
-                                                                    (uu____14940,
-                                                                    (Some
-                                                                    "data constructor typing intro"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "data_typing_intro_"
-                                                                    ddtok))) in
-                                                                    FStar_SMTEncoding_Term.Assume
-                                                                    uu____14935 in
-                                                                    [uu____14934] in
-                                                                    uu____14911
-                                                                    ::
-                                                                    uu____14932 in
-                                                                    (FStar_SMTEncoding_Term.Assume
-                                                                    (tok_typing,
-                                                                    (Some
-                                                                    "typing for data constructor proxy"),
-                                                                    (Some
-                                                                    (Prims.strcat
-                                                                    "typing_tok_"
-                                                                    ddtok))))
-                                                                    ::
-                                                                    uu____14909 in
-                                                                  FStar_List.append
-                                                                    uu____14907
-                                                                    elim in
-                                                                FStar_List.append
-                                                                  decls_pred
-                                                                  uu____14905 in
-                                                              FStar_List.append
-                                                                decls_formals
-                                                                uu____14903 in
-                                                            FStar_List.append
-                                                              proxy_fresh
-                                                              uu____14901 in
-                                                          FStar_List.append
-                                                            uu____14884
-                                                            uu____14899 in
-                                                        FStar_List.append
-                                                          decls3 uu____14882 in
-                                                      FStar_List.append
-                                                        decls2 uu____14880 in
-                                                    FStar_List.append
-                                                      binder_decls
-                                                      uu____14878 in
-                                                  ((FStar_List.append
-                                                      datacons g), env1)))))))))
-and encode_signature:
-  env_t ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      (FStar_SMTEncoding_Term.decl Prims.list* env_t)
-  =
-  fun env  ->
-    fun ses  ->
-      FStar_All.pipe_right ses
-        (FStar_List.fold_left
-           (fun uu____14976  ->
-              fun se  ->
-                match uu____14976 with
-                | (g,env1) ->
-                    let uu____14988 = encode_sigelt env1 se in
-                    (match uu____14988 with
-                     | (g',env2) -> ((FStar_List.append g g'), env2)))
-           ([], env))
-let encode_env_bindings:
-  env_t ->
-    FStar_TypeChecker_Env.binding Prims.list ->
-      (FStar_SMTEncoding_Term.decls_t* env_t)
-  =
-  fun env  ->
-    fun bindings  ->
-      let encode_binding b uu____15024 =
-        match uu____15024 with
-        | (i,decls,env1) ->
-            (match b with
-             | FStar_TypeChecker_Env.Binding_univ uu____15042 ->
-                 ((i + (Prims.parse_int "1")), [], env1)
-             | FStar_TypeChecker_Env.Binding_var x ->
-                 let t1 =
-                   FStar_TypeChecker_Normalize.normalize
-                     [FStar_TypeChecker_Normalize.Beta;
-                     FStar_TypeChecker_Normalize.Eager_unfolding;
-                     FStar_TypeChecker_Normalize.Simplify;
-                     FStar_TypeChecker_Normalize.EraseUniverses] env1.tcenv
-                     x.FStar_Syntax_Syntax.sort in
-                 ((let uu____15047 =
-                     FStar_All.pipe_left
-                       (FStar_TypeChecker_Env.debug env1.tcenv)
-                       (FStar_Options.Other "SMTEncoding") in
-                   if uu____15047
-                   then
-                     let uu____15048 = FStar_Syntax_Print.bv_to_string x in
-                     let uu____15049 =
-                       FStar_Syntax_Print.term_to_string
-                         x.FStar_Syntax_Syntax.sort in
-                     let uu____15050 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print3 "Normalized %s : %s to %s\n"
-                       uu____15048 uu____15049 uu____15050
-                   else ());
-                  (let uu____15052 = encode_term t1 env1 in
-                   match uu____15052 with
-                   | (t,decls') ->
-                       let t_hash = FStar_SMTEncoding_Term.hash_of_term t in
-                       let uu____15062 =
-                         let uu____15066 =
-                           let uu____15067 =
-                             let uu____15068 =
-                               FStar_Util.digest_of_string t_hash in
-                             Prims.strcat uu____15068
-                               (Prims.strcat "_" (Prims.string_of_int i)) in
-                           Prims.strcat "x_" uu____15067 in
-                         new_term_constant_from_string env1 x uu____15066 in
-                       (match uu____15062 with
-                        | (xxsym,xx,env') ->
-                            let t2 =
-                              FStar_SMTEncoding_Term.mk_HasTypeWithFuel None
-                                xx t in
-                            let caption =
-                              let uu____15079 = FStar_Options.log_queries () in
-                              if uu____15079
-                              then
-                                let uu____15081 =
-                                  let uu____15082 =
-                                    FStar_Syntax_Print.bv_to_string x in
-                                  let uu____15083 =
-                                    FStar_Syntax_Print.term_to_string
-                                      x.FStar_Syntax_Syntax.sort in
-                                  let uu____15084 =
-                                    FStar_Syntax_Print.term_to_string t1 in
-                                  FStar_Util.format3 "%s : %s (%s)"
-                                    uu____15082 uu____15083 uu____15084 in
-                                Some uu____15081
-                              else None in
-                            let ax =
-                              let a_name =
-                                Some (Prims.strcat "binder_" xxsym) in
-                              FStar_SMTEncoding_Term.Assume
-                                (t2, a_name, a_name) in
-                            let g =
-                              FStar_List.append
-                                [FStar_SMTEncoding_Term.DeclFun
-                                   (xxsym, [],
-                                     FStar_SMTEncoding_Term.Term_sort,
-                                     caption)]
-                                (FStar_List.append decls' [ax]) in
-                            ((i + (Prims.parse_int "1")),
-                              (FStar_List.append decls g), env'))))
-             | FStar_TypeChecker_Env.Binding_lid (x,(uu____15097,t)) ->
-                 let t_norm = whnf env1 t in
-                 let fv =
-                   FStar_Syntax_Syntax.lid_as_fv x
-                     FStar_Syntax_Syntax.Delta_constant None in
-                 let uu____15106 = encode_free_var env1 fv t t_norm [] in
-                 (match uu____15106 with
-                  | (g,env') ->
-                      ((i + (Prims.parse_int "1")),
-                        (FStar_List.append decls g), env'))
-             | FStar_TypeChecker_Env.Binding_sig_inst (_,se,_)
-               |FStar_TypeChecker_Env.Binding_sig (_,se) ->
-                 let uu____15125 = encode_sigelt env1 se in
-                 (match uu____15125 with
-                  | (g,env') ->
-                      ((i + (Prims.parse_int "1")),
-                        (FStar_List.append decls g), env'))) in
-      let uu____15135 =
-        FStar_List.fold_right encode_binding bindings
-          ((Prims.parse_int "0"), [], env) in
-      match uu____15135 with | (uu____15147,decls,env1) -> (decls, env1)
-let encode_labels labs =
-  let prefix1 =
-    FStar_All.pipe_right labs
-      (FStar_List.map
-         (fun uu____15192  ->
-            match uu____15192 with
-            | (l,uu____15199,uu____15200) ->
-                FStar_SMTEncoding_Term.DeclFun
-                  ((Prims.fst l), [], FStar_SMTEncoding_Term.Bool_sort, None))) in
-  let suffix =
-    FStar_All.pipe_right labs
-      (FStar_List.collect
-         (fun uu____15221  ->
-            match uu____15221 with
-            | (l,uu____15229,uu____15230) ->
-                let uu____15235 =
-                  FStar_All.pipe_left
-                    (fun _0_39  -> FStar_SMTEncoding_Term.Echo _0_39)
-                    (Prims.fst l) in
-                let uu____15236 =
-                  let uu____15238 =
-                    let uu____15239 = FStar_SMTEncoding_Util.mkFreeV l in
-                    FStar_SMTEncoding_Term.Eval uu____15239 in
-                  [uu____15238] in
-                uu____15235 :: uu____15236)) in
-  (prefix1, suffix)
-let last_env: env_t Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let init_env: FStar_TypeChecker_Env.env -> Prims.unit =
-  fun tcenv  ->
-    let uu____15250 =
-      let uu____15252 =
-        let uu____15253 = FStar_Util.smap_create (Prims.parse_int "100") in
-        {
-          bindings = [];
-          depth = (Prims.parse_int "0");
-          tcenv;
-          warn = true;
-          cache = uu____15253;
-          nolabels = false;
-          use_zfuel_name = false;
-          encode_non_total_function_typ = true
-        } in
-      [uu____15252] in
-    FStar_ST.write last_env uu____15250
-let get_env: FStar_TypeChecker_Env.env -> env_t =
-  fun tcenv  ->
-    let uu____15271 = FStar_ST.read last_env in
-    match uu____15271 with
-    | [] -> failwith "No env; call init first!"
-    | e::uu____15277 ->
-        let uu___161_15279 = e in
-        {
-          bindings = (uu___161_15279.bindings);
-          depth = (uu___161_15279.depth);
-          tcenv;
-          warn = (uu___161_15279.warn);
-          cache = (uu___161_15279.cache);
-          nolabels = (uu___161_15279.nolabels);
-          use_zfuel_name = (uu___161_15279.use_zfuel_name);
-          encode_non_total_function_typ =
-            (uu___161_15279.encode_non_total_function_typ)
-        }
-let set_env: env_t -> Prims.unit =
-  fun env  ->
-    let uu____15283 = FStar_ST.read last_env in
-    match uu____15283 with
-    | [] -> failwith "Empty env stack"
-    | uu____15288::tl1 -> FStar_ST.write last_env (env :: tl1)
-let push_env: Prims.unit -> Prims.unit =
-  fun uu____15296  ->
-    let uu____15297 = FStar_ST.read last_env in
-    match uu____15297 with
-    | [] -> failwith "Empty env stack"
-    | hd1::tl1 ->
-        let refs = FStar_Util.smap_copy hd1.cache in
-        let top =
-          let uu___162_15318 = hd1 in
-          {
-            bindings = (uu___162_15318.bindings);
-            depth = (uu___162_15318.depth);
-            tcenv = (uu___162_15318.tcenv);
-            warn = (uu___162_15318.warn);
-            cache = refs;
-            nolabels = (uu___162_15318.nolabels);
-            use_zfuel_name = (uu___162_15318.use_zfuel_name);
-            encode_non_total_function_typ =
-              (uu___162_15318.encode_non_total_function_typ)
-          } in
-        FStar_ST.write last_env (top :: hd1 :: tl1)
-let pop_env: Prims.unit -> Prims.unit =
-  fun uu____15324  ->
-    let uu____15325 = FStar_ST.read last_env in
-    match uu____15325 with
-    | [] -> failwith "Popping an empty stack"
-    | uu____15330::tl1 -> FStar_ST.write last_env tl1
-let mark_env: Prims.unit -> Prims.unit = fun uu____15338  -> push_env ()
-let reset_mark_env: Prims.unit -> Prims.unit = fun uu____15341  -> pop_env ()
-let commit_mark_env: Prims.unit -> Prims.unit =
-  fun uu____15344  ->
-    let uu____15345 = FStar_ST.read last_env in
-    match uu____15345 with
-    | hd1::uu____15351::tl1 -> FStar_ST.write last_env (hd1 :: tl1)
-    | uu____15357 -> failwith "Impossible"
-let init: FStar_TypeChecker_Env.env -> Prims.unit =
-  fun tcenv  ->
-    init_env tcenv;
-    FStar_SMTEncoding_Z3.init ();
-    FStar_SMTEncoding_Z3.giveZ3 [FStar_SMTEncoding_Term.DefPrelude]
-let push: Prims.string -> Prims.unit =
-  fun msg  -> push_env (); varops.push (); FStar_SMTEncoding_Z3.push msg
-let pop: Prims.string -> Prims.unit =
-  fun msg  -> pop_env (); varops.pop (); FStar_SMTEncoding_Z3.pop msg
-let mark: Prims.string -> Prims.unit =
-  fun msg  -> mark_env (); varops.mark (); FStar_SMTEncoding_Z3.mark msg
-let reset_mark: Prims.string -> Prims.unit =
-  fun msg  ->
-    reset_mark_env ();
-    varops.reset_mark ();
-    FStar_SMTEncoding_Z3.reset_mark msg
-let commit_mark: Prims.string -> Prims.unit =
-  fun msg  ->
-    commit_mark_env ();
-    varops.commit_mark ();
-    FStar_SMTEncoding_Z3.commit_mark msg
-let encode_sig:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
-  fun tcenv  ->
-    fun se  ->
-      let caption decls =
-        let uu____15402 = FStar_Options.log_queries () in
-        if uu____15402
-        then
-          let uu____15404 =
-            let uu____15405 =
-              let uu____15406 =
-                let uu____15407 =
-                  FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
-                    (FStar_List.map FStar_Syntax_Print.lid_to_string) in
-                FStar_All.pipe_right uu____15407 (FStar_String.concat ", ") in
-              Prims.strcat "encoding sigelt " uu____15406 in
-            FStar_SMTEncoding_Term.Caption uu____15405 in
-          uu____15404 :: decls
-        else decls in
-      let env = get_env tcenv in
-      let uu____15414 = encode_sigelt env se in
-      match uu____15414 with
-      | (decls,env1) ->
-          (set_env env1;
-           (let uu____15420 = caption decls in
-            FStar_SMTEncoding_Z3.giveZ3 uu____15420))
-let encode_modul:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.modul -> Prims.unit =
-  fun tcenv  ->
-    fun modul  ->
-      let name =
-        FStar_Util.format2 "%s %s"
-          (if modul.FStar_Syntax_Syntax.is_interface
-           then "interface"
-           else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
-      (let uu____15431 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Low in
-       if uu____15431
-       then
-         let uu____15432 =
-           FStar_All.pipe_right
-             (FStar_List.length modul.FStar_Syntax_Syntax.exports)
-             Prims.string_of_int in
-         FStar_Util.print2
-           "+++++++++++Encoding externals for %s ... %s exports\n" name
-           uu____15432
-       else ());
-      (let env = get_env tcenv in
-       let uu____15437 =
-         encode_signature
-           (let uu___163_15441 = env in
-            {
-              bindings = (uu___163_15441.bindings);
-              depth = (uu___163_15441.depth);
-              tcenv = (uu___163_15441.tcenv);
-              warn = false;
-              cache = (uu___163_15441.cache);
-              nolabels = (uu___163_15441.nolabels);
-              use_zfuel_name = (uu___163_15441.use_zfuel_name);
-              encode_non_total_function_typ =
-                (uu___163_15441.encode_non_total_function_typ)
-            }) modul.FStar_Syntax_Syntax.exports in
-       match uu____15437 with
-       | (decls,env1) ->
-           let caption decls1 =
-             let uu____15453 = FStar_Options.log_queries () in
-             if uu____15453
-             then
-               let msg = Prims.strcat "Externals for " name in
-               FStar_List.append ((FStar_SMTEncoding_Term.Caption msg) ::
-                 decls1)
-                 [FStar_SMTEncoding_Term.Caption (Prims.strcat "End " msg)]
-             else decls1 in
-           (set_env
-              (let uu___164_15458 = env1 in
-               {
-                 bindings = (uu___164_15458.bindings);
-                 depth = (uu___164_15458.depth);
-                 tcenv = (uu___164_15458.tcenv);
-                 warn = true;
-                 cache = (uu___164_15458.cache);
-                 nolabels = (uu___164_15458.nolabels);
-                 use_zfuel_name = (uu___164_15458.use_zfuel_name);
-                 encode_non_total_function_typ =
-                   (uu___164_15458.encode_non_total_function_typ)
-               });
-            (let uu____15460 =
-               FStar_TypeChecker_Env.debug tcenv FStar_Options.Low in
-             if uu____15460
-             then FStar_Util.print1 "Done encoding externals for %s\n" name
-             else ());
-            (let decls1 = caption decls in FStar_SMTEncoding_Z3.giveZ3 decls1)))
-let encode_query:
-  (Prims.unit -> Prims.string) Prims.option ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term ->
-        (FStar_SMTEncoding_Term.decl Prims.list*
-          FStar_SMTEncoding_ErrorReporting.label Prims.list*
-          FStar_SMTEncoding_Term.decl* FStar_SMTEncoding_Term.decl
-          Prims.list)
-  =
-  fun use_env_msg  ->
-    fun tcenv  ->
-      fun q  ->
-        (let uu____15495 =
-           let uu____15496 = FStar_TypeChecker_Env.current_module tcenv in
-           uu____15496.FStar_Ident.str in
-         FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name
-           uu____15495);
-        (let env = get_env tcenv in
-         let bindings =
-           FStar_TypeChecker_Env.fold_env tcenv
-             (fun bs  -> fun b  -> b :: bs) [] in
-         let uu____15504 =
-           let rec aux bindings1 =
-             match bindings1 with
-             | (FStar_TypeChecker_Env.Binding_var x)::rest ->
-                 let uu____15525 = aux rest in
-                 (match uu____15525 with
-                  | (out,rest1) ->
-                      let t =
-                        let uu____15543 =
-                          FStar_Syntax_Util.destruct_typ_as_formula
-                            x.FStar_Syntax_Syntax.sort in
-                        match uu____15543 with
-                        | Some uu____15547 ->
-                            let uu____15548 =
-                              FStar_Syntax_Syntax.new_bv None
-                                FStar_TypeChecker_Common.t_unit in
-                            FStar_Syntax_Util.refine uu____15548
-                              x.FStar_Syntax_Syntax.sort
-                        | uu____15549 -> x.FStar_Syntax_Syntax.sort in
-                      let t1 =
-                        FStar_TypeChecker_Normalize.normalize
-                          [FStar_TypeChecker_Normalize.Eager_unfolding;
-                          FStar_TypeChecker_Normalize.Beta;
-                          FStar_TypeChecker_Normalize.Simplify;
-                          FStar_TypeChecker_Normalize.EraseUniverses]
-                          env.tcenv t in
-                      let uu____15552 =
-                        let uu____15554 =
-                          FStar_Syntax_Syntax.mk_binder
-                            (let uu___165_15555 = x in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (uu___165_15555.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (uu___165_15555.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = t1
-                             }) in
-                        uu____15554 :: out in
-                      (uu____15552, rest1))
-             | uu____15558 -> ([], bindings1) in
-           let uu____15562 = aux bindings in
-           match uu____15562 with
-           | (closing,bindings1) ->
-               let uu____15576 =
-                 FStar_Syntax_Util.close_forall_no_univs
-                   (FStar_List.rev closing) q in
-               (uu____15576, bindings1) in
-         match uu____15504 with
-         | (q1,bindings1) ->
-             let uu____15589 =
-               let uu____15592 =
-                 FStar_List.filter
-                   (fun uu___134_15594  ->
-                      match uu___134_15594 with
-                      | FStar_TypeChecker_Env.Binding_sig uu____15595 ->
-                          false
-                      | uu____15599 -> true) bindings1 in
-               encode_env_bindings env uu____15592 in
-             (match uu____15589 with
-              | (env_decls,env1) ->
-                  ((let uu____15610 =
-                      ((FStar_TypeChecker_Env.debug tcenv FStar_Options.Low)
-                         ||
-                         (FStar_All.pipe_left
-                            (FStar_TypeChecker_Env.debug tcenv)
-                            (FStar_Options.Other "SMTEncoding")))
-                        ||
-                        (FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug tcenv)
-                           (FStar_Options.Other "SMTQuery")) in
-                    if uu____15610
-                    then
-                      let uu____15611 = FStar_Syntax_Print.term_to_string q1 in
-                      FStar_Util.print1 "Encoding query formula: %s\n"
-                        uu____15611
-                    else ());
-                   (let uu____15613 = encode_formula q1 env1 in
-                    match uu____15613 with
-                    | (phi,qdecls) ->
-                        let uu____15625 =
-                          let uu____15628 =
-                            FStar_TypeChecker_Env.get_range tcenv in
-                          FStar_SMTEncoding_ErrorReporting.label_goals
-                            use_env_msg uu____15628 phi in
-                        (match uu____15625 with
-                         | (labels,phi1) ->
-                             let uu____15638 = encode_labels labels in
-                             (match uu____15638 with
-                              | (label_prefix,label_suffix) ->
-                                  let query_prelude =
-                                    FStar_List.append env_decls
-                                      (FStar_List.append label_prefix qdecls) in
-                                  let qry =
-                                    let uu____15659 =
-                                      let uu____15664 =
-                                        FStar_SMTEncoding_Util.mkNot phi1 in
-                                      let uu____15665 =
-                                        let uu____15667 =
-                                          varops.mk_unique "@query" in
-                                        Some uu____15667 in
-                                      (uu____15664, (Some "query"),
-                                        uu____15665) in
-                                    FStar_SMTEncoding_Term.Assume uu____15659 in
-                                  let suffix =
-                                    let uu____15672 =
-                                      let uu____15674 =
-                                        let uu____15676 =
-                                          FStar_Options.print_z3_statistics
-                                            () in
-                                        if uu____15676
-                                        then
-                                          [FStar_SMTEncoding_Term.PrintStats]
-                                        else [] in
-                                      FStar_List.append uu____15674
-                                        [FStar_SMTEncoding_Term.Echo "Done!"] in
-                                    FStar_List.append label_suffix
-                                      uu____15672 in
-                                  (query_prelude, labels, qry, suffix)))))))
-let is_trivial:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun tcenv  ->
-    fun q  ->
-      let env = get_env tcenv in
-      FStar_SMTEncoding_Z3.push "query";
-      (let uu____15689 = encode_formula q env in
-       match uu____15689 with
-       | (f,uu____15693) ->
-           (FStar_SMTEncoding_Z3.pop "query";
-            (match f.FStar_SMTEncoding_Term.tm with
-             | FStar_SMTEncoding_Term.App
-                 (FStar_SMTEncoding_Term.TrueOp ,uu____15695) -> true
-             | uu____15698 -> false)))
+{mk : FStar_Ident.lident  ->  Prims.string  ->  (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decl Prims.list); is : FStar_Ident.lident  ->  Prims.bool}
+
+
+let prims : prims_t = (
+
+let uu____7488 = (fresh_fvar "a" FStar_SMTEncoding_Term.Term_sort)
+in (match (uu____7488) with
+| (asym, a) -> begin
+(
+
+let uu____7493 = (fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort)
+in (match (uu____7493) with
+| (xsym, x) -> begin
+(
+
+let uu____7498 = (fresh_fvar "y" FStar_SMTEncoding_Term.Term_sort)
+in (match (uu____7498) with
+| (ysym, y) -> begin
+(
+
+let quant = (fun vars body x1 -> (
+
+let xname_decl = (
+
+let uu____7528 = (
+
+let uu____7534 = (FStar_All.pipe_right vars (FStar_List.map Prims.snd))
+in ((x1), (uu____7534), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in FStar_SMTEncoding_Term.DeclFun (uu____7528))
+in (
+
+let xtok = (Prims.strcat x1 "@tok")
+in (
+
+let xtok_decl = FStar_SMTEncoding_Term.DeclFun (((xtok), ([]), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let xapp = (
+
+let uu____7549 = (
+
+let uu____7553 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in ((x1), (uu____7553)))
+in (FStar_SMTEncoding_Util.mkApp uu____7549))
+in (
+
+let xtok1 = (FStar_SMTEncoding_Util.mkApp ((xtok), ([])))
+in (
+
+let xtok_app = (mk_Apply xtok1 vars)
+in (
+
+let uu____7561 = (
+
+let uu____7563 = (
+
+let uu____7565 = (
+
+let uu____7567 = (
+
+let uu____7568 = (
+
+let uu____7573 = (
+
+let uu____7574 = (
+
+let uu____7580 = (FStar_SMTEncoding_Util.mkEq ((xapp), (body)))
+in ((((xapp)::[])::[]), (vars), (uu____7580)))
+in (FStar_SMTEncoding_Util.mkForall uu____7574))
+in ((uu____7573), (None), (Some ((Prims.strcat "primitive_" x1)))))
+in FStar_SMTEncoding_Term.Assume (uu____7568))
+in (
+
+let uu____7590 = (
+
+let uu____7592 = (
+
+let uu____7593 = (
+
+let uu____7598 = (
+
+let uu____7599 = (
+
+let uu____7605 = (FStar_SMTEncoding_Util.mkEq ((xtok_app), (xapp)))
+in ((((xtok_app)::[])::[]), (vars), (uu____7605)))
+in (FStar_SMTEncoding_Util.mkForall uu____7599))
+in ((uu____7598), (Some ("Name-token correspondence")), (Some ((Prims.strcat "token_correspondence_" x1)))))
+in FStar_SMTEncoding_Term.Assume (uu____7593))
+in (uu____7592)::[])
+in (uu____7567)::uu____7590))
+in (xtok_decl)::uu____7565)
+in (xname_decl)::uu____7563)
+in ((xtok1), (uu____7561))))))))))
+in (
+
+let axy = (((asym), (FStar_SMTEncoding_Term.Term_sort)))::(((xsym), (FStar_SMTEncoding_Term.Term_sort)))::(((ysym), (FStar_SMTEncoding_Term.Term_sort)))::[]
+in (
+
+let xy = (((xsym), (FStar_SMTEncoding_Term.Term_sort)))::(((ysym), (FStar_SMTEncoding_Term.Term_sort)))::[]
+in (
+
+let qx = (((xsym), (FStar_SMTEncoding_Term.Term_sort)))::[]
+in (
+
+let prims1 = (
+
+let uu____7655 = (
+
+let uu____7663 = (
+
+let uu____7669 = (
+
+let uu____7670 = (FStar_SMTEncoding_Util.mkEq ((x), (y)))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7670))
+in (quant axy uu____7669))
+in ((FStar_Syntax_Const.op_Eq), (uu____7663)))
+in (
+
+let uu____7676 = (
+
+let uu____7685 = (
+
+let uu____7693 = (
+
+let uu____7699 = (
+
+let uu____7700 = (
+
+let uu____7701 = (FStar_SMTEncoding_Util.mkEq ((x), (y)))
+in (FStar_SMTEncoding_Util.mkNot uu____7701))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7700))
+in (quant axy uu____7699))
+in ((FStar_Syntax_Const.op_notEq), (uu____7693)))
+in (
+
+let uu____7707 = (
+
+let uu____7716 = (
+
+let uu____7724 = (
+
+let uu____7730 = (
+
+let uu____7731 = (
+
+let uu____7732 = (
+
+let uu____7735 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7736 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7735), (uu____7736))))
+in (FStar_SMTEncoding_Util.mkLT uu____7732))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7731))
+in (quant xy uu____7730))
+in ((FStar_Syntax_Const.op_LT), (uu____7724)))
+in (
+
+let uu____7742 = (
+
+let uu____7751 = (
+
+let uu____7759 = (
+
+let uu____7765 = (
+
+let uu____7766 = (
+
+let uu____7767 = (
+
+let uu____7770 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7771 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7770), (uu____7771))))
+in (FStar_SMTEncoding_Util.mkLTE uu____7767))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7766))
+in (quant xy uu____7765))
+in ((FStar_Syntax_Const.op_LTE), (uu____7759)))
+in (
+
+let uu____7777 = (
+
+let uu____7786 = (
+
+let uu____7794 = (
+
+let uu____7800 = (
+
+let uu____7801 = (
+
+let uu____7802 = (
+
+let uu____7805 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7806 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7805), (uu____7806))))
+in (FStar_SMTEncoding_Util.mkGT uu____7802))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7801))
+in (quant xy uu____7800))
+in ((FStar_Syntax_Const.op_GT), (uu____7794)))
+in (
+
+let uu____7812 = (
+
+let uu____7821 = (
+
+let uu____7829 = (
+
+let uu____7835 = (
+
+let uu____7836 = (
+
+let uu____7837 = (
+
+let uu____7840 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7841 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7840), (uu____7841))))
+in (FStar_SMTEncoding_Util.mkGTE uu____7837))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____7836))
+in (quant xy uu____7835))
+in ((FStar_Syntax_Const.op_GTE), (uu____7829)))
+in (
+
+let uu____7847 = (
+
+let uu____7856 = (
+
+let uu____7864 = (
+
+let uu____7870 = (
+
+let uu____7871 = (
+
+let uu____7872 = (
+
+let uu____7875 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7876 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7875), (uu____7876))))
+in (FStar_SMTEncoding_Util.mkSub uu____7872))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____7871))
+in (quant xy uu____7870))
+in ((FStar_Syntax_Const.op_Subtraction), (uu____7864)))
+in (
+
+let uu____7882 = (
+
+let uu____7891 = (
+
+let uu____7899 = (
+
+let uu____7905 = (
+
+let uu____7906 = (
+
+let uu____7907 = (FStar_SMTEncoding_Term.unboxInt x)
+in (FStar_SMTEncoding_Util.mkMinus uu____7907))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____7906))
+in (quant qx uu____7905))
+in ((FStar_Syntax_Const.op_Minus), (uu____7899)))
+in (
+
+let uu____7913 = (
+
+let uu____7922 = (
+
+let uu____7930 = (
+
+let uu____7936 = (
+
+let uu____7937 = (
+
+let uu____7938 = (
+
+let uu____7941 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7942 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7941), (uu____7942))))
+in (FStar_SMTEncoding_Util.mkAdd uu____7938))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____7937))
+in (quant xy uu____7936))
+in ((FStar_Syntax_Const.op_Addition), (uu____7930)))
+in (
+
+let uu____7948 = (
+
+let uu____7957 = (
+
+let uu____7965 = (
+
+let uu____7971 = (
+
+let uu____7972 = (
+
+let uu____7973 = (
+
+let uu____7976 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____7977 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____7976), (uu____7977))))
+in (FStar_SMTEncoding_Util.mkMul uu____7973))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____7972))
+in (quant xy uu____7971))
+in ((FStar_Syntax_Const.op_Multiply), (uu____7965)))
+in (
+
+let uu____7983 = (
+
+let uu____7992 = (
+
+let uu____8000 = (
+
+let uu____8006 = (
+
+let uu____8007 = (
+
+let uu____8008 = (
+
+let uu____8011 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____8012 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____8011), (uu____8012))))
+in (FStar_SMTEncoding_Util.mkDiv uu____8008))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____8007))
+in (quant xy uu____8006))
+in ((FStar_Syntax_Const.op_Division), (uu____8000)))
+in (
+
+let uu____8018 = (
+
+let uu____8027 = (
+
+let uu____8035 = (
+
+let uu____8041 = (
+
+let uu____8042 = (
+
+let uu____8043 = (
+
+let uu____8046 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____8047 = (FStar_SMTEncoding_Term.unboxInt y)
+in ((uu____8046), (uu____8047))))
+in (FStar_SMTEncoding_Util.mkMod uu____8043))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxInt uu____8042))
+in (quant xy uu____8041))
+in ((FStar_Syntax_Const.op_Modulus), (uu____8035)))
+in (
+
+let uu____8053 = (
+
+let uu____8062 = (
+
+let uu____8070 = (
+
+let uu____8076 = (
+
+let uu____8077 = (
+
+let uu____8078 = (
+
+let uu____8081 = (FStar_SMTEncoding_Term.unboxBool x)
+in (
+
+let uu____8082 = (FStar_SMTEncoding_Term.unboxBool y)
+in ((uu____8081), (uu____8082))))
+in (FStar_SMTEncoding_Util.mkAnd uu____8078))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____8077))
+in (quant xy uu____8076))
+in ((FStar_Syntax_Const.op_And), (uu____8070)))
+in (
+
+let uu____8088 = (
+
+let uu____8097 = (
+
+let uu____8105 = (
+
+let uu____8111 = (
+
+let uu____8112 = (
+
+let uu____8113 = (
+
+let uu____8116 = (FStar_SMTEncoding_Term.unboxBool x)
+in (
+
+let uu____8117 = (FStar_SMTEncoding_Term.unboxBool y)
+in ((uu____8116), (uu____8117))))
+in (FStar_SMTEncoding_Util.mkOr uu____8113))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____8112))
+in (quant xy uu____8111))
+in ((FStar_Syntax_Const.op_Or), (uu____8105)))
+in (
+
+let uu____8123 = (
+
+let uu____8132 = (
+
+let uu____8140 = (
+
+let uu____8146 = (
+
+let uu____8147 = (
+
+let uu____8148 = (FStar_SMTEncoding_Term.unboxBool x)
+in (FStar_SMTEncoding_Util.mkNot uu____8148))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____8147))
+in (quant qx uu____8146))
+in ((FStar_Syntax_Const.op_Negation), (uu____8140)))
+in (uu____8132)::[])
+in (uu____8097)::uu____8123))
+in (uu____8062)::uu____8088))
+in (uu____8027)::uu____8053))
+in (uu____7992)::uu____8018))
+in (uu____7957)::uu____7983))
+in (uu____7922)::uu____7948))
+in (uu____7891)::uu____7913))
+in (uu____7856)::uu____7882))
+in (uu____7821)::uu____7847))
+in (uu____7786)::uu____7812))
+in (uu____7751)::uu____7777))
+in (uu____7716)::uu____7742))
+in (uu____7685)::uu____7707))
+in (uu____7655)::uu____7676))
+in (
+
+let mk1 = (fun l v1 -> (
+
+let uu____8276 = (
+
+let uu____8281 = (FStar_All.pipe_right prims1 (FStar_List.find (fun uu____8313 -> (match (uu____8313) with
+| (l', uu____8322) -> begin
+(FStar_Ident.lid_equals l l')
+end))))
+in (FStar_All.pipe_right uu____8281 (FStar_Option.map (fun uu____8355 -> (match (uu____8355) with
+| (uu____8366, b) -> begin
+(b v1)
+end)))))
+in (FStar_All.pipe_right uu____8276 FStar_Option.get)))
+in (
+
+let is = (fun l -> (FStar_All.pipe_right prims1 (FStar_Util.for_some (fun uu____8407 -> (match (uu____8407) with
+| (l', uu____8416) -> begin
+(FStar_Ident.lid_equals l l')
+end)))))
+in {mk = mk1; is = is})))))))
+end))
+end))
+end))
+
+
+let pretype_axiom : FStar_SMTEncoding_Term.term  ->  (Prims.string * FStar_SMTEncoding_Term.sort) Prims.list  ->  FStar_SMTEncoding_Term.decl = (fun tapp vars -> (
+
+let uu____8439 = (fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort)
+in (match (uu____8439) with
+| (xxsym, xx) -> begin
+(
+
+let uu____8444 = (fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort)
+in (match (uu____8444) with
+| (ffsym, ff) -> begin
+(
+
+let xx_has_type = (FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp)
+in (
+
+let tapp_hash = (FStar_SMTEncoding_Term.hash_of_term tapp)
+in (
+
+let uu____8451 = (
+
+let uu____8456 = (
+
+let uu____8457 = (
+
+let uu____8463 = (
+
+let uu____8464 = (
+
+let uu____8467 = (
+
+let uu____8468 = (
+
+let uu____8471 = (FStar_SMTEncoding_Util.mkApp (("PreType"), ((xx)::[])))
+in ((tapp), (uu____8471)))
+in (FStar_SMTEncoding_Util.mkEq uu____8468))
+in ((xx_has_type), (uu____8467)))
+in (FStar_SMTEncoding_Util.mkImp uu____8464))
+in ((((xx_has_type)::[])::[]), ((((xxsym), (FStar_SMTEncoding_Term.Term_sort)))::(((ffsym), (FStar_SMTEncoding_Term.Fuel_sort)))::vars), (uu____8463)))
+in (FStar_SMTEncoding_Util.mkForall uu____8457))
+in (
+
+let uu____8484 = (
+
+let uu____8486 = (
+
+let uu____8487 = (
+
+let uu____8488 = (FStar_Util.digest_of_string tapp_hash)
+in (Prims.strcat "pretyping_" uu____8488))
+in (varops.mk_unique uu____8487))
+in Some (uu____8486))
+in ((uu____8456), (Some ("pretyping")), (uu____8484))))
+in FStar_SMTEncoding_Term.Assume (uu____8451))))
+end))
+end)))
+
+
+let primitive_type_axioms : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  Prims.string  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.decl Prims.list = (
+
+let xx = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let x = (FStar_SMTEncoding_Util.mkFreeV xx)
+in (
+
+let yy = (("y"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let y = (FStar_SMTEncoding_Util.mkFreeV yy)
+in (
+
+let mk_unit = (fun env nm tt -> (
+
+let typing_pred = (FStar_SMTEncoding_Term.mk_HasType x tt)
+in (
+
+let uu____8519 = (
+
+let uu____8520 = (
+
+let uu____8525 = (FStar_SMTEncoding_Term.mk_HasType FStar_SMTEncoding_Term.mk_Term_unit tt)
+in ((uu____8525), (Some ("unit typing")), (Some ("unit_typing"))))
+in FStar_SMTEncoding_Term.Assume (uu____8520))
+in (
+
+let uu____8528 = (
+
+let uu____8530 = (
+
+let uu____8531 = (
+
+let uu____8536 = (
+
+let uu____8537 = (
+
+let uu____8543 = (
+
+let uu____8544 = (
+
+let uu____8547 = (FStar_SMTEncoding_Util.mkEq ((x), (FStar_SMTEncoding_Term.mk_Term_unit)))
+in ((typing_pred), (uu____8547)))
+in (FStar_SMTEncoding_Util.mkImp uu____8544))
+in ((((typing_pred)::[])::[]), ((xx)::[]), (uu____8543)))
+in (mkForall_fuel uu____8537))
+in ((uu____8536), (Some ("unit inversion")), (Some ("unit_inversion"))))
+in FStar_SMTEncoding_Term.Assume (uu____8531))
+in (uu____8530)::[])
+in (uu____8519)::uu____8528))))
+in (
+
+let mk_bool = (fun env nm tt -> (
+
+let typing_pred = (FStar_SMTEncoding_Term.mk_HasType x tt)
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Bool_sort))
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let uu____8576 = (
+
+let uu____8577 = (
+
+let uu____8582 = (
+
+let uu____8583 = (
+
+let uu____8589 = (
+
+let uu____8592 = (
+
+let uu____8594 = (FStar_SMTEncoding_Term.boxBool b)
+in (uu____8594)::[])
+in (uu____8592)::[])
+in (
+
+let uu____8597 = (
+
+let uu____8598 = (FStar_SMTEncoding_Term.boxBool b)
+in (FStar_SMTEncoding_Term.mk_HasType uu____8598 tt))
+in ((uu____8589), ((bb)::[]), (uu____8597))))
+in (FStar_SMTEncoding_Util.mkForall uu____8583))
+in ((uu____8582), (Some ("bool typing")), (Some ("bool_typing"))))
+in FStar_SMTEncoding_Term.Assume (uu____8577))
+in (
+
+let uu____8610 = (
+
+let uu____8612 = (
+
+let uu____8613 = (
+
+let uu____8618 = (
+
+let uu____8619 = (
+
+let uu____8625 = (
+
+let uu____8626 = (
+
+let uu____8629 = (FStar_SMTEncoding_Term.mk_tester "BoxBool" x)
+in ((typing_pred), (uu____8629)))
+in (FStar_SMTEncoding_Util.mkImp uu____8626))
+in ((((typing_pred)::[])::[]), ((xx)::[]), (uu____8625)))
+in (mkForall_fuel uu____8619))
+in ((uu____8618), (Some ("bool inversion")), (Some ("bool_inversion"))))
+in FStar_SMTEncoding_Term.Assume (uu____8613))
+in (uu____8612)::[])
+in (uu____8576)::uu____8610))))))
+in (
+
+let mk_int = (fun env nm tt -> (
+
+let typing_pred = (FStar_SMTEncoding_Term.mk_HasType x tt)
+in (
+
+let typing_pred_y = (FStar_SMTEncoding_Term.mk_HasType y tt)
+in (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Int_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Int_sort))
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let precedes = (
+
+let uu____8664 = (
+
+let uu____8665 = (
+
+let uu____8669 = (
+
+let uu____8671 = (
+
+let uu____8673 = (
+
+let uu____8675 = (FStar_SMTEncoding_Term.boxInt a)
+in (
+
+let uu____8676 = (
+
+let uu____8678 = (FStar_SMTEncoding_Term.boxInt b)
+in (uu____8678)::[])
+in (uu____8675)::uu____8676))
+in (tt)::uu____8673)
+in (tt)::uu____8671)
+in (("Prims.Precedes"), (uu____8669)))
+in (FStar_SMTEncoding_Util.mkApp uu____8665))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____8664))
+in (
+
+let precedes_y_x = (
+
+let uu____8681 = (FStar_SMTEncoding_Util.mkApp (("Precedes"), ((y)::(x)::[])))
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____8681))
+in (
+
+let uu____8683 = (
+
+let uu____8684 = (
+
+let uu____8689 = (
+
+let uu____8690 = (
+
+let uu____8696 = (
+
+let uu____8699 = (
+
+let uu____8701 = (FStar_SMTEncoding_Term.boxInt b)
+in (uu____8701)::[])
+in (uu____8699)::[])
+in (
+
+let uu____8704 = (
+
+let uu____8705 = (FStar_SMTEncoding_Term.boxInt b)
+in (FStar_SMTEncoding_Term.mk_HasType uu____8705 tt))
+in ((uu____8696), ((bb)::[]), (uu____8704))))
+in (FStar_SMTEncoding_Util.mkForall uu____8690))
+in ((uu____8689), (Some ("int typing")), (Some ("int_typing"))))
+in FStar_SMTEncoding_Term.Assume (uu____8684))
+in (
+
+let uu____8717 = (
+
+let uu____8719 = (
+
+let uu____8720 = (
+
+let uu____8725 = (
+
+let uu____8726 = (
+
+let uu____8732 = (
+
+let uu____8733 = (
+
+let uu____8736 = (FStar_SMTEncoding_Term.mk_tester "BoxInt" x)
+in ((typing_pred), (uu____8736)))
+in (FStar_SMTEncoding_Util.mkImp uu____8733))
+in ((((typing_pred)::[])::[]), ((xx)::[]), (uu____8732)))
+in (mkForall_fuel uu____8726))
+in ((uu____8725), (Some ("int inversion")), (Some ("int_inversion"))))
+in FStar_SMTEncoding_Term.Assume (uu____8720))
+in (
+
+let uu____8750 = (
+
+let uu____8752 = (
+
+let uu____8753 = (
+
+let uu____8758 = (
+
+let uu____8759 = (
+
+let uu____8765 = (
+
+let uu____8766 = (
+
+let uu____8769 = (
+
+let uu____8770 = (
+
+let uu____8772 = (
+
+let uu____8774 = (
+
+let uu____8776 = (
+
+let uu____8777 = (
+
+let uu____8780 = (FStar_SMTEncoding_Term.unboxInt x)
+in (
+
+let uu____8781 = (FStar_SMTEncoding_Util.mkInteger' (Prims.parse_int "0"))
+in ((uu____8780), (uu____8781))))
+in (FStar_SMTEncoding_Util.mkGT uu____8777))
+in (
+
+let uu____8782 = (
+
+let uu____8784 = (
+
+let uu____8785 = (
+
+let uu____8788 = (FStar_SMTEncoding_Term.unboxInt y)
+in (
+
+let uu____8789 = (FStar_SMTEncoding_Util.mkInteger' (Prims.parse_int "0"))
+in ((uu____8788), (uu____8789))))
+in (FStar_SMTEncoding_Util.mkGTE uu____8785))
+in (
+
+let uu____8790 = (
+
+let uu____8792 = (
+
+let uu____8793 = (
+
+let uu____8796 = (FStar_SMTEncoding_Term.unboxInt y)
+in (
+
+let uu____8797 = (FStar_SMTEncoding_Term.unboxInt x)
+in ((uu____8796), (uu____8797))))
+in (FStar_SMTEncoding_Util.mkLT uu____8793))
+in (uu____8792)::[])
+in (uu____8784)::uu____8790))
+in (uu____8776)::uu____8782))
+in (typing_pred_y)::uu____8774)
+in (typing_pred)::uu____8772)
+in (FStar_SMTEncoding_Util.mk_and_l uu____8770))
+in ((uu____8769), (precedes_y_x)))
+in (FStar_SMTEncoding_Util.mkImp uu____8766))
+in ((((typing_pred)::(typing_pred_y)::(precedes_y_x)::[])::[]), ((xx)::(yy)::[]), (uu____8765)))
+in (mkForall_fuel uu____8759))
+in ((uu____8758), (Some ("well-founded ordering on nat (alt)")), (Some ("well-founded-ordering-on-nat"))))
+in FStar_SMTEncoding_Term.Assume (uu____8753))
+in (uu____8752)::[])
+in (uu____8719)::uu____8750))
+in (uu____8683)::uu____8717)))))))))))
+in (
+
+let mk_str = (fun env nm tt -> (
+
+let typing_pred = (FStar_SMTEncoding_Term.mk_HasType x tt)
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.String_sort))
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let uu____8828 = (
+
+let uu____8829 = (
+
+let uu____8834 = (
+
+let uu____8835 = (
+
+let uu____8841 = (
+
+let uu____8844 = (
+
+let uu____8846 = (FStar_SMTEncoding_Term.boxString b)
+in (uu____8846)::[])
+in (uu____8844)::[])
+in (
+
+let uu____8849 = (
+
+let uu____8850 = (FStar_SMTEncoding_Term.boxString b)
+in (FStar_SMTEncoding_Term.mk_HasType uu____8850 tt))
+in ((uu____8841), ((bb)::[]), (uu____8849))))
+in (FStar_SMTEncoding_Util.mkForall uu____8835))
+in ((uu____8834), (Some ("string typing")), (Some ("string_typing"))))
+in FStar_SMTEncoding_Term.Assume (uu____8829))
+in (
+
+let uu____8862 = (
+
+let uu____8864 = (
+
+let uu____8865 = (
+
+let uu____8870 = (
+
+let uu____8871 = (
+
+let uu____8877 = (
+
+let uu____8878 = (
+
+let uu____8881 = (FStar_SMTEncoding_Term.mk_tester "BoxString" x)
+in ((typing_pred), (uu____8881)))
+in (FStar_SMTEncoding_Util.mkImp uu____8878))
+in ((((typing_pred)::[])::[]), ((xx)::[]), (uu____8877)))
+in (mkForall_fuel uu____8871))
+in ((uu____8870), (Some ("string inversion")), (Some ("string_inversion"))))
+in FStar_SMTEncoding_Term.Assume (uu____8865))
+in (uu____8864)::[])
+in (uu____8828)::uu____8862))))))
+in (
+
+let mk_ref1 = (fun env reft_name uu____8904 -> (
+
+let r = (("r"), (FStar_SMTEncoding_Term.Ref_sort))
+in (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let refa = (
+
+let uu____8915 = (
+
+let uu____8919 = (
+
+let uu____8921 = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (uu____8921)::[])
+in ((reft_name), (uu____8919)))
+in (FStar_SMTEncoding_Util.mkApp uu____8915))
+in (
+
+let refb = (
+
+let uu____8924 = (
+
+let uu____8928 = (
+
+let uu____8930 = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (uu____8930)::[])
+in ((reft_name), (uu____8928)))
+in (FStar_SMTEncoding_Util.mkApp uu____8924))
+in (
+
+let typing_pred = (FStar_SMTEncoding_Term.mk_HasType x refa)
+in (
+
+let typing_pred_b = (FStar_SMTEncoding_Term.mk_HasType x refb)
+in (
+
+let uu____8934 = (
+
+let uu____8935 = (
+
+let uu____8940 = (
+
+let uu____8941 = (
+
+let uu____8947 = (
+
+let uu____8948 = (
+
+let uu____8951 = (FStar_SMTEncoding_Term.mk_tester "BoxRef" x)
+in ((typing_pred), (uu____8951)))
+in (FStar_SMTEncoding_Util.mkImp uu____8948))
+in ((((typing_pred)::[])::[]), ((xx)::(aa)::[]), (uu____8947)))
+in (mkForall_fuel uu____8941))
+in ((uu____8940), (Some ("ref inversion")), (Some ("ref_inversion"))))
+in FStar_SMTEncoding_Term.Assume (uu____8935))
+in (
+
+let uu____8967 = (
+
+let uu____8969 = (
+
+let uu____8970 = (
+
+let uu____8975 = (
+
+let uu____8976 = (
+
+let uu____8982 = (
+
+let uu____8983 = (
+
+let uu____8986 = (FStar_SMTEncoding_Util.mkAnd ((typing_pred), (typing_pred_b)))
+in (
+
+let uu____8987 = (
+
+let uu____8988 = (
+
+let uu____8991 = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let uu____8992 = (FStar_SMTEncoding_Util.mkFreeV bb)
+in ((uu____8991), (uu____8992))))
+in (FStar_SMTEncoding_Util.mkEq uu____8988))
+in ((uu____8986), (uu____8987))))
+in (FStar_SMTEncoding_Util.mkImp uu____8983))
+in ((((typing_pred)::(typing_pred_b)::[])::[]), ((xx)::(aa)::(bb)::[]), (uu____8982)))
+in (mkForall_fuel' (Prims.parse_int "2") uu____8976))
+in ((uu____8975), (Some ("ref typing is injective")), (Some ("ref_injectivity"))))
+in FStar_SMTEncoding_Term.Assume (uu____8970))
+in (uu____8969)::[])
+in (uu____8934)::uu____8967))))))))))
+in (
+
+let mk_true_interp = (fun env nm true_tm -> (
+
+let valid = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((true_tm)::[])))
+in (FStar_SMTEncoding_Term.Assume (((valid), (Some ("True interpretation")), (Some ("true_interp")))))::[]))
+in (
+
+let mk_false_interp = (fun env nm false_tm -> (
+
+let valid = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((false_tm)::[])))
+in (
+
+let uu____9036 = (
+
+let uu____9037 = (
+
+let uu____9042 = (FStar_SMTEncoding_Util.mkIff ((FStar_SMTEncoding_Util.mkFalse), (valid)))
+in ((uu____9042), (Some ("False interpretation")), (Some ("false_interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9037))
+in (uu____9036)::[])))
+in (
+
+let mk_and_interp = (fun env conj uu____9054 -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let valid = (
+
+let uu____9064 = (
+
+let uu____9068 = (
+
+let uu____9070 = (FStar_SMTEncoding_Util.mkApp ((conj), ((a)::(b)::[])))
+in (uu____9070)::[])
+in (("Valid"), (uu____9068)))
+in (FStar_SMTEncoding_Util.mkApp uu____9064))
+in (
+
+let valid_a = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((a)::[])))
+in (
+
+let valid_b = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((b)::[])))
+in (
+
+let uu____9077 = (
+
+let uu____9078 = (
+
+let uu____9083 = (
+
+let uu____9084 = (
+
+let uu____9090 = (
+
+let uu____9091 = (
+
+let uu____9094 = (FStar_SMTEncoding_Util.mkAnd ((valid_a), (valid_b)))
+in ((uu____9094), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9091))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9090)))
+in (FStar_SMTEncoding_Util.mkForall uu____9084))
+in ((uu____9083), (Some ("/\\ interpretation")), (Some ("l_and-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9078))
+in (uu____9077)::[])))))))))
+in (
+
+let mk_or_interp = (fun env disj uu____9119 -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let valid = (
+
+let uu____9129 = (
+
+let uu____9133 = (
+
+let uu____9135 = (FStar_SMTEncoding_Util.mkApp ((disj), ((a)::(b)::[])))
+in (uu____9135)::[])
+in (("Valid"), (uu____9133)))
+in (FStar_SMTEncoding_Util.mkApp uu____9129))
+in (
+
+let valid_a = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((a)::[])))
+in (
+
+let valid_b = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((b)::[])))
+in (
+
+let uu____9142 = (
+
+let uu____9143 = (
+
+let uu____9148 = (
+
+let uu____9149 = (
+
+let uu____9155 = (
+
+let uu____9156 = (
+
+let uu____9159 = (FStar_SMTEncoding_Util.mkOr ((valid_a), (valid_b)))
+in ((uu____9159), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9156))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9155)))
+in (FStar_SMTEncoding_Util.mkForall uu____9149))
+in ((uu____9148), (Some ("\\/ interpretation")), (Some ("l_or-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9143))
+in (uu____9142)::[])))))))))
+in (
+
+let mk_eq2_interp = (fun env eq2 tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let xx1 = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let yy1 = (("y"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let x1 = (FStar_SMTEncoding_Util.mkFreeV xx1)
+in (
+
+let y1 = (FStar_SMTEncoding_Util.mkFreeV yy1)
+in (
+
+let valid = (
+
+let uu____9198 = (
+
+let uu____9202 = (
+
+let uu____9204 = (FStar_SMTEncoding_Util.mkApp ((eq2), ((a)::(x1)::(y1)::[])))
+in (uu____9204)::[])
+in (("Valid"), (uu____9202)))
+in (FStar_SMTEncoding_Util.mkApp uu____9198))
+in (
+
+let uu____9207 = (
+
+let uu____9208 = (
+
+let uu____9213 = (
+
+let uu____9214 = (
+
+let uu____9220 = (
+
+let uu____9221 = (
+
+let uu____9224 = (FStar_SMTEncoding_Util.mkEq ((x1), (y1)))
+in ((uu____9224), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9221))
+in ((((valid)::[])::[]), ((aa)::(xx1)::(yy1)::[]), (uu____9220)))
+in (FStar_SMTEncoding_Util.mkForall uu____9214))
+in ((uu____9213), (Some ("Eq2 interpretation")), (Some ("eq2-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9208))
+in (uu____9207)::[])))))))))
+in (
+
+let mk_eq3_interp = (fun env eq3 tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let xx1 = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let yy1 = (("y"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let x1 = (FStar_SMTEncoding_Util.mkFreeV xx1)
+in (
+
+let y1 = (FStar_SMTEncoding_Util.mkFreeV yy1)
+in (
+
+let valid = (
+
+let uu____9269 = (
+
+let uu____9273 = (
+
+let uu____9275 = (FStar_SMTEncoding_Util.mkApp ((eq3), ((a)::(b)::(x1)::(y1)::[])))
+in (uu____9275)::[])
+in (("Valid"), (uu____9273)))
+in (FStar_SMTEncoding_Util.mkApp uu____9269))
+in (
+
+let uu____9278 = (
+
+let uu____9279 = (
+
+let uu____9284 = (
+
+let uu____9285 = (
+
+let uu____9291 = (
+
+let uu____9292 = (
+
+let uu____9295 = (FStar_SMTEncoding_Util.mkEq ((x1), (y1)))
+in ((uu____9295), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9292))
+in ((((valid)::[])::[]), ((aa)::(bb)::(xx1)::(yy1)::[]), (uu____9291)))
+in (FStar_SMTEncoding_Util.mkForall uu____9285))
+in ((uu____9284), (Some ("Eq3 interpretation")), (Some ("eq3-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9279))
+in (uu____9278)::[])))))))))))
+in (
+
+let mk_imp_interp = (fun env imp tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let valid = (
+
+let uu____9334 = (
+
+let uu____9338 = (
+
+let uu____9340 = (FStar_SMTEncoding_Util.mkApp ((imp), ((a)::(b)::[])))
+in (uu____9340)::[])
+in (("Valid"), (uu____9338)))
+in (FStar_SMTEncoding_Util.mkApp uu____9334))
+in (
+
+let valid_a = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((a)::[])))
+in (
+
+let valid_b = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((b)::[])))
+in (
+
+let uu____9347 = (
+
+let uu____9348 = (
+
+let uu____9353 = (
+
+let uu____9354 = (
+
+let uu____9360 = (
+
+let uu____9361 = (
+
+let uu____9364 = (FStar_SMTEncoding_Util.mkImp ((valid_a), (valid_b)))
+in ((uu____9364), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9361))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9360)))
+in (FStar_SMTEncoding_Util.mkForall uu____9354))
+in ((uu____9353), (Some ("==> interpretation")), (Some ("l_imp-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9348))
+in (uu____9347)::[])))))))))
+in (
+
+let mk_iff_interp = (fun env iff tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let valid = (
+
+let uu____9399 = (
+
+let uu____9403 = (
+
+let uu____9405 = (FStar_SMTEncoding_Util.mkApp ((iff), ((a)::(b)::[])))
+in (uu____9405)::[])
+in (("Valid"), (uu____9403)))
+in (FStar_SMTEncoding_Util.mkApp uu____9399))
+in (
+
+let valid_a = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((a)::[])))
+in (
+
+let valid_b = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((b)::[])))
+in (
+
+let uu____9412 = (
+
+let uu____9413 = (
+
+let uu____9418 = (
+
+let uu____9419 = (
+
+let uu____9425 = (
+
+let uu____9426 = (
+
+let uu____9429 = (FStar_SMTEncoding_Util.mkIff ((valid_a), (valid_b)))
+in ((uu____9429), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9426))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9425)))
+in (FStar_SMTEncoding_Util.mkForall uu____9419))
+in ((uu____9418), (Some ("<==> interpretation")), (Some ("l_iff-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9413))
+in (uu____9412)::[])))))))))
+in (
+
+let mk_not_interp = (fun env l_not tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let valid = (
+
+let uu____9460 = (
+
+let uu____9464 = (
+
+let uu____9466 = (FStar_SMTEncoding_Util.mkApp ((l_not), ((a)::[])))
+in (uu____9466)::[])
+in (("Valid"), (uu____9464)))
+in (FStar_SMTEncoding_Util.mkApp uu____9460))
+in (
+
+let not_valid_a = (
+
+let uu____9470 = (FStar_SMTEncoding_Util.mkApp (("Valid"), ((a)::[])))
+in (FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu____9470))
+in (
+
+let uu____9472 = (
+
+let uu____9473 = (
+
+let uu____9478 = (
+
+let uu____9479 = (
+
+let uu____9485 = (FStar_SMTEncoding_Util.mkIff ((not_valid_a), (valid)))
+in ((((valid)::[])::[]), ((aa)::[]), (uu____9485)))
+in (FStar_SMTEncoding_Util.mkForall uu____9479))
+in ((uu____9478), (Some ("not interpretation")), (Some ("l_not-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9473))
+in (uu____9472)::[]))))))
+in (
+
+let mk_forall_interp = (fun env for_all1 tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let xx1 = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let x1 = (FStar_SMTEncoding_Util.mkFreeV xx1)
+in (
+
+let valid = (
+
+let uu____9522 = (
+
+let uu____9526 = (
+
+let uu____9528 = (FStar_SMTEncoding_Util.mkApp ((for_all1), ((a)::(b)::[])))
+in (uu____9528)::[])
+in (("Valid"), (uu____9526)))
+in (FStar_SMTEncoding_Util.mkApp uu____9522))
+in (
+
+let valid_b_x = (
+
+let uu____9532 = (
+
+let uu____9536 = (
+
+let uu____9538 = (FStar_SMTEncoding_Util.mk_ApplyTT b x1)
+in (uu____9538)::[])
+in (("Valid"), (uu____9536)))
+in (FStar_SMTEncoding_Util.mkApp uu____9532))
+in (
+
+let uu____9540 = (
+
+let uu____9541 = (
+
+let uu____9546 = (
+
+let uu____9547 = (
+
+let uu____9553 = (
+
+let uu____9554 = (
+
+let uu____9557 = (
+
+let uu____9558 = (
+
+let uu____9564 = (
+
+let uu____9567 = (
+
+let uu____9569 = (FStar_SMTEncoding_Term.mk_HasTypeZ x1 a)
+in (uu____9569)::[])
+in (uu____9567)::[])
+in (
+
+let uu____9572 = (
+
+let uu____9573 = (
+
+let uu____9576 = (FStar_SMTEncoding_Term.mk_HasTypeZ x1 a)
+in ((uu____9576), (valid_b_x)))
+in (FStar_SMTEncoding_Util.mkImp uu____9573))
+in ((uu____9564), ((xx1)::[]), (uu____9572))))
+in (FStar_SMTEncoding_Util.mkForall uu____9558))
+in ((uu____9557), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9554))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9553)))
+in (FStar_SMTEncoding_Util.mkForall uu____9547))
+in ((uu____9546), (Some ("forall interpretation")), (Some ("forall-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9541))
+in (uu____9540)::[]))))))))))
+in (
+
+let mk_exists_interp = (fun env for_some1 tt -> (
+
+let aa = (("a"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let bb = (("b"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let xx1 = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let a = (FStar_SMTEncoding_Util.mkFreeV aa)
+in (
+
+let b = (FStar_SMTEncoding_Util.mkFreeV bb)
+in (
+
+let x1 = (FStar_SMTEncoding_Util.mkFreeV xx1)
+in (
+
+let valid = (
+
+let uu____9624 = (
+
+let uu____9628 = (
+
+let uu____9630 = (FStar_SMTEncoding_Util.mkApp ((for_some1), ((a)::(b)::[])))
+in (uu____9630)::[])
+in (("Valid"), (uu____9628)))
+in (FStar_SMTEncoding_Util.mkApp uu____9624))
+in (
+
+let valid_b_x = (
+
+let uu____9634 = (
+
+let uu____9638 = (
+
+let uu____9640 = (FStar_SMTEncoding_Util.mk_ApplyTT b x1)
+in (uu____9640)::[])
+in (("Valid"), (uu____9638)))
+in (FStar_SMTEncoding_Util.mkApp uu____9634))
+in (
+
+let uu____9642 = (
+
+let uu____9643 = (
+
+let uu____9648 = (
+
+let uu____9649 = (
+
+let uu____9655 = (
+
+let uu____9656 = (
+
+let uu____9659 = (
+
+let uu____9660 = (
+
+let uu____9666 = (
+
+let uu____9669 = (
+
+let uu____9671 = (FStar_SMTEncoding_Term.mk_HasTypeZ x1 a)
+in (uu____9671)::[])
+in (uu____9669)::[])
+in (
+
+let uu____9674 = (
+
+let uu____9675 = (
+
+let uu____9678 = (FStar_SMTEncoding_Term.mk_HasTypeZ x1 a)
+in ((uu____9678), (valid_b_x)))
+in (FStar_SMTEncoding_Util.mkImp uu____9675))
+in ((uu____9666), ((xx1)::[]), (uu____9674))))
+in (FStar_SMTEncoding_Util.mkExists uu____9660))
+in ((uu____9659), (valid)))
+in (FStar_SMTEncoding_Util.mkIff uu____9656))
+in ((((valid)::[])::[]), ((aa)::(bb)::[]), (uu____9655)))
+in (FStar_SMTEncoding_Util.mkForall uu____9649))
+in ((uu____9648), (Some ("exists interpretation")), (Some ("exists-interp"))))
+in FStar_SMTEncoding_Term.Assume (uu____9643))
+in (uu____9642)::[]))))))))))
+in (
+
+let mk_range_interp = (fun env range tt -> (
+
+let range_ty = (FStar_SMTEncoding_Util.mkApp ((range), ([])))
+in (
+
+let uu____9715 = (
+
+let uu____9716 = (
+
+let uu____9721 = (FStar_SMTEncoding_Term.mk_HasTypeZ FStar_SMTEncoding_Term.mk_Range_const range_ty)
+in (
+
+let uu____9722 = (
+
+let uu____9724 = (varops.mk_unique "typing_range_const")
+in Some (uu____9724))
+in ((uu____9721), (Some ("Range_const typing")), (uu____9722))))
+in FStar_SMTEncoding_Term.Assume (uu____9716))
+in (uu____9715)::[])))
+in (
+
+let prims1 = (((FStar_Syntax_Const.unit_lid), (mk_unit)))::(((FStar_Syntax_Const.bool_lid), (mk_bool)))::(((FStar_Syntax_Const.int_lid), (mk_int)))::(((FStar_Syntax_Const.string_lid), (mk_str)))::(((FStar_Syntax_Const.ref_lid), (mk_ref1)))::(((FStar_Syntax_Const.true_lid), (mk_true_interp)))::(((FStar_Syntax_Const.false_lid), (mk_false_interp)))::(((FStar_Syntax_Const.and_lid), (mk_and_interp)))::(((FStar_Syntax_Const.or_lid), (mk_or_interp)))::(((FStar_Syntax_Const.eq2_lid), (mk_eq2_interp)))::(((FStar_Syntax_Const.eq3_lid), (mk_eq3_interp)))::(((FStar_Syntax_Const.imp_lid), (mk_imp_interp)))::(((FStar_Syntax_Const.iff_lid), (mk_iff_interp)))::(((FStar_Syntax_Const.not_lid), (mk_not_interp)))::(((FStar_Syntax_Const.forall_lid), (mk_forall_interp)))::(((FStar_Syntax_Const.exists_lid), (mk_exists_interp)))::(((FStar_Syntax_Const.range_lid), (mk_range_interp)))::[]
+in (fun env t s tt -> (
+
+let uu____9987 = (FStar_Util.find_opt (fun uu____10005 -> (match (uu____10005) with
+| (l, uu____10015) -> begin
+(FStar_Ident.lid_equals l t)
+end)) prims1)
+in (match (uu____9987) with
+| None -> begin
+[]
+end
+| Some (uu____10037, f) -> begin
+(f env s tt)
+end)))))))))))))))))))))))))
+
+
+let encode_smt_lemma : env_t  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.typ  ->  FStar_SMTEncoding_Term.decl Prims.list = (fun env fv t -> (
+
+let lid = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____10074 = (encode_function_type_as_formula None None t env)
+in (match (uu____10074) with
+| (form, decls) -> begin
+(FStar_List.append decls ((FStar_SMTEncoding_Term.Assume (((form), (Some ((Prims.strcat "Lemma: " lid.FStar_Ident.str))), (Some ((Prims.strcat "lemma_" lid.FStar_Ident.str))))))::[]))
+end))))
+
+
+let encode_free_var : env_t  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env fv tt t_norm quals -> (
+
+let lid = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____10107 = ((
+
+let uu____10108 = ((FStar_Syntax_Util.is_pure_or_ghost_function t_norm) || (FStar_TypeChecker_Env.is_reifiable_function env.tcenv t_norm))
+in (FStar_All.pipe_left Prims.op_Negation uu____10108)) || (FStar_Syntax_Util.is_lemma t_norm))
+in (match (uu____10107) with
+| true -> begin
+(
+
+let uu____10112 = (new_term_constant_and_tok_from_lid env lid)
+in (match (uu____10112) with
+| (vname, vtok, env1) -> begin
+(
+
+let arg_sorts = (
+
+let uu____10124 = (
+
+let uu____10125 = (FStar_Syntax_Subst.compress t_norm)
+in uu____10125.FStar_Syntax_Syntax.n)
+in (match (uu____10124) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, uu____10130) -> begin
+(FStar_All.pipe_right binders (FStar_List.map (fun uu____10147 -> FStar_SMTEncoding_Term.Term_sort)))
+end
+| uu____10150 -> begin
+[]
+end))
+in (
+
+let d = FStar_SMTEncoding_Term.DeclFun (((vname), (arg_sorts), (FStar_SMTEncoding_Term.Term_sort), (Some ("Uninterpreted function symbol for impure function"))))
+in (
+
+let dd = FStar_SMTEncoding_Term.DeclFun (((vtok), ([]), (FStar_SMTEncoding_Term.Term_sort), (Some ("Uninterpreted name for impure function"))))
+in (((d)::(dd)::[]), (env1)))))
+end))
+end
+| uu____10158 -> begin
+(
+
+let uu____10159 = (prims.is lid)
+in (match (uu____10159) with
+| true -> begin
+(
+
+let vname = (varops.new_fvar lid)
+in (
+
+let uu____10164 = (prims.mk lid vname)
+in (match (uu____10164) with
+| (tok, definition) -> begin
+(
+
+let env1 = (push_free_var env lid vname (Some (tok)))
+in ((definition), (env1)))
+end)))
+end
+| uu____10177 -> begin
+(
+
+let encode_non_total_function_typ = (lid.FStar_Ident.nsstr <> "Prims")
+in (
+
+let uu____10179 = (
+
+let uu____10185 = (curried_arrow_formals_comp t_norm)
+in (match (uu____10185) with
+| (args, comp) -> begin
+(
+
+let comp1 = (
+
+let uu____10196 = (FStar_TypeChecker_Env.is_reifiable_comp env.tcenv comp)
+in (match (uu____10196) with
+| true -> begin
+(
+
+let uu____10197 = (FStar_TypeChecker_Env.reify_comp (
+
+let uu___153_10198 = env.tcenv
+in {FStar_TypeChecker_Env.solver = uu___153_10198.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___153_10198.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___153_10198.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___153_10198.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___153_10198.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___153_10198.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___153_10198.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___153_10198.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___153_10198.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___153_10198.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___153_10198.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___153_10198.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___153_10198.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___153_10198.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___153_10198.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___153_10198.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___153_10198.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___153_10198.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___153_10198.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___153_10198.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___153_10198.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___153_10198.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___153_10198.FStar_TypeChecker_Env.qname_and_index}) comp FStar_Syntax_Syntax.U_unknown)
+in (FStar_Syntax_Syntax.mk_Total uu____10197))
+end
+| uu____10199 -> begin
+comp
+end))
+in (match (encode_non_total_function_typ) with
+| true -> begin
+(
+
+let uu____10205 = (FStar_TypeChecker_Util.pure_or_ghost_pre_and_post env.tcenv comp1)
+in ((args), (uu____10205)))
+end
+| uu____10212 -> begin
+((args), (((None), ((FStar_Syntax_Util.comp_result comp1)))))
+end))
+end))
+in (match (uu____10179) with
+| (formals, (pre_opt, res_t)) -> begin
+(
+
+let uu____10232 = (new_term_constant_and_tok_from_lid env lid)
+in (match (uu____10232) with
+| (vname, vtok, env1) -> begin
+(
+
+let vtok_tm = (match (formals) with
+| [] -> begin
+(FStar_SMTEncoding_Util.mkFreeV ((vname), (FStar_SMTEncoding_Term.Term_sort)))
+end
+| uu____10245 -> begin
+(FStar_SMTEncoding_Util.mkApp ((vtok), ([])))
+end)
+in (
+
+let mk_disc_proj_axioms = (fun guard encoded_res_t vapp vars -> (FStar_All.pipe_right quals (FStar_List.collect (fun uu___124_10269 -> (match (uu___124_10269) with
+| FStar_Syntax_Syntax.Discriminator (d) -> begin
+(
+
+let uu____10272 = (FStar_Util.prefix vars)
+in (match (uu____10272) with
+| (uu____10283, (xxsym, uu____10285)) -> begin
+(
+
+let xx = (FStar_SMTEncoding_Util.mkFreeV ((xxsym), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let uu____10295 = (
+
+let uu____10296 = (
+
+let uu____10301 = (
+
+let uu____10302 = (
+
+let uu____10308 = (
+
+let uu____10309 = (
+
+let uu____10312 = (
+
+let uu____10313 = (FStar_SMTEncoding_Term.mk_tester (escape d.FStar_Ident.str) xx)
+in (FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool uu____10313))
+in ((vapp), (uu____10312)))
+in (FStar_SMTEncoding_Util.mkEq uu____10309))
+in ((((vapp)::[])::[]), (vars), (uu____10308)))
+in (FStar_SMTEncoding_Util.mkForall uu____10302))
+in ((uu____10301), (Some ("Discriminator equation")), (Some ((Prims.strcat "disc_equation_" (escape d.FStar_Ident.str))))))
+in FStar_SMTEncoding_Term.Assume (uu____10296))
+in (uu____10295)::[]))
+end))
+end
+| FStar_Syntax_Syntax.Projector (d, f) -> begin
+(
+
+let uu____10325 = (FStar_Util.prefix vars)
+in (match (uu____10325) with
+| (uu____10336, (xxsym, uu____10338)) -> begin
+(
+
+let xx = (FStar_SMTEncoding_Util.mkFreeV ((xxsym), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let f1 = {FStar_Syntax_Syntax.ppname = f; FStar_Syntax_Syntax.index = (Prims.parse_int "0"); FStar_Syntax_Syntax.sort = FStar_Syntax_Syntax.tun}
+in (
+
+let tp_name = (mk_term_projector_name d f1)
+in (
+
+let prim_app = (FStar_SMTEncoding_Util.mkApp ((tp_name), ((xx)::[])))
+in (
+
+let uu____10352 = (
+
+let uu____10353 = (
+
+let uu____10358 = (
+
+let uu____10359 = (
+
+let uu____10365 = (FStar_SMTEncoding_Util.mkEq ((vapp), (prim_app)))
+in ((((vapp)::[])::[]), (vars), (uu____10365)))
+in (FStar_SMTEncoding_Util.mkForall uu____10359))
+in ((uu____10358), (Some ("Projector equation")), (Some ((Prims.strcat "proj_equation_" tp_name)))))
+in FStar_SMTEncoding_Term.Assume (uu____10353))
+in (uu____10352)::[])))))
+end))
+end
+| uu____10375 -> begin
+[]
+end)))))
+in (
+
+let uu____10376 = (encode_binders None formals env1)
+in (match (uu____10376) with
+| (vars, guards, env', decls1, uu____10392) -> begin
+(
+
+let uu____10399 = (match (pre_opt) with
+| None -> begin
+(
+
+let uu____10404 = (FStar_SMTEncoding_Util.mk_and_l guards)
+in ((uu____10404), (decls1)))
+end
+| Some (p) -> begin
+(
+
+let uu____10406 = (encode_formula p env')
+in (match (uu____10406) with
+| (g, ds) -> begin
+(
+
+let uu____10413 = (FStar_SMTEncoding_Util.mk_and_l ((g)::guards))
+in ((uu____10413), ((FStar_List.append decls1 ds))))
+end))
+end)
+in (match (uu____10399) with
+| (guard, decls11) -> begin
+(
+
+let vtok_app = (mk_Apply vtok_tm vars)
+in (
+
+let vapp = (
+
+let uu____10422 = (
+
+let uu____10426 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in ((vname), (uu____10426)))
+in (FStar_SMTEncoding_Util.mkApp uu____10422))
+in (
+
+let uu____10431 = (
+
+let vname_decl = (
+
+let uu____10436 = (
+
+let uu____10442 = (FStar_All.pipe_right formals (FStar_List.map (fun uu____10447 -> FStar_SMTEncoding_Term.Term_sort)))
+in ((vname), (uu____10442), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in FStar_SMTEncoding_Term.DeclFun (uu____10436))
+in (
+
+let uu____10452 = (
+
+let env2 = (
+
+let uu___154_10456 = env1
+in {bindings = uu___154_10456.bindings; depth = uu___154_10456.depth; tcenv = uu___154_10456.tcenv; warn = uu___154_10456.warn; cache = uu___154_10456.cache; nolabels = uu___154_10456.nolabels; use_zfuel_name = uu___154_10456.use_zfuel_name; encode_non_total_function_typ = encode_non_total_function_typ})
+in (
+
+let uu____10457 = (
+
+let uu____10458 = (head_normal env2 tt)
+in (not (uu____10458)))
+in (match (uu____10457) with
+| true -> begin
+(encode_term_pred None tt env2 vtok_tm)
+end
+| uu____10461 -> begin
+(encode_term_pred None t_norm env2 vtok_tm)
+end)))
+in (match (uu____10452) with
+| (tok_typing, decls2) -> begin
+(
+
+let tok_typing1 = FStar_SMTEncoding_Term.Assume (((tok_typing), (Some ("function token typing")), (Some ((Prims.strcat "function_token_typing_" vname)))))
+in (
+
+let uu____10470 = (match (formals) with
+| [] -> begin
+(
+
+let uu____10479 = (
+
+let uu____10480 = (
+
+let uu____10482 = (FStar_SMTEncoding_Util.mkFreeV ((vname), (FStar_SMTEncoding_Term.Term_sort)))
+in (FStar_All.pipe_left (fun _0_34 -> Some (_0_34)) uu____10482))
+in (push_free_var env1 lid vname uu____10480))
+in (((FStar_List.append decls2 ((tok_typing1)::[]))), (uu____10479)))
+end
+| uu____10485 -> begin
+(
+
+let vtok_decl = FStar_SMTEncoding_Term.DeclFun (((vtok), ([]), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in (
+
+let vtok_fresh = (
+
+let uu____10490 = (varops.next_id ())
+in (FStar_SMTEncoding_Term.fresh_token ((vtok), (FStar_SMTEncoding_Term.Term_sort)) uu____10490))
+in (
+
+let name_tok_corr = (
+
+let uu____10492 = (
+
+let uu____10497 = (
+
+let uu____10498 = (
+
+let uu____10504 = (FStar_SMTEncoding_Util.mkEq ((vtok_app), (vapp)))
+in ((((vtok_app)::[])::((vapp)::[])::[]), (vars), (uu____10504)))
+in (FStar_SMTEncoding_Util.mkForall uu____10498))
+in ((uu____10497), (Some ("Name-token correspondence")), (Some ((Prims.strcat "token_correspondence_" vname)))))
+in FStar_SMTEncoding_Term.Assume (uu____10492))
+in (((FStar_List.append decls2 ((vtok_decl)::(vtok_fresh)::(name_tok_corr)::(tok_typing1)::[]))), (env1)))))
+end)
+in (match (uu____10470) with
+| (tok_decl, env2) -> begin
+(((vname_decl)::tok_decl), (env2))
+end)))
+end)))
+in (match (uu____10431) with
+| (decls2, env2) -> begin
+(
+
+let uu____10529 = (
+
+let res_t1 = (FStar_Syntax_Subst.compress res_t)
+in (
+
+let uu____10534 = (encode_term res_t1 env')
+in (match (uu____10534) with
+| (encoded_res_t, decls) -> begin
+(
+
+let uu____10542 = (FStar_SMTEncoding_Term.mk_HasType vapp encoded_res_t)
+in ((encoded_res_t), (uu____10542), (decls)))
+end)))
+in (match (uu____10529) with
+| (encoded_res_t, ty_pred, decls3) -> begin
+(
+
+let typingAx = (
+
+let uu____10550 = (
+
+let uu____10555 = (
+
+let uu____10556 = (
+
+let uu____10562 = (FStar_SMTEncoding_Util.mkImp ((guard), (ty_pred)))
+in ((((vapp)::[])::[]), (vars), (uu____10562)))
+in (FStar_SMTEncoding_Util.mkForall uu____10556))
+in ((uu____10555), (Some ("free var typing")), (Some ((Prims.strcat "typing_" vname)))))
+in FStar_SMTEncoding_Term.Assume (uu____10550))
+in (
+
+let freshness = (
+
+let uu____10572 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.New))
+in (match (uu____10572) with
+| true -> begin
+(
+
+let uu____10575 = (
+
+let uu____10576 = (
+
+let uu____10582 = (FStar_All.pipe_right vars (FStar_List.map Prims.snd))
+in (
+
+let uu____10588 = (varops.next_id ())
+in ((vname), (uu____10582), (FStar_SMTEncoding_Term.Term_sort), (uu____10588))))
+in (FStar_SMTEncoding_Term.fresh_constructor uu____10576))
+in (
+
+let uu____10590 = (
+
+let uu____10592 = (pretype_axiom vapp vars)
+in (uu____10592)::[])
+in (uu____10575)::uu____10590))
+end
+| uu____10593 -> begin
+[]
+end))
+in (
+
+let g = (
+
+let uu____10596 = (
+
+let uu____10598 = (
+
+let uu____10600 = (
+
+let uu____10602 = (
+
+let uu____10604 = (mk_disc_proj_axioms guard encoded_res_t vapp vars)
+in (typingAx)::uu____10604)
+in (FStar_List.append freshness uu____10602))
+in (FStar_List.append decls3 uu____10600))
+in (FStar_List.append decls2 uu____10598))
+in (FStar_List.append decls11 uu____10596))
+in ((g), (env2)))))
+end))
+end))))
+end))
+end))))
+end))
+end)))
+end))
+end))))
+
+
+let declare_top_level_let : env_t  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  ((Prims.string * FStar_SMTEncoding_Term.term Prims.option) * FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env x t t_norm -> (
+
+let uu____10626 = (try_lookup_lid env x.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____10626) with
+| None -> begin
+(
+
+let uu____10649 = (encode_free_var env x t t_norm [])
+in (match (uu____10649) with
+| (decls, env1) -> begin
+(
+
+let uu____10664 = (lookup_lid env1 x.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____10664) with
+| (n1, x', uu____10683) -> begin
+((((n1), (x'))), (decls), (env1))
+end))
+end))
+end
+| Some (n1, x1, uu____10695) -> begin
+((((n1), (x1))), ([]), (env))
+end)))
+
+
+let encode_top_level_val : env_t  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env lid t quals -> (
+
+let tt = (norm env t)
+in (
+
+let uu____10728 = (encode_free_var env lid t tt quals)
+in (match (uu____10728) with
+| (decls, env1) -> begin
+(
+
+let uu____10739 = (FStar_Syntax_Util.is_smt_lemma t)
+in (match (uu____10739) with
+| true -> begin
+(
+
+let uu____10743 = (
+
+let uu____10745 = (encode_smt_lemma env1 lid tt)
+in (FStar_List.append decls uu____10745))
+in ((uu____10743), (env1)))
+end
+| uu____10748 -> begin
+((decls), (env1))
+end))
+end))))
+
+
+let encode_top_level_vals : env_t  ->  FStar_Syntax_Syntax.letbinding Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env bindings quals -> (FStar_All.pipe_right bindings (FStar_List.fold_left (fun uu____10773 lb -> (match (uu____10773) with
+| (decls, env1) -> begin
+(
+
+let uu____10785 = (
+
+let uu____10789 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (encode_top_level_val env1 uu____10789 lb.FStar_Syntax_Syntax.lbtyp quals))
+in (match (uu____10785) with
+| (decls', env2) -> begin
+(((FStar_List.append decls decls')), (env2))
+end))
+end)) (([]), (env)))))
+
+
+let is_tactic : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let fstar_tactics_tactic_lid = (FStar_Syntax_Const.p2l (("FStar")::("Tactics")::("tactic")::[]))
+in (
+
+let uu____10803 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____10803) with
+| (hd1, args) -> begin
+(
+
+let uu____10829 = (
+
+let uu____10830 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____10830.FStar_Syntax_Syntax.n)
+in (match (uu____10829) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_tactic_lid) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____10834, c) -> begin
+(
+
+let effect_name = (FStar_Syntax_Util.comp_effect_name c)
+in (FStar_Util.starts_with "FStar.Tactics" effect_name.FStar_Ident.str))
+end
+| uu____10847 -> begin
+false
+end))
+end))))
+
+
+let encode_top_level_let : env_t  ->  (Prims.bool * FStar_Syntax_Syntax.letbinding Prims.list)  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env uu____10862 quals -> (match (uu____10862) with
+| (is_rec, bindings) -> begin
+(
+
+let eta_expand1 = (fun binders formals body t -> (
+
+let nbinders = (FStar_List.length binders)
+in (
+
+let uu____10911 = (FStar_Util.first_N nbinders formals)
+in (match (uu____10911) with
+| (formals1, extra_formals) -> begin
+(
+
+let subst1 = (FStar_List.map2 (fun uu____10951 uu____10952 -> (match (((uu____10951), (uu____10952))) with
+| ((formal, uu____10962), (binder, uu____10964)) -> begin
+(
+
+let uu____10969 = (
+
+let uu____10974 = (FStar_Syntax_Syntax.bv_to_name binder)
+in ((formal), (uu____10974)))
+in FStar_Syntax_Syntax.NT (uu____10969))
+end)) formals1 binders)
+in (
+
+let extra_formals1 = (
+
+let uu____10979 = (FStar_All.pipe_right extra_formals (FStar_List.map (fun uu____10993 -> (match (uu____10993) with
+| (x, i) -> begin
+(
+
+let uu____11000 = (
+
+let uu___155_11001 = x
+in (
+
+let uu____11002 = (FStar_Syntax_Subst.subst subst1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___155_11001.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___155_11001.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____11002}))
+in ((uu____11000), (i)))
+end))))
+in (FStar_All.pipe_right uu____10979 FStar_Syntax_Util.name_binders))
+in (
+
+let body1 = (
+
+let uu____11014 = (
+
+let uu____11016 = (
+
+let uu____11017 = (FStar_Syntax_Subst.subst subst1 t)
+in uu____11017.FStar_Syntax_Syntax.n)
+in (FStar_All.pipe_left (fun _0_35 -> Some (_0_35)) uu____11016))
+in (
+
+let uu____11021 = (
+
+let uu____11022 = (FStar_Syntax_Subst.compress body)
+in (
+
+let uu____11023 = (
+
+let uu____11024 = (FStar_Syntax_Util.args_of_binders extra_formals1)
+in (FStar_All.pipe_left Prims.snd uu____11024))
+in (FStar_Syntax_Syntax.extend_app_n uu____11022 uu____11023)))
+in (uu____11021 uu____11014 body.FStar_Syntax_Syntax.pos)))
+in (((FStar_List.append binders extra_formals1)), (body1)))))
+end))))
+in (
+
+let destruct_bound_function = (fun flid t_norm e -> (
+
+let get_result_type = (fun c -> (
+
+let uu____11066 = (FStar_TypeChecker_Env.is_reifiable_comp env.tcenv c)
+in (match (uu____11066) with
+| true -> begin
+(FStar_TypeChecker_Env.reify_comp (
+
+let uu___156_11067 = env.tcenv
+in {FStar_TypeChecker_Env.solver = uu___156_11067.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___156_11067.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___156_11067.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___156_11067.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___156_11067.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___156_11067.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___156_11067.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___156_11067.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___156_11067.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___156_11067.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___156_11067.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___156_11067.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___156_11067.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___156_11067.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___156_11067.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___156_11067.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___156_11067.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___156_11067.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___156_11067.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___156_11067.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___156_11067.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___156_11067.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___156_11067.FStar_TypeChecker_Env.qname_and_index}) c FStar_Syntax_Syntax.U_unknown)
+end
+| uu____11068 -> begin
+(FStar_Syntax_Util.comp_result c)
+end)))
+in (
+
+let rec aux = (fun norm1 t_norm1 -> (
+
+let uu____11088 = (FStar_Syntax_Util.abs_formals e)
+in (match (uu____11088) with
+| (binders, body, lopt) -> begin
+(match (binders) with
+| (uu____11137)::uu____11138 -> begin
+(
+
+let uu____11146 = (
+
+let uu____11147 = (FStar_Syntax_Subst.compress t_norm1)
+in uu____11147.FStar_Syntax_Syntax.n)
+in (match (uu____11146) with
+| FStar_Syntax_Syntax.Tm_arrow (formals, c) -> begin
+(
+
+let uu____11174 = (FStar_Syntax_Subst.open_comp formals c)
+in (match (uu____11174) with
+| (formals1, c1) -> begin
+(
+
+let nformals = (FStar_List.length formals1)
+in (
+
+let nbinders = (FStar_List.length binders)
+in (
+
+let tres = (get_result_type c1)
+in (
+
+let uu____11200 = ((nformals < nbinders) && (FStar_Syntax_Util.is_total_comp c1))
+in (match (uu____11200) with
+| true -> begin
+(
+
+let uu____11218 = (FStar_Util.first_N nformals binders)
+in (match (uu____11218) with
+| (bs0, rest) -> begin
+(
+
+let c2 = (
+
+let subst1 = (FStar_List.map2 (fun uu____11264 uu____11265 -> (match (((uu____11264), (uu____11265))) with
+| ((x, uu____11275), (b, uu____11277)) -> begin
+(
+
+let uu____11282 = (
+
+let uu____11287 = (FStar_Syntax_Syntax.bv_to_name b)
+in ((x), (uu____11287)))
+in FStar_Syntax_Syntax.NT (uu____11282))
+end)) formals1 bs0)
+in (FStar_Syntax_Subst.subst_comp subst1 c1))
+in (
+
+let body1 = (FStar_Syntax_Util.abs rest body lopt)
+in (
+
+let uu____11289 = (
+
+let uu____11300 = (get_result_type c2)
+in ((bs0), (body1), (bs0), (uu____11300)))
+in ((uu____11289), (false)))))
+end))
+end
+| uu____11317 -> begin
+(match ((nformals > nbinders)) with
+| true -> begin
+(
+
+let uu____11335 = (eta_expand1 binders formals1 body tres)
+in (match (uu____11335) with
+| (binders1, body1) -> begin
+((((binders1), (body1), (formals1), (tres))), (false))
+end))
+end
+| uu____11381 -> begin
+((((binders), (body), (formals1), (tres))), (false))
+end)
+end)))))
+end))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, uu____11387) -> begin
+(
+
+let uu____11392 = (
+
+let uu____11403 = (aux norm1 x.FStar_Syntax_Syntax.sort)
+in (Prims.fst uu____11403))
+in ((uu____11392), (true)))
+end
+| uu____11436 when (not (norm1)) -> begin
+(
+
+let t_norm2 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.AllowUnboundUniverses)::(FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Zeta))::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv t_norm1)
+in (aux true t_norm2))
+end
+| uu____11438 -> begin
+(
+
+let uu____11439 = (
+
+let uu____11440 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____11441 = (FStar_Syntax_Print.term_to_string t_norm1)
+in (FStar_Util.format3 "Impossible! let-bound lambda %s = %s has a type that\'s not a function: %s\n" flid.FStar_Ident.str uu____11440 uu____11441)))
+in (failwith uu____11439))
+end))
+end
+| uu____11454 -> begin
+(
+
+let uu____11455 = (
+
+let uu____11456 = (FStar_Syntax_Subst.compress t_norm1)
+in uu____11456.FStar_Syntax_Syntax.n)
+in (match (uu____11455) with
+| FStar_Syntax_Syntax.Tm_arrow (formals, c) -> begin
+(
+
+let uu____11483 = (FStar_Syntax_Subst.open_comp formals c)
+in (match (uu____11483) with
+| (formals1, c1) -> begin
+(
+
+let tres = (get_result_type c1)
+in (
+
+let uu____11501 = (eta_expand1 [] formals1 e tres)
+in (match (uu____11501) with
+| (binders1, body1) -> begin
+((((binders1), (body1), (formals1), (tres))), (false))
+end)))
+end))
+end
+| uu____11549 -> begin
+(((([]), (e), ([]), (t_norm1))), (false))
+end))
+end)
+end)))
+in (aux false t_norm))))
+in try
+(match (()) with
+| () -> begin
+(
+
+let uu____11577 = (FStar_All.pipe_right bindings (FStar_Util.for_all (fun lb -> ((FStar_Syntax_Util.is_lemma lb.FStar_Syntax_Syntax.lbtyp) || (is_tactic lb.FStar_Syntax_Syntax.lbtyp)))))
+in (match (uu____11577) with
+| true -> begin
+(encode_top_level_vals env bindings quals)
+end
+| uu____11583 -> begin
+(
+
+let uu____11584 = (FStar_All.pipe_right bindings (FStar_List.fold_left (fun uu____11625 lb -> (match (uu____11625) with
+| (toks, typs, decls, env1) -> begin
+((
+
+let uu____11676 = (FStar_Syntax_Util.is_lemma lb.FStar_Syntax_Syntax.lbtyp)
+in (match (uu____11676) with
+| true -> begin
+(Prims.raise Let_rec_unencodeable)
+end
+| uu____11677 -> begin
+()
+end));
+(
+
+let t_norm = (whnf env1 lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____11679 = (
+
+let uu____11687 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (declare_top_level_let env1 uu____11687 lb.FStar_Syntax_Syntax.lbtyp t_norm))
+in (match (uu____11679) with
+| (tok, decl, env2) -> begin
+(
+
+let uu____11712 = (
+
+let uu____11719 = (
+
+let uu____11725 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in ((uu____11725), (tok)))
+in (uu____11719)::toks)
+in ((uu____11712), ((t_norm)::typs), ((decl)::decls), (env2)))
+end)));
+)
+end)) (([]), ([]), ([]), (env))))
+in (match (uu____11584) with
+| (toks, typs, decls, env1) -> begin
+(
+
+let toks1 = (FStar_List.rev toks)
+in (
+
+let decls1 = (FStar_All.pipe_right (FStar_List.rev decls) FStar_List.flatten)
+in (
+
+let typs1 = (FStar_List.rev typs)
+in (
+
+let mk_app1 = (fun curry f ftok vars -> (match (vars) with
+| [] -> begin
+(FStar_SMTEncoding_Util.mkFreeV ((f), (FStar_SMTEncoding_Term.Term_sort)))
+end
+| uu____11827 -> begin
+(match (curry) with
+| true -> begin
+(match (ftok) with
+| Some (ftok1) -> begin
+(mk_Apply ftok1 vars)
+end
+| None -> begin
+(
+
+let uu____11832 = (FStar_SMTEncoding_Util.mkFreeV ((f), (FStar_SMTEncoding_Term.Term_sort)))
+in (mk_Apply uu____11832 vars))
+end)
+end
+| uu____11833 -> begin
+(
+
+let uu____11834 = (
+
+let uu____11838 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in ((f), (uu____11838)))
+in (FStar_SMTEncoding_Util.mkApp uu____11834))
+end)
+end))
+in (
+
+let uu____11843 = ((FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___125_11845 -> (match (uu___125_11845) with
+| FStar_Syntax_Syntax.HasMaskedEffect -> begin
+true
+end
+| uu____11846 -> begin
+false
+end)))) || (FStar_All.pipe_right typs1 (FStar_Util.for_some (fun t -> (
+
+let uu____11849 = ((FStar_Syntax_Util.is_pure_or_ghost_function t) || (FStar_TypeChecker_Env.is_reifiable_function env1.tcenv t))
+in (FStar_All.pipe_left Prims.op_Negation uu____11849))))))
+in (match (uu____11843) with
+| true -> begin
+((decls1), (env1))
+end
+| uu____11854 -> begin
+(match ((not (is_rec))) with
+| true -> begin
+(match (((bindings), (typs1), (toks1))) with
+| (({FStar_Syntax_Syntax.lbname = uu____11869; FStar_Syntax_Syntax.lbunivs = uvs; FStar_Syntax_Syntax.lbtyp = uu____11871; FStar_Syntax_Syntax.lbeff = uu____11872; FStar_Syntax_Syntax.lbdef = e})::[], (t_norm)::[], ((flid_fv, (f, ftok)))::[]) -> begin
+(
+
+let flid = flid_fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____11913 = (FStar_Syntax_Subst.univ_var_opening uvs)
+in (match (uu____11913) with
+| (univ_subst, univ_vars1) -> begin
+(
+
+let env' = (
+
+let uu___159_11928 = env1
+in (
+
+let uu____11929 = (FStar_TypeChecker_Env.push_univ_vars env1.tcenv univ_vars1)
+in {bindings = uu___159_11928.bindings; depth = uu___159_11928.depth; tcenv = uu____11929; warn = uu___159_11928.warn; cache = uu___159_11928.cache; nolabels = uu___159_11928.nolabels; use_zfuel_name = uu___159_11928.use_zfuel_name; encode_non_total_function_typ = uu___159_11928.encode_non_total_function_typ}))
+in (
+
+let t_norm1 = (FStar_Syntax_Subst.subst univ_subst t_norm)
+in (
+
+let e1 = (
+
+let uu____11932 = (FStar_Syntax_Subst.subst univ_subst e)
+in (FStar_Syntax_Subst.compress uu____11932))
+in (
+
+let uu____11933 = (destruct_bound_function flid t_norm1 e1)
+in (match (uu____11933) with
+| ((binders, body, uu____11945, uu____11946), curry) -> begin
+((
+
+let uu____11953 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____11953) with
+| true -> begin
+(
+
+let uu____11954 = (FStar_Syntax_Print.binders_to_string ", " binders)
+in (
+
+let uu____11955 = (FStar_Syntax_Print.term_to_string body)
+in (FStar_Util.print2 "Encoding let : binders=[%s], body=%s\n" uu____11954 uu____11955)))
+end
+| uu____11956 -> begin
+()
+end));
+(
+
+let uu____11957 = (encode_binders None binders env')
+in (match (uu____11957) with
+| (vars, guards, env'1, binder_decls, uu____11973) -> begin
+(
+
+let body1 = (
+
+let uu____11981 = (FStar_TypeChecker_Env.is_reifiable_function env'1.tcenv t_norm1)
+in (match (uu____11981) with
+| true -> begin
+(reify_body env'1.tcenv body)
+end
+| uu____11982 -> begin
+body
+end))
+in (
+
+let app = (mk_app1 curry f ftok vars)
+in (
+
+let uu____11984 = (
+
+let uu____11989 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Logic))
+in (match (uu____11989) with
+| true -> begin
+(
+
+let uu____11995 = (FStar_SMTEncoding_Term.mk_Valid app)
+in (
+
+let uu____11996 = (encode_formula body1 env'1)
+in ((uu____11995), (uu____11996))))
+end
+| uu____12001 -> begin
+(
+
+let uu____12002 = (encode_term body1 env'1)
+in ((app), (uu____12002)))
+end))
+in (match (uu____11984) with
+| (app1, (body2, decls2)) -> begin
+(
+
+let eqn = (
+
+let uu____12016 = (
+
+let uu____12021 = (
+
+let uu____12022 = (
+
+let uu____12028 = (FStar_SMTEncoding_Util.mkEq ((app1), (body2)))
+in ((((app1)::[])::[]), (vars), (uu____12028)))
+in (FStar_SMTEncoding_Util.mkForall uu____12022))
+in (
+
+let uu____12034 = (
+
+let uu____12036 = (FStar_Util.format1 "Equation for %s" flid.FStar_Ident.str)
+in Some (uu____12036))
+in ((uu____12021), (uu____12034), (Some ((Prims.strcat "equation_" f))))))
+in FStar_SMTEncoding_Term.Assume (uu____12016))
+in (
+
+let uu____12039 = (
+
+let uu____12041 = (
+
+let uu____12043 = (
+
+let uu____12045 = (
+
+let uu____12047 = (primitive_type_axioms env1.tcenv flid f app1)
+in (FStar_List.append ((eqn)::[]) uu____12047))
+in (FStar_List.append decls2 uu____12045))
+in (FStar_List.append binder_decls uu____12043))
+in (FStar_List.append decls1 uu____12041))
+in ((uu____12039), (env1))))
+end))))
+end));
+)
+end)))))
+end)))
+end
+| uu____12050 -> begin
+(failwith "Impossible")
+end)
+end
+| uu____12065 -> begin
+(
+
+let fuel = (
+
+let uu____12069 = (varops.fresh "fuel")
+in ((uu____12069), (FStar_SMTEncoding_Term.Fuel_sort)))
+in (
+
+let fuel_tm = (FStar_SMTEncoding_Util.mkFreeV fuel)
+in (
+
+let env0 = env1
+in (
+
+let uu____12072 = (FStar_All.pipe_right toks1 (FStar_List.fold_left (fun uu____12111 uu____12112 -> (match (((uu____12111), (uu____12112))) with
+| ((gtoks, env2), (flid_fv, (f, ftok))) -> begin
+(
+
+let flid = flid_fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let g = (
+
+let uu____12194 = (FStar_Ident.lid_add_suffix flid "fuel_instrumented")
+in (varops.new_fvar uu____12194))
+in (
+
+let gtok = (
+
+let uu____12196 = (FStar_Ident.lid_add_suffix flid "fuel_instrumented_token")
+in (varops.new_fvar uu____12196))
+in (
+
+let env3 = (
+
+let uu____12198 = (
+
+let uu____12200 = (FStar_SMTEncoding_Util.mkApp ((g), ((fuel_tm)::[])))
+in (FStar_All.pipe_left (fun _0_36 -> Some (_0_36)) uu____12200))
+in (push_free_var env2 flid gtok uu____12198))
+in (((((flid), (f), (ftok), (g), (gtok)))::gtoks), (env3))))))
+end)) (([]), (env1))))
+in (match (uu____12072) with
+| (gtoks, env2) -> begin
+(
+
+let gtoks1 = (FStar_List.rev gtoks)
+in (
+
+let encode_one_binding = (fun env01 uu____12284 t_norm uu____12286 -> (match (((uu____12284), (uu____12286))) with
+| ((flid, f, ftok, g, gtok), {FStar_Syntax_Syntax.lbname = lbn; FStar_Syntax_Syntax.lbunivs = uvs; FStar_Syntax_Syntax.lbtyp = uu____12311; FStar_Syntax_Syntax.lbeff = uu____12312; FStar_Syntax_Syntax.lbdef = e}) -> begin
+(
+
+let uu____12329 = (FStar_Syntax_Subst.univ_var_opening uvs)
+in (match (uu____12329) with
+| (univ_subst, univ_vars1) -> begin
+(
+
+let env' = (
+
+let uu___160_12346 = env2
+in (
+
+let uu____12347 = (FStar_TypeChecker_Env.push_univ_vars env2.tcenv univ_vars1)
+in {bindings = uu___160_12346.bindings; depth = uu___160_12346.depth; tcenv = uu____12347; warn = uu___160_12346.warn; cache = uu___160_12346.cache; nolabels = uu___160_12346.nolabels; use_zfuel_name = uu___160_12346.use_zfuel_name; encode_non_total_function_typ = uu___160_12346.encode_non_total_function_typ}))
+in (
+
+let t_norm1 = (FStar_Syntax_Subst.subst univ_subst t_norm)
+in (
+
+let e1 = (FStar_Syntax_Subst.subst univ_subst e)
+in ((
+
+let uu____12351 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env01.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____12351) with
+| true -> begin
+(
+
+let uu____12352 = (FStar_Syntax_Print.lbname_to_string lbn)
+in (
+
+let uu____12353 = (FStar_Syntax_Print.term_to_string t_norm1)
+in (
+
+let uu____12354 = (FStar_Syntax_Print.term_to_string e1)
+in (FStar_Util.print3 "Encoding let rec %s : %s = %s\n" uu____12352 uu____12353 uu____12354))))
+end
+| uu____12355 -> begin
+()
+end));
+(
+
+let uu____12356 = (destruct_bound_function flid t_norm1 e1)
+in (match (uu____12356) with
+| ((binders, body, formals, tres), curry) -> begin
+((
+
+let uu____12378 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env01.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____12378) with
+| true -> begin
+(
+
+let uu____12379 = (FStar_Syntax_Print.binders_to_string ", " binders)
+in (
+
+let uu____12380 = (FStar_Syntax_Print.term_to_string body)
+in (
+
+let uu____12381 = (FStar_Syntax_Print.binders_to_string ", " formals)
+in (
+
+let uu____12382 = (FStar_Syntax_Print.term_to_string tres)
+in (FStar_Util.print4 "Encoding let rec: binders=[%s], body=%s, formals=[%s], tres=%s\n" uu____12379 uu____12380 uu____12381 uu____12382)))))
+end
+| uu____12383 -> begin
+()
+end));
+(match (curry) with
+| true -> begin
+(failwith "Unexpected type of let rec in SMT Encoding; expected it to be annotated with an arrow type")
+end
+| uu____12385 -> begin
+()
+end);
+(
+
+let uu____12386 = (encode_binders None binders env')
+in (match (uu____12386) with
+| (vars, guards, env'1, binder_decls, uu____12404) -> begin
+(
+
+let decl_g = (
+
+let uu____12412 = (
+
+let uu____12418 = (
+
+let uu____12420 = (FStar_List.map Prims.snd vars)
+in (FStar_SMTEncoding_Term.Fuel_sort)::uu____12420)
+in ((g), (uu____12418), (FStar_SMTEncoding_Term.Term_sort), (Some ("Fuel-instrumented function name"))))
+in FStar_SMTEncoding_Term.DeclFun (uu____12412))
+in (
+
+let env02 = (push_zfuel_name env01 flid g)
+in (
+
+let decl_g_tok = FStar_SMTEncoding_Term.DeclFun (((gtok), ([]), (FStar_SMTEncoding_Term.Term_sort), (Some ("Token for fuel-instrumented partial applications"))))
+in (
+
+let vars_tm = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in (
+
+let app = (
+
+let uu____12435 = (
+
+let uu____12439 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in ((f), (uu____12439)))
+in (FStar_SMTEncoding_Util.mkApp uu____12435))
+in (
+
+let gsapp = (
+
+let uu____12445 = (
+
+let uu____12449 = (
+
+let uu____12451 = (FStar_SMTEncoding_Util.mkApp (("SFuel"), ((fuel_tm)::[])))
+in (uu____12451)::vars_tm)
+in ((g), (uu____12449)))
+in (FStar_SMTEncoding_Util.mkApp uu____12445))
+in (
+
+let gmax = (
+
+let uu____12455 = (
+
+let uu____12459 = (
+
+let uu____12461 = (FStar_SMTEncoding_Util.mkApp (("MaxFuel"), ([])))
+in (uu____12461)::vars_tm)
+in ((g), (uu____12459)))
+in (FStar_SMTEncoding_Util.mkApp uu____12455))
+in (
+
+let body1 = (
+
+let uu____12465 = (FStar_TypeChecker_Env.is_reifiable_function env'1.tcenv t_norm1)
+in (match (uu____12465) with
+| true -> begin
+(reify_body env'1.tcenv body)
+end
+| uu____12466 -> begin
+body
+end))
+in (
+
+let uu____12467 = (encode_term body1 env'1)
+in (match (uu____12467) with
+| (body_tm, decls2) -> begin
+(
+
+let eqn_g = (
+
+let uu____12478 = (
+
+let uu____12483 = (
+
+let uu____12484 = (
+
+let uu____12492 = (FStar_SMTEncoding_Util.mkEq ((gsapp), (body_tm)))
+in ((((gsapp)::[])::[]), (Some ((Prims.parse_int "0"))), ((fuel)::vars), (uu____12492)))
+in (FStar_SMTEncoding_Util.mkForall' uu____12484))
+in (
+
+let uu____12503 = (
+
+let uu____12505 = (FStar_Util.format1 "Equation for fuel-instrumented recursive function: %s" flid.FStar_Ident.str)
+in Some (uu____12505))
+in ((uu____12483), (uu____12503), (Some ((Prims.strcat "equation_with_fuel_" g))))))
+in FStar_SMTEncoding_Term.Assume (uu____12478))
+in (
+
+let eqn_f = (
+
+let uu____12509 = (
+
+let uu____12514 = (
+
+let uu____12515 = (
+
+let uu____12521 = (FStar_SMTEncoding_Util.mkEq ((app), (gmax)))
+in ((((app)::[])::[]), (vars), (uu____12521)))
+in (FStar_SMTEncoding_Util.mkForall uu____12515))
+in ((uu____12514), (Some ("Correspondence of recursive function to instrumented version")), (Some ((Prims.strcat "fuel_correspondence_" g)))))
+in FStar_SMTEncoding_Term.Assume (uu____12509))
+in (
+
+let eqn_g' = (
+
+let uu____12530 = (
+
+let uu____12535 = (
+
+let uu____12536 = (
+
+let uu____12542 = (
+
+let uu____12543 = (
+
+let uu____12546 = (
+
+let uu____12547 = (
+
+let uu____12551 = (
+
+let uu____12553 = (FStar_SMTEncoding_Term.n_fuel (Prims.parse_int "0"))
+in (uu____12553)::vars_tm)
+in ((g), (uu____12551)))
+in (FStar_SMTEncoding_Util.mkApp uu____12547))
+in ((gsapp), (uu____12546)))
+in (FStar_SMTEncoding_Util.mkEq uu____12543))
+in ((((gsapp)::[])::[]), ((fuel)::vars), (uu____12542)))
+in (FStar_SMTEncoding_Util.mkForall uu____12536))
+in ((uu____12535), (Some ("Fuel irrelevance")), (Some ((Prims.strcat "fuel_irrelevance_" g)))))
+in FStar_SMTEncoding_Term.Assume (uu____12530))
+in (
+
+let uu____12566 = (
+
+let uu____12571 = (encode_binders None formals env02)
+in (match (uu____12571) with
+| (vars1, v_guards, env3, binder_decls1, uu____12588) -> begin
+(
+
+let vars_tm1 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars1)
+in (
+
+let gapp = (FStar_SMTEncoding_Util.mkApp ((g), ((fuel_tm)::vars_tm1)))
+in (
+
+let tok_corr = (
+
+let tok_app = (
+
+let uu____12603 = (FStar_SMTEncoding_Util.mkFreeV ((gtok), (FStar_SMTEncoding_Term.Term_sort)))
+in (mk_Apply uu____12603 ((fuel)::vars1)))
+in (
+
+let uu____12606 = (
+
+let uu____12611 = (
+
+let uu____12612 = (
+
+let uu____12618 = (FStar_SMTEncoding_Util.mkEq ((tok_app), (gapp)))
+in ((((tok_app)::[])::[]), ((fuel)::vars1), (uu____12618)))
+in (FStar_SMTEncoding_Util.mkForall uu____12612))
+in ((uu____12611), (Some ("Fuel token correspondence")), (Some ((Prims.strcat "fuel_token_correspondence_" gtok)))))
+in FStar_SMTEncoding_Term.Assume (uu____12606)))
+in (
+
+let uu____12630 = (
+
+let uu____12634 = (encode_term_pred None tres env3 gapp)
+in (match (uu____12634) with
+| (g_typing, d3) -> begin
+(
+
+let uu____12642 = (
+
+let uu____12644 = (
+
+let uu____12645 = (
+
+let uu____12650 = (
+
+let uu____12651 = (
+
+let uu____12657 = (
+
+let uu____12658 = (
+
+let uu____12661 = (FStar_SMTEncoding_Util.mk_and_l v_guards)
+in ((uu____12661), (g_typing)))
+in (FStar_SMTEncoding_Util.mkImp uu____12658))
+in ((((gapp)::[])::[]), ((fuel)::vars1), (uu____12657)))
+in (FStar_SMTEncoding_Util.mkForall uu____12651))
+in ((uu____12650), (Some ("Typing correspondence of token to term")), (Some ((Prims.strcat "token_correspondence_" g)))))
+in FStar_SMTEncoding_Term.Assume (uu____12645))
+in (uu____12644)::[])
+in ((d3), (uu____12642)))
+end))
+in (match (uu____12630) with
+| (aux_decls, typing_corr) -> begin
+(((FStar_List.append binder_decls1 aux_decls)), ((FStar_List.append typing_corr ((tok_corr)::[]))))
+end)))))
+end))
+in (match (uu____12566) with
+| (aux_decls, g_typing) -> begin
+(((FStar_List.append binder_decls (FStar_List.append decls2 (FStar_List.append aux_decls ((decl_g)::(decl_g_tok)::[]))))), ((FStar_List.append ((eqn_g)::(eqn_g')::(eqn_f)::[]) g_typing)), (env02))
+end)))))
+end))))))))))
+end));
+)
+end));
+))))
+end))
+end))
+in (
+
+let uu____12697 = (
+
+let uu____12704 = (FStar_List.zip3 gtoks1 typs1 bindings)
+in (FStar_List.fold_left (fun uu____12736 uu____12737 -> (match (((uu____12736), (uu____12737))) with
+| ((decls2, eqns, env01), (gtok, ty, lb)) -> begin
+(
+
+let uu____12813 = (encode_one_binding env01 gtok ty lb)
+in (match (uu____12813) with
+| (decls', eqns', env02) -> begin
+(((decls')::decls2), ((FStar_List.append eqns' eqns)), (env02))
+end))
+end)) (((decls1)::[]), ([]), (env0)) uu____12704))
+in (match (uu____12697) with
+| (decls2, eqns, env01) -> begin
+(
+
+let uu____12853 = (
+
+let isDeclFun = (fun uu___126_12861 -> (match (uu___126_12861) with
+| FStar_SMTEncoding_Term.DeclFun (uu____12862) -> begin
+true
+end
+| uu____12868 -> begin
+false
+end))
+in (
+
+let uu____12869 = (FStar_All.pipe_right decls2 FStar_List.flatten)
+in (FStar_All.pipe_right uu____12869 (FStar_List.partition isDeclFun))))
+in (match (uu____12853) with
+| (prefix_decls, rest) -> begin
+(
+
+let eqns1 = (FStar_List.rev eqns)
+in (((FStar_List.append prefix_decls (FStar_List.append rest eqns1))), (env01)))
+end))
+end))))
+end)))))
+end)
+end))))))
+end))
+end))
+end)
+with
+| Let_rec_unencodeable -> begin
+(
+
+let msg = (
+
+let uu____12896 = (FStar_All.pipe_right bindings (FStar_List.map (fun lb -> (FStar_Syntax_Print.lbname_to_string lb.FStar_Syntax_Syntax.lbname))))
+in (FStar_All.pipe_right uu____12896 (FStar_String.concat " and ")))
+in (
+
+let decl = FStar_SMTEncoding_Term.Caption ((Prims.strcat "let rec unencodeable: Skipping: " msg))
+in (((decl)::[]), (env))))
+end))
+end))
+
+
+let rec encode_sigelt : env_t  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_SMTEncoding_Term.decls_t * env_t) = (fun env se -> ((
+
+let uu____12929 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____12929) with
+| true -> begin
+(
+
+let uu____12930 = (FStar_Syntax_Print.sigelt_to_string se)
+in (FStar_All.pipe_left (FStar_Util.print1 ">>>>Encoding [%s]\n") uu____12930))
+end
+| uu____12931 -> begin
+()
+end));
+(
+
+let nm = (
+
+let uu____12933 = (FStar_Syntax_Util.lid_of_sigelt se)
+in (match (uu____12933) with
+| None -> begin
+""
+end
+| Some (l) -> begin
+l.FStar_Ident.str
+end))
+in (
+
+let uu____12936 = (encode_sigelt' env se)
+in (match (uu____12936) with
+| (g, e) -> begin
+(match (g) with
+| [] -> begin
+(
+
+let uu____12945 = (
+
+let uu____12947 = (
+
+let uu____12948 = (FStar_Util.format1 "<Skipped %s/>" nm)
+in FStar_SMTEncoding_Term.Caption (uu____12948))
+in (uu____12947)::[])
+in ((uu____12945), (e)))
+end
+| uu____12950 -> begin
+(
+
+let uu____12951 = (
+
+let uu____12953 = (
+
+let uu____12955 = (
+
+let uu____12956 = (FStar_Util.format1 "<Start encoding %s>" nm)
+in FStar_SMTEncoding_Term.Caption (uu____12956))
+in (uu____12955)::g)
+in (
+
+let uu____12957 = (
+
+let uu____12959 = (
+
+let uu____12960 = (FStar_Util.format1 "</end encoding %s>" nm)
+in FStar_SMTEncoding_Term.Caption (uu____12960))
+in (uu____12959)::[])
+in (FStar_List.append uu____12953 uu____12957)))
+in ((uu____12951), (e)))
+end)
+end)));
+))
+and encode_sigelt' : env_t  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_SMTEncoding_Term.decls_t * env_t) = (fun env se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_new_effect_for_free (uu____12968) -> begin
+(failwith "impossible -- removed by tc.fs")
+end
+| (FStar_Syntax_Syntax.Sig_pragma (_)) | (FStar_Syntax_Syntax.Sig_main (_)) | (FStar_Syntax_Syntax.Sig_effect_abbrev (_)) | (FStar_Syntax_Syntax.Sig_sub_effect (_)) -> begin
+(([]), (env))
+end
+| FStar_Syntax_Syntax.Sig_new_effect (ed) -> begin
+(
+
+let uu____12977 = (
+
+let uu____12978 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (FStar_All.pipe_right uu____12978 Prims.op_Negation))
+in (match (uu____12977) with
+| true -> begin
+(([]), (env))
+end
+| uu____12983 -> begin
+(
+
+let close_effect_params = (fun tm -> (match (ed.FStar_Syntax_Syntax.binders) with
+| [] -> begin
+tm
+end
+| uu____12998 -> begin
+(
+
+let uu____12999 = (
+
+let uu____13002 = (
+
+let uu____13003 = (
+
+let uu____13018 = (FStar_All.pipe_left (fun _0_37 -> Some (_0_37)) (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[])))))
+in ((ed.FStar_Syntax_Syntax.binders), (tm), (uu____13018)))
+in FStar_Syntax_Syntax.Tm_abs (uu____13003))
+in (FStar_Syntax_Syntax.mk uu____13002))
+in (uu____12999 None tm.FStar_Syntax_Syntax.pos))
+end))
+in (
+
+let encode_action = (fun env1 a -> (
+
+let uu____13071 = (new_term_constant_and_tok_from_lid env1 a.FStar_Syntax_Syntax.action_name)
+in (match (uu____13071) with
+| (aname, atok, env2) -> begin
+(
+
+let uu____13081 = (FStar_Syntax_Util.arrow_formals_comp a.FStar_Syntax_Syntax.action_typ)
+in (match (uu____13081) with
+| (formals, uu____13091) -> begin
+(
+
+let uu____13098 = (
+
+let uu____13101 = (close_effect_params a.FStar_Syntax_Syntax.action_defn)
+in (encode_term uu____13101 env2))
+in (match (uu____13098) with
+| (tm, decls) -> begin
+(
+
+let a_decls = (
+
+let uu____13109 = (
+
+let uu____13110 = (
+
+let uu____13116 = (FStar_All.pipe_right formals (FStar_List.map (fun uu____13124 -> FStar_SMTEncoding_Term.Term_sort)))
+in ((aname), (uu____13116), (FStar_SMTEncoding_Term.Term_sort), (Some ("Action"))))
+in FStar_SMTEncoding_Term.DeclFun (uu____13110))
+in (uu____13109)::(FStar_SMTEncoding_Term.DeclFun (((atok), ([]), (FStar_SMTEncoding_Term.Term_sort), (Some ("Action token")))))::[])
+in (
+
+let uu____13131 = (
+
+let aux = (fun uu____13160 uu____13161 -> (match (((uu____13160), (uu____13161))) with
+| ((bv, uu____13188), (env3, acc_sorts, acc)) -> begin
+(
+
+let uu____13209 = (gen_term_var env3 bv)
+in (match (uu____13209) with
+| (xxsym, xx, env4) -> begin
+((env4), ((((xxsym), (FStar_SMTEncoding_Term.Term_sort)))::acc_sorts), ((xx)::acc))
+end))
+end))
+in (FStar_List.fold_right aux formals ((env2), ([]), ([]))))
+in (match (uu____13131) with
+| (uu____13247, xs_sorts, xs) -> begin
+(
+
+let app = (FStar_SMTEncoding_Util.mkApp ((aname), (xs)))
+in (
+
+let a_eq = (
+
+let uu____13261 = (
+
+let uu____13266 = (
+
+let uu____13267 = (
+
+let uu____13273 = (
+
+let uu____13274 = (
+
+let uu____13277 = (mk_Apply tm xs_sorts)
+in ((app), (uu____13277)))
+in (FStar_SMTEncoding_Util.mkEq uu____13274))
+in ((((app)::[])::[]), (xs_sorts), (uu____13273)))
+in (FStar_SMTEncoding_Util.mkForall uu____13267))
+in ((uu____13266), (Some ("Action equality")), (Some ((Prims.strcat aname "_equality")))))
+in FStar_SMTEncoding_Term.Assume (uu____13261))
+in (
+
+let tok_correspondence = (
+
+let tok_term = (FStar_SMTEncoding_Util.mkFreeV ((atok), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let tok_app = (mk_Apply tok_term xs_sorts)
+in (
+
+let uu____13290 = (
+
+let uu____13295 = (
+
+let uu____13296 = (
+
+let uu____13302 = (FStar_SMTEncoding_Util.mkEq ((tok_app), (app)))
+in ((((tok_app)::[])::[]), (xs_sorts), (uu____13302)))
+in (FStar_SMTEncoding_Util.mkForall uu____13296))
+in ((uu____13295), (Some ("Action token correspondence")), (Some ((Prims.strcat aname "_token_correspondence")))))
+in FStar_SMTEncoding_Term.Assume (uu____13290))))
+in ((env2), ((FStar_List.append decls (FStar_List.append a_decls ((a_eq)::(tok_correspondence)::[]))))))))
+end)))
+end))
+end))
+end)))
+in (
+
+let uu____13313 = (FStar_Util.fold_map encode_action env ed.FStar_Syntax_Syntax.actions)
+in (match (uu____13313) with
+| (env1, decls2) -> begin
+(((FStar_List.flatten decls2)), (env1))
+end))))
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____13329, uu____13330, uu____13331) when (FStar_Ident.lid_equals lid FStar_Syntax_Const.precedes_lid) -> begin
+(
+
+let uu____13334 = (new_term_constant_and_tok_from_lid env lid)
+in (match (uu____13334) with
+| (tname, ttok, env1) -> begin
+(([]), (env1))
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____13345, t, quals) -> begin
+(
+
+let will_encode_definition = (
+
+let uu____13351 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___127_13353 -> (match (uu___127_13353) with
+| (FStar_Syntax_Syntax.Assumption) | (FStar_Syntax_Syntax.Projector (_)) | (FStar_Syntax_Syntax.Discriminator (_)) | (FStar_Syntax_Syntax.Irreducible) -> begin
+true
+end
+| uu____13356 -> begin
+false
+end))))
+in (not (uu____13351)))
+in (match (will_encode_definition) with
+| true -> begin
+(([]), (env))
+end
+| uu____13360 -> begin
+(
+
+let fv = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____13362 = (encode_top_level_val env fv t quals)
+in (match (uu____13362) with
+| (decls, env1) -> begin
+(
+
+let tname = lid.FStar_Ident.str
+in (
+
+let tsym = (FStar_SMTEncoding_Util.mkFreeV ((tname), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let uu____13374 = (
+
+let uu____13376 = (primitive_type_axioms env1.tcenv lid tname tsym)
+in (FStar_List.append decls uu____13376))
+in ((uu____13374), (env1)))))
+end)))
+end))
+end
+| FStar_Syntax_Syntax.Sig_assume (l, f, uu____13381) -> begin
+(
+
+let uu____13384 = (encode_formula f env)
+in (match (uu____13384) with
+| (f1, decls) -> begin
+(
+
+let g = (
+
+let uu____13393 = (
+
+let uu____13394 = (
+
+let uu____13399 = (
+
+let uu____13401 = (
+
+let uu____13402 = (FStar_Syntax_Print.lid_to_string l)
+in (FStar_Util.format1 "Assumption: %s" uu____13402))
+in Some (uu____13401))
+in (
+
+let uu____13403 = (
+
+let uu____13405 = (varops.mk_unique (Prims.strcat "assumption_" l.FStar_Ident.str))
+in Some (uu____13405))
+in ((f1), (uu____13399), (uu____13403))))
+in FStar_SMTEncoding_Term.Assume (uu____13394))
+in (uu____13393)::[])
+in (((FStar_List.append decls g)), (env)))
+end))
+end
+| FStar_Syntax_Syntax.Sig_let (lbs, uu____13410, quals, uu____13412) when (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Irreducible)) -> begin
+(
+
+let uu____13420 = (FStar_Util.fold_map (fun env1 lb -> (
+
+let lid = (
+
+let uu____13427 = (
+
+let uu____13432 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in uu____13432.FStar_Syntax_Syntax.fv_name)
+in uu____13427.FStar_Syntax_Syntax.v)
+in (
+
+let uu____13436 = (
+
+let uu____13437 = (FStar_TypeChecker_Env.try_lookup_val_decl env1.tcenv lid)
+in (FStar_All.pipe_left FStar_Option.isNone uu____13437))
+in (match (uu____13436) with
+| true -> begin
+(
+
+let val_decl = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((lid), (lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp), (quals))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = se.FStar_Syntax_Syntax.sigrng}
+in (
+
+let uu____13456 = (encode_sigelt' env1 val_decl)
+in (match (uu____13456) with
+| (decls, env2) -> begin
+((env2), (decls))
+end)))
+end
+| uu____13463 -> begin
+((env1), ([]))
+end)))) env (Prims.snd lbs))
+in (match (uu____13420) with
+| (env1, decls) -> begin
+(((FStar_List.flatten decls)), (env1))
+end))
+end
+| FStar_Syntax_Syntax.Sig_let ((uu____13473, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (b2t1); FStar_Syntax_Syntax.lbunivs = uu____13475; FStar_Syntax_Syntax.lbtyp = uu____13476; FStar_Syntax_Syntax.lbeff = uu____13477; FStar_Syntax_Syntax.lbdef = uu____13478})::[]), uu____13479, uu____13480, uu____13481) when (FStar_Syntax_Syntax.fv_eq_lid b2t1 FStar_Syntax_Const.b2t_lid) -> begin
+(
+
+let uu____13497 = (new_term_constant_and_tok_from_lid env b2t1.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____13497) with
+| (tname, ttok, env1) -> begin
+(
+
+let xx = (("x"), (FStar_SMTEncoding_Term.Term_sort))
+in (
+
+let x = (FStar_SMTEncoding_Util.mkFreeV xx)
+in (
+
+let valid_b2t_x = (
+
+let uu____13515 = (
+
+let uu____13519 = (
+
+let uu____13521 = (FStar_SMTEncoding_Util.mkApp (("Prims.b2t"), ((x)::[])))
+in (uu____13521)::[])
+in (("Valid"), (uu____13519)))
+in (FStar_SMTEncoding_Util.mkApp uu____13515))
+in (
+
+let decls = (
+
+let uu____13526 = (
+
+let uu____13528 = (
+
+let uu____13529 = (
+
+let uu____13534 = (
+
+let uu____13535 = (
+
+let uu____13541 = (
+
+let uu____13542 = (
+
+let uu____13545 = (FStar_SMTEncoding_Util.mkApp (("BoxBool_proj_0"), ((x)::[])))
+in ((valid_b2t_x), (uu____13545)))
+in (FStar_SMTEncoding_Util.mkEq uu____13542))
+in ((((valid_b2t_x)::[])::[]), ((xx)::[]), (uu____13541)))
+in (FStar_SMTEncoding_Util.mkForall uu____13535))
+in ((uu____13534), (Some ("b2t def")), (Some ("b2t_def"))))
+in FStar_SMTEncoding_Term.Assume (uu____13529))
+in (uu____13528)::[])
+in (FStar_SMTEncoding_Term.DeclFun (((tname), ((FStar_SMTEncoding_Term.Term_sort)::[]), (FStar_SMTEncoding_Term.Term_sort), (None))))::uu____13526)
+in ((decls), (env1))))))
+end))
+end
+| FStar_Syntax_Syntax.Sig_let (uu____13563, uu____13564, quals, uu____13566) when (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___128_13574 -> (match (uu___128_13574) with
+| FStar_Syntax_Syntax.Discriminator (uu____13575) -> begin
+true
+end
+| uu____13576 -> begin
+false
+end)))) -> begin
+(([]), (env))
+end
+| FStar_Syntax_Syntax.Sig_let (uu____13578, lids, quals, uu____13581) when ((FStar_All.pipe_right lids (FStar_Util.for_some (fun l -> (
+
+let uu____13590 = (
+
+let uu____13591 = (FStar_List.hd l.FStar_Ident.ns)
+in uu____13591.FStar_Ident.idText)
+in (uu____13590 = "Prims"))))) && (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___129_13593 -> (match (uu___129_13593) with
+| FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen -> begin
+true
+end
+| uu____13594 -> begin
+false
+end))))) -> begin
+(([]), (env))
+end
+| FStar_Syntax_Syntax.Sig_let ((false, (lb)::[]), uu____13597, quals, uu____13599) when (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___130_13611 -> (match (uu___130_13611) with
+| FStar_Syntax_Syntax.Projector (uu____13612) -> begin
+true
+end
+| uu____13615 -> begin
+false
+end)))) -> begin
+(
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let l = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____13622 = (try_lookup_free_var env l)
+in (match (uu____13622) with
+| Some (uu____13626) -> begin
+(([]), (env))
+end
+| None -> begin
+(
+
+let se1 = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), (lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp), (quals))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid l)}
+in (encode_sigelt env se1))
+end))))
+end
+| FStar_Syntax_Syntax.Sig_let ((is_rec, bindings), uu____13635, quals, uu____13637) -> begin
+(encode_top_level_let env ((is_rec), (bindings)) quals)
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, uu____13651, uu____13652) -> begin
+(
+
+let uu____13659 = (encode_signature env ses)
+in (match (uu____13659) with
+| (g, env1) -> begin
+(
+
+let uu____13669 = (FStar_All.pipe_right g (FStar_List.partition (fun uu___131_13679 -> (match (uu___131_13679) with
+| FStar_SMTEncoding_Term.Assume (uu____13680, Some ("inversion axiom"), uu____13681) -> begin
+false
+end
+| uu____13685 -> begin
+true
+end))))
+in (match (uu____13669) with
+| (g', inversions) -> begin
+(
+
+let uu____13694 = (FStar_All.pipe_right g' (FStar_List.partition (fun uu___132_13704 -> (match (uu___132_13704) with
+| FStar_SMTEncoding_Term.DeclFun (uu____13705) -> begin
+true
+end
+| uu____13711 -> begin
+false
+end))))
+in (match (uu____13694) with
+| (decls, rest) -> begin
+(((FStar_List.append decls (FStar_List.append rest inversions))), (env1))
+end))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Sig_inductive_typ (t, uu____13722, tps, k, uu____13725, datas, quals) -> begin
+(
+
+let is_logical = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___133_13736 -> (match (uu___133_13736) with
+| (FStar_Syntax_Syntax.Logic) | (FStar_Syntax_Syntax.Assumption) -> begin
+true
+end
+| uu____13737 -> begin
+false
+end))))
+in (
+
+let constructor_or_logic_type_decl = (fun c -> (match (is_logical) with
+| true -> begin
+(
+
+let uu____13744 = c
+in (match (uu____13744) with
+| (name, args, uu____13748, uu____13749, uu____13750) -> begin
+(
+
+let uu____13753 = (
+
+let uu____13754 = (
+
+let uu____13760 = (FStar_All.pipe_right args (FStar_List.map (fun uu____13767 -> (match (uu____13767) with
+| (uu____13771, sort, uu____13773) -> begin
+sort
+end))))
+in ((name), (uu____13760), (FStar_SMTEncoding_Term.Term_sort), (None)))
+in FStar_SMTEncoding_Term.DeclFun (uu____13754))
+in (uu____13753)::[])
+end))
+end
+| uu____13776 -> begin
+(FStar_SMTEncoding_Term.constructor_to_decl c)
+end))
+in (
+
+let inversion_axioms = (fun tapp vars -> (
+
+let uu____13791 = (FStar_All.pipe_right datas (FStar_Util.for_some (fun l -> (
+
+let uu____13794 = (FStar_TypeChecker_Env.try_lookup_lid env.tcenv l)
+in (FStar_All.pipe_right uu____13794 FStar_Option.isNone)))))
+in (match (uu____13791) with
+| true -> begin
+[]
+end
+| uu____13810 -> begin
+(
+
+let uu____13811 = (fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort)
+in (match (uu____13811) with
+| (xxsym, xx) -> begin
+(
+
+let uu____13817 = (FStar_All.pipe_right datas (FStar_List.fold_left (fun uu____13828 l -> (match (uu____13828) with
+| (out, decls) -> begin
+(
+
+let uu____13840 = (FStar_TypeChecker_Env.lookup_datacon env.tcenv l)
+in (match (uu____13840) with
+| (uu____13846, data_t) -> begin
+(
+
+let uu____13848 = (FStar_Syntax_Util.arrow_formals data_t)
+in (match (uu____13848) with
+| (args, res) -> begin
+(
+
+let indices = (
+
+let uu____13877 = (
+
+let uu____13878 = (FStar_Syntax_Subst.compress res)
+in uu____13878.FStar_Syntax_Syntax.n)
+in (match (uu____13877) with
+| FStar_Syntax_Syntax.Tm_app (uu____13886, indices) -> begin
+indices
+end
+| uu____13902 -> begin
+[]
+end))
+in (
+
+let env1 = (FStar_All.pipe_right args (FStar_List.fold_left (fun env1 uu____13914 -> (match (uu____13914) with
+| (x, uu____13918) -> begin
+(
+
+let uu____13919 = (
+
+let uu____13920 = (
+
+let uu____13924 = (mk_term_projector_name l x)
+in ((uu____13924), ((xx)::[])))
+in (FStar_SMTEncoding_Util.mkApp uu____13920))
+in (push_term_var env1 x uu____13919))
+end)) env))
+in (
+
+let uu____13926 = (encode_args indices env1)
+in (match (uu____13926) with
+| (indices1, decls') -> begin
+((match (((FStar_List.length indices1) <> (FStar_List.length vars))) with
+| true -> begin
+(failwith "Impossible")
+end
+| uu____13944 -> begin
+()
+end);
+(
+
+let eqs = (
+
+let uu____13946 = (FStar_List.map2 (fun v1 a -> (
+
+let uu____13954 = (
+
+let uu____13957 = (FStar_SMTEncoding_Util.mkFreeV v1)
+in ((uu____13957), (a)))
+in (FStar_SMTEncoding_Util.mkEq uu____13954))) vars indices1)
+in (FStar_All.pipe_right uu____13946 FStar_SMTEncoding_Util.mk_and_l))
+in (
+
+let uu____13959 = (
+
+let uu____13960 = (
+
+let uu____13963 = (
+
+let uu____13964 = (
+
+let uu____13967 = (mk_data_tester env1 l xx)
+in ((uu____13967), (eqs)))
+in (FStar_SMTEncoding_Util.mkAnd uu____13964))
+in ((out), (uu____13963)))
+in (FStar_SMTEncoding_Util.mkOr uu____13960))
+in ((uu____13959), ((FStar_List.append decls decls')))));
+)
+end))))
+end))
+end))
+end)) ((FStar_SMTEncoding_Util.mkFalse), ([]))))
+in (match (uu____13817) with
+| (data_ax, decls) -> begin
+(
+
+let uu____13975 = (fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort)
+in (match (uu____13975) with
+| (ffsym, ff) -> begin
+(
+
+let fuel_guarded_inversion = (
+
+let xx_has_type_sfuel = (match (((FStar_List.length datas) > (Prims.parse_int "1"))) with
+| true -> begin
+(
+
+let uu____13986 = (FStar_SMTEncoding_Util.mkApp (("SFuel"), ((ff)::[])))
+in (FStar_SMTEncoding_Term.mk_HasTypeFuel uu____13986 xx tapp))
+end
+| uu____13988 -> begin
+(FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp)
+end)
+in (
+
+let uu____13989 = (
+
+let uu____13994 = (
+
+let uu____13995 = (
+
+let uu____14001 = (add_fuel ((ffsym), (FStar_SMTEncoding_Term.Fuel_sort)) ((((xxsym), (FStar_SMTEncoding_Term.Term_sort)))::vars))
+in (
+
+let uu____14009 = (FStar_SMTEncoding_Util.mkImp ((xx_has_type_sfuel), (data_ax)))
+in ((((xx_has_type_sfuel)::[])::[]), (uu____14001), (uu____14009))))
+in (FStar_SMTEncoding_Util.mkForall uu____13995))
+in (
+
+let uu____14017 = (
+
+let uu____14019 = (varops.mk_unique (Prims.strcat "fuel_guarded_inversion_" t.FStar_Ident.str))
+in Some (uu____14019))
+in ((uu____13994), (Some ("inversion axiom")), (uu____14017))))
+in FStar_SMTEncoding_Term.Assume (uu____13989)))
+in (
+
+let pattern_guarded_inversion = (
+
+let uu____14024 = ((contains_name env "Prims.inversion") && ((FStar_List.length datas) > (Prims.parse_int "1")))
+in (match (uu____14024) with
+| true -> begin
+(
+
+let xx_has_type_fuel = (FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp)
+in (
+
+let pattern_guard = (FStar_SMTEncoding_Util.mkApp (("Prims.inversion"), ((tapp)::[])))
+in (
+
+let uu____14032 = (
+
+let uu____14033 = (
+
+let uu____14038 = (
+
+let uu____14039 = (
+
+let uu____14045 = (add_fuel ((ffsym), (FStar_SMTEncoding_Term.Fuel_sort)) ((((xxsym), (FStar_SMTEncoding_Term.Term_sort)))::vars))
+in (
+
+let uu____14053 = (FStar_SMTEncoding_Util.mkImp ((xx_has_type_fuel), (data_ax)))
+in ((((xx_has_type_fuel)::(pattern_guard)::[])::[]), (uu____14045), (uu____14053))))
+in (FStar_SMTEncoding_Util.mkForall uu____14039))
+in (
+
+let uu____14061 = (
+
+let uu____14063 = (varops.mk_unique (Prims.strcat "pattern_guarded_inversion_" t.FStar_Ident.str))
+in Some (uu____14063))
+in ((uu____14038), (Some ("inversion axiom")), (uu____14061))))
+in FStar_SMTEncoding_Term.Assume (uu____14033))
+in (uu____14032)::[])))
+end
+| uu____14066 -> begin
+[]
+end))
+in (FStar_List.append decls (FStar_List.append ((fuel_guarded_inversion)::[]) pattern_guarded_inversion))))
+end))
+end))
+end))
+end)))
+in (
+
+let uu____14067 = (
+
+let uu____14075 = (
+
+let uu____14076 = (FStar_Syntax_Subst.compress k)
+in uu____14076.FStar_Syntax_Syntax.n)
+in (match (uu____14075) with
+| FStar_Syntax_Syntax.Tm_arrow (formals, kres) -> begin
+(((FStar_List.append tps formals)), ((FStar_Syntax_Util.comp_result kres)))
+end
+| uu____14105 -> begin
+((tps), (k))
+end))
+in (match (uu____14067) with
+| (formals, res) -> begin
+(
+
+let uu____14120 = (FStar_Syntax_Subst.open_term formals res)
+in (match (uu____14120) with
+| (formals1, res1) -> begin
+(
+
+let uu____14127 = (encode_binders None formals1 env)
+in (match (uu____14127) with
+| (vars, guards, env', binder_decls, uu____14142) -> begin
+(
+
+let uu____14149 = (new_term_constant_and_tok_from_lid env t)
+in (match (uu____14149) with
+| (tname, ttok, env1) -> begin
+(
+
+let ttok_tm = (FStar_SMTEncoding_Util.mkApp ((ttok), ([])))
+in (
+
+let guard = (FStar_SMTEncoding_Util.mk_and_l guards)
+in (
+
+let tapp = (
+
+let uu____14162 = (
+
+let uu____14166 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in ((tname), (uu____14166)))
+in (FStar_SMTEncoding_Util.mkApp uu____14162))
+in (
+
+let uu____14171 = (
+
+let tname_decl = (
+
+let uu____14177 = (
+
+let uu____14178 = (FStar_All.pipe_right vars (FStar_List.map (fun uu____14193 -> (match (uu____14193) with
+| (n1, s) -> begin
+(((Prims.strcat tname n1)), (s), (false))
+end))))
+in (
+
+let uu____14201 = (varops.next_id ())
+in ((tname), (uu____14178), (FStar_SMTEncoding_Term.Term_sort), (uu____14201), (false))))
+in (constructor_or_logic_type_decl uu____14177))
+in (
+
+let uu____14206 = (match (vars) with
+| [] -> begin
+(
+
+let uu____14213 = (
+
+let uu____14214 = (
+
+let uu____14216 = (FStar_SMTEncoding_Util.mkApp ((tname), ([])))
+in (FStar_All.pipe_left (fun _0_38 -> Some (_0_38)) uu____14216))
+in (push_free_var env1 t tname uu____14214))
+in (([]), (uu____14213)))
+end
+| uu____14220 -> begin
+(
+
+let ttok_decl = FStar_SMTEncoding_Term.DeclFun (((ttok), ([]), (FStar_SMTEncoding_Term.Term_sort), (Some ("token"))))
+in (
+
+let ttok_fresh = (
+
+let uu____14226 = (varops.next_id ())
+in (FStar_SMTEncoding_Term.fresh_token ((ttok), (FStar_SMTEncoding_Term.Term_sort)) uu____14226))
+in (
+
+let ttok_app = (mk_Apply ttok_tm vars)
+in (
+
+let pats = ((ttok_app)::[])::((tapp)::[])::[]
+in (
+
+let name_tok_corr = (
+
+let uu____14235 = (
+
+let uu____14240 = (
+
+let uu____14241 = (
+
+let uu____14249 = (FStar_SMTEncoding_Util.mkEq ((ttok_app), (tapp)))
+in ((pats), (None), (vars), (uu____14249)))
+in (FStar_SMTEncoding_Util.mkForall' uu____14241))
+in ((uu____14240), (Some ("name-token correspondence")), (Some ((Prims.strcat "token_correspondence_" ttok)))))
+in FStar_SMTEncoding_Term.Assume (uu____14235))
+in (((ttok_decl)::(ttok_fresh)::(name_tok_corr)::[]), (env1)))))))
+end)
+in (match (uu____14206) with
+| (tok_decls, env2) -> begin
+(((FStar_List.append tname_decl tok_decls)), (env2))
+end)))
+in (match (uu____14171) with
+| (decls, env2) -> begin
+(
+
+let kindingAx = (
+
+let uu____14273 = (encode_term_pred None res1 env' tapp)
+in (match (uu____14273) with
+| (k1, decls1) -> begin
+(
+
+let karr = (match (((FStar_List.length formals1) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____14287 = (
+
+let uu____14288 = (
+
+let uu____14293 = (
+
+let uu____14294 = (FStar_SMTEncoding_Term.mk_PreType ttok_tm)
+in (FStar_SMTEncoding_Term.mk_tester "Tm_arrow" uu____14294))
+in ((uu____14293), (Some ("kinding")), (Some ((Prims.strcat "pre_kinding_" ttok)))))
+in FStar_SMTEncoding_Term.Assume (uu____14288))
+in (uu____14287)::[])
+end
+| uu____14297 -> begin
+[]
+end)
+in (
+
+let uu____14298 = (
+
+let uu____14300 = (
+
+let uu____14302 = (
+
+let uu____14303 = (
+
+let uu____14308 = (
+
+let uu____14309 = (
+
+let uu____14315 = (FStar_SMTEncoding_Util.mkImp ((guard), (k1)))
+in ((((tapp)::[])::[]), (vars), (uu____14315)))
+in (FStar_SMTEncoding_Util.mkForall uu____14309))
+in ((uu____14308), (None), (Some ((Prims.strcat "kinding_" ttok)))))
+in FStar_SMTEncoding_Term.Assume (uu____14303))
+in (uu____14302)::[])
+in (FStar_List.append karr uu____14300))
+in (FStar_List.append decls1 uu____14298)))
+end))
+in (
+
+let aux = (
+
+let uu____14325 = (
+
+let uu____14327 = (inversion_axioms tapp vars)
+in (
+
+let uu____14329 = (
+
+let uu____14331 = (pretype_axiom tapp vars)
+in (uu____14331)::[])
+in (FStar_List.append uu____14327 uu____14329)))
+in (FStar_List.append kindingAx uu____14325))
+in (
+
+let g = (FStar_List.append decls (FStar_List.append binder_decls aux))
+in ((g), (env2)))))
+end)))))
+end))
+end))
+end))
+end)))))
+end
+| FStar_Syntax_Syntax.Sig_datacon (d, uu____14336, uu____14337, uu____14338, uu____14339, uu____14340, uu____14341) when (FStar_Ident.lid_equals d FStar_Syntax_Const.lexcons_lid) -> begin
+(([]), (env))
+end
+| FStar_Syntax_Syntax.Sig_datacon (d, uu____14348, t, uu____14350, n_tps, quals, uu____14353) -> begin
+(
+
+let uu____14358 = (new_term_constant_and_tok_from_lid env d)
+in (match (uu____14358) with
+| (ddconstrsym, ddtok, env1) -> begin
+(
+
+let ddtok_tm = (FStar_SMTEncoding_Util.mkApp ((ddtok), ([])))
+in (
+
+let uu____14369 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____14369) with
+| (formals, t_res) -> begin
+(
+
+let uu____14391 = (fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort)
+in (match (uu____14391) with
+| (fuel_var, fuel_tm) -> begin
+(
+
+let s_fuel_tm = (FStar_SMTEncoding_Util.mkApp (("SFuel"), ((fuel_tm)::[])))
+in (
+
+let uu____14400 = (encode_binders (Some (fuel_tm)) formals env1)
+in (match (uu____14400) with
+| (vars, guards, env', binder_decls, names1) -> begin
+(
+
+let fields = (FStar_All.pipe_right names1 (FStar_List.mapi (fun n1 x -> (
+
+let projectible = true
+in (
+
+let uu____14438 = (mk_term_projector_name d x)
+in ((uu____14438), (FStar_SMTEncoding_Term.Term_sort), (projectible)))))))
+in (
+
+let datacons = (
+
+let uu____14440 = (
+
+let uu____14450 = (varops.next_id ())
+in ((ddconstrsym), (fields), (FStar_SMTEncoding_Term.Term_sort), (uu____14450), (true)))
+in (FStar_All.pipe_right uu____14440 FStar_SMTEncoding_Term.constructor_to_decl))
+in (
+
+let app = (mk_Apply ddtok_tm vars)
+in (
+
+let guard = (FStar_SMTEncoding_Util.mk_and_l guards)
+in (
+
+let xvars = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in (
+
+let dapp = (FStar_SMTEncoding_Util.mkApp ((ddconstrsym), (xvars)))
+in (
+
+let uu____14472 = (encode_term_pred None t env1 ddtok_tm)
+in (match (uu____14472) with
+| (tok_typing, decls3) -> begin
+(
+
+let uu____14479 = (encode_binders (Some (fuel_tm)) formals env1)
+in (match (uu____14479) with
+| (vars', guards', env'', decls_formals, uu____14494) -> begin
+(
+
+let uu____14501 = (
+
+let xvars1 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars')
+in (
+
+let dapp1 = (FStar_SMTEncoding_Util.mkApp ((ddconstrsym), (xvars1)))
+in (encode_term_pred (Some (fuel_tm)) t_res env'' dapp1)))
+in (match (uu____14501) with
+| (ty_pred', decls_pred) -> begin
+(
+
+let guard' = (FStar_SMTEncoding_Util.mk_and_l guards')
+in (
+
+let proxy_fresh = (match (formals) with
+| [] -> begin
+[]
+end
+| uu____14520 -> begin
+(
+
+let uu____14524 = (
+
+let uu____14525 = (varops.next_id ())
+in (FStar_SMTEncoding_Term.fresh_token ((ddtok), (FStar_SMTEncoding_Term.Term_sort)) uu____14525))
+in (uu____14524)::[])
+end)
+in (
+
+let encode_elim = (fun uu____14532 -> (
+
+let uu____14533 = (FStar_Syntax_Util.head_and_args t_res)
+in (match (uu____14533) with
+| (head1, args) -> begin
+(
+
+let uu____14562 = (
+
+let uu____14563 = (FStar_Syntax_Subst.compress head1)
+in uu____14563.FStar_Syntax_Syntax.n)
+in (match (uu____14562) with
+| (FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) | (FStar_Syntax_Syntax.Tm_fvar (fv)) -> begin
+(
+
+let encoded_head = (lookup_free_var_name env' fv.FStar_Syntax_Syntax.fv_name)
+in (
+
+let uu____14581 = (encode_args args env')
+in (match (uu____14581) with
+| (encoded_args, arg_decls) -> begin
+(
+
+let guards_for_parameter = (fun arg xv -> (
+
+let fv1 = (match (arg.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.FreeV (fv1) -> begin
+fv1
+end
+| uu____14607 -> begin
+(failwith "Impossible: parameter must be a variable")
+end)
+in (
+
+let guards1 = (FStar_All.pipe_right guards (FStar_List.collect (fun g -> (
+
+let uu____14615 = (
+
+let uu____14616 = (FStar_SMTEncoding_Term.free_variables g)
+in (FStar_List.contains fv1 uu____14616))
+in (match (uu____14615) with
+| true -> begin
+(
+
+let uu____14623 = (FStar_SMTEncoding_Term.subst g fv1 xv)
+in (uu____14623)::[])
+end
+| uu____14624 -> begin
+[]
+end)))))
+in (FStar_SMTEncoding_Util.mk_and_l guards1))))
+in (
+
+let uu____14625 = (FStar_List.fold_left (fun uu____14638 arg -> (match (uu____14638) with
+| (env2, arg_vars, eqns_or_guards, i) -> begin
+(
+
+let uu____14660 = (
+
+let uu____14664 = (FStar_Syntax_Syntax.new_bv None FStar_Syntax_Syntax.tun)
+in (gen_term_var env2 uu____14664))
+in (match (uu____14660) with
+| (uu____14671, xv, env3) -> begin
+(
+
+let eqns = (match ((i < n_tps)) with
+| true -> begin
+(
+
+let uu____14677 = (guards_for_parameter arg xv)
+in (uu____14677)::eqns_or_guards)
+end
+| uu____14678 -> begin
+(
+
+let uu____14679 = (FStar_SMTEncoding_Util.mkEq ((arg), (xv)))
+in (uu____14679)::eqns_or_guards)
+end)
+in ((env3), ((xv)::arg_vars), (eqns), ((i + (Prims.parse_int "1")))))
+end))
+end)) ((env'), ([]), ([]), ((Prims.parse_int "0"))) encoded_args)
+in (match (uu____14625) with
+| (uu____14687, arg_vars, elim_eqns_or_guards, uu____14690) -> begin
+(
+
+let arg_vars1 = (FStar_List.rev arg_vars)
+in (
+
+let ty = (FStar_SMTEncoding_Util.mkApp ((encoded_head), (arg_vars1)))
+in (
+
+let xvars1 = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars)
+in (
+
+let dapp1 = (FStar_SMTEncoding_Util.mkApp ((ddconstrsym), (xvars1)))
+in (
+
+let ty_pred = (FStar_SMTEncoding_Term.mk_HasTypeWithFuel (Some (s_fuel_tm)) dapp1 ty)
+in (
+
+let arg_binders = (FStar_List.map FStar_SMTEncoding_Term.fv_of_term arg_vars1)
+in (
+
+let typing_inversion = (
+
+let uu____14709 = (
+
+let uu____14714 = (
+
+let uu____14715 = (
+
+let uu____14721 = (add_fuel ((fuel_var), (FStar_SMTEncoding_Term.Fuel_sort)) (FStar_List.append vars arg_binders))
+in (
+
+let uu____14727 = (
+
+let uu____14728 = (
+
+let uu____14731 = (FStar_SMTEncoding_Util.mk_and_l (FStar_List.append elim_eqns_or_guards guards))
+in ((ty_pred), (uu____14731)))
+in (FStar_SMTEncoding_Util.mkImp uu____14728))
+in ((((ty_pred)::[])::[]), (uu____14721), (uu____14727))))
+in (FStar_SMTEncoding_Util.mkForall uu____14715))
+in ((uu____14714), (Some ("data constructor typing elim")), (Some ((Prims.strcat "data_elim_" ddconstrsym)))))
+in FStar_SMTEncoding_Term.Assume (uu____14709))
+in (
+
+let subterm_ordering = (match ((FStar_Ident.lid_equals d FStar_Syntax_Const.lextop_lid)) with
+| true -> begin
+(
+
+let x = (
+
+let uu____14745 = (varops.fresh "x")
+in ((uu____14745), (FStar_SMTEncoding_Term.Term_sort)))
+in (
+
+let xtm = (FStar_SMTEncoding_Util.mkFreeV x)
+in (
+
+let uu____14747 = (
+
+let uu____14752 = (
+
+let uu____14753 = (
+
+let uu____14759 = (
+
+let uu____14762 = (
+
+let uu____14764 = (FStar_SMTEncoding_Util.mk_Precedes xtm dapp1)
+in (uu____14764)::[])
+in (uu____14762)::[])
+in (
+
+let uu____14767 = (
+
+let uu____14768 = (
+
+let uu____14771 = (FStar_SMTEncoding_Term.mk_tester "LexCons" xtm)
+in (
+
+let uu____14772 = (FStar_SMTEncoding_Util.mk_Precedes xtm dapp1)
+in ((uu____14771), (uu____14772))))
+in (FStar_SMTEncoding_Util.mkImp uu____14768))
+in ((uu____14759), ((x)::[]), (uu____14767))))
+in (FStar_SMTEncoding_Util.mkForall uu____14753))
+in (
+
+let uu____14782 = (
+
+let uu____14784 = (varops.mk_unique "lextop")
+in Some (uu____14784))
+in ((uu____14752), (Some ("lextop is top")), (uu____14782))))
+in FStar_SMTEncoding_Term.Assume (uu____14747))))
+end
+| uu____14787 -> begin
+(
+
+let prec = (
+
+let uu____14790 = (FStar_All.pipe_right vars (FStar_List.mapi (fun i v1 -> (match ((i < n_tps)) with
+| true -> begin
+[]
+end
+| uu____14804 -> begin
+(
+
+let uu____14805 = (
+
+let uu____14806 = (FStar_SMTEncoding_Util.mkFreeV v1)
+in (FStar_SMTEncoding_Util.mk_Precedes uu____14806 dapp1))
+in (uu____14805)::[])
+end))))
+in (FStar_All.pipe_right uu____14790 FStar_List.flatten))
+in (
+
+let uu____14810 = (
+
+let uu____14815 = (
+
+let uu____14816 = (
+
+let uu____14822 = (add_fuel ((fuel_var), (FStar_SMTEncoding_Term.Fuel_sort)) (FStar_List.append vars arg_binders))
+in (
+
+let uu____14828 = (
+
+let uu____14829 = (
+
+let uu____14832 = (FStar_SMTEncoding_Util.mk_and_l prec)
+in ((ty_pred), (uu____14832)))
+in (FStar_SMTEncoding_Util.mkImp uu____14829))
+in ((((ty_pred)::[])::[]), (uu____14822), (uu____14828))))
+in (FStar_SMTEncoding_Util.mkForall uu____14816))
+in ((uu____14815), (Some ("subterm ordering")), (Some ((Prims.strcat "subterm_ordering_" ddconstrsym)))))
+in FStar_SMTEncoding_Term.Assume (uu____14810)))
+end)
+in ((arg_decls), ((typing_inversion)::(subterm_ordering)::[]))))))))))
+end)))
+end)))
+end
+| uu____14843 -> begin
+((
+
+let uu____14845 = (
+
+let uu____14846 = (FStar_Syntax_Print.lid_to_string d)
+in (
+
+let uu____14847 = (FStar_Syntax_Print.term_to_string head1)
+in (FStar_Util.format2 "Constructor %s builds an unexpected type %s\n" uu____14846 uu____14847)))
+in (FStar_Errors.warn se.FStar_Syntax_Syntax.sigrng uu____14845));
+(([]), ([]));
+)
+end))
+end)))
+in (
+
+let uu____14850 = (encode_elim ())
+in (match (uu____14850) with
+| (decls2, elim) -> begin
+(
+
+let g = (
+
+let uu____14862 = (
+
+let uu____14864 = (
+
+let uu____14866 = (
+
+let uu____14868 = (
+
+let uu____14870 = (
+
+let uu____14871 = (
+
+let uu____14877 = (
+
+let uu____14879 = (
+
+let uu____14880 = (FStar_Syntax_Print.lid_to_string d)
+in (FStar_Util.format1 "data constructor proxy: %s" uu____14880))
+in Some (uu____14879))
+in ((ddtok), ([]), (FStar_SMTEncoding_Term.Term_sort), (uu____14877)))
+in FStar_SMTEncoding_Term.DeclFun (uu____14871))
+in (uu____14870)::[])
+in (
+
+let uu____14883 = (
+
+let uu____14885 = (
+
+let uu____14887 = (
+
+let uu____14889 = (
+
+let uu____14891 = (
+
+let uu____14893 = (
+
+let uu____14895 = (
+
+let uu____14896 = (
+
+let uu____14901 = (
+
+let uu____14902 = (
+
+let uu____14908 = (FStar_SMTEncoding_Util.mkEq ((app), (dapp)))
+in ((((app)::[])::[]), (vars), (uu____14908)))
+in (FStar_SMTEncoding_Util.mkForall uu____14902))
+in ((uu____14901), (Some ("equality for proxy")), (Some ((Prims.strcat "equality_tok_" ddtok)))))
+in FStar_SMTEncoding_Term.Assume (uu____14896))
+in (
+
+let uu____14916 = (
+
+let uu____14918 = (
+
+let uu____14919 = (
+
+let uu____14924 = (
+
+let uu____14925 = (
+
+let uu____14931 = (add_fuel ((fuel_var), (FStar_SMTEncoding_Term.Fuel_sort)) vars')
+in (
+
+let uu____14937 = (FStar_SMTEncoding_Util.mkImp ((guard'), (ty_pred')))
+in ((((ty_pred')::[])::[]), (uu____14931), (uu____14937))))
+in (FStar_SMTEncoding_Util.mkForall uu____14925))
+in ((uu____14924), (Some ("data constructor typing intro")), (Some ((Prims.strcat "data_typing_intro_" ddtok)))))
+in FStar_SMTEncoding_Term.Assume (uu____14919))
+in (uu____14918)::[])
+in (uu____14895)::uu____14916))
+in (FStar_SMTEncoding_Term.Assume (((tok_typing), (Some ("typing for data constructor proxy")), (Some ((Prims.strcat "typing_tok_" ddtok))))))::uu____14893)
+in (FStar_List.append uu____14891 elim))
+in (FStar_List.append decls_pred uu____14889))
+in (FStar_List.append decls_formals uu____14887))
+in (FStar_List.append proxy_fresh uu____14885))
+in (FStar_List.append uu____14868 uu____14883)))
+in (FStar_List.append decls3 uu____14866))
+in (FStar_List.append decls2 uu____14864))
+in (FStar_List.append binder_decls uu____14862))
+in (((FStar_List.append datacons g)), (env1)))
+end)))))
+end))
+end))
+end))))))))
+end)))
+end))
+end)))
+end))
+end))
+and encode_signature : env_t  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * env_t) = (fun env ses -> (FStar_All.pipe_right ses (FStar_List.fold_left (fun uu____14960 se -> (match (uu____14960) with
+| (g, env1) -> begin
+(
+
+let uu____14972 = (encode_sigelt env1 se)
+in (match (uu____14972) with
+| (g', env2) -> begin
+(((FStar_List.append g g')), (env2))
+end))
+end)) (([]), (env)))))
+
+
+let encode_env_bindings : env_t  ->  FStar_TypeChecker_Env.binding Prims.list  ->  (FStar_SMTEncoding_Term.decls_t * env_t) = (fun env bindings -> (
+
+let encode_binding = (fun b uu____15008 -> (match (uu____15008) with
+| (i, decls, env1) -> begin
+(match (b) with
+| FStar_TypeChecker_Env.Binding_univ (uu____15026) -> begin
+(((i + (Prims.parse_int "1"))), ([]), (env1))
+end
+| FStar_TypeChecker_Env.Binding_var (x) -> begin
+(
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Simplify)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env1.tcenv x.FStar_Syntax_Syntax.sort)
+in ((
+
+let uu____15031 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1.tcenv) (FStar_Options.Other ("SMTEncoding")))
+in (match (uu____15031) with
+| true -> begin
+(
+
+let uu____15032 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____15033 = (FStar_Syntax_Print.term_to_string x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____15034 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print3 "Normalized %s : %s to %s\n" uu____15032 uu____15033 uu____15034))))
+end
+| uu____15035 -> begin
+()
+end));
+(
+
+let uu____15036 = (encode_term t1 env1)
+in (match (uu____15036) with
+| (t, decls') -> begin
+(
+
+let t_hash = (FStar_SMTEncoding_Term.hash_of_term t)
+in (
+
+let uu____15046 = (
+
+let uu____15050 = (
+
+let uu____15051 = (
+
+let uu____15052 = (FStar_Util.digest_of_string t_hash)
+in (Prims.strcat uu____15052 (Prims.strcat "_" (Prims.string_of_int i))))
+in (Prims.strcat "x_" uu____15051))
+in (new_term_constant_from_string env1 x uu____15050))
+in (match (uu____15046) with
+| (xxsym, xx, env') -> begin
+(
+
+let t2 = (FStar_SMTEncoding_Term.mk_HasTypeWithFuel None xx t)
+in (
+
+let caption = (
+
+let uu____15063 = (FStar_Options.log_queries ())
+in (match (uu____15063) with
+| true -> begin
+(
+
+let uu____15065 = (
+
+let uu____15066 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____15067 = (FStar_Syntax_Print.term_to_string x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____15068 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format3 "%s : %s (%s)" uu____15066 uu____15067 uu____15068))))
+in Some (uu____15065))
+end
+| uu____15069 -> begin
+None
+end))
+in (
+
+let ax = (
+
+let a_name = Some ((Prims.strcat "binder_" xxsym))
+in FStar_SMTEncoding_Term.Assume (((t2), (a_name), (a_name))))
+in (
+
+let g = (FStar_List.append ((FStar_SMTEncoding_Term.DeclFun (((xxsym), ([]), (FStar_SMTEncoding_Term.Term_sort), (caption))))::[]) (FStar_List.append decls' ((ax)::[])))
+in (((i + (Prims.parse_int "1"))), ((FStar_List.append decls g)), (env'))))))
+end)))
+end));
+))
+end
+| FStar_TypeChecker_Env.Binding_lid (x, (uu____15081, t)) -> begin
+(
+
+let t_norm = (whnf env1 t)
+in (
+
+let fv = (FStar_Syntax_Syntax.lid_as_fv x FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____15090 = (encode_free_var env1 fv t t_norm [])
+in (match (uu____15090) with
+| (g, env') -> begin
+(((i + (Prims.parse_int "1"))), ((FStar_List.append decls g)), (env'))
+end))))
+end
+| (FStar_TypeChecker_Env.Binding_sig_inst (_, se, _)) | (FStar_TypeChecker_Env.Binding_sig (_, se)) -> begin
+(
+
+let uu____15109 = (encode_sigelt env1 se)
+in (match (uu____15109) with
+| (g, env') -> begin
+(((i + (Prims.parse_int "1"))), ((FStar_List.append decls g)), (env'))
+end))
+end)
+end))
+in (
+
+let uu____15119 = (FStar_List.fold_right encode_binding bindings (((Prims.parse_int "0")), ([]), (env)))
+in (match (uu____15119) with
+| (uu____15131, decls, env1) -> begin
+((decls), (env1))
+end))))
+
+
+let encode_labels = (fun labs -> (
+
+let prefix1 = (FStar_All.pipe_right labs (FStar_List.map (fun uu____15176 -> (match (uu____15176) with
+| (l, uu____15183, uu____15184) -> begin
+FStar_SMTEncoding_Term.DeclFun ((((Prims.fst l)), ([]), (FStar_SMTEncoding_Term.Bool_sort), (None)))
+end))))
+in (
+
+let suffix = (FStar_All.pipe_right labs (FStar_List.collect (fun uu____15205 -> (match (uu____15205) with
+| (l, uu____15213, uu____15214) -> begin
+(
+
+let uu____15219 = (FStar_All.pipe_left (fun _0_39 -> FStar_SMTEncoding_Term.Echo (_0_39)) (Prims.fst l))
+in (
+
+let uu____15220 = (
+
+let uu____15222 = (
+
+let uu____15223 = (FStar_SMTEncoding_Util.mkFreeV l)
+in FStar_SMTEncoding_Term.Eval (uu____15223))
+in (uu____15222)::[])
+in (uu____15219)::uu____15220))
+end))))
+in ((prefix1), (suffix)))))
+
+
+let last_env : env_t Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let init_env : FStar_TypeChecker_Env.env  ->  Prims.unit = (fun tcenv -> (
+
+let uu____15234 = (
+
+let uu____15236 = (
+
+let uu____15237 = (FStar_Util.smap_create (Prims.parse_int "100"))
+in {bindings = []; depth = (Prims.parse_int "0"); tcenv = tcenv; warn = true; cache = uu____15237; nolabels = false; use_zfuel_name = false; encode_non_total_function_typ = true})
+in (uu____15236)::[])
+in (FStar_ST.write last_env uu____15234)))
+
+
+let get_env : FStar_TypeChecker_Env.env  ->  env_t = (fun tcenv -> (
+
+let uu____15255 = (FStar_ST.read last_env)
+in (match (uu____15255) with
+| [] -> begin
+(failwith "No env; call init first!")
+end
+| (e)::uu____15261 -> begin
+(
+
+let uu___161_15263 = e
+in {bindings = uu___161_15263.bindings; depth = uu___161_15263.depth; tcenv = tcenv; warn = uu___161_15263.warn; cache = uu___161_15263.cache; nolabels = uu___161_15263.nolabels; use_zfuel_name = uu___161_15263.use_zfuel_name; encode_non_total_function_typ = uu___161_15263.encode_non_total_function_typ})
+end)))
+
+
+let set_env : env_t  ->  Prims.unit = (fun env -> (
+
+let uu____15267 = (FStar_ST.read last_env)
+in (match (uu____15267) with
+| [] -> begin
+(failwith "Empty env stack")
+end
+| (uu____15272)::tl1 -> begin
+(FStar_ST.write last_env ((env)::tl1))
+end)))
+
+
+let push_env : Prims.unit  ->  Prims.unit = (fun uu____15280 -> (
+
+let uu____15281 = (FStar_ST.read last_env)
+in (match (uu____15281) with
+| [] -> begin
+(failwith "Empty env stack")
+end
+| (hd1)::tl1 -> begin
+(
+
+let refs = (FStar_Util.smap_copy hd1.cache)
+in (
+
+let top = (
+
+let uu___162_15302 = hd1
+in {bindings = uu___162_15302.bindings; depth = uu___162_15302.depth; tcenv = uu___162_15302.tcenv; warn = uu___162_15302.warn; cache = refs; nolabels = uu___162_15302.nolabels; use_zfuel_name = uu___162_15302.use_zfuel_name; encode_non_total_function_typ = uu___162_15302.encode_non_total_function_typ})
+in (FStar_ST.write last_env ((top)::(hd1)::tl1))))
+end)))
+
+
+let pop_env : Prims.unit  ->  Prims.unit = (fun uu____15308 -> (
+
+let uu____15309 = (FStar_ST.read last_env)
+in (match (uu____15309) with
+| [] -> begin
+(failwith "Popping an empty stack")
+end
+| (uu____15314)::tl1 -> begin
+(FStar_ST.write last_env tl1)
+end)))
+
+
+let mark_env : Prims.unit  ->  Prims.unit = (fun uu____15322 -> (push_env ()))
+
+
+let reset_mark_env : Prims.unit  ->  Prims.unit = (fun uu____15325 -> (pop_env ()))
+
+
+let commit_mark_env : Prims.unit  ->  Prims.unit = (fun uu____15328 -> (
+
+let uu____15329 = (FStar_ST.read last_env)
+in (match (uu____15329) with
+| (hd1)::(uu____15335)::tl1 -> begin
+(FStar_ST.write last_env ((hd1)::tl1))
+end
+| uu____15341 -> begin
+(failwith "Impossible")
+end)))
+
+
+let init : FStar_TypeChecker_Env.env  ->  Prims.unit = (fun tcenv -> ((init_env tcenv);
+(FStar_SMTEncoding_Z3.init ());
+(FStar_SMTEncoding_Z3.giveZ3 ((FStar_SMTEncoding_Term.DefPrelude)::[]));
+))
+
+
+let push : Prims.string  ->  Prims.unit = (fun msg -> ((push_env ());
+(varops.push ());
+(FStar_SMTEncoding_Z3.push msg);
+))
+
+
+let pop : Prims.string  ->  Prims.unit = (fun msg -> ((pop_env ());
+(varops.pop ());
+(FStar_SMTEncoding_Z3.pop msg);
+))
+
+
+let mark : Prims.string  ->  Prims.unit = (fun msg -> ((mark_env ());
+(varops.mark ());
+(FStar_SMTEncoding_Z3.mark msg);
+))
+
+
+let reset_mark : Prims.string  ->  Prims.unit = (fun msg -> ((reset_mark_env ());
+(varops.reset_mark ());
+(FStar_SMTEncoding_Z3.reset_mark msg);
+))
+
+
+let commit_mark : Prims.string  ->  Prims.unit = (fun msg -> ((commit_mark_env ());
+(varops.commit_mark ());
+(FStar_SMTEncoding_Z3.commit_mark msg);
+))
+
+
+let encode_sig : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt  ->  Prims.unit = (fun tcenv se -> (
+
+let caption = (fun decls -> (
+
+let uu____15386 = (FStar_Options.log_queries ())
+in (match (uu____15386) with
+| true -> begin
+(
+
+let uu____15388 = (
+
+let uu____15389 = (
+
+let uu____15390 = (
+
+let uu____15391 = (FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se) (FStar_List.map FStar_Syntax_Print.lid_to_string))
+in (FStar_All.pipe_right uu____15391 (FStar_String.concat ", ")))
+in (Prims.strcat "encoding sigelt " uu____15390))
+in FStar_SMTEncoding_Term.Caption (uu____15389))
+in (uu____15388)::decls)
+end
+| uu____15396 -> begin
+decls
+end)))
+in (
+
+let env = (get_env tcenv)
+in (
+
+let uu____15398 = (encode_sigelt env se)
+in (match (uu____15398) with
+| (decls, env1) -> begin
+((set_env env1);
+(
+
+let uu____15404 = (caption decls)
+in (FStar_SMTEncoding_Z3.giveZ3 uu____15404));
+)
+end)))))
+
+
+let encode_modul : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  Prims.unit = (fun tcenv modul -> (
+
+let name = (FStar_Util.format2 "%s %s" (match (modul.FStar_Syntax_Syntax.is_interface) with
+| true -> begin
+"interface"
+end
+| uu____15413 -> begin
+"module"
+end) modul.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in ((
+
+let uu____15415 = (FStar_TypeChecker_Env.debug tcenv FStar_Options.Low)
+in (match (uu____15415) with
+| true -> begin
+(
+
+let uu____15416 = (FStar_All.pipe_right (FStar_List.length modul.FStar_Syntax_Syntax.exports) Prims.string_of_int)
+in (FStar_Util.print2 "+++++++++++Encoding externals for %s ... %s exports\n" name uu____15416))
+end
+| uu____15419 -> begin
+()
+end));
+(
+
+let env = (get_env tcenv)
+in (
+
+let uu____15421 = (encode_signature (
+
+let uu___163_15425 = env
+in {bindings = uu___163_15425.bindings; depth = uu___163_15425.depth; tcenv = uu___163_15425.tcenv; warn = false; cache = uu___163_15425.cache; nolabels = uu___163_15425.nolabels; use_zfuel_name = uu___163_15425.use_zfuel_name; encode_non_total_function_typ = uu___163_15425.encode_non_total_function_typ}) modul.FStar_Syntax_Syntax.exports)
+in (match (uu____15421) with
+| (decls, env1) -> begin
+(
+
+let caption = (fun decls1 -> (
+
+let uu____15437 = (FStar_Options.log_queries ())
+in (match (uu____15437) with
+| true -> begin
+(
+
+let msg = (Prims.strcat "Externals for " name)
+in (FStar_List.append ((FStar_SMTEncoding_Term.Caption (msg))::decls1) ((FStar_SMTEncoding_Term.Caption ((Prims.strcat "End " msg)))::[])))
+end
+| uu____15440 -> begin
+decls1
+end)))
+in ((set_env (
+
+let uu___164_15442 = env1
+in {bindings = uu___164_15442.bindings; depth = uu___164_15442.depth; tcenv = uu___164_15442.tcenv; warn = true; cache = uu___164_15442.cache; nolabels = uu___164_15442.nolabels; use_zfuel_name = uu___164_15442.use_zfuel_name; encode_non_total_function_typ = uu___164_15442.encode_non_total_function_typ}));
+(
+
+let uu____15444 = (FStar_TypeChecker_Env.debug tcenv FStar_Options.Low)
+in (match (uu____15444) with
+| true -> begin
+(FStar_Util.print1 "Done encoding externals for %s\n" name)
+end
+| uu____15445 -> begin
+()
+end));
+(
+
+let decls1 = (caption decls)
+in (FStar_SMTEncoding_Z3.giveZ3 decls1));
+))
+end)));
+)))
+
+
+let encode_query : (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_SMTEncoding_Term.decl Prims.list * FStar_SMTEncoding_ErrorReporting.label Prims.list * FStar_SMTEncoding_Term.decl * FStar_SMTEncoding_Term.decl Prims.list) = (fun use_env_msg tcenv q -> ((
+
+let uu____15479 = (
+
+let uu____15480 = (FStar_TypeChecker_Env.current_module tcenv)
+in uu____15480.FStar_Ident.str)
+in (FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name uu____15479));
+(
+
+let env = (get_env tcenv)
+in (
+
+let bindings = (FStar_TypeChecker_Env.fold_env tcenv (fun bs b -> (b)::bs) [])
+in (
+
+let uu____15488 = (
+
+let rec aux = (fun bindings1 -> (match (bindings1) with
+| (FStar_TypeChecker_Env.Binding_var (x))::rest -> begin
+(
+
+let uu____15509 = (aux rest)
+in (match (uu____15509) with
+| (out, rest1) -> begin
+(
+
+let t = (
+
+let uu____15527 = (FStar_Syntax_Util.destruct_typ_as_formula x.FStar_Syntax_Syntax.sort)
+in (match (uu____15527) with
+| Some (uu____15531) -> begin
+(
+
+let uu____15532 = (FStar_Syntax_Syntax.new_bv None FStar_TypeChecker_Common.t_unit)
+in (FStar_Syntax_Util.refine uu____15532 x.FStar_Syntax_Syntax.sort))
+end
+| uu____15533 -> begin
+x.FStar_Syntax_Syntax.sort
+end))
+in (
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Simplify)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.tcenv t)
+in (
+
+let uu____15536 = (
+
+let uu____15538 = (FStar_Syntax_Syntax.mk_binder (
+
+let uu___165_15539 = x
+in {FStar_Syntax_Syntax.ppname = uu___165_15539.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___165_15539.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1}))
+in (uu____15538)::out)
+in ((uu____15536), (rest1)))))
+end))
+end
+| uu____15542 -> begin
+(([]), (bindings1))
+end))
+in (
+
+let uu____15546 = (aux bindings)
+in (match (uu____15546) with
+| (closing, bindings1) -> begin
+(
+
+let uu____15560 = (FStar_Syntax_Util.close_forall_no_univs (FStar_List.rev closing) q)
+in ((uu____15560), (bindings1)))
+end)))
+in (match (uu____15488) with
+| (q1, bindings1) -> begin
+(
+
+let uu____15573 = (
+
+let uu____15576 = (FStar_List.filter (fun uu___134_15578 -> (match (uu___134_15578) with
+| FStar_TypeChecker_Env.Binding_sig (uu____15579) -> begin
+false
+end
+| uu____15583 -> begin
+true
+end)) bindings1)
+in (encode_env_bindings env uu____15576))
+in (match (uu____15573) with
+| (env_decls, env1) -> begin
+((
+
+let uu____15594 = (((FStar_TypeChecker_Env.debug tcenv FStar_Options.Low) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug tcenv) (FStar_Options.Other ("SMTEncoding")))) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug tcenv) (FStar_Options.Other ("SMTQuery"))))
+in (match (uu____15594) with
+| true -> begin
+(
+
+let uu____15595 = (FStar_Syntax_Print.term_to_string q1)
+in (FStar_Util.print1 "Encoding query formula: %s\n" uu____15595))
+end
+| uu____15596 -> begin
+()
+end));
+(
+
+let uu____15597 = (encode_formula q1 env1)
+in (match (uu____15597) with
+| (phi, qdecls) -> begin
+(
+
+let uu____15609 = (
+
+let uu____15612 = (FStar_TypeChecker_Env.get_range tcenv)
+in (FStar_SMTEncoding_ErrorReporting.label_goals use_env_msg uu____15612 phi))
+in (match (uu____15609) with
+| (labels, phi1) -> begin
+(
+
+let uu____15622 = (encode_labels labels)
+in (match (uu____15622) with
+| (label_prefix, label_suffix) -> begin
+(
+
+let query_prelude = (FStar_List.append env_decls (FStar_List.append label_prefix qdecls))
+in (
+
+let qry = (
+
+let uu____15643 = (
+
+let uu____15648 = (FStar_SMTEncoding_Util.mkNot phi1)
+in (
+
+let uu____15649 = (
+
+let uu____15651 = (varops.mk_unique "@query")
+in Some (uu____15651))
+in ((uu____15648), (Some ("query")), (uu____15649))))
+in FStar_SMTEncoding_Term.Assume (uu____15643))
+in (
+
+let suffix = (
+
+let uu____15656 = (
+
+let uu____15658 = (
+
+let uu____15660 = (FStar_Options.print_z3_statistics ())
+in (match (uu____15660) with
+| true -> begin
+(FStar_SMTEncoding_Term.PrintStats)::[]
+end
+| uu____15662 -> begin
+[]
+end))
+in (FStar_List.append uu____15658 ((FStar_SMTEncoding_Term.Echo ("Done!"))::[])))
+in (FStar_List.append label_suffix uu____15656))
+in ((query_prelude), (labels), (qry), (suffix)))))
+end))
+end))
+end));
+)
+end))
+end))));
+))
+
+
+let is_trivial : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun tcenv q -> (
+
+let env = (get_env tcenv)
+in ((FStar_SMTEncoding_Z3.push "query");
+(
+
+let uu____15673 = (encode_formula q env)
+in (match (uu____15673) with
+| (f, uu____15677) -> begin
+((FStar_SMTEncoding_Z3.pop "query");
+(match (f.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.TrueOp, uu____15679) -> begin
+true
+end
+| uu____15682 -> begin
+false
+end);
+)
+end));
+)))
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
@@ -1,592 +1,612 @@
+
 open Prims
-exception Not_a_wp_implication of Prims.string
-let uu___is_Not_a_wp_implication: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Not_a_wp_implication uu____6 -> true
-    | uu____7 -> false
-let __proj__Not_a_wp_implication__item__uu___: Prims.exn -> Prims.string =
-  fun projectee  ->
-    match projectee with | Not_a_wp_implication uu____14 -> uu____14
-type label = FStar_SMTEncoding_Term.error_label
-type labels = FStar_SMTEncoding_Term.error_labels
-let sort_labels:
-  (FStar_SMTEncoding_Term.error_label* Prims.bool) Prims.list ->
-    ((FStar_SMTEncoding_Term.fv* Prims.string* FStar_Range.range)*
-      Prims.bool) Prims.list
-  =
-  fun l  ->
-    FStar_List.sortWith
-      (fun uu____35  ->
-         fun uu____36  ->
-           match (uu____35, uu____36) with
-           | (((uu____57,uu____58,r1),uu____60),((uu____61,uu____62,r2),uu____64))
-               -> FStar_Range.compare r1 r2) l
-let remove_dups:
-  labels ->
-    (FStar_SMTEncoding_Term.fv* Prims.string* FStar_Range.range) Prims.list
-  =
-  fun l  ->
-    FStar_Util.remove_dups
-      (fun uu____91  ->
-         fun uu____92  ->
-           match (uu____91, uu____92) with
-           | ((uu____105,m1,r1),(uu____108,m2,r2)) -> (r1 = r2) && (m1 = m2))
-      l
-type msg = (Prims.string* FStar_Range.range)
-type ranges = (Prims.string Prims.option* FStar_Range.range) Prims.list
-let fresh_label:
-  Prims.string ->
-    FStar_Range.range ->
-      FStar_SMTEncoding_Term.term ->
-        (((Prims.string* FStar_SMTEncoding_Term.sort)* Prims.string*
-          FStar_Range.range)* FStar_SMTEncoding_Term.term)
-  =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
-  fun message  ->
-    fun range  ->
-      fun t  ->
-        let l =
-          FStar_Util.incr ctr;
-          (let uu____142 =
-             let uu____143 = FStar_ST.read ctr in
-             FStar_Util.string_of_int uu____143 in
-           FStar_Util.format1 "label_%s" uu____142) in
-        let lvar = (l, FStar_SMTEncoding_Term.Bool_sort) in
-        let label = (lvar, message, range) in
-        let lterm = FStar_SMTEncoding_Util.mkFreeV lvar in
-        let lt1 = FStar_SMTEncoding_Term.mkOr (lterm, t) range in
-        (label, lt1)
-let label_goals:
-  (Prims.unit -> Prims.string) Prims.option ->
-    FStar_Range.range ->
-      FStar_SMTEncoding_Term.term -> (labels* FStar_SMTEncoding_Term.term)
-  =
-  fun use_env_msg  ->
-    fun r  ->
-      fun q  ->
-        let rec is_a_post_condition post_name_opt tm =
-          match (post_name_opt, (tm.FStar_SMTEncoding_Term.tm)) with
-          | (None ,uu____194) -> false
-          | (Some nm,FStar_SMTEncoding_Term.FreeV (nm',uu____198)) ->
-              nm = nm'
-          | (_,FStar_SMTEncoding_Term.App
-             (FStar_SMTEncoding_Term.Var "Valid",tm1::[]))
-            |(_,FStar_SMTEncoding_Term.App
-              (FStar_SMTEncoding_Term.Var "ApplyTT",tm1::_)) ->
-              is_a_post_condition post_name_opt tm1
-          | uu____208 -> false in
-        let conjuncts t =
-          match t.FStar_SMTEncoding_Term.tm with
-          | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And ,cs) -> cs
-          | uu____221 -> [t] in
-        let is_guard_free tm =
-          match tm.FStar_SMTEncoding_Term.tm with
-          | FStar_SMTEncoding_Term.Quant
-              (FStar_SMTEncoding_Term.Forall
-               ,({
-                   FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
-                     (FStar_SMTEncoding_Term.Var "Prims.guard_free",p::[]);
-                   FStar_SMTEncoding_Term.freevars = uu____227;
-                   FStar_SMTEncoding_Term.rng = uu____228;_}::[])::[],iopt,uu____230,
-               {
-                 FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
-                   (FStar_SMTEncoding_Term.Iff ,l::r1::[]);
-                 FStar_SMTEncoding_Term.freevars = uu____233;
-                 FStar_SMTEncoding_Term.rng = uu____234;_})
-              -> true
-          | uu____253 -> false in
-        let is_a_named_continuation lhs =
-          FStar_All.pipe_right (conjuncts lhs)
-            (FStar_Util.for_some is_guard_free) in
-        let uu____259 =
-          match use_env_msg with
-          | None  -> (false, "")
-          | Some f -> let uu____271 = f () in (true, uu____271) in
-        match uu____259 with
-        | (flag,msg_prefix) ->
-            let fresh_label1 msg ropt rng t =
-              let msg1 =
-                if flag
-                then Prims.strcat "Failed to verify implicit argument: " msg
-                else msg in
-              let rng1 =
-                match ropt with
-                | None  -> rng
-                | Some r1 ->
-                    let uu___102_297 = r1 in
-                    {
-                      FStar_Range.def_range = (rng.FStar_Range.def_range);
-                      FStar_Range.use_range =
-                        (uu___102_297.FStar_Range.use_range)
-                    } in
-              fresh_label msg1 rng1 t in
-            let rec aux default_msg ropt post_name_opt labels q1 =
-              match q1.FStar_SMTEncoding_Term.tm with
-              | FStar_SMTEncoding_Term.BoundV _
-                |FStar_SMTEncoding_Term.Integer _ -> (labels, q1)
-              | FStar_SMTEncoding_Term.LblPos uu____329 ->
-                  failwith "Impossible"
-              | FStar_SMTEncoding_Term.Labeled
-                  (arg,"could not prove post-condition",uu____336) ->
-                  let fallback msg =
-                    aux default_msg ropt post_name_opt labels arg in
-                  (try
-                     match arg.FStar_SMTEncoding_Term.tm with
-                     | FStar_SMTEncoding_Term.Quant
-                         (FStar_SMTEncoding_Term.Forall
-                          ,pats,iopt,post::sorts,{
-                                                   FStar_SMTEncoding_Term.tm
-                                                     =
-                                                     FStar_SMTEncoding_Term.App
-                                                     (FStar_SMTEncoding_Term.Imp
-                                                      ,lhs::rhs::[]);
-                                                   FStar_SMTEncoding_Term.freevars
-                                                     = uu____360;
-                                                   FStar_SMTEncoding_Term.rng
-                                                     = rng;_})
-                         ->
-                         let post_name =
-                           let uu____376 =
-                             let uu____377 = FStar_Syntax_Syntax.next_id () in
-                             FStar_All.pipe_left FStar_Util.string_of_int
-                               uu____377 in
-                           Prims.strcat "^^post_condition_" uu____376 in
-                         let names =
-                           let uu____382 =
-                             FStar_List.mapi
-                               (fun i  ->
-                                  fun s  ->
-                                    let uu____390 =
-                                      let uu____391 =
-                                        FStar_Util.string_of_int i in
-                                      Prims.strcat "^^" uu____391 in
-                                    (uu____390, s)) sorts in
-                           (post_name, post) :: uu____382 in
-                         let instantiation =
-                           FStar_List.map FStar_SMTEncoding_Util.mkFreeV
-                             names in
-                         let uu____398 =
-                           let uu____401 =
-                             FStar_SMTEncoding_Term.inst instantiation lhs in
-                           let uu____402 =
-                             FStar_SMTEncoding_Term.inst instantiation rhs in
-                           (uu____401, uu____402) in
-                         (match uu____398 with
-                          | (lhs1,rhs1) ->
-                              let uu____408 =
-                                match lhs1.FStar_SMTEncoding_Term.tm with
-                                | FStar_SMTEncoding_Term.App
-                                    (FStar_SMTEncoding_Term.And ,clauses_lhs)
-                                    ->
-                                    let uu____418 =
-                                      FStar_Util.prefix clauses_lhs in
-                                    (match uu____418 with
-                                     | (req,ens) ->
-                                         (match ens.FStar_SMTEncoding_Term.tm
-                                          with
-                                          | FStar_SMTEncoding_Term.Quant
-                                              (FStar_SMTEncoding_Term.Forall
-                                               ,pats_ens,iopt_ens,sorts_ens,
-                                               {
-                                                 FStar_SMTEncoding_Term.tm =
-                                                   FStar_SMTEncoding_Term.App
-                                                   (FStar_SMTEncoding_Term.Imp
-                                                    ,ensures_conjuncts::post1::[]);
-                                                 FStar_SMTEncoding_Term.freevars
-                                                   = uu____437;
-                                                 FStar_SMTEncoding_Term.rng =
-                                                   rng_ens;_})
-                                              when
-                                              is_a_post_condition
-                                                (Some post_name) post1
-                                              ->
-                                              let uu____452 =
-                                                aux
-                                                  "could not prove post-condition"
-                                                  None (Some post_name)
-                                                  labels ensures_conjuncts in
-                                              (match uu____452 with
-                                               | (labels1,ensures_conjuncts1)
-                                                   ->
-                                                   let pats_ens1 =
-                                                     match pats_ens with
-                                                     | []|[]::[] -> [[post1]]
-                                                     | uu____473 -> pats_ens in
-                                                   let ens1 =
-                                                     let uu____477 =
-                                                       let uu____478 =
-                                                         let uu____488 =
-                                                           FStar_SMTEncoding_Term.mk
-                                                             (FStar_SMTEncoding_Term.App
-                                                                (FStar_SMTEncoding_Term.Imp,
-                                                                  [ensures_conjuncts1;
-                                                                  post1]))
-                                                             rng_ens in
-                                                         (FStar_SMTEncoding_Term.Forall,
-                                                           pats_ens1,
-                                                           iopt_ens,
-                                                           sorts_ens,
-                                                           uu____488) in
-                                                       FStar_SMTEncoding_Term.Quant
-                                                         uu____478 in
-                                                     FStar_SMTEncoding_Term.mk
-                                                       uu____477
-                                                       ens.FStar_SMTEncoding_Term.rng in
-                                                   let lhs2 =
-                                                     FStar_SMTEncoding_Term.mk
-                                                       (FStar_SMTEncoding_Term.App
-                                                          (FStar_SMTEncoding_Term.And,
-                                                            (FStar_List.append
-                                                               req [ens1])))
-                                                       lhs1.FStar_SMTEncoding_Term.rng in
-                                                   let uu____496 =
-                                                     FStar_SMTEncoding_Term.abstr
-                                                       names lhs2 in
-                                                   (labels1, uu____496))
-                                          | uu____498 ->
-                                              let uu____499 =
-                                                let uu____500 =
-                                                  let uu____501 =
-                                                    let uu____502 =
-                                                      let uu____503 =
-                                                        FStar_SMTEncoding_Term.print_smt_term
-                                                          ens in
-                                                      Prims.strcat "  ... "
-                                                        uu____503 in
-                                                    Prims.strcat post_name
-                                                      uu____502 in
-                                                  Prims.strcat
-                                                    "Ensures clause doesn't match post name:  "
-                                                    uu____501 in
-                                                Not_a_wp_implication
-                                                  uu____500 in
-                                              Prims.raise uu____499))
-                                | uu____507 ->
-                                    let uu____508 =
-                                      let uu____509 =
-                                        let uu____510 =
-                                          FStar_SMTEncoding_Term.print_smt_term
-                                            lhs1 in
-                                        Prims.strcat "LHS not a conjunct: "
-                                          uu____510 in
-                                      Not_a_wp_implication uu____509 in
-                                    Prims.raise uu____508 in
-                              (match uu____408 with
-                               | (labels1,lhs2) ->
-                                   let uu____521 =
-                                     let uu____525 =
-                                       aux default_msg None (Some post_name)
-                                         labels1 rhs1 in
-                                     match uu____525 with
-                                     | (labels2,rhs2) ->
-                                         let uu____536 =
-                                           FStar_SMTEncoding_Term.abstr names
-                                             rhs2 in
-                                         (labels2, uu____536) in
-                                   (match uu____521 with
-                                    | (labels2,rhs2) ->
-                                        let body =
-                                          FStar_SMTEncoding_Term.mkImp
-                                            (lhs2, rhs2) rng in
-                                        let uu____546 =
-                                          FStar_SMTEncoding_Term.mk
-                                            (FStar_SMTEncoding_Term.Quant
-                                               (FStar_SMTEncoding_Term.Forall,
-                                                 pats, iopt, (post :: sorts),
-                                                 body))
-                                            q1.FStar_SMTEncoding_Term.rng in
-                                        (labels2, uu____546))))
-                     | uu____552 ->
-                         let uu____553 =
-                           let uu____554 =
-                             FStar_SMTEncoding_Term.print_smt_term arg in
-                           Prims.strcat "arg not a quant: " uu____554 in
-                         fallback uu____553
-                   with | Not_a_wp_implication msg -> fallback msg)
-              | FStar_SMTEncoding_Term.Labeled (arg,reason,r1) ->
-                  aux reason (Some r1) post_name_opt labels arg
-              | FStar_SMTEncoding_Term.Quant
-                  (FStar_SMTEncoding_Term.Forall ,[],None
-                   ,post::[],{
-                               FStar_SMTEncoding_Term.tm =
-                                 FStar_SMTEncoding_Term.App
-                                 (FStar_SMTEncoding_Term.Imp ,lhs::rhs::[]);
-                               FStar_SMTEncoding_Term.freevars = uu____566;
-                               FStar_SMTEncoding_Term.rng = rng;_})
-                  when is_a_named_continuation lhs ->
-                  let post_name =
-                    let uu____579 =
-                      let uu____580 = FStar_Syntax_Syntax.next_id () in
-                      FStar_All.pipe_left FStar_Util.string_of_int uu____580 in
-                    Prims.strcat "^^post_condition_" uu____579 in
-                  let names = (post_name, post) in
-                  let instantiation =
-                    let uu____586 = FStar_SMTEncoding_Util.mkFreeV names in
-                    [uu____586] in
-                  let uu____587 =
-                    let uu____590 =
-                      FStar_SMTEncoding_Term.inst instantiation lhs in
-                    let uu____591 =
-                      FStar_SMTEncoding_Term.inst instantiation rhs in
-                    (uu____590, uu____591) in
-                  (match uu____587 with
-                   | (lhs1,rhs1) ->
-                       let uu____597 =
-                         FStar_Util.fold_map
-                           (fun labels1  ->
-                              fun tm  ->
-                                match tm.FStar_SMTEncoding_Term.tm with
-                                | FStar_SMTEncoding_Term.Quant
-                                    (FStar_SMTEncoding_Term.Forall
-                                     ,({
-                                         FStar_SMTEncoding_Term.tm =
-                                           FStar_SMTEncoding_Term.App
-                                           (FStar_SMTEncoding_Term.Var
-                                            "Prims.guard_free",p::[]);
-                                         FStar_SMTEncoding_Term.freevars =
-                                           uu____610;
-                                         FStar_SMTEncoding_Term.rng =
-                                           uu____611;_}::[])::[],iopt,sorts,
-                                     {
-                                       FStar_SMTEncoding_Term.tm =
-                                         FStar_SMTEncoding_Term.App
-                                         (FStar_SMTEncoding_Term.Iff
-                                          ,l::r1::[]);
-                                       FStar_SMTEncoding_Term.freevars =
-                                         uu____616;
-                                       FStar_SMTEncoding_Term.rng = uu____617;_})
-                                    ->
-                                    let uu____636 =
-                                      aux default_msg None post_name_opt
-                                        labels1 r1 in
-                                    (match uu____636 with
-                                     | (labels2,r2) ->
-                                         let uu____647 =
-                                           let uu____648 =
-                                             let uu____649 =
-                                               let uu____659 =
-                                                 FStar_SMTEncoding_Util.norng
-                                                   FStar_SMTEncoding_Term.mk
-                                                   (FStar_SMTEncoding_Term.App
-                                                      (FStar_SMTEncoding_Term.Iff,
-                                                        [l; r2])) in
-                                               (FStar_SMTEncoding_Term.Forall,
-                                                 [[p]],
-                                                 (Some (Prims.parse_int "0")),
-                                                 sorts, uu____659) in
-                                             FStar_SMTEncoding_Term.Quant
-                                               uu____649 in
-                                           FStar_SMTEncoding_Term.mk
-                                             uu____648
-                                             q1.FStar_SMTEncoding_Term.rng in
-                                         (labels2, uu____647))
-                                | uu____668 -> (labels1, tm)) labels
-                           (conjuncts lhs1) in
-                       (match uu____597 with
-                        | (labels1,lhs_conjs) ->
-                            let uu____679 =
-                              aux default_msg None (Some post_name) labels1
-                                rhs1 in
-                            (match uu____679 with
-                             | (labels2,rhs2) ->
-                                 let body =
-                                   let uu____691 =
-                                     let uu____692 =
-                                       let uu____695 =
-                                         FStar_SMTEncoding_Term.mk_and_l
-                                           lhs_conjs
-                                           lhs1.FStar_SMTEncoding_Term.rng in
-                                       (uu____695, rhs2) in
-                                     FStar_SMTEncoding_Term.mkImp uu____692
-                                       rng in
-                                   FStar_All.pipe_right uu____691
-                                     (FStar_SMTEncoding_Term.abstr [names]) in
-                                 let q2 =
-                                   FStar_SMTEncoding_Term.mk
-                                     (FStar_SMTEncoding_Term.Quant
-                                        (FStar_SMTEncoding_Term.Forall, [],
-                                          None, [post], body))
-                                     q1.FStar_SMTEncoding_Term.rng in
-                                 (labels2, q2))))
-              | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Imp ,lhs::rhs::[]) ->
-                  let uu____710 =
-                    aux default_msg ropt post_name_opt labels rhs in
-                  (match uu____710 with
-                   | (labels1,rhs1) ->
-                       let uu____721 =
-                         FStar_SMTEncoding_Util.mkImp (lhs, rhs1) in
-                       (labels1, uu____721))
-              | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.And ,conjuncts1) ->
-                  let uu____726 =
-                    FStar_Util.fold_map (aux default_msg ropt post_name_opt)
-                      labels conjuncts1 in
-                  (match uu____726 with
-                   | (labels1,conjuncts2) ->
-                       let uu____741 =
-                         FStar_SMTEncoding_Term.mk_and_l conjuncts2
-                           q1.FStar_SMTEncoding_Term.rng in
-                       (labels1, uu____741))
-              | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.ITE ,hd1::q11::q2::[]) ->
-                  let uu____747 =
-                    aux default_msg ropt post_name_opt labels q11 in
-                  (match uu____747 with
-                   | (labels1,q12) ->
-                       let uu____758 =
-                         aux default_msg ropt post_name_opt labels1 q2 in
-                       (match uu____758 with
-                        | (labels2,q21) ->
-                            let uu____769 =
-                              FStar_SMTEncoding_Term.mkITE (hd1, q12, q21)
-                                q1.FStar_SMTEncoding_Term.rng in
-                            (labels2, uu____769)))
-              | FStar_SMTEncoding_Term.Quant
-                (FStar_SMTEncoding_Term.Exists ,_,_,_,_)
-                |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Iff ,_)
-                 |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Or ,_)
-                  ->
-                  let uu____783 =
-                    fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____783 with | (lab,q2) -> ((lab :: labels), q2))
-              | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Var uu____792,uu____793) when
-                  is_a_post_condition post_name_opt q1 -> (labels, q1)
-              | FStar_SMTEncoding_Term.FreeV _
-                |FStar_SMTEncoding_Term.App
-                 (FStar_SMTEncoding_Term.TrueOp ,_)
-                 |FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.FalseOp ,_)
-                  |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Not ,_)
-                   |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Eq ,_)
-                    |FStar_SMTEncoding_Term.App
-                     (FStar_SMTEncoding_Term.LT ,_)
-                     |FStar_SMTEncoding_Term.App
-                      (FStar_SMTEncoding_Term.LTE ,_)
-                      |FStar_SMTEncoding_Term.App
-                       (FStar_SMTEncoding_Term.GT ,_)
-                       |FStar_SMTEncoding_Term.App
-                        (FStar_SMTEncoding_Term.GTE ,_)
-                        |FStar_SMTEncoding_Term.App
-                        (FStar_SMTEncoding_Term.Var _,_)
-                  ->
-                  let uu____817 =
-                    fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____817 with | (lab,q2) -> ((lab :: labels), q2))
-              | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Add ,_)
-                |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Sub ,_)
-                 |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Div ,_)
-                  |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Mul ,_)
-                   |FStar_SMTEncoding_Term.App
-                    (FStar_SMTEncoding_Term.Minus ,_)
-                    |FStar_SMTEncoding_Term.App
-                    (FStar_SMTEncoding_Term.Mod ,_)
-                  -> failwith "Impossible: non-propositional term"
-              | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE ,_)
-                |FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp ,_)
-                  -> failwith "Impossible: arity mismatch"
-              | FStar_SMTEncoding_Term.Quant
-                  (FStar_SMTEncoding_Term.Forall ,pats,iopt,sorts,body) ->
-                  let uu____860 =
-                    aux default_msg ropt post_name_opt labels body in
-                  (match uu____860 with
-                   | (labels1,body1) ->
-                       let uu____871 =
-                         FStar_SMTEncoding_Term.mk
-                           (FStar_SMTEncoding_Term.Quant
-                              (FStar_SMTEncoding_Term.Forall, pats, iopt,
-                                sorts, body1)) q1.FStar_SMTEncoding_Term.rng in
-                       (labels1, uu____871))
-              | FStar_SMTEncoding_Term.Let (es,body) ->
-                  let uu____881 =
-                    aux default_msg ropt post_name_opt labels body in
-                  (match uu____881 with
-                   | (labels1,body1) ->
-                       let uu____892 =
-                         FStar_SMTEncoding_Term.mkLet (es, body1)
-                           q1.FStar_SMTEncoding_Term.rng in
-                       (labels1, uu____892)) in
-            aux "assertion failed" None None [] q
-let detail_errors:
-  FStar_TypeChecker_Env.env ->
-    labels ->
-      (FStar_SMTEncoding_Term.decls_t ->
-         ((FStar_SMTEncoding_Z3.unsat_core,(FStar_SMTEncoding_Term.error_labels*
-                                             FStar_SMTEncoding_Z3.error_kind))
-           FStar_Util.either* Prims.int))
-        -> FStar_SMTEncoding_Term.error_label Prims.list
-  =
-  fun env  ->
-    fun all_labels  ->
-      fun askZ3  ->
-        let print_banner uu____924 =
-          let uu____925 =
-            let uu____926 = FStar_TypeChecker_Env.get_range env in
-            FStar_Range.string_of_range uu____926 in
-          let uu____927 = FStar_Util.string_of_int (Prims.parse_int "5") in
-          let uu____928 =
-            FStar_Util.string_of_int (FStar_List.length all_labels) in
-          FStar_Util.print3_error
-            "Detailed error report follows for %s\nTaking %s seconds per proof obligation (%s proofs in total)\n"
-            uu____925 uu____927 uu____928 in
-        let print_result uu____940 =
-          match uu____940 with
-          | ((uu____946,msg,r),success) ->
-              if success
-              then
-                let uu____953 = FStar_Range.string_of_range r in
-                FStar_Util.print1_error
-                  "OK: proof obligation at %s was proven\n" uu____953
-              else FStar_Errors.report r msg in
-        let elim labs =
-          FStar_All.pipe_right labs
-            (FStar_List.map
-               (fun uu____984  ->
-                  match uu____984 with
-                  | (l,uu____991,uu____992) ->
-                      let uu____997 =
-                        let uu____1002 =
-                          let uu____1003 =
-                            let uu____1006 = FStar_SMTEncoding_Util.mkFreeV l in
-                            (uu____1006, FStar_SMTEncoding_Util.mkTrue) in
-                          FStar_SMTEncoding_Util.mkEq uu____1003 in
-                        (uu____1002, (Some "Disabling label"),
-                          (Some (Prims.strcat "disable_label_" (Prims.fst l)))) in
-                      FStar_SMTEncoding_Term.Assume uu____997)) in
-        let rec linear_check eliminated errors active =
-          match active with
-          | [] ->
-              let results =
-                let uu____1041 =
-                  FStar_List.map (fun x  -> (x, true)) eliminated in
-                let uu____1048 = FStar_List.map (fun x  -> (x, false)) errors in
-                FStar_List.append uu____1041 uu____1048 in
-              sort_labels results
-          | hd1::tl1 ->
-              ((let uu____1061 =
-                  FStar_Util.string_of_int (FStar_List.length active) in
-                FStar_Util.print1 "%s, " uu____1061);
-               FStar_SMTEncoding_Z3.refresh ();
-               (let uu____1066 =
-                  let uu____1073 =
-                    FStar_All.pipe_left elim
-                      (FStar_List.append eliminated
-                         (FStar_List.append errors tl1)) in
-                  askZ3 uu____1073 in
-                match uu____1066 with
-                | (result,uu____1088) ->
-                    let uu____1097 = FStar_Util.is_left result in
-                    if uu____1097
-                    then linear_check (hd1 :: eliminated) errors tl1
-                    else linear_check eliminated (hd1 :: errors) tl1)) in
-        print_banner ();
-        FStar_Options.set_option "z3rlimit"
-          (FStar_Options.Int (Prims.parse_int "5"));
-        (let res = linear_check [] [] all_labels in
-         FStar_Util.print_string "\n";
-         FStar_All.pipe_right res (FStar_List.iter print_result);
-         [])
+exception Not_a_wp_implication of (Prims.string)
+
+
+let uu___is_Not_a_wp_implication : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Not_a_wp_implication (uu____6) -> begin
+true
+end
+| uu____7 -> begin
+false
+end))
+
+
+let __proj__Not_a_wp_implication__item__uu___ : Prims.exn  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Not_a_wp_implication (uu____14) -> begin
+uu____14
+end))
+
+
+type label =
+FStar_SMTEncoding_Term.error_label
+
+
+type labels =
+FStar_SMTEncoding_Term.error_labels
+
+
+let sort_labels : (FStar_SMTEncoding_Term.error_label * Prims.bool) Prims.list  ->  ((FStar_SMTEncoding_Term.fv * Prims.string * FStar_Range.range) * Prims.bool) Prims.list = (fun l -> (FStar_List.sortWith (fun uu____35 uu____36 -> (match (((uu____35), (uu____36))) with
+| (((uu____57, uu____58, r1), uu____60), ((uu____61, uu____62, r2), uu____64)) -> begin
+(FStar_Range.compare r1 r2)
+end)) l))
+
+
+let remove_dups : labels  ->  (FStar_SMTEncoding_Term.fv * Prims.string * FStar_Range.range) Prims.list = (fun l -> (FStar_Util.remove_dups (fun uu____91 uu____92 -> (match (((uu____91), (uu____92))) with
+| ((uu____105, m1, r1), (uu____108, m2, r2)) -> begin
+((r1 = r2) && (m1 = m2))
+end)) l))
+
+
+type msg =
+(Prims.string * FStar_Range.range)
+
+
+type ranges =
+(Prims.string Prims.option * FStar_Range.range) Prims.list
+
+
+let fresh_label : Prims.string  ->  FStar_Range.range  ->  FStar_SMTEncoding_Term.term  ->  (label * FStar_SMTEncoding_Term.term) = (
+
+let ctr = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (fun message range t -> (
+
+let l = ((FStar_Util.incr ctr);
+(
+
+let uu____142 = (
+
+let uu____143 = (FStar_ST.read ctr)
+in (FStar_Util.string_of_int uu____143))
+in (FStar_Util.format1 "label_%s" uu____142));
+)
+in (
+
+let lvar = ((l), (FStar_SMTEncoding_Term.Bool_sort))
+in (
+
+let label = ((lvar), (message), (range))
+in (
+
+let lterm = (FStar_SMTEncoding_Util.mkFreeV lvar)
+in (
+
+let lt1 = (FStar_SMTEncoding_Term.mkOr ((lterm), (t)) range)
+in ((label), (lt1)))))))))
+
+
+let label_goals : (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_Range.range  ->  FStar_SMTEncoding_Term.term  ->  (labels * FStar_SMTEncoding_Term.term) = (fun use_env_msg r q -> (
+
+let rec is_a_post_condition = (fun post_name_opt tm -> (match (((post_name_opt), (tm.FStar_SMTEncoding_Term.tm))) with
+| (None, uu____194) -> begin
+false
+end
+| (Some (nm), FStar_SMTEncoding_Term.FreeV (nm', uu____198)) -> begin
+(nm = nm')
+end
+| ((_, FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var ("Valid"), (tm1)::[]))) | ((_, FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var ("ApplyTT"), (tm1)::_))) -> begin
+(is_a_post_condition post_name_opt tm1)
+end
+| uu____208 -> begin
+false
+end))
+in (
+
+let conjuncts = (fun t -> (match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And, cs) -> begin
+cs
+end
+| uu____221 -> begin
+(t)::[]
+end))
+in (
+
+let is_guard_free = (fun tm -> (match (tm.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, (({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var ("Prims.guard_free"), (p)::[]); FStar_SMTEncoding_Term.freevars = uu____227; FStar_SMTEncoding_Term.rng = uu____228})::[])::[], iopt, uu____230, {FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Iff, (l)::(r1)::[]); FStar_SMTEncoding_Term.freevars = uu____233; FStar_SMTEncoding_Term.rng = uu____234}) -> begin
+true
+end
+| uu____253 -> begin
+false
+end))
+in (
+
+let is_a_named_continuation = (fun lhs -> (FStar_All.pipe_right (conjuncts lhs) (FStar_Util.for_some is_guard_free)))
+in (
+
+let uu____259 = (match (use_env_msg) with
+| None -> begin
+((false), (""))
+end
+| Some (f) -> begin
+(
+
+let uu____271 = (f ())
+in ((true), (uu____271)))
+end)
+in (match (uu____259) with
+| (flag, msg_prefix) -> begin
+(
+
+let fresh_label1 = (fun msg ropt rng t -> (
+
+let msg1 = (match (flag) with
+| true -> begin
+(Prims.strcat "Failed to verify implicit argument: " msg)
+end
+| uu____294 -> begin
+msg
+end)
+in (
+
+let rng1 = (match (ropt) with
+| None -> begin
+rng
+end
+| Some (r1) -> begin
+(
+
+let uu___102_297 = r1
+in {FStar_Range.def_range = rng.FStar_Range.def_range; FStar_Range.use_range = uu___102_297.FStar_Range.use_range})
+end)
+in (fresh_label msg1 rng1 t))))
+in (
+
+let rec aux = (fun default_msg ropt post_name_opt labels q1 -> (match (q1.FStar_SMTEncoding_Term.tm) with
+| (FStar_SMTEncoding_Term.BoundV (_)) | (FStar_SMTEncoding_Term.Integer (_)) -> begin
+((labels), (q1))
+end
+| FStar_SMTEncoding_Term.LblPos (uu____329) -> begin
+(failwith "Impossible")
+end
+| FStar_SMTEncoding_Term.Labeled (arg, "could not prove post-condition", uu____336) -> begin
+(
+
+let fallback = (fun msg -> (aux default_msg ropt post_name_opt labels arg))
+in try
+(match (()) with
+| () -> begin
+(match (arg.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, pats, iopt, (post)::sorts, {FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (lhs)::(rhs)::[]); FStar_SMTEncoding_Term.freevars = uu____360; FStar_SMTEncoding_Term.rng = rng}) -> begin
+(
+
+let post_name = (
+
+let uu____376 = (
+
+let uu____377 = (FStar_Syntax_Syntax.next_id ())
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____377))
+in (Prims.strcat "^^post_condition_" uu____376))
+in (
+
+let names = (
+
+let uu____382 = (FStar_List.mapi (fun i s -> (
+
+let uu____390 = (
+
+let uu____391 = (FStar_Util.string_of_int i)
+in (Prims.strcat "^^" uu____391))
+in ((uu____390), (s)))) sorts)
+in (((post_name), (post)))::uu____382)
+in (
+
+let instantiation = (FStar_List.map FStar_SMTEncoding_Util.mkFreeV names)
+in (
+
+let uu____398 = (
+
+let uu____401 = (FStar_SMTEncoding_Term.inst instantiation lhs)
+in (
+
+let uu____402 = (FStar_SMTEncoding_Term.inst instantiation rhs)
+in ((uu____401), (uu____402))))
+in (match (uu____398) with
+| (lhs1, rhs1) -> begin
+(
+
+let uu____408 = (match (lhs1.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And, clauses_lhs) -> begin
+(
+
+let uu____418 = (FStar_Util.prefix clauses_lhs)
+in (match (uu____418) with
+| (req, ens) -> begin
+(match (ens.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, pats_ens, iopt_ens, sorts_ens, {FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (ensures_conjuncts)::(post1)::[]); FStar_SMTEncoding_Term.freevars = uu____437; FStar_SMTEncoding_Term.rng = rng_ens}) when (is_a_post_condition (Some (post_name)) post1) -> begin
+(
+
+let uu____452 = (aux "could not prove post-condition" None (Some (post_name)) labels ensures_conjuncts)
+in (match (uu____452) with
+| (labels1, ensures_conjuncts1) -> begin
+(
+
+let pats_ens1 = (match (pats_ens) with
+| ([]) | (([])::[]) -> begin
+((post1)::[])::[]
+end
+| uu____473 -> begin
+pats_ens
+end)
+in (
+
+let ens1 = (
+
+let uu____477 = (
+
+let uu____478 = (
+
+let uu____488 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.App (((FStar_SMTEncoding_Term.Imp), ((ensures_conjuncts1)::(post1)::[])))) rng_ens)
+in ((FStar_SMTEncoding_Term.Forall), (pats_ens1), (iopt_ens), (sorts_ens), (uu____488)))
+in FStar_SMTEncoding_Term.Quant (uu____478))
+in (FStar_SMTEncoding_Term.mk uu____477 ens.FStar_SMTEncoding_Term.rng))
+in (
+
+let lhs2 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.App (((FStar_SMTEncoding_Term.And), ((FStar_List.append req ((ens1)::[])))))) lhs1.FStar_SMTEncoding_Term.rng)
+in (
+
+let uu____496 = (FStar_SMTEncoding_Term.abstr names lhs2)
+in ((labels1), (uu____496))))))
+end))
+end
+| uu____498 -> begin
+(
+
+let uu____499 = (
+
+let uu____500 = (
+
+let uu____501 = (
+
+let uu____502 = (
+
+let uu____503 = (FStar_SMTEncoding_Term.print_smt_term ens)
+in (Prims.strcat "  ... " uu____503))
+in (Prims.strcat post_name uu____502))
+in (Prims.strcat "Ensures clause doesn\'t match post name:  " uu____501))
+in Not_a_wp_implication (uu____500))
+in (Prims.raise uu____499))
+end)
+end))
+end
+| uu____507 -> begin
+(
+
+let uu____508 = (
+
+let uu____509 = (
+
+let uu____510 = (FStar_SMTEncoding_Term.print_smt_term lhs1)
+in (Prims.strcat "LHS not a conjunct: " uu____510))
+in Not_a_wp_implication (uu____509))
+in (Prims.raise uu____508))
+end)
+in (match (uu____408) with
+| (labels1, lhs2) -> begin
+(
+
+let uu____521 = (
+
+let uu____525 = (aux default_msg None (Some (post_name)) labels1 rhs1)
+in (match (uu____525) with
+| (labels2, rhs2) -> begin
+(
+
+let uu____536 = (FStar_SMTEncoding_Term.abstr names rhs2)
+in ((labels2), (uu____536)))
+end))
+in (match (uu____521) with
+| (labels2, rhs2) -> begin
+(
+
+let body = (FStar_SMTEncoding_Term.mkImp ((lhs2), (rhs2)) rng)
+in (
+
+let uu____546 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.Quant (((FStar_SMTEncoding_Term.Forall), (pats), (iopt), ((post)::sorts), (body)))) q1.FStar_SMTEncoding_Term.rng)
+in ((labels2), (uu____546))))
+end))
+end))
+end)))))
+end
+| uu____552 -> begin
+(
+
+let uu____553 = (
+
+let uu____554 = (FStar_SMTEncoding_Term.print_smt_term arg)
+in (Prims.strcat "arg not a quant: " uu____554))
+in (fallback uu____553))
+end)
+end)
+with
+| Not_a_wp_implication (msg) -> begin
+(fallback msg)
+end)
+end
+| FStar_SMTEncoding_Term.Labeled (arg, reason, r1) -> begin
+(aux reason (Some (r1)) post_name_opt labels arg)
+end
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, [], None, (post)::[], {FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (lhs)::(rhs)::[]); FStar_SMTEncoding_Term.freevars = uu____566; FStar_SMTEncoding_Term.rng = rng}) when (is_a_named_continuation lhs) -> begin
+(
+
+let post_name = (
+
+let uu____579 = (
+
+let uu____580 = (FStar_Syntax_Syntax.next_id ())
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____580))
+in (Prims.strcat "^^post_condition_" uu____579))
+in (
+
+let names = ((post_name), (post))
+in (
+
+let instantiation = (
+
+let uu____586 = (FStar_SMTEncoding_Util.mkFreeV names)
+in (uu____586)::[])
+in (
+
+let uu____587 = (
+
+let uu____590 = (FStar_SMTEncoding_Term.inst instantiation lhs)
+in (
+
+let uu____591 = (FStar_SMTEncoding_Term.inst instantiation rhs)
+in ((uu____590), (uu____591))))
+in (match (uu____587) with
+| (lhs1, rhs1) -> begin
+(
+
+let uu____597 = (FStar_Util.fold_map (fun labels1 tm -> (match (tm.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, (({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var ("Prims.guard_free"), (p)::[]); FStar_SMTEncoding_Term.freevars = uu____610; FStar_SMTEncoding_Term.rng = uu____611})::[])::[], iopt, sorts, {FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Iff, (l)::(r1)::[]); FStar_SMTEncoding_Term.freevars = uu____616; FStar_SMTEncoding_Term.rng = uu____617}) -> begin
+(
+
+let uu____636 = (aux default_msg None post_name_opt labels1 r1)
+in (match (uu____636) with
+| (labels2, r2) -> begin
+(
+
+let uu____647 = (
+
+let uu____648 = (
+
+let uu____649 = (
+
+let uu____659 = (FStar_SMTEncoding_Util.norng FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.App (((FStar_SMTEncoding_Term.Iff), ((l)::(r2)::[])))))
+in ((FStar_SMTEncoding_Term.Forall), (((p)::[])::[]), (Some ((Prims.parse_int "0"))), (sorts), (uu____659)))
+in FStar_SMTEncoding_Term.Quant (uu____649))
+in (FStar_SMTEncoding_Term.mk uu____648 q1.FStar_SMTEncoding_Term.rng))
+in ((labels2), (uu____647)))
+end))
+end
+| uu____668 -> begin
+((labels1), (tm))
+end)) labels (conjuncts lhs1))
+in (match (uu____597) with
+| (labels1, lhs_conjs) -> begin
+(
+
+let uu____679 = (aux default_msg None (Some (post_name)) labels1 rhs1)
+in (match (uu____679) with
+| (labels2, rhs2) -> begin
+(
+
+let body = (
+
+let uu____691 = (
+
+let uu____692 = (
+
+let uu____695 = (FStar_SMTEncoding_Term.mk_and_l lhs_conjs lhs1.FStar_SMTEncoding_Term.rng)
+in ((uu____695), (rhs2)))
+in (FStar_SMTEncoding_Term.mkImp uu____692 rng))
+in (FStar_All.pipe_right uu____691 (FStar_SMTEncoding_Term.abstr ((names)::[]))))
+in (
+
+let q2 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.Quant (((FStar_SMTEncoding_Term.Forall), ([]), (None), ((post)::[]), (body)))) q1.FStar_SMTEncoding_Term.rng)
+in ((labels2), (q2))))
+end))
+end))
+end)))))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (lhs)::(rhs)::[]) -> begin
+(
+
+let uu____710 = (aux default_msg ropt post_name_opt labels rhs)
+in (match (uu____710) with
+| (labels1, rhs1) -> begin
+(
+
+let uu____721 = (FStar_SMTEncoding_Util.mkImp ((lhs), (rhs1)))
+in ((labels1), (uu____721)))
+end))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And, conjuncts1) -> begin
+(
+
+let uu____726 = (FStar_Util.fold_map (aux default_msg ropt post_name_opt) labels conjuncts1)
+in (match (uu____726) with
+| (labels1, conjuncts2) -> begin
+(
+
+let uu____741 = (FStar_SMTEncoding_Term.mk_and_l conjuncts2 q1.FStar_SMTEncoding_Term.rng)
+in ((labels1), (uu____741)))
+end))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE, (hd1)::(q11)::(q2)::[]) -> begin
+(
+
+let uu____747 = (aux default_msg ropt post_name_opt labels q11)
+in (match (uu____747) with
+| (labels1, q12) -> begin
+(
+
+let uu____758 = (aux default_msg ropt post_name_opt labels1 q2)
+in (match (uu____758) with
+| (labels2, q21) -> begin
+(
+
+let uu____769 = (FStar_SMTEncoding_Term.mkITE ((hd1), (q12), (q21)) q1.FStar_SMTEncoding_Term.rng)
+in ((labels2), (uu____769)))
+end))
+end))
+end
+| (FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Exists, _, _, _, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Iff, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Or, _)) -> begin
+(
+
+let uu____783 = (fresh_label1 default_msg ropt q1.FStar_SMTEncoding_Term.rng q1)
+in (match (uu____783) with
+| (lab, q2) -> begin
+(((lab)::labels), (q2))
+end))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var (uu____792), uu____793) when (is_a_post_condition post_name_opt q1) -> begin
+((labels), (q1))
+end
+| (FStar_SMTEncoding_Term.FreeV (_)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.TrueOp, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.FalseOp, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Not, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Eq, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.LT, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.LTE, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.GT, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.GTE, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var (_), _)) -> begin
+(
+
+let uu____817 = (fresh_label1 default_msg ropt q1.FStar_SMTEncoding_Term.rng q1)
+in (match (uu____817) with
+| (lab, q2) -> begin
+(((lab)::labels), (q2))
+end))
+end
+| (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Add, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Sub, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Div, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Mul, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Minus, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Mod, _)) -> begin
+(failwith "Impossible: non-propositional term")
+end
+| (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE, _)) | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, _)) -> begin
+(failwith "Impossible: arity mismatch")
+end
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, pats, iopt, sorts, body) -> begin
+(
+
+let uu____860 = (aux default_msg ropt post_name_opt labels body)
+in (match (uu____860) with
+| (labels1, body1) -> begin
+(
+
+let uu____871 = (FStar_SMTEncoding_Term.mk (FStar_SMTEncoding_Term.Quant (((FStar_SMTEncoding_Term.Forall), (pats), (iopt), (sorts), (body1)))) q1.FStar_SMTEncoding_Term.rng)
+in ((labels1), (uu____871)))
+end))
+end
+| FStar_SMTEncoding_Term.Let (es, body) -> begin
+(
+
+let uu____881 = (aux default_msg ropt post_name_opt labels body)
+in (match (uu____881) with
+| (labels1, body1) -> begin
+(
+
+let uu____892 = (FStar_SMTEncoding_Term.mkLet ((es), (body1)) q1.FStar_SMTEncoding_Term.rng)
+in ((labels1), (uu____892)))
+end))
+end))
+in (aux "assertion failed" None None [] q)))
+end)))))))
+
+
+let detail_errors : FStar_TypeChecker_Env.env  ->  labels  ->  (FStar_SMTEncoding_Term.decls_t  ->  ((FStar_SMTEncoding_Z3.unsat_core, (labels * FStar_SMTEncoding_Z3.error_kind)) FStar_Util.either * Prims.int))  ->  labels = (fun env all_labels askZ3 -> (
+
+let print_banner = (fun uu____924 -> (
+
+let uu____925 = (
+
+let uu____926 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_Range.string_of_range uu____926))
+in (
+
+let uu____927 = (FStar_Util.string_of_int (Prims.parse_int "5"))
+in (
+
+let uu____928 = (FStar_Util.string_of_int (FStar_List.length all_labels))
+in (FStar_Util.print3_error "Detailed error report follows for %s\nTaking %s seconds per proof obligation (%s proofs in total)\n" uu____925 uu____927 uu____928)))))
+in (
+
+let print_result = (fun uu____940 -> (match (uu____940) with
+| ((uu____946, msg, r), success) -> begin
+(match (success) with
+| true -> begin
+(
+
+let uu____953 = (FStar_Range.string_of_range r)
+in (FStar_Util.print1_error "OK: proof obligation at %s was proven\n" uu____953))
+end
+| uu____954 -> begin
+(FStar_Errors.report r msg)
+end)
+end))
+in (
+
+let elim = (fun labs -> (FStar_All.pipe_right labs (FStar_List.map (fun uu____984 -> (match (uu____984) with
+| (l, uu____991, uu____992) -> begin
+(
+
+let uu____997 = (
+
+let uu____1002 = (
+
+let uu____1003 = (
+
+let uu____1006 = (FStar_SMTEncoding_Util.mkFreeV l)
+in ((uu____1006), (FStar_SMTEncoding_Util.mkTrue)))
+in (FStar_SMTEncoding_Util.mkEq uu____1003))
+in ((uu____1002), (Some ("Disabling label")), (Some ((Prims.strcat "disable_label_" (Prims.fst l))))))
+in FStar_SMTEncoding_Term.Assume (uu____997))
+end)))))
+in (
+
+let rec linear_check = (fun eliminated errors active -> (match (active) with
+| [] -> begin
+(
+
+let results = (
+
+let uu____1041 = (FStar_List.map (fun x -> ((x), (true))) eliminated)
+in (
+
+let uu____1048 = (FStar_List.map (fun x -> ((x), (false))) errors)
+in (FStar_List.append uu____1041 uu____1048)))
+in (sort_labels results))
+end
+| (hd1)::tl1 -> begin
+((
+
+let uu____1061 = (FStar_Util.string_of_int (FStar_List.length active))
+in (FStar_Util.print1 "%s, " uu____1061));
+(FStar_SMTEncoding_Z3.refresh ());
+(
+
+let uu____1066 = (
+
+let uu____1073 = (FStar_All.pipe_left elim (FStar_List.append eliminated (FStar_List.append errors tl1)))
+in (askZ3 uu____1073))
+in (match (uu____1066) with
+| (result, uu____1088) -> begin
+(
+
+let uu____1097 = (FStar_Util.is_left result)
+in (match (uu____1097) with
+| true -> begin
+(linear_check ((hd1)::eliminated) errors tl1)
+end
+| uu____1106 -> begin
+(linear_check eliminated ((hd1)::errors) tl1)
+end))
+end));
+)
+end))
+in ((print_banner ());
+(FStar_Options.set_option "z3rlimit" (FStar_Options.Int ((Prims.parse_int "5"))));
+(
+
+let res = (linear_check [] [] all_labels)
+in ((FStar_Util.print_string "\n");
+(FStar_All.pipe_right res (FStar_List.iter print_result));
+[];
+));
+))))))
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_Solver.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Solver.ml
@@ -1,685 +1,947 @@
+
 open Prims
+
 type z3_err =
-  (FStar_SMTEncoding_Term.error_labels* FStar_SMTEncoding_Z3.error_kind)
-type z3_result = (FStar_SMTEncoding_Z3.unsat_core,z3_err) FStar_Util.either
+(FStar_SMTEncoding_Term.error_labels * FStar_SMTEncoding_Z3.error_kind)
+
+
+type z3_result =
+(FStar_SMTEncoding_Z3.unsat_core, z3_err) FStar_Util.either
+
+
 type z3_replay_result =
-  (FStar_SMTEncoding_Z3.unsat_core,FStar_SMTEncoding_Term.error_labels)
-    FStar_Util.either
-let z3_result_as_replay_result uu___91_23 =
-  match uu___91_23 with
-  | FStar_Util.Inl l -> FStar_Util.Inl l
-  | FStar_Util.Inr (r,uu____32) -> FStar_Util.Inr r
+(FStar_SMTEncoding_Z3.unsat_core, FStar_SMTEncoding_Term.error_labels) FStar_Util.either
+
+
+let z3_result_as_replay_result = (fun uu___91_23 -> (match (uu___91_23) with
+| FStar_Util.Inl (l) -> begin
+FStar_Util.Inl (l)
+end
+| FStar_Util.Inr (r, uu____32) -> begin
+FStar_Util.Inr (r)
+end))
+
 type hint_stat =
-  {
-  hint: FStar_Util.hint Prims.option;
-  replay_result: z3_replay_result;
-  elapsed_time: Prims.int;
-  source_location: FStar_Range.range;}
-type hint_stats_t = hint_stat Prims.list
-let recorded_hints: FStar_Util.hints Prims.option FStar_ST.ref =
-  FStar_Util.mk_ref None
-let replaying_hints: FStar_Util.hints Prims.option FStar_ST.ref =
-  FStar_Util.mk_ref None
-let hint_stats: hint_stat Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let format_hints_file_name: Prims.string -> Prims.string =
-  fun src_filename  -> FStar_Util.format1 "%s.hints" src_filename
-let initialize_hints_db src_filename force_record =
-  FStar_ST.write hint_stats [];
-  (let uu____102 = FStar_Options.record_hints () in
-   if uu____102 then FStar_ST.write recorded_hints (Some []) else ());
-  (let uu____110 = FStar_Options.use_hints () in
-   if uu____110
-   then
-     let norm_src_filename = FStar_Util.normalize_file_path src_filename in
-     let val_filename = format_hints_file_name norm_src_filename in
-     let uu____113 = FStar_Util.read_hints val_filename in
-     match uu____113 with
-     | Some hints ->
-         let expected_digest = FStar_Util.digest_of_file norm_src_filename in
-         ((let uu____118 = FStar_Options.hint_info () in
-           if uu____118
-           then
-             (if hints.FStar_Util.module_digest = expected_digest
-              then
-                FStar_Util.print1 "(%s) digest is valid; using hints db.\n"
-                  norm_src_filename
-              else
-                FStar_Util.print1
-                  "(%s) digest is invalid; using potentially stale hints\n"
-                  norm_src_filename)
-           else ());
-          FStar_ST.write replaying_hints (Some (hints.FStar_Util.hints)))
-     | None  ->
-         let uu____124 = FStar_Options.hint_info () in
-         (if uu____124
-          then
-            FStar_Util.print1 "(%s) Unable to read hints db.\n"
-              norm_src_filename
-          else ())
-   else ())
-let finalize_hints_db: Prims.string -> Prims.unit =
-  fun src_filename  ->
-    (let uu____131 = FStar_Options.record_hints () in
-     if uu____131
-     then
-       let hints =
-         let uu____133 = FStar_ST.read recorded_hints in
-         FStar_Option.get uu____133 in
-       let hints_db =
-         let uu____139 = FStar_Util.digest_of_file src_filename in
-         { FStar_Util.module_digest = uu____139; FStar_Util.hints = hints } in
-       let hints_file_name = format_hints_file_name src_filename in
-       FStar_Util.write_hints hints_file_name hints_db
-     else ());
-    (let uu____143 = FStar_Options.hint_info () in
-     if uu____143
-     then
-       let stats =
-         let uu____146 = FStar_ST.read hint_stats in
-         FStar_All.pipe_right uu____146 FStar_List.rev in
-       FStar_All.pipe_right stats
-         (FStar_List.iter
-            (fun s  ->
-               match s.replay_result with
-               | FStar_Util.Inl _unsat_core ->
-                   let uu____156 =
-                     FStar_Range.string_of_range s.source_location in
-                   let uu____157 = FStar_Util.string_of_int s.elapsed_time in
-                   FStar_Util.print2
-                     "Hint-info (%s): Replay succeeded in %s milliseconds\n"
-                     uu____156 uu____157
-               | FStar_Util.Inr _error ->
-                   let uu____159 =
-                     FStar_Range.string_of_range s.source_location in
-                   let uu____160 = FStar_Util.string_of_int s.elapsed_time in
-                   FStar_Util.print2
-                     "Hint-info (%s): Replay failed in %s milliseconds\n"
-                     uu____159 uu____160))
-     else ());
-    FStar_ST.write recorded_hints None;
-    FStar_ST.write replaying_hints None;
-    FStar_ST.write hint_stats []
-let with_hints_db fname f =
-  initialize_hints_db fname false;
-  (let result = f () in finalize_hints_db fname; result)
-let next_hint: Prims.string -> Prims.int -> FStar_Util.hint Prims.option =
-  fun qname  ->
-    fun qindex  ->
-      let uu____200 = FStar_ST.read replaying_hints in
-      match uu____200 with
-      | Some hints ->
-          FStar_Util.find_map hints
-            (fun uu___92_208  ->
-               match uu___92_208 with
-               | Some hint when
-                   (hint.FStar_Util.hint_name = qname) &&
-                     (hint.FStar_Util.hint_index = qindex)
-                   -> Some hint
-               | uu____212 -> None)
-      | uu____214 -> None
-let record_hint: FStar_Util.hint Prims.option -> Prims.unit =
-  fun hint  ->
-    let hint1 =
-      match hint with
-      | None  -> None
-      | Some h ->
-          Some
-            (let uu___94_225 = h in
-             {
-               FStar_Util.hint_name = (uu___94_225.FStar_Util.hint_name);
-               FStar_Util.hint_index = (uu___94_225.FStar_Util.hint_index);
-               FStar_Util.fuel = (uu___94_225.FStar_Util.fuel);
-               FStar_Util.ifuel = (uu___94_225.FStar_Util.ifuel);
-               FStar_Util.unsat_core = (uu___94_225.FStar_Util.unsat_core);
-               FStar_Util.query_elapsed_time = (Prims.parse_int "0")
-             }) in
-    let uu____226 = FStar_ST.read recorded_hints in
-    match uu____226 with
-    | Some l ->
-        FStar_ST.write recorded_hints (Some (FStar_List.append l [hint1]))
-    | uu____240 -> ()
-let record_hint_stat:
-  FStar_Util.hint Prims.option ->
-    z3_result -> Prims.int -> FStar_Range.range -> Prims.unit
-  =
-  fun h  ->
-    fun res  ->
-      fun time  ->
-        fun r  ->
-          let s =
-            {
-              hint = h;
-              replay_result = (z3_result_as_replay_result res);
-              elapsed_time = time;
-              source_location = r
-            } in
-          let uu____257 =
-            let uu____259 = FStar_ST.read hint_stats in s :: uu____259 in
-          FStar_ST.write hint_stats uu____257
-let ask_and_report_errors:
-  FStar_TypeChecker_Env.env ->
-    ((FStar_SMTEncoding_Z3.label* FStar_SMTEncoding_Term.sort)* Prims.string*
-      FStar_Range.range) Prims.list ->
-      FStar_SMTEncoding_Term.decl Prims.list ->
-        FStar_SMTEncoding_Term.decl ->
-          FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit
-  =
-  fun env  ->
-    fun all_labels  ->
-      fun prefix1  ->
-        fun query  ->
-          fun suffix  ->
-            FStar_SMTEncoding_Z3.giveZ3 prefix1;
-            (let uu____299 =
-               match env.FStar_TypeChecker_Env.qname_and_index with
-               | None  -> failwith "No query name set!"
-               | Some (q,n1) -> ((FStar_Ident.text_of_lid q), n1) in
-             match uu____299 with
-             | (query_name,query_index) ->
-                 let minimum_workable_fuel = FStar_Util.mk_ref None in
-                 let set_minimum_workable_fuel f uu___93_355 =
-                   match uu___93_355 with
-                   | ([],uu____362) -> ()
-                   | errs ->
-                       let uu____368 = FStar_ST.read minimum_workable_fuel in
-                       (match uu____368 with
-                        | Some uu____389 -> ()
-                        | None  ->
-                            FStar_ST.write minimum_workable_fuel
-                              (Some (f, errs))) in
-                 let with_fuel label_assumptions p uu____453 =
-                   match uu____453 with
-                   | (n1,i,rlimit) ->
-                       let uu____462 =
-                         let uu____464 =
-                           let uu____465 =
-                             let uu____466 = FStar_Util.string_of_int n1 in
-                             let uu____467 = FStar_Util.string_of_int i in
-                             FStar_Util.format2 "<fuel='%s' ifuel='%s'>"
-                               uu____466 uu____467 in
-                           FStar_SMTEncoding_Term.Caption uu____465 in
-                         let uu____468 =
-                           let uu____470 =
-                             let uu____471 =
-                               let uu____476 =
-                                 let uu____477 =
-                                   let uu____480 =
-                                     FStar_SMTEncoding_Util.mkApp
-                                       ("MaxFuel", []) in
-                                   let uu____482 =
-                                     FStar_SMTEncoding_Term.n_fuel n1 in
-                                   (uu____480, uu____482) in
-                                 FStar_SMTEncoding_Util.mkEq uu____477 in
-                               (uu____476, None, None) in
-                             FStar_SMTEncoding_Term.Assume uu____471 in
-                           let uu____485 =
-                             let uu____487 =
-                               let uu____488 =
-                                 let uu____493 =
-                                   let uu____494 =
-                                     let uu____497 =
-                                       FStar_SMTEncoding_Util.mkApp
-                                         ("MaxIFuel", []) in
-                                     let uu____499 =
-                                       FStar_SMTEncoding_Term.n_fuel i in
-                                     (uu____497, uu____499) in
-                                   FStar_SMTEncoding_Util.mkEq uu____494 in
-                                 (uu____493, None, None) in
-                               FStar_SMTEncoding_Term.Assume uu____488 in
-                             [uu____487; p] in
-                           uu____470 :: uu____485 in
-                         uu____464 :: uu____468 in
-                       let uu____502 =
-                         let uu____504 =
-                           let uu____506 =
-                             let uu____508 =
-                               let uu____509 =
-                                 let uu____512 =
-                                   FStar_Util.string_of_int rlimit in
-                                 ("rlimit", uu____512) in
-                               FStar_SMTEncoding_Term.SetOption uu____509 in
-                             [uu____508] in
-                           let uu____513 =
-                             let uu____515 =
-                               let uu____517 =
-                                 let uu____519 =
-                                   FStar_Options.record_hints () in
-                                 if uu____519
-                                 then [FStar_SMTEncoding_Term.GetUnsatCore]
-                                 else [] in
-                               FStar_List.append uu____517 suffix in
-                             FStar_List.append
-                               [FStar_SMTEncoding_Term.CheckSat] uu____515 in
-                           FStar_List.append uu____506 uu____513 in
-                         FStar_List.append label_assumptions uu____504 in
-                       FStar_List.append uu____462 uu____502 in
-                 let check p =
-                   let rlimit =
-                     let uu____527 = FStar_Options.z3_rlimit () in
-                     uu____527 * (Prims.parse_int "544656") in
-                   let default_initial_config =
-                     let uu____532 = FStar_Options.initial_fuel () in
-                     let uu____533 = FStar_Options.initial_ifuel () in
-                     (uu____532, uu____533, rlimit) in
-                   let hint_opt = next_hint query_name query_index in
-                   let uu____536 =
-                     match hint_opt with
-                     | None  -> (None, default_initial_config)
-                     | Some hint ->
-                         let uu____558 =
-                           if FStar_Option.isSome hint.FStar_Util.unsat_core
-                           then ((hint.FStar_Util.unsat_core), rlimit)
-                           else
-                             (None,
-                               ((Prims.parse_int "60") *
-                                  (Prims.parse_int "544656"))) in
-                         (match uu____558 with
-                          | (core,timeout) ->
-                              (core,
-                                ((hint.FStar_Util.fuel),
-                                  (hint.FStar_Util.ifuel), timeout))) in
-                   match uu____536 with
-                   | (unsat_core,initial_config) ->
-                       let alt_configs =
-                         let uu____609 =
-                           let uu____615 =
-                             let uu____621 =
-                               let uu____626 =
-                                 let uu____627 = FStar_Options.max_ifuel () in
-                                 let uu____628 =
-                                   FStar_Options.initial_ifuel () in
-                                 uu____627 > uu____628 in
-                               if uu____626
-                               then
-                                 let uu____633 =
-                                   let uu____637 =
-                                     FStar_Options.initial_fuel () in
-                                   let uu____638 = FStar_Options.max_ifuel () in
-                                   (uu____637, uu____638, rlimit) in
-                                 [uu____633]
-                               else [] in
-                             let uu____649 =
-                               let uu____655 =
-                                 let uu____660 =
-                                   let uu____661 =
-                                     let uu____662 =
-                                       FStar_Options.max_fuel () in
-                                     uu____662 / (Prims.parse_int "2") in
-                                   let uu____666 =
-                                     FStar_Options.initial_fuel () in
-                                   uu____661 > uu____666 in
-                                 if uu____660
-                                 then
-                                   let uu____671 =
-                                     let uu____675 =
-                                       let uu____676 =
-                                         FStar_Options.max_fuel () in
-                                       uu____676 / (Prims.parse_int "2") in
-                                     let uu____680 =
-                                       FStar_Options.max_ifuel () in
-                                     (uu____675, uu____680, rlimit) in
-                                   [uu____671]
-                                 else [] in
-                               let uu____691 =
-                                 let uu____697 =
-                                   let uu____702 =
-                                     (let uu____703 =
-                                        FStar_Options.max_fuel () in
-                                      let uu____704 =
-                                        FStar_Options.initial_fuel () in
-                                      uu____703 > uu____704) &&
-                                       (let uu____705 =
-                                          FStar_Options.max_ifuel () in
-                                        let uu____706 =
-                                          FStar_Options.initial_ifuel () in
-                                        uu____705 > uu____706) in
-                                   if uu____702
-                                   then
-                                     let uu____711 =
-                                       let uu____715 =
-                                         FStar_Options.max_fuel () in
-                                       let uu____716 =
-                                         FStar_Options.max_ifuel () in
-                                       (uu____715, uu____716, rlimit) in
-                                     [uu____711]
-                                   else [] in
-                                 let uu____727 =
-                                   let uu____733 =
-                                     let uu____738 =
-                                       let uu____739 =
-                                         FStar_Options.min_fuel () in
-                                       let uu____740 =
-                                         FStar_Options.initial_fuel () in
-                                       uu____739 < uu____740 in
-                                     if uu____738
-                                     then
-                                       let uu____745 =
-                                         let uu____749 =
-                                           FStar_Options.min_fuel () in
-                                         (uu____749, (Prims.parse_int "1"),
-                                           rlimit) in
-                                       [uu____745]
-                                     else [] in
-                                   [uu____733] in
-                                 uu____697 :: uu____727 in
-                               uu____655 :: uu____691 in
-                             uu____621 :: uu____649 in
-                           (if
-                              (default_initial_config <> initial_config) ||
-                                (FStar_Option.isSome unsat_core)
-                            then [default_initial_config]
-                            else []) :: uu____615 in
-                         FStar_List.flatten uu____609 in
-                       let report1 p1 errs =
-                         let errs1 =
-                           let uu____813 =
-                             (FStar_Options.detail_errors ()) &&
-                               (let uu____814 = FStar_Options.n_cores () in
-                                uu____814 = (Prims.parse_int "1")) in
-                           if uu____813
-                           then
-                             let uu____815 =
-                               let uu____824 =
-                                 FStar_ST.read minimum_workable_fuel in
-                               match uu____824 with
-                               | Some (f,errs1) -> (f, errs1)
-                               | None  ->
-                                   let uu____889 =
-                                     let uu____893 =
-                                       FStar_Options.min_fuel () in
-                                     (uu____893, (Prims.parse_int "1"),
-                                       rlimit) in
-                                   (uu____889, errs) in
-                             match uu____815 with
-                             | (min_fuel1,potential_errors) ->
-                                 let ask_z3 label_assumptions =
-                                   let res = FStar_Util.mk_ref None in
-                                   (let uu____947 =
-                                      with_fuel label_assumptions p1
-                                        min_fuel1 in
-                                    FStar_SMTEncoding_Z3.ask None all_labels
-                                      uu____947 None
-                                      (fun r  -> FStar_ST.write res (Some r)));
-                                   (let uu____972 = FStar_ST.read res in
-                                    FStar_Option.get uu____972) in
-                                 let uu____995 =
-                                   FStar_SMTEncoding_ErrorReporting.detail_errors
-                                     env all_labels ask_z3 in
-                                 (uu____995, FStar_SMTEncoding_Z3.Default)
-                           else
-                             (match errs with
-                              | ([],FStar_SMTEncoding_Z3.Timeout ) ->
-                                  ([(("", FStar_SMTEncoding_Term.Term_sort),
-                                      "Timeout: Unknown assertion failed",
-                                      FStar_Range.dummyRange)],
-                                    (Prims.snd errs))
-                              | ([],FStar_SMTEncoding_Z3.Default ) ->
-                                  ([(("", FStar_SMTEncoding_Term.Term_sort),
-                                      "Unknown assertion failed",
-                                      FStar_Range.dummyRange)],
-                                    (Prims.snd errs))
-                              | (uu____1035,FStar_SMTEncoding_Z3.Kill ) ->
-                                  ([(("", FStar_SMTEncoding_Term.Term_sort),
-                                      "Killed: Unknown assertion failed",
-                                      FStar_Range.dummyRange)],
-                                    (Prims.snd errs))
-                              | uu____1054 -> errs) in
-                         record_hint None;
-                         (let uu____1057 = FStar_Options.print_fuels () in
-                          if uu____1057
-                          then
-                            let uu____1058 =
-                              let uu____1059 =
-                                FStar_TypeChecker_Env.get_range env in
-                              FStar_Range.string_of_range uu____1059 in
-                            let uu____1060 =
-                              let uu____1061 = FStar_Options.max_fuel () in
-                              FStar_All.pipe_right uu____1061
-                                FStar_Util.string_of_int in
-                            let uu____1062 =
-                              let uu____1063 = FStar_Options.max_ifuel () in
-                              FStar_All.pipe_right uu____1063
-                                FStar_Util.string_of_int in
-                            FStar_Util.print3
-                              "(%s) Query failed with maximum fuel %s and ifuel %s\n"
-                              uu____1058 uu____1060 uu____1062
-                          else ());
-                         (let uu____1065 =
-                            FStar_All.pipe_right (Prims.fst errs1)
-                              (FStar_List.map
-                                 (fun uu____1077  ->
-                                    match uu____1077 with
-                                    | (uu____1083,x,y) -> (x, y))) in
-                          FStar_TypeChecker_Err.add_errors env uu____1065) in
-                       let use_errors errs result =
-                         match (errs, result) with
-                         | (([],_),_)|(_,FStar_Util.Inl _) -> result
-                         | (uu____1111,FStar_Util.Inr uu____1112) ->
-                             FStar_Util.Inr errs in
-                       let rec try_alt_configs prev_f p1 errs cfgs scope =
-                         set_minimum_workable_fuel prev_f errs;
-                         (match (cfgs, (Prims.snd errs)) with
-                          | ([],_)|(_,FStar_SMTEncoding_Z3.Kill ) ->
-                              report1 p1 errs
-                          | (mi::[],uu____1196) ->
-                              (match errs with
-                               | ([],uu____1210) ->
-                                   let uu____1212 = with_fuel [] p1 mi in
-                                   FStar_SMTEncoding_Z3.ask None all_labels
-                                     uu____1212 (Some scope)
-                                     (cb false mi p1 [] scope)
-                               | uu____1218 ->
-                                   (set_minimum_workable_fuel prev_f errs;
-                                    report1 p1 errs))
-                          | (mi::tl1,uu____1222) ->
-                              let uu____1237 = with_fuel [] p1 mi in
-                              FStar_SMTEncoding_Z3.ask None all_labels
-                                uu____1237 (Some scope)
-                                (fun uu____1240  ->
-                                   match uu____1240 with
-                                   | (result,elapsed_time) ->
-                                       let uu____1257 =
-                                         let uu____1264 =
-                                           use_errors errs result in
-                                         (uu____1264, elapsed_time) in
-                                       cb false mi p1 tl1 scope uu____1257))
-                       and cb used_hint uu____1266 p1 alt scope uu____1270 =
-                         match (uu____1266, uu____1270) with
-                         | ((prev_fuel,prev_ifuel,timeout),(result,elapsed_time))
-                             ->
-                             (if used_hint
-                              then
-                                (FStar_SMTEncoding_Z3.refresh ();
-                                 (let uu____1317 =
-                                    FStar_TypeChecker_Env.get_range env in
-                                  record_hint_stat hint_opt result
-                                    elapsed_time uu____1317))
-                              else ();
-                              (let uu____1320 =
-                                 (FStar_Options.z3_refresh ()) ||
-                                   (FStar_Options.print_z3_statistics ()) in
-                               if uu____1320
-                               then FStar_SMTEncoding_Z3.refresh ()
-                               else ());
-                              (let query_info tag =
-                                 let uu____1326 =
-                                   let uu____1328 =
-                                     let uu____1329 =
-                                       FStar_TypeChecker_Env.get_range env in
-                                     FStar_Range.string_of_range uu____1329 in
-                                   let uu____1330 =
-                                     let uu____1332 =
-                                       FStar_SMTEncoding_Z3.at_log_file () in
-                                     let uu____1333 =
-                                       let uu____1335 =
-                                         let uu____1337 =
-                                           FStar_Util.string_of_int
-                                             query_index in
-                                         let uu____1338 =
-                                           let uu____1340 =
-                                             let uu____1342 =
-                                               let uu____1344 =
-                                                 FStar_Util.string_of_int
-                                                   elapsed_time in
-                                               let uu____1345 =
-                                                 let uu____1347 =
-                                                   FStar_Util.string_of_int
-                                                     prev_fuel in
-                                                 let uu____1348 =
-                                                   let uu____1350 =
-                                                     FStar_Util.string_of_int
-                                                       prev_ifuel in
-                                                   [uu____1350] in
-                                                 uu____1347 :: uu____1348 in
-                                               uu____1344 :: uu____1345 in
-                                             (if used_hint
-                                              then " (with hint)"
-                                              else "") :: uu____1342 in
-                                           tag :: uu____1340 in
-                                         uu____1337 :: uu____1338 in
-                                       query_name :: uu____1335 in
-                                     uu____1332 :: uu____1333 in
-                                   uu____1328 :: uu____1330 in
-                                 FStar_Util.print
-                                   "(%s%s)\n\tQuery (%s, %s)\t%s%s in %s milliseconds with fuel %s and ifuel %s\n"
-                                   uu____1326 in
-                               match result with
-                               | FStar_Util.Inl unsat_core1 ->
-                                   (if Prims.op_Negation used_hint
-                                    then
-                                      (let hint =
-                                         {
-                                           FStar_Util.hint_name = query_name;
-                                           FStar_Util.hint_index =
-                                             query_index;
-                                           FStar_Util.fuel = prev_fuel;
-                                           FStar_Util.ifuel = prev_ifuel;
-                                           FStar_Util.unsat_core =
-                                             unsat_core1;
-                                           FStar_Util.query_elapsed_time =
-                                             elapsed_time
-                                         } in
-                                       record_hint (Some hint))
-                                    else record_hint hint_opt;
-                                    (let uu____1358 =
-                                       (FStar_Options.print_fuels ()) ||
-                                         (FStar_Options.hint_info ()) in
-                                     if uu____1358
-                                     then query_info "succeeded"
-                                     else ()))
-                               | FStar_Util.Inr errs ->
-                                   ((let uu____1366 =
-                                       (FStar_Options.print_fuels ()) ||
-                                         (FStar_Options.hint_info ()) in
-                                     if uu____1366
-                                     then query_info "failed"
-                                     else ());
-                                    try_alt_configs
-                                      (prev_fuel, prev_ifuel, timeout) p1
-                                      errs alt scope))) in
-                       (if FStar_Option.isSome unsat_core
-                        then FStar_SMTEncoding_Z3.refresh ()
-                        else ();
-                        (let uu____1371 = with_fuel [] p initial_config in
-                         let uu____1373 =
-                           let uu____1382 =
-                             FStar_ST.read FStar_SMTEncoding_Z3.fresh_scope in
-                           cb (FStar_Option.isSome unsat_core) initial_config
-                             p alt_configs uu____1382 in
-                         FStar_SMTEncoding_Z3.ask unsat_core all_labels
-                           uu____1371 None uu____1373)) in
-                 let process_query q =
-                   let uu____1392 =
-                     let uu____1393 = FStar_Options.split_cases () in
-                     uu____1393 > (Prims.parse_int "0") in
-                   if uu____1392
-                   then
-                     let uu____1394 =
-                       let uu____1403 = FStar_Options.split_cases () in
-                       FStar_SMTEncoding_SplitQueryCases.can_handle_query
-                         uu____1403 q in
-                     match uu____1394 with
-                     | (b,cb) ->
-                         (if b
-                          then
-                            FStar_SMTEncoding_SplitQueryCases.handle_query cb
-                              check
-                          else check q)
-                   else check q in
-                 let uu____1420 = FStar_Options.admit_smt_queries () in
-                 if uu____1420 then () else process_query query)
-let solve:
-  (Prims.unit -> Prims.string) Prims.option ->
-    FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.unit
-  =
-  fun use_env_msg  ->
-    fun tcenv  ->
-      fun q  ->
-        (let uu____1439 =
-           let uu____1440 =
-             let uu____1441 = FStar_TypeChecker_Env.get_range tcenv in
-             FStar_All.pipe_left FStar_Range.string_of_range uu____1441 in
-           FStar_Util.format1 "Starting query at %s" uu____1440 in
-         FStar_SMTEncoding_Encode.push uu____1439);
-        (let tcenv1 = FStar_TypeChecker_Env.incr_query_index tcenv in
-         let uu____1443 =
-           FStar_SMTEncoding_Encode.encode_query use_env_msg tcenv1 q in
-         match uu____1443 with
-         | (prefix1,labels,qry,suffix) ->
-             let pop1 uu____1464 =
-               let uu____1465 =
-                 let uu____1466 =
-                   let uu____1467 = FStar_TypeChecker_Env.get_range tcenv1 in
-                   FStar_All.pipe_left FStar_Range.string_of_range uu____1467 in
-                 FStar_Util.format1 "Ending query at %s" uu____1466 in
-               FStar_SMTEncoding_Encode.pop uu____1465 in
-             (match qry with
-              | FStar_SMTEncoding_Term.Assume
-                  ({
-                     FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
-                       (FStar_SMTEncoding_Term.FalseOp ,uu____1468);
-                     FStar_SMTEncoding_Term.freevars = uu____1469;
-                     FStar_SMTEncoding_Term.rng = uu____1470;_},uu____1471,uu____1472)
-                  -> pop1 ()
-              | uu____1482 when tcenv1.FStar_TypeChecker_Env.admit -> pop1 ()
-              | FStar_SMTEncoding_Term.Assume (q1,uu____1485,uu____1486) ->
-                  (ask_and_report_errors tcenv1 labels prefix1 qry suffix;
-                   pop1 ())
-              | uu____1490 -> failwith "Impossible"))
-let solver: FStar_TypeChecker_Env.solver_t =
-  {
-    FStar_TypeChecker_Env.init = FStar_SMTEncoding_Encode.init;
-    FStar_TypeChecker_Env.push = FStar_SMTEncoding_Encode.push;
-    FStar_TypeChecker_Env.pop = FStar_SMTEncoding_Encode.pop;
-    FStar_TypeChecker_Env.mark = FStar_SMTEncoding_Encode.mark;
-    FStar_TypeChecker_Env.reset_mark = FStar_SMTEncoding_Encode.reset_mark;
-    FStar_TypeChecker_Env.commit_mark = FStar_SMTEncoding_Encode.commit_mark;
-    FStar_TypeChecker_Env.encode_modul =
-      FStar_SMTEncoding_Encode.encode_modul;
-    FStar_TypeChecker_Env.encode_sig = FStar_SMTEncoding_Encode.encode_sig;
-    FStar_TypeChecker_Env.preprocess = (fun e  -> fun g  -> [(e, g)]);
-    FStar_TypeChecker_Env.solve = solve;
-    FStar_TypeChecker_Env.is_trivial = FStar_SMTEncoding_Encode.is_trivial;
-    FStar_TypeChecker_Env.finish = FStar_SMTEncoding_Z3.finish;
-    FStar_TypeChecker_Env.refresh = FStar_SMTEncoding_Z3.refresh
-  }
-let dummy: FStar_TypeChecker_Env.solver_t =
-  {
-    FStar_TypeChecker_Env.init = (fun uu____1497  -> ());
-    FStar_TypeChecker_Env.push = (fun uu____1498  -> ());
-    FStar_TypeChecker_Env.pop = (fun uu____1499  -> ());
-    FStar_TypeChecker_Env.mark = (fun uu____1500  -> ());
-    FStar_TypeChecker_Env.reset_mark = (fun uu____1501  -> ());
-    FStar_TypeChecker_Env.commit_mark = (fun uu____1502  -> ());
-    FStar_TypeChecker_Env.encode_modul =
-      (fun uu____1503  -> fun uu____1504  -> ());
-    FStar_TypeChecker_Env.encode_sig =
-      (fun uu____1505  -> fun uu____1506  -> ());
-    FStar_TypeChecker_Env.preprocess = (fun e  -> fun g  -> [(e, g)]);
-    FStar_TypeChecker_Env.solve =
-      (fun uu____1513  -> fun uu____1514  -> fun uu____1515  -> ());
-    FStar_TypeChecker_Env.is_trivial =
-      (fun uu____1519  -> fun uu____1520  -> false);
-    FStar_TypeChecker_Env.finish = (fun uu____1521  -> ());
-    FStar_TypeChecker_Env.refresh = (fun uu____1522  -> ())
-  }
+{hint : FStar_Util.hint Prims.option; replay_result : z3_replay_result; elapsed_time : Prims.int; source_location : FStar_Range.range}
+
+
+type hint_stats_t =
+hint_stat Prims.list
+
+
+let recorded_hints : FStar_Util.hints Prims.option FStar_ST.ref = (FStar_Util.mk_ref None)
+
+
+let replaying_hints : FStar_Util.hints Prims.option FStar_ST.ref = (FStar_Util.mk_ref None)
+
+
+let hint_stats : hint_stat Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let format_hints_file_name : Prims.string  ->  Prims.string = (fun src_filename -> (FStar_Util.format1 "%s.hints" src_filename))
+
+
+let initialize_hints_db = (fun src_filename force_record -> ((FStar_ST.write hint_stats []);
+(
+
+let uu____102 = (FStar_Options.record_hints ())
+in (match (uu____102) with
+| true -> begin
+(FStar_ST.write recorded_hints (Some ([])))
+end
+| uu____109 -> begin
+()
+end));
+(
+
+let uu____110 = (FStar_Options.use_hints ())
+in (match (uu____110) with
+| true -> begin
+(
+
+let norm_src_filename = (FStar_Util.normalize_file_path src_filename)
+in (
+
+let val_filename = (format_hints_file_name norm_src_filename)
+in (
+
+let uu____113 = (FStar_Util.read_hints val_filename)
+in (match (uu____113) with
+| Some (hints) -> begin
+(
+
+let expected_digest = (FStar_Util.digest_of_file norm_src_filename)
+in ((
+
+let uu____118 = (FStar_Options.hint_info ())
+in (match (uu____118) with
+| true -> begin
+(match ((hints.FStar_Util.module_digest = expected_digest)) with
+| true -> begin
+(FStar_Util.print1 "(%s) digest is valid; using hints db.\n" norm_src_filename)
+end
+| uu____119 -> begin
+(FStar_Util.print1 "(%s) digest is invalid; using potentially stale hints\n" norm_src_filename)
+end)
+end
+| uu____120 -> begin
+()
+end));
+(FStar_ST.write replaying_hints (Some (hints.FStar_Util.hints)));
+))
+end
+| None -> begin
+(
+
+let uu____124 = (FStar_Options.hint_info ())
+in (match (uu____124) with
+| true -> begin
+(FStar_Util.print1 "(%s) Unable to read hints db.\n" norm_src_filename)
+end
+| uu____125 -> begin
+()
+end))
+end))))
+end
+| uu____126 -> begin
+()
+end));
+))
+
+
+let finalize_hints_db : Prims.string  ->  Prims.unit = (fun src_filename -> ((
+
+let uu____131 = (FStar_Options.record_hints ())
+in (match (uu____131) with
+| true -> begin
+(
+
+let hints = (
+
+let uu____133 = (FStar_ST.read recorded_hints)
+in (FStar_Option.get uu____133))
+in (
+
+let hints_db = (
+
+let uu____139 = (FStar_Util.digest_of_file src_filename)
+in {FStar_Util.module_digest = uu____139; FStar_Util.hints = hints})
+in (
+
+let hints_file_name = (format_hints_file_name src_filename)
+in (FStar_Util.write_hints hints_file_name hints_db))))
+end
+| uu____141 -> begin
+()
+end));
+(
+
+let uu____143 = (FStar_Options.hint_info ())
+in (match (uu____143) with
+| true -> begin
+(
+
+let stats = (
+
+let uu____146 = (FStar_ST.read hint_stats)
+in (FStar_All.pipe_right uu____146 FStar_List.rev))
+in (FStar_All.pipe_right stats (FStar_List.iter (fun s -> (match (s.replay_result) with
+| FStar_Util.Inl (_unsat_core) -> begin
+(
+
+let uu____156 = (FStar_Range.string_of_range s.source_location)
+in (
+
+let uu____157 = (FStar_Util.string_of_int s.elapsed_time)
+in (FStar_Util.print2 "Hint-info (%s): Replay succeeded in %s milliseconds\n" uu____156 uu____157)))
+end
+| FStar_Util.Inr (_error) -> begin
+(
+
+let uu____159 = (FStar_Range.string_of_range s.source_location)
+in (
+
+let uu____160 = (FStar_Util.string_of_int s.elapsed_time)
+in (FStar_Util.print2 "Hint-info (%s): Replay failed in %s milliseconds\n" uu____159 uu____160)))
+end)))))
+end
+| uu____161 -> begin
+()
+end));
+(FStar_ST.write recorded_hints None);
+(FStar_ST.write replaying_hints None);
+(FStar_ST.write hint_stats []);
+))
+
+
+let with_hints_db = (fun fname f -> ((initialize_hints_db fname false);
+(
+
+let result = (f ())
+in ((finalize_hints_db fname);
+result;
+));
+))
+
+
+let next_hint : Prims.string  ->  Prims.int  ->  FStar_Util.hint Prims.option = (fun qname qindex -> (
+
+let uu____200 = (FStar_ST.read replaying_hints)
+in (match (uu____200) with
+| Some (hints) -> begin
+(FStar_Util.find_map hints (fun uu___92_208 -> (match (uu___92_208) with
+| Some (hint) when ((hint.FStar_Util.hint_name = qname) && (hint.FStar_Util.hint_index = qindex)) -> begin
+Some (hint)
+end
+| uu____212 -> begin
+None
+end)))
+end
+| uu____214 -> begin
+None
+end)))
+
+
+let record_hint : FStar_Util.hint Prims.option  ->  Prims.unit = (fun hint -> (
+
+let hint1 = (match (hint) with
+| None -> begin
+None
+end
+| Some (h) -> begin
+Some ((
+
+let uu___94_225 = h
+in {FStar_Util.hint_name = uu___94_225.FStar_Util.hint_name; FStar_Util.hint_index = uu___94_225.FStar_Util.hint_index; FStar_Util.fuel = uu___94_225.FStar_Util.fuel; FStar_Util.ifuel = uu___94_225.FStar_Util.ifuel; FStar_Util.unsat_core = uu___94_225.FStar_Util.unsat_core; FStar_Util.query_elapsed_time = (Prims.parse_int "0")}))
+end)
+in (
+
+let uu____226 = (FStar_ST.read recorded_hints)
+in (match (uu____226) with
+| Some (l) -> begin
+(FStar_ST.write recorded_hints (Some ((FStar_List.append l ((hint1)::[])))))
+end
+| uu____240 -> begin
+()
+end))))
+
+
+let record_hint_stat : FStar_Util.hint Prims.option  ->  z3_result  ->  Prims.int  ->  FStar_Range.range  ->  Prims.unit = (fun h res time r -> (
+
+let s = {hint = h; replay_result = (z3_result_as_replay_result res); elapsed_time = time; source_location = r}
+in (
+
+let uu____257 = (
+
+let uu____259 = (FStar_ST.read hint_stats)
+in (s)::uu____259)
+in (FStar_ST.write hint_stats uu____257))))
+
+
+let ask_and_report_errors : FStar_TypeChecker_Env.env  ->  ((FStar_SMTEncoding_Z3.label * FStar_SMTEncoding_Term.sort) * Prims.string * FStar_Range.range) Prims.list  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  FStar_SMTEncoding_Term.decl  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  Prims.unit = (fun env all_labels prefix1 query suffix -> ((FStar_SMTEncoding_Z3.giveZ3 prefix1);
+(
+
+let uu____299 = (match (env.FStar_TypeChecker_Env.qname_and_index) with
+| None -> begin
+(failwith "No query name set!")
+end
+| Some (q, n1) -> begin
+(((FStar_Ident.text_of_lid q)), (n1))
+end)
+in (match (uu____299) with
+| (query_name, query_index) -> begin
+(
+
+let minimum_workable_fuel = (FStar_Util.mk_ref None)
+in (
+
+let set_minimum_workable_fuel = (fun f uu___93_355 -> (match (uu___93_355) with
+| ([], uu____362) -> begin
+()
+end
+| errs -> begin
+(
+
+let uu____368 = (FStar_ST.read minimum_workable_fuel)
+in (match (uu____368) with
+| Some (uu____389) -> begin
+()
+end
+| None -> begin
+(FStar_ST.write minimum_workable_fuel (Some (((f), (errs)))))
+end))
+end))
+in (
+
+let with_fuel = (fun label_assumptions p uu____453 -> (match (uu____453) with
+| (n1, i, rlimit) -> begin
+(
+
+let uu____462 = (
+
+let uu____464 = (
+
+let uu____465 = (
+
+let uu____466 = (FStar_Util.string_of_int n1)
+in (
+
+let uu____467 = (FStar_Util.string_of_int i)
+in (FStar_Util.format2 "<fuel=\'%s\' ifuel=\'%s\'>" uu____466 uu____467)))
+in FStar_SMTEncoding_Term.Caption (uu____465))
+in (
+
+let uu____468 = (
+
+let uu____470 = (
+
+let uu____471 = (
+
+let uu____476 = (
+
+let uu____477 = (
+
+let uu____480 = (FStar_SMTEncoding_Util.mkApp (("MaxFuel"), ([])))
+in (
+
+let uu____482 = (FStar_SMTEncoding_Term.n_fuel n1)
+in ((uu____480), (uu____482))))
+in (FStar_SMTEncoding_Util.mkEq uu____477))
+in ((uu____476), (None), (None)))
+in FStar_SMTEncoding_Term.Assume (uu____471))
+in (
+
+let uu____485 = (
+
+let uu____487 = (
+
+let uu____488 = (
+
+let uu____493 = (
+
+let uu____494 = (
+
+let uu____497 = (FStar_SMTEncoding_Util.mkApp (("MaxIFuel"), ([])))
+in (
+
+let uu____499 = (FStar_SMTEncoding_Term.n_fuel i)
+in ((uu____497), (uu____499))))
+in (FStar_SMTEncoding_Util.mkEq uu____494))
+in ((uu____493), (None), (None)))
+in FStar_SMTEncoding_Term.Assume (uu____488))
+in (uu____487)::(p)::[])
+in (uu____470)::uu____485))
+in (uu____464)::uu____468))
+in (
+
+let uu____502 = (
+
+let uu____504 = (
+
+let uu____506 = (
+
+let uu____508 = (
+
+let uu____509 = (
+
+let uu____512 = (FStar_Util.string_of_int rlimit)
+in (("rlimit"), (uu____512)))
+in FStar_SMTEncoding_Term.SetOption (uu____509))
+in (uu____508)::[])
+in (
+
+let uu____513 = (
+
+let uu____515 = (
+
+let uu____517 = (
+
+let uu____519 = (FStar_Options.record_hints ())
+in (match (uu____519) with
+| true -> begin
+(FStar_SMTEncoding_Term.GetUnsatCore)::[]
+end
+| uu____521 -> begin
+[]
+end))
+in (FStar_List.append uu____517 suffix))
+in (FStar_List.append ((FStar_SMTEncoding_Term.CheckSat)::[]) uu____515))
+in (FStar_List.append uu____506 uu____513)))
+in (FStar_List.append label_assumptions uu____504))
+in (FStar_List.append uu____462 uu____502)))
+end))
+in (
+
+let check = (fun p -> (
+
+let rlimit = (
+
+let uu____527 = (FStar_Options.z3_rlimit ())
+in (uu____527 * (Prims.parse_int "544656")))
+in (
+
+let default_initial_config = (
+
+let uu____532 = (FStar_Options.initial_fuel ())
+in (
+
+let uu____533 = (FStar_Options.initial_ifuel ())
+in ((uu____532), (uu____533), (rlimit))))
+in (
+
+let hint_opt = (next_hint query_name query_index)
+in (
+
+let uu____536 = (match (hint_opt) with
+| None -> begin
+((None), (default_initial_config))
+end
+| Some (hint) -> begin
+(
+
+let uu____558 = (match ((FStar_Option.isSome hint.FStar_Util.unsat_core)) with
+| true -> begin
+((hint.FStar_Util.unsat_core), (rlimit))
+end
+| uu____570 -> begin
+((None), (((Prims.parse_int "60") * (Prims.parse_int "544656"))))
+end)
+in (match (uu____558) with
+| (core, timeout) -> begin
+((core), (((hint.FStar_Util.fuel), (hint.FStar_Util.ifuel), (timeout))))
+end))
+end)
+in (match (uu____536) with
+| (unsat_core, initial_config) -> begin
+(
+
+let alt_configs = (
+
+let uu____609 = (
+
+let uu____615 = (
+
+let uu____621 = (
+
+let uu____626 = (
+
+let uu____627 = (FStar_Options.max_ifuel ())
+in (
+
+let uu____628 = (FStar_Options.initial_ifuel ())
+in (uu____627 > uu____628)))
+in (match (uu____626) with
+| true -> begin
+(
+
+let uu____633 = (
+
+let uu____637 = (FStar_Options.initial_fuel ())
+in (
+
+let uu____638 = (FStar_Options.max_ifuel ())
+in ((uu____637), (uu____638), (rlimit))))
+in (uu____633)::[])
+end
+| uu____645 -> begin
+[]
+end))
+in (
+
+let uu____649 = (
+
+let uu____655 = (
+
+let uu____660 = (
+
+let uu____661 = (
+
+let uu____662 = (FStar_Options.max_fuel ())
+in (uu____662 / (Prims.parse_int "2")))
+in (
+
+let uu____666 = (FStar_Options.initial_fuel ())
+in (uu____661 > uu____666)))
+in (match (uu____660) with
+| true -> begin
+(
+
+let uu____671 = (
+
+let uu____675 = (
+
+let uu____676 = (FStar_Options.max_fuel ())
+in (uu____676 / (Prims.parse_int "2")))
+in (
+
+let uu____680 = (FStar_Options.max_ifuel ())
+in ((uu____675), (uu____680), (rlimit))))
+in (uu____671)::[])
+end
+| uu____687 -> begin
+[]
+end))
+in (
+
+let uu____691 = (
+
+let uu____697 = (
+
+let uu____702 = ((
+
+let uu____703 = (FStar_Options.max_fuel ())
+in (
+
+let uu____704 = (FStar_Options.initial_fuel ())
+in (uu____703 > uu____704))) && (
+
+let uu____705 = (FStar_Options.max_ifuel ())
+in (
+
+let uu____706 = (FStar_Options.initial_ifuel ())
+in (uu____705 > uu____706))))
+in (match (uu____702) with
+| true -> begin
+(
+
+let uu____711 = (
+
+let uu____715 = (FStar_Options.max_fuel ())
+in (
+
+let uu____716 = (FStar_Options.max_ifuel ())
+in ((uu____715), (uu____716), (rlimit))))
+in (uu____711)::[])
+end
+| uu____723 -> begin
+[]
+end))
+in (
+
+let uu____727 = (
+
+let uu____733 = (
+
+let uu____738 = (
+
+let uu____739 = (FStar_Options.min_fuel ())
+in (
+
+let uu____740 = (FStar_Options.initial_fuel ())
+in (uu____739 < uu____740)))
+in (match (uu____738) with
+| true -> begin
+(
+
+let uu____745 = (
+
+let uu____749 = (FStar_Options.min_fuel ())
+in ((uu____749), ((Prims.parse_int "1")), (rlimit)))
+in (uu____745)::[])
+end
+| uu____756 -> begin
+[]
+end))
+in (uu____733)::[])
+in (uu____697)::uu____727))
+in (uu____655)::uu____691))
+in (uu____621)::uu____649))
+in ((match (((default_initial_config <> initial_config) || (FStar_Option.isSome unsat_core))) with
+| true -> begin
+(default_initial_config)::[]
+end
+| uu____798 -> begin
+[]
+end))::uu____615)
+in (FStar_List.flatten uu____609))
+in (
+
+let report1 = (fun p1 errs -> (
+
+let errs1 = (
+
+let uu____813 = ((FStar_Options.detail_errors ()) && (
+
+let uu____814 = (FStar_Options.n_cores ())
+in (uu____814 = (Prims.parse_int "1"))))
+in (match (uu____813) with
+| true -> begin
+(
+
+let uu____815 = (
+
+let uu____824 = (FStar_ST.read minimum_workable_fuel)
+in (match (uu____824) with
+| Some (f, errs1) -> begin
+((f), (errs1))
+end
+| None -> begin
+(
+
+let uu____889 = (
+
+let uu____893 = (FStar_Options.min_fuel ())
+in ((uu____893), ((Prims.parse_int "1")), (rlimit)))
+in ((uu____889), (errs)))
+end))
+in (match (uu____815) with
+| (min_fuel1, potential_errors) -> begin
+(
+
+let ask_z3 = (fun label_assumptions -> (
+
+let res = (FStar_Util.mk_ref None)
+in ((
+
+let uu____947 = (with_fuel label_assumptions p1 min_fuel1)
+in (FStar_SMTEncoding_Z3.ask None all_labels uu____947 None (fun r -> (FStar_ST.write res (Some (r))))));
+(
+
+let uu____972 = (FStar_ST.read res)
+in (FStar_Option.get uu____972));
+)))
+in (
+
+let uu____995 = (FStar_SMTEncoding_ErrorReporting.detail_errors env all_labels ask_z3)
+in ((uu____995), (FStar_SMTEncoding_Z3.Default))))
+end))
+end
+| uu____996 -> begin
+(match (errs) with
+| ([], FStar_SMTEncoding_Z3.Timeout) -> begin
+(((((((""), (FStar_SMTEncoding_Term.Term_sort))), ("Timeout: Unknown assertion failed"), (FStar_Range.dummyRange)))::[]), ((Prims.snd errs)))
+end
+| ([], FStar_SMTEncoding_Z3.Default) -> begin
+(((((((""), (FStar_SMTEncoding_Term.Term_sort))), ("Unknown assertion failed"), (FStar_Range.dummyRange)))::[]), ((Prims.snd errs)))
+end
+| (uu____1035, FStar_SMTEncoding_Z3.Kill) -> begin
+(((((((""), (FStar_SMTEncoding_Term.Term_sort))), ("Killed: Unknown assertion failed"), (FStar_Range.dummyRange)))::[]), ((Prims.snd errs)))
+end
+| uu____1054 -> begin
+errs
+end)
+end))
+in ((record_hint None);
+(
+
+let uu____1057 = (FStar_Options.print_fuels ())
+in (match (uu____1057) with
+| true -> begin
+(
+
+let uu____1058 = (
+
+let uu____1059 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_Range.string_of_range uu____1059))
+in (
+
+let uu____1060 = (
+
+let uu____1061 = (FStar_Options.max_fuel ())
+in (FStar_All.pipe_right uu____1061 FStar_Util.string_of_int))
+in (
+
+let uu____1062 = (
+
+let uu____1063 = (FStar_Options.max_ifuel ())
+in (FStar_All.pipe_right uu____1063 FStar_Util.string_of_int))
+in (FStar_Util.print3 "(%s) Query failed with maximum fuel %s and ifuel %s\n" uu____1058 uu____1060 uu____1062))))
+end
+| uu____1064 -> begin
+()
+end));
+(
+
+let uu____1065 = (FStar_All.pipe_right (Prims.fst errs1) (FStar_List.map (fun uu____1077 -> (match (uu____1077) with
+| (uu____1083, x, y) -> begin
+((x), (y))
+end))))
+in (FStar_TypeChecker_Err.add_errors env uu____1065));
+)))
+in (
+
+let use_errors = (fun errs result -> (match (((errs), (result))) with
+| ((([], _), _)) | ((_, FStar_Util.Inl (_))) -> begin
+result
+end
+| (uu____1111, FStar_Util.Inr (uu____1112)) -> begin
+FStar_Util.Inr (errs)
+end))
+in (
+
+let rec try_alt_configs = (fun prev_f p1 errs cfgs scope -> ((set_minimum_workable_fuel prev_f errs);
+(match (((cfgs), ((Prims.snd errs)))) with
+| (([], _)) | ((_, FStar_SMTEncoding_Z3.Kill)) -> begin
+(report1 p1 errs)
+end
+| ((mi)::[], uu____1196) -> begin
+(match (errs) with
+| ([], uu____1210) -> begin
+(
+
+let uu____1212 = (with_fuel [] p1 mi)
+in (FStar_SMTEncoding_Z3.ask None all_labels uu____1212 (Some (scope)) (cb false mi p1 [] scope)))
+end
+| uu____1218 -> begin
+((set_minimum_workable_fuel prev_f errs);
+(report1 p1 errs);
+)
+end)
+end
+| ((mi)::tl1, uu____1222) -> begin
+(
+
+let uu____1237 = (with_fuel [] p1 mi)
+in (FStar_SMTEncoding_Z3.ask None all_labels uu____1237 (Some (scope)) (fun uu____1240 -> (match (uu____1240) with
+| (result, elapsed_time) -> begin
+(
+
+let uu____1257 = (
+
+let uu____1264 = (use_errors errs result)
+in ((uu____1264), (elapsed_time)))
+in (cb false mi p1 tl1 scope uu____1257))
+end))))
+end);
+))
+and cb = (fun used_hint uu____1266 p1 alt scope uu____1270 -> (match (((uu____1266), (uu____1270))) with
+| ((prev_fuel, prev_ifuel, timeout), (result, elapsed_time)) -> begin
+((match (used_hint) with
+| true -> begin
+((FStar_SMTEncoding_Z3.refresh ());
+(
+
+let uu____1317 = (FStar_TypeChecker_Env.get_range env)
+in (record_hint_stat hint_opt result elapsed_time uu____1317));
+)
+end
+| uu____1318 -> begin
+()
+end);
+(
+
+let uu____1320 = ((FStar_Options.z3_refresh ()) || (FStar_Options.print_z3_statistics ()))
+in (match (uu____1320) with
+| true -> begin
+(FStar_SMTEncoding_Z3.refresh ())
+end
+| uu____1321 -> begin
+()
+end));
+(
+
+let query_info = (fun tag -> (
+
+let uu____1326 = (
+
+let uu____1328 = (
+
+let uu____1329 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_Range.string_of_range uu____1329))
+in (
+
+let uu____1330 = (
+
+let uu____1332 = (FStar_SMTEncoding_Z3.at_log_file ())
+in (
+
+let uu____1333 = (
+
+let uu____1335 = (
+
+let uu____1337 = (FStar_Util.string_of_int query_index)
+in (
+
+let uu____1338 = (
+
+let uu____1340 = (
+
+let uu____1342 = (
+
+let uu____1344 = (FStar_Util.string_of_int elapsed_time)
+in (
+
+let uu____1345 = (
+
+let uu____1347 = (FStar_Util.string_of_int prev_fuel)
+in (
+
+let uu____1348 = (
+
+let uu____1350 = (FStar_Util.string_of_int prev_ifuel)
+in (uu____1350)::[])
+in (uu____1347)::uu____1348))
+in (uu____1344)::uu____1345))
+in ((match (used_hint) with
+| true -> begin
+" (with hint)"
+end
+| uu____1351 -> begin
+""
+end))::uu____1342)
+in (tag)::uu____1340)
+in (uu____1337)::uu____1338))
+in (query_name)::uu____1335)
+in (uu____1332)::uu____1333))
+in (uu____1328)::uu____1330))
+in (FStar_Util.print "(%s%s)\n\tQuery (%s, %s)\t%s%s in %s milliseconds with fuel %s and ifuel %s\n" uu____1326)))
+in (match (result) with
+| FStar_Util.Inl (unsat_core1) -> begin
+((match ((not (used_hint))) with
+| true -> begin
+(
+
+let hint = {FStar_Util.hint_name = query_name; FStar_Util.hint_index = query_index; FStar_Util.fuel = prev_fuel; FStar_Util.ifuel = prev_ifuel; FStar_Util.unsat_core = unsat_core1; FStar_Util.query_elapsed_time = elapsed_time}
+in (record_hint (Some (hint))))
+end
+| uu____1357 -> begin
+(record_hint hint_opt)
+end);
+(
+
+let uu____1358 = ((FStar_Options.print_fuels ()) || (FStar_Options.hint_info ()))
+in (match (uu____1358) with
+| true -> begin
+(query_info "succeeded")
+end
+| uu____1359 -> begin
+()
+end));
+)
+end
+| FStar_Util.Inr (errs) -> begin
+((
+
+let uu____1366 = ((FStar_Options.print_fuels ()) || (FStar_Options.hint_info ()))
+in (match (uu____1366) with
+| true -> begin
+(query_info "failed")
+end
+| uu____1367 -> begin
+()
+end));
+(try_alt_configs ((prev_fuel), (prev_ifuel), (timeout)) p1 errs alt scope);
+)
+end));
+)
+end))
+in ((match ((FStar_Option.isSome unsat_core)) with
+| true -> begin
+(FStar_SMTEncoding_Z3.refresh ())
+end
+| uu____1370 -> begin
+()
+end);
+(
+
+let uu____1371 = (with_fuel [] p initial_config)
+in (
+
+let uu____1373 = (
+
+let uu____1382 = (FStar_ST.read FStar_SMTEncoding_Z3.fresh_scope)
+in (cb (FStar_Option.isSome unsat_core) initial_config p alt_configs uu____1382))
+in (FStar_SMTEncoding_Z3.ask unsat_core all_labels uu____1371 None uu____1373)));
+)))))
+end))))))
+in (
+
+let process_query = (fun q -> (
+
+let uu____1392 = (
+
+let uu____1393 = (FStar_Options.split_cases ())
+in (uu____1393 > (Prims.parse_int "0")))
+in (match (uu____1392) with
+| true -> begin
+(
+
+let uu____1394 = (
+
+let uu____1403 = (FStar_Options.split_cases ())
+in (FStar_SMTEncoding_SplitQueryCases.can_handle_query uu____1403 q))
+in (match (uu____1394) with
+| (b, cb) -> begin
+(match (b) with
+| true -> begin
+(FStar_SMTEncoding_SplitQueryCases.handle_query cb check)
+end
+| uu____1418 -> begin
+(check q)
+end)
+end))
+end
+| uu____1419 -> begin
+(check q)
+end)))
+in (
+
+let uu____1420 = (FStar_Options.admit_smt_queries ())
+in (match (uu____1420) with
+| true -> begin
+()
+end
+| uu____1421 -> begin
+(process_query query)
+end)))))))
+end));
+))
+
+
+let solve : (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  Prims.unit = (fun use_env_msg tcenv q -> ((
+
+let uu____1439 = (
+
+let uu____1440 = (
+
+let uu____1441 = (FStar_TypeChecker_Env.get_range tcenv)
+in (FStar_All.pipe_left FStar_Range.string_of_range uu____1441))
+in (FStar_Util.format1 "Starting query at %s" uu____1440))
+in (FStar_SMTEncoding_Encode.push uu____1439));
+(
+
+let tcenv1 = (FStar_TypeChecker_Env.incr_query_index tcenv)
+in (
+
+let uu____1443 = (FStar_SMTEncoding_Encode.encode_query use_env_msg tcenv1 q)
+in (match (uu____1443) with
+| (prefix1, labels, qry, suffix) -> begin
+(
+
+let pop1 = (fun uu____1464 -> (
+
+let uu____1465 = (
+
+let uu____1466 = (
+
+let uu____1467 = (FStar_TypeChecker_Env.get_range tcenv1)
+in (FStar_All.pipe_left FStar_Range.string_of_range uu____1467))
+in (FStar_Util.format1 "Ending query at %s" uu____1466))
+in (FStar_SMTEncoding_Encode.pop uu____1465)))
+in (match (qry) with
+| FStar_SMTEncoding_Term.Assume ({FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.FalseOp, uu____1468); FStar_SMTEncoding_Term.freevars = uu____1469; FStar_SMTEncoding_Term.rng = uu____1470}, uu____1471, uu____1472) -> begin
+(pop1 ())
+end
+| uu____1482 when tcenv1.FStar_TypeChecker_Env.admit -> begin
+(pop1 ())
+end
+| FStar_SMTEncoding_Term.Assume (q1, uu____1485, uu____1486) -> begin
+((ask_and_report_errors tcenv1 labels prefix1 qry suffix);
+(pop1 ());
+)
+end
+| uu____1490 -> begin
+(failwith "Impossible")
+end))
+end)));
+))
+
+
+let solver : FStar_TypeChecker_Env.solver_t = {FStar_TypeChecker_Env.init = FStar_SMTEncoding_Encode.init; FStar_TypeChecker_Env.push = FStar_SMTEncoding_Encode.push; FStar_TypeChecker_Env.pop = FStar_SMTEncoding_Encode.pop; FStar_TypeChecker_Env.mark = FStar_SMTEncoding_Encode.mark; FStar_TypeChecker_Env.reset_mark = FStar_SMTEncoding_Encode.reset_mark; FStar_TypeChecker_Env.commit_mark = FStar_SMTEncoding_Encode.commit_mark; FStar_TypeChecker_Env.encode_modul = FStar_SMTEncoding_Encode.encode_modul; FStar_TypeChecker_Env.encode_sig = FStar_SMTEncoding_Encode.encode_sig; FStar_TypeChecker_Env.preprocess = (fun e g -> (((e), (g)))::[]); FStar_TypeChecker_Env.solve = solve; FStar_TypeChecker_Env.is_trivial = FStar_SMTEncoding_Encode.is_trivial; FStar_TypeChecker_Env.finish = FStar_SMTEncoding_Z3.finish; FStar_TypeChecker_Env.refresh = FStar_SMTEncoding_Z3.refresh}
+
+
+let dummy : FStar_TypeChecker_Env.solver_t = {FStar_TypeChecker_Env.init = (fun uu____1497 -> ()); FStar_TypeChecker_Env.push = (fun uu____1498 -> ()); FStar_TypeChecker_Env.pop = (fun uu____1499 -> ()); FStar_TypeChecker_Env.mark = (fun uu____1500 -> ()); FStar_TypeChecker_Env.reset_mark = (fun uu____1501 -> ()); FStar_TypeChecker_Env.commit_mark = (fun uu____1502 -> ()); FStar_TypeChecker_Env.encode_modul = (fun uu____1503 uu____1504 -> ()); FStar_TypeChecker_Env.encode_sig = (fun uu____1505 uu____1506 -> ()); FStar_TypeChecker_Env.preprocess = (fun e g -> (((e), (g)))::[]); FStar_TypeChecker_Env.solve = (fun uu____1513 uu____1514 uu____1515 -> ()); FStar_TypeChecker_Env.is_trivial = (fun uu____1519 uu____1520 -> false); FStar_TypeChecker_Env.finish = (fun uu____1521 -> ()); FStar_TypeChecker_Env.refresh = (fun uu____1522 -> ())}
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_SplitQueryCases.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_SplitQueryCases.ml
@@ -1,196 +1,193 @@
+
 open Prims
-let rec get_next_n_ite:
-  Prims.int ->
-    FStar_SMTEncoding_Term.term ->
-      FStar_SMTEncoding_Term.term ->
-        (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
-          (Prims.bool* FStar_SMTEncoding_Term.term*
-            FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term)
-  =
-  fun n1  ->
-    fun t  ->
-      fun negs  ->
-        fun f  ->
-          if n1 <= (Prims.parse_int "0")
-          then
-            let uu____30 = f FStar_SMTEncoding_Util.mkTrue in
-            (true, uu____30, negs, t)
-          else
-            (match t.FStar_SMTEncoding_Term.tm with
-             | FStar_SMTEncoding_Term.App
-                 (FStar_SMTEncoding_Term.ITE ,g::t1::e::uu____39) ->
-                 let uu____42 =
-                   let uu____43 =
-                     let uu____46 = FStar_SMTEncoding_Util.mkNot g in
-                     (negs, uu____46) in
-                   FStar_SMTEncoding_Util.mkAnd uu____43 in
-                 get_next_n_ite (n1 - (Prims.parse_int "1")) e uu____42
-                   (fun x  ->
-                      let uu____48 = FStar_SMTEncoding_Util.mkITE (g, t1, x) in
-                      f uu____48)
-             | FStar_SMTEncoding_Term.FreeV uu____49 ->
-                 let uu____52 = f FStar_SMTEncoding_Util.mkTrue in
-                 (true, uu____52, negs, t)
-             | uu____53 ->
-                 (false, FStar_SMTEncoding_Util.mkFalse,
-                   FStar_SMTEncoding_Util.mkFalse,
-                   FStar_SMTEncoding_Util.mkFalse))
-let rec is_ite_all_the_way:
-  Prims.int ->
-    FStar_SMTEncoding_Term.term ->
-      FStar_SMTEncoding_Term.term ->
-        FStar_SMTEncoding_Term.term Prims.list ->
-          (Prims.bool* FStar_SMTEncoding_Term.term Prims.list*
-            FStar_SMTEncoding_Term.term)
-  =
-  fun n1  ->
-    fun t  ->
-      fun negs  ->
-        fun l  ->
-          if n1 <= (Prims.parse_int "0")
-          then Prims.raise FStar_Util.Impos
-          else
-            (match t.FStar_SMTEncoding_Term.tm with
-             | FStar_SMTEncoding_Term.FreeV uu____89 ->
-                 let uu____92 =
-                   let uu____93 =
-                     let uu____96 = FStar_SMTEncoding_Util.mkNot t in
-                     (negs, uu____96) in
-                   FStar_SMTEncoding_Util.mkAnd uu____93 in
-                 (true, l, uu____92)
-             | uu____98 ->
-                 let uu____99 = get_next_n_ite n1 t negs (fun x  -> x) in
-                 (match uu____99 with
-                  | (b,t1,negs',rest) ->
-                      if b
-                      then
-                        let uu____117 =
-                          let uu____119 =
-                            FStar_SMTEncoding_Util.mkImp (negs, t1) in
-                          uu____119 :: l in
-                        is_ite_all_the_way n1 rest negs' uu____117
-                      else (false, [], FStar_SMTEncoding_Util.mkFalse)))
-let rec parse_query_for_split_cases:
-  Prims.int ->
-    FStar_SMTEncoding_Term.term ->
-      (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
-        (Prims.bool*
-          ((FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)*
-          FStar_SMTEncoding_Term.term Prims.list*
-          FStar_SMTEncoding_Term.term))
-  =
-  fun n1  ->
-    fun t  ->
-      fun f  ->
-        match t.FStar_SMTEncoding_Term.tm with
-        | FStar_SMTEncoding_Term.Quant
-            (FStar_SMTEncoding_Term.Forall ,l,opt,l',t1) ->
-            parse_query_for_split_cases n1 t1
-              (fun x  ->
-                 let uu____173 =
-                   FStar_SMTEncoding_Util.mkForall'' (l, opt, l', x) in
-                 f uu____173)
-        | FStar_SMTEncoding_Term.App
-            (FStar_SMTEncoding_Term.Imp ,t1::t2::uu____180) ->
-            let r =
-              match t2.FStar_SMTEncoding_Term.tm with
-              | FStar_SMTEncoding_Term.Quant
-                  (FStar_SMTEncoding_Term.Forall
-                   ,uu____200,uu____201,uu____202,uu____203)
-                  ->
-                  parse_query_for_split_cases n1 t2
-                    (fun x  ->
-                       let uu____213 = FStar_SMTEncoding_Util.mkImp (t1, x) in
-                       f uu____213)
-              | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.ITE ,uu____214) ->
-                  let uu____217 =
-                    is_ite_all_the_way n1 t2 FStar_SMTEncoding_Util.mkTrue [] in
-                  (match uu____217 with
-                   | (b,l,negs) ->
-                       (b,
-                         (((fun x  ->
-                              let uu____245 =
-                                FStar_SMTEncoding_Util.mkImp (t1, x) in
-                              f uu____245)), l, negs)))
-              | uu____246 ->
-                  (false,
-                    (((fun uu____256  -> FStar_SMTEncoding_Util.mkFalse)),
-                      [], FStar_SMTEncoding_Util.mkFalse)) in
-            r
-        | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE ,uu____257)
-            ->
-            let uu____260 =
-              is_ite_all_the_way n1 t FStar_SMTEncoding_Util.mkTrue [] in
-            (match uu____260 with | (b,l,negs) -> (b, (f, l, negs)))
-        | uu____287 ->
-            (false,
-              (((fun uu____297  -> FStar_SMTEncoding_Util.mkFalse)), [],
-                FStar_SMTEncoding_Util.mkFalse))
-let strip_not: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
-  fun t  ->
-    match t.FStar_SMTEncoding_Term.tm with
-    | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Not ,hd1::uu____302)
-        -> hd1
-    | uu____305 -> t
-let rec check_split_cases:
-  (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term Prims.list ->
-      (FStar_SMTEncoding_Term.decl -> Prims.unit) -> Prims.unit
-  =
-  fun f  ->
-    fun l  ->
-      fun check  ->
-        FStar_List.iter
-          (fun t  ->
-             let uu____328 =
-               let uu____329 =
-                 let uu____334 =
-                   let uu____335 = f t in
-                   FStar_SMTEncoding_Util.mkNot uu____335 in
-                 (uu____334, None, None) in
-               FStar_SMTEncoding_Term.Assume uu____329 in
-             check uu____328) (FStar_List.rev l)
-let check_exhaustiveness:
-  (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term ->
-      (FStar_SMTEncoding_Term.decl -> Prims.unit) -> Prims.unit
-  =
-  fun f  ->
-    fun negs  ->
-      fun check  ->
-        let uu____357 =
-          let uu____358 =
-            let uu____363 =
-              let uu____364 =
-                let uu____365 = FStar_SMTEncoding_Util.mkNot negs in
-                f uu____365 in
-              FStar_SMTEncoding_Util.mkNot uu____364 in
-            (uu____363, None, None) in
-          FStar_SMTEncoding_Term.Assume uu____358 in
-        check uu____357
-let can_handle_query:
-  Prims.int ->
-    FStar_SMTEncoding_Term.decl ->
-      (Prims.bool*
-        ((FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)*
-        FStar_SMTEncoding_Term.term Prims.list* FStar_SMTEncoding_Term.term))
-  =
-  fun n1  ->
-    fun q  ->
-      match q with
-      | FStar_SMTEncoding_Term.Assume (q',uu____399,uu____400) ->
-          let uu____403 = strip_not q' in
-          parse_query_for_split_cases n1 uu____403 (fun x  -> x)
-      | uu____405 ->
-          (false, (((fun x  -> x)), [], FStar_SMTEncoding_Util.mkFalse))
-let handle_query:
-  ((FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)*
-    FStar_SMTEncoding_Term.term Prims.list* FStar_SMTEncoding_Term.term) ->
-    (FStar_SMTEncoding_Term.decl -> Prims.unit) -> Prims.unit
-  =
-  fun uu____430  ->
-    fun check  ->
-      match uu____430 with
-      | (f,l,negs) ->
-          (check_split_cases f l check; check_exhaustiveness f negs check)
+
+let rec get_next_n_ite : Prims.int  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  (FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term)  ->  (Prims.bool * FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term) = (fun n1 t negs f -> (match ((n1 <= (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____30 = (f FStar_SMTEncoding_Util.mkTrue)
+in ((true), (uu____30), (negs), (t)))
+end
+| uu____31 -> begin
+(match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE, (g)::(t1)::(e)::uu____39) -> begin
+(
+
+let uu____42 = (
+
+let uu____43 = (
+
+let uu____46 = (FStar_SMTEncoding_Util.mkNot g)
+in ((negs), (uu____46)))
+in (FStar_SMTEncoding_Util.mkAnd uu____43))
+in (get_next_n_ite (n1 - (Prims.parse_int "1")) e uu____42 (fun x -> (
+
+let uu____48 = (FStar_SMTEncoding_Util.mkITE ((g), (t1), (x)))
+in (f uu____48)))))
+end
+| FStar_SMTEncoding_Term.FreeV (uu____49) -> begin
+(
+
+let uu____52 = (f FStar_SMTEncoding_Util.mkTrue)
+in ((true), (uu____52), (negs), (t)))
+end
+| uu____53 -> begin
+((false), (FStar_SMTEncoding_Util.mkFalse), (FStar_SMTEncoding_Util.mkFalse), (FStar_SMTEncoding_Util.mkFalse))
+end)
+end))
+
+
+let rec is_ite_all_the_way : Prims.int  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term Prims.list  ->  (Prims.bool * FStar_SMTEncoding_Term.term Prims.list * FStar_SMTEncoding_Term.term) = (fun n1 t negs l -> (match ((n1 <= (Prims.parse_int "0"))) with
+| true -> begin
+(Prims.raise FStar_Util.Impos)
+end
+| uu____84 -> begin
+(match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.FreeV (uu____89) -> begin
+(
+
+let uu____92 = (
+
+let uu____93 = (
+
+let uu____96 = (FStar_SMTEncoding_Util.mkNot t)
+in ((negs), (uu____96)))
+in (FStar_SMTEncoding_Util.mkAnd uu____93))
+in ((true), (l), (uu____92)))
+end
+| uu____98 -> begin
+(
+
+let uu____99 = (get_next_n_ite n1 t negs (fun x -> x))
+in (match (uu____99) with
+| (b, t1, negs', rest) -> begin
+(match (b) with
+| true -> begin
+(
+
+let uu____117 = (
+
+let uu____119 = (FStar_SMTEncoding_Util.mkImp ((negs), (t1)))
+in (uu____119)::l)
+in (is_ite_all_the_way n1 rest negs' uu____117))
+end
+| uu____120 -> begin
+((false), ([]), (FStar_SMTEncoding_Util.mkFalse))
+end)
+end))
+end)
+end))
+
+
+let rec parse_query_for_split_cases : Prims.int  ->  FStar_SMTEncoding_Term.term  ->  (FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term)  ->  (Prims.bool * ((FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term) * FStar_SMTEncoding_Term.term Prims.list * FStar_SMTEncoding_Term.term)) = (fun n1 t f -> (match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, l, opt, l', t1) -> begin
+(parse_query_for_split_cases n1 t1 (fun x -> (
+
+let uu____173 = (FStar_SMTEncoding_Util.mkForall'' ((l), (opt), (l'), (x)))
+in (f uu____173))))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Imp, (t1)::(t2)::uu____180) -> begin
+(
+
+let r = (match (t2.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.Quant (FStar_SMTEncoding_Term.Forall, uu____200, uu____201, uu____202, uu____203) -> begin
+(parse_query_for_split_cases n1 t2 (fun x -> (
+
+let uu____213 = (FStar_SMTEncoding_Util.mkImp ((t1), (x)))
+in (f uu____213))))
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE, uu____214) -> begin
+(
+
+let uu____217 = (is_ite_all_the_way n1 t2 FStar_SMTEncoding_Util.mkTrue [])
+in (match (uu____217) with
+| (b, l, negs) -> begin
+((b), ((((fun x -> (
+
+let uu____245 = (FStar_SMTEncoding_Util.mkImp ((t1), (x)))
+in (f uu____245)))), (l), (negs))))
+end))
+end
+| uu____246 -> begin
+((false), ((((fun uu____256 -> FStar_SMTEncoding_Util.mkFalse)), ([]), (FStar_SMTEncoding_Util.mkFalse))))
+end)
+in r)
+end
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE, uu____257) -> begin
+(
+
+let uu____260 = (is_ite_all_the_way n1 t FStar_SMTEncoding_Util.mkTrue [])
+in (match (uu____260) with
+| (b, l, negs) -> begin
+((b), (((f), (l), (negs))))
+end))
+end
+| uu____287 -> begin
+((false), ((((fun uu____297 -> FStar_SMTEncoding_Util.mkFalse)), ([]), (FStar_SMTEncoding_Util.mkFalse))))
+end))
+
+
+let strip_not : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (fun t -> (match (t.FStar_SMTEncoding_Term.tm) with
+| FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Not, (hd1)::uu____302) -> begin
+hd1
+end
+| uu____305 -> begin
+t
+end))
+
+
+let rec check_split_cases : (FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term Prims.list  ->  (FStar_SMTEncoding_Term.decl  ->  Prims.unit)  ->  Prims.unit = (fun f l check -> (FStar_List.iter (fun t -> (
+
+let uu____328 = (
+
+let uu____329 = (
+
+let uu____334 = (
+
+let uu____335 = (f t)
+in (FStar_SMTEncoding_Util.mkNot uu____335))
+in ((uu____334), (None), (None)))
+in FStar_SMTEncoding_Term.Assume (uu____329))
+in (check uu____328))) (FStar_List.rev l)))
+
+
+let check_exhaustiveness : (FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term  ->  (FStar_SMTEncoding_Term.decl  ->  Prims.unit)  ->  Prims.unit = (fun f negs check -> (
+
+let uu____357 = (
+
+let uu____358 = (
+
+let uu____363 = (
+
+let uu____364 = (
+
+let uu____365 = (FStar_SMTEncoding_Util.mkNot negs)
+in (f uu____365))
+in (FStar_SMTEncoding_Util.mkNot uu____364))
+in ((uu____363), (None), (None)))
+in FStar_SMTEncoding_Term.Assume (uu____358))
+in (check uu____357)))
+
+
+let can_handle_query : Prims.int  ->  FStar_SMTEncoding_Term.decl  ->  (Prims.bool * ((FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term) * FStar_SMTEncoding_Term.term Prims.list * FStar_SMTEncoding_Term.term)) = (fun n1 q -> (match (q) with
+| FStar_SMTEncoding_Term.Assume (q', uu____399, uu____400) -> begin
+(
+
+let uu____403 = (strip_not q')
+in (parse_query_for_split_cases n1 uu____403 (fun x -> x)))
+end
+| uu____405 -> begin
+((false), ((((fun x -> x)), ([]), (FStar_SMTEncoding_Util.mkFalse))))
+end))
+
+
+let handle_query : ((FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term) * FStar_SMTEncoding_Term.term Prims.list * FStar_SMTEncoding_Term.term)  ->  (FStar_SMTEncoding_Term.decl  ->  Prims.unit)  ->  Prims.unit = (fun uu____430 check -> (match (uu____430) with
+| (f, l, negs) -> begin
+((check_split_cases f l check);
+(check_exhaustiveness f negs check);
+)
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_Term.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Term.ml
@@ -1,1485 +1,2637 @@
+
 open Prims
 type sort =
-  | Bool_sort
-  | Int_sort
-  | String_sort
-  | Ref_sort
-  | Term_sort
-  | Fuel_sort
-  | Array of (sort* sort)
-  | Arrow of (sort* sort)
-  | Sort of Prims.string
-let uu___is_Bool_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Bool_sort  -> true | uu____17 -> false
-let uu___is_Int_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int_sort  -> true | uu____21 -> false
-let uu___is_String_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | String_sort  -> true | uu____25 -> false
-let uu___is_Ref_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Ref_sort  -> true | uu____29 -> false
-let uu___is_Term_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Term_sort  -> true | uu____33 -> false
-let uu___is_Fuel_sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Fuel_sort  -> true | uu____37 -> false
-let uu___is_Array: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Array _0 -> true | uu____44 -> false
-let __proj__Array__item___0: sort -> (sort* sort) =
-  fun projectee  -> match projectee with | Array _0 -> _0
-let uu___is_Arrow: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Arrow _0 -> true | uu____64 -> false
-let __proj__Arrow__item___0: sort -> (sort* sort) =
-  fun projectee  -> match projectee with | Arrow _0 -> _0
-let uu___is_Sort: sort -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sort _0 -> true | uu____82 -> false
-let __proj__Sort__item___0: sort -> Prims.string =
-  fun projectee  -> match projectee with | Sort _0 -> _0
-let rec strSort: sort -> Prims.string =
-  fun x  ->
-    match x with
-    | Bool_sort  -> "Bool"
-    | Int_sort  -> "Int"
-    | Term_sort  -> "Term"
-    | String_sort  -> "FString"
-    | Ref_sort  -> "Ref"
-    | Fuel_sort  -> "Fuel"
-    | Array (s1,s2) ->
-        let uu____95 = strSort s1 in
-        let uu____96 = strSort s2 in
-        FStar_Util.format2 "(Array %s %s)" uu____95 uu____96
-    | Arrow (s1,s2) ->
-        let uu____99 = strSort s1 in
-        let uu____100 = strSort s2 in
-        FStar_Util.format2 "(%s -> %s)" uu____99 uu____100
-    | Sort s -> s
+| Bool_sort
+| Int_sort
+| String_sort
+| Ref_sort
+| Term_sort
+| Fuel_sort
+| Array of (sort * sort)
+| Arrow of (sort * sort)
+| Sort of Prims.string
+
+
+let uu___is_Bool_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Bool_sort -> begin
+true
+end
+| uu____17 -> begin
+false
+end))
+
+
+let uu___is_Int_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Int_sort -> begin
+true
+end
+| uu____21 -> begin
+false
+end))
+
+
+let uu___is_String_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| String_sort -> begin
+true
+end
+| uu____25 -> begin
+false
+end))
+
+
+let uu___is_Ref_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Ref_sort -> begin
+true
+end
+| uu____29 -> begin
+false
+end))
+
+
+let uu___is_Term_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Term_sort -> begin
+true
+end
+| uu____33 -> begin
+false
+end))
+
+
+let uu___is_Fuel_sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Fuel_sort -> begin
+true
+end
+| uu____37 -> begin
+false
+end))
+
+
+let uu___is_Array : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Array (_0) -> begin
+true
+end
+| uu____44 -> begin
+false
+end))
+
+
+let __proj__Array__item___0 : sort  ->  (sort * sort) = (fun projectee -> (match (projectee) with
+| Array (_0) -> begin
+_0
+end))
+
+
+let uu___is_Arrow : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Arrow (_0) -> begin
+true
+end
+| uu____64 -> begin
+false
+end))
+
+
+let __proj__Arrow__item___0 : sort  ->  (sort * sort) = (fun projectee -> (match (projectee) with
+| Arrow (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sort : sort  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sort (_0) -> begin
+true
+end
+| uu____82 -> begin
+false
+end))
+
+
+let __proj__Sort__item___0 : sort  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Sort (_0) -> begin
+_0
+end))
+
+
+let rec strSort : sort  ->  Prims.string = (fun x -> (match (x) with
+| Bool_sort -> begin
+"Bool"
+end
+| Int_sort -> begin
+"Int"
+end
+| Term_sort -> begin
+"Term"
+end
+| String_sort -> begin
+"FString"
+end
+| Ref_sort -> begin
+"Ref"
+end
+| Fuel_sort -> begin
+"Fuel"
+end
+| Array (s1, s2) -> begin
+(
+
+let uu____95 = (strSort s1)
+in (
+
+let uu____96 = (strSort s2)
+in (FStar_Util.format2 "(Array %s %s)" uu____95 uu____96)))
+end
+| Arrow (s1, s2) -> begin
+(
+
+let uu____99 = (strSort s1)
+in (
+
+let uu____100 = (strSort s2)
+in (FStar_Util.format2 "(%s -> %s)" uu____99 uu____100)))
+end
+| Sort (s) -> begin
+s
+end))
+
 type op =
-  | TrueOp
-  | FalseOp
-  | Not
-  | And
-  | Or
-  | Imp
-  | Iff
-  | Eq
-  | LT
-  | LTE
-  | GT
-  | GTE
-  | Add
-  | Sub
-  | Div
-  | Mul
-  | Minus
-  | Mod
-  | ITE
-  | Var of Prims.string
-let uu___is_TrueOp: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TrueOp  -> true | uu____108 -> false
-let uu___is_FalseOp: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FalseOp  -> true | uu____112 -> false
-let uu___is_Not: op -> Prims.bool =
-  fun projectee  -> match projectee with | Not  -> true | uu____116 -> false
-let uu___is_And: op -> Prims.bool =
-  fun projectee  -> match projectee with | And  -> true | uu____120 -> false
-let uu___is_Or: op -> Prims.bool =
-  fun projectee  -> match projectee with | Or  -> true | uu____124 -> false
-let uu___is_Imp: op -> Prims.bool =
-  fun projectee  -> match projectee with | Imp  -> true | uu____128 -> false
-let uu___is_Iff: op -> Prims.bool =
-  fun projectee  -> match projectee with | Iff  -> true | uu____132 -> false
-let uu___is_Eq: op -> Prims.bool =
-  fun projectee  -> match projectee with | Eq  -> true | uu____136 -> false
-let uu___is_LT: op -> Prims.bool =
-  fun projectee  -> match projectee with | LT  -> true | uu____140 -> false
-let uu___is_LTE: op -> Prims.bool =
-  fun projectee  -> match projectee with | LTE  -> true | uu____144 -> false
-let uu___is_GT: op -> Prims.bool =
-  fun projectee  -> match projectee with | GT  -> true | uu____148 -> false
-let uu___is_GTE: op -> Prims.bool =
-  fun projectee  -> match projectee with | GTE  -> true | uu____152 -> false
-let uu___is_Add: op -> Prims.bool =
-  fun projectee  -> match projectee with | Add  -> true | uu____156 -> false
-let uu___is_Sub: op -> Prims.bool =
-  fun projectee  -> match projectee with | Sub  -> true | uu____160 -> false
-let uu___is_Div: op -> Prims.bool =
-  fun projectee  -> match projectee with | Div  -> true | uu____164 -> false
-let uu___is_Mul: op -> Prims.bool =
-  fun projectee  -> match projectee with | Mul  -> true | uu____168 -> false
-let uu___is_Minus: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Minus  -> true | uu____172 -> false
-let uu___is_Mod: op -> Prims.bool =
-  fun projectee  -> match projectee with | Mod  -> true | uu____176 -> false
-let uu___is_ITE: op -> Prims.bool =
-  fun projectee  -> match projectee with | ITE  -> true | uu____180 -> false
-let uu___is_Var: op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Var _0 -> true | uu____185 -> false
-let __proj__Var__item___0: op -> Prims.string =
-  fun projectee  -> match projectee with | Var _0 -> _0
+| TrueOp
+| FalseOp
+| Not
+| And
+| Or
+| Imp
+| Iff
+| Eq
+| LT
+| LTE
+| GT
+| GTE
+| Add
+| Sub
+| Div
+| Mul
+| Minus
+| Mod
+| ITE
+| Var of Prims.string
+
+
+let uu___is_TrueOp : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TrueOp -> begin
+true
+end
+| uu____108 -> begin
+false
+end))
+
+
+let uu___is_FalseOp : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FalseOp -> begin
+true
+end
+| uu____112 -> begin
+false
+end))
+
+
+let uu___is_Not : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Not -> begin
+true
+end
+| uu____116 -> begin
+false
+end))
+
+
+let uu___is_And : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| And -> begin
+true
+end
+| uu____120 -> begin
+false
+end))
+
+
+let uu___is_Or : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Or -> begin
+true
+end
+| uu____124 -> begin
+false
+end))
+
+
+let uu___is_Imp : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Imp -> begin
+true
+end
+| uu____128 -> begin
+false
+end))
+
+
+let uu___is_Iff : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Iff -> begin
+true
+end
+| uu____132 -> begin
+false
+end))
+
+
+let uu___is_Eq : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eq -> begin
+true
+end
+| uu____136 -> begin
+false
+end))
+
+
+let uu___is_LT : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LT -> begin
+true
+end
+| uu____140 -> begin
+false
+end))
+
+
+let uu___is_LTE : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LTE -> begin
+true
+end
+| uu____144 -> begin
+false
+end))
+
+
+let uu___is_GT : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| GT -> begin
+true
+end
+| uu____148 -> begin
+false
+end))
+
+
+let uu___is_GTE : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| GTE -> begin
+true
+end
+| uu____152 -> begin
+false
+end))
+
+
+let uu___is_Add : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Add -> begin
+true
+end
+| uu____156 -> begin
+false
+end))
+
+
+let uu___is_Sub : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sub -> begin
+true
+end
+| uu____160 -> begin
+false
+end))
+
+
+let uu___is_Div : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Div -> begin
+true
+end
+| uu____164 -> begin
+false
+end))
+
+
+let uu___is_Mul : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mul -> begin
+true
+end
+| uu____168 -> begin
+false
+end))
+
+
+let uu___is_Minus : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Minus -> begin
+true
+end
+| uu____172 -> begin
+false
+end))
+
+
+let uu___is_Mod : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mod -> begin
+true
+end
+| uu____176 -> begin
+false
+end))
+
+
+let uu___is_ITE : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ITE -> begin
+true
+end
+| uu____180 -> begin
+false
+end))
+
+
+let uu___is_Var : op  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Var (_0) -> begin
+true
+end
+| uu____185 -> begin
+false
+end))
+
+
+let __proj__Var__item___0 : op  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Var (_0) -> begin
+_0
+end))
+
 type qop =
-  | Forall
-  | Exists
-let uu___is_Forall: qop -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Forall  -> true | uu____196 -> false
-let uu___is_Exists: qop -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Exists  -> true | uu____200 -> false
+| Forall
+| Exists
+
+
+let uu___is_Forall : qop  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Forall -> begin
+true
+end
+| uu____196 -> begin
+false
+end))
+
+
+let uu___is_Exists : qop  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exists -> begin
+true
+end
+| uu____200 -> begin
+false
+end))
+
 type term' =
-  | Integer of Prims.string
-  | BoundV of Prims.int
-  | FreeV of (Prims.string* sort)
-  | App of (op* term Prims.list)
-  | Quant of (qop* term Prims.list Prims.list* Prims.int Prims.option* sort
-  Prims.list* term)
-  | Let of (term Prims.list* term)
-  | Labeled of (term* Prims.string* FStar_Range.range)
-  | LblPos of (term* Prims.string)
-and term =
-  {
-  tm: term';
-  freevars: (Prims.string* sort) Prims.list FStar_Syntax_Syntax.memo;
-  rng: FStar_Range.range;}
-let uu___is_Integer: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Integer _0 -> true | uu____265 -> false
-let __proj__Integer__item___0: term' -> Prims.string =
-  fun projectee  -> match projectee with | Integer _0 -> _0
-let uu___is_BoundV: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BoundV _0 -> true | uu____277 -> false
-let __proj__BoundV__item___0: term' -> Prims.int =
-  fun projectee  -> match projectee with | BoundV _0 -> _0
-let uu___is_FreeV: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FreeV _0 -> true | uu____291 -> false
-let __proj__FreeV__item___0: term' -> (Prims.string* sort) =
-  fun projectee  -> match projectee with | FreeV _0 -> _0
-let uu___is_App: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | App _0 -> true | uu____312 -> false
-let __proj__App__item___0: term' -> (op* term Prims.list) =
-  fun projectee  -> match projectee with | App _0 -> _0
-let uu___is_Quant: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Quant _0 -> true | uu____342 -> false
-let __proj__Quant__item___0:
-  term' ->
-    (qop* term Prims.list Prims.list* Prims.int Prims.option* sort
-      Prims.list* term)
-  = fun projectee  -> match projectee with | Quant _0 -> _0
-let uu___is_Let: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Let _0 -> true | uu____384 -> false
-let __proj__Let__item___0: term' -> (term Prims.list* term) =
-  fun projectee  -> match projectee with | Let _0 -> _0
-let uu___is_Labeled: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Labeled _0 -> true | uu____408 -> false
-let __proj__Labeled__item___0:
-  term' -> (term* Prims.string* FStar_Range.range) =
-  fun projectee  -> match projectee with | Labeled _0 -> _0
-let uu___is_LblPos: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LblPos _0 -> true | uu____431 -> false
-let __proj__LblPos__item___0: term' -> (term* Prims.string) =
-  fun projectee  -> match projectee with | LblPos _0 -> _0
-type pat = term
-type fv = (Prims.string* sort)
-type fvs = (Prims.string* sort) Prims.list
-type caption = Prims.string Prims.option
-type binders = (Prims.string* sort) Prims.list
-type constructor_field = (Prims.string* sort* Prims.bool)
+| Integer of Prims.string
+| BoundV of Prims.int
+| FreeV of (Prims.string * sort)
+| App of (op * term Prims.list)
+| Quant of (qop * term Prims.list Prims.list * Prims.int Prims.option * sort Prims.list * term)
+| Let of (term Prims.list * term)
+| Labeled of (term * Prims.string * FStar_Range.range)
+| LblPos of (term * Prims.string) 
+ and term =
+{tm : term'; freevars : (Prims.string * sort) Prims.list FStar_Syntax_Syntax.memo; rng : FStar_Range.range}
+
+
+let uu___is_Integer : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Integer (_0) -> begin
+true
+end
+| uu____265 -> begin
+false
+end))
+
+
+let __proj__Integer__item___0 : term'  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Integer (_0) -> begin
+_0
+end))
+
+
+let uu___is_BoundV : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BoundV (_0) -> begin
+true
+end
+| uu____277 -> begin
+false
+end))
+
+
+let __proj__BoundV__item___0 : term'  ->  Prims.int = (fun projectee -> (match (projectee) with
+| BoundV (_0) -> begin
+_0
+end))
+
+
+let uu___is_FreeV : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FreeV (_0) -> begin
+true
+end
+| uu____291 -> begin
+false
+end))
+
+
+let __proj__FreeV__item___0 : term'  ->  (Prims.string * sort) = (fun projectee -> (match (projectee) with
+| FreeV (_0) -> begin
+_0
+end))
+
+
+let uu___is_App : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+true
+end
+| uu____312 -> begin
+false
+end))
+
+
+let __proj__App__item___0 : term'  ->  (op * term Prims.list) = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+_0
+end))
+
+
+let uu___is_Quant : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Quant (_0) -> begin
+true
+end
+| uu____342 -> begin
+false
+end))
+
+
+let __proj__Quant__item___0 : term'  ->  (qop * term Prims.list Prims.list * Prims.int Prims.option * sort Prims.list * term) = (fun projectee -> (match (projectee) with
+| Quant (_0) -> begin
+_0
+end))
+
+
+let uu___is_Let : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+true
+end
+| uu____384 -> begin
+false
+end))
+
+
+let __proj__Let__item___0 : term'  ->  (term Prims.list * term) = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+_0
+end))
+
+
+let uu___is_Labeled : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Labeled (_0) -> begin
+true
+end
+| uu____408 -> begin
+false
+end))
+
+
+let __proj__Labeled__item___0 : term'  ->  (term * Prims.string * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Labeled (_0) -> begin
+_0
+end))
+
+
+let uu___is_LblPos : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LblPos (_0) -> begin
+true
+end
+| uu____431 -> begin
+false
+end))
+
+
+let __proj__LblPos__item___0 : term'  ->  (term * Prims.string) = (fun projectee -> (match (projectee) with
+| LblPos (_0) -> begin
+_0
+end))
+
+
+type pat =
+term
+
+
+type fv =
+(Prims.string * sort)
+
+
+type fvs =
+(Prims.string * sort) Prims.list
+
+
+type caption =
+Prims.string Prims.option
+
+
+type binders =
+(Prims.string * sort) Prims.list
+
+
+type constructor_field =
+(Prims.string * sort * Prims.bool)
+
+
 type constructor_t =
-  (Prims.string* constructor_field Prims.list* sort* Prims.int* Prims.bool)
-type constructors = constructor_t Prims.list
+(Prims.string * constructor_field Prims.list * sort * Prims.int * Prims.bool)
+
+
+type constructors =
+constructor_t Prims.list
+
 type decl =
-  | DefPrelude
-  | DeclFun of (Prims.string* sort Prims.list* sort* caption)
-  | DefineFun of (Prims.string* sort Prims.list* sort* term* caption)
-  | Assume of (term* caption* Prims.string Prims.option)
-  | Caption of Prims.string
-  | Eval of term
-  | Echo of Prims.string
-  | Push
-  | Pop
-  | CheckSat
-  | GetUnsatCore
-  | SetOption of (Prims.string* Prims.string)
-  | PrintStats
-let uu___is_DefPrelude: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DefPrelude  -> true | uu____527 -> false
-let uu___is_DeclFun: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DeclFun _0 -> true | uu____537 -> false
-let __proj__DeclFun__item___0:
-  decl -> (Prims.string* sort Prims.list* sort* caption) =
-  fun projectee  -> match projectee with | DeclFun _0 -> _0
-let uu___is_DefineFun: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DefineFun _0 -> true | uu____570 -> false
-let __proj__DefineFun__item___0:
-  decl -> (Prims.string* sort Prims.list* sort* term* caption) =
-  fun projectee  -> match projectee with | DefineFun _0 -> _0
-let uu___is_Assume: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assume _0 -> true | uu____604 -> false
-let __proj__Assume__item___0:
-  decl -> (term* caption* Prims.string Prims.option) =
-  fun projectee  -> match projectee with | Assume _0 -> _0
-let uu___is_Caption: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Caption _0 -> true | uu____628 -> false
-let __proj__Caption__item___0: decl -> Prims.string =
-  fun projectee  -> match projectee with | Caption _0 -> _0
-let uu___is_Eval: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eval _0 -> true | uu____640 -> false
-let __proj__Eval__item___0: decl -> term =
-  fun projectee  -> match projectee with | Eval _0 -> _0
-let uu___is_Echo: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Echo _0 -> true | uu____652 -> false
-let __proj__Echo__item___0: decl -> Prims.string =
-  fun projectee  -> match projectee with | Echo _0 -> _0
-let uu___is_Push: decl -> Prims.bool =
-  fun projectee  -> match projectee with | Push  -> true | uu____663 -> false
-let uu___is_Pop: decl -> Prims.bool =
-  fun projectee  -> match projectee with | Pop  -> true | uu____667 -> false
-let uu___is_CheckSat: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CheckSat  -> true | uu____671 -> false
-let uu___is_GetUnsatCore: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | GetUnsatCore  -> true | uu____675 -> false
-let uu___is_SetOption: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SetOption _0 -> true | uu____682 -> false
-let __proj__SetOption__item___0: decl -> (Prims.string* Prims.string) =
-  fun projectee  -> match projectee with | SetOption _0 -> _0
-let uu___is_PrintStats: decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PrintStats  -> true | uu____699 -> false
-type decls_t = decl Prims.list
-type error_label = (fv* Prims.string* FStar_Range.range)
-type error_labels = error_label Prims.list
-let fv_eq: fv -> fv -> Prims.bool =
-  fun x  -> fun y  -> (Prims.fst x) = (Prims.fst y)
-let fv_sort x = Prims.snd x
-let freevar_eq: term -> term -> Prims.bool =
-  fun x  ->
-    fun y  ->
-      match ((x.tm), (y.tm)) with
-      | (FreeV x1,FreeV y1) -> fv_eq x1 y1
-      | uu____736 -> false
-let freevar_sort: term -> sort =
-  fun uu___83_741  ->
-    match uu___83_741 with
-    | { tm = FreeV x; freevars = uu____743; rng = uu____744;_} -> fv_sort x
-    | uu____751 -> failwith "impossible"
-let fv_of_term: term -> fv =
-  fun uu___84_754  ->
-    match uu___84_754 with
-    | { tm = FreeV fv; freevars = uu____756; rng = uu____757;_} -> fv
-    | uu____764 -> failwith "impossible"
-let rec freevars: term -> (Prims.string* sort) Prims.list =
-  fun t  ->
-    match t.tm with
-    | Integer _|BoundV _ -> []
-    | FreeV fv -> [fv]
-    | App (uu____785,tms) -> FStar_List.collect freevars tms
-    | Quant (_,_,_,_,t1)|Labeled (t1,_,_)|LblPos (t1,_) -> freevars t1
-    | Let (es,body) -> FStar_List.collect freevars (body :: es)
-let free_variables: term -> fvs =
-  fun t  ->
-    let uu____812 = FStar_ST.read t.freevars in
-    match uu____812 with
-    | Some b -> b
-    | None  ->
-        let fvs =
-          let uu____835 = freevars t in
-          FStar_Util.remove_dups fv_eq uu____835 in
-        (FStar_ST.write t.freevars (Some fvs); fvs)
-let qop_to_string: qop -> Prims.string =
-  fun uu___85_847  ->
-    match uu___85_847 with | Forall  -> "forall" | Exists  -> "exists"
-let op_to_string: op -> Prims.string =
-  fun uu___86_850  ->
-    match uu___86_850 with
-    | TrueOp  -> "true"
-    | FalseOp  -> "false"
-    | Not  -> "not"
-    | And  -> "and"
-    | Or  -> "or"
-    | Imp  -> "implies"
-    | Iff  -> "iff"
-    | Eq  -> "="
-    | LT  -> "<"
-    | LTE  -> "<="
-    | GT  -> ">"
-    | GTE  -> ">="
-    | Add  -> "+"
-    | Sub  -> "-"
-    | Div  -> "div"
-    | Mul  -> "*"
-    | Minus  -> "-"
-    | Mod  -> "mod"
-    | ITE  -> "ite"
-    | Var s -> s
-let weightToSmt: Prims.int Prims.option -> Prims.string =
-  fun uu___87_855  ->
-    match uu___87_855 with
-    | None  -> ""
-    | Some i ->
-        let uu____858 = FStar_Util.string_of_int i in
-        FStar_Util.format1 ":weight %s\n" uu____858
-let rec hash_of_term': term' -> Prims.string =
-  fun t  ->
-    match t with
-    | Integer i -> i
-    | BoundV i ->
-        let uu____866 = FStar_Util.string_of_int i in
-        Prims.strcat "@" uu____866
-    | FreeV x ->
-        let uu____870 =
-          let uu____871 = strSort (Prims.snd x) in Prims.strcat ":" uu____871 in
-        Prims.strcat (Prims.fst x) uu____870
-    | App (op,tms) ->
-        let uu____876 =
-          let uu____877 =
-            let uu____878 =
-              let uu____879 = FStar_List.map hash_of_term tms in
-              FStar_All.pipe_right uu____879 (FStar_String.concat " ") in
-            Prims.strcat uu____878 ")" in
-          Prims.strcat (op_to_string op) uu____877 in
-        Prims.strcat "(" uu____876
-    | Labeled (t1,r1,r2) ->
-        let uu____885 = hash_of_term t1 in
-        let uu____886 =
-          let uu____887 = FStar_Range.string_of_range r2 in
-          Prims.strcat r1 uu____887 in
-        Prims.strcat uu____885 uu____886
-    | LblPos (t1,r) ->
-        let uu____890 =
-          let uu____891 = hash_of_term t1 in
-          Prims.strcat uu____891
-            (Prims.strcat " :lblpos " (Prims.strcat r ")")) in
-        Prims.strcat "(! " uu____890
-    | Quant (qop,pats,wopt,sorts,body) ->
-        let uu____905 =
-          let uu____906 =
-            let uu____907 =
-              let uu____908 =
-                let uu____909 = FStar_List.map strSort sorts in
-                FStar_All.pipe_right uu____909 (FStar_String.concat " ") in
-              let uu____912 =
-                let uu____913 =
-                  let uu____914 = hash_of_term body in
-                  let uu____915 =
-                    let uu____916 =
-                      let uu____917 = weightToSmt wopt in
-                      let uu____918 =
-                        let uu____919 =
-                          let uu____920 =
-                            let uu____921 =
-                              FStar_All.pipe_right pats
-                                (FStar_List.map
-                                   (fun pats1  ->
-                                      let uu____929 =
-                                        FStar_List.map hash_of_term pats1 in
-                                      FStar_All.pipe_right uu____929
-                                        (FStar_String.concat " "))) in
-                            FStar_All.pipe_right uu____921
-                              (FStar_String.concat "; ") in
-                          Prims.strcat uu____920 "))" in
-                        Prims.strcat " " uu____919 in
-                      Prims.strcat uu____917 uu____918 in
-                    Prims.strcat " " uu____916 in
-                  Prims.strcat uu____914 uu____915 in
-                Prims.strcat ")(! " uu____913 in
-              Prims.strcat uu____908 uu____912 in
-            Prims.strcat " (" uu____907 in
-          Prims.strcat (qop_to_string qop) uu____906 in
-        Prims.strcat "(" uu____905
-    | Let (es,body) ->
-        let uu____937 =
-          let uu____938 =
-            let uu____939 = FStar_List.map hash_of_term es in
-            FStar_All.pipe_right uu____939 (FStar_String.concat " ") in
-          let uu____942 =
-            let uu____943 =
-              let uu____944 = hash_of_term body in Prims.strcat uu____944 ")" in
-            Prims.strcat ") " uu____943 in
-          Prims.strcat uu____938 uu____942 in
-        Prims.strcat "(let (" uu____937
-and hash_of_term: term -> Prims.string = fun tm  -> hash_of_term' tm.tm
-let mk: term' -> FStar_Range.range -> term =
-  fun t  ->
-    fun r  ->
-      let uu____952 = FStar_Util.mk_ref None in
-      { tm = t; freevars = uu____952; rng = r }
-let mkTrue: FStar_Range.range -> term = fun r  -> mk (App (TrueOp, [])) r
-let mkFalse: FStar_Range.range -> term = fun r  -> mk (App (FalseOp, [])) r
-let mkInteger: Prims.string -> FStar_Range.range -> term =
-  fun i  ->
-    fun r  ->
-      let uu____981 =
-        let uu____982 = FStar_Util.ensure_decimal i in Integer uu____982 in
-      mk uu____981 r
-let mkInteger': Prims.int -> FStar_Range.range -> term =
-  fun i  ->
-    fun r  ->
-      let uu____989 = FStar_Util.string_of_int i in mkInteger uu____989 r
-let mkBoundV: Prims.int -> FStar_Range.range -> term =
-  fun i  -> fun r  -> mk (BoundV i) r
-let mkFreeV: (Prims.string* sort) -> FStar_Range.range -> term =
-  fun x  -> fun r  -> mk (FreeV x) r
-let mkApp': (op* term Prims.list) -> FStar_Range.range -> term =
-  fun f  -> fun r  -> mk (App f) r
-let mkApp: (Prims.string* term Prims.list) -> FStar_Range.range -> term =
-  fun uu____1025  ->
-    fun r  -> match uu____1025 with | (s,args) -> mk (App ((Var s), args)) r
-let mkNot: term -> FStar_Range.range -> term =
-  fun t  ->
-    fun r  ->
-      match t.tm with
-      | App (TrueOp ,uu____1041) -> mkFalse r
-      | App (FalseOp ,uu____1044) -> mkTrue r
-      | uu____1047 -> mkApp' (Not, [t]) r
-let mkAnd: (term* term) -> FStar_Range.range -> term =
-  fun uu____1055  ->
-    fun r  ->
-      match uu____1055 with
-      | (t1,t2) ->
-          (match ((t1.tm), (t2.tm)) with
-           | (App (TrueOp ,uu____1061),uu____1062) -> t2
-           | (uu____1065,App (TrueOp ,uu____1066)) -> t1
-           | (App (FalseOp ,_),_)|(_,App (FalseOp ,_)) -> mkFalse r
-           | (App (And ,ts1),App (And ,ts2)) ->
-               mkApp' (And, (FStar_List.append ts1 ts2)) r
-           | (uu____1082,App (And ,ts2)) -> mkApp' (And, (t1 :: ts2)) r
-           | (App (And ,ts1),uu____1088) ->
-               mkApp' (And, (FStar_List.append ts1 [t2])) r
-           | uu____1092 -> mkApp' (And, [t1; t2]) r)
-let mkOr: (term* term) -> FStar_Range.range -> term =
-  fun uu____1102  ->
-    fun r  ->
-      match uu____1102 with
-      | (t1,t2) ->
-          (match ((t1.tm), (t2.tm)) with
-           | (App (TrueOp ,_),_)|(_,App (TrueOp ,_)) -> mkTrue r
-           | (App (FalseOp ,uu____1114),uu____1115) -> t2
-           | (uu____1118,App (FalseOp ,uu____1119)) -> t1
-           | (App (Or ,ts1),App (Or ,ts2)) ->
-               mkApp' (Or, (FStar_List.append ts1 ts2)) r
-           | (uu____1129,App (Or ,ts2)) -> mkApp' (Or, (t1 :: ts2)) r
-           | (App (Or ,ts1),uu____1135) ->
-               mkApp' (Or, (FStar_List.append ts1 [t2])) r
-           | uu____1139 -> mkApp' (Or, [t1; t2]) r)
-let mkImp: (term* term) -> FStar_Range.range -> term =
-  fun uu____1149  ->
-    fun r  ->
-      match uu____1149 with
-      | (t1,t2) ->
-          (match ((t1.tm), (t2.tm)) with
-           | (_,App (TrueOp ,_))|(App (FalseOp ,_),_) -> mkTrue r
-           | (App (TrueOp ,uu____1161),uu____1162) -> t2
-           | (uu____1165,App (Imp ,t1'::t2'::[])) ->
-               let uu____1169 =
-                 let uu____1173 =
-                   let uu____1175 = mkAnd (t1, t1') r in [uu____1175; t2'] in
-                 (Imp, uu____1173) in
-               mkApp' uu____1169 r
-           | uu____1177 -> mkApp' (Imp, [t1; t2]) r)
-let mk_bin_op: op -> (term* term) -> FStar_Range.range -> term =
-  fun op  ->
-    fun uu____1190  ->
-      fun r  -> match uu____1190 with | (t1,t2) -> mkApp' (op, [t1; t2]) r
-let mkMinus: term -> FStar_Range.range -> term =
-  fun t  -> fun r  -> mkApp' (Minus, [t]) r
-let mkIff: (term* term) -> FStar_Range.range -> term = mk_bin_op Iff
-let mkEq: (term* term) -> FStar_Range.range -> term = mk_bin_op Eq
-let mkLT: (term* term) -> FStar_Range.range -> term = mk_bin_op LT
-let mkLTE: (term* term) -> FStar_Range.range -> term = mk_bin_op LTE
-let mkGT: (term* term) -> FStar_Range.range -> term = mk_bin_op GT
-let mkGTE: (term* term) -> FStar_Range.range -> term = mk_bin_op GTE
-let mkAdd: (term* term) -> FStar_Range.range -> term = mk_bin_op Add
-let mkSub: (term* term) -> FStar_Range.range -> term = mk_bin_op Sub
-let mkDiv: (term* term) -> FStar_Range.range -> term = mk_bin_op Div
-let mkMul: (term* term) -> FStar_Range.range -> term = mk_bin_op Mul
-let mkMod: (term* term) -> FStar_Range.range -> term = mk_bin_op Mod
-let mkITE: (term* term* term) -> FStar_Range.range -> term =
-  fun uu____1277  ->
-    fun r  ->
-      match uu____1277 with
-      | (t1,t2,t3) ->
-          (match t1.tm with
-           | App (TrueOp ,uu____1285) -> t2
-           | App (FalseOp ,uu____1288) -> t3
-           | uu____1291 ->
-               (match ((t2.tm), (t3.tm)) with
-                | (App (TrueOp ,uu____1292),App (TrueOp ,uu____1293)) ->
-                    mkTrue r
-                | (App (TrueOp ,uu____1298),uu____1299) ->
-                    let uu____1302 =
-                      let uu____1305 = mkNot t1 t1.rng in (uu____1305, t3) in
-                    mkImp uu____1302 r
-                | (uu____1306,App (TrueOp ,uu____1307)) -> mkImp (t1, t2) r
-                | (uu____1310,uu____1311) -> mkApp' (ITE, [t1; t2; t3]) r))
-let mkCases: term Prims.list -> FStar_Range.range -> term =
-  fun t  ->
-    fun r  ->
-      match t with
-      | [] -> failwith "Impos"
-      | hd1::tl1 ->
-          FStar_List.fold_left (fun out  -> fun t1  -> mkAnd (out, t1) r) hd1
-            tl1
-let mkQuant:
-  (qop* term Prims.list Prims.list* Prims.int Prims.option* sort Prims.list*
-    term) -> FStar_Range.range -> term
-  =
-  fun uu____1339  ->
-    fun r  ->
-      match uu____1339 with
-      | (qop,pats,wopt,vars,body) ->
-          if (FStar_List.length vars) = (Prims.parse_int "0")
-          then body
-          else
-            (match body.tm with
-             | App (TrueOp ,uu____1366) -> body
-             | uu____1369 -> mk (Quant (qop, pats, wopt, vars, body)) r)
-let mkLet: (term Prims.list* term) -> FStar_Range.range -> term =
-  fun uu____1381  ->
-    fun r  ->
-      match uu____1381 with
-      | (es,body) ->
-          if (FStar_List.length es) = (Prims.parse_int "0")
-          then body
-          else mk (Let (es, body)) r
-let abstr: fv Prims.list -> term -> term =
-  fun fvs  ->
-    fun t  ->
-      let nvars = FStar_List.length fvs in
-      let index_of fv =
-        let uu____1409 = FStar_Util.try_find_index (fv_eq fv) fvs in
-        match uu____1409 with
-        | None  -> None
-        | Some i -> Some (nvars - (i + (Prims.parse_int "1"))) in
-      let rec aux ix t1 =
-        let uu____1423 = FStar_ST.read t1.freevars in
-        match uu____1423 with
-        | Some [] -> t1
-        | uu____1439 ->
-            (match t1.tm with
-             | Integer _|BoundV _ -> t1
-             | FreeV x ->
-                 let uu____1449 = index_of x in
-                 (match uu____1449 with
-                  | None  -> t1
-                  | Some i -> mkBoundV (i + ix) t1.rng)
-             | App (op,tms) ->
-                 let uu____1456 =
-                   let uu____1460 = FStar_List.map (aux ix) tms in
-                   (op, uu____1460) in
-                 mkApp' uu____1456 t1.rng
-             | Labeled (t2,r1,r2) ->
-                 let uu____1466 =
-                   let uu____1467 =
-                     let uu____1471 = aux ix t2 in (uu____1471, r1, r2) in
-                   Labeled uu____1467 in
-                 mk uu____1466 t2.rng
-             | LblPos (t2,r) ->
-                 let uu____1474 =
-                   let uu____1475 =
-                     let uu____1478 = aux ix t2 in (uu____1478, r) in
-                   LblPos uu____1475 in
-                 mk uu____1474 t2.rng
-             | Quant (qop,pats,wopt,vars,body) ->
-                 let n1 = FStar_List.length vars in
-                 let uu____1494 =
-                   let uu____1504 =
-                     FStar_All.pipe_right pats
-                       (FStar_List.map (FStar_List.map (aux (ix + n1)))) in
-                   let uu____1515 = aux (ix + n1) body in
-                   (qop, uu____1504, wopt, vars, uu____1515) in
-                 mkQuant uu____1494 t1.rng
-             | Let (es,body) ->
-                 let uu____1526 =
-                   FStar_List.fold_left
-                     (fun uu____1533  ->
-                        fun e  ->
-                          match uu____1533 with
-                          | (ix1,l) ->
-                              let uu____1545 =
-                                let uu____1547 = aux ix1 e in uu____1547 :: l in
-                              ((ix1 + (Prims.parse_int "1")), uu____1545))
-                     (ix, []) es in
-                 (match uu____1526 with
-                  | (ix1,es_rev) ->
-                      let uu____1554 =
-                        let uu____1558 = aux ix1 body in
-                        ((FStar_List.rev es_rev), uu____1558) in
-                      mkLet uu____1554 t1.rng)) in
-      aux (Prims.parse_int "0") t
-let inst: term Prims.list -> term -> term =
-  fun tms  ->
-    fun t  ->
-      let tms1 = FStar_List.rev tms in
-      let n1 = FStar_List.length tms1 in
-      let rec aux shift t1 =
-        match t1.tm with
-        | Integer _|FreeV _ -> t1
-        | BoundV i ->
-            if ((Prims.parse_int "0") <= (i - shift)) && ((i - shift) < n1)
-            then FStar_List.nth tms1 (i - shift)
-            else t1
-        | App (op,tms2) ->
-            let uu____1589 =
-              let uu____1593 = FStar_List.map (aux shift) tms2 in
-              (op, uu____1593) in
-            mkApp' uu____1589 t1.rng
-        | Labeled (t2,r1,r2) ->
-            let uu____1599 =
-              let uu____1600 =
-                let uu____1604 = aux shift t2 in (uu____1604, r1, r2) in
-              Labeled uu____1600 in
-            mk uu____1599 t2.rng
-        | LblPos (t2,r) ->
-            let uu____1607 =
-              let uu____1608 =
-                let uu____1611 = aux shift t2 in (uu____1611, r) in
-              LblPos uu____1608 in
-            mk uu____1607 t2.rng
-        | Quant (qop,pats,wopt,vars,body) ->
-            let m = FStar_List.length vars in
-            let shift1 = shift + m in
-            let uu____1630 =
-              let uu____1640 =
-                FStar_All.pipe_right pats
-                  (FStar_List.map (FStar_List.map (aux shift1))) in
-              let uu____1649 = aux shift1 body in
-              (qop, uu____1640, wopt, vars, uu____1649) in
-            mkQuant uu____1630 t1.rng
-        | Let (es,body) ->
-            let uu____1658 =
-              FStar_List.fold_left
-                (fun uu____1665  ->
-                   fun e  ->
-                     match uu____1665 with
-                     | (ix,es1) ->
-                         let uu____1677 =
-                           let uu____1679 = aux shift e in uu____1679 :: es1 in
-                         ((shift + (Prims.parse_int "1")), uu____1677))
-                (shift, []) es in
-            (match uu____1658 with
-             | (shift1,es_rev) ->
-                 let uu____1686 =
-                   let uu____1690 = aux shift1 body in
-                   ((FStar_List.rev es_rev), uu____1690) in
-                 mkLet uu____1686 t1.rng) in
-      aux (Prims.parse_int "0") t
-let subst: term -> fv -> term -> term =
-  fun t  ->
-    fun fv  -> fun s  -> let uu____1701 = abstr [fv] t in inst [s] uu____1701
-let mkQuant':
-  (qop* term Prims.list Prims.list* Prims.int Prims.option* fv Prims.list*
-    term) -> FStar_Range.range -> term
-  =
-  fun uu____1715  ->
-    match uu____1715 with
-    | (qop,pats,wopt,vars,body) ->
-        let uu____1740 =
-          let uu____1750 =
-            FStar_All.pipe_right pats
-              (FStar_List.map (FStar_List.map (abstr vars))) in
-          let uu____1759 = FStar_List.map fv_sort vars in
-          let uu____1763 = abstr vars body in
-          (qop, uu____1750, wopt, uu____1759, uu____1763) in
-        mkQuant uu____1740
-let mkForall'':
-  (pat Prims.list Prims.list* Prims.int Prims.option* sort Prims.list* term)
-    -> FStar_Range.range -> term
-  =
-  fun uu____1780  ->
-    fun r  ->
-      match uu____1780 with
-      | (pats,wopt,sorts,body) -> mkQuant (Forall, pats, wopt, sorts, body) r
-let mkForall':
-  (pat Prims.list Prims.list* Prims.int Prims.option* fvs* term) ->
-    FStar_Range.range -> term
-  =
-  fun uu____1817  ->
-    fun r  ->
-      match uu____1817 with
-      | (pats,wopt,vars,body) ->
-          let uu____1836 = mkQuant' (Forall, pats, wopt, vars, body) in
-          uu____1836 r
-let mkForall:
-  (pat Prims.list Prims.list* fvs* term) -> FStar_Range.range -> term =
-  fun uu____1851  ->
-    fun r  ->
-      match uu____1851 with
-      | (pats,vars,body) ->
-          let uu____1865 = mkQuant' (Forall, pats, None, vars, body) in
-          uu____1865 r
-let mkExists:
-  (pat Prims.list Prims.list* fvs* term) -> FStar_Range.range -> term =
-  fun uu____1880  ->
-    fun r  ->
-      match uu____1880 with
-      | (pats,vars,body) ->
-          let uu____1894 = mkQuant' (Exists, pats, None, vars, body) in
-          uu____1894 r
-let mkLet': ((fv* term) Prims.list* term) -> FStar_Range.range -> term =
-  fun uu____1909  ->
-    fun r  ->
-      match uu____1909 with
-      | (bindings,body) ->
-          let uu____1924 = FStar_List.split bindings in
-          (match uu____1924 with
-           | (vars,es) ->
-               let uu____1935 =
-                 let uu____1939 = abstr vars body in (es, uu____1939) in
-               mkLet uu____1935 r)
-let norng: FStar_Range.range = FStar_Range.dummyRange
-let mkDefineFun:
-  (Prims.string* (Prims.string* sort) Prims.list* sort* term* caption) ->
-    decl
-  =
-  fun uu____1951  ->
-    match uu____1951 with
-    | (nm,vars,s,tm,c) ->
-        let uu____1971 =
-          let uu____1978 = FStar_List.map fv_sort vars in
-          let uu____1982 = abstr vars tm in
-          (nm, uu____1978, s, uu____1982, c) in
-        DefineFun uu____1971
-let constr_id_of_sort: sort -> Prims.string =
-  fun sort  ->
-    let uu____1987 = strSort sort in
-    FStar_Util.format1 "%s_constr_id" uu____1987
-let fresh_token: (Prims.string* sort) -> Prims.int -> decl =
-  fun uu____1994  ->
-    fun id  ->
-      match uu____1994 with
-      | (tok_name,sort) ->
-          let a_name = Prims.strcat "fresh_token_" tok_name in
-          let uu____2001 =
-            let uu____2006 =
-              let uu____2007 =
-                let uu____2010 = mkInteger' id norng in
-                let uu____2011 =
-                  let uu____2012 =
-                    let uu____2016 = constr_id_of_sort sort in
-                    let uu____2017 =
-                      let uu____2019 = mkApp (tok_name, []) norng in
-                      [uu____2019] in
-                    (uu____2016, uu____2017) in
-                  mkApp uu____2012 norng in
-                (uu____2010, uu____2011) in
-              mkEq uu____2007 norng in
-            (uu____2006, (Some "fresh token"), (Some a_name)) in
-          Assume uu____2001
-let fresh_constructor:
-  (Prims.string* sort Prims.list* sort* Prims.int) -> decl =
-  fun uu____2031  ->
-    match uu____2031 with
-    | (name,arg_sorts,sort,id) ->
-        let id1 = FStar_Util.string_of_int id in
-        let bvars =
-          FStar_All.pipe_right arg_sorts
-            (FStar_List.mapi
-               (fun i  ->
-                  fun s  ->
-                    let uu____2050 =
-                      let uu____2053 =
-                        let uu____2054 = FStar_Util.string_of_int i in
-                        Prims.strcat "x_" uu____2054 in
-                      (uu____2053, s) in
-                    mkFreeV uu____2050 norng)) in
-        let bvar_names = FStar_List.map fv_of_term bvars in
-        let capp = mkApp (name, bvars) norng in
-        let cid_app =
-          let uu____2060 =
-            let uu____2064 = constr_id_of_sort sort in (uu____2064, [capp]) in
-          mkApp uu____2060 norng in
-        let a_name = Prims.strcat "constructor_distinct_" name in
-        let uu____2067 =
-          let uu____2072 =
-            let uu____2073 =
-              let uu____2079 =
-                let uu____2080 =
-                  let uu____2083 = mkInteger id1 norng in
-                  (uu____2083, cid_app) in
-                mkEq uu____2080 norng in
-              ([[capp]], bvar_names, uu____2079) in
-            mkForall uu____2073 norng in
-          (uu____2072, (Some "Constructor distinct"), (Some a_name)) in
-        Assume uu____2067
-let injective_constructor:
-  (Prims.string* constructor_field Prims.list* sort) -> decl Prims.list =
-  fun uu____2097  ->
-    match uu____2097 with
-    | (name,fields,sort) ->
-        let n_bvars = FStar_List.length fields in
-        let bvar_name i =
-          let uu____2113 = FStar_Util.string_of_int i in
-          Prims.strcat "x_" uu____2113 in
-        let bvar_index i = n_bvars - (i + (Prims.parse_int "1")) in
-        let bvar i s =
-          let uu____2130 = let uu____2133 = bvar_name i in (uu____2133, s) in
-          mkFreeV uu____2130 in
-        let bvars =
-          FStar_All.pipe_right fields
-            (FStar_List.mapi
-               (fun i  ->
-                  fun uu____2142  ->
-                    match uu____2142 with
-                    | (uu____2146,s,uu____2148) ->
-                        let uu____2149 = bvar i s in uu____2149 norng)) in
-        let bvar_names = FStar_List.map fv_of_term bvars in
-        let capp = mkApp (name, bvars) norng in
-        let uu____2156 =
-          FStar_All.pipe_right fields
-            (FStar_List.mapi
-               (fun i  ->
-                  fun uu____2167  ->
-                    match uu____2167 with
-                    | (name1,s,projectible) ->
-                        let cproj_app = mkApp (name1, [capp]) norng in
-                        let proj_name =
-                          DeclFun (name1, [sort], s, (Some "Projector")) in
-                        if projectible
-                        then
-                          let a_name =
-                            Prims.strcat "projection_inverse_" name1 in
-                          let uu____2182 =
-                            let uu____2184 =
-                              let uu____2185 =
-                                let uu____2190 =
-                                  let uu____2191 =
-                                    let uu____2197 =
-                                      let uu____2198 =
-                                        let uu____2201 =
-                                          let uu____2202 = bvar i s in
-                                          uu____2202 norng in
-                                        (cproj_app, uu____2201) in
-                                      mkEq uu____2198 norng in
-                                    ([[capp]], bvar_names, uu____2197) in
-                                  mkForall uu____2191 norng in
-                                (uu____2190, (Some "Projection inverse"),
-                                  (Some a_name)) in
-                              Assume uu____2185 in
-                            [uu____2184] in
-                          proj_name :: uu____2182
-                        else [proj_name])) in
-        FStar_All.pipe_right uu____2156 FStar_List.flatten
-let constructor_to_decl: constructor_t -> decl Prims.list =
-  fun uu____2218  ->
-    match uu____2218 with
-    | (name,fields,sort,id,injective) ->
-        let injective1 = injective || true in
-        let field_sorts =
-          FStar_All.pipe_right fields
-            (FStar_List.map
-               (fun uu____2234  ->
-                  match uu____2234 with
-                  | (uu____2238,sort1,uu____2240) -> sort1)) in
-        let cdecl = DeclFun (name, field_sorts, sort, (Some "Constructor")) in
-        let cid = fresh_constructor (name, field_sorts, sort, id) in
-        let disc =
-          let disc_name = Prims.strcat "is-" name in
-          let xfv = ("x", sort) in
-          let xx = mkFreeV xfv norng in
-          let disc_eq =
-            let uu____2253 =
-              let uu____2256 =
-                let uu____2257 =
-                  let uu____2261 = constr_id_of_sort sort in
-                  (uu____2261, [xx]) in
-                mkApp uu____2257 norng in
-              let uu____2263 =
-                let uu____2264 = FStar_Util.string_of_int id in
-                mkInteger uu____2264 norng in
-              (uu____2256, uu____2263) in
-            mkEq uu____2253 norng in
-          let uu____2265 =
-            let uu____2273 =
-              FStar_All.pipe_right fields
-                (FStar_List.mapi
-                   (fun i  ->
-                      fun uu____2296  ->
-                        match uu____2296 with
-                        | (proj,s,projectible) ->
-                            if projectible
-                            then
-                              let uu____2313 = mkApp (proj, [xx]) norng in
-                              (uu____2313, [])
-                            else
-                              (let fi =
-                                 let uu____2324 =
-                                   let uu____2325 =
-                                     FStar_Util.string_of_int i in
-                                   Prims.strcat "f_" uu____2325 in
-                                 (uu____2324, s) in
-                               let uu____2326 = mkFreeV fi norng in
-                               (uu____2326, [fi])))) in
-            FStar_All.pipe_right uu____2273 FStar_List.split in
-          match uu____2265 with
-          | (proj_terms,ex_vars) ->
-              let ex_vars1 = FStar_List.flatten ex_vars in
-              let disc_inv_body =
-                let uu____2369 =
-                  let uu____2372 = mkApp (name, proj_terms) norng in
-                  (xx, uu____2372) in
-                mkEq uu____2369 norng in
-              let disc_inv_body1 =
-                match ex_vars1 with
-                | [] -> disc_inv_body
-                | uu____2377 -> mkExists ([], ex_vars1, disc_inv_body) norng in
-              let disc_ax = mkAnd (disc_eq, disc_inv_body1) norng in
-              let def =
-                mkDefineFun
-                  (disc_name, [xfv], Bool_sort, disc_ax,
-                    (Some "Discriminator definition")) in
-              def in
-        let projs =
-          if injective1
-          then injective_constructor (name, fields, sort)
-          else [] in
-        let uu____2400 =
-          let uu____2402 =
-            let uu____2403 = FStar_Util.format1 "<start constructor %s>" name in
-            Caption uu____2403 in
-          uu____2402 :: cdecl :: cid :: projs in
-        let uu____2404 =
-          let uu____2406 =
-            let uu____2408 =
-              let uu____2409 =
-                FStar_Util.format1 "</end constructor %s>" name in
-              Caption uu____2409 in
-            [uu____2408] in
-          FStar_List.append [disc] uu____2406 in
-        FStar_List.append uu____2400 uu____2404
-let name_binders_inner:
-  Prims.string Prims.option ->
-    (Prims.string* sort) Prims.list ->
-      Prims.int ->
-        sort Prims.list ->
-          ((Prims.string* sort) Prims.list* Prims.string Prims.list*
-            Prims.int)
-  =
-  fun prefix_opt  ->
-    fun outer_names  ->
-      fun start  ->
-        fun sorts  ->
-          let uu____2439 =
-            FStar_All.pipe_right sorts
-              (FStar_List.fold_left
-                 (fun uu____2462  ->
-                    fun s  ->
-                      match uu____2462 with
-                      | (names,binders,n1) ->
-                          let prefix1 =
-                            match s with
-                            | Term_sort  -> "@x"
-                            | uu____2490 -> "@u" in
-                          let prefix2 =
-                            match prefix_opt with
-                            | None  -> prefix1
-                            | Some p -> Prims.strcat p prefix1 in
-                          let nm =
-                            let uu____2494 = FStar_Util.string_of_int n1 in
-                            Prims.strcat prefix2 uu____2494 in
-                          let names1 = (nm, s) :: names in
-                          let b =
-                            let uu____2502 = strSort s in
-                            FStar_Util.format2 "(%s %s)" nm uu____2502 in
-                          (names1, (b :: binders),
-                            (n1 + (Prims.parse_int "1"))))
-                 (outer_names, [], start)) in
-          match uu____2439 with
-          | (names,binders,n1) -> (names, (FStar_List.rev binders), n1)
-let name_macro_binders:
-  sort Prims.list ->
-    ((Prims.string* sort) Prims.list* Prims.string Prims.list)
-  =
-  fun sorts  ->
-    let uu____2544 =
-      name_binders_inner (Some "__") [] (Prims.parse_int "0") sorts in
-    match uu____2544 with
-    | (names,binders,n1) -> ((FStar_List.rev names), binders)
-let termToSmt: term -> Prims.string =
-  fun t  ->
-    let remove_guard_free pats =
-      FStar_All.pipe_right pats
-        (FStar_List.map
-           (fun ps  ->
-              FStar_All.pipe_right ps
-                (FStar_List.map
-                   (fun tm  ->
-                      match tm.tm with
-                      | App
-                          (Var
-                           "Prims.guard_free",{ tm = BoundV uu____2601;
-                                                freevars = uu____2602;
-                                                rng = uu____2603;_}::[])
-                          -> tm
-                      | App (Var "Prims.guard_free",p::[]) -> p
-                      | uu____2611 -> tm)))) in
-    let rec aux' n1 names t1 =
-      match t1.tm with
-      | Integer i -> i
-      | BoundV i ->
-          let uu____2634 = FStar_List.nth names i in
-          FStar_All.pipe_right uu____2634 Prims.fst
-      | FreeV x -> Prims.fst x
-      | App (op,[]) -> op_to_string op
-      | App (op,tms) ->
-          let uu____2644 =
-            let uu____2645 = FStar_List.map (aux n1 names) tms in
-            FStar_All.pipe_right uu____2645 (FStar_String.concat "\n") in
-          FStar_Util.format2 "(%s %s)" (op_to_string op) uu____2644
-      | Labeled (t2,uu____2649,uu____2650) -> aux n1 names t2
-      | LblPos (t2,s) ->
-          let uu____2653 = aux n1 names t2 in
-          FStar_Util.format2 "(! %s :lblpos %s)" uu____2653 s
-      | Quant (qop,pats,wopt,sorts,body) ->
-          let uu____2667 = name_binders_inner None names n1 sorts in
-          (match uu____2667 with
-           | (names1,binders,n2) ->
-               let binders1 =
-                 FStar_All.pipe_right binders (FStar_String.concat " ") in
-               let pats1 = remove_guard_free pats in
-               let pats_str =
-                 match pats1 with
-                 | []::[]|[] -> ""
-                 | uu____2695 ->
-                     let uu____2698 =
-                       FStar_All.pipe_right pats1
-                         (FStar_List.map
-                            (fun pats2  ->
-                               let uu____2706 =
-                                 let uu____2707 =
-                                   FStar_List.map
-                                     (fun p  ->
-                                        let uu____2710 = aux n2 names1 p in
-                                        FStar_Util.format1 "%s" uu____2710)
-                                     pats2 in
-                                 FStar_String.concat " " uu____2707 in
-                               FStar_Util.format1 "\n:pattern (%s)"
-                                 uu____2706)) in
-                     FStar_All.pipe_right uu____2698
-                       (FStar_String.concat "\n") in
-               (match (pats1, wopt) with
-                | ([]::[],None )|([],None ) ->
-                    let uu____2724 = aux n2 names1 body in
-                    FStar_Util.format3 "(%s (%s)\n %s);;no pats\n"
-                      (qop_to_string qop) binders1 uu____2724
-                | uu____2725 ->
-                    let uu____2731 = aux n2 names1 body in
-                    let uu____2732 = weightToSmt wopt in
-                    FStar_Util.format5 "(%s (%s)\n (! %s\n %s %s))"
-                      (qop_to_string qop) binders1 uu____2731 uu____2732
-                      pats_str))
-      | Let (es,body) ->
-          let uu____2737 =
-            FStar_List.fold_left
-              (fun uu____2752  ->
-                 fun e  ->
-                   match uu____2752 with
-                   | (names0,binders,n0) ->
-                       let nm =
-                         let uu____2780 = FStar_Util.string_of_int n0 in
-                         Prims.strcat "@lb" uu____2780 in
-                       let names01 = (nm, Term_sort) :: names0 in
-                       let b =
-                         let uu____2788 = aux n1 names e in
-                         FStar_Util.format2 "(%s %s)" nm uu____2788 in
-                       (names01, (b :: binders),
-                         (n0 + (Prims.parse_int "1")))) (names, [], n1) es in
-          (match uu____2737 with
-           | (names1,binders,n2) ->
-               let uu____2806 = aux n2 names1 body in
-               FStar_Util.format2 "(let (%s) %s)"
-                 (FStar_String.concat " " binders) uu____2806)
-    and aux n1 names t1 =
-      let s = aux' n1 names t1 in
-      if t1.rng <> norng
-      then
-        let uu____2812 = FStar_Range.string_of_range t1.rng in
-        let uu____2813 = FStar_Range.string_of_use_range t1.rng in
-        FStar_Util.format3 "\n;; def=%s; use=%s\n%s\n" uu____2812 uu____2813
-          s
-      else s in
-    aux (Prims.parse_int "0") [] t
-let caption_to_string: Prims.string Prims.option -> Prims.string =
-  fun uu___88_2818  ->
-    match uu___88_2818 with
-    | None  -> ""
-    | Some c ->
-        let uu____2821 =
-          match FStar_Util.splitlines c with
-          | [] -> failwith "Impossible"
-          | hd1::[] -> (hd1, "")
-          | hd1::uu____2830 -> (hd1, "...") in
-        (match uu____2821 with
-         | (hd1,suffix) ->
-             FStar_Util.format2 ";;;;;;;;;;;;;;;;%s%s\n" hd1 suffix)
-let rec declToSmt: Prims.string -> decl -> Prims.string =
-  fun z3options  ->
-    fun decl  ->
-      let escape s = FStar_Util.replace_char s '\'' '_' in
-      match decl with
-      | DefPrelude  -> mkPrelude z3options
-      | Caption c ->
-          let uu____2847 =
-            FStar_All.pipe_right (FStar_Util.splitlines c)
-              (fun uu___89_2849  ->
-                 match uu___89_2849 with | [] -> "" | h::t -> h) in
-          FStar_Util.format1 "\n; %s" uu____2847
-      | DeclFun (f,argsorts,retsort,c) ->
-          let l = FStar_List.map strSort argsorts in
-          let uu____2862 = caption_to_string c in
-          let uu____2863 = strSort retsort in
-          FStar_Util.format4 "%s(declare-fun %s (%s) %s)" uu____2862 f
-            (FStar_String.concat " " l) uu____2863
-      | DefineFun (f,arg_sorts,retsort,body,c) ->
-          let uu____2871 = name_macro_binders arg_sorts in
-          (match uu____2871 with
-           | (names,binders) ->
-               let body1 =
-                 let uu____2889 =
-                   FStar_List.map (fun x  -> mkFreeV x norng) names in
-                 inst uu____2889 body in
-               let uu____2896 = caption_to_string c in
-               let uu____2897 = strSort retsort in
-               let uu____2898 = termToSmt body1 in
-               FStar_Util.format5 "%s(define-fun %s (%s) %s\n %s)" uu____2896
-                 f (FStar_String.concat " " binders) uu____2897 uu____2898)
-      | Assume (t,c,Some n1) ->
-          let uu____2903 = caption_to_string c in
-          let uu____2904 = termToSmt t in
-          FStar_Util.format3 "%s(assert (!\n%s\n:named %s))" uu____2903
-            uu____2904 (escape n1)
-      | Assume (t,c,None ) ->
-          let uu____2908 = caption_to_string c in
-          let uu____2909 = termToSmt t in
-          FStar_Util.format2 "%s(assert %s)" uu____2908 uu____2909
-      | Eval t ->
-          let uu____2911 = termToSmt t in
-          FStar_Util.format1 "(eval %s)" uu____2911
-      | Echo s -> FStar_Util.format1 "(echo \"%s\")" s
-      | CheckSat  -> "(check-sat)"
-      | GetUnsatCore  ->
-          "(echo \"<unsat-core>\")\n(get-unsat-core)\n(echo \"</unsat-core>\")"
-      | Push  -> "(push)"
-      | Pop  -> "(pop)"
-      | SetOption (s,v1) -> FStar_Util.format2 "(set-option :%s %s)" s v1
-      | PrintStats  -> "(get-info :all-statistics)"
-and mkPrelude: Prims.string -> Prims.string =
-  fun z3options  ->
-    let basic =
-      Prims.strcat z3options
-        "(declare-sort Ref)\n(declare-fun Ref_constr_id (Ref) Int)\n\n(declare-sort FString)\n(declare-fun FString_constr_id (FString) Int)\n\n(declare-sort Term)\n(declare-fun Term_constr_id (Term) Int)\n(declare-datatypes () ((Fuel \n(ZFuel) \n(SFuel (prec Fuel)))))\n(declare-fun MaxIFuel () Fuel)\n(declare-fun MaxFuel () Fuel)\n(declare-fun PreType (Term) Term)\n(declare-fun Valid (Term) Bool)\n(declare-fun HasTypeFuel (Fuel Term Term) Bool)\n(define-fun HasTypeZ ((x Term) (t Term)) Bool\n(HasTypeFuel ZFuel x t))\n(define-fun HasType ((x Term) (t Term)) Bool\n(HasTypeFuel MaxIFuel x t))\n;;fuel irrelevance\n(assert (forall ((f Fuel) (x Term) (t Term))\n(! (= (HasTypeFuel (SFuel f) x t)\n(HasTypeZ x t))\n:pattern ((HasTypeFuel (SFuel f) x t)))))\n(define-fun  IsTyped ((x Term)) Bool\n(exists ((t Term)) (HasTypeZ x t)))\n(declare-fun ApplyTF (Term Fuel) Term)\n(declare-fun ApplyTT (Term Term) Term)\n(declare-fun Rank (Term) Int)\n(declare-fun Closure (Term) Term)\n(declare-fun ConsTerm (Term Term) Term)\n(declare-fun ConsFuel (Fuel Term) Term)\n(declare-fun Precedes (Term Term) Term)\n(define-fun Reify ((x Term)) Term x)\n(assert (forall ((t Term))\n(! (implies (exists ((e Term)) (HasType e t))\n(Valid t))\n:pattern ((Valid t)))))\n(assert (forall ((t1 Term) (t2 Term))\n(! (iff (Valid (Precedes t1 t2)) \n(< (Rank t1) (Rank t2)))\n:pattern ((Precedes t1 t2)))))\n(define-fun Prims.precedes ((a Term) (b Term) (t1 Term) (t2 Term)) Term\n(Precedes t1 t2))\n(declare-fun Range_const () Term)\n" in
-    let constrs =
-      [("FString_const", [("FString_const_proj_0", Int_sort, true)],
-         String_sort, (Prims.parse_int "0"), true);
-      ("Tm_type", [], Term_sort, (Prims.parse_int "2"), true);
-      ("Tm_arrow", [("Tm_arrow_id", Int_sort, true)], Term_sort,
-        (Prims.parse_int "3"), false);
-      ("Tm_uvar", [("Tm_uvar_fst", Int_sort, true)], Term_sort,
-        (Prims.parse_int "5"), true);
-      ("Tm_unit", [], Term_sort, (Prims.parse_int "6"), true);
-      ("BoxInt", [("BoxInt_proj_0", Int_sort, true)], Term_sort,
-        (Prims.parse_int "7"), true);
-      ("BoxBool", [("BoxBool_proj_0", Bool_sort, true)], Term_sort,
-        (Prims.parse_int "8"), true);
-      ("BoxString", [("BoxString_proj_0", String_sort, true)], Term_sort,
-        (Prims.parse_int "9"), true);
-      ("BoxRef", [("BoxRef_proj_0", Ref_sort, true)], Term_sort,
-        (Prims.parse_int "10"), true);
-      ("LexCons",
-        [("LexCons_0", Term_sort, true); ("LexCons_1", Term_sort, true)],
-        Term_sort, (Prims.parse_int "11"), true)] in
-    let bcons =
-      let uu____3115 =
-        let uu____3117 =
-          FStar_All.pipe_right constrs
-            (FStar_List.collect constructor_to_decl) in
-        FStar_All.pipe_right uu____3117
-          (FStar_List.map (declToSmt z3options)) in
-      FStar_All.pipe_right uu____3115 (FStar_String.concat "\n") in
-    let lex_ordering =
-      "\n(define-fun is-Prims.LexCons ((t Term)) Bool \n(is-LexCons t))\n(assert (forall ((x1 Term) (x2 Term) (y1 Term) (y2 Term))\n(iff (Valid (Precedes (LexCons x1 x2) (LexCons y1 y2)))\n(or (Valid (Precedes x1 y1))\n(and (= x1 y1)\n(Valid (Precedes x2 y2)))))))\n" in
-    Prims.strcat basic (Prims.strcat bcons lex_ordering)
-let mk_Range_const: term = mkApp ("Range_const", []) norng
-let mk_Term_type: term = mkApp ("Tm_type", []) norng
-let mk_Term_app: term -> term -> FStar_Range.range -> term =
-  fun t1  -> fun t2  -> fun r  -> mkApp ("Tm_app", [t1; t2]) r
-let mk_Term_uvar: Prims.int -> FStar_Range.range -> term =
-  fun i  ->
-    fun r  ->
-      let uu____3142 =
-        let uu____3146 = let uu____3148 = mkInteger' i norng in [uu____3148] in
-        ("Tm_uvar", uu____3146) in
-      mkApp uu____3142 r
-let mk_Term_unit: term = mkApp ("Tm_unit", []) norng
-let boxInt: term -> term = fun t  -> mkApp ("BoxInt", [t]) t.rng
-let unboxInt: term -> term = fun t  -> mkApp ("BoxInt_proj_0", [t]) t.rng
-let boxBool: term -> term = fun t  -> mkApp ("BoxBool", [t]) t.rng
-let unboxBool: term -> term = fun t  -> mkApp ("BoxBool_proj_0", [t]) t.rng
-let boxString: term -> term = fun t  -> mkApp ("BoxString", [t]) t.rng
-let unboxString: term -> term =
-  fun t  -> mkApp ("BoxString_proj_0", [t]) t.rng
-let boxRef: term -> term = fun t  -> mkApp ("BoxRef", [t]) t.rng
-let unboxRef: term -> term = fun t  -> mkApp ("BoxRef_proj_0", [t]) t.rng
-let boxTerm: sort -> term -> term =
-  fun sort  ->
-    fun t  ->
-      match sort with
-      | Int_sort  -> boxInt t
-      | Bool_sort  -> boxBool t
-      | String_sort  -> boxString t
-      | Ref_sort  -> boxRef t
-      | uu____3189 -> Prims.raise FStar_Util.Impos
-let unboxTerm: sort -> term -> term =
-  fun sort  ->
-    fun t  ->
-      match sort with
-      | Int_sort  -> unboxInt t
-      | Bool_sort  -> unboxBool t
-      | String_sort  -> unboxString t
-      | Ref_sort  -> unboxRef t
-      | uu____3196 -> Prims.raise FStar_Util.Impos
-let mk_PreType: term -> term = fun t  -> mkApp ("PreType", [t]) t.rng
-let mk_Valid: term -> term =
-  fun t  ->
-    match t.tm with
-    | App
-        (Var
-         "Prims.b2t",{
-                       tm = App
-                         (Var "Prims.op_Equality",uu____3204::t1::t2::[]);
-                       freevars = uu____3207; rng = uu____3208;_}::[])
-        -> mkEq (t1, t2) t.rng
-    | App
-        (Var
-         "Prims.b2t",{
-                       tm = App
-                         (Var "Prims.op_disEquality",uu____3215::t1::t2::[]);
-                       freevars = uu____3218; rng = uu____3219;_}::[])
-        -> let uu____3226 = mkEq (t1, t2) norng in mkNot uu____3226 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_LessThanOrEqual",t1::t2::[]);
-                       freevars = uu____3229; rng = uu____3230;_}::[])
-        ->
-        let uu____3237 =
-          let uu____3240 = unboxInt t1 in
-          let uu____3241 = unboxInt t2 in (uu____3240, uu____3241) in
-        mkLTE uu____3237 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_LessThan",t1::t2::[]);
-                       freevars = uu____3244; rng = uu____3245;_}::[])
-        ->
-        let uu____3252 =
-          let uu____3255 = unboxInt t1 in
-          let uu____3256 = unboxInt t2 in (uu____3255, uu____3256) in
-        mkLT uu____3252 t.rng
-    | App
-        (Var
-         "Prims.b2t",{
-                       tm = App
-                         (Var "Prims.op_GreaterThanOrEqual",t1::t2::[]);
-                       freevars = uu____3259; rng = uu____3260;_}::[])
-        ->
-        let uu____3267 =
-          let uu____3270 = unboxInt t1 in
-          let uu____3271 = unboxInt t2 in (uu____3270, uu____3271) in
-        mkGTE uu____3267 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_GreaterThan",t1::t2::[]);
-                       freevars = uu____3274; rng = uu____3275;_}::[])
-        ->
-        let uu____3282 =
-          let uu____3285 = unboxInt t1 in
-          let uu____3286 = unboxInt t2 in (uu____3285, uu____3286) in
-        mkGT uu____3282 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_AmpAmp",t1::t2::[]);
-                       freevars = uu____3289; rng = uu____3290;_}::[])
-        ->
-        let uu____3297 =
-          let uu____3300 = unboxBool t1 in
-          let uu____3301 = unboxBool t2 in (uu____3300, uu____3301) in
-        mkAnd uu____3297 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_BarBar",t1::t2::[]);
-                       freevars = uu____3304; rng = uu____3305;_}::[])
-        ->
-        let uu____3312 =
-          let uu____3315 = unboxBool t1 in
-          let uu____3316 = unboxBool t2 in (uu____3315, uu____3316) in
-        mkOr uu____3312 t.rng
-    | App
-        (Var
-         "Prims.b2t",{ tm = App (Var "Prims.op_Negation",t1::[]);
-                       freevars = uu____3318; rng = uu____3319;_}::[])
-        -> let uu____3326 = unboxBool t1 in mkNot uu____3326 t1.rng
-    | App (Var "Prims.b2t",t1::[]) ->
-        let uu___90_3329 = unboxBool t1 in
-        {
-          tm = (uu___90_3329.tm);
-          freevars = (uu___90_3329.freevars);
-          rng = (t.rng)
-        }
-    | uu____3332 -> mkApp ("Valid", [t]) t.rng
-let mk_HasType: term -> term -> term =
-  fun v1  -> fun t  -> mkApp ("HasType", [v1; t]) t.rng
-let mk_HasTypeZ: term -> term -> term =
-  fun v1  -> fun t  -> mkApp ("HasTypeZ", [v1; t]) t.rng
-let mk_IsTyped: term -> term = fun v1  -> mkApp ("IsTyped", [v1]) norng
-let mk_HasTypeFuel: term -> term -> term -> term =
-  fun f  ->
-    fun v1  ->
-      fun t  ->
-        let uu____3361 = FStar_Options.unthrottle_inductives () in
-        if uu____3361
-        then mk_HasType v1 t
-        else mkApp ("HasTypeFuel", [f; v1; t]) t.rng
-let mk_HasTypeWithFuel: term Prims.option -> term -> term -> term =
-  fun f  ->
-    fun v1  ->
-      fun t  ->
-        match f with
-        | None  -> mk_HasType v1 t
-        | Some f1 -> mk_HasTypeFuel f1 v1 t
-let mk_Destruct: term -> FStar_Range.range -> term =
-  fun v1  -> mkApp ("Destruct", [v1])
-let mk_Rank: term -> FStar_Range.range -> term =
-  fun x  -> mkApp ("Rank", [x])
-let mk_tester: Prims.string -> term -> term =
-  fun n1  -> fun t  -> mkApp ((Prims.strcat "is-" n1), [t]) t.rng
-let mk_ApplyTF: term -> term -> term =
-  fun t  -> fun t'  -> mkApp ("ApplyTF", [t; t']) t.rng
-let mk_ApplyTT: term -> term -> FStar_Range.range -> term =
-  fun t  -> fun t'  -> fun r  -> mkApp ("ApplyTT", [t; t']) r
-let mk_String_const: Prims.int -> FStar_Range.range -> term =
-  fun i  ->
-    fun r  ->
-      let uu____3418 =
-        let uu____3422 = let uu____3424 = mkInteger' i norng in [uu____3424] in
-        ("FString_const", uu____3422) in
-      mkApp uu____3418 r
-let mk_Precedes: term -> term -> FStar_Range.range -> term =
-  fun x1  ->
-    fun x2  ->
-      fun r  ->
-        let uu____3435 = mkApp ("Precedes", [x1; x2]) r in
-        FStar_All.pipe_right uu____3435 mk_Valid
-let mk_LexCons: term -> term -> FStar_Range.range -> term =
-  fun x1  -> fun x2  -> fun r  -> mkApp ("LexCons", [x1; x2]) r
-let rec n_fuel: Prims.int -> term =
-  fun n1  ->
-    if n1 = (Prims.parse_int "0")
-    then mkApp ("ZFuel", []) norng
-    else
-      (let uu____3452 =
-         let uu____3456 =
-           let uu____3458 = n_fuel (n1 - (Prims.parse_int "1")) in
-           [uu____3458] in
-         ("SFuel", uu____3456) in
-       mkApp uu____3452 norng)
-let fuel_2: term = n_fuel (Prims.parse_int "2")
-let fuel_100: term = n_fuel (Prims.parse_int "100")
-let mk_and_opt:
-  term Prims.option ->
-    term Prims.option -> FStar_Range.range -> term Prims.option
-  =
-  fun p1  ->
-    fun p2  ->
-      fun r  ->
-        match (p1, p2) with
-        | (Some p11,Some p21) ->
-            let uu____3481 = mkAnd (p11, p21) r in Some uu____3481
-        | (Some p,None )|(None ,Some p) -> Some p
-        | (None ,None ) -> None
-let mk_and_opt_l:
-  term Prims.option Prims.list -> FStar_Range.range -> term Prims.option =
-  fun pl  ->
-    fun r  ->
-      FStar_List.fold_right (fun p  -> fun out  -> mk_and_opt p out r) pl
-        None
-let mk_and_l: term Prims.list -> FStar_Range.range -> term =
-  fun l  ->
-    fun r  ->
-      let uu____3514 = mkTrue r in
-      FStar_List.fold_right (fun p1  -> fun p2  -> mkAnd (p1, p2) r) l
-        uu____3514
-let mk_or_l: term Prims.list -> FStar_Range.range -> term =
-  fun l  ->
-    fun r  ->
-      let uu____3525 = mkFalse r in
-      FStar_List.fold_right (fun p1  -> fun p2  -> mkOr (p1, p2) r) l
-        uu____3525
-let mk_haseq: term -> term =
-  fun t  ->
-    let uu____3531 = mkApp ("Prims.hasEq", [t]) t.rng in mk_Valid uu____3531
-let rec print_smt_term: term -> Prims.string =
-  fun t  ->
-    match t.tm with
-    | Integer n1 -> FStar_Util.format1 "(Integer %s)" n1
-    | BoundV n1 ->
-        let uu____3545 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "(BoundV %s)" uu____3545
-    | FreeV fv -> FStar_Util.format1 "(FreeV %s)" (Prims.fst fv)
-    | App (op,l) ->
-        let uu____3553 = print_smt_term_list l in
-        FStar_Util.format2 "(%s %s)" (op_to_string op) uu____3553
-    | Labeled (t1,r1,r2) ->
-        let uu____3557 = print_smt_term t1 in
-        FStar_Util.format2 "(Labeled '%s' %s)" r1 uu____3557
-    | LblPos (t1,s) ->
-        let uu____3560 = print_smt_term t1 in
-        FStar_Util.format2 "(LblPos %s %s)" s uu____3560
-    | Quant (qop,l,uu____3563,uu____3564,t1) ->
-        let uu____3574 = print_smt_term_list_list l in
-        let uu____3575 = print_smt_term t1 in
-        FStar_Util.format3 "(%s %s %s)" (qop_to_string qop) uu____3574
-          uu____3575
-    | Let (es,body) ->
-        let uu____3580 = print_smt_term_list es in
-        let uu____3581 = print_smt_term body in
-        FStar_Util.format2 "(let %s %s)" uu____3580 uu____3581
-and print_smt_term_list: term Prims.list -> Prims.string =
-  fun l  ->
-    let uu____3584 = FStar_List.map print_smt_term l in
-    FStar_All.pipe_right uu____3584 (FStar_String.concat " ")
-and print_smt_term_list_list: term Prims.list Prims.list -> Prims.string =
-  fun l  ->
-    FStar_List.fold_left
-      (fun s  ->
-         fun l1  ->
-           let uu____3594 =
-             let uu____3595 =
-               let uu____3596 = print_smt_term_list l1 in
-               Prims.strcat uu____3596 " ] " in
-             Prims.strcat "; [ " uu____3595 in
-           Prims.strcat s uu____3594) "" l
+| DefPrelude
+| DeclFun of (Prims.string * sort Prims.list * sort * caption)
+| DefineFun of (Prims.string * sort Prims.list * sort * term * caption)
+| Assume of (term * caption * Prims.string Prims.option)
+| Caption of Prims.string
+| Eval of term
+| Echo of Prims.string
+| Push
+| Pop
+| CheckSat
+| GetUnsatCore
+| SetOption of (Prims.string * Prims.string)
+| PrintStats
+
+
+let uu___is_DefPrelude : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DefPrelude -> begin
+true
+end
+| uu____527 -> begin
+false
+end))
+
+
+let uu___is_DeclFun : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DeclFun (_0) -> begin
+true
+end
+| uu____537 -> begin
+false
+end))
+
+
+let __proj__DeclFun__item___0 : decl  ->  (Prims.string * sort Prims.list * sort * caption) = (fun projectee -> (match (projectee) with
+| DeclFun (_0) -> begin
+_0
+end))
+
+
+let uu___is_DefineFun : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DefineFun (_0) -> begin
+true
+end
+| uu____570 -> begin
+false
+end))
+
+
+let __proj__DefineFun__item___0 : decl  ->  (Prims.string * sort Prims.list * sort * term * caption) = (fun projectee -> (match (projectee) with
+| DefineFun (_0) -> begin
+_0
+end))
+
+
+let uu___is_Assume : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assume (_0) -> begin
+true
+end
+| uu____604 -> begin
+false
+end))
+
+
+let __proj__Assume__item___0 : decl  ->  (term * caption * Prims.string Prims.option) = (fun projectee -> (match (projectee) with
+| Assume (_0) -> begin
+_0
+end))
+
+
+let uu___is_Caption : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Caption (_0) -> begin
+true
+end
+| uu____628 -> begin
+false
+end))
+
+
+let __proj__Caption__item___0 : decl  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Caption (_0) -> begin
+_0
+end))
+
+
+let uu___is_Eval : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eval (_0) -> begin
+true
+end
+| uu____640 -> begin
+false
+end))
+
+
+let __proj__Eval__item___0 : decl  ->  term = (fun projectee -> (match (projectee) with
+| Eval (_0) -> begin
+_0
+end))
+
+
+let uu___is_Echo : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Echo (_0) -> begin
+true
+end
+| uu____652 -> begin
+false
+end))
+
+
+let __proj__Echo__item___0 : decl  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Echo (_0) -> begin
+_0
+end))
+
+
+let uu___is_Push : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Push -> begin
+true
+end
+| uu____663 -> begin
+false
+end))
+
+
+let uu___is_Pop : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pop -> begin
+true
+end
+| uu____667 -> begin
+false
+end))
+
+
+let uu___is_CheckSat : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CheckSat -> begin
+true
+end
+| uu____671 -> begin
+false
+end))
+
+
+let uu___is_GetUnsatCore : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| GetUnsatCore -> begin
+true
+end
+| uu____675 -> begin
+false
+end))
+
+
+let uu___is_SetOption : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SetOption (_0) -> begin
+true
+end
+| uu____682 -> begin
+false
+end))
+
+
+let __proj__SetOption__item___0 : decl  ->  (Prims.string * Prims.string) = (fun projectee -> (match (projectee) with
+| SetOption (_0) -> begin
+_0
+end))
+
+
+let uu___is_PrintStats : decl  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PrintStats -> begin
+true
+end
+| uu____699 -> begin
+false
+end))
+
+
+type decls_t =
+decl Prims.list
+
+
+type error_label =
+(fv * Prims.string * FStar_Range.range)
+
+
+type error_labels =
+error_label Prims.list
+
+
+let fv_eq : fv  ->  fv  ->  Prims.bool = (fun x y -> ((Prims.fst x) = (Prims.fst y)))
+
+
+let fv_sort = (fun x -> (Prims.snd x))
+
+
+let freevar_eq : term  ->  term  ->  Prims.bool = (fun x y -> (match (((x.tm), (y.tm))) with
+| (FreeV (x1), FreeV (y1)) -> begin
+(fv_eq x1 y1)
+end
+| uu____736 -> begin
+false
+end))
+
+
+let freevar_sort : term  ->  sort = (fun uu___83_741 -> (match (uu___83_741) with
+| {tm = FreeV (x); freevars = uu____743; rng = uu____744} -> begin
+(fv_sort x)
+end
+| uu____751 -> begin
+(failwith "impossible")
+end))
+
+
+let fv_of_term : term  ->  fv = (fun uu___84_754 -> (match (uu___84_754) with
+| {tm = FreeV (fv); freevars = uu____756; rng = uu____757} -> begin
+fv
+end
+| uu____764 -> begin
+(failwith "impossible")
+end))
+
+
+let rec freevars : term  ->  (Prims.string * sort) Prims.list = (fun t -> (match (t.tm) with
+| (Integer (_)) | (BoundV (_)) -> begin
+[]
+end
+| FreeV (fv) -> begin
+(fv)::[]
+end
+| App (uu____785, tms) -> begin
+(FStar_List.collect freevars tms)
+end
+| (Quant (_, _, _, _, t1)) | (Labeled (t1, _, _)) | (LblPos (t1, _)) -> begin
+(freevars t1)
+end
+| Let (es, body) -> begin
+(FStar_List.collect freevars ((body)::es))
+end))
+
+
+let free_variables : term  ->  fvs = (fun t -> (
+
+let uu____812 = (FStar_ST.read t.freevars)
+in (match (uu____812) with
+| Some (b) -> begin
+b
+end
+| None -> begin
+(
+
+let fvs = (
+
+let uu____835 = (freevars t)
+in (FStar_Util.remove_dups fv_eq uu____835))
+in ((FStar_ST.write t.freevars (Some (fvs)));
+fvs;
+))
+end)))
+
+
+let qop_to_string : qop  ->  Prims.string = (fun uu___85_847 -> (match (uu___85_847) with
+| Forall -> begin
+"forall"
+end
+| Exists -> begin
+"exists"
+end))
+
+
+let op_to_string : op  ->  Prims.string = (fun uu___86_850 -> (match (uu___86_850) with
+| TrueOp -> begin
+"true"
+end
+| FalseOp -> begin
+"false"
+end
+| Not -> begin
+"not"
+end
+| And -> begin
+"and"
+end
+| Or -> begin
+"or"
+end
+| Imp -> begin
+"implies"
+end
+| Iff -> begin
+"iff"
+end
+| Eq -> begin
+"="
+end
+| LT -> begin
+"<"
+end
+| LTE -> begin
+"<="
+end
+| GT -> begin
+">"
+end
+| GTE -> begin
+">="
+end
+| Add -> begin
+"+"
+end
+| Sub -> begin
+"-"
+end
+| Div -> begin
+"div"
+end
+| Mul -> begin
+"*"
+end
+| Minus -> begin
+"-"
+end
+| Mod -> begin
+"mod"
+end
+| ITE -> begin
+"ite"
+end
+| Var (s) -> begin
+s
+end))
+
+
+let weightToSmt : Prims.int Prims.option  ->  Prims.string = (fun uu___87_855 -> (match (uu___87_855) with
+| None -> begin
+""
+end
+| Some (i) -> begin
+(
+
+let uu____858 = (FStar_Util.string_of_int i)
+in (FStar_Util.format1 ":weight %s\n" uu____858))
+end))
+
+
+let rec hash_of_term' : term'  ->  Prims.string = (fun t -> (match (t) with
+| Integer (i) -> begin
+i
+end
+| BoundV (i) -> begin
+(
+
+let uu____866 = (FStar_Util.string_of_int i)
+in (Prims.strcat "@" uu____866))
+end
+| FreeV (x) -> begin
+(
+
+let uu____870 = (
+
+let uu____871 = (strSort (Prims.snd x))
+in (Prims.strcat ":" uu____871))
+in (Prims.strcat (Prims.fst x) uu____870))
+end
+| App (op, tms) -> begin
+(
+
+let uu____876 = (
+
+let uu____877 = (
+
+let uu____878 = (
+
+let uu____879 = (FStar_List.map hash_of_term tms)
+in (FStar_All.pipe_right uu____879 (FStar_String.concat " ")))
+in (Prims.strcat uu____878 ")"))
+in (Prims.strcat (op_to_string op) uu____877))
+in (Prims.strcat "(" uu____876))
+end
+| Labeled (t1, r1, r2) -> begin
+(
+
+let uu____885 = (hash_of_term t1)
+in (
+
+let uu____886 = (
+
+let uu____887 = (FStar_Range.string_of_range r2)
+in (Prims.strcat r1 uu____887))
+in (Prims.strcat uu____885 uu____886)))
+end
+| LblPos (t1, r) -> begin
+(
+
+let uu____890 = (
+
+let uu____891 = (hash_of_term t1)
+in (Prims.strcat uu____891 (Prims.strcat " :lblpos " (Prims.strcat r ")"))))
+in (Prims.strcat "(! " uu____890))
+end
+| Quant (qop, pats, wopt, sorts, body) -> begin
+(
+
+let uu____905 = (
+
+let uu____906 = (
+
+let uu____907 = (
+
+let uu____908 = (
+
+let uu____909 = (FStar_List.map strSort sorts)
+in (FStar_All.pipe_right uu____909 (FStar_String.concat " ")))
+in (
+
+let uu____912 = (
+
+let uu____913 = (
+
+let uu____914 = (hash_of_term body)
+in (
+
+let uu____915 = (
+
+let uu____916 = (
+
+let uu____917 = (weightToSmt wopt)
+in (
+
+let uu____918 = (
+
+let uu____919 = (
+
+let uu____920 = (
+
+let uu____921 = (FStar_All.pipe_right pats (FStar_List.map (fun pats1 -> (
+
+let uu____929 = (FStar_List.map hash_of_term pats1)
+in (FStar_All.pipe_right uu____929 (FStar_String.concat " "))))))
+in (FStar_All.pipe_right uu____921 (FStar_String.concat "; ")))
+in (Prims.strcat uu____920 "))"))
+in (Prims.strcat " " uu____919))
+in (Prims.strcat uu____917 uu____918)))
+in (Prims.strcat " " uu____916))
+in (Prims.strcat uu____914 uu____915)))
+in (Prims.strcat ")(! " uu____913))
+in (Prims.strcat uu____908 uu____912)))
+in (Prims.strcat " (" uu____907))
+in (Prims.strcat (qop_to_string qop) uu____906))
+in (Prims.strcat "(" uu____905))
+end
+| Let (es, body) -> begin
+(
+
+let uu____937 = (
+
+let uu____938 = (
+
+let uu____939 = (FStar_List.map hash_of_term es)
+in (FStar_All.pipe_right uu____939 (FStar_String.concat " ")))
+in (
+
+let uu____942 = (
+
+let uu____943 = (
+
+let uu____944 = (hash_of_term body)
+in (Prims.strcat uu____944 ")"))
+in (Prims.strcat ") " uu____943))
+in (Prims.strcat uu____938 uu____942)))
+in (Prims.strcat "(let (" uu____937))
+end))
+and hash_of_term : term  ->  Prims.string = (fun tm -> (hash_of_term' tm.tm))
+
+
+let mk : term'  ->  FStar_Range.range  ->  term = (fun t r -> (
+
+let uu____952 = (FStar_Util.mk_ref None)
+in {tm = t; freevars = uu____952; rng = r}))
+
+
+let mkTrue : FStar_Range.range  ->  term = (fun r -> (mk (App (((TrueOp), ([])))) r))
+
+
+let mkFalse : FStar_Range.range  ->  term = (fun r -> (mk (App (((FalseOp), ([])))) r))
+
+
+let mkInteger : Prims.string  ->  FStar_Range.range  ->  term = (fun i r -> (
+
+let uu____981 = (
+
+let uu____982 = (FStar_Util.ensure_decimal i)
+in Integer (uu____982))
+in (mk uu____981 r)))
+
+
+let mkInteger' : Prims.int  ->  FStar_Range.range  ->  term = (fun i r -> (
+
+let uu____989 = (FStar_Util.string_of_int i)
+in (mkInteger uu____989 r)))
+
+
+let mkBoundV : Prims.int  ->  FStar_Range.range  ->  term = (fun i r -> (mk (BoundV (i)) r))
+
+
+let mkFreeV : (Prims.string * sort)  ->  FStar_Range.range  ->  term = (fun x r -> (mk (FreeV (x)) r))
+
+
+let mkApp' : (op * term Prims.list)  ->  FStar_Range.range  ->  term = (fun f r -> (mk (App (f)) r))
+
+
+let mkApp : (Prims.string * term Prims.list)  ->  FStar_Range.range  ->  term = (fun uu____1025 r -> (match (uu____1025) with
+| (s, args) -> begin
+(mk (App (((Var (s)), (args)))) r)
+end))
+
+
+let mkNot : term  ->  FStar_Range.range  ->  term = (fun t r -> (match (t.tm) with
+| App (TrueOp, uu____1041) -> begin
+(mkFalse r)
+end
+| App (FalseOp, uu____1044) -> begin
+(mkTrue r)
+end
+| uu____1047 -> begin
+(mkApp' ((Not), ((t)::[])) r)
+end))
+
+
+let mkAnd : (term * term)  ->  FStar_Range.range  ->  term = (fun uu____1055 r -> (match (uu____1055) with
+| (t1, t2) -> begin
+(match (((t1.tm), (t2.tm))) with
+| (App (TrueOp, uu____1061), uu____1062) -> begin
+t2
+end
+| (uu____1065, App (TrueOp, uu____1066)) -> begin
+t1
+end
+| ((App (FalseOp, _), _)) | ((_, App (FalseOp, _))) -> begin
+(mkFalse r)
+end
+| (App (And, ts1), App (And, ts2)) -> begin
+(mkApp' ((And), ((FStar_List.append ts1 ts2))) r)
+end
+| (uu____1082, App (And, ts2)) -> begin
+(mkApp' ((And), ((t1)::ts2)) r)
+end
+| (App (And, ts1), uu____1088) -> begin
+(mkApp' ((And), ((FStar_List.append ts1 ((t2)::[])))) r)
+end
+| uu____1092 -> begin
+(mkApp' ((And), ((t1)::(t2)::[])) r)
+end)
+end))
+
+
+let mkOr : (term * term)  ->  FStar_Range.range  ->  term = (fun uu____1102 r -> (match (uu____1102) with
+| (t1, t2) -> begin
+(match (((t1.tm), (t2.tm))) with
+| ((App (TrueOp, _), _)) | ((_, App (TrueOp, _))) -> begin
+(mkTrue r)
+end
+| (App (FalseOp, uu____1114), uu____1115) -> begin
+t2
+end
+| (uu____1118, App (FalseOp, uu____1119)) -> begin
+t1
+end
+| (App (Or, ts1), App (Or, ts2)) -> begin
+(mkApp' ((Or), ((FStar_List.append ts1 ts2))) r)
+end
+| (uu____1129, App (Or, ts2)) -> begin
+(mkApp' ((Or), ((t1)::ts2)) r)
+end
+| (App (Or, ts1), uu____1135) -> begin
+(mkApp' ((Or), ((FStar_List.append ts1 ((t2)::[])))) r)
+end
+| uu____1139 -> begin
+(mkApp' ((Or), ((t1)::(t2)::[])) r)
+end)
+end))
+
+
+let mkImp : (term * term)  ->  FStar_Range.range  ->  term = (fun uu____1149 r -> (match (uu____1149) with
+| (t1, t2) -> begin
+(match (((t1.tm), (t2.tm))) with
+| ((_, App (TrueOp, _))) | ((App (FalseOp, _), _)) -> begin
+(mkTrue r)
+end
+| (App (TrueOp, uu____1161), uu____1162) -> begin
+t2
+end
+| (uu____1165, App (Imp, (t1')::(t2')::[])) -> begin
+(
+
+let uu____1169 = (
+
+let uu____1173 = (
+
+let uu____1175 = (mkAnd ((t1), (t1')) r)
+in (uu____1175)::(t2')::[])
+in ((Imp), (uu____1173)))
+in (mkApp' uu____1169 r))
+end
+| uu____1177 -> begin
+(mkApp' ((Imp), ((t1)::(t2)::[])) r)
+end)
+end))
+
+
+let mk_bin_op : op  ->  (term * term)  ->  FStar_Range.range  ->  term = (fun op uu____1190 r -> (match (uu____1190) with
+| (t1, t2) -> begin
+(mkApp' ((op), ((t1)::(t2)::[])) r)
+end))
+
+
+let mkMinus : term  ->  FStar_Range.range  ->  term = (fun t r -> (mkApp' ((Minus), ((t)::[])) r))
+
+
+let mkIff : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Iff)
+
+
+let mkEq : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Eq)
+
+
+let mkLT : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op LT)
+
+
+let mkLTE : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op LTE)
+
+
+let mkGT : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op GT)
+
+
+let mkGTE : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op GTE)
+
+
+let mkAdd : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Add)
+
+
+let mkSub : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Sub)
+
+
+let mkDiv : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Div)
+
+
+let mkMul : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Mul)
+
+
+let mkMod : (term * term)  ->  FStar_Range.range  ->  term = (mk_bin_op Mod)
+
+
+let mkITE : (term * term * term)  ->  FStar_Range.range  ->  term = (fun uu____1277 r -> (match (uu____1277) with
+| (t1, t2, t3) -> begin
+(match (t1.tm) with
+| App (TrueOp, uu____1285) -> begin
+t2
+end
+| App (FalseOp, uu____1288) -> begin
+t3
+end
+| uu____1291 -> begin
+(match (((t2.tm), (t3.tm))) with
+| (App (TrueOp, uu____1292), App (TrueOp, uu____1293)) -> begin
+(mkTrue r)
+end
+| (App (TrueOp, uu____1298), uu____1299) -> begin
+(
+
+let uu____1302 = (
+
+let uu____1305 = (mkNot t1 t1.rng)
+in ((uu____1305), (t3)))
+in (mkImp uu____1302 r))
+end
+| (uu____1306, App (TrueOp, uu____1307)) -> begin
+(mkImp ((t1), (t2)) r)
+end
+| (uu____1310, uu____1311) -> begin
+(mkApp' ((ITE), ((t1)::(t2)::(t3)::[])) r)
+end)
+end)
+end))
+
+
+let mkCases : term Prims.list  ->  FStar_Range.range  ->  term = (fun t r -> (match (t) with
+| [] -> begin
+(failwith "Impos")
+end
+| (hd1)::tl1 -> begin
+(FStar_List.fold_left (fun out t1 -> (mkAnd ((out), (t1)) r)) hd1 tl1)
+end))
+
+
+let mkQuant : (qop * term Prims.list Prims.list * Prims.int Prims.option * sort Prims.list * term)  ->  FStar_Range.range  ->  term = (fun uu____1339 r -> (match (uu____1339) with
+| (qop, pats, wopt, vars, body) -> begin
+(match (((FStar_List.length vars) = (Prims.parse_int "0"))) with
+| true -> begin
+body
+end
+| uu____1365 -> begin
+(match (body.tm) with
+| App (TrueOp, uu____1366) -> begin
+body
+end
+| uu____1369 -> begin
+(mk (Quant (((qop), (pats), (wopt), (vars), (body)))) r)
+end)
+end)
+end))
+
+
+let mkLet : (term Prims.list * term)  ->  FStar_Range.range  ->  term = (fun uu____1381 r -> (match (uu____1381) with
+| (es, body) -> begin
+(match (((FStar_List.length es) = (Prims.parse_int "0"))) with
+| true -> begin
+body
+end
+| uu____1392 -> begin
+(mk (Let (((es), (body)))) r)
+end)
+end))
+
+
+let abstr : fv Prims.list  ->  term  ->  term = (fun fvs t -> (
+
+let nvars = (FStar_List.length fvs)
+in (
+
+let index_of = (fun fv -> (
+
+let uu____1409 = (FStar_Util.try_find_index (fv_eq fv) fvs)
+in (match (uu____1409) with
+| None -> begin
+None
+end
+| Some (i) -> begin
+Some ((nvars - (i + (Prims.parse_int "1"))))
+end)))
+in (
+
+let rec aux = (fun ix t1 -> (
+
+let uu____1423 = (FStar_ST.read t1.freevars)
+in (match (uu____1423) with
+| Some ([]) -> begin
+t1
+end
+| uu____1439 -> begin
+(match (t1.tm) with
+| (Integer (_)) | (BoundV (_)) -> begin
+t1
+end
+| FreeV (x) -> begin
+(
+
+let uu____1449 = (index_of x)
+in (match (uu____1449) with
+| None -> begin
+t1
+end
+| Some (i) -> begin
+(mkBoundV (i + ix) t1.rng)
+end))
+end
+| App (op, tms) -> begin
+(
+
+let uu____1456 = (
+
+let uu____1460 = (FStar_List.map (aux ix) tms)
+in ((op), (uu____1460)))
+in (mkApp' uu____1456 t1.rng))
+end
+| Labeled (t2, r1, r2) -> begin
+(
+
+let uu____1466 = (
+
+let uu____1467 = (
+
+let uu____1471 = (aux ix t2)
+in ((uu____1471), (r1), (r2)))
+in Labeled (uu____1467))
+in (mk uu____1466 t2.rng))
+end
+| LblPos (t2, r) -> begin
+(
+
+let uu____1474 = (
+
+let uu____1475 = (
+
+let uu____1478 = (aux ix t2)
+in ((uu____1478), (r)))
+in LblPos (uu____1475))
+in (mk uu____1474 t2.rng))
+end
+| Quant (qop, pats, wopt, vars, body) -> begin
+(
+
+let n1 = (FStar_List.length vars)
+in (
+
+let uu____1494 = (
+
+let uu____1504 = (FStar_All.pipe_right pats (FStar_List.map (FStar_List.map (aux (ix + n1)))))
+in (
+
+let uu____1515 = (aux (ix + n1) body)
+in ((qop), (uu____1504), (wopt), (vars), (uu____1515))))
+in (mkQuant uu____1494 t1.rng)))
+end
+| Let (es, body) -> begin
+(
+
+let uu____1526 = (FStar_List.fold_left (fun uu____1533 e -> (match (uu____1533) with
+| (ix1, l) -> begin
+(
+
+let uu____1545 = (
+
+let uu____1547 = (aux ix1 e)
+in (uu____1547)::l)
+in (((ix1 + (Prims.parse_int "1"))), (uu____1545)))
+end)) ((ix), ([])) es)
+in (match (uu____1526) with
+| (ix1, es_rev) -> begin
+(
+
+let uu____1554 = (
+
+let uu____1558 = (aux ix1 body)
+in (((FStar_List.rev es_rev)), (uu____1558)))
+in (mkLet uu____1554 t1.rng))
+end))
+end)
+end)))
+in (aux (Prims.parse_int "0") t)))))
+
+
+let inst : term Prims.list  ->  term  ->  term = (fun tms t -> (
+
+let tms1 = (FStar_List.rev tms)
+in (
+
+let n1 = (FStar_List.length tms1)
+in (
+
+let rec aux = (fun shift t1 -> (match (t1.tm) with
+| (Integer (_)) | (FreeV (_)) -> begin
+t1
+end
+| BoundV (i) -> begin
+(match ((((Prims.parse_int "0") <= (i - shift)) && ((i - shift) < n1))) with
+| true -> begin
+(FStar_List.nth tms1 (i - shift))
+end
+| uu____1584 -> begin
+t1
+end)
+end
+| App (op, tms2) -> begin
+(
+
+let uu____1589 = (
+
+let uu____1593 = (FStar_List.map (aux shift) tms2)
+in ((op), (uu____1593)))
+in (mkApp' uu____1589 t1.rng))
+end
+| Labeled (t2, r1, r2) -> begin
+(
+
+let uu____1599 = (
+
+let uu____1600 = (
+
+let uu____1604 = (aux shift t2)
+in ((uu____1604), (r1), (r2)))
+in Labeled (uu____1600))
+in (mk uu____1599 t2.rng))
+end
+| LblPos (t2, r) -> begin
+(
+
+let uu____1607 = (
+
+let uu____1608 = (
+
+let uu____1611 = (aux shift t2)
+in ((uu____1611), (r)))
+in LblPos (uu____1608))
+in (mk uu____1607 t2.rng))
+end
+| Quant (qop, pats, wopt, vars, body) -> begin
+(
+
+let m = (FStar_List.length vars)
+in (
+
+let shift1 = (shift + m)
+in (
+
+let uu____1630 = (
+
+let uu____1640 = (FStar_All.pipe_right pats (FStar_List.map (FStar_List.map (aux shift1))))
+in (
+
+let uu____1649 = (aux shift1 body)
+in ((qop), (uu____1640), (wopt), (vars), (uu____1649))))
+in (mkQuant uu____1630 t1.rng))))
+end
+| Let (es, body) -> begin
+(
+
+let uu____1658 = (FStar_List.fold_left (fun uu____1665 e -> (match (uu____1665) with
+| (ix, es1) -> begin
+(
+
+let uu____1677 = (
+
+let uu____1679 = (aux shift e)
+in (uu____1679)::es1)
+in (((shift + (Prims.parse_int "1"))), (uu____1677)))
+end)) ((shift), ([])) es)
+in (match (uu____1658) with
+| (shift1, es_rev) -> begin
+(
+
+let uu____1686 = (
+
+let uu____1690 = (aux shift1 body)
+in (((FStar_List.rev es_rev)), (uu____1690)))
+in (mkLet uu____1686 t1.rng))
+end))
+end))
+in (aux (Prims.parse_int "0") t)))))
+
+
+let subst : term  ->  fv  ->  term  ->  term = (fun t fv s -> (
+
+let uu____1701 = (abstr ((fv)::[]) t)
+in (inst ((s)::[]) uu____1701)))
+
+
+let mkQuant' : (qop * term Prims.list Prims.list * Prims.int Prims.option * fv Prims.list * term)  ->  FStar_Range.range  ->  term = (fun uu____1715 -> (match (uu____1715) with
+| (qop, pats, wopt, vars, body) -> begin
+(
+
+let uu____1740 = (
+
+let uu____1750 = (FStar_All.pipe_right pats (FStar_List.map (FStar_List.map (abstr vars))))
+in (
+
+let uu____1759 = (FStar_List.map fv_sort vars)
+in (
+
+let uu____1763 = (abstr vars body)
+in ((qop), (uu____1750), (wopt), (uu____1759), (uu____1763)))))
+in (mkQuant uu____1740))
+end))
+
+
+let mkForall'' : (pat Prims.list Prims.list * Prims.int Prims.option * sort Prims.list * term)  ->  FStar_Range.range  ->  term = (fun uu____1780 r -> (match (uu____1780) with
+| (pats, wopt, sorts, body) -> begin
+(mkQuant ((Forall), (pats), (wopt), (sorts), (body)) r)
+end))
+
+
+let mkForall' : (pat Prims.list Prims.list * Prims.int Prims.option * fvs * term)  ->  FStar_Range.range  ->  term = (fun uu____1817 r -> (match (uu____1817) with
+| (pats, wopt, vars, body) -> begin
+(
+
+let uu____1836 = (mkQuant' ((Forall), (pats), (wopt), (vars), (body)))
+in (uu____1836 r))
+end))
+
+
+let mkForall : (pat Prims.list Prims.list * fvs * term)  ->  FStar_Range.range  ->  term = (fun uu____1851 r -> (match (uu____1851) with
+| (pats, vars, body) -> begin
+(
+
+let uu____1865 = (mkQuant' ((Forall), (pats), (None), (vars), (body)))
+in (uu____1865 r))
+end))
+
+
+let mkExists : (pat Prims.list Prims.list * fvs * term)  ->  FStar_Range.range  ->  term = (fun uu____1880 r -> (match (uu____1880) with
+| (pats, vars, body) -> begin
+(
+
+let uu____1894 = (mkQuant' ((Exists), (pats), (None), (vars), (body)))
+in (uu____1894 r))
+end))
+
+
+let mkLet' : ((fv * term) Prims.list * term)  ->  FStar_Range.range  ->  term = (fun uu____1909 r -> (match (uu____1909) with
+| (bindings, body) -> begin
+(
+
+let uu____1924 = (FStar_List.split bindings)
+in (match (uu____1924) with
+| (vars, es) -> begin
+(
+
+let uu____1935 = (
+
+let uu____1939 = (abstr vars body)
+in ((es), (uu____1939)))
+in (mkLet uu____1935 r))
+end))
+end))
+
+
+let norng : FStar_Range.range = FStar_Range.dummyRange
+
+
+let mkDefineFun : (Prims.string * (Prims.string * sort) Prims.list * sort * term * caption)  ->  decl = (fun uu____1951 -> (match (uu____1951) with
+| (nm, vars, s, tm, c) -> begin
+(
+
+let uu____1971 = (
+
+let uu____1978 = (FStar_List.map fv_sort vars)
+in (
+
+let uu____1982 = (abstr vars tm)
+in ((nm), (uu____1978), (s), (uu____1982), (c))))
+in DefineFun (uu____1971))
+end))
+
+
+let constr_id_of_sort : sort  ->  Prims.string = (fun sort -> (
+
+let uu____1987 = (strSort sort)
+in (FStar_Util.format1 "%s_constr_id" uu____1987)))
+
+
+let fresh_token : (Prims.string * sort)  ->  Prims.int  ->  decl = (fun uu____1994 id -> (match (uu____1994) with
+| (tok_name, sort) -> begin
+(
+
+let a_name = (Prims.strcat "fresh_token_" tok_name)
+in (
+
+let uu____2001 = (
+
+let uu____2006 = (
+
+let uu____2007 = (
+
+let uu____2010 = (mkInteger' id norng)
+in (
+
+let uu____2011 = (
+
+let uu____2012 = (
+
+let uu____2016 = (constr_id_of_sort sort)
+in (
+
+let uu____2017 = (
+
+let uu____2019 = (mkApp ((tok_name), ([])) norng)
+in (uu____2019)::[])
+in ((uu____2016), (uu____2017))))
+in (mkApp uu____2012 norng))
+in ((uu____2010), (uu____2011))))
+in (mkEq uu____2007 norng))
+in ((uu____2006), (Some ("fresh token")), (Some (a_name))))
+in Assume (uu____2001)))
+end))
+
+
+let fresh_constructor : (Prims.string * sort Prims.list * sort * Prims.int)  ->  decl = (fun uu____2031 -> (match (uu____2031) with
+| (name, arg_sorts, sort, id) -> begin
+(
+
+let id1 = (FStar_Util.string_of_int id)
+in (
+
+let bvars = (FStar_All.pipe_right arg_sorts (FStar_List.mapi (fun i s -> (
+
+let uu____2050 = (
+
+let uu____2053 = (
+
+let uu____2054 = (FStar_Util.string_of_int i)
+in (Prims.strcat "x_" uu____2054))
+in ((uu____2053), (s)))
+in (mkFreeV uu____2050 norng)))))
+in (
+
+let bvar_names = (FStar_List.map fv_of_term bvars)
+in (
+
+let capp = (mkApp ((name), (bvars)) norng)
+in (
+
+let cid_app = (
+
+let uu____2060 = (
+
+let uu____2064 = (constr_id_of_sort sort)
+in ((uu____2064), ((capp)::[])))
+in (mkApp uu____2060 norng))
+in (
+
+let a_name = (Prims.strcat "constructor_distinct_" name)
+in (
+
+let uu____2067 = (
+
+let uu____2072 = (
+
+let uu____2073 = (
+
+let uu____2079 = (
+
+let uu____2080 = (
+
+let uu____2083 = (mkInteger id1 norng)
+in ((uu____2083), (cid_app)))
+in (mkEq uu____2080 norng))
+in ((((capp)::[])::[]), (bvar_names), (uu____2079)))
+in (mkForall uu____2073 norng))
+in ((uu____2072), (Some ("Constructor distinct")), (Some (a_name))))
+in Assume (uu____2067))))))))
+end))
+
+
+let injective_constructor : (Prims.string * constructor_field Prims.list * sort)  ->  decls_t = (fun uu____2097 -> (match (uu____2097) with
+| (name, fields, sort) -> begin
+(
+
+let n_bvars = (FStar_List.length fields)
+in (
+
+let bvar_name = (fun i -> (
+
+let uu____2113 = (FStar_Util.string_of_int i)
+in (Prims.strcat "x_" uu____2113)))
+in (
+
+let bvar_index = (fun i -> (n_bvars - (i + (Prims.parse_int "1"))))
+in (
+
+let bvar = (fun i s -> (
+
+let uu____2130 = (
+
+let uu____2133 = (bvar_name i)
+in ((uu____2133), (s)))
+in (mkFreeV uu____2130)))
+in (
+
+let bvars = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____2142 -> (match (uu____2142) with
+| (uu____2146, s, uu____2148) -> begin
+(
+
+let uu____2149 = (bvar i s)
+in (uu____2149 norng))
+end))))
+in (
+
+let bvar_names = (FStar_List.map fv_of_term bvars)
+in (
+
+let capp = (mkApp ((name), (bvars)) norng)
+in (
+
+let uu____2156 = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____2167 -> (match (uu____2167) with
+| (name1, s, projectible) -> begin
+(
+
+let cproj_app = (mkApp ((name1), ((capp)::[])) norng)
+in (
+
+let proj_name = DeclFun (((name1), ((sort)::[]), (s), (Some ("Projector"))))
+in (match (projectible) with
+| true -> begin
+(
+
+let a_name = (Prims.strcat "projection_inverse_" name1)
+in (
+
+let uu____2182 = (
+
+let uu____2184 = (
+
+let uu____2185 = (
+
+let uu____2190 = (
+
+let uu____2191 = (
+
+let uu____2197 = (
+
+let uu____2198 = (
+
+let uu____2201 = (
+
+let uu____2202 = (bvar i s)
+in (uu____2202 norng))
+in ((cproj_app), (uu____2201)))
+in (mkEq uu____2198 norng))
+in ((((capp)::[])::[]), (bvar_names), (uu____2197)))
+in (mkForall uu____2191 norng))
+in ((uu____2190), (Some ("Projection inverse")), (Some (a_name))))
+in Assume (uu____2185))
+in (uu____2184)::[])
+in (proj_name)::uu____2182))
+end
+| uu____2212 -> begin
+(proj_name)::[]
+end)))
+end))))
+in (FStar_All.pipe_right uu____2156 FStar_List.flatten)))))))))
+end))
+
+
+let constructor_to_decl : constructor_t  ->  decls_t = (fun uu____2218 -> (match (uu____2218) with
+| (name, fields, sort, id, injective) -> begin
+(
+
+let injective1 = (injective || true)
+in (
+
+let field_sorts = (FStar_All.pipe_right fields (FStar_List.map (fun uu____2234 -> (match (uu____2234) with
+| (uu____2238, sort1, uu____2240) -> begin
+sort1
+end))))
+in (
+
+let cdecl = DeclFun (((name), (field_sorts), (sort), (Some ("Constructor"))))
+in (
+
+let cid = (fresh_constructor ((name), (field_sorts), (sort), (id)))
+in (
+
+let disc = (
+
+let disc_name = (Prims.strcat "is-" name)
+in (
+
+let xfv = (("x"), (sort))
+in (
+
+let xx = (mkFreeV xfv norng)
+in (
+
+let disc_eq = (
+
+let uu____2253 = (
+
+let uu____2256 = (
+
+let uu____2257 = (
+
+let uu____2261 = (constr_id_of_sort sort)
+in ((uu____2261), ((xx)::[])))
+in (mkApp uu____2257 norng))
+in (
+
+let uu____2263 = (
+
+let uu____2264 = (FStar_Util.string_of_int id)
+in (mkInteger uu____2264 norng))
+in ((uu____2256), (uu____2263))))
+in (mkEq uu____2253 norng))
+in (
+
+let uu____2265 = (
+
+let uu____2273 = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____2296 -> (match (uu____2296) with
+| (proj, s, projectible) -> begin
+(match (projectible) with
+| true -> begin
+(
+
+let uu____2313 = (mkApp ((proj), ((xx)::[])) norng)
+in ((uu____2313), ([])))
+end
+| uu____2320 -> begin
+(
+
+let fi = (
+
+let uu____2324 = (
+
+let uu____2325 = (FStar_Util.string_of_int i)
+in (Prims.strcat "f_" uu____2325))
+in ((uu____2324), (s)))
+in (
+
+let uu____2326 = (mkFreeV fi norng)
+in ((uu____2326), ((fi)::[]))))
+end)
+end))))
+in (FStar_All.pipe_right uu____2273 FStar_List.split))
+in (match (uu____2265) with
+| (proj_terms, ex_vars) -> begin
+(
+
+let ex_vars1 = (FStar_List.flatten ex_vars)
+in (
+
+let disc_inv_body = (
+
+let uu____2369 = (
+
+let uu____2372 = (mkApp ((name), (proj_terms)) norng)
+in ((xx), (uu____2372)))
+in (mkEq uu____2369 norng))
+in (
+
+let disc_inv_body1 = (match (ex_vars1) with
+| [] -> begin
+disc_inv_body
+end
+| uu____2377 -> begin
+(mkExists (([]), (ex_vars1), (disc_inv_body)) norng)
+end)
+in (
+
+let disc_ax = (mkAnd ((disc_eq), (disc_inv_body1)) norng)
+in (
+
+let def = (mkDefineFun ((disc_name), ((xfv)::[]), (Bool_sort), (disc_ax), (Some ("Discriminator definition"))))
+in def)))))
+end))))))
+in (
+
+let projs = (match (injective1) with
+| true -> begin
+(injective_constructor ((name), (fields), (sort)))
+end
+| uu____2399 -> begin
+[]
+end)
+in (
+
+let uu____2400 = (
+
+let uu____2402 = (
+
+let uu____2403 = (FStar_Util.format1 "<start constructor %s>" name)
+in Caption (uu____2403))
+in (uu____2402)::(cdecl)::(cid)::projs)
+in (
+
+let uu____2404 = (
+
+let uu____2406 = (
+
+let uu____2408 = (
+
+let uu____2409 = (FStar_Util.format1 "</end constructor %s>" name)
+in Caption (uu____2409))
+in (uu____2408)::[])
+in (FStar_List.append ((disc)::[]) uu____2406))
+in (FStar_List.append uu____2400 uu____2404)))))))))
+end))
+
+
+let name_binders_inner : Prims.string Prims.option  ->  (Prims.string * sort) Prims.list  ->  Prims.int  ->  sort Prims.list  ->  ((Prims.string * sort) Prims.list * Prims.string Prims.list * Prims.int) = (fun prefix_opt outer_names start sorts -> (
+
+let uu____2439 = (FStar_All.pipe_right sorts (FStar_List.fold_left (fun uu____2462 s -> (match (uu____2462) with
+| (names, binders, n1) -> begin
+(
+
+let prefix1 = (match (s) with
+| Term_sort -> begin
+"@x"
+end
+| uu____2490 -> begin
+"@u"
+end)
+in (
+
+let prefix2 = (match (prefix_opt) with
+| None -> begin
+prefix1
+end
+| Some (p) -> begin
+(Prims.strcat p prefix1)
+end)
+in (
+
+let nm = (
+
+let uu____2494 = (FStar_Util.string_of_int n1)
+in (Prims.strcat prefix2 uu____2494))
+in (
+
+let names1 = (((nm), (s)))::names
+in (
+
+let b = (
+
+let uu____2502 = (strSort s)
+in (FStar_Util.format2 "(%s %s)" nm uu____2502))
+in ((names1), ((b)::binders), ((n1 + (Prims.parse_int "1")))))))))
+end)) ((outer_names), ([]), (start))))
+in (match (uu____2439) with
+| (names, binders, n1) -> begin
+((names), ((FStar_List.rev binders)), (n1))
+end)))
+
+
+let name_macro_binders : sort Prims.list  ->  ((Prims.string * sort) Prims.list * Prims.string Prims.list) = (fun sorts -> (
+
+let uu____2544 = (name_binders_inner (Some ("__")) [] (Prims.parse_int "0") sorts)
+in (match (uu____2544) with
+| (names, binders, n1) -> begin
+(((FStar_List.rev names)), (binders))
+end)))
+
+
+let termToSmt : term  ->  Prims.string = (fun t -> (
+
+let remove_guard_free = (fun pats -> (FStar_All.pipe_right pats (FStar_List.map (fun ps -> (FStar_All.pipe_right ps (FStar_List.map (fun tm -> (match (tm.tm) with
+| App (Var ("Prims.guard_free"), ({tm = BoundV (uu____2601); freevars = uu____2602; rng = uu____2603})::[]) -> begin
+tm
+end
+| App (Var ("Prims.guard_free"), (p)::[]) -> begin
+p
+end
+| uu____2611 -> begin
+tm
+end))))))))
+in (
+
+let rec aux' = (fun n1 names t1 -> (match (t1.tm) with
+| Integer (i) -> begin
+i
+end
+| BoundV (i) -> begin
+(
+
+let uu____2634 = (FStar_List.nth names i)
+in (FStar_All.pipe_right uu____2634 Prims.fst))
+end
+| FreeV (x) -> begin
+(Prims.fst x)
+end
+| App (op, []) -> begin
+(op_to_string op)
+end
+| App (op, tms) -> begin
+(
+
+let uu____2644 = (
+
+let uu____2645 = (FStar_List.map (aux n1 names) tms)
+in (FStar_All.pipe_right uu____2645 (FStar_String.concat "\n")))
+in (FStar_Util.format2 "(%s %s)" (op_to_string op) uu____2644))
+end
+| Labeled (t2, uu____2649, uu____2650) -> begin
+(aux n1 names t2)
+end
+| LblPos (t2, s) -> begin
+(
+
+let uu____2653 = (aux n1 names t2)
+in (FStar_Util.format2 "(! %s :lblpos %s)" uu____2653 s))
+end
+| Quant (qop, pats, wopt, sorts, body) -> begin
+(
+
+let uu____2667 = (name_binders_inner None names n1 sorts)
+in (match (uu____2667) with
+| (names1, binders, n2) -> begin
+(
+
+let binders1 = (FStar_All.pipe_right binders (FStar_String.concat " "))
+in (
+
+let pats1 = (remove_guard_free pats)
+in (
+
+let pats_str = (match (pats1) with
+| (([])::[]) | ([]) -> begin
+""
+end
+| uu____2695 -> begin
+(
+
+let uu____2698 = (FStar_All.pipe_right pats1 (FStar_List.map (fun pats2 -> (
+
+let uu____2706 = (
+
+let uu____2707 = (FStar_List.map (fun p -> (
+
+let uu____2710 = (aux n2 names1 p)
+in (FStar_Util.format1 "%s" uu____2710))) pats2)
+in (FStar_String.concat " " uu____2707))
+in (FStar_Util.format1 "\n:pattern (%s)" uu____2706)))))
+in (FStar_All.pipe_right uu____2698 (FStar_String.concat "\n")))
+end)
+in (match (((pats1), (wopt))) with
+| ((([])::[], None)) | (([], None)) -> begin
+(
+
+let uu____2724 = (aux n2 names1 body)
+in (FStar_Util.format3 "(%s (%s)\n %s);;no pats\n" (qop_to_string qop) binders1 uu____2724))
+end
+| uu____2725 -> begin
+(
+
+let uu____2731 = (aux n2 names1 body)
+in (
+
+let uu____2732 = (weightToSmt wopt)
+in (FStar_Util.format5 "(%s (%s)\n (! %s\n %s %s))" (qop_to_string qop) binders1 uu____2731 uu____2732 pats_str)))
+end))))
+end))
+end
+| Let (es, body) -> begin
+(
+
+let uu____2737 = (FStar_List.fold_left (fun uu____2752 e -> (match (uu____2752) with
+| (names0, binders, n0) -> begin
+(
+
+let nm = (
+
+let uu____2780 = (FStar_Util.string_of_int n0)
+in (Prims.strcat "@lb" uu____2780))
+in (
+
+let names01 = (((nm), (Term_sort)))::names0
+in (
+
+let b = (
+
+let uu____2788 = (aux n1 names e)
+in (FStar_Util.format2 "(%s %s)" nm uu____2788))
+in ((names01), ((b)::binders), ((n0 + (Prims.parse_int "1")))))))
+end)) ((names), ([]), (n1)) es)
+in (match (uu____2737) with
+| (names1, binders, n2) -> begin
+(
+
+let uu____2806 = (aux n2 names1 body)
+in (FStar_Util.format2 "(let (%s) %s)" (FStar_String.concat " " binders) uu____2806))
+end))
+end))
+and aux = (fun n1 names t1 -> (
+
+let s = (aux' n1 names t1)
+in (match ((t1.rng <> norng)) with
+| true -> begin
+(
+
+let uu____2812 = (FStar_Range.string_of_range t1.rng)
+in (
+
+let uu____2813 = (FStar_Range.string_of_use_range t1.rng)
+in (FStar_Util.format3 "\n;; def=%s; use=%s\n%s\n" uu____2812 uu____2813 s)))
+end
+| uu____2814 -> begin
+s
+end)))
+in (aux (Prims.parse_int "0") [] t))))
+
+
+let caption_to_string : Prims.string Prims.option  ->  Prims.string = (fun uu___88_2818 -> (match (uu___88_2818) with
+| None -> begin
+""
+end
+| Some (c) -> begin
+(
+
+let uu____2821 = (match ((FStar_Util.splitlines c)) with
+| [] -> begin
+(failwith "Impossible")
+end
+| (hd1)::[] -> begin
+((hd1), (""))
+end
+| (hd1)::uu____2830 -> begin
+((hd1), ("..."))
+end)
+in (match (uu____2821) with
+| (hd1, suffix) -> begin
+(FStar_Util.format2 ";;;;;;;;;;;;;;;;%s%s\n" hd1 suffix)
+end))
+end))
+
+
+let rec declToSmt : Prims.string  ->  decl  ->  Prims.string = (fun z3options decl -> (
+
+let escape = (fun s -> (FStar_Util.replace_char s '\'' '_'))
+in (match (decl) with
+| DefPrelude -> begin
+(mkPrelude z3options)
+end
+| Caption (c) -> begin
+(
+
+let uu____2847 = (FStar_All.pipe_right (FStar_Util.splitlines c) (fun uu___89_2849 -> (match (uu___89_2849) with
+| [] -> begin
+""
+end
+| (h)::t -> begin
+h
+end)))
+in (FStar_Util.format1 "\n; %s" uu____2847))
+end
+| DeclFun (f, argsorts, retsort, c) -> begin
+(
+
+let l = (FStar_List.map strSort argsorts)
+in (
+
+let uu____2862 = (caption_to_string c)
+in (
+
+let uu____2863 = (strSort retsort)
+in (FStar_Util.format4 "%s(declare-fun %s (%s) %s)" uu____2862 f (FStar_String.concat " " l) uu____2863))))
+end
+| DefineFun (f, arg_sorts, retsort, body, c) -> begin
+(
+
+let uu____2871 = (name_macro_binders arg_sorts)
+in (match (uu____2871) with
+| (names, binders) -> begin
+(
+
+let body1 = (
+
+let uu____2889 = (FStar_List.map (fun x -> (mkFreeV x norng)) names)
+in (inst uu____2889 body))
+in (
+
+let uu____2896 = (caption_to_string c)
+in (
+
+let uu____2897 = (strSort retsort)
+in (
+
+let uu____2898 = (termToSmt body1)
+in (FStar_Util.format5 "%s(define-fun %s (%s) %s\n %s)" uu____2896 f (FStar_String.concat " " binders) uu____2897 uu____2898)))))
+end))
+end
+| Assume (t, c, Some (n1)) -> begin
+(
+
+let uu____2903 = (caption_to_string c)
+in (
+
+let uu____2904 = (termToSmt t)
+in (FStar_Util.format3 "%s(assert (!\n%s\n:named %s))" uu____2903 uu____2904 (escape n1))))
+end
+| Assume (t, c, None) -> begin
+(
+
+let uu____2908 = (caption_to_string c)
+in (
+
+let uu____2909 = (termToSmt t)
+in (FStar_Util.format2 "%s(assert %s)" uu____2908 uu____2909)))
+end
+| Eval (t) -> begin
+(
+
+let uu____2911 = (termToSmt t)
+in (FStar_Util.format1 "(eval %s)" uu____2911))
+end
+| Echo (s) -> begin
+(FStar_Util.format1 "(echo \"%s\")" s)
+end
+| CheckSat -> begin
+"(check-sat)"
+end
+| GetUnsatCore -> begin
+"(echo \"<unsat-core>\")\n(get-unsat-core)\n(echo \"</unsat-core>\")"
+end
+| Push -> begin
+"(push)"
+end
+| Pop -> begin
+"(pop)"
+end
+| SetOption (s, v1) -> begin
+(FStar_Util.format2 "(set-option :%s %s)" s v1)
+end
+| PrintStats -> begin
+"(get-info :all-statistics)"
+end)))
+and mkPrelude : Prims.string  ->  Prims.string = (fun z3options -> (
+
+let basic = (Prims.strcat z3options "(declare-sort Ref)\n(declare-fun Ref_constr_id (Ref) Int)\n\n(declare-sort FString)\n(declare-fun FString_constr_id (FString) Int)\n\n(declare-sort Term)\n(declare-fun Term_constr_id (Term) Int)\n(declare-datatypes () ((Fuel \n(ZFuel) \n(SFuel (prec Fuel)))))\n(declare-fun MaxIFuel () Fuel)\n(declare-fun MaxFuel () Fuel)\n(declare-fun PreType (Term) Term)\n(declare-fun Valid (Term) Bool)\n(declare-fun HasTypeFuel (Fuel Term Term) Bool)\n(define-fun HasTypeZ ((x Term) (t Term)) Bool\n(HasTypeFuel ZFuel x t))\n(define-fun HasType ((x Term) (t Term)) Bool\n(HasTypeFuel MaxIFuel x t))\n;;fuel irrelevance\n(assert (forall ((f Fuel) (x Term) (t Term))\n(! (= (HasTypeFuel (SFuel f) x t)\n(HasTypeZ x t))\n:pattern ((HasTypeFuel (SFuel f) x t)))))\n(define-fun  IsTyped ((x Term)) Bool\n(exists ((t Term)) (HasTypeZ x t)))\n(declare-fun ApplyTF (Term Fuel) Term)\n(declare-fun ApplyTT (Term Term) Term)\n(declare-fun Rank (Term) Int)\n(declare-fun Closure (Term) Term)\n(declare-fun ConsTerm (Term Term) Term)\n(declare-fun ConsFuel (Fuel Term) Term)\n(declare-fun Precedes (Term Term) Term)\n(define-fun Reify ((x Term)) Term x)\n(assert (forall ((t Term))\n(! (implies (exists ((e Term)) (HasType e t))\n(Valid t))\n:pattern ((Valid t)))))\n(assert (forall ((t1 Term) (t2 Term))\n(! (iff (Valid (Precedes t1 t2)) \n(< (Rank t1) (Rank t2)))\n:pattern ((Precedes t1 t2)))))\n(define-fun Prims.precedes ((a Term) (b Term) (t1 Term) (t2 Term)) Term\n(Precedes t1 t2))\n(declare-fun Range_const () Term)\n")
+in (
+
+let constrs = ((("FString_const"), (((("FString_const_proj_0"), (Int_sort), (true)))::[]), (String_sort), ((Prims.parse_int "0")), (true)))::((("Tm_type"), ([]), (Term_sort), ((Prims.parse_int "2")), (true)))::((("Tm_arrow"), (((("Tm_arrow_id"), (Int_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "3")), (false)))::((("Tm_uvar"), (((("Tm_uvar_fst"), (Int_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "5")), (true)))::((("Tm_unit"), ([]), (Term_sort), ((Prims.parse_int "6")), (true)))::((("BoxInt"), (((("BoxInt_proj_0"), (Int_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "7")), (true)))::((("BoxBool"), (((("BoxBool_proj_0"), (Bool_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "8")), (true)))::((("BoxString"), (((("BoxString_proj_0"), (String_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "9")), (true)))::((("BoxRef"), (((("BoxRef_proj_0"), (Ref_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "10")), (true)))::((("LexCons"), (((("LexCons_0"), (Term_sort), (true)))::((("LexCons_1"), (Term_sort), (true)))::[]), (Term_sort), ((Prims.parse_int "11")), (true)))::[]
+in (
+
+let bcons = (
+
+let uu____3115 = (
+
+let uu____3117 = (FStar_All.pipe_right constrs (FStar_List.collect constructor_to_decl))
+in (FStar_All.pipe_right uu____3117 (FStar_List.map (declToSmt z3options))))
+in (FStar_All.pipe_right uu____3115 (FStar_String.concat "\n")))
+in (
+
+let lex_ordering = "\n(define-fun is-Prims.LexCons ((t Term)) Bool \n(is-LexCons t))\n(assert (forall ((x1 Term) (x2 Term) (y1 Term) (y2 Term))\n(iff (Valid (Precedes (LexCons x1 x2) (LexCons y1 y2)))\n(or (Valid (Precedes x1 y1))\n(and (= x1 y1)\n(Valid (Precedes x2 y2)))))))\n"
+in (Prims.strcat basic (Prims.strcat bcons lex_ordering)))))))
+
+
+let mk_Range_const : term = (mkApp (("Range_const"), ([])) norng)
+
+
+let mk_Term_type : term = (mkApp (("Tm_type"), ([])) norng)
+
+
+let mk_Term_app : term  ->  term  ->  FStar_Range.range  ->  term = (fun t1 t2 r -> (mkApp (("Tm_app"), ((t1)::(t2)::[])) r))
+
+
+let mk_Term_uvar : Prims.int  ->  FStar_Range.range  ->  term = (fun i r -> (
+
+let uu____3142 = (
+
+let uu____3146 = (
+
+let uu____3148 = (mkInteger' i norng)
+in (uu____3148)::[])
+in (("Tm_uvar"), (uu____3146)))
+in (mkApp uu____3142 r)))
+
+
+let mk_Term_unit : term = (mkApp (("Tm_unit"), ([])) norng)
+
+
+let boxInt : term  ->  term = (fun t -> (mkApp (("BoxInt"), ((t)::[])) t.rng))
+
+
+let unboxInt : term  ->  term = (fun t -> (mkApp (("BoxInt_proj_0"), ((t)::[])) t.rng))
+
+
+let boxBool : term  ->  term = (fun t -> (mkApp (("BoxBool"), ((t)::[])) t.rng))
+
+
+let unboxBool : term  ->  term = (fun t -> (mkApp (("BoxBool_proj_0"), ((t)::[])) t.rng))
+
+
+let boxString : term  ->  term = (fun t -> (mkApp (("BoxString"), ((t)::[])) t.rng))
+
+
+let unboxString : term  ->  term = (fun t -> (mkApp (("BoxString_proj_0"), ((t)::[])) t.rng))
+
+
+let boxRef : term  ->  term = (fun t -> (mkApp (("BoxRef"), ((t)::[])) t.rng))
+
+
+let unboxRef : term  ->  term = (fun t -> (mkApp (("BoxRef_proj_0"), ((t)::[])) t.rng))
+
+
+let boxTerm : sort  ->  term  ->  term = (fun sort t -> (match (sort) with
+| Int_sort -> begin
+(boxInt t)
+end
+| Bool_sort -> begin
+(boxBool t)
+end
+| String_sort -> begin
+(boxString t)
+end
+| Ref_sort -> begin
+(boxRef t)
+end
+| uu____3189 -> begin
+(Prims.raise FStar_Util.Impos)
+end))
+
+
+let unboxTerm : sort  ->  term  ->  term = (fun sort t -> (match (sort) with
+| Int_sort -> begin
+(unboxInt t)
+end
+| Bool_sort -> begin
+(unboxBool t)
+end
+| String_sort -> begin
+(unboxString t)
+end
+| Ref_sort -> begin
+(unboxRef t)
+end
+| uu____3196 -> begin
+(Prims.raise FStar_Util.Impos)
+end))
+
+
+let mk_PreType : term  ->  term = (fun t -> (mkApp (("PreType"), ((t)::[])) t.rng))
+
+
+let mk_Valid : term  ->  term = (fun t -> (match (t.tm) with
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_Equality"), (uu____3204)::(t1)::(t2)::[]); freevars = uu____3207; rng = uu____3208})::[]) -> begin
+(mkEq ((t1), (t2)) t.rng)
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_disEquality"), (uu____3215)::(t1)::(t2)::[]); freevars = uu____3218; rng = uu____3219})::[]) -> begin
+(
+
+let uu____3226 = (mkEq ((t1), (t2)) norng)
+in (mkNot uu____3226 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_LessThanOrEqual"), (t1)::(t2)::[]); freevars = uu____3229; rng = uu____3230})::[]) -> begin
+(
+
+let uu____3237 = (
+
+let uu____3240 = (unboxInt t1)
+in (
+
+let uu____3241 = (unboxInt t2)
+in ((uu____3240), (uu____3241))))
+in (mkLTE uu____3237 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_LessThan"), (t1)::(t2)::[]); freevars = uu____3244; rng = uu____3245})::[]) -> begin
+(
+
+let uu____3252 = (
+
+let uu____3255 = (unboxInt t1)
+in (
+
+let uu____3256 = (unboxInt t2)
+in ((uu____3255), (uu____3256))))
+in (mkLT uu____3252 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_GreaterThanOrEqual"), (t1)::(t2)::[]); freevars = uu____3259; rng = uu____3260})::[]) -> begin
+(
+
+let uu____3267 = (
+
+let uu____3270 = (unboxInt t1)
+in (
+
+let uu____3271 = (unboxInt t2)
+in ((uu____3270), (uu____3271))))
+in (mkGTE uu____3267 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_GreaterThan"), (t1)::(t2)::[]); freevars = uu____3274; rng = uu____3275})::[]) -> begin
+(
+
+let uu____3282 = (
+
+let uu____3285 = (unboxInt t1)
+in (
+
+let uu____3286 = (unboxInt t2)
+in ((uu____3285), (uu____3286))))
+in (mkGT uu____3282 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_AmpAmp"), (t1)::(t2)::[]); freevars = uu____3289; rng = uu____3290})::[]) -> begin
+(
+
+let uu____3297 = (
+
+let uu____3300 = (unboxBool t1)
+in (
+
+let uu____3301 = (unboxBool t2)
+in ((uu____3300), (uu____3301))))
+in (mkAnd uu____3297 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_BarBar"), (t1)::(t2)::[]); freevars = uu____3304; rng = uu____3305})::[]) -> begin
+(
+
+let uu____3312 = (
+
+let uu____3315 = (unboxBool t1)
+in (
+
+let uu____3316 = (unboxBool t2)
+in ((uu____3315), (uu____3316))))
+in (mkOr uu____3312 t.rng))
+end
+| App (Var ("Prims.b2t"), ({tm = App (Var ("Prims.op_Negation"), (t1)::[]); freevars = uu____3318; rng = uu____3319})::[]) -> begin
+(
+
+let uu____3326 = (unboxBool t1)
+in (mkNot uu____3326 t1.rng))
+end
+| App (Var ("Prims.b2t"), (t1)::[]) -> begin
+(
+
+let uu___90_3329 = (unboxBool t1)
+in {tm = uu___90_3329.tm; freevars = uu___90_3329.freevars; rng = t.rng})
+end
+| uu____3332 -> begin
+(mkApp (("Valid"), ((t)::[])) t.rng)
+end))
+
+
+let mk_HasType : term  ->  term  ->  term = (fun v1 t -> (mkApp (("HasType"), ((v1)::(t)::[])) t.rng))
+
+
+let mk_HasTypeZ : term  ->  term  ->  term = (fun v1 t -> (mkApp (("HasTypeZ"), ((v1)::(t)::[])) t.rng))
+
+
+let mk_IsTyped : term  ->  term = (fun v1 -> (mkApp (("IsTyped"), ((v1)::[])) norng))
+
+
+let mk_HasTypeFuel : term  ->  term  ->  term  ->  term = (fun f v1 t -> (
+
+let uu____3361 = (FStar_Options.unthrottle_inductives ())
+in (match (uu____3361) with
+| true -> begin
+(mk_HasType v1 t)
+end
+| uu____3362 -> begin
+(mkApp (("HasTypeFuel"), ((f)::(v1)::(t)::[])) t.rng)
+end)))
+
+
+let mk_HasTypeWithFuel : term Prims.option  ->  term  ->  term  ->  term = (fun f v1 t -> (match (f) with
+| None -> begin
+(mk_HasType v1 t)
+end
+| Some (f1) -> begin
+(mk_HasTypeFuel f1 v1 t)
+end))
+
+
+let mk_Destruct : term  ->  FStar_Range.range  ->  term = (fun v1 -> (mkApp (("Destruct"), ((v1)::[]))))
+
+
+let mk_Rank : term  ->  FStar_Range.range  ->  term = (fun x -> (mkApp (("Rank"), ((x)::[]))))
+
+
+let mk_tester : Prims.string  ->  term  ->  term = (fun n1 t -> (mkApp (((Prims.strcat "is-" n1)), ((t)::[])) t.rng))
+
+
+let mk_ApplyTF : term  ->  term  ->  term = (fun t t' -> (mkApp (("ApplyTF"), ((t)::(t')::[])) t.rng))
+
+
+let mk_ApplyTT : term  ->  term  ->  FStar_Range.range  ->  term = (fun t t' r -> (mkApp (("ApplyTT"), ((t)::(t')::[])) r))
+
+
+let mk_String_const : Prims.int  ->  FStar_Range.range  ->  term = (fun i r -> (
+
+let uu____3418 = (
+
+let uu____3422 = (
+
+let uu____3424 = (mkInteger' i norng)
+in (uu____3424)::[])
+in (("FString_const"), (uu____3422)))
+in (mkApp uu____3418 r)))
+
+
+let mk_Precedes : term  ->  term  ->  FStar_Range.range  ->  term = (fun x1 x2 r -> (
+
+let uu____3435 = (mkApp (("Precedes"), ((x1)::(x2)::[])) r)
+in (FStar_All.pipe_right uu____3435 mk_Valid)))
+
+
+let mk_LexCons : term  ->  term  ->  FStar_Range.range  ->  term = (fun x1 x2 r -> (mkApp (("LexCons"), ((x1)::(x2)::[])) r))
+
+
+let rec n_fuel : Prims.int  ->  term = (fun n1 -> (match ((n1 = (Prims.parse_int "0"))) with
+| true -> begin
+(mkApp (("ZFuel"), ([])) norng)
+end
+| uu____3451 -> begin
+(
+
+let uu____3452 = (
+
+let uu____3456 = (
+
+let uu____3458 = (n_fuel (n1 - (Prims.parse_int "1")))
+in (uu____3458)::[])
+in (("SFuel"), (uu____3456)))
+in (mkApp uu____3452 norng))
+end))
+
+
+let fuel_2 : term = (n_fuel (Prims.parse_int "2"))
+
+
+let fuel_100 : term = (n_fuel (Prims.parse_int "100"))
+
+
+let mk_and_opt : term Prims.option  ->  term Prims.option  ->  FStar_Range.range  ->  term Prims.option = (fun p1 p2 r -> (match (((p1), (p2))) with
+| (Some (p11), Some (p21)) -> begin
+(
+
+let uu____3481 = (mkAnd ((p11), (p21)) r)
+in Some (uu____3481))
+end
+| ((Some (p), None)) | ((None, Some (p))) -> begin
+Some (p)
+end
+| (None, None) -> begin
+None
+end))
+
+
+let mk_and_opt_l : term Prims.option Prims.list  ->  FStar_Range.range  ->  term Prims.option = (fun pl r -> (FStar_List.fold_right (fun p out -> (mk_and_opt p out r)) pl None))
+
+
+let mk_and_l : term Prims.list  ->  FStar_Range.range  ->  term = (fun l r -> (
+
+let uu____3514 = (mkTrue r)
+in (FStar_List.fold_right (fun p1 p2 -> (mkAnd ((p1), (p2)) r)) l uu____3514)))
+
+
+let mk_or_l : term Prims.list  ->  FStar_Range.range  ->  term = (fun l r -> (
+
+let uu____3525 = (mkFalse r)
+in (FStar_List.fold_right (fun p1 p2 -> (mkOr ((p1), (p2)) r)) l uu____3525)))
+
+
+let mk_haseq : term  ->  term = (fun t -> (
+
+let uu____3531 = (mkApp (("Prims.hasEq"), ((t)::[])) t.rng)
+in (mk_Valid uu____3531)))
+
+
+let rec print_smt_term : term  ->  Prims.string = (fun t -> (match (t.tm) with
+| Integer (n1) -> begin
+(FStar_Util.format1 "(Integer %s)" n1)
+end
+| BoundV (n1) -> begin
+(
+
+let uu____3545 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "(BoundV %s)" uu____3545))
+end
+| FreeV (fv) -> begin
+(FStar_Util.format1 "(FreeV %s)" (Prims.fst fv))
+end
+| App (op, l) -> begin
+(
+
+let uu____3553 = (print_smt_term_list l)
+in (FStar_Util.format2 "(%s %s)" (op_to_string op) uu____3553))
+end
+| Labeled (t1, r1, r2) -> begin
+(
+
+let uu____3557 = (print_smt_term t1)
+in (FStar_Util.format2 "(Labeled \'%s\' %s)" r1 uu____3557))
+end
+| LblPos (t1, s) -> begin
+(
+
+let uu____3560 = (print_smt_term t1)
+in (FStar_Util.format2 "(LblPos %s %s)" s uu____3560))
+end
+| Quant (qop, l, uu____3563, uu____3564, t1) -> begin
+(
+
+let uu____3574 = (print_smt_term_list_list l)
+in (
+
+let uu____3575 = (print_smt_term t1)
+in (FStar_Util.format3 "(%s %s %s)" (qop_to_string qop) uu____3574 uu____3575)))
+end
+| Let (es, body) -> begin
+(
+
+let uu____3580 = (print_smt_term_list es)
+in (
+
+let uu____3581 = (print_smt_term body)
+in (FStar_Util.format2 "(let %s %s)" uu____3580 uu____3581)))
+end))
+and print_smt_term_list : term Prims.list  ->  Prims.string = (fun l -> (
+
+let uu____3584 = (FStar_List.map print_smt_term l)
+in (FStar_All.pipe_right uu____3584 (FStar_String.concat " "))))
+and print_smt_term_list_list : term Prims.list Prims.list  ->  Prims.string = (fun l -> (FStar_List.fold_left (fun s l1 -> (
+
+let uu____3594 = (
+
+let uu____3595 = (
+
+let uu____3596 = (print_smt_term_list l1)
+in (Prims.strcat uu____3596 " ] "))
+in (Prims.strcat "; [ " uu____3595))
+in (Prims.strcat s uu____3594))) "" l))
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_Util.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Util.ml
@@ -1,137 +1,125 @@
+
 open Prims
-let norng f x = f x FStar_Range.dummyRange
-let mkTrue: FStar_SMTEncoding_Term.term =
-  FStar_SMTEncoding_Term.mkTrue FStar_Range.dummyRange
-let mkFalse: FStar_SMTEncoding_Term.term =
-  FStar_SMTEncoding_Term.mkFalse FStar_Range.dummyRange
-let mkInteger: Prims.string -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkInteger
-let mkInteger': Prims.int -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkInteger'
-let mkBoundV: Prims.int -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkBoundV
-let mkFreeV:
-  (Prims.string* FStar_SMTEncoding_Term.sort) -> FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkFreeV
-let mkApp':
-  (FStar_SMTEncoding_Term.op* FStar_SMTEncoding_Term.term Prims.list) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkApp'
-let mkApp:
-  (Prims.string* FStar_SMTEncoding_Term.term Prims.list) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkApp
-let mkNot: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkNot
-let mkMinus: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkMinus
-let mkAnd:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkAnd
-let mkOr:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkOr
-let mkImp:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkImp
-let mkIff:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkIff
-let mkEq:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkEq
-let mkLT:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkLT
-let mkLTE:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkLTE
-let mkGT:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkGT
-let mkGTE:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkGTE
-let mkAdd:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkAdd
-let mkSub:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkSub
-let mkDiv:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkDiv
-let mkMul:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkMul
-let mkMod:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkMod
-let mkITE:
-  (FStar_SMTEncoding_Term.term* FStar_SMTEncoding_Term.term*
-    FStar_SMTEncoding_Term.term) -> FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkITE
-let mkCases:
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mkCases
-let mkForall:
-  (FStar_SMTEncoding_Term.pat Prims.list Prims.list*
-    FStar_SMTEncoding_Term.fvs* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkForall
-let mkForall':
-  (FStar_SMTEncoding_Term.pat Prims.list Prims.list* Prims.int Prims.option*
-    FStar_SMTEncoding_Term.fvs* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkForall'
-let mkForall'':
-  (FStar_SMTEncoding_Term.pat Prims.list Prims.list* Prims.int Prims.option*
-    FStar_SMTEncoding_Term.sort Prims.list* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkForall''
-let mkExists:
-  (FStar_SMTEncoding_Term.pat Prims.list Prims.list*
-    FStar_SMTEncoding_Term.fvs* FStar_SMTEncoding_Term.term) ->
-    FStar_SMTEncoding_Term.term
-  = norng FStar_SMTEncoding_Term.mkExists
-let norng2 f x y = f x y FStar_Range.dummyRange
-let mk_Term_app:
-  FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
-  = norng2 FStar_SMTEncoding_Term.mk_Term_app
-let mk_Term_uvar: Prims.int -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mk_Term_uvar
-let mk_and_l:
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mk_and_l
-let mk_or_l:
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mk_or_l
-let mk_ApplyTT:
-  FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
-  = norng2 FStar_SMTEncoding_Term.mk_ApplyTT
-let mk_String_const: Prims.int -> FStar_SMTEncoding_Term.term =
-  norng FStar_SMTEncoding_Term.mk_String_const
-let mk_Precedes:
-  FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
-  = norng2 FStar_SMTEncoding_Term.mk_Precedes
-let mk_LexCons:
-  FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
-  = norng2 FStar_SMTEncoding_Term.mk_LexCons
+
+let norng = (fun f x -> (f x FStar_Range.dummyRange))
+
+
+let mkTrue : FStar_SMTEncoding_Term.term = (FStar_SMTEncoding_Term.mkTrue FStar_Range.dummyRange)
+
+
+let mkFalse : FStar_SMTEncoding_Term.term = (FStar_SMTEncoding_Term.mkFalse FStar_Range.dummyRange)
+
+
+let mkInteger : Prims.string  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkInteger)
+
+
+let mkInteger' : Prims.int  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkInteger')
+
+
+let mkBoundV : Prims.int  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkBoundV)
+
+
+let mkFreeV : (Prims.string * FStar_SMTEncoding_Term.sort)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkFreeV)
+
+
+let mkApp' : (FStar_SMTEncoding_Term.op * FStar_SMTEncoding_Term.term Prims.list)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkApp')
+
+
+let mkApp : (Prims.string * FStar_SMTEncoding_Term.term Prims.list)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkApp)
+
+
+let mkNot : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkNot)
+
+
+let mkMinus : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkMinus)
+
+
+let mkAnd : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkAnd)
+
+
+let mkOr : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkOr)
+
+
+let mkImp : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkImp)
+
+
+let mkIff : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkIff)
+
+
+let mkEq : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkEq)
+
+
+let mkLT : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkLT)
+
+
+let mkLTE : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkLTE)
+
+
+let mkGT : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkGT)
+
+
+let mkGTE : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkGTE)
+
+
+let mkAdd : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkAdd)
+
+
+let mkSub : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkSub)
+
+
+let mkDiv : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkDiv)
+
+
+let mkMul : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkMul)
+
+
+let mkMod : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkMod)
+
+
+let mkITE : (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkITE)
+
+
+let mkCases : FStar_SMTEncoding_Term.term Prims.list  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkCases)
+
+
+let mkForall : (FStar_SMTEncoding_Term.pat Prims.list Prims.list * FStar_SMTEncoding_Term.fvs * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkForall)
+
+
+let mkForall' : (FStar_SMTEncoding_Term.pat Prims.list Prims.list * Prims.int Prims.option * FStar_SMTEncoding_Term.fvs * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkForall')
+
+
+let mkForall'' : (FStar_SMTEncoding_Term.pat Prims.list Prims.list * Prims.int Prims.option * FStar_SMTEncoding_Term.sort Prims.list * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkForall'')
+
+
+let mkExists : (FStar_SMTEncoding_Term.pat Prims.list Prims.list * FStar_SMTEncoding_Term.fvs * FStar_SMTEncoding_Term.term)  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mkExists)
+
+
+let norng2 = (fun f x y -> (f x y FStar_Range.dummyRange))
+
+
+let mk_Term_app : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng2 FStar_SMTEncoding_Term.mk_Term_app)
+
+
+let mk_Term_uvar : Prims.int  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mk_Term_uvar)
+
+
+let mk_and_l : FStar_SMTEncoding_Term.term Prims.list  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mk_and_l)
+
+
+let mk_or_l : FStar_SMTEncoding_Term.term Prims.list  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mk_or_l)
+
+
+let mk_ApplyTT : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng2 FStar_SMTEncoding_Term.mk_ApplyTT)
+
+
+let mk_String_const : Prims.int  ->  FStar_SMTEncoding_Term.term = (norng FStar_SMTEncoding_Term.mk_String_const)
+
+
+let mk_Precedes : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng2 FStar_SMTEncoding_Term.mk_Precedes)
+
+
+let mk_LexCons : FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term  ->  FStar_SMTEncoding_Term.term = (norng2 FStar_SMTEncoding_Term.mk_LexCons)
+
+
+
+

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -1,864 +1,1483 @@
+
 open Prims
 type z3version =
-  | Z3V_Unknown of Prims.string
-  | Z3V of (Prims.int* Prims.int* Prims.int)
-let uu___is_Z3V_Unknown: z3version -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Z3V_Unknown _0 -> true | uu____14 -> false
-let __proj__Z3V_Unknown__item___0: z3version -> Prims.string =
-  fun projectee  -> match projectee with | Z3V_Unknown _0 -> _0
-let uu___is_Z3V: z3version -> Prims.bool =
-  fun projectee  -> match projectee with | Z3V _0 -> true | uu____29 -> false
-let __proj__Z3V__item___0: z3version -> (Prims.int* Prims.int* Prims.int) =
-  fun projectee  -> match projectee with | Z3V _0 -> _0
-let z3version_as_string: z3version -> Prims.string =
-  fun uu___91_48  ->
-    match uu___91_48 with
-    | Z3V_Unknown s -> FStar_Util.format1 "unknown version: %s" s
-    | Z3V (i,j,k) ->
-        let uu____53 = FStar_Util.string_of_int i in
-        let uu____54 = FStar_Util.string_of_int j in
-        let uu____55 = FStar_Util.string_of_int k in
-        FStar_Util.format3 "%s.%s.%s" uu____53 uu____54 uu____55
-let z3v_compare:
-  z3version -> (Prims.int* Prims.int* Prims.int) -> Prims.int Prims.option =
-  fun known  ->
-    fun uu____65  ->
-      match uu____65 with
-      | (w1,w2,w3) ->
-          (match known with
-           | Z3V_Unknown uu____74 -> None
-           | Z3V (k1,k2,k3) ->
-               Some
-                 (if k1 <> w1
-                  then w1 - k1
-                  else if k2 <> w2 then w2 - k2 else w3 - k3))
-let z3v_le: z3version -> (Prims.int* Prims.int* Prims.int) -> Prims.bool =
-  fun known  ->
-    fun wanted  ->
-      match z3v_compare known wanted with
-      | None  -> false
-      | Some i -> i >= (Prims.parse_int "0")
-let _z3version: z3version Prims.option FStar_ST.ref = FStar_Util.mk_ref None
-let get_z3version: Prims.unit -> z3version =
-  fun uu____100  ->
-    let prefix1 = "Z3 version " in
-    let uu____102 = FStar_ST.read _z3version in
-    match uu____102 with
-    | Some version -> version
-    | None  ->
-        let uu____108 =
-          let uu____112 = FStar_Options.z3_exe () in
-          FStar_Util.run_proc uu____112 "-version" "" in
-        (match uu____108 with
-         | (uu____113,out,uu____115) ->
-             let out1 =
-               match FStar_Util.splitlines out with
-               | x::uu____118 when FStar_Util.starts_with x prefix1 ->
-                   let x1 =
-                     let uu____121 =
-                       FStar_Util.substring_from x
-                         (FStar_String.length prefix1) in
-                     FStar_Util.trim_string uu____121 in
-                   let x2 =
-                     try
-                       FStar_List.map FStar_Util.int_of_string
-                         (FStar_Util.split x1 ".")
-                     with | uu____131 -> [] in
-                   (match x2 with
-                    | i1::i2::i3::[] -> Z3V (i1, i2, i3)
-                    | uu____135 -> Z3V_Unknown out)
-               | uu____137 -> Z3V_Unknown out in
-             (FStar_ST.write _z3version (Some out1); out1))
-let ini_params: Prims.unit -> Prims.string =
-  fun uu____145  ->
-    let z3_v = get_z3version () in
-    (let uu____148 =
-       let uu____149 = get_z3version () in
-       z3v_le uu____149
-         ((Prims.parse_int "4"), (Prims.parse_int "4"),
-           (Prims.parse_int "0")) in
-     if uu____148
-     then
-       let uu____150 =
-         let uu____151 =
-           let uu____152 = z3version_as_string z3_v in
-           FStar_Util.format1
-             "Z3 4.5.0 recommended; at least Z3 v4.4.1 required; got %s\n"
-             uu____152 in
-         FStar_Util.Failure uu____151 in
-       FStar_All.pipe_left Prims.raise uu____150
-     else ());
-    (let uu____154 =
-       let uu____156 =
-         let uu____158 =
-           let uu____160 =
-             let uu____161 =
-               let uu____162 = FStar_Options.z3_seed () in
-               FStar_Util.string_of_int uu____162 in
-             FStar_Util.format1 "smt.random_seed=%s" uu____161 in
-           [uu____160] in
-         "-smt2 -in auto_config=false model=true smt.relevancy=2" ::
-           uu____158 in
-       let uu____163 = FStar_Options.z3_cliopt () in
-       FStar_List.append uu____156 uu____163 in
-     FStar_String.concat " " uu____154)
-type label = Prims.string
-type unsat_core = Prims.string Prims.list Prims.option
+| Z3V_Unknown of Prims.string
+| Z3V of (Prims.int * Prims.int * Prims.int)
+
+
+let uu___is_Z3V_Unknown : z3version  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Z3V_Unknown (_0) -> begin
+true
+end
+| uu____14 -> begin
+false
+end))
+
+
+let __proj__Z3V_Unknown__item___0 : z3version  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Z3V_Unknown (_0) -> begin
+_0
+end))
+
+
+let uu___is_Z3V : z3version  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Z3V (_0) -> begin
+true
+end
+| uu____29 -> begin
+false
+end))
+
+
+let __proj__Z3V__item___0 : z3version  ->  (Prims.int * Prims.int * Prims.int) = (fun projectee -> (match (projectee) with
+| Z3V (_0) -> begin
+_0
+end))
+
+
+let z3version_as_string : z3version  ->  Prims.string = (fun uu___91_48 -> (match (uu___91_48) with
+| Z3V_Unknown (s) -> begin
+(FStar_Util.format1 "unknown version: %s" s)
+end
+| Z3V (i, j, k) -> begin
+(
+
+let uu____53 = (FStar_Util.string_of_int i)
+in (
+
+let uu____54 = (FStar_Util.string_of_int j)
+in (
+
+let uu____55 = (FStar_Util.string_of_int k)
+in (FStar_Util.format3 "%s.%s.%s" uu____53 uu____54 uu____55))))
+end))
+
+
+let z3v_compare : z3version  ->  (Prims.int * Prims.int * Prims.int)  ->  Prims.int Prims.option = (fun known uu____65 -> (match (uu____65) with
+| (w1, w2, w3) -> begin
+(match (known) with
+| Z3V_Unknown (uu____74) -> begin
+None
+end
+| Z3V (k1, k2, k3) -> begin
+Some ((match ((k1 <> w1)) with
+| true -> begin
+(w1 - k1)
+end
+| uu____78 -> begin
+(match ((k2 <> w2)) with
+| true -> begin
+(w2 - k2)
+end
+| uu____79 -> begin
+(w3 - k3)
+end)
+end))
+end)
+end))
+
+
+let z3v_le : z3version  ->  (Prims.int * Prims.int * Prims.int)  ->  Prims.bool = (fun known wanted -> (match ((z3v_compare known wanted)) with
+| None -> begin
+false
+end
+| Some (i) -> begin
+(i >= (Prims.parse_int "0"))
+end))
+
+
+let _z3version : z3version Prims.option FStar_ST.ref = (FStar_Util.mk_ref None)
+
+
+let get_z3version : Prims.unit  ->  z3version = (fun uu____100 -> (
+
+let prefix1 = "Z3 version "
+in (
+
+let uu____102 = (FStar_ST.read _z3version)
+in (match (uu____102) with
+| Some (version) -> begin
+version
+end
+| None -> begin
+(
+
+let uu____108 = (
+
+let uu____112 = (FStar_Options.z3_exe ())
+in (FStar_Util.run_proc uu____112 "-version" ""))
+in (match (uu____108) with
+| (uu____113, out, uu____115) -> begin
+(
+
+let out1 = (match ((FStar_Util.splitlines out)) with
+| (x)::uu____118 when (FStar_Util.starts_with x prefix1) -> begin
+(
+
+let x1 = (
+
+let uu____121 = (FStar_Util.substring_from x (FStar_String.length prefix1))
+in (FStar_Util.trim_string uu____121))
+in (
+
+let x2 = try
+(match (()) with
+| () -> begin
+(FStar_List.map FStar_Util.int_of_string (FStar_Util.split x1 "."))
+end)
+with
+| uu____131 -> begin
+[]
+end
+in (match (x2) with
+| (i1)::(i2)::(i3)::[] -> begin
+Z3V (((i1), (i2), (i3)))
+end
+| uu____135 -> begin
+Z3V_Unknown (out)
+end)))
+end
+| uu____137 -> begin
+Z3V_Unknown (out)
+end)
+in ((FStar_ST.write _z3version (Some (out1)));
+out1;
+))
+end))
+end))))
+
+
+let ini_params : Prims.unit  ->  Prims.string = (fun uu____145 -> (
+
+let z3_v = (get_z3version ())
+in ((
+
+let uu____148 = (
+
+let uu____149 = (get_z3version ())
+in (z3v_le uu____149 (((Prims.parse_int "4")), ((Prims.parse_int "4")), ((Prims.parse_int "0")))))
+in (match (uu____148) with
+| true -> begin
+(
+
+let uu____150 = (
+
+let uu____151 = (
+
+let uu____152 = (z3version_as_string z3_v)
+in (FStar_Util.format1 "Z3 4.5.0 recommended; at least Z3 v4.4.1 required; got %s\n" uu____152))
+in FStar_Util.Failure (uu____151))
+in (FStar_All.pipe_left Prims.raise uu____150))
+end
+| uu____153 -> begin
+()
+end));
+(
+
+let uu____154 = (
+
+let uu____156 = (
+
+let uu____158 = (
+
+let uu____160 = (
+
+let uu____161 = (
+
+let uu____162 = (FStar_Options.z3_seed ())
+in (FStar_Util.string_of_int uu____162))
+in (FStar_Util.format1 "smt.random_seed=%s" uu____161))
+in (uu____160)::[])
+in ("-smt2 -in auto_config=false model=true smt.relevancy=2")::uu____158)
+in (
+
+let uu____163 = (FStar_Options.z3_cliopt ())
+in (FStar_List.append uu____156 uu____163)))
+in (FStar_String.concat " " uu____154));
+)))
+
+
+type label =
+Prims.string
+
+
+type unsat_core =
+Prims.string Prims.list Prims.option
+
 type z3status =
-  | UNSAT of unsat_core
-  | SAT of label Prims.list
-  | UNKNOWN of label Prims.list
-  | TIMEOUT of label Prims.list
-  | KILLED
-let uu___is_UNSAT: z3status -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UNSAT _0 -> true | uu____186 -> false
-let __proj__UNSAT__item___0: z3status -> unsat_core =
-  fun projectee  -> match projectee with | UNSAT _0 -> _0
-let uu___is_SAT: z3status -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SAT _0 -> true | uu____199 -> false
-let __proj__SAT__item___0: z3status -> label Prims.list =
-  fun projectee  -> match projectee with | SAT _0 -> _0
-let uu___is_UNKNOWN: z3status -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UNKNOWN _0 -> true | uu____215 -> false
-let __proj__UNKNOWN__item___0: z3status -> label Prims.list =
-  fun projectee  -> match projectee with | UNKNOWN _0 -> _0
-let uu___is_TIMEOUT: z3status -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TIMEOUT _0 -> true | uu____231 -> false
-let __proj__TIMEOUT__item___0: z3status -> label Prims.list =
-  fun projectee  -> match projectee with | TIMEOUT _0 -> _0
-let uu___is_KILLED: z3status -> Prims.bool =
-  fun projectee  ->
-    match projectee with | KILLED  -> true | uu____245 -> false
-let status_to_string: z3status -> Prims.string =
-  fun uu___92_248  ->
-    match uu___92_248 with
-    | SAT uu____249 -> "sat"
-    | UNSAT uu____251 -> "unsat"
-    | UNKNOWN uu____252 -> "unknown"
-    | TIMEOUT uu____254 -> "timeout"
-    | KILLED  -> "killed"
-let tid: Prims.unit -> Prims.string =
-  fun uu____258  ->
-    let uu____259 = FStar_Util.current_tid () in
-    FStar_All.pipe_right uu____259 FStar_Util.string_of_int
-let new_z3proc: Prims.string -> FStar_Util.proc =
-  fun id  ->
-    let cond pid s = let x = (FStar_Util.trim_string s) = "Done!" in x in
-    let uu____271 = FStar_Options.z3_exe () in
-    let uu____272 = ini_params () in
-    FStar_Util.start_process id uu____271 uu____272 cond
+| UNSAT of unsat_core
+| SAT of label Prims.list
+| UNKNOWN of label Prims.list
+| TIMEOUT of label Prims.list
+| KILLED
+
+
+let uu___is_UNSAT : z3status  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UNSAT (_0) -> begin
+true
+end
+| uu____186 -> begin
+false
+end))
+
+
+let __proj__UNSAT__item___0 : z3status  ->  unsat_core = (fun projectee -> (match (projectee) with
+| UNSAT (_0) -> begin
+_0
+end))
+
+
+let uu___is_SAT : z3status  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SAT (_0) -> begin
+true
+end
+| uu____199 -> begin
+false
+end))
+
+
+let __proj__SAT__item___0 : z3status  ->  label Prims.list = (fun projectee -> (match (projectee) with
+| SAT (_0) -> begin
+_0
+end))
+
+
+let uu___is_UNKNOWN : z3status  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UNKNOWN (_0) -> begin
+true
+end
+| uu____215 -> begin
+false
+end))
+
+
+let __proj__UNKNOWN__item___0 : z3status  ->  label Prims.list = (fun projectee -> (match (projectee) with
+| UNKNOWN (_0) -> begin
+_0
+end))
+
+
+let uu___is_TIMEOUT : z3status  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TIMEOUT (_0) -> begin
+true
+end
+| uu____231 -> begin
+false
+end))
+
+
+let __proj__TIMEOUT__item___0 : z3status  ->  label Prims.list = (fun projectee -> (match (projectee) with
+| TIMEOUT (_0) -> begin
+_0
+end))
+
+
+let uu___is_KILLED : z3status  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| KILLED -> begin
+true
+end
+| uu____245 -> begin
+false
+end))
+
+
+let status_to_string : z3status  ->  Prims.string = (fun uu___92_248 -> (match (uu___92_248) with
+| SAT (uu____249) -> begin
+"sat"
+end
+| UNSAT (uu____251) -> begin
+"unsat"
+end
+| UNKNOWN (uu____252) -> begin
+"unknown"
+end
+| TIMEOUT (uu____254) -> begin
+"timeout"
+end
+| KILLED -> begin
+"killed"
+end))
+
+
+let tid : Prims.unit  ->  Prims.string = (fun uu____258 -> (
+
+let uu____259 = (FStar_Util.current_tid ())
+in (FStar_All.pipe_right uu____259 FStar_Util.string_of_int)))
+
+
+let new_z3proc : Prims.string  ->  FStar_Util.proc = (fun id -> (
+
+let cond = (fun pid s -> (
+
+let x = ((FStar_Util.trim_string s) = "Done!")
+in x))
+in (
+
+let uu____271 = (FStar_Options.z3_exe ())
+in (
+
+let uu____272 = (ini_params ())
+in (FStar_Util.start_process id uu____271 uu____272 cond)))))
+
 type bgproc =
-  {
-  grab: Prims.unit -> FStar_Util.proc;
-  release: Prims.unit -> Prims.unit;
-  refresh: Prims.unit -> Prims.unit;
-  restart: Prims.unit -> Prims.unit;}
+{grab : Prims.unit  ->  FStar_Util.proc; release : Prims.unit  ->  Prims.unit; refresh : Prims.unit  ->  Prims.unit; restart : Prims.unit  ->  Prims.unit}
+
 type query_log =
-  {
-  get_module_name: Prims.unit -> Prims.string;
-  set_module_name: Prims.string -> Prims.unit;
-  write_to_log: Prims.string -> Prims.unit;
-  close_log: Prims.unit -> Prims.unit;
-  log_file_name: Prims.unit -> Prims.string;}
-let query_logging: query_log =
-  let query_number = FStar_Util.mk_ref (Prims.parse_int "0") in
-  let log_file_opt = FStar_Util.mk_ref None in
-  let used_file_names = FStar_Util.mk_ref [] in
-  let current_module_name = FStar_Util.mk_ref None in
-  let current_file_name = FStar_Util.mk_ref None in
-  let set_module_name n1 = FStar_ST.write current_module_name (Some n1) in
-  let get_module_name uu____438 =
-    let uu____439 = FStar_ST.read current_module_name in
-    match uu____439 with
-    | None  -> failwith "Module name not set"
-    | Some n1 -> n1 in
-  let new_log_file uu____448 =
-    let uu____449 = FStar_ST.read current_module_name in
-    match uu____449 with
-    | None  -> failwith "current module not set"
-    | Some n1 ->
-        let file_name =
-          let uu____456 =
-            let uu____460 = FStar_ST.read used_file_names in
-            FStar_List.tryFind
-              (fun uu____471  ->
-                 match uu____471 with | (m,uu____475) -> n1 = m) uu____460 in
-          match uu____456 with
-          | None  ->
-              ((let uu____479 =
-                  let uu____483 = FStar_ST.read used_file_names in
-                  (n1, (Prims.parse_int "0")) :: uu____483 in
-                FStar_ST.write used_file_names uu____479);
-               n1)
-          | Some (uu____499,k) ->
-              ((let uu____504 =
-                  let uu____508 = FStar_ST.read used_file_names in
-                  (n1, (k + (Prims.parse_int "1"))) :: uu____508 in
-                FStar_ST.write used_file_names uu____504);
-               (let uu____524 =
-                  FStar_Util.string_of_int (k + (Prims.parse_int "1")) in
-                FStar_Util.format2 "%s-%s" n1 uu____524)) in
-        let file_name1 = FStar_Util.format1 "queries-%s.smt2" file_name in
-        (FStar_ST.write current_file_name (Some file_name1);
-         (let fh = FStar_Util.open_file_for_writing file_name1 in
-          FStar_ST.write log_file_opt (Some fh); fh)) in
-  let get_log_file uu____538 =
-    let uu____539 = FStar_ST.read log_file_opt in
-    match uu____539 with | None  -> new_log_file () | Some fh -> fh in
-  let append_to_log str =
-    let uu____549 = get_log_file () in
-    FStar_Util.append_to_file uu____549 str in
-  let write_to_new_log str =
-    let dir_name =
-      let uu____555 = FStar_ST.read current_file_name in
-      match uu____555 with
-      | None  ->
-          let dir_name =
-            let uu____561 = FStar_ST.read current_module_name in
-            match uu____561 with
-            | None  -> failwith "current module not set"
-            | Some n1 -> FStar_Util.format1 "queries-%s" n1 in
-          (FStar_Util.mkdir_clean dir_name;
-           FStar_ST.write current_file_name (Some dir_name);
-           dir_name)
-      | Some n1 -> n1 in
-    let qnum = FStar_ST.read query_number in
-    (let uu____577 =
-       let uu____578 = FStar_ST.read query_number in
-       uu____578 + (Prims.parse_int "1") in
-     FStar_ST.write query_number uu____577);
-    (let file_name =
-       let uu____584 = FStar_Util.string_of_int qnum in
-       FStar_Util.format1 "query-%s.smt2" uu____584 in
-     let file_name1 = FStar_Util.concat_dir_filename dir_name file_name in
-     FStar_Util.write_file file_name1 str) in
-  let write_to_log str =
-    let uu____590 =
-      let uu____591 = FStar_Options.n_cores () in
-      uu____591 > (Prims.parse_int "1") in
-    if uu____590 then write_to_new_log str else append_to_log str in
-  let close_log uu____596 =
-    let uu____597 = FStar_ST.read log_file_opt in
-    match uu____597 with
-    | None  -> ()
-    | Some fh -> (FStar_Util.close_file fh; FStar_ST.write log_file_opt None) in
-  let log_file_name uu____610 =
-    let uu____611 = FStar_ST.read current_file_name in
-    match uu____611 with | None  -> failwith "no log file" | Some n1 -> n1 in
-  { get_module_name; set_module_name; write_to_log; close_log; log_file_name
-  }
-let bg_z3_proc: bgproc =
-  let the_z3proc = FStar_Util.mk_ref None in
-  let new_proc =
-    let ctr = FStar_Util.mk_ref (- (Prims.parse_int "1")) in
-    fun uu____628  ->
-      let uu____629 =
-        let uu____630 =
-          FStar_Util.incr ctr;
-          (let uu____635 = FStar_ST.read ctr in
-           FStar_All.pipe_right uu____635 FStar_Util.string_of_int) in
-        FStar_Util.format1 "bg-%s" uu____630 in
-      new_z3proc uu____629 in
-  let z3proc uu____641 =
-    (let uu____643 =
-       let uu____644 = FStar_ST.read the_z3proc in uu____644 = None in
-     if uu____643
-     then
-       let uu____650 = let uu____652 = new_proc () in Some uu____652 in
-       FStar_ST.write the_z3proc uu____650
-     else ());
-    (let uu____657 = FStar_ST.read the_z3proc in FStar_Util.must uu____657) in
-  let x = [] in
-  let grab uu____667 = FStar_Util.monitor_enter x; z3proc () in
-  let release uu____673 = FStar_Util.monitor_exit x in
-  let refresh uu____678 =
-    let proc = grab () in
-    FStar_Util.kill_process proc;
-    (let uu____682 = let uu____684 = new_proc () in Some uu____684 in
-     FStar_ST.write the_z3proc uu____682);
-    query_logging.close_log ();
-    release () in
-  let restart uu____692 =
-    FStar_Util.monitor_enter ();
-    query_logging.close_log ();
-    FStar_ST.write the_z3proc None;
-    (let uu____700 = let uu____702 = new_proc () in Some uu____702 in
-     FStar_ST.write the_z3proc uu____700);
-    FStar_Util.monitor_exit () in
-  { grab; release; refresh; restart }
-let at_log_file: Prims.unit -> Prims.string =
-  fun uu____708  ->
-    let uu____709 = FStar_Options.log_queries () in
-    if uu____709
-    then
-      let uu____710 = query_logging.log_file_name () in
-      Prims.strcat "@" uu____710
-    else ""
-let doZ3Exe': Prims.bool -> Prims.string -> z3status =
-  fun fresh1  ->
-    fun input  ->
-      let parse z3out =
-        let lines =
-          FStar_All.pipe_right (FStar_String.split ['\n'] z3out)
-            (FStar_List.map FStar_Util.trim_string) in
-        let print_stats lines1 =
-          let starts_with1 c s =
-            ((FStar_String.length s) >= (Prims.parse_int "1")) &&
-              (let uu____742 = FStar_String.get s (Prims.parse_int "0") in
-               uu____742 = c) in
-          let ends_with1 c s =
-            ((FStar_String.length s) >= (Prims.parse_int "1")) &&
-              (let uu____753 =
-                 FStar_String.get s
-                   ((FStar_String.length s) - (Prims.parse_int "1")) in
-               uu____753 = c) in
-          let last1 l =
-            FStar_List.nth l ((FStar_List.length l) - (Prims.parse_int "1")) in
-          let uu____766 = FStar_Options.print_z3_statistics () in
-          if uu____766
-          then
-            let uu____767 =
-              (((FStar_List.length lines1) >= (Prims.parse_int "2")) &&
-                 (let uu____771 = FStar_List.hd lines1 in
-                  starts_with1 '(' uu____771))
-                && (let uu____772 = last1 lines1 in ends_with1 ')' uu____772) in
-            (if uu____767
-             then
-               ((let uu____774 =
-                   let uu____775 =
-                     let uu____776 = query_logging.get_module_name () in
-                     FStar_Util.format1 "BEGIN-STATS %s\n" uu____776 in
-                   let uu____777 = at_log_file () in
-                   Prims.strcat uu____775 uu____777 in
-                 FStar_Util.print_string uu____774);
-                FStar_List.iter
-                  (fun s  ->
-                     let uu____780 = FStar_Util.format1 "%s\n" s in
-                     FStar_Util.print_string uu____780) lines1;
-                FStar_Util.print_string "END-STATS\n")
-             else
-               failwith
-                 "Unexpected output from Z3: could not find statistics\n")
-          else () in
-        let unsat_core lines1 =
-          let parse_core s =
-            let s1 = FStar_Util.trim_string s in
-            let s2 =
-              FStar_Util.substring s1 (Prims.parse_int "1")
-                ((FStar_String.length s1) - (Prims.parse_int "2")) in
-            if FStar_Util.starts_with s2 "error"
-            then None
-            else
-              (let uu____809 =
-                 FStar_All.pipe_right (FStar_Util.split s2 " ")
-                   (FStar_Util.sort_with FStar_String.compare) in
-               FStar_All.pipe_right uu____809 (fun _0_27  -> Some _0_27)) in
-          match lines1 with
-          | "<unsat-core>"::core::"</unsat-core>"::rest ->
-              let uu____825 = parse_core core in (uu____825, lines1)
-          | uu____831 -> (None, lines1) in
-        let rec lblnegs lines1 succeeded =
-          match lines1 with
-          | lname::"false"::rest when FStar_Util.starts_with lname "label_"
-              -> let uu____851 = lblnegs rest succeeded in lname :: uu____851
-          | lname::uu____854::rest when FStar_Util.starts_with lname "label_"
-              -> lblnegs rest succeeded
-          | uu____857 -> (if succeeded then print_stats lines1 else (); []) in
-        let unsat_core_and_lblnegs lines1 succeeded =
-          let uu____875 = unsat_core lines1 in
-          match uu____875 with
-          | (core_opt,rest) ->
-              let uu____894 = lblnegs rest succeeded in (core_opt, uu____894) in
-        let rec result x =
-          match x with
-          | "timeout"::tl1 -> TIMEOUT []
-          | "unknown"::tl1 ->
-              let uu____909 =
-                let uu____911 = unsat_core_and_lblnegs tl1 false in
-                Prims.snd uu____911 in
-              UNKNOWN uu____909
-          | "sat"::tl1 ->
-              let uu____922 =
-                let uu____924 = unsat_core_and_lblnegs tl1 false in
-                Prims.snd uu____924 in
-              SAT uu____922
-          | "unsat"::tl1 ->
-              let uu____935 =
-                let uu____936 = unsat_core_and_lblnegs tl1 true in
-                Prims.fst uu____936 in
-              UNSAT uu____935
-          | "killed"::tl1 -> (bg_z3_proc.restart (); KILLED)
-          | hd1::tl1 ->
-              ((let uu____952 =
-                  let uu____953 = query_logging.get_module_name () in
-                  FStar_Util.format2 "%s: Unexpected output from Z3: %s\n"
-                    uu____953 hd1 in
-                FStar_Errors.warn FStar_Range.dummyRange uu____952);
-               result tl1)
-          | uu____954 ->
-              let uu____956 =
-                let uu____957 =
-                  let uu____958 =
-                    FStar_List.map
-                      (fun l  ->
-                         FStar_Util.format1 "<%s>" (FStar_Util.trim_string l))
-                      lines in
-                  FStar_String.concat "\n" uu____958 in
-                FStar_Util.format1
-                  "Unexpected output from Z3: got output lines: %s\n"
-                  uu____957 in
-              FStar_All.pipe_left failwith uu____956 in
-        result lines in
-      let cond pid s = let x = (FStar_Util.trim_string s) = "Done!" in x in
-      let stdout1 =
-        if fresh1
-        then
-          let uu____970 = tid () in
-          let uu____971 = FStar_Options.z3_exe () in
-          let uu____972 = ini_params () in
-          FStar_Util.launch_process uu____970 uu____971 uu____972 input cond
-        else
-          (let proc = bg_z3_proc.grab () in
-           let stdout1 = FStar_Util.ask_process proc input in
-           bg_z3_proc.release (); stdout1) in
-      parse (FStar_Util.trim_string stdout1)
-let doZ3Exe: Prims.bool -> Prims.string -> z3status =
-  fun fresh1  -> fun input  -> doZ3Exe' fresh1 input
-let z3_options: Prims.unit -> Prims.string =
-  fun uu____985  ->
-    "(set-option :global-decls false)\n(set-option :smt.mbqi false)\n(set-option :auto_config false)\n(set-option :produce-unsat-cores true)\n"
-type 'a job = {
-  job: Prims.unit -> 'a;
-  callback: 'a -> Prims.unit;}
+{get_module_name : Prims.unit  ->  Prims.string; set_module_name : Prims.string  ->  Prims.unit; write_to_log : Prims.string  ->  Prims.unit; close_log : Prims.unit  ->  Prims.unit; log_file_name : Prims.unit  ->  Prims.string}
+
+
+let query_logging : query_log = (
+
+let query_number = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (
+
+let log_file_opt = (FStar_Util.mk_ref None)
+in (
+
+let used_file_names = (FStar_Util.mk_ref [])
+in (
+
+let current_module_name = (FStar_Util.mk_ref None)
+in (
+
+let current_file_name = (FStar_Util.mk_ref None)
+in (
+
+let set_module_name = (fun n1 -> (FStar_ST.write current_module_name (Some (n1))))
+in (
+
+let get_module_name = (fun uu____438 -> (
+
+let uu____439 = (FStar_ST.read current_module_name)
+in (match (uu____439) with
+| None -> begin
+(failwith "Module name not set")
+end
+| Some (n1) -> begin
+n1
+end)))
+in (
+
+let new_log_file = (fun uu____448 -> (
+
+let uu____449 = (FStar_ST.read current_module_name)
+in (match (uu____449) with
+| None -> begin
+(failwith "current module not set")
+end
+| Some (n1) -> begin
+(
+
+let file_name = (
+
+let uu____456 = (
+
+let uu____460 = (FStar_ST.read used_file_names)
+in (FStar_List.tryFind (fun uu____471 -> (match (uu____471) with
+| (m, uu____475) -> begin
+(n1 = m)
+end)) uu____460))
+in (match (uu____456) with
+| None -> begin
+((
+
+let uu____479 = (
+
+let uu____483 = (FStar_ST.read used_file_names)
+in (((n1), ((Prims.parse_int "0"))))::uu____483)
+in (FStar_ST.write used_file_names uu____479));
+n1;
+)
+end
+| Some (uu____499, k) -> begin
+((
+
+let uu____504 = (
+
+let uu____508 = (FStar_ST.read used_file_names)
+in (((n1), ((k + (Prims.parse_int "1")))))::uu____508)
+in (FStar_ST.write used_file_names uu____504));
+(
+
+let uu____524 = (FStar_Util.string_of_int (k + (Prims.parse_int "1")))
+in (FStar_Util.format2 "%s-%s" n1 uu____524));
+)
+end))
+in (
+
+let file_name1 = (FStar_Util.format1 "queries-%s.smt2" file_name)
+in ((FStar_ST.write current_file_name (Some (file_name1)));
+(
+
+let fh = (FStar_Util.open_file_for_writing file_name1)
+in ((FStar_ST.write log_file_opt (Some (fh)));
+fh;
+));
+)))
+end)))
+in (
+
+let get_log_file = (fun uu____538 -> (
+
+let uu____539 = (FStar_ST.read log_file_opt)
+in (match (uu____539) with
+| None -> begin
+(new_log_file ())
+end
+| Some (fh) -> begin
+fh
+end)))
+in (
+
+let append_to_log = (fun str -> (
+
+let uu____549 = (get_log_file ())
+in (FStar_Util.append_to_file uu____549 str)))
+in (
+
+let write_to_new_log = (fun str -> (
+
+let dir_name = (
+
+let uu____555 = (FStar_ST.read current_file_name)
+in (match (uu____555) with
+| None -> begin
+(
+
+let dir_name = (
+
+let uu____561 = (FStar_ST.read current_module_name)
+in (match (uu____561) with
+| None -> begin
+(failwith "current module not set")
+end
+| Some (n1) -> begin
+(FStar_Util.format1 "queries-%s" n1)
+end))
+in ((FStar_Util.mkdir_clean dir_name);
+(FStar_ST.write current_file_name (Some (dir_name)));
+dir_name;
+))
+end
+| Some (n1) -> begin
+n1
+end))
+in (
+
+let qnum = (FStar_ST.read query_number)
+in ((
+
+let uu____577 = (
+
+let uu____578 = (FStar_ST.read query_number)
+in (uu____578 + (Prims.parse_int "1")))
+in (FStar_ST.write query_number uu____577));
+(
+
+let file_name = (
+
+let uu____584 = (FStar_Util.string_of_int qnum)
+in (FStar_Util.format1 "query-%s.smt2" uu____584))
+in (
+
+let file_name1 = (FStar_Util.concat_dir_filename dir_name file_name)
+in (FStar_Util.write_file file_name1 str)));
+))))
+in (
+
+let write_to_log = (fun str -> (
+
+let uu____590 = (
+
+let uu____591 = (FStar_Options.n_cores ())
+in (uu____591 > (Prims.parse_int "1")))
+in (match (uu____590) with
+| true -> begin
+(write_to_new_log str)
+end
+| uu____592 -> begin
+(append_to_log str)
+end)))
+in (
+
+let close_log = (fun uu____596 -> (
+
+let uu____597 = (FStar_ST.read log_file_opt)
+in (match (uu____597) with
+| None -> begin
+()
+end
+| Some (fh) -> begin
+((FStar_Util.close_file fh);
+(FStar_ST.write log_file_opt None);
+)
+end)))
+in (
+
+let log_file_name = (fun uu____610 -> (
+
+let uu____611 = (FStar_ST.read current_file_name)
+in (match (uu____611) with
+| None -> begin
+(failwith "no log file")
+end
+| Some (n1) -> begin
+n1
+end)))
+in {get_module_name = get_module_name; set_module_name = set_module_name; write_to_log = write_to_log; close_log = close_log; log_file_name = log_file_name}))))))))))))))
+
+
+let bg_z3_proc : bgproc = (
+
+let the_z3proc = (FStar_Util.mk_ref None)
+in (
+
+let new_proc = (
+
+let ctr = (FStar_Util.mk_ref (~- ((Prims.parse_int "1"))))
+in (fun uu____628 -> (
+
+let uu____629 = (
+
+let uu____630 = ((FStar_Util.incr ctr);
+(
+
+let uu____635 = (FStar_ST.read ctr)
+in (FStar_All.pipe_right uu____635 FStar_Util.string_of_int));
+)
+in (FStar_Util.format1 "bg-%s" uu____630))
+in (new_z3proc uu____629))))
+in (
+
+let z3proc = (fun uu____641 -> ((
+
+let uu____643 = (
+
+let uu____644 = (FStar_ST.read the_z3proc)
+in (uu____644 = None))
+in (match (uu____643) with
+| true -> begin
+(
+
+let uu____650 = (
+
+let uu____652 = (new_proc ())
+in Some (uu____652))
+in (FStar_ST.write the_z3proc uu____650))
+end
+| uu____656 -> begin
+()
+end));
+(
+
+let uu____657 = (FStar_ST.read the_z3proc)
+in (FStar_Util.must uu____657));
+))
+in (
+
+let x = []
+in (
+
+let grab = (fun uu____667 -> ((FStar_Util.monitor_enter x);
+(z3proc ());
+))
+in (
+
+let release = (fun uu____673 -> (FStar_Util.monitor_exit x))
+in (
+
+let refresh = (fun uu____678 -> (
+
+let proc = (grab ())
+in ((FStar_Util.kill_process proc);
+(
+
+let uu____682 = (
+
+let uu____684 = (new_proc ())
+in Some (uu____684))
+in (FStar_ST.write the_z3proc uu____682));
+(query_logging.close_log ());
+(release ());
+)))
+in (
+
+let restart = (fun uu____692 -> ((FStar_Util.monitor_enter ());
+(query_logging.close_log ());
+(FStar_ST.write the_z3proc None);
+(
+
+let uu____700 = (
+
+let uu____702 = (new_proc ())
+in Some (uu____702))
+in (FStar_ST.write the_z3proc uu____700));
+(FStar_Util.monitor_exit ());
+))
+in {grab = grab; release = release; refresh = refresh; restart = restart}))))))))
+
+
+let at_log_file : Prims.unit  ->  Prims.string = (fun uu____708 -> (
+
+let uu____709 = (FStar_Options.log_queries ())
+in (match (uu____709) with
+| true -> begin
+(
+
+let uu____710 = (query_logging.log_file_name ())
+in (Prims.strcat "@" uu____710))
+end
+| uu____711 -> begin
+""
+end)))
+
+
+let doZ3Exe' : Prims.bool  ->  Prims.string  ->  z3status = (fun fresh1 input -> (
+
+let parse = (fun z3out -> (
+
+let lines = (FStar_All.pipe_right (FStar_String.split (('\n')::[]) z3out) (FStar_List.map FStar_Util.trim_string))
+in (
+
+let print_stats = (fun lines1 -> (
+
+let starts_with1 = (fun c s -> (((FStar_String.length s) >= (Prims.parse_int "1")) && (
+
+let uu____742 = (FStar_String.get s (Prims.parse_int "0"))
+in (uu____742 = c))))
+in (
+
+let ends_with1 = (fun c s -> (((FStar_String.length s) >= (Prims.parse_int "1")) && (
+
+let uu____753 = (FStar_String.get s ((FStar_String.length s) - (Prims.parse_int "1")))
+in (uu____753 = c))))
+in (
+
+let last1 = (fun l -> (FStar_List.nth l ((FStar_List.length l) - (Prims.parse_int "1"))))
+in (
+
+let uu____766 = (FStar_Options.print_z3_statistics ())
+in (match (uu____766) with
+| true -> begin
+(
+
+let uu____767 = ((((FStar_List.length lines1) >= (Prims.parse_int "2")) && (
+
+let uu____771 = (FStar_List.hd lines1)
+in (starts_with1 '(' uu____771))) && (
+
+let uu____772 = (last1 lines1)
+in (ends_with1 ')' uu____772)))
+in (match (uu____767) with
+| true -> begin
+((
+
+let uu____774 = (
+
+let uu____775 = (
+
+let uu____776 = (query_logging.get_module_name ())
+in (FStar_Util.format1 "BEGIN-STATS %s\n" uu____776))
+in (
+
+let uu____777 = (at_log_file ())
+in (Prims.strcat uu____775 uu____777)))
+in (FStar_Util.print_string uu____774));
+(FStar_List.iter (fun s -> (
+
+let uu____780 = (FStar_Util.format1 "%s\n" s)
+in (FStar_Util.print_string uu____780))) lines1);
+(FStar_Util.print_string "END-STATS\n");
+)
+end
+| uu____781 -> begin
+(failwith "Unexpected output from Z3: could not find statistics\n")
+end))
+end
+| uu____782 -> begin
+()
+end))))))
+in (
+
+let unsat_core = (fun lines1 -> (
+
+let parse_core = (fun s -> (
+
+let s1 = (FStar_Util.trim_string s)
+in (
+
+let s2 = (FStar_Util.substring s1 (Prims.parse_int "1") ((FStar_String.length s1) - (Prims.parse_int "2")))
+in (match ((FStar_Util.starts_with s2 "error")) with
+| true -> begin
+None
+end
+| uu____808 -> begin
+(
+
+let uu____809 = (FStar_All.pipe_right (FStar_Util.split s2 " ") (FStar_Util.sort_with FStar_String.compare))
+in (FStar_All.pipe_right uu____809 (fun _0_27 -> Some (_0_27))))
+end))))
+in (match (lines1) with
+| ("<unsat-core>")::(core)::("</unsat-core>")::rest -> begin
+(
+
+let uu____825 = (parse_core core)
+in ((uu____825), (lines1)))
+end
+| uu____831 -> begin
+((None), (lines1))
+end)))
+in (
+
+let rec lblnegs = (fun lines1 succeeded -> (match (lines1) with
+| (lname)::("false")::rest when (FStar_Util.starts_with lname "label_") -> begin
+(
+
+let uu____851 = (lblnegs rest succeeded)
+in (lname)::uu____851)
+end
+| (lname)::(uu____854)::rest when (FStar_Util.starts_with lname "label_") -> begin
+(lblnegs rest succeeded)
+end
+| uu____857 -> begin
+((match (succeeded) with
+| true -> begin
+(print_stats lines1)
+end
+| uu____860 -> begin
+()
+end);
+[];
+)
+end))
+in (
+
+let unsat_core_and_lblnegs = (fun lines1 succeeded -> (
+
+let uu____875 = (unsat_core lines1)
+in (match (uu____875) with
+| (core_opt, rest) -> begin
+(
+
+let uu____894 = (lblnegs rest succeeded)
+in ((core_opt), (uu____894)))
+end)))
+in (
+
+let rec result = (fun x -> (match (x) with
+| ("timeout")::tl1 -> begin
+TIMEOUT ([])
+end
+| ("unknown")::tl1 -> begin
+(
+
+let uu____909 = (
+
+let uu____911 = (unsat_core_and_lblnegs tl1 false)
+in (Prims.snd uu____911))
+in UNKNOWN (uu____909))
+end
+| ("sat")::tl1 -> begin
+(
+
+let uu____922 = (
+
+let uu____924 = (unsat_core_and_lblnegs tl1 false)
+in (Prims.snd uu____924))
+in SAT (uu____922))
+end
+| ("unsat")::tl1 -> begin
+(
+
+let uu____935 = (
+
+let uu____936 = (unsat_core_and_lblnegs tl1 true)
+in (Prims.fst uu____936))
+in UNSAT (uu____935))
+end
+| ("killed")::tl1 -> begin
+((bg_z3_proc.restart ());
+KILLED;
+)
+end
+| (hd1)::tl1 -> begin
+((
+
+let uu____952 = (
+
+let uu____953 = (query_logging.get_module_name ())
+in (FStar_Util.format2 "%s: Unexpected output from Z3: %s\n" uu____953 hd1))
+in (FStar_Errors.warn FStar_Range.dummyRange uu____952));
+(result tl1);
+)
+end
+| uu____954 -> begin
+(
+
+let uu____956 = (
+
+let uu____957 = (
+
+let uu____958 = (FStar_List.map (fun l -> (FStar_Util.format1 "<%s>" (FStar_Util.trim_string l))) lines)
+in (FStar_String.concat "\n" uu____958))
+in (FStar_Util.format1 "Unexpected output from Z3: got output lines: %s\n" uu____957))
+in (FStar_All.pipe_left failwith uu____956))
+end))
+in (result lines))))))))
+in (
+
+let cond = (fun pid s -> (
+
+let x = ((FStar_Util.trim_string s) = "Done!")
+in x))
+in (
+
+let stdout1 = (match (fresh1) with
+| true -> begin
+(
+
+let uu____970 = (tid ())
+in (
+
+let uu____971 = (FStar_Options.z3_exe ())
+in (
+
+let uu____972 = (ini_params ())
+in (FStar_Util.launch_process uu____970 uu____971 uu____972 input cond))))
+end
+| uu____973 -> begin
+(
+
+let proc = (bg_z3_proc.grab ())
+in (
+
+let stdout1 = (FStar_Util.ask_process proc input)
+in ((bg_z3_proc.release ());
+stdout1;
+)))
+end)
+in (parse (FStar_Util.trim_string stdout1))))))
+
+
+let doZ3Exe : Prims.bool  ->  Prims.string  ->  z3status = (fun fresh1 input -> (doZ3Exe' fresh1 input))
+
+
+let z3_options : Prims.unit  ->  Prims.string = (fun uu____985 -> "(set-option :global-decls false)\n(set-option :smt.mbqi false)\n(set-option :auto_config false)\n(set-option :produce-unsat-cores true)\n")
+
+type 'a job =
+{job : Prims.unit  ->  'a; callback : 'a  ->  Prims.unit}
+
 type error_kind =
-  | Timeout
-  | Kill
-  | Default
-let uu___is_Timeout: error_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Timeout  -> true | uu____1036 -> false
-let uu___is_Kill: error_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Kill  -> true | uu____1040 -> false
-let uu___is_Default: error_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Default  -> true | uu____1044 -> false
+| Timeout
+| Kill
+| Default
+
+
+let uu___is_Timeout : error_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Timeout -> begin
+true
+end
+| uu____1036 -> begin
+false
+end))
+
+
+let uu___is_Kill : error_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Kill -> begin
+true
+end
+| uu____1040 -> begin
+false
+end))
+
+
+let uu___is_Default : error_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Default -> begin
+true
+end
+| uu____1044 -> begin
+false
+end))
+
+
 type z3job =
-  ((unsat_core,(FStar_SMTEncoding_Term.error_labels* error_kind))
-    FStar_Util.either* Prims.int) job
-let job_queue: z3job Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let pending_jobs: Prims.int FStar_ST.ref =
-  FStar_Util.mk_ref (Prims.parse_int "0")
-let with_monitor m f =
-  FStar_Util.monitor_enter m;
-  (let res = f () in FStar_Util.monitor_exit m; res)
-let z3_job:
-  Prims.bool ->
-    ((label* FStar_SMTEncoding_Term.sort)* Prims.string* FStar_Range.range)
-      Prims.list ->
-      Prims.string ->
-        Prims.unit ->
-          ((unsat_core,(FStar_SMTEncoding_Term.error_labels* error_kind))
-            FStar_Util.either* Prims.int)
-  =
-  fun fresh1  ->
-    fun label_messages  ->
-      fun input  ->
-        fun uu____1105  ->
-          let ekind uu___93_1121 =
-            match uu___93_1121 with
-            | TIMEOUT uu____1122 -> Timeout
-            | SAT _|UNKNOWN _ -> Default
-            | KILLED  -> Kill
-            | uu____1126 -> failwith "Impossible" in
-          let start = FStar_Util.now () in
-          let status = doZ3Exe fresh1 input in
-          let uu____1129 =
-            let uu____1132 = FStar_Util.now () in
-            FStar_Util.time_diff start uu____1132 in
-          match uu____1129 with
-          | (uu____1139,elapsed_time) ->
-              let result =
-                match status with
-                | UNSAT core -> ((FStar_Util.Inl core), elapsed_time)
-                | KILLED  -> ((FStar_Util.Inr ([], Kill)), elapsed_time)
-                | TIMEOUT lblnegs|SAT lblnegs|UNKNOWN lblnegs ->
-                    ((let uu____1219 = FStar_Options.debug_any () in
-                      if uu____1219
-                      then
-                        let uu____1220 =
-                          FStar_Util.format1 "Z3 says: %s\n"
-                            (status_to_string status) in
-                        FStar_All.pipe_left FStar_Util.print_string
-                          uu____1220
-                      else ());
-                     (let failing_assertions =
-                        FStar_All.pipe_right lblnegs
-                          (FStar_List.collect
-                             (fun l  ->
-                                let uu____1242 =
-                                  FStar_All.pipe_right label_messages
-                                    (FStar_List.tryFind
-                                       (fun uu____1266  ->
-                                          match uu____1266 with
-                                          | (m,uu____1273,uu____1274) ->
-                                              (Prims.fst m) = l)) in
-                                match uu____1242 with
-                                | None  -> []
-                                | Some (lbl,msg,r) -> [(lbl, msg, r)])) in
-                      let uu____1319 =
-                        let uu____1330 =
-                          let uu____1339 = ekind status in
-                          (failing_assertions, uu____1339) in
-                        FStar_Util.Inr uu____1330 in
-                      (uu____1319, elapsed_time))) in
-              result
-let running: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
-let rec dequeue': Prims.unit -> Prims.unit =
-  fun uu____1373  ->
-    let j =
-      let uu____1375 = FStar_ST.read job_queue in
-      match uu____1375 with
-      | [] -> failwith "Impossible"
-      | hd1::tl1 -> (FStar_ST.write job_queue tl1; hd1) in
-    FStar_Util.incr pending_jobs;
-    FStar_Util.monitor_exit job_queue;
-    run_job j;
-    with_monitor job_queue (fun uu____1402  -> FStar_Util.decr pending_jobs);
-    dequeue ()
-and dequeue: Prims.unit -> Prims.unit =
-  fun uu____1407  ->
-    let uu____1408 = FStar_ST.read running in
-    if uu____1408
-    then
-      let rec aux uu____1414 =
-        FStar_Util.monitor_enter job_queue;
-        (let uu____1420 = FStar_ST.read job_queue in
-         match uu____1420 with
-         | [] ->
-             (FStar_Util.monitor_exit job_queue;
-              FStar_Util.sleep (Prims.parse_int "50");
-              aux ())
-         | uu____1431 -> dequeue' ()) in
-      aux ()
-    else ()
-and run_job: z3job -> Prims.unit =
-  fun j  ->
-    let uu____1434 = j.job () in FStar_All.pipe_left j.callback uu____1434
-let init: Prims.unit -> Prims.unit =
-  fun uu____1461  ->
-    FStar_ST.write running true;
-    (let n_cores1 = FStar_Options.n_cores () in
-     if n_cores1 > (Prims.parse_int "1")
-     then
-       let rec aux n1 =
-         if n1 = (Prims.parse_int "0")
-         then ()
-         else (FStar_Util.spawn dequeue; aux (n1 - (Prims.parse_int "1"))) in
-       aux n_cores1
-     else ())
-let enqueue: z3job -> Prims.unit =
-  fun j  ->
-    FStar_Util.monitor_enter job_queue;
-    (let uu____1482 =
-       let uu____1484 = FStar_ST.read job_queue in
-       FStar_List.append uu____1484 [j] in
-     FStar_ST.write job_queue uu____1482);
-    FStar_Util.monitor_pulse job_queue;
-    FStar_Util.monitor_exit job_queue
-let finish: Prims.unit -> Prims.unit =
-  fun uu____1503  ->
-    let rec aux uu____1507 =
-      let uu____1508 =
-        with_monitor job_queue
-          (fun uu____1517  ->
-             let uu____1518 = FStar_ST.read pending_jobs in
-             let uu____1521 =
-               let uu____1522 = FStar_ST.read job_queue in
-               FStar_List.length uu____1522 in
-             (uu____1518, uu____1521)) in
-      match uu____1508 with
-      | (n1,m) ->
-          if (n1 + m) = (Prims.parse_int "0")
-          then
-            (FStar_ST.write running false;
-             (let uu____1537 = FStar_Errors.report_all () in
-              FStar_All.pipe_right uu____1537 Prims.ignore))
-          else (FStar_Util.sleep (Prims.parse_int "500"); aux ()) in
-    aux ()
-type scope_t = FStar_SMTEncoding_Term.decl Prims.list Prims.list
-let fresh_scope:
-  FStar_SMTEncoding_Term.decl Prims.list Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref [[]]
-let bg_scope: FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref []
-let push: Prims.string -> Prims.unit =
-  fun msg  ->
-    (let uu____1563 =
-       let uu____1566 = FStar_ST.read fresh_scope in
-       [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Push] ::
-         uu____1566 in
-     FStar_ST.write fresh_scope uu____1563);
-    (let uu____1578 =
-       let uu____1580 = FStar_ST.read bg_scope in
-       FStar_List.append uu____1580
-         [FStar_SMTEncoding_Term.Push; FStar_SMTEncoding_Term.Caption msg] in
-     FStar_ST.write bg_scope uu____1578)
-let pop: Prims.string -> Prims.unit =
-  fun msg  ->
-    (let uu____1592 =
-       let uu____1595 = FStar_ST.read fresh_scope in FStar_List.tl uu____1595 in
-     FStar_ST.write fresh_scope uu____1592);
-    (let uu____1607 =
-       let uu____1609 = FStar_ST.read bg_scope in
-       FStar_List.append uu____1609
-         [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Pop] in
-     FStar_ST.write bg_scope uu____1607)
-let giveZ3: FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit =
-  fun decls  ->
-    FStar_All.pipe_right decls
-      (FStar_List.iter
-         (fun uu___94_1624  ->
-            match uu___94_1624 with
-            | FStar_SMTEncoding_Term.Push |FStar_SMTEncoding_Term.Pop  ->
-                failwith "Unexpected push/pop"
-            | uu____1625 -> ()));
-    (let uu____1627 = FStar_ST.read fresh_scope in
-     match uu____1627 with
-     | hd1::tl1 ->
-         FStar_ST.write fresh_scope ((FStar_List.append hd1 decls) :: tl1)
-     | uu____1645 -> failwith "Impossible");
-    (let uu____1648 =
-       let uu____1650 = FStar_ST.read bg_scope in
-       FStar_List.append uu____1650 decls in
-     FStar_ST.write bg_scope uu____1648)
-let refresh: Prims.unit -> Prims.unit =
-  fun uu____1660  ->
-    (let uu____1662 =
-       let uu____1663 = FStar_Options.n_cores () in
-       uu____1663 < (Prims.parse_int "2") in
-     if uu____1662 then bg_z3_proc.refresh () else ());
-    (let uu____1665 =
-       let uu____1667 =
-         let uu____1670 = FStar_ST.read fresh_scope in
-         FStar_List.rev uu____1670 in
-       FStar_List.flatten uu____1667 in
-     FStar_ST.write bg_scope uu____1665)
-let mark: Prims.string -> Prims.unit = fun msg  -> push msg
-let reset_mark: Prims.string -> Prims.unit = fun msg  -> pop msg; refresh ()
-let commit_mark msg =
-  let uu____1695 = FStar_ST.read fresh_scope in
-  match uu____1695 with
-  | hd1::s::tl1 ->
-      FStar_ST.write fresh_scope ((FStar_List.append hd1 s) :: tl1)
-  | uu____1716 -> failwith "Impossible"
-let filter_assertions:
-  Prims.string Prims.list Prims.option ->
-    FStar_SMTEncoding_Term.decl Prims.list ->
-      (FStar_SMTEncoding_Term.decl Prims.list* Prims.bool)
-  =
-  fun core  ->
-    fun theory  ->
-      match core with
-      | None  -> (theory, false)
-      | Some core1 ->
-          let uu____1742 =
-            FStar_List.fold_right
-              (fun d  ->
-                 fun uu____1752  ->
-                   match uu____1752 with
-                   | (theory1,n_retained,n_pruned) ->
-                       (match d with
-                        | FStar_SMTEncoding_Term.Assume
-                            (uu____1770,uu____1771,Some name) ->
-                            if FStar_List.contains name core1
-                            then
-                              ((d :: theory1),
-                                (n_retained + (Prims.parse_int "1")),
-                                n_pruned)
-                            else
-                              if FStar_Util.starts_with name "@"
-                              then ((d :: theory1), n_retained, n_pruned)
-                              else
-                                (theory1, n_retained,
-                                  (n_pruned + (Prims.parse_int "1")))
-                        | uu____1787 ->
-                            ((d :: theory1), n_retained, n_pruned))) theory
-              ([], (Prims.parse_int "0"), (Prims.parse_int "0")) in
-          (match uu____1742 with
-           | (theory',n_retained,n_pruned) ->
-               let missed_assertions th core2 =
-                 let missed =
-                   let uu____1810 =
-                     FStar_All.pipe_right core2
-                       (FStar_List.filter
-                          (fun nm  ->
-                             let uu____1815 =
-                               FStar_All.pipe_right th
-                                 (FStar_Util.for_some
-                                    (fun uu___95_1817  ->
-                                       match uu___95_1817 with
-                                       | FStar_SMTEncoding_Term.Assume
-                                           (uu____1818,uu____1819,Some nm')
-                                           -> nm = nm'
-                                       | uu____1822 -> false)) in
-                             FStar_All.pipe_right uu____1815
-                               Prims.op_Negation)) in
-                   FStar_All.pipe_right uu____1810 (FStar_String.concat ", ") in
-                 let included =
-                   let uu____1825 =
-                     FStar_All.pipe_right th
-                       (FStar_List.collect
-                          (fun uu___96_1829  ->
-                             match uu___96_1829 with
-                             | FStar_SMTEncoding_Term.Assume
-                                 (uu____1831,uu____1832,Some nm) -> [nm]
-                             | uu____1835 -> [])) in
-                   FStar_All.pipe_right uu____1825 (FStar_String.concat ", ") in
-                 FStar_Util.format2 "missed={%s}; included={%s}" missed
-                   included in
-               ((let uu____1838 =
-                   (FStar_Options.hint_info ()) &&
-                     (FStar_Options.debug_any ()) in
-                 if uu____1838
-                 then
-                   let n1 = FStar_List.length core1 in
-                   let missed =
-                     if n1 <> n_retained
-                     then missed_assertions theory' core1
-                     else "" in
-                   let uu____1845 = FStar_Util.string_of_int n_retained in
-                   let uu____1846 =
-                     if n1 <> n_retained
-                     then
-                       let uu____1849 = FStar_Util.string_of_int n1 in
-                       FStar_Util.format2
-                         " (expected %s (%s); replay may be inaccurate)"
-                         uu____1849 missed
-                     else "" in
-                   let uu____1854 = FStar_Util.string_of_int n_pruned in
-                   FStar_Util.print3
-                     "Hint-info: Retained %s assertions%s and pruned %s assertions using recorded unsat core\n"
-                     uu____1845 uu____1846 uu____1854
-                 else ());
-                (let uu____1856 =
-                   let uu____1858 =
-                     let uu____1860 =
-                       let uu____1861 =
-                         let uu____1862 =
-                           FStar_All.pipe_right core1
-                             (FStar_String.concat ", ") in
-                         Prims.strcat "UNSAT CORE: " uu____1862 in
-                       FStar_SMTEncoding_Term.Caption uu____1861 in
-                     [uu____1860] in
-                   FStar_List.append theory' uu____1858 in
-                 (uu____1856, true))))
-let mk_cb used_unsat_core cb uu____1906 =
-  match uu____1906 with
-  | (uc_errs,time) ->
-      if used_unsat_core
-      then
-        (match uc_errs with
-         | FStar_Util.Inl uu____1935 -> cb (uc_errs, time)
-         | FStar_Util.Inr (uu____1944,ek) ->
-             cb ((FStar_Util.Inr ([], ek)), time))
-      else cb (uc_errs, time)
-let mk_input: FStar_SMTEncoding_Term.decl Prims.list -> Prims.string =
-  fun theory  ->
-    let r =
-      let uu____1972 =
-        FStar_List.map (FStar_SMTEncoding_Term.declToSmt (z3_options ()))
-          theory in
-      FStar_All.pipe_right uu____1972 (FStar_String.concat "\n") in
-    (let uu____1976 = FStar_Options.log_queries () in
-     if uu____1976 then query_logging.write_to_log r else ());
-    r
-let ask_1_core:
-  unsat_core ->
-    ((label* FStar_SMTEncoding_Term.sort)* Prims.string* FStar_Range.range)
-      Prims.list ->
-      FStar_SMTEncoding_Term.decl Prims.list ->
-        (((unsat_core,(FStar_SMTEncoding_Term.error_labels* error_kind))
-           FStar_Util.either* Prims.int) -> Prims.unit)
-          -> Prims.unit
-  =
-  fun core  ->
-    fun label_messages  ->
-      fun qry  ->
-        fun cb  ->
-          let theory =
-            let uu____2023 = FStar_ST.read bg_scope in
-            FStar_List.append uu____2023
-              (FStar_List.append [FStar_SMTEncoding_Term.Push]
-                 (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
-          let uu____2028 = filter_assertions core theory in
-          match uu____2028 with
-          | (theory1,used_unsat_core) ->
-              let cb1 = mk_cb used_unsat_core cb in
-              let input = mk_input theory1 in
-              (FStar_ST.write bg_scope [];
-               run_job
-                 { job = (z3_job false label_messages input); callback = cb1
-                 })
-let ask_n_cores:
-  unsat_core ->
-    ((label* FStar_SMTEncoding_Term.sort)* Prims.string* FStar_Range.range)
-      Prims.list ->
-      FStar_SMTEncoding_Term.decl Prims.list ->
-        scope_t Prims.option ->
-          (((unsat_core,(FStar_SMTEncoding_Term.error_labels* error_kind))
-             FStar_Util.either* Prims.int) -> Prims.unit)
-            -> Prims.unit
-  =
-  fun core  ->
-    fun label_messages  ->
-      fun qry  ->
-        fun scope  ->
-          fun cb  ->
-            let theory =
-              let uu____2107 =
-                match scope with
-                | Some s -> FStar_List.rev s
-                | None  ->
-                    (FStar_ST.write bg_scope [];
-                     (let uu____2118 = FStar_ST.read fresh_scope in
-                      FStar_List.rev uu____2118)) in
-              FStar_List.flatten uu____2107 in
-            let theory1 =
-              FStar_List.append theory
-                (FStar_List.append [FStar_SMTEncoding_Term.Push]
-                   (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
-            let uu____2128 = filter_assertions core theory1 in
-            match uu____2128 with
-            | (theory2,used_unsat_core) ->
-                let cb1 = mk_cb used_unsat_core cb in
-                let input = mk_input theory2 in
-                enqueue
-                  { job = (z3_job true label_messages input); callback = cb1
-                  }
-let ask:
-  unsat_core ->
-    ((label* FStar_SMTEncoding_Term.sort)* Prims.string* FStar_Range.range)
-      Prims.list ->
-      FStar_SMTEncoding_Term.decl Prims.list ->
-        scope_t Prims.option ->
-          (((unsat_core,(FStar_SMTEncoding_Term.error_labels* error_kind))
-             FStar_Util.either* Prims.int) -> Prims.unit)
-            -> Prims.unit
-  =
-  fun core  ->
-    fun label_messages  ->
-      fun qry  ->
-        fun scope  ->
-          fun cb  ->
-            let uu____2201 =
-              let uu____2202 = FStar_Options.n_cores () in
-              uu____2202 = (Prims.parse_int "1") in
-            if uu____2201
-            then ask_1_core core label_messages qry cb
-            else ask_n_cores core label_messages qry scope cb
+((unsat_core, (FStar_SMTEncoding_Term.error_labels * error_kind)) FStar_Util.either * Prims.int) job
+
+
+let job_queue : z3job Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let pending_jobs : Prims.int FStar_ST.ref = (FStar_Util.mk_ref (Prims.parse_int "0"))
+
+
+let with_monitor = (fun m f -> ((FStar_Util.monitor_enter m);
+(
+
+let res = (f ())
+in ((FStar_Util.monitor_exit m);
+res;
+));
+))
+
+
+let z3_job : Prims.bool  ->  ((label * FStar_SMTEncoding_Term.sort) * Prims.string * FStar_Range.range) Prims.list  ->  Prims.string  ->  Prims.unit  ->  ((unsat_core, (FStar_SMTEncoding_Term.error_labels * error_kind)) FStar_Util.either * Prims.int) = (fun fresh1 label_messages input uu____1105 -> (
+
+let ekind = (fun uu___93_1121 -> (match (uu___93_1121) with
+| TIMEOUT (uu____1122) -> begin
+Timeout
+end
+| (SAT (_)) | (UNKNOWN (_)) -> begin
+Default
+end
+| KILLED -> begin
+Kill
+end
+| uu____1126 -> begin
+(failwith "Impossible")
+end))
+in (
+
+let start = (FStar_Util.now ())
+in (
+
+let status = (doZ3Exe fresh1 input)
+in (
+
+let uu____1129 = (
+
+let uu____1132 = (FStar_Util.now ())
+in (FStar_Util.time_diff start uu____1132))
+in (match (uu____1129) with
+| (uu____1139, elapsed_time) -> begin
+(
+
+let result = (match (status) with
+| UNSAT (core) -> begin
+((FStar_Util.Inl (core)), (elapsed_time))
+end
+| KILLED -> begin
+((FStar_Util.Inr ((([]), (Kill)))), (elapsed_time))
+end
+| (TIMEOUT (lblnegs)) | (SAT (lblnegs)) | (UNKNOWN (lblnegs)) -> begin
+((
+
+let uu____1219 = (FStar_Options.debug_any ())
+in (match (uu____1219) with
+| true -> begin
+(
+
+let uu____1220 = (FStar_Util.format1 "Z3 says: %s\n" (status_to_string status))
+in (FStar_All.pipe_left FStar_Util.print_string uu____1220))
+end
+| uu____1221 -> begin
+()
+end));
+(
+
+let failing_assertions = (FStar_All.pipe_right lblnegs (FStar_List.collect (fun l -> (
+
+let uu____1242 = (FStar_All.pipe_right label_messages (FStar_List.tryFind (fun uu____1266 -> (match (uu____1266) with
+| (m, uu____1273, uu____1274) -> begin
+((Prims.fst m) = l)
+end))))
+in (match (uu____1242) with
+| None -> begin
+[]
+end
+| Some (lbl, msg, r) -> begin
+(((lbl), (msg), (r)))::[]
+end)))))
+in (
+
+let uu____1319 = (
+
+let uu____1330 = (
+
+let uu____1339 = (ekind status)
+in ((failing_assertions), (uu____1339)))
+in FStar_Util.Inr (uu____1330))
+in ((uu____1319), (elapsed_time))));
+)
+end)
+in result)
+end))))))
+
+
+let running : Prims.bool FStar_ST.ref = (FStar_Util.mk_ref false)
+
+
+let rec dequeue' : Prims.unit  ->  Prims.unit = (fun uu____1373 -> (
+
+let j = (
+
+let uu____1375 = (FStar_ST.read job_queue)
+in (match (uu____1375) with
+| [] -> begin
+(failwith "Impossible")
+end
+| (hd1)::tl1 -> begin
+((FStar_ST.write job_queue tl1);
+hd1;
+)
+end))
+in ((FStar_Util.incr pending_jobs);
+(FStar_Util.monitor_exit job_queue);
+(run_job j);
+(with_monitor job_queue (fun uu____1402 -> (FStar_Util.decr pending_jobs)));
+(dequeue ());
+)))
+and dequeue : Prims.unit  ->  Prims.unit = (fun uu____1407 -> (
+
+let uu____1408 = (FStar_ST.read running)
+in if uu____1408 then begin
+(
+
+let rec aux = (fun uu____1414 -> ((FStar_Util.monitor_enter job_queue);
+(
+
+let uu____1420 = (FStar_ST.read job_queue)
+in (match (uu____1420) with
+| [] -> begin
+((FStar_Util.monitor_exit job_queue);
+(FStar_Util.sleep (Prims.parse_int "50"));
+(aux ());
+)
+end
+| uu____1431 -> begin
+(dequeue' ())
+end));
+))
+in (aux ()))
+end else begin
+()
+end))
+and run_job : z3job  ->  Prims.unit = (fun j -> (
+
+let uu____1434 = (j.job ())
+in (FStar_All.pipe_left j.callback uu____1434)))
+
+
+let init : Prims.unit  ->  Prims.unit = (fun uu____1461 -> ((FStar_ST.write running true);
+(
+
+let n_cores1 = (FStar_Options.n_cores ())
+in (match ((n_cores1 > (Prims.parse_int "1"))) with
+| true -> begin
+(
+
+let rec aux = (fun n1 -> (match ((n1 = (Prims.parse_int "0"))) with
+| true -> begin
+()
+end
+| uu____1470 -> begin
+((FStar_Util.spawn dequeue);
+(aux (n1 - (Prims.parse_int "1")));
+)
+end))
+in (aux n_cores1))
+end
+| uu____1472 -> begin
+()
+end));
+))
+
+
+let enqueue : z3job  ->  Prims.unit = (fun j -> ((FStar_Util.monitor_enter job_queue);
+(
+
+let uu____1482 = (
+
+let uu____1484 = (FStar_ST.read job_queue)
+in (FStar_List.append uu____1484 ((j)::[])))
+in (FStar_ST.write job_queue uu____1482));
+(FStar_Util.monitor_pulse job_queue);
+(FStar_Util.monitor_exit job_queue);
+))
+
+
+let finish : Prims.unit  ->  Prims.unit = (fun uu____1503 -> (
+
+let rec aux = (fun uu____1507 -> (
+
+let uu____1508 = (with_monitor job_queue (fun uu____1517 -> (
+
+let uu____1518 = (FStar_ST.read pending_jobs)
+in (
+
+let uu____1521 = (
+
+let uu____1522 = (FStar_ST.read job_queue)
+in (FStar_List.length uu____1522))
+in ((uu____1518), (uu____1521))))))
+in (match (uu____1508) with
+| (n1, m) -> begin
+(match (((n1 + m) = (Prims.parse_int "0"))) with
+| true -> begin
+((FStar_ST.write running false);
+(
+
+let uu____1537 = (FStar_Errors.report_all ())
+in (FStar_All.pipe_right uu____1537 Prims.ignore));
+)
+end
+| uu____1541 -> begin
+((FStar_Util.sleep (Prims.parse_int "500"));
+(aux ());
+)
+end)
+end)))
+in (aux ())))
+
+
+type scope_t =
+FStar_SMTEncoding_Term.decl Prims.list Prims.list
+
+
+let fresh_scope : FStar_SMTEncoding_Term.decl Prims.list Prims.list FStar_ST.ref = (FStar_Util.mk_ref (([])::[]))
+
+
+let bg_scope : FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let push : Prims.string  ->  Prims.unit = (fun msg -> ((
+
+let uu____1563 = (
+
+let uu____1566 = (FStar_ST.read fresh_scope)
+in ((FStar_SMTEncoding_Term.Caption (msg))::(FStar_SMTEncoding_Term.Push)::[])::uu____1566)
+in (FStar_ST.write fresh_scope uu____1563));
+(
+
+let uu____1578 = (
+
+let uu____1580 = (FStar_ST.read bg_scope)
+in (FStar_List.append uu____1580 ((FStar_SMTEncoding_Term.Push)::(FStar_SMTEncoding_Term.Caption (msg))::[])))
+in (FStar_ST.write bg_scope uu____1578));
+))
+
+
+let pop : Prims.string  ->  Prims.unit = (fun msg -> ((
+
+let uu____1592 = (
+
+let uu____1595 = (FStar_ST.read fresh_scope)
+in (FStar_List.tl uu____1595))
+in (FStar_ST.write fresh_scope uu____1592));
+(
+
+let uu____1607 = (
+
+let uu____1609 = (FStar_ST.read bg_scope)
+in (FStar_List.append uu____1609 ((FStar_SMTEncoding_Term.Caption (msg))::(FStar_SMTEncoding_Term.Pop)::[])))
+in (FStar_ST.write bg_scope uu____1607));
+))
+
+
+let giveZ3 : FStar_SMTEncoding_Term.decl Prims.list  ->  Prims.unit = (fun decls -> ((FStar_All.pipe_right decls (FStar_List.iter (fun uu___94_1624 -> (match (uu___94_1624) with
+| (FStar_SMTEncoding_Term.Push) | (FStar_SMTEncoding_Term.Pop) -> begin
+(failwith "Unexpected push/pop")
+end
+| uu____1625 -> begin
+()
+end))));
+(
+
+let uu____1627 = (FStar_ST.read fresh_scope)
+in (match (uu____1627) with
+| (hd1)::tl1 -> begin
+(FStar_ST.write fresh_scope (((FStar_List.append hd1 decls))::tl1))
+end
+| uu____1645 -> begin
+(failwith "Impossible")
+end));
+(
+
+let uu____1648 = (
+
+let uu____1650 = (FStar_ST.read bg_scope)
+in (FStar_List.append uu____1650 decls))
+in (FStar_ST.write bg_scope uu____1648));
+))
+
+
+let refresh : Prims.unit  ->  Prims.unit = (fun uu____1660 -> ((
+
+let uu____1662 = (
+
+let uu____1663 = (FStar_Options.n_cores ())
+in (uu____1663 < (Prims.parse_int "2")))
+in (match (uu____1662) with
+| true -> begin
+(bg_z3_proc.refresh ())
+end
+| uu____1664 -> begin
+()
+end));
+(
+
+let uu____1665 = (
+
+let uu____1667 = (
+
+let uu____1670 = (FStar_ST.read fresh_scope)
+in (FStar_List.rev uu____1670))
+in (FStar_List.flatten uu____1667))
+in (FStar_ST.write bg_scope uu____1665));
+))
+
+
+let mark : Prims.string  ->  Prims.unit = (fun msg -> (push msg))
+
+
+let reset_mark : Prims.string  ->  Prims.unit = (fun msg -> ((pop msg);
+(refresh ());
+))
+
+
+let commit_mark = (fun msg -> (
+
+let uu____1695 = (FStar_ST.read fresh_scope)
+in (match (uu____1695) with
+| (hd1)::(s)::tl1 -> begin
+(FStar_ST.write fresh_scope (((FStar_List.append hd1 s))::tl1))
+end
+| uu____1716 -> begin
+(failwith "Impossible")
+end)))
+
+
+let filter_assertions : Prims.string Prims.list Prims.option  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  (FStar_SMTEncoding_Term.decl Prims.list * Prims.bool) = (fun core theory -> (match (core) with
+| None -> begin
+((theory), (false))
+end
+| Some (core1) -> begin
+(
+
+let uu____1742 = (FStar_List.fold_right (fun d uu____1752 -> (match (uu____1752) with
+| (theory1, n_retained, n_pruned) -> begin
+(match (d) with
+| FStar_SMTEncoding_Term.Assume (uu____1770, uu____1771, Some (name)) -> begin
+(match ((FStar_List.contains name core1)) with
+| true -> begin
+(((d)::theory1), ((n_retained + (Prims.parse_int "1"))), (n_pruned))
+end
+| uu____1779 -> begin
+(match ((FStar_Util.starts_with name "@")) with
+| true -> begin
+(((d)::theory1), (n_retained), (n_pruned))
+end
+| uu____1785 -> begin
+((theory1), (n_retained), ((n_pruned + (Prims.parse_int "1"))))
+end)
+end)
+end
+| uu____1787 -> begin
+(((d)::theory1), (n_retained), (n_pruned))
+end)
+end)) theory (([]), ((Prims.parse_int "0")), ((Prims.parse_int "0"))))
+in (match (uu____1742) with
+| (theory', n_retained, n_pruned) -> begin
+(
+
+let missed_assertions = (fun th core2 -> (
+
+let missed = (
+
+let uu____1810 = (FStar_All.pipe_right core2 (FStar_List.filter (fun nm -> (
+
+let uu____1815 = (FStar_All.pipe_right th (FStar_Util.for_some (fun uu___95_1817 -> (match (uu___95_1817) with
+| FStar_SMTEncoding_Term.Assume (uu____1818, uu____1819, Some (nm')) -> begin
+(nm = nm')
+end
+| uu____1822 -> begin
+false
+end))))
+in (FStar_All.pipe_right uu____1815 Prims.op_Negation)))))
+in (FStar_All.pipe_right uu____1810 (FStar_String.concat ", ")))
+in (
+
+let included = (
+
+let uu____1825 = (FStar_All.pipe_right th (FStar_List.collect (fun uu___96_1829 -> (match (uu___96_1829) with
+| FStar_SMTEncoding_Term.Assume (uu____1831, uu____1832, Some (nm)) -> begin
+(nm)::[]
+end
+| uu____1835 -> begin
+[]
+end))))
+in (FStar_All.pipe_right uu____1825 (FStar_String.concat ", ")))
+in (FStar_Util.format2 "missed={%s}; included={%s}" missed included))))
+in ((
+
+let uu____1838 = ((FStar_Options.hint_info ()) && (FStar_Options.debug_any ()))
+in (match (uu____1838) with
+| true -> begin
+(
+
+let n1 = (FStar_List.length core1)
+in (
+
+let missed = (match ((n1 <> n_retained)) with
+| true -> begin
+(missed_assertions theory' core1)
+end
+| uu____1844 -> begin
+""
+end)
+in (
+
+let uu____1845 = (FStar_Util.string_of_int n_retained)
+in (
+
+let uu____1846 = (match ((n1 <> n_retained)) with
+| true -> begin
+(
+
+let uu____1849 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format2 " (expected %s (%s); replay may be inaccurate)" uu____1849 missed))
+end
+| uu____1853 -> begin
+""
+end)
+in (
+
+let uu____1854 = (FStar_Util.string_of_int n_pruned)
+in (FStar_Util.print3 "Hint-info: Retained %s assertions%s and pruned %s assertions using recorded unsat core\n" uu____1845 uu____1846 uu____1854))))))
+end
+| uu____1855 -> begin
+()
+end));
+(
+
+let uu____1856 = (
+
+let uu____1858 = (
+
+let uu____1860 = (
+
+let uu____1861 = (
+
+let uu____1862 = (FStar_All.pipe_right core1 (FStar_String.concat ", "))
+in (Prims.strcat "UNSAT CORE: " uu____1862))
+in FStar_SMTEncoding_Term.Caption (uu____1861))
+in (uu____1860)::[])
+in (FStar_List.append theory' uu____1858))
+in ((uu____1856), (true)));
+))
+end))
+end))
+
+
+let mk_cb = (fun used_unsat_core cb uu____1906 -> (match (uu____1906) with
+| (uc_errs, time) -> begin
+(match (used_unsat_core) with
+| true -> begin
+(match (uc_errs) with
+| FStar_Util.Inl (uu____1935) -> begin
+(cb ((uc_errs), (time)))
+end
+| FStar_Util.Inr (uu____1944, ek) -> begin
+(cb ((FStar_Util.Inr ((([]), (ek)))), (time)))
+end)
+end
+| uu____1960 -> begin
+(cb ((uc_errs), (time)))
+end)
+end))
+
+
+let mk_input : FStar_SMTEncoding_Term.decl Prims.list  ->  Prims.string = (fun theory -> (
+
+let r = (
+
+let uu____1972 = (FStar_List.map (FStar_SMTEncoding_Term.declToSmt (z3_options ())) theory)
+in (FStar_All.pipe_right uu____1972 (FStar_String.concat "\n")))
+in ((
+
+let uu____1976 = (FStar_Options.log_queries ())
+in (match (uu____1976) with
+| true -> begin
+(query_logging.write_to_log r)
+end
+| uu____1977 -> begin
+()
+end));
+r;
+)))
+
+
+let ask_1_core : unsat_core  ->  ((label * FStar_SMTEncoding_Term.sort) * Prims.string * FStar_Range.range) Prims.list  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  (((unsat_core, (FStar_SMTEncoding_Term.error_labels * error_kind)) FStar_Util.either * Prims.int)  ->  Prims.unit)  ->  Prims.unit = (fun core label_messages qry cb -> (
+
+let theory = (
+
+let uu____2023 = (FStar_ST.read bg_scope)
+in (FStar_List.append uu____2023 (FStar_List.append ((FStar_SMTEncoding_Term.Push)::[]) (FStar_List.append qry ((FStar_SMTEncoding_Term.Pop)::[])))))
+in (
+
+let uu____2028 = (filter_assertions core theory)
+in (match (uu____2028) with
+| (theory1, used_unsat_core) -> begin
+(
+
+let cb1 = (mk_cb used_unsat_core cb)
+in (
+
+let input = (mk_input theory1)
+in ((FStar_ST.write bg_scope []);
+(run_job {job = (z3_job false label_messages input); callback = cb1});
+)))
+end))))
+
+
+let ask_n_cores : unsat_core  ->  ((label * FStar_SMTEncoding_Term.sort) * Prims.string * FStar_Range.range) Prims.list  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  scope_t Prims.option  ->  (((unsat_core, (FStar_SMTEncoding_Term.error_labels * error_kind)) FStar_Util.either * Prims.int)  ->  Prims.unit)  ->  Prims.unit = (fun core label_messages qry scope cb -> (
+
+let theory = (
+
+let uu____2107 = (match (scope) with
+| Some (s) -> begin
+(FStar_List.rev s)
+end
+| None -> begin
+((FStar_ST.write bg_scope []);
+(
+
+let uu____2118 = (FStar_ST.read fresh_scope)
+in (FStar_List.rev uu____2118));
+)
+end)
+in (FStar_List.flatten uu____2107))
+in (
+
+let theory1 = (FStar_List.append theory (FStar_List.append ((FStar_SMTEncoding_Term.Push)::[]) (FStar_List.append qry ((FStar_SMTEncoding_Term.Pop)::[]))))
+in (
+
+let uu____2128 = (filter_assertions core theory1)
+in (match (uu____2128) with
+| (theory2, used_unsat_core) -> begin
+(
+
+let cb1 = (mk_cb used_unsat_core cb)
+in (
+
+let input = (mk_input theory2)
+in (enqueue {job = (z3_job true label_messages input); callback = cb1})))
+end)))))
+
+
+let ask : unsat_core  ->  ((label * FStar_SMTEncoding_Term.sort) * Prims.string * FStar_Range.range) Prims.list  ->  FStar_SMTEncoding_Term.decl Prims.list  ->  scope_t Prims.option  ->  (((unsat_core, (FStar_SMTEncoding_Term.error_labels * error_kind)) FStar_Util.either * Prims.int)  ->  Prims.unit)  ->  Prims.unit = (fun core label_messages qry scope cb -> (
+
+let uu____2201 = (
+
+let uu____2202 = (FStar_Options.n_cores ())
+in (uu____2202 = (Prims.parse_int "1")))
+in (match (uu____2201) with
+| true -> begin
+(ask_1_core core label_messages qry cb)
+end
+| uu____2203 -> begin
+(ask_n_cores core label_messages qry scope cb)
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Const.ml
+++ b/src/ocaml-output/FStar_Syntax_Const.ml
@@ -1,206 +1,476 @@
+
 open Prims
-let mk:
-  FStar_Syntax_Syntax.term' ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  = fun t  -> (FStar_Syntax_Syntax.mk t) None FStar_Range.dummyRange
-let p2l: Prims.string Prims.list -> FStar_Ident.lident =
-  fun l  -> FStar_Ident.lid_of_path l FStar_Range.dummyRange
-let pconst: Prims.string -> FStar_Ident.lident = fun s  -> p2l ["Prims"; s]
-let prims_lid: FStar_Ident.lident = p2l ["Prims"]
-let fstar_ns_lid: FStar_Ident.lident = p2l ["FStar"]
-let bool_lid: FStar_Ident.lident = pconst "bool"
-let unit_lid: FStar_Ident.lident = pconst "unit"
-let squash_lid: FStar_Ident.lident = pconst "squash"
-let string_lid: FStar_Ident.lident = pconst "string"
-let bytes_lid: FStar_Ident.lident = pconst "bytes"
-let int_lid: FStar_Ident.lident = pconst "int"
-let exn_lid: FStar_Ident.lident = pconst "exn"
-let list_lid: FStar_Ident.lident = pconst "list"
-let option_lid: FStar_Ident.lident = pconst "option"
-let either_lid: FStar_Ident.lident = pconst "either"
-let pattern_lid: FStar_Ident.lident = pconst "pattern"
-let precedes_lid: FStar_Ident.lident = pconst "precedes"
-let lex_t_lid: FStar_Ident.lident = pconst "lex_t"
-let lexcons_lid: FStar_Ident.lident = pconst "LexCons"
-let lextop_lid: FStar_Ident.lident = pconst "LexTop"
-let smtpat_lid: FStar_Ident.lident = pconst "SMTPat"
-let smtpatT_lid: FStar_Ident.lident = pconst "SMTPatT"
-let smtpatOr_lid: FStar_Ident.lident = pconst "SMTPatOr"
-let monadic_lid: FStar_Ident.lident = pconst "M"
-let int8_lid: FStar_Ident.lident = p2l ["FStar"; "Int8"; "t"]
-let uint8_lid: FStar_Ident.lident = p2l ["FStar"; "UInt8"; "t"]
-let int16_lid: FStar_Ident.lident = p2l ["FStar"; "Int16"; "t"]
-let uint16_lid: FStar_Ident.lident = p2l ["FStar"; "UInt16"; "t"]
-let int32_lid: FStar_Ident.lident = p2l ["FStar"; "Int32"; "t"]
-let uint32_lid: FStar_Ident.lident = p2l ["FStar"; "UInt32"; "t"]
-let int64_lid: FStar_Ident.lident = p2l ["FStar"; "Int64"; "t"]
-let uint64_lid: FStar_Ident.lident = p2l ["FStar"; "UInt64"; "t"]
-let salloc_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "salloc"]
-let swrite_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Colon_Equals"]
-let sread_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Bang"]
-let max_lid: FStar_Ident.lident = p2l ["max"]
-let float_lid: FStar_Ident.lident = p2l ["FStar"; "Float"; "float"]
-let char_lid: FStar_Ident.lident = p2l ["FStar"; "Char"; "char"]
-let heap_lid: FStar_Ident.lident = p2l ["FStar"; "Heap"; "heap"]
-let kunary:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun k  ->
-    fun k'  ->
-      let uu____26 =
-        let uu____27 =
-          let uu____35 =
-            let uu____37 = FStar_Syntax_Syntax.null_binder k in [uu____37] in
-          let uu____38 = FStar_Syntax_Syntax.mk_Total k' in
-          (uu____35, uu____38) in
-        FStar_Syntax_Syntax.Tm_arrow uu____27 in
-      mk uu____26
-let kbin:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun k1  ->
-    fun k2  ->
-      fun k'  ->
-        let uu____49 =
-          let uu____50 =
-            let uu____58 =
-              let uu____60 = FStar_Syntax_Syntax.null_binder k1 in
-              let uu____61 =
-                let uu____63 = FStar_Syntax_Syntax.null_binder k2 in
-                [uu____63] in
-              uu____60 :: uu____61 in
-            let uu____64 = FStar_Syntax_Syntax.mk_Total k' in
-            (uu____58, uu____64) in
-          FStar_Syntax_Syntax.Tm_arrow uu____50 in
-        mk uu____49
-let ktern:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun k1  ->
-    fun k2  ->
-      fun k3  ->
-        fun k'  ->
-          let uu____78 =
-            let uu____79 =
-              let uu____87 =
-                let uu____89 = FStar_Syntax_Syntax.null_binder k1 in
-                let uu____90 =
-                  let uu____92 = FStar_Syntax_Syntax.null_binder k2 in
-                  let uu____93 =
-                    let uu____95 = FStar_Syntax_Syntax.null_binder k3 in
-                    [uu____95] in
-                  uu____92 :: uu____93 in
-                uu____89 :: uu____90 in
-              let uu____96 = FStar_Syntax_Syntax.mk_Total k' in
-              (uu____87, uu____96) in
-            FStar_Syntax_Syntax.Tm_arrow uu____79 in
-          mk uu____78
-let true_lid: FStar_Ident.lident = pconst "l_True"
-let false_lid: FStar_Ident.lident = pconst "l_False"
-let and_lid: FStar_Ident.lident = pconst "l_and"
-let or_lid: FStar_Ident.lident = pconst "l_or"
-let not_lid: FStar_Ident.lident = pconst "l_not"
-let imp_lid: FStar_Ident.lident = pconst "l_imp"
-let iff_lid: FStar_Ident.lident = pconst "l_iff"
-let ite_lid: FStar_Ident.lident = pconst "l_ITE"
-let exists_lid: FStar_Ident.lident = pconst "l_Exists"
-let forall_lid: FStar_Ident.lident = pconst "l_Forall"
-let haseq_lid: FStar_Ident.lident = pconst "hasEq"
-let b2t_lid: FStar_Ident.lident = pconst "b2t"
-let admit_lid: FStar_Ident.lident = pconst "admit"
-let magic_lid: FStar_Ident.lident = pconst "magic"
-let has_type_lid: FStar_Ident.lident = pconst "has_type"
-let eq2_lid: FStar_Ident.lident = pconst "eq2"
-let eq3_lid: FStar_Ident.lident = pconst "eq3"
-let exp_true_bool: FStar_Syntax_Syntax.term =
-  mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
-let exp_false_bool: FStar_Syntax_Syntax.term =
-  mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false))
-let exp_unit: FStar_Syntax_Syntax.term =
-  mk (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_unit)
-let cons_lid: FStar_Ident.lident = pconst "Cons"
-let nil_lid: FStar_Ident.lident = pconst "Nil"
-let some_lid: FStar_Ident.lident = pconst "Some"
-let none_lid: FStar_Ident.lident = pconst "None"
-let assume_lid: FStar_Ident.lident = pconst "_assume"
-let assert_lid: FStar_Ident.lident = pconst "_assert"
-let list_append_lid: FStar_Ident.lident = p2l ["FStar"; "List"; "append"]
-let list_tot_append_lid: FStar_Ident.lident =
-  p2l ["FStar"; "List"; "Tot"; "Base"; "append"]
-let strcat_lid: FStar_Ident.lident = p2l ["Prims"; "strcat"]
-let let_in_typ: FStar_Ident.lident = p2l ["Prims"; "Let"]
-let op_Eq: FStar_Ident.lident = pconst "op_Equality"
-let op_notEq: FStar_Ident.lident = pconst "op_disEquality"
-let op_LT: FStar_Ident.lident = pconst "op_LessThan"
-let op_LTE: FStar_Ident.lident = pconst "op_LessThanOrEqual"
-let op_GT: FStar_Ident.lident = pconst "op_GreaterThan"
-let op_GTE: FStar_Ident.lident = pconst "op_GreaterThanOrEqual"
-let op_Subtraction: FStar_Ident.lident = pconst "op_Subtraction"
-let op_Minus: FStar_Ident.lident = pconst "op_Minus"
-let op_Addition: FStar_Ident.lident = pconst "op_Addition"
-let op_Multiply: FStar_Ident.lident = pconst "op_Multiply"
-let op_Division: FStar_Ident.lident = pconst "op_Division"
-let op_Modulus: FStar_Ident.lident = pconst "op_Modulus"
-let op_And: FStar_Ident.lident = pconst "op_AmpAmp"
-let op_Or: FStar_Ident.lident = pconst "op_BarBar"
-let op_Negation: FStar_Ident.lident = pconst "op_Negation"
-let array_lid: FStar_Ident.lident = p2l ["FStar"; "Array"; "array"]
-let array_mk_array_lid: FStar_Ident.lident =
-  p2l ["FStar"; "Array"; "mk_array"]
-let st_lid: FStar_Ident.lident = p2l ["FStar"; "ST"]
-let write_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "write"]
-let read_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "read"]
-let alloc_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "alloc"]
-let op_ColonEq: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Colon_Equals"]
-let ref_lid: FStar_Ident.lident = p2l ["FStar"; "Heap"; "ref"]
-let heap_ref: FStar_Ident.lident = p2l ["FStar"; "Heap"; "Ref"]
-let set_empty: FStar_Ident.lident = p2l ["FStar"; "Set"; "empty"]
-let set_singleton: FStar_Ident.lident = p2l ["FStar"; "Set"; "singleton"]
-let set_union: FStar_Ident.lident = p2l ["FStar"; "Set"; "union"]
-let fstar_hyperheap_lid: FStar_Ident.lident = p2l ["FStar"; "HyperHeap"]
-let rref_lid: FStar_Ident.lident = p2l ["FStar"; "HyperHeap"; "rref"]
-let tset_empty: FStar_Ident.lident = p2l ["FStar"; "TSet"; "empty"]
-let tset_singleton: FStar_Ident.lident = p2l ["FStar"; "TSet"; "singleton"]
-let tset_union: FStar_Ident.lident = p2l ["FStar"; "TSet"; "union"]
-let erased_lid: FStar_Ident.lident = p2l ["FStar"; "Ghost"; "erased"]
-let effect_PURE_lid: FStar_Ident.lident = pconst "PURE"
-let effect_Pure_lid: FStar_Ident.lident = pconst "Pure"
-let effect_Tot_lid: FStar_Ident.lident = pconst "Tot"
-let effect_Lemma_lid: FStar_Ident.lident = pconst "Lemma"
-let effect_GTot_lid: FStar_Ident.lident = pconst "GTot"
-let effect_GHOST_lid: FStar_Ident.lident = pconst "GHOST"
-let effect_Ghost_lid: FStar_Ident.lident = pconst "Ghost"
-let effect_DIV_lid: FStar_Ident.lident = pconst "DIV"
-let all_lid: FStar_Ident.lident = p2l ["FStar"; "All"]
-let effect_ALL_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "ALL"]
-let effect_ML_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "ML"]
-let failwith_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "failwith"]
-let pipe_right_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "pipe_right"]
-let pipe_left_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "pipe_left"]
-let try_with_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "try_with"]
-let as_requires: FStar_Ident.lident = pconst "as_requires"
-let as_ensures: FStar_Ident.lident = pconst "as_ensures"
-let decreases_lid: FStar_Ident.lident = pconst "decreases"
-let range_lid: FStar_Ident.lident = pconst "range"
-let range_of_lid: FStar_Ident.lident = pconst "range_of"
-let labeled_lid: FStar_Ident.lident = pconst "labeled"
-let range_0: FStar_Ident.lident = pconst "range_0"
-let guard_free: FStar_Ident.lident = pconst "guard_free"
-let normalize: FStar_Ident.lident = pconst "normalize"
-let normalize_term: FStar_Ident.lident = pconst "normalize_term"
-let fstar_tactics_lid: Prims.string -> FStar_Ident.lident =
-  fun s  ->
-    FStar_Ident.lid_of_path (FStar_List.append ["FStar"; "Tactics"] [s])
-      FStar_Range.dummyRange
-let tactic_lid: FStar_Ident.lident = fstar_tactics_lid "tactic"
-let by_tactic_lid: FStar_Ident.lident = fstar_tactics_lid "by_tactic"
-let reify_tactic_lid: FStar_Ident.lident = fstar_tactics_lid "reify_tactic"
-let fstar_tactics_embed_lid: FStar_Ident.lident = fstar_tactics_lid "embed"
-let fstar_tactics_quote_lid: FStar_Ident.lident = fstar_tactics_lid "quote"
+
+let mk : FStar_Syntax_Syntax.term'  ->  FStar_Syntax_Syntax.term = (fun t -> ((FStar_Syntax_Syntax.mk t) None FStar_Range.dummyRange))
+
+
+let p2l : Prims.string Prims.list  ->  FStar_Ident.lident = (fun l -> (FStar_Ident.lid_of_path l FStar_Range.dummyRange))
+
+
+let pconst : Prims.string  ->  FStar_Ident.lident = (fun s -> (p2l (("Prims")::(s)::[])))
+
+
+let prims_lid : FStar_Ident.lident = (p2l (("Prims")::[]))
+
+
+let fstar_ns_lid : FStar_Ident.lident = (p2l (("FStar")::[]))
+
+
+let bool_lid : FStar_Ident.lident = (pconst "bool")
+
+
+let unit_lid : FStar_Ident.lident = (pconst "unit")
+
+
+let squash_lid : FStar_Ident.lident = (pconst "squash")
+
+
+let string_lid : FStar_Ident.lident = (pconst "string")
+
+
+let bytes_lid : FStar_Ident.lident = (pconst "bytes")
+
+
+let int_lid : FStar_Ident.lident = (pconst "int")
+
+
+let exn_lid : FStar_Ident.lident = (pconst "exn")
+
+
+let list_lid : FStar_Ident.lident = (pconst "list")
+
+
+let option_lid : FStar_Ident.lident = (pconst "option")
+
+
+let either_lid : FStar_Ident.lident = (pconst "either")
+
+
+let pattern_lid : FStar_Ident.lident = (pconst "pattern")
+
+
+let precedes_lid : FStar_Ident.lident = (pconst "precedes")
+
+
+let lex_t_lid : FStar_Ident.lident = (pconst "lex_t")
+
+
+let lexcons_lid : FStar_Ident.lident = (pconst "LexCons")
+
+
+let lextop_lid : FStar_Ident.lident = (pconst "LexTop")
+
+
+let smtpat_lid : FStar_Ident.lident = (pconst "SMTPat")
+
+
+let smtpatT_lid : FStar_Ident.lident = (pconst "SMTPatT")
+
+
+let smtpatOr_lid : FStar_Ident.lident = (pconst "SMTPatOr")
+
+
+let monadic_lid : FStar_Ident.lident = (pconst "M")
+
+
+let int8_lid : FStar_Ident.lident = (p2l (("FStar")::("Int8")::("t")::[]))
+
+
+let uint8_lid : FStar_Ident.lident = (p2l (("FStar")::("UInt8")::("t")::[]))
+
+
+let int16_lid : FStar_Ident.lident = (p2l (("FStar")::("Int16")::("t")::[]))
+
+
+let uint16_lid : FStar_Ident.lident = (p2l (("FStar")::("UInt16")::("t")::[]))
+
+
+let int32_lid : FStar_Ident.lident = (p2l (("FStar")::("Int32")::("t")::[]))
+
+
+let uint32_lid : FStar_Ident.lident = (p2l (("FStar")::("UInt32")::("t")::[]))
+
+
+let int64_lid : FStar_Ident.lident = (p2l (("FStar")::("Int64")::("t")::[]))
+
+
+let uint64_lid : FStar_Ident.lident = (p2l (("FStar")::("UInt64")::("t")::[]))
+
+
+let salloc_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("salloc")::[]))
+
+
+let swrite_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("op_Colon_Equals")::[]))
+
+
+let sread_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("op_Bang")::[]))
+
+
+let max_lid : FStar_Ident.lident = (p2l (("max")::[]))
+
+
+let float_lid : FStar_Ident.lident = (p2l (("FStar")::("Float")::("float")::[]))
+
+
+let char_lid : FStar_Ident.lident = (p2l (("FStar")::("Char")::("char")::[]))
+
+
+let heap_lid : FStar_Ident.lident = (p2l (("FStar")::("Heap")::("heap")::[]))
+
+
+let kunary : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun k k' -> (
+
+let uu____26 = (
+
+let uu____27 = (
+
+let uu____35 = (
+
+let uu____37 = (FStar_Syntax_Syntax.null_binder k)
+in (uu____37)::[])
+in (
+
+let uu____38 = (FStar_Syntax_Syntax.mk_Total k')
+in ((uu____35), (uu____38))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____27))
+in (mk uu____26)))
+
+
+let kbin : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun k1 k2 k' -> (
+
+let uu____49 = (
+
+let uu____50 = (
+
+let uu____58 = (
+
+let uu____60 = (FStar_Syntax_Syntax.null_binder k1)
+in (
+
+let uu____61 = (
+
+let uu____63 = (FStar_Syntax_Syntax.null_binder k2)
+in (uu____63)::[])
+in (uu____60)::uu____61))
+in (
+
+let uu____64 = (FStar_Syntax_Syntax.mk_Total k')
+in ((uu____58), (uu____64))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____50))
+in (mk uu____49)))
+
+
+let ktern : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun k1 k2 k3 k' -> (
+
+let uu____78 = (
+
+let uu____79 = (
+
+let uu____87 = (
+
+let uu____89 = (FStar_Syntax_Syntax.null_binder k1)
+in (
+
+let uu____90 = (
+
+let uu____92 = (FStar_Syntax_Syntax.null_binder k2)
+in (
+
+let uu____93 = (
+
+let uu____95 = (FStar_Syntax_Syntax.null_binder k3)
+in (uu____95)::[])
+in (uu____92)::uu____93))
+in (uu____89)::uu____90))
+in (
+
+let uu____96 = (FStar_Syntax_Syntax.mk_Total k')
+in ((uu____87), (uu____96))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____79))
+in (mk uu____78)))
+
+
+let true_lid : FStar_Ident.lident = (pconst "l_True")
+
+
+let false_lid : FStar_Ident.lident = (pconst "l_False")
+
+
+let and_lid : FStar_Ident.lident = (pconst "l_and")
+
+
+let or_lid : FStar_Ident.lident = (pconst "l_or")
+
+
+let not_lid : FStar_Ident.lident = (pconst "l_not")
+
+
+let imp_lid : FStar_Ident.lident = (pconst "l_imp")
+
+
+let iff_lid : FStar_Ident.lident = (pconst "l_iff")
+
+
+let ite_lid : FStar_Ident.lident = (pconst "l_ITE")
+
+
+let exists_lid : FStar_Ident.lident = (pconst "l_Exists")
+
+
+let forall_lid : FStar_Ident.lident = (pconst "l_Forall")
+
+
+let haseq_lid : FStar_Ident.lident = (pconst "hasEq")
+
+
+let b2t_lid : FStar_Ident.lident = (pconst "b2t")
+
+
+let admit_lid : FStar_Ident.lident = (pconst "admit")
+
+
+let magic_lid : FStar_Ident.lident = (pconst "magic")
+
+
+let has_type_lid : FStar_Ident.lident = (pconst "has_type")
+
+
+let eq2_lid : FStar_Ident.lident = (pconst "eq2")
+
+
+let eq3_lid : FStar_Ident.lident = (pconst "eq3")
+
+
+let exp_true_bool : FStar_Syntax_Syntax.term = (mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool (true))))
+
+
+let exp_false_bool : FStar_Syntax_Syntax.term = (mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool (false))))
+
+
+let exp_unit : FStar_Syntax_Syntax.term = (mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit)))
+
+
+let cons_lid : FStar_Ident.lident = (pconst "Cons")
+
+
+let nil_lid : FStar_Ident.lident = (pconst "Nil")
+
+
+let some_lid : FStar_Ident.lident = (pconst "Some")
+
+
+let none_lid : FStar_Ident.lident = (pconst "None")
+
+
+let assume_lid : FStar_Ident.lident = (pconst "_assume")
+
+
+let assert_lid : FStar_Ident.lident = (pconst "_assert")
+
+
+let list_append_lid : FStar_Ident.lident = (p2l (("FStar")::("List")::("append")::[]))
+
+
+let list_tot_append_lid : FStar_Ident.lident = (p2l (("FStar")::("List")::("Tot")::("Base")::("append")::[]))
+
+
+let strcat_lid : FStar_Ident.lident = (p2l (("Prims")::("strcat")::[]))
+
+
+let let_in_typ : FStar_Ident.lident = (p2l (("Prims")::("Let")::[]))
+
+
+let op_Eq : FStar_Ident.lident = (pconst "op_Equality")
+
+
+let op_notEq : FStar_Ident.lident = (pconst "op_disEquality")
+
+
+let op_LT : FStar_Ident.lident = (pconst "op_LessThan")
+
+
+let op_LTE : FStar_Ident.lident = (pconst "op_LessThanOrEqual")
+
+
+let op_GT : FStar_Ident.lident = (pconst "op_GreaterThan")
+
+
+let op_GTE : FStar_Ident.lident = (pconst "op_GreaterThanOrEqual")
+
+
+let op_Subtraction : FStar_Ident.lident = (pconst "op_Subtraction")
+
+
+let op_Minus : FStar_Ident.lident = (pconst "op_Minus")
+
+
+let op_Addition : FStar_Ident.lident = (pconst "op_Addition")
+
+
+let op_Multiply : FStar_Ident.lident = (pconst "op_Multiply")
+
+
+let op_Division : FStar_Ident.lident = (pconst "op_Division")
+
+
+let op_Modulus : FStar_Ident.lident = (pconst "op_Modulus")
+
+
+let op_And : FStar_Ident.lident = (pconst "op_AmpAmp")
+
+
+let op_Or : FStar_Ident.lident = (pconst "op_BarBar")
+
+
+let op_Negation : FStar_Ident.lident = (pconst "op_Negation")
+
+
+let array_lid : FStar_Ident.lident = (p2l (("FStar")::("Array")::("array")::[]))
+
+
+let array_mk_array_lid : FStar_Ident.lident = (p2l (("FStar")::("Array")::("mk_array")::[]))
+
+
+let st_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::[]))
+
+
+let write_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("write")::[]))
+
+
+let read_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("read")::[]))
+
+
+let alloc_lid : FStar_Ident.lident = (p2l (("FStar")::("ST")::("alloc")::[]))
+
+
+let op_ColonEq : FStar_Ident.lident = (p2l (("FStar")::("ST")::("op_Colon_Equals")::[]))
+
+
+let ref_lid : FStar_Ident.lident = (p2l (("FStar")::("Heap")::("ref")::[]))
+
+
+let heap_ref : FStar_Ident.lident = (p2l (("FStar")::("Heap")::("Ref")::[]))
+
+
+let set_empty : FStar_Ident.lident = (p2l (("FStar")::("Set")::("empty")::[]))
+
+
+let set_singleton : FStar_Ident.lident = (p2l (("FStar")::("Set")::("singleton")::[]))
+
+
+let set_union : FStar_Ident.lident = (p2l (("FStar")::("Set")::("union")::[]))
+
+
+let fstar_hyperheap_lid : FStar_Ident.lident = (p2l (("FStar")::("HyperHeap")::[]))
+
+
+let rref_lid : FStar_Ident.lident = (p2l (("FStar")::("HyperHeap")::("rref")::[]))
+
+
+let tset_empty : FStar_Ident.lident = (p2l (("FStar")::("TSet")::("empty")::[]))
+
+
+let tset_singleton : FStar_Ident.lident = (p2l (("FStar")::("TSet")::("singleton")::[]))
+
+
+let tset_union : FStar_Ident.lident = (p2l (("FStar")::("TSet")::("union")::[]))
+
+
+let erased_lid : FStar_Ident.lident = (p2l (("FStar")::("Ghost")::("erased")::[]))
+
+
+let effect_PURE_lid : FStar_Ident.lident = (pconst "PURE")
+
+
+let effect_Pure_lid : FStar_Ident.lident = (pconst "Pure")
+
+
+let effect_Tot_lid : FStar_Ident.lident = (pconst "Tot")
+
+
+let effect_Lemma_lid : FStar_Ident.lident = (pconst "Lemma")
+
+
+let effect_GTot_lid : FStar_Ident.lident = (pconst "GTot")
+
+
+let effect_GHOST_lid : FStar_Ident.lident = (pconst "GHOST")
+
+
+let effect_Ghost_lid : FStar_Ident.lident = (pconst "Ghost")
+
+
+let effect_DIV_lid : FStar_Ident.lident = (pconst "DIV")
+
+
+let all_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::[]))
+
+
+let effect_ALL_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("ALL")::[]))
+
+
+let effect_ML_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("ML")::[]))
+
+
+let failwith_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("failwith")::[]))
+
+
+let pipe_right_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("pipe_right")::[]))
+
+
+let pipe_left_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("pipe_left")::[]))
+
+
+let try_with_lid : FStar_Ident.lident = (p2l (("FStar")::("All")::("try_with")::[]))
+
+
+let as_requires : FStar_Ident.lident = (pconst "as_requires")
+
+
+let as_ensures : FStar_Ident.lident = (pconst "as_ensures")
+
+
+let decreases_lid : FStar_Ident.lident = (pconst "decreases")
+
+
+let range_lid : FStar_Ident.lident = (pconst "range")
+
+
+let range_of_lid : FStar_Ident.lident = (pconst "range_of")
+
+
+let labeled_lid : FStar_Ident.lident = (pconst "labeled")
+
+
+let range_0 : FStar_Ident.lident = (pconst "range_0")
+
+
+let guard_free : FStar_Ident.lident = (pconst "guard_free")
+
+
+let normalize : FStar_Ident.lident = (pconst "normalize")
+
+
+let normalize_term : FStar_Ident.lident = (pconst "normalize_term")
+
+
+let fstar_tactics_lid : Prims.string  ->  FStar_Ident.lident = (fun s -> (FStar_Ident.lid_of_path (FStar_List.append (("FStar")::("Tactics")::[]) ((s)::[])) FStar_Range.dummyRange))
+
+
+let tactic_lid : FStar_Ident.lident = (fstar_tactics_lid "tactic")
+
+
+let by_tactic_lid : FStar_Ident.lident = (fstar_tactics_lid "by_tactic")
+
+
+let reify_tactic_lid : FStar_Ident.lident = (fstar_tactics_lid "reify_tactic")
+
+
+let fstar_tactics_embed_lid : FStar_Ident.lident = (fstar_tactics_lid "embed")
+
+
+let fstar_tactics_quote_lid : FStar_Ident.lident = (fstar_tactics_lid "quote")
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -1,421 +1,472 @@
+
 open Prims
+
 type free_vars_and_fvars =
-  (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-let no_free_vars:
-  (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set) =
-  let uu____7 = FStar_Syntax_Syntax.new_fv_set () in
-  ({
-     FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names;
-     FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs;
-     FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars;
-     FStar_Syntax_Syntax.free_univ_names =
-       FStar_Syntax_Syntax.no_universe_names
-   }, uu____7)
-let singleton_fvar:
-  FStar_Syntax_Syntax.fv ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun fv  ->
-    let uu____18 =
-      let uu____20 = FStar_Syntax_Syntax.new_fv_set () in
-      FStar_Util.set_add
-        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v uu____20 in
-    ({
-       FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names;
-       FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs;
-       FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars;
-       FStar_Syntax_Syntax.free_univ_names =
-         FStar_Syntax_Syntax.no_universe_names
-     }, uu____18)
-let singleton_bv:
-  FStar_Syntax_Syntax.bv ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun x  ->
-    let uu____35 =
-      let uu____36 =
-        let uu____38 = FStar_Syntax_Syntax.new_bv_set () in
-        FStar_Util.set_add x uu____38 in
-      {
-        FStar_Syntax_Syntax.free_names = uu____36;
-        FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs;
-        FStar_Syntax_Syntax.free_univs =
-          FStar_Syntax_Syntax.no_universe_uvars;
-        FStar_Syntax_Syntax.free_univ_names =
-          FStar_Syntax_Syntax.no_universe_names
-      } in
-    let uu____42 = FStar_Syntax_Syntax.new_fv_set () in (uu____35, uu____42)
-let singleton_uv:
-  ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax FStar_Syntax_Syntax.uvar_basis
-    FStar_Unionfind.uvar*
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax) ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun x  ->
-    let uu____67 =
-      let uu____68 =
-        let uu____78 = FStar_Syntax_Syntax.new_uv_set () in
-        FStar_Util.set_add x uu____78 in
-      {
-        FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names;
-        FStar_Syntax_Syntax.free_uvars = uu____68;
-        FStar_Syntax_Syntax.free_univs =
-          FStar_Syntax_Syntax.no_universe_uvars;
-        FStar_Syntax_Syntax.free_univ_names =
-          FStar_Syntax_Syntax.no_universe_names
-      } in
-    let uu____98 = FStar_Syntax_Syntax.new_fv_set () in (uu____67, uu____98)
-let singleton_univ:
-  FStar_Syntax_Syntax.universe_uvar ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun x  ->
-    let uu____107 =
-      let uu____108 =
-        let uu____110 = FStar_Syntax_Syntax.new_universe_uvar_set () in
-        FStar_Util.set_add x uu____110 in
-      {
-        FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names;
-        FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs;
-        FStar_Syntax_Syntax.free_univs = uu____108;
-        FStar_Syntax_Syntax.free_univ_names =
-          FStar_Syntax_Syntax.no_universe_names
-      } in
-    let uu____114 = FStar_Syntax_Syntax.new_fv_set () in
-    (uu____107, uu____114)
-let singleton_univ_name:
-  FStar_Syntax_Syntax.univ_name ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun x  ->
-    let uu____123 =
-      let uu____124 =
-        let uu____126 = FStar_Syntax_Syntax.new_universe_names_fifo_set () in
-        FStar_Util.fifo_set_add x uu____126 in
-      {
-        FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names;
-        FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs;
-        FStar_Syntax_Syntax.free_univs =
-          FStar_Syntax_Syntax.no_universe_uvars;
-        FStar_Syntax_Syntax.free_univ_names = uu____124
-      } in
-    let uu____134 = FStar_Syntax_Syntax.new_fv_set () in
-    (uu____123, uu____134)
-let union f1 f2 =
-  let uu____164 =
-    let uu____165 =
-      FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_names
-        (Prims.fst f2).FStar_Syntax_Syntax.free_names in
-    let uu____169 =
-      FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_uvars
-        (Prims.fst f2).FStar_Syntax_Syntax.free_uvars in
-    let uu____189 =
-      FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_univs
-        (Prims.fst f2).FStar_Syntax_Syntax.free_univs in
-    let uu____193 =
-      FStar_Util.fifo_set_union
-        (Prims.fst f1).FStar_Syntax_Syntax.free_univ_names
-        (Prims.fst f2).FStar_Syntax_Syntax.free_univ_names in
-    {
-      FStar_Syntax_Syntax.free_names = uu____165;
-      FStar_Syntax_Syntax.free_uvars = uu____169;
-      FStar_Syntax_Syntax.free_univs = uu____189;
-      FStar_Syntax_Syntax.free_univ_names = uu____193
-    } in
-  let uu____204 = FStar_Util.set_union (Prims.snd f1) (Prims.snd f2) in
-  (uu____164, uu____204)
-let rec free_univs:
-  FStar_Syntax_Syntax.universe ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun u  ->
-    let uu____215 = FStar_Syntax_Subst.compress_univ u in
-    match uu____215 with
-    | FStar_Syntax_Syntax.U_zero 
-      |FStar_Syntax_Syntax.U_bvar _|FStar_Syntax_Syntax.U_unknown  ->
-        no_free_vars
-    | FStar_Syntax_Syntax.U_name uname -> singleton_univ_name uname
-    | FStar_Syntax_Syntax.U_succ u1 -> free_univs u1
-    | FStar_Syntax_Syntax.U_max us ->
-        FStar_List.fold_left
-          (fun out  ->
-             fun x  -> let uu____232 = free_univs x in union out uu____232)
-          no_free_vars us
-    | FStar_Syntax_Syntax.U_unif u1 -> singleton_univ u1
-let rec free_names_and_uvs':
-  FStar_Syntax_Syntax.term -> Prims.bool -> free_vars_and_fvars =
-  fun tm  ->
-    fun use_cache  ->
-      let aux_binders bs from_body =
-        let from_binders =
-          FStar_All.pipe_right bs
-            (FStar_List.fold_left
-               (fun n1  ->
-                  fun uu____342  ->
-                    match uu____342 with
-                    | (x,uu____352) ->
-                        let uu____353 =
-                          free_names_and_uvars x.FStar_Syntax_Syntax.sort
-                            use_cache in
-                        union n1 uu____353) no_free_vars) in
-        union from_binders from_body in
-      let t = FStar_Syntax_Subst.compress tm in
-      match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____358 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_name x -> singleton_bv x
-      | FStar_Syntax_Syntax.Tm_uvar (x,t1) -> singleton_uv (x, t1)
-      | FStar_Syntax_Syntax.Tm_type u -> free_univs u
-      | FStar_Syntax_Syntax.Tm_bvar uu____401 -> no_free_vars
-      | FStar_Syntax_Syntax.Tm_fvar fv -> singleton_fvar fv
-      | FStar_Syntax_Syntax.Tm_constant _|FStar_Syntax_Syntax.Tm_unknown  ->
-          no_free_vars
-      | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-          let f = free_names_and_uvars t1 use_cache in
-          FStar_List.fold_left
-            (fun out  ->
-               fun u  -> let uu____422 = free_univs u in union out uu____422)
-            f us
-      | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____428) ->
-          let uu____451 = free_names_and_uvars t1 use_cache in
-          aux_binders bs uu____451
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____467 = free_names_and_uvars_comp c use_cache in
-          aux_binders bs uu____467
-      | FStar_Syntax_Syntax.Tm_refine (bv,t1) ->
-          let uu____477 = free_names_and_uvars t1 use_cache in
-          aux_binders [(bv, None)] uu____477
-      | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-          let uu____504 = free_names_and_uvars t1 use_cache in
-          free_names_and_uvars_args args uu____504 use_cache
-      | FStar_Syntax_Syntax.Tm_match (t1,pats) ->
-          let uu____536 =
-            let uu____553 = free_names_and_uvars t1 use_cache in
-            FStar_List.fold_left
-              (fun n1  ->
-                 fun uu____569  ->
-                   match uu____569 with
-                   | (p,wopt,t2) ->
-                       let n11 =
-                         match wopt with
-                         | None  -> no_free_vars
-                         | Some w -> free_names_and_uvars w use_cache in
-                       let n2 = free_names_and_uvars t2 use_cache in
-                       let n3 =
-                         let uu____619 = FStar_Syntax_Syntax.pat_bvs p in
-                         FStar_All.pipe_right uu____619
-                           (FStar_List.fold_left
-                              (fun n3  ->
-                                 fun x  ->
-                                   let uu____633 =
-                                     free_names_and_uvars
-                                       x.FStar_Syntax_Syntax.sort use_cache in
-                                   union n3 uu____633) n1) in
-                       let uu____637 = union n11 n2 in union n3 uu____637)
-              uu____553 in
-          FStar_All.pipe_right pats uu____536
-      | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____657) ->
-          let u1 = free_names_and_uvars t1 use_cache in
-          let u2 =
-            match Prims.fst asc with
-            | FStar_Util.Inl t2 -> free_names_and_uvars t2 use_cache
-            | FStar_Util.Inr c2 -> free_names_and_uvars_comp c2 use_cache in
-          (match Prims.snd asc with
-           | None  -> union u1 u2
-           | Some tac ->
-               let uu____736 = union u1 u2 in
-               let uu____740 = free_names_and_uvars tac use_cache in
-               union uu____736 uu____740)
-      | FStar_Syntax_Syntax.Tm_let (lbs,t1) ->
-          let uu____756 =
-            let uu____763 = free_names_and_uvars t1 use_cache in
-            FStar_List.fold_left
-              (fun n1  ->
-                 fun lb  ->
-                   let uu____775 =
-                     let uu____779 =
-                       free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp
-                         use_cache in
-                     let uu____783 =
-                       free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef
-                         use_cache in
-                     union uu____779 uu____783 in
-                   union n1 uu____775) uu____763 in
-          FStar_All.pipe_right (Prims.snd lbs) uu____756
-      | FStar_Syntax_Syntax.Tm_meta
-          (t1,FStar_Syntax_Syntax.Meta_pattern args) ->
-          let uu____804 = free_names_and_uvars t1 use_cache in
-          FStar_List.fold_right
-            (fun a  -> fun acc  -> free_names_and_uvars_args a acc use_cache)
-            args uu____804
-      | FStar_Syntax_Syntax.Tm_meta
-          (t1,FStar_Syntax_Syntax.Meta_monadic (uu____827,t')) ->
-          let uu____837 = free_names_and_uvars t1 use_cache in
-          let uu____841 = free_names_and_uvars t' use_cache in
-          union uu____837 uu____841
-      | FStar_Syntax_Syntax.Tm_meta (t1,uu____846) ->
-          free_names_and_uvars t1 use_cache
-and free_names_and_uvars:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    Prims.bool ->
-      (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun t  ->
-    fun use_cache  ->
-      let t1 = FStar_Syntax_Subst.compress t in
-      let uu____856 = FStar_ST.read t1.FStar_Syntax_Syntax.vars in
-      match uu____856 with
-      | Some n1 when
-          let uu____865 = should_invalidate_cache n1 use_cache in
-          Prims.op_Negation uu____865 ->
-          let uu____866 = FStar_Syntax_Syntax.new_fv_set () in
-          (n1, uu____866)
-      | uu____869 ->
-          (FStar_ST.write t1.FStar_Syntax_Syntax.vars None;
-           (let n1 = free_names_and_uvs' t1 use_cache in
-            FStar_ST.write t1.FStar_Syntax_Syntax.vars (Some (Prims.fst n1));
-            n1))
-and free_names_and_uvars_args:
-  ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list ->
-    (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set) ->
-      Prims.bool ->
-        (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun args  ->
-    fun acc  ->
-      fun use_cache  ->
-        FStar_All.pipe_right args
-          (FStar_List.fold_left
-             (fun n1  ->
-                fun uu____908  ->
-                  match uu____908 with
-                  | (x,uu____920) ->
-                      let uu____925 = free_names_and_uvars x use_cache in
-                      union n1 uu____925) acc)
-and free_names_and_uvars_binders bs acc use_cache =
-  FStar_All.pipe_right bs
-    (FStar_List.fold_left
-       (fun n1  ->
-          fun uu____950  ->
-            match uu____950 with
-            | (x,uu____960) ->
-                let uu____961 =
-                  free_names_and_uvars x.FStar_Syntax_Syntax.sort use_cache in
-                union n1 uu____961) acc)
-and free_names_and_uvars_comp:
-  (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-    Prims.bool ->
-      (FStar_Syntax_Syntax.free_vars* FStar_Ident.lident FStar_Util.set)
-  =
-  fun c  ->
-    fun use_cache  ->
-      let uu____969 = FStar_ST.read c.FStar_Syntax_Syntax.vars in
-      match uu____969 with
-      | Some n1 ->
-          let uu____978 = should_invalidate_cache n1 use_cache in
-          if uu____978
-          then
-            (FStar_ST.write c.FStar_Syntax_Syntax.vars None;
-             free_names_and_uvars_comp c use_cache)
-          else
-            (let uu____987 = FStar_Syntax_Syntax.new_fv_set () in
-             (n1, uu____987))
-      | uu____990 ->
-          let n1 =
-            match c.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.GTotal (t,None )|FStar_Syntax_Syntax.Total
-              (t,None ) -> free_names_and_uvars t use_cache
-            | FStar_Syntax_Syntax.GTotal (t,Some u)|FStar_Syntax_Syntax.Total
-              (t,Some u) ->
-                let uu____1022 = free_univs u in
-                let uu____1026 = free_names_and_uvars t use_cache in
-                union uu____1022 uu____1026
-            | FStar_Syntax_Syntax.Comp ct ->
-                let us =
-                  let uu____1032 =
-                    free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ
-                      use_cache in
-                  free_names_and_uvars_args
-                    ct.FStar_Syntax_Syntax.effect_args uu____1032 use_cache in
-                FStar_List.fold_left
-                  (fun us1  ->
-                     fun u  ->
-                       let uu____1044 = free_univs u in union us1 uu____1044)
-                  us ct.FStar_Syntax_Syntax.comp_univs in
-          (FStar_ST.write c.FStar_Syntax_Syntax.vars (Some (Prims.fst n1));
-           n1)
-and should_invalidate_cache:
-  FStar_Syntax_Syntax.free_vars -> Prims.bool -> Prims.bool =
-  fun n1  ->
-    fun use_cache  ->
-      (Prims.op_Negation use_cache) ||
-        ((let uu____1055 =
-            FStar_All.pipe_right n1.FStar_Syntax_Syntax.free_uvars
-              FStar_Util.set_elements in
-          FStar_All.pipe_right uu____1055
-            (FStar_Util.for_some
-               (fun uu____1108  ->
-                  match uu____1108 with
-                  | (u,uu____1118) ->
-                      let uu____1131 = FStar_Unionfind.find u in
-                      (match uu____1131 with
-                       | FStar_Syntax_Syntax.Fixed uu____1138 -> true
-                       | uu____1143 -> false))))
-           ||
-           (let uu____1147 =
-              FStar_All.pipe_right n1.FStar_Syntax_Syntax.free_univs
-                FStar_Util.set_elements in
-            FStar_All.pipe_right uu____1147
-              (FStar_Util.for_some
-                 (fun u  ->
-                    let uu____1157 = FStar_Unionfind.find u in
-                    match uu____1157 with
-                    | Some uu____1160 -> true
-                    | None  -> false))))
-let names: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set
-  =
-  fun t  ->
-    let uu____1165 =
-      let uu____1166 = free_names_and_uvars t true in Prims.fst uu____1166 in
-    uu____1165.FStar_Syntax_Syntax.free_names
-let uvars:
-  FStar_Syntax_Syntax.term ->
-    ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax FStar_Syntax_Syntax.uvar_basis
-      FStar_Unionfind.uvar*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax) FStar_Util.set
-  =
-  fun t  ->
-    let uu____1177 =
-      let uu____1178 = free_names_and_uvars t true in Prims.fst uu____1178 in
-    uu____1177.FStar_Syntax_Syntax.free_uvars
-let univs:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.universe_uvar FStar_Util.set
-  =
-  fun t  ->
-    let uu____1187 =
-      let uu____1188 = free_names_and_uvars t true in Prims.fst uu____1188 in
-    uu____1187.FStar_Syntax_Syntax.free_univs
-let univnames:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set
-  =
-  fun t  ->
-    let uu____1197 =
-      let uu____1198 = free_names_and_uvars t true in Prims.fst uu____1198 in
-    uu____1197.FStar_Syntax_Syntax.free_univ_names
-let fvars: FStar_Syntax_Syntax.term -> FStar_Ident.lident FStar_Util.set =
-  fun t  ->
-    let uu____1208 = free_names_and_uvars t false in Prims.snd uu____1208
-let names_of_binders:
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.bv FStar_Util.set =
-  fun bs  ->
-    let uu____1217 =
-      let uu____1218 = free_names_and_uvars_binders bs no_free_vars true in
-      Prims.fst uu____1218 in
-    uu____1217.FStar_Syntax_Syntax.free_names
+(FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set)
+
+
+let no_free_vars : (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (
+
+let uu____7 = (FStar_Syntax_Syntax.new_fv_set ())
+in (({FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names; FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs; FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars; FStar_Syntax_Syntax.free_univ_names = FStar_Syntax_Syntax.no_universe_names}), (uu____7)))
+
+
+let singleton_fvar : FStar_Syntax_Syntax.fv  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun fv -> (
+
+let uu____18 = (
+
+let uu____20 = (FStar_Syntax_Syntax.new_fv_set ())
+in (FStar_Util.set_add fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v uu____20))
+in (({FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names; FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs; FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars; FStar_Syntax_Syntax.free_univ_names = FStar_Syntax_Syntax.no_universe_names}), (uu____18))))
+
+
+let singleton_bv : FStar_Syntax_Syntax.bv  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun x -> (
+
+let uu____35 = (
+
+let uu____36 = (
+
+let uu____38 = (FStar_Syntax_Syntax.new_bv_set ())
+in (FStar_Util.set_add x uu____38))
+in {FStar_Syntax_Syntax.free_names = uu____36; FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs; FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars; FStar_Syntax_Syntax.free_univ_names = FStar_Syntax_Syntax.no_universe_names})
+in (
+
+let uu____42 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((uu____35), (uu____42)))))
+
+
+let singleton_uv : ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax FStar_Syntax_Syntax.uvar_basis FStar_Unionfind.uvar * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun x -> (
+
+let uu____67 = (
+
+let uu____68 = (
+
+let uu____78 = (FStar_Syntax_Syntax.new_uv_set ())
+in (FStar_Util.set_add x uu____78))
+in {FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names; FStar_Syntax_Syntax.free_uvars = uu____68; FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars; FStar_Syntax_Syntax.free_univ_names = FStar_Syntax_Syntax.no_universe_names})
+in (
+
+let uu____98 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((uu____67), (uu____98)))))
+
+
+let singleton_univ : FStar_Syntax_Syntax.universe_uvar  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun x -> (
+
+let uu____107 = (
+
+let uu____108 = (
+
+let uu____110 = (FStar_Syntax_Syntax.new_universe_uvar_set ())
+in (FStar_Util.set_add x uu____110))
+in {FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names; FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs; FStar_Syntax_Syntax.free_univs = uu____108; FStar_Syntax_Syntax.free_univ_names = FStar_Syntax_Syntax.no_universe_names})
+in (
+
+let uu____114 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((uu____107), (uu____114)))))
+
+
+let singleton_univ_name : FStar_Syntax_Syntax.univ_name  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun x -> (
+
+let uu____123 = (
+
+let uu____124 = (
+
+let uu____126 = (FStar_Syntax_Syntax.new_universe_names_fifo_set ())
+in (FStar_Util.fifo_set_add x uu____126))
+in {FStar_Syntax_Syntax.free_names = FStar_Syntax_Syntax.no_names; FStar_Syntax_Syntax.free_uvars = FStar_Syntax_Syntax.no_uvs; FStar_Syntax_Syntax.free_univs = FStar_Syntax_Syntax.no_universe_uvars; FStar_Syntax_Syntax.free_univ_names = uu____124})
+in (
+
+let uu____134 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((uu____123), (uu____134)))))
+
+
+let union = (fun f1 f2 -> (
+
+let uu____164 = (
+
+let uu____165 = (FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_names (Prims.fst f2).FStar_Syntax_Syntax.free_names)
+in (
+
+let uu____169 = (FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_uvars (Prims.fst f2).FStar_Syntax_Syntax.free_uvars)
+in (
+
+let uu____189 = (FStar_Util.set_union (Prims.fst f1).FStar_Syntax_Syntax.free_univs (Prims.fst f2).FStar_Syntax_Syntax.free_univs)
+in (
+
+let uu____193 = (FStar_Util.fifo_set_union (Prims.fst f1).FStar_Syntax_Syntax.free_univ_names (Prims.fst f2).FStar_Syntax_Syntax.free_univ_names)
+in {FStar_Syntax_Syntax.free_names = uu____165; FStar_Syntax_Syntax.free_uvars = uu____169; FStar_Syntax_Syntax.free_univs = uu____189; FStar_Syntax_Syntax.free_univ_names = uu____193}))))
+in (
+
+let uu____204 = (FStar_Util.set_union (Prims.snd f1) (Prims.snd f2))
+in ((uu____164), (uu____204)))))
+
+
+let rec free_univs : FStar_Syntax_Syntax.universe  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun u -> (
+
+let uu____215 = (FStar_Syntax_Subst.compress_univ u)
+in (match (uu____215) with
+| (FStar_Syntax_Syntax.U_zero) | (FStar_Syntax_Syntax.U_bvar (_)) | (FStar_Syntax_Syntax.U_unknown) -> begin
+no_free_vars
+end
+| FStar_Syntax_Syntax.U_name (uname) -> begin
+(singleton_univ_name uname)
+end
+| FStar_Syntax_Syntax.U_succ (u1) -> begin
+(free_univs u1)
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(FStar_List.fold_left (fun out x -> (
+
+let uu____232 = (free_univs x)
+in (union out uu____232))) no_free_vars us)
+end
+| FStar_Syntax_Syntax.U_unif (u1) -> begin
+(singleton_univ u1)
+end)))
+
+
+let rec free_names_and_uvs' : FStar_Syntax_Syntax.term  ->  Prims.bool  ->  free_vars_and_fvars = (fun tm use_cache -> (
+
+let aux_binders = (fun bs from_body -> (
+
+let from_binders = (FStar_All.pipe_right bs (FStar_List.fold_left (fun n1 uu____342 -> (match (uu____342) with
+| (x, uu____352) -> begin
+(
+
+let uu____353 = (free_names_and_uvars x.FStar_Syntax_Syntax.sort use_cache)
+in (union n1 uu____353))
+end)) no_free_vars))
+in (union from_binders from_body)))
+in (
+
+let t = (FStar_Syntax_Subst.compress tm)
+in (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____358) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+(singleton_bv x)
+end
+| FStar_Syntax_Syntax.Tm_uvar (x, t1) -> begin
+(singleton_uv ((x), (t1)))
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(free_univs u)
+end
+| FStar_Syntax_Syntax.Tm_bvar (uu____401) -> begin
+no_free_vars
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(singleton_fvar fv)
+end
+| (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+no_free_vars
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, us) -> begin
+(
+
+let f = (free_names_and_uvars t1 use_cache)
+in (FStar_List.fold_left (fun out u -> (
+
+let uu____422 = (free_univs u)
+in (union out uu____422))) f us))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, t1, uu____428) -> begin
+(
+
+let uu____451 = (free_names_and_uvars t1 use_cache)
+in (aux_binders bs uu____451))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____467 = (free_names_and_uvars_comp c use_cache)
+in (aux_binders bs uu____467))
+end
+| FStar_Syntax_Syntax.Tm_refine (bv, t1) -> begin
+(
+
+let uu____477 = (free_names_and_uvars t1 use_cache)
+in (aux_binders ((((bv), (None)))::[]) uu____477))
+end
+| FStar_Syntax_Syntax.Tm_app (t1, args) -> begin
+(
+
+let uu____504 = (free_names_and_uvars t1 use_cache)
+in (free_names_and_uvars_args args uu____504 use_cache))
+end
+| FStar_Syntax_Syntax.Tm_match (t1, pats) -> begin
+(
+
+let uu____536 = (
+
+let uu____553 = (free_names_and_uvars t1 use_cache)
+in (FStar_List.fold_left (fun n1 uu____569 -> (match (uu____569) with
+| (p, wopt, t2) -> begin
+(
+
+let n11 = (match (wopt) with
+| None -> begin
+no_free_vars
+end
+| Some (w) -> begin
+(free_names_and_uvars w use_cache)
+end)
+in (
+
+let n2 = (free_names_and_uvars t2 use_cache)
+in (
+
+let n3 = (
+
+let uu____619 = (FStar_Syntax_Syntax.pat_bvs p)
+in (FStar_All.pipe_right uu____619 (FStar_List.fold_left (fun n3 x -> (
+
+let uu____633 = (free_names_and_uvars x.FStar_Syntax_Syntax.sort use_cache)
+in (union n3 uu____633))) n1)))
+in (
+
+let uu____637 = (union n11 n2)
+in (union n3 uu____637)))))
+end)) uu____553))
+in (FStar_All.pipe_right pats uu____536))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____657) -> begin
+(
+
+let u1 = (free_names_and_uvars t1 use_cache)
+in (
+
+let u2 = (match ((Prims.fst asc)) with
+| FStar_Util.Inl (t2) -> begin
+(free_names_and_uvars t2 use_cache)
+end
+| FStar_Util.Inr (c2) -> begin
+(free_names_and_uvars_comp c2 use_cache)
+end)
+in (match ((Prims.snd asc)) with
+| None -> begin
+(union u1 u2)
+end
+| Some (tac) -> begin
+(
+
+let uu____736 = (union u1 u2)
+in (
+
+let uu____740 = (free_names_and_uvars tac use_cache)
+in (union uu____736 uu____740)))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_let (lbs, t1) -> begin
+(
+
+let uu____756 = (
+
+let uu____763 = (free_names_and_uvars t1 use_cache)
+in (FStar_List.fold_left (fun n1 lb -> (
+
+let uu____775 = (
+
+let uu____779 = (free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp use_cache)
+in (
+
+let uu____783 = (free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef use_cache)
+in (union uu____779 uu____783)))
+in (union n1 uu____775))) uu____763))
+in (FStar_All.pipe_right (Prims.snd lbs) uu____756))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, FStar_Syntax_Syntax.Meta_pattern (args)) -> begin
+(
+
+let uu____804 = (free_names_and_uvars t1 use_cache)
+in (FStar_List.fold_right (fun a acc -> (free_names_and_uvars_args a acc use_cache)) args uu____804))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, FStar_Syntax_Syntax.Meta_monadic (uu____827, t')) -> begin
+(
+
+let uu____837 = (free_names_and_uvars t1 use_cache)
+in (
+
+let uu____841 = (free_names_and_uvars t' use_cache)
+in (union uu____837 uu____841)))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, uu____846) -> begin
+(free_names_and_uvars t1 use_cache)
+end))))
+and free_names_and_uvars : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  Prims.bool  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun t use_cache -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (
+
+let uu____856 = (FStar_ST.read t1.FStar_Syntax_Syntax.vars)
+in (match (uu____856) with
+| Some (n1) when (
+
+let uu____865 = (should_invalidate_cache n1 use_cache)
+in (not (uu____865))) -> begin
+(
+
+let uu____866 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((n1), (uu____866)))
+end
+| uu____869 -> begin
+((FStar_ST.write t1.FStar_Syntax_Syntax.vars None);
+(
+
+let n1 = (free_names_and_uvs' t1 use_cache)
+in ((FStar_ST.write t1.FStar_Syntax_Syntax.vars (Some ((Prims.fst n1))));
+n1;
+));
+)
+end))))
+and free_names_and_uvars_args : ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set)  ->  Prims.bool  ->  free_vars_and_fvars = (fun args acc use_cache -> (FStar_All.pipe_right args (FStar_List.fold_left (fun n1 uu____908 -> (match (uu____908) with
+| (x, uu____920) -> begin
+(
+
+let uu____925 = (free_names_and_uvars x use_cache)
+in (union n1 uu____925))
+end)) acc)))
+and free_names_and_uvars_binders = (fun bs acc use_cache -> (FStar_All.pipe_right bs (FStar_List.fold_left (fun n1 uu____950 -> (match (uu____950) with
+| (x, uu____960) -> begin
+(
+
+let uu____961 = (free_names_and_uvars x.FStar_Syntax_Syntax.sort use_cache)
+in (union n1 uu____961))
+end)) acc)))
+and free_names_and_uvars_comp : (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  Prims.bool  ->  (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set) = (fun c use_cache -> (
+
+let uu____969 = (FStar_ST.read c.FStar_Syntax_Syntax.vars)
+in (match (uu____969) with
+| Some (n1) -> begin
+(
+
+let uu____978 = (should_invalidate_cache n1 use_cache)
+in (match (uu____978) with
+| true -> begin
+((FStar_ST.write c.FStar_Syntax_Syntax.vars None);
+(free_names_and_uvars_comp c use_cache);
+)
+end
+| uu____986 -> begin
+(
+
+let uu____987 = (FStar_Syntax_Syntax.new_fv_set ())
+in ((n1), (uu____987)))
+end))
+end
+| uu____990 -> begin
+(
+
+let n1 = (match (c.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.GTotal (t, None)) | (FStar_Syntax_Syntax.Total (t, None)) -> begin
+(free_names_and_uvars t use_cache)
+end
+| (FStar_Syntax_Syntax.GTotal (t, Some (u))) | (FStar_Syntax_Syntax.Total (t, Some (u))) -> begin
+(
+
+let uu____1022 = (free_univs u)
+in (
+
+let uu____1026 = (free_names_and_uvars t use_cache)
+in (union uu____1022 uu____1026)))
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let us = (
+
+let uu____1032 = (free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ use_cache)
+in (free_names_and_uvars_args ct.FStar_Syntax_Syntax.effect_args uu____1032 use_cache))
+in (FStar_List.fold_left (fun us1 u -> (
+
+let uu____1044 = (free_univs u)
+in (union us1 uu____1044))) us ct.FStar_Syntax_Syntax.comp_univs))
+end)
+in ((FStar_ST.write c.FStar_Syntax_Syntax.vars (Some ((Prims.fst n1))));
+n1;
+))
+end)))
+and should_invalidate_cache : FStar_Syntax_Syntax.free_vars  ->  Prims.bool  ->  Prims.bool = (fun n1 use_cache -> ((not (use_cache)) || ((
+
+let uu____1055 = (FStar_All.pipe_right n1.FStar_Syntax_Syntax.free_uvars FStar_Util.set_elements)
+in (FStar_All.pipe_right uu____1055 (FStar_Util.for_some (fun uu____1108 -> (match (uu____1108) with
+| (u, uu____1118) -> begin
+(
+
+let uu____1131 = (FStar_Unionfind.find u)
+in (match (uu____1131) with
+| FStar_Syntax_Syntax.Fixed (uu____1138) -> begin
+true
+end
+| uu____1143 -> begin
+false
+end))
+end))))) || (
+
+let uu____1147 = (FStar_All.pipe_right n1.FStar_Syntax_Syntax.free_univs FStar_Util.set_elements)
+in (FStar_All.pipe_right uu____1147 (FStar_Util.for_some (fun u -> (
+
+let uu____1157 = (FStar_Unionfind.find u)
+in (match (uu____1157) with
+| Some (uu____1160) -> begin
+true
+end
+| None -> begin
+false
+end)))))))))
+
+
+let names : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.bv FStar_Util.set = (fun t -> (
+
+let uu____1165 = (
+
+let uu____1166 = (free_names_and_uvars t true)
+in (Prims.fst uu____1166))
+in uu____1165.FStar_Syntax_Syntax.free_names))
+
+
+let uvars : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.typ) FStar_Util.set = (fun t -> (
+
+let uu____1177 = (
+
+let uu____1178 = (free_names_and_uvars t true)
+in (Prims.fst uu____1178))
+in uu____1177.FStar_Syntax_Syntax.free_uvars))
+
+
+let univs : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.universe_uvar FStar_Util.set = (fun t -> (
+
+let uu____1187 = (
+
+let uu____1188 = (free_names_and_uvars t true)
+in (Prims.fst uu____1188))
+in uu____1187.FStar_Syntax_Syntax.free_univs))
+
+
+let univnames : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.univ_name FStar_Util.set = (fun t -> (
+
+let uu____1197 = (
+
+let uu____1198 = (free_names_and_uvars t true)
+in (Prims.fst uu____1198))
+in uu____1197.FStar_Syntax_Syntax.free_univ_names))
+
+
+let fvars : FStar_Syntax_Syntax.term  ->  FStar_Ident.lident FStar_Util.set = (fun t -> (
+
+let uu____1208 = (free_names_and_uvars t false)
+in (Prims.snd uu____1208)))
+
+
+let names_of_binders : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.bv FStar_Util.set = (fun bs -> (
+
+let uu____1217 = (
+
+let uu____1218 = (free_names_and_uvars_binders bs no_free_vars true)
+in (Prims.fst uu____1218))
+in uu____1217.FStar_Syntax_Syntax.free_names))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_InstFV.ml
+++ b/src/ocaml-output/FStar_Syntax_InstFV.ml
@@ -1,279 +1,346 @@
+
 open Prims
-type inst_t = (FStar_Ident.lident* FStar_Syntax_Syntax.universes) Prims.list
-let mk t s =
-  let uu____26 = FStar_ST.read t.FStar_Syntax_Syntax.tk in
-  FStar_Syntax_Syntax.mk s uu____26 t.FStar_Syntax_Syntax.pos
-let rec inst:
-  (FStar_Syntax_Syntax.term ->
-     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun s  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t in
-      let mk1 = mk t1 in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____123 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_name _
-        |FStar_Syntax_Syntax.Tm_uvar _
-         |FStar_Syntax_Syntax.Tm_uvar _
-          |FStar_Syntax_Syntax.Tm_type _
-           |FStar_Syntax_Syntax.Tm_bvar _
-            |FStar_Syntax_Syntax.Tm_constant _
-             |FStar_Syntax_Syntax.Tm_unknown |FStar_Syntax_Syntax.Tm_uinst _
-          -> t1
-      | FStar_Syntax_Syntax.Tm_fvar fv -> s t1 fv
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-          let bs1 = inst_binders s bs in
-          let body1 = inst s body in
-          let uu____179 =
-            let uu____180 =
-              let uu____195 = inst_lcomp_opt s lopt in
-              (bs1, body1, uu____195) in
-            FStar_Syntax_Syntax.Tm_abs uu____180 in
-          mk1 uu____179
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let bs1 = inst_binders s bs in
-          let c1 = inst_comp s c in
-          mk1 (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
-      | FStar_Syntax_Syntax.Tm_refine (bv,t2) ->
-          let bv1 =
-            let uu___160_233 = bv in
-            let uu____234 = inst s bv.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___160_233.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___160_233.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____234
-            } in
-          let t3 = inst s t2 in mk1 (FStar_Syntax_Syntax.Tm_refine (bv1, t3))
-      | FStar_Syntax_Syntax.Tm_app (t2,args) ->
-          let uu____254 =
-            let uu____255 =
-              let uu____265 = inst s t2 in
-              let uu____266 = inst_args s args in (uu____265, uu____266) in
-            FStar_Syntax_Syntax.Tm_app uu____255 in
-          mk1 uu____254
-      | FStar_Syntax_Syntax.Tm_match (t2,pats) ->
-          let pats1 =
-            FStar_All.pipe_right pats
-              (FStar_List.map
-                 (fun uu____343  ->
-                    match uu____343 with
-                    | (p,wopt,t3) ->
-                        let wopt1 =
-                          match wopt with
-                          | None  -> None
-                          | Some w ->
-                              let uu____369 = inst s w in Some uu____369 in
-                        let t4 = inst s t3 in (p, wopt1, t4))) in
-          let uu____374 =
-            let uu____375 = let uu____391 = inst s t2 in (uu____391, pats1) in
-            FStar_Syntax_Syntax.Tm_match uu____375 in
-          mk1 uu____374
-      | FStar_Syntax_Syntax.Tm_ascribed (t11,asc,f) ->
-          let inst_asc uu____447 =
-            match uu____447 with
-            | (annot,topt) ->
-                let topt1 = FStar_Util.map_opt topt (inst s) in
-                let annot1 =
-                  match annot with
-                  | FStar_Util.Inl t2 ->
-                      let uu____488 = inst s t2 in FStar_Util.Inl uu____488
-                  | FStar_Util.Inr c ->
-                      let uu____496 = inst_comp s c in
-                      FStar_Util.Inr uu____496 in
-                (annot1, topt1) in
-          let uu____506 =
-            let uu____507 =
-              let uu____525 = inst s t11 in
-              let uu____526 = inst_asc asc in (uu____525, uu____526, f) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____507 in
-          mk1 uu____506
-      | FStar_Syntax_Syntax.Tm_let (lbs,t2) ->
-          let lbs1 =
-            let uu____558 =
-              FStar_All.pipe_right (Prims.snd lbs)
-                (FStar_List.map
-                   (fun lb  ->
-                      let uu___161_564 = lb in
-                      let uu____565 = inst s lb.FStar_Syntax_Syntax.lbtyp in
-                      let uu____568 = inst s lb.FStar_Syntax_Syntax.lbdef in
-                      {
-                        FStar_Syntax_Syntax.lbname =
-                          (uu___161_564.FStar_Syntax_Syntax.lbname);
-                        FStar_Syntax_Syntax.lbunivs =
-                          (uu___161_564.FStar_Syntax_Syntax.lbunivs);
-                        FStar_Syntax_Syntax.lbtyp = uu____565;
-                        FStar_Syntax_Syntax.lbeff =
-                          (uu___161_564.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu____568
-                      })) in
-            ((Prims.fst lbs), uu____558) in
-          let uu____573 =
-            let uu____574 = let uu____582 = inst s t2 in (lbs1, uu____582) in
-            FStar_Syntax_Syntax.Tm_let uu____574 in
-          mk1 uu____573
-      | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_pattern args) ->
-          let uu____598 =
-            let uu____599 =
-              let uu____604 = inst s t2 in
-              let uu____605 =
-                let uu____606 =
-                  FStar_All.pipe_right args (FStar_List.map (inst_args s)) in
-                FStar_Syntax_Syntax.Meta_pattern uu____606 in
-              (uu____604, uu____605) in
-            FStar_Syntax_Syntax.Tm_meta uu____599 in
-          mk1 uu____598
-      | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_monadic (m,t')) ->
-          let uu____646 =
-            let uu____647 =
-              let uu____652 = inst s t2 in
-              let uu____653 =
-                let uu____654 = let uu____659 = inst s t' in (m, uu____659) in
-                FStar_Syntax_Syntax.Meta_monadic uu____654 in
-              (uu____652, uu____653) in
-            FStar_Syntax_Syntax.Tm_meta uu____647 in
-          mk1 uu____646
-      | FStar_Syntax_Syntax.Tm_meta (t2,tag) ->
-          let uu____666 =
-            let uu____667 = let uu____672 = inst s t2 in (uu____672, tag) in
-            FStar_Syntax_Syntax.Tm_meta uu____667 in
-          mk1 uu____666
-and inst_binders:
-  (FStar_Syntax_Syntax.term ->
-     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    ->
-    FStar_Syntax_Syntax.binders ->
-      (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun s  ->
-    fun bs  ->
-      FStar_All.pipe_right bs
-        (FStar_List.map
-           (fun uu____686  ->
-              match uu____686 with
-              | (x,imp) ->
-                  let uu____693 =
-                    let uu___162_694 = x in
-                    let uu____695 = inst s x.FStar_Syntax_Syntax.sort in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___162_694.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index =
-                        (uu___162_694.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu____695
-                    } in
-                  (uu____693, imp)))
-and inst_args:
-  (FStar_Syntax_Syntax.term ->
-     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    ->
-    ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun s  ->
-    fun args  ->
-      FStar_All.pipe_right args
-        (FStar_List.map
-           (fun uu____721  ->
-              match uu____721 with
-              | (a,imp) -> let uu____728 = inst s a in (uu____728, imp)))
-and inst_comp:
-  (FStar_Syntax_Syntax.term ->
-     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    ->
-    (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.comp
-  =
-  fun s  ->
-    fun c  ->
-      match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t,uopt) ->
-          let uu____747 = inst s t in
-          FStar_Syntax_Syntax.mk_Total' uu____747 uopt
-      | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-          let uu____756 = inst s t in
-          FStar_Syntax_Syntax.mk_GTotal' uu____756 uopt
-      | FStar_Syntax_Syntax.Comp ct ->
-          let ct1 =
-            let uu___163_759 = ct in
-            let uu____760 = inst s ct.FStar_Syntax_Syntax.result_typ in
-            let uu____763 = inst_args s ct.FStar_Syntax_Syntax.effect_args in
-            let uu____769 =
-              FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
-                (FStar_List.map
-                   (fun uu___159_773  ->
-                      match uu___159_773 with
-                      | FStar_Syntax_Syntax.DECREASES t ->
-                          let uu____777 = inst s t in
-                          FStar_Syntax_Syntax.DECREASES uu____777
-                      | f -> f)) in
-            {
-              FStar_Syntax_Syntax.comp_univs =
-                (uu___163_759.FStar_Syntax_Syntax.comp_univs);
-              FStar_Syntax_Syntax.effect_name =
-                (uu___163_759.FStar_Syntax_Syntax.effect_name);
-              FStar_Syntax_Syntax.result_typ = uu____760;
-              FStar_Syntax_Syntax.effect_args = uu____763;
-              FStar_Syntax_Syntax.flags = uu____769
-            } in
-          FStar_Syntax_Syntax.mk_Comp ct1
-and inst_lcomp_opt:
-  (FStar_Syntax_Syntax.term ->
-     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    ->
-    (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                 FStar_Syntax_Syntax.cflags Prims.list))
-      FStar_Util.either Prims.option ->
-      (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                   FStar_Syntax_Syntax.cflags Prims.list))
-        FStar_Util.either Prims.option
-  =
-  fun s  ->
-    fun l  ->
-      match l with
-      | None |Some (FStar_Util.Inr _) -> l
-      | Some (FStar_Util.Inl lc) ->
-          let uu____822 =
-            let uu____828 =
-              let uu___164_829 = lc in
-              let uu____830 = inst s lc.FStar_Syntax_Syntax.res_typ in
-              {
-                FStar_Syntax_Syntax.eff_name =
-                  (uu___164_829.FStar_Syntax_Syntax.eff_name);
-                FStar_Syntax_Syntax.res_typ = uu____830;
-                FStar_Syntax_Syntax.cflags =
-                  (uu___164_829.FStar_Syntax_Syntax.cflags);
-                FStar_Syntax_Syntax.comp =
-                  (fun uu____833  ->
-                     let uu____834 = lc.FStar_Syntax_Syntax.comp () in
-                     inst_comp s uu____834)
-              } in
-            FStar_Util.Inl uu____828 in
-          Some uu____822
-let instantiate:
-  inst_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun i  ->
-    fun t  ->
-      match i with
-      | [] -> t
-      | uu____853 ->
-          let inst_fv t1 fv =
-            let uu____861 =
-              FStar_Util.find_opt
-                (fun uu____867  ->
-                   match uu____867 with
-                   | (x,uu____871) ->
-                       FStar_Ident.lid_equals x
-                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                i in
-            match uu____861 with
-            | None  -> t1
-            | Some (uu____878,us) ->
-                mk t1 (FStar_Syntax_Syntax.Tm_uinst (t1, us)) in
-          inst inst_fv t
+
+type inst_t =
+(FStar_Ident.lident * FStar_Syntax_Syntax.universes) Prims.list
+
+
+let mk = (fun t s -> (
+
+let uu____26 = (FStar_ST.read t.FStar_Syntax_Syntax.tk)
+in (FStar_Syntax_Syntax.mk s uu____26 t.FStar_Syntax_Syntax.pos)))
+
+
+let rec inst : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term)  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun s t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (
+
+let mk1 = (mk t1)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____123) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_uinst (_)) -> begin
+t1
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(s t1 fv)
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) -> begin
+(
+
+let bs1 = (inst_binders s bs)
+in (
+
+let body1 = (inst s body)
+in (
+
+let uu____179 = (
+
+let uu____180 = (
+
+let uu____195 = (inst_lcomp_opt s lopt)
+in ((bs1), (body1), (uu____195)))
+in FStar_Syntax_Syntax.Tm_abs (uu____180))
+in (mk1 uu____179))))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let bs1 = (inst_binders s bs)
+in (
+
+let c1 = (inst_comp s c)
+in (mk1 (FStar_Syntax_Syntax.Tm_arrow (((bs1), (c1)))))))
+end
+| FStar_Syntax_Syntax.Tm_refine (bv, t2) -> begin
+(
+
+let bv1 = (
+
+let uu___156_233 = bv
+in (
+
+let uu____234 = (inst s bv.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___156_233.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___156_233.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____234}))
+in (
+
+let t3 = (inst s t2)
+in (mk1 (FStar_Syntax_Syntax.Tm_refine (((bv1), (t3)))))))
+end
+| FStar_Syntax_Syntax.Tm_app (t2, args) -> begin
+(
+
+let uu____254 = (
+
+let uu____255 = (
+
+let uu____265 = (inst s t2)
+in (
+
+let uu____266 = (inst_args s args)
+in ((uu____265), (uu____266))))
+in FStar_Syntax_Syntax.Tm_app (uu____255))
+in (mk1 uu____254))
+end
+| FStar_Syntax_Syntax.Tm_match (t2, pats) -> begin
+(
+
+let pats1 = (FStar_All.pipe_right pats (FStar_List.map (fun uu____343 -> (match (uu____343) with
+| (p, wopt, t3) -> begin
+(
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____369 = (inst s w)
+in Some (uu____369))
+end)
+in (
+
+let t4 = (inst s t3)
+in ((p), (wopt1), (t4))))
+end))))
+in (
+
+let uu____374 = (
+
+let uu____375 = (
+
+let uu____391 = (inst s t2)
+in ((uu____391), (pats1)))
+in FStar_Syntax_Syntax.Tm_match (uu____375))
+in (mk1 uu____374)))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t11, asc, f) -> begin
+(
+
+let inst_asc = (fun uu____447 -> (match (uu____447) with
+| (annot, topt) -> begin
+(
+
+let topt1 = (FStar_Util.map_opt topt (inst s))
+in (
+
+let annot1 = (match (annot) with
+| FStar_Util.Inl (t2) -> begin
+(
+
+let uu____488 = (inst s t2)
+in FStar_Util.Inl (uu____488))
+end
+| FStar_Util.Inr (c) -> begin
+(
+
+let uu____496 = (inst_comp s c)
+in FStar_Util.Inr (uu____496))
+end)
+in ((annot1), (topt1))))
+end))
+in (
+
+let uu____506 = (
+
+let uu____507 = (
+
+let uu____525 = (inst s t11)
+in (
+
+let uu____526 = (inst_asc asc)
+in ((uu____525), (uu____526), (f))))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____507))
+in (mk1 uu____506)))
+end
+| FStar_Syntax_Syntax.Tm_let (lbs, t2) -> begin
+(
+
+let lbs1 = (
+
+let uu____558 = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.map (fun lb -> (
+
+let uu___157_564 = lb
+in (
+
+let uu____565 = (inst s lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____568 = (inst s lb.FStar_Syntax_Syntax.lbdef)
+in {FStar_Syntax_Syntax.lbname = uu___157_564.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___157_564.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu____565; FStar_Syntax_Syntax.lbeff = uu___157_564.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____568}))))))
+in (((Prims.fst lbs)), (uu____558)))
+in (
+
+let uu____573 = (
+
+let uu____574 = (
+
+let uu____582 = (inst s t2)
+in ((lbs1), (uu____582)))
+in FStar_Syntax_Syntax.Tm_let (uu____574))
+in (mk1 uu____573)))
+end
+| FStar_Syntax_Syntax.Tm_meta (t2, FStar_Syntax_Syntax.Meta_pattern (args)) -> begin
+(
+
+let uu____598 = (
+
+let uu____599 = (
+
+let uu____604 = (inst s t2)
+in (
+
+let uu____605 = (
+
+let uu____606 = (FStar_All.pipe_right args (FStar_List.map (inst_args s)))
+in FStar_Syntax_Syntax.Meta_pattern (uu____606))
+in ((uu____604), (uu____605))))
+in FStar_Syntax_Syntax.Tm_meta (uu____599))
+in (mk1 uu____598))
+end
+| FStar_Syntax_Syntax.Tm_meta (t2, FStar_Syntax_Syntax.Meta_monadic (m, t')) -> begin
+(
+
+let uu____646 = (
+
+let uu____647 = (
+
+let uu____652 = (inst s t2)
+in (
+
+let uu____653 = (
+
+let uu____654 = (
+
+let uu____659 = (inst s t')
+in ((m), (uu____659)))
+in FStar_Syntax_Syntax.Meta_monadic (uu____654))
+in ((uu____652), (uu____653))))
+in FStar_Syntax_Syntax.Tm_meta (uu____647))
+in (mk1 uu____646))
+end
+| FStar_Syntax_Syntax.Tm_meta (t2, tag) -> begin
+(
+
+let uu____666 = (
+
+let uu____667 = (
+
+let uu____672 = (inst s t2)
+in ((uu____672), (tag)))
+in FStar_Syntax_Syntax.Tm_meta (uu____667))
+in (mk1 uu____666))
+end))))
+and inst_binders : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term)  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun s bs -> (FStar_All.pipe_right bs (FStar_List.map (fun uu____686 -> (match (uu____686) with
+| (x, imp) -> begin
+(
+
+let uu____693 = (
+
+let uu___158_694 = x
+in (
+
+let uu____695 = (inst s x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___158_694.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___158_694.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____695}))
+in ((uu____693), (imp)))
+end)))))
+and inst_args : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term)  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list = (fun s args -> (FStar_All.pipe_right args (FStar_List.map (fun uu____721 -> (match (uu____721) with
+| (a, imp) -> begin
+(
+
+let uu____728 = (inst s a)
+in ((uu____728), (imp)))
+end)))))
+and inst_comp : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term)  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun s c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uopt) -> begin
+(
+
+let uu____747 = (inst s t)
+in (FStar_Syntax_Syntax.mk_Total' uu____747 uopt))
+end
+| FStar_Syntax_Syntax.GTotal (t, uopt) -> begin
+(
+
+let uu____756 = (inst s t)
+in (FStar_Syntax_Syntax.mk_GTotal' uu____756 uopt))
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let ct1 = (
+
+let uu___159_759 = ct
+in (
+
+let uu____760 = (inst s ct.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____763 = (inst_args s ct.FStar_Syntax_Syntax.effect_args)
+in (
+
+let uu____769 = (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags (FStar_List.map (fun uu___155_773 -> (match (uu___155_773) with
+| FStar_Syntax_Syntax.DECREASES (t) -> begin
+(
+
+let uu____777 = (inst s t)
+in FStar_Syntax_Syntax.DECREASES (uu____777))
+end
+| f -> begin
+f
+end))))
+in {FStar_Syntax_Syntax.comp_univs = uu___159_759.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = uu___159_759.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = uu____760; FStar_Syntax_Syntax.effect_args = uu____763; FStar_Syntax_Syntax.flags = uu____769}))))
+in (FStar_Syntax_Syntax.mk_Comp ct1))
+end))
+and inst_lcomp_opt : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.term)  ->  (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option  ->  (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option = (fun s l -> (match (l) with
+| (None) | (Some (FStar_Util.Inr (_))) -> begin
+l
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let uu____822 = (
+
+let uu____828 = (
+
+let uu___160_829 = lc
+in (
+
+let uu____830 = (inst s lc.FStar_Syntax_Syntax.res_typ)
+in {FStar_Syntax_Syntax.eff_name = uu___160_829.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu____830; FStar_Syntax_Syntax.cflags = uu___160_829.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____833 -> (
+
+let uu____834 = (lc.FStar_Syntax_Syntax.comp ())
+in (inst_comp s uu____834)))}))
+in FStar_Util.Inl (uu____828))
+in Some (uu____822))
+end))
+
+
+let instantiate : inst_t  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun i t -> (match (i) with
+| [] -> begin
+t
+end
+| uu____853 -> begin
+(
+
+let inst_fv = (fun t1 fv -> (
+
+let uu____861 = (FStar_Util.find_opt (fun uu____867 -> (match (uu____867) with
+| (x, uu____871) -> begin
+(FStar_Ident.lid_equals x fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end)) i)
+in (match (uu____861) with
+| None -> begin
+t1
+end
+| Some (uu____878, us) -> begin
+(mk t1 (FStar_Syntax_Syntax.Tm_uinst (((t1), (us)))))
+end)))
+in (inst inst_fv t))
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_MutRecTy.ml
+++ b/src/ocaml-output/FStar_Syntax_MutRecTy.ml
@@ -1,278 +1,287 @@
+
 open Prims
-let disentangle_abbrevs_from_bundle:
-  FStar_Syntax_Syntax.sigelt Prims.list ->
-    FStar_Syntax_Syntax.qualifier Prims.list ->
-      FStar_Ident.lident Prims.list ->
-        FStar_Range.range ->
-          (FStar_Syntax_Syntax.sigelt* FStar_Syntax_Syntax.sigelt Prims.list)
-  =
-  fun sigelts  ->
-    fun quals  ->
-      fun members  ->
-        fun rng  ->
-          let type_abbrev_sigelts =
-            FStar_All.pipe_right sigelts
-              (FStar_List.collect
-                 (fun x  ->
-                    match x with
-                    | FStar_Syntax_Syntax.Sig_let
-                        ((false
-                          ,{
-                             FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                               uu____31;
-                             FStar_Syntax_Syntax.lbunivs = uu____32;
-                             FStar_Syntax_Syntax.lbtyp = uu____33;
-                             FStar_Syntax_Syntax.lbeff = uu____34;
-                             FStar_Syntax_Syntax.lbdef = uu____35;_}::[]),uu____36,uu____37,uu____38,uu____39)
-                        -> [x]
-                    | FStar_Syntax_Syntax.Sig_let
-                        (uu____55,uu____56,uu____57,uu____58,uu____59) ->
-                        failwith
-                          "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
-                    | uu____67 -> [])) in
-          match type_abbrev_sigelts with
-          | [] ->
-              ((FStar_Syntax_Syntax.Sig_bundle (sigelts, quals, members, rng)),
-                [])
-          | uu____75 ->
-              let type_abbrevs =
-                FStar_All.pipe_right type_abbrev_sigelts
-                  (FStar_List.map
-                     (fun uu___202_81  ->
-                        match uu___202_81 with
-                        | FStar_Syntax_Syntax.Sig_let
-                            ((uu____82,{
-                                         FStar_Syntax_Syntax.lbname =
-                                           FStar_Util.Inr fv;
-                                         FStar_Syntax_Syntax.lbunivs =
-                                           uu____84;
-                                         FStar_Syntax_Syntax.lbtyp = uu____85;
-                                         FStar_Syntax_Syntax.lbeff = uu____86;
-                                         FStar_Syntax_Syntax.lbdef = uu____87;_}::[]),uu____88,uu____89,uu____90,uu____91)
-                            ->
-                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____111 ->
-                            failwith
-                              "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")) in
-              let unfolded_type_abbrevs =
-                let rev_unfolded_type_abbrevs = FStar_Util.mk_ref [] in
-                let in_progress = FStar_Util.mk_ref [] in
-                let not_unfolded_yet = FStar_Util.mk_ref type_abbrev_sigelts in
-                let remove_not_unfolded lid =
-                  let uu____133 =
-                    let uu____135 = FStar_ST.read not_unfolded_yet in
-                    FStar_All.pipe_right uu____135
-                      (FStar_List.filter
-                         (fun uu___203_142  ->
-                            match uu___203_142 with
-                            | FStar_Syntax_Syntax.Sig_let
-                                ((uu____143,{
-                                              FStar_Syntax_Syntax.lbname =
-                                                FStar_Util.Inr fv;
-                                              FStar_Syntax_Syntax.lbunivs =
-                                                uu____145;
-                                              FStar_Syntax_Syntax.lbtyp =
-                                                uu____146;
-                                              FStar_Syntax_Syntax.lbeff =
-                                                uu____147;
-                                              FStar_Syntax_Syntax.lbdef =
-                                                uu____148;_}::[]),uu____149,uu____150,uu____151,uu____152)
-                                ->
-                                Prims.op_Negation
-                                  (FStar_Ident.lid_equals lid
-                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                            | uu____172 -> true)) in
-                  FStar_ST.write not_unfolded_yet uu____133 in
-                let rec unfold_abbrev_fv t fv =
-                  let replacee x =
-                    match x with
-                    | FStar_Syntax_Syntax.Sig_let
-                        ((uu____192,{
-                                      FStar_Syntax_Syntax.lbname =
-                                        FStar_Util.Inr fv';
-                                      FStar_Syntax_Syntax.lbunivs = uu____194;
-                                      FStar_Syntax_Syntax.lbtyp = uu____195;
-                                      FStar_Syntax_Syntax.lbeff = uu____196;
-                                      FStar_Syntax_Syntax.lbdef = uu____197;_}::[]),uu____198,uu____199,uu____200,uu____201)
-                        when
-                        FStar_Ident.lid_equals
-                          (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        -> Some x
-                    | uu____225 -> None in
-                  let replacee_term x =
-                    match replacee x with
-                    | Some (FStar_Syntax_Syntax.Sig_let
-                        ((uu____236,{ FStar_Syntax_Syntax.lbname = uu____237;
-                                      FStar_Syntax_Syntax.lbunivs = uu____238;
-                                      FStar_Syntax_Syntax.lbtyp = uu____239;
-                                      FStar_Syntax_Syntax.lbeff = uu____240;
-                                      FStar_Syntax_Syntax.lbdef = tm;_}::[]),uu____242,uu____243,uu____244,uu____245))
-                        -> Some tm
-                    | uu____265 -> None in
-                  let uu____269 =
-                    let uu____273 = FStar_ST.read rev_unfolded_type_abbrevs in
-                    FStar_Util.find_map uu____273 replacee_term in
-                  match uu____269 with
-                  | Some x -> x
-                  | None  ->
-                      let uu____287 =
-                        FStar_Util.find_map type_abbrev_sigelts replacee in
-                      (match uu____287 with
-                       | Some se ->
-                           let uu____290 =
-                             let uu____291 = FStar_ST.read in_progress in
-                             FStar_List.existsb
-                               (fun x  ->
-                                  FStar_Ident.lid_equals x
-                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                               uu____291 in
-                           if uu____290
-                           then
-                             let msg =
-                               FStar_Util.format1
-                                 "Cycle on %s in mutually recursive type abbreviations"
-                                 ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
-                             Prims.raise
-                               (FStar_Errors.Error
-                                  (msg,
-                                    (FStar_Ident.range_of_lid
-                                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)))
-                           else unfold_abbrev se
-                       | uu____311 -> t)
-                and unfold_abbrev uu___205_313 =
-                  match uu___205_313 with
-                  | FStar_Syntax_Syntax.Sig_let
-                      ((false ,lb::[]),rng1,uu____316,quals1,attr) ->
-                      let quals2 =
-                        FStar_All.pipe_right quals1
-                          (FStar_List.filter
-                             (fun uu___204_333  ->
-                                match uu___204_333 with
-                                | FStar_Syntax_Syntax.Noeq  -> false
-                                | uu____334 -> true)) in
-                      let lid =
-                        match lb.FStar_Syntax_Syntax.lbname with
-                        | FStar_Util.Inr fv ->
-                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____341 ->
-                            failwith
-                              "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible" in
-                      ((let uu____345 =
-                          let uu____347 = FStar_ST.read in_progress in lid ::
-                            uu____347 in
-                        FStar_ST.write in_progress uu____345);
-                       (match () with
-                        | () ->
-                            (remove_not_unfolded lid;
-                             (match () with
-                              | () ->
-                                  let ty' =
-                                    FStar_Syntax_InstFV.inst unfold_abbrev_fv
-                                      lb.FStar_Syntax_Syntax.lbtyp in
-                                  let tm' =
-                                    FStar_Syntax_InstFV.inst unfold_abbrev_fv
-                                      lb.FStar_Syntax_Syntax.lbdef in
-                                  let lb' =
-                                    let uu___207_359 = lb in
-                                    {
-                                      FStar_Syntax_Syntax.lbname =
-                                        (uu___207_359.FStar_Syntax_Syntax.lbname);
-                                      FStar_Syntax_Syntax.lbunivs =
-                                        (uu___207_359.FStar_Syntax_Syntax.lbunivs);
-                                      FStar_Syntax_Syntax.lbtyp = ty';
-                                      FStar_Syntax_Syntax.lbeff =
-                                        (uu___207_359.FStar_Syntax_Syntax.lbeff);
-                                      FStar_Syntax_Syntax.lbdef = tm'
-                                    } in
-                                  let sigelt' =
-                                    FStar_Syntax_Syntax.Sig_let
-                                      ((false, [lb']), rng1, [lid], quals2,
-                                        attr) in
-                                  ((let uu____369 =
-                                      let uu____371 =
-                                        FStar_ST.read
-                                          rev_unfolded_type_abbrevs in
-                                      sigelt' :: uu____371 in
-                                    FStar_ST.write rev_unfolded_type_abbrevs
-                                      uu____369);
-                                   (match () with
-                                    | () ->
-                                        ((let uu____380 =
-                                            let uu____382 =
-                                              FStar_ST.read in_progress in
-                                            FStar_List.tl uu____382 in
-                                          FStar_ST.write in_progress
-                                            uu____380);
-                                         (match () with | () -> tm'))))))))
-                  | uu____390 ->
-                      failwith
-                        "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible" in
-                let rec aux uu____395 =
-                  let uu____396 = FStar_ST.read not_unfolded_yet in
-                  match uu____396 with
-                  | x::uu____403 -> let _unused = unfold_abbrev x in aux ()
-                  | uu____406 ->
-                      let uu____408 = FStar_ST.read rev_unfolded_type_abbrevs in
-                      FStar_List.rev uu____408 in
-                aux () in
-              let filter_out_type_abbrevs l =
-                FStar_List.filter
-                  (fun lid  ->
-                     FStar_List.for_all
-                       (fun lid'  ->
-                          Prims.op_Negation (FStar_Ident.lid_equals lid lid'))
-                       type_abbrevs) l in
-              let inductives_with_abbrevs_unfolded =
-                let find_in_unfolded fv =
-                  FStar_Util.find_map unfolded_type_abbrevs
-                    (fun x  ->
-                       match x with
-                       | FStar_Syntax_Syntax.Sig_let
-                           ((uu____437,{
-                                         FStar_Syntax_Syntax.lbname =
-                                           FStar_Util.Inr fv';
-                                         FStar_Syntax_Syntax.lbunivs =
-                                           uu____439;
-                                         FStar_Syntax_Syntax.lbtyp =
-                                           uu____440;
-                                         FStar_Syntax_Syntax.lbeff =
-                                           uu____441;
-                                         FStar_Syntax_Syntax.lbdef = tm;_}::[]),uu____443,uu____444,uu____445,uu____446)
-                           when
-                           FStar_Ident.lid_equals
-                             (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                           -> Some tm
-                       | uu____472 -> None) in
-                let unfold_fv t fv =
-                  let uu____482 = find_in_unfolded fv in
-                  match uu____482 with | Some t' -> t' | uu____491 -> t in
-                let unfold_in_sig uu___206_499 =
-                  match uu___206_499 with
-                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                      (lid,univs1,bnd,ty,mut,dc,quals1,rng1) ->
-                      let bnd' =
-                        FStar_Syntax_InstFV.inst_binders unfold_fv bnd in
-                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
-                      let mut' = filter_out_type_abbrevs mut in
-                      [FStar_Syntax_Syntax.Sig_inductive_typ
-                         (lid, univs1, bnd', ty', mut', dc, quals1, rng1)]
-                  | FStar_Syntax_Syntax.Sig_datacon
-                      (lid,univs1,ty,res,npars,quals1,mut,rng1) ->
-                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
-                      let mut' = filter_out_type_abbrevs mut in
-                      [FStar_Syntax_Syntax.Sig_datacon
-                         (lid, univs1, ty', res, npars, quals1, mut', rng1)]
-                  | FStar_Syntax_Syntax.Sig_let
-                      (uu____539,uu____540,uu____541,uu____542,uu____543) ->
-                      []
-                  | uu____550 ->
-                      failwith
-                        "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible" in
-                FStar_List.collect unfold_in_sig sigelts in
-              let new_members = filter_out_type_abbrevs members in
-              let new_bundle =
-                FStar_Syntax_Syntax.Sig_bundle
-                  (inductives_with_abbrevs_unfolded, quals, new_members, rng) in
-              (new_bundle, unfolded_type_abbrevs)
+
+let disentangle_abbrevs_from_bundle : FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Ident.lident Prims.list  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.fsdoc Prims.option  ->  (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.sigelt Prims.list) = (fun sigelts quals members rng doc1 -> (
+
+let type_abbrev_sigelts = (FStar_All.pipe_right sigelts (FStar_List.collect (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((false, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (uu____36); FStar_Syntax_Syntax.lbunivs = uu____37; FStar_Syntax_Syntax.lbtyp = uu____38; FStar_Syntax_Syntax.lbeff = uu____39; FStar_Syntax_Syntax.lbdef = uu____40})::[]), uu____41, uu____42, uu____43) -> begin
+(x)::[]
+end
+| FStar_Syntax_Syntax.Sig_let (uu____59, uu____60, uu____61, uu____62) -> begin
+(failwith "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible")
+end
+| uu____70 -> begin
+[]
+end))))
+in (match (type_abbrev_sigelts) with
+| [] -> begin
+(({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle (((sigelts), (quals), (members))); FStar_Syntax_Syntax.sigdoc = doc1; FStar_Syntax_Syntax.sigrng = rng}), ([]))
+end
+| uu____78 -> begin
+(
+
+let type_abbrevs = (FStar_All.pipe_right type_abbrev_sigelts (FStar_List.map (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____85, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv); FStar_Syntax_Syntax.lbunivs = uu____87; FStar_Syntax_Syntax.lbtyp = uu____88; FStar_Syntax_Syntax.lbeff = uu____89; FStar_Syntax_Syntax.lbdef = uu____90})::[]), uu____91, uu____92, uu____93) -> begin
+fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+end
+| uu____113 -> begin
+(failwith "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")
+end))))
+in (
+
+let unfolded_type_abbrevs = (
+
+let rev_unfolded_type_abbrevs = (FStar_Util.mk_ref [])
+in (
+
+let in_progress = (FStar_Util.mk_ref [])
+in (
+
+let not_unfolded_yet = (FStar_Util.mk_ref type_abbrev_sigelts)
+in (
+
+let remove_not_unfolded = (fun lid -> (
+
+let uu____135 = (
+
+let uu____137 = (FStar_ST.read not_unfolded_yet)
+in (FStar_All.pipe_right uu____137 (FStar_List.filter (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____145, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv); FStar_Syntax_Syntax.lbunivs = uu____147; FStar_Syntax_Syntax.lbtyp = uu____148; FStar_Syntax_Syntax.lbeff = uu____149; FStar_Syntax_Syntax.lbdef = uu____150})::[]), uu____151, uu____152, uu____153) -> begin
+(not ((FStar_Ident.lid_equals lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))
+end
+| uu____173 -> begin
+true
+end)))))
+in (FStar_ST.write not_unfolded_yet uu____135)))
+in (
+
+let rec unfold_abbrev_fv = (fun t fv -> (
+
+let replacee = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____193, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv'); FStar_Syntax_Syntax.lbunivs = uu____195; FStar_Syntax_Syntax.lbtyp = uu____196; FStar_Syntax_Syntax.lbeff = uu____197; FStar_Syntax_Syntax.lbdef = uu____198})::[]), uu____199, uu____200, uu____201) when (FStar_Ident.lid_equals fv'.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v) -> begin
+Some (x)
+end
+| uu____225 -> begin
+None
+end))
+in (
+
+let replacee_term = (fun x -> (match ((replacee x)) with
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let ((uu____236, ({FStar_Syntax_Syntax.lbname = uu____237; FStar_Syntax_Syntax.lbunivs = uu____238; FStar_Syntax_Syntax.lbtyp = uu____239; FStar_Syntax_Syntax.lbeff = uu____240; FStar_Syntax_Syntax.lbdef = tm})::[]), uu____242, uu____243, uu____244); FStar_Syntax_Syntax.sigdoc = uu____245; FStar_Syntax_Syntax.sigrng = uu____246}) -> begin
+Some (tm)
+end
+| uu____267 -> begin
+None
+end))
+in (
+
+let uu____271 = (
+
+let uu____275 = (FStar_ST.read rev_unfolded_type_abbrevs)
+in (FStar_Util.find_map uu____275 replacee_term))
+in (match (uu____271) with
+| Some (x) -> begin
+x
+end
+| None -> begin
+(
+
+let uu____289 = (FStar_Util.find_map type_abbrev_sigelts replacee)
+in (match (uu____289) with
+| Some (se) -> begin
+(
+
+let uu____292 = (
+
+let uu____293 = (FStar_ST.read in_progress)
+in (FStar_List.existsb (fun x -> (FStar_Ident.lid_equals x fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)) uu____293))
+in (match (uu____292) with
+| true -> begin
+(
+
+let msg = (FStar_Util.format1 "Cycle on %s in mutually recursive type abbreviations" fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str)
+in (Prims.raise (FStar_Errors.Error (((msg), ((FStar_Ident.range_of_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))))))
+end
+| uu____312 -> begin
+(unfold_abbrev se)
+end))
+end
+| uu____313 -> begin
+t
+end))
+end)))))
+and unfold_abbrev = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((false, (lb)::[]), uu____317, quals1, attr) -> begin
+(
+
+let quals2 = (FStar_All.pipe_right quals1 (FStar_List.filter (fun uu___198_334 -> (match (uu___198_334) with
+| FStar_Syntax_Syntax.Noeq -> begin
+false
+end
+| uu____335 -> begin
+true
+end))))
+in (
+
+let lid = (match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inr (fv) -> begin
+fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+end
+| uu____342 -> begin
+(failwith "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible")
+end)
+in ((
+
+let uu____346 = (
+
+let uu____348 = (FStar_ST.read in_progress)
+in (lid)::uu____348)
+in (FStar_ST.write in_progress uu____346));
+(match (()) with
+| () -> begin
+((remove_not_unfolded lid);
+(match (()) with
+| () -> begin
+(
+
+let ty' = (FStar_Syntax_InstFV.inst unfold_abbrev_fv lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let tm' = (FStar_Syntax_InstFV.inst unfold_abbrev_fv lb.FStar_Syntax_Syntax.lbdef)
+in (
+
+let lb' = (
+
+let uu___199_360 = lb
+in {FStar_Syntax_Syntax.lbname = uu___199_360.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___199_360.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = ty'; FStar_Syntax_Syntax.lbeff = uu___199_360.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = tm'})
+in (
+
+let sigelt' = FStar_Syntax_Syntax.Sig_let (((((false), ((lb')::[]))), ((lid)::[]), (quals2), (attr)))
+in ((
+
+let uu____370 = (
+
+let uu____372 = (FStar_ST.read rev_unfolded_type_abbrevs)
+in ((
+
+let uu___200_377 = x
+in {FStar_Syntax_Syntax.sigel = sigelt'; FStar_Syntax_Syntax.sigdoc = uu___200_377.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___200_377.FStar_Syntax_Syntax.sigrng}))::uu____372)
+in (FStar_ST.write rev_unfolded_type_abbrevs uu____370));
+(match (()) with
+| () -> begin
+((
+
+let uu____382 = (
+
+let uu____384 = (FStar_ST.read in_progress)
+in (FStar_List.tl uu____384))
+in (FStar_ST.write in_progress uu____382));
+(match (()) with
+| () -> begin
+tm'
+end);
+)
+end);
+)))))
+end);
+)
+end);
+)))
+end
+| uu____392 -> begin
+(failwith "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible")
+end))
+in (
+
+let rec aux = (fun uu____397 -> (
+
+let uu____398 = (FStar_ST.read not_unfolded_yet)
+in (match (uu____398) with
+| (x)::uu____405 -> begin
+(
+
+let _unused = (unfold_abbrev x)
+in (aux ()))
+end
+| uu____408 -> begin
+(
+
+let uu____410 = (FStar_ST.read rev_unfolded_type_abbrevs)
+in (FStar_List.rev uu____410))
+end)))
+in (aux ())))))))
+in (
+
+let filter_out_type_abbrevs = (fun l -> (FStar_List.filter (fun lid -> (FStar_List.for_all (fun lid' -> (not ((FStar_Ident.lid_equals lid lid')))) type_abbrevs)) l))
+in (
+
+let inductives_with_abbrevs_unfolded = (
+
+let find_in_unfolded = (fun fv -> (FStar_Util.find_map unfolded_type_abbrevs (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____439, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv'); FStar_Syntax_Syntax.lbunivs = uu____441; FStar_Syntax_Syntax.lbtyp = uu____442; FStar_Syntax_Syntax.lbeff = uu____443; FStar_Syntax_Syntax.lbdef = tm})::[]), uu____445, uu____446, uu____447) when (FStar_Ident.lid_equals fv'.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v) -> begin
+Some (tm)
+end
+| uu____473 -> begin
+None
+end))))
+in (
+
+let unfold_fv = (fun t fv -> (
+
+let uu____483 = (find_in_unfolded fv)
+in (match (uu____483) with
+| Some (t') -> begin
+t'
+end
+| uu____492 -> begin
+t
+end)))
+in (
+
+let unfold_in_sig = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, univs1, bnd, ty, mut, dc, quals1) -> begin
+(
+
+let bnd' = (FStar_Syntax_InstFV.inst_binders unfold_fv bnd)
+in (
+
+let ty' = (FStar_Syntax_InstFV.inst unfold_fv ty)
+in (
+
+let mut' = (filter_out_type_abbrevs mut)
+in ((
+
+let uu___201_519 = x
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((lid), (univs1), (bnd'), (ty'), (mut'), (dc), (quals1))); FStar_Syntax_Syntax.sigdoc = uu___201_519.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___201_519.FStar_Syntax_Syntax.sigrng}))::[])))
+end
+| FStar_Syntax_Syntax.Sig_datacon (lid, univs1, ty, res, npars, quals1, mut) -> begin
+(
+
+let ty' = (FStar_Syntax_InstFV.inst unfold_fv ty)
+in (
+
+let mut' = (filter_out_type_abbrevs mut)
+in ((
+
+let uu___202_537 = x
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (((lid), (univs1), (ty'), (res), (npars), (quals1), (mut'))); FStar_Syntax_Syntax.sigdoc = uu___202_537.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___202_537.FStar_Syntax_Syntax.sigrng}))::[]))
+end
+| FStar_Syntax_Syntax.Sig_let (uu____540, uu____541, uu____542, uu____543) -> begin
+[]
+end
+| uu____550 -> begin
+(failwith "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible")
+end))
+in (FStar_List.collect unfold_in_sig sigelts))))
+in (
+
+let new_members = (filter_out_type_abbrevs members)
+in (
+
+let new_bundle = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle (((inductives_with_abbrevs_unfolded), (quals), (new_members))); FStar_Syntax_Syntax.sigdoc = doc1; FStar_Syntax_Syntax.sigrng = rng}
+in ((new_bundle), (unfolded_type_abbrevs))))))))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -1,1151 +1,1881 @@
+
 open Prims
-let sli: FStar_Ident.lident -> Prims.string =
-  fun l  ->
-    let uu____4 = FStar_Options.print_real_names () in
-    if uu____4
-    then l.FStar_Ident.str
-    else (l.FStar_Ident.ident).FStar_Ident.idText
-let lid_to_string: FStar_Ident.lid -> Prims.string = fun l  -> sli l
-let fv_to_string: FStar_Syntax_Syntax.fv -> Prims.string =
-  fun fv  ->
-    lid_to_string (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-let bv_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
-  fun bv  ->
-    let uu____19 =
-      let uu____20 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
-      Prims.strcat "#" uu____20 in
-    Prims.strcat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____19
-let nm_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
-  fun bv  ->
-    let uu____24 = FStar_Options.print_real_names () in
-    if uu____24
-    then bv_to_string bv
-    else (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-let db_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
-  fun bv  ->
-    let uu____29 =
-      let uu____30 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
-      Prims.strcat "@" uu____30 in
-    Prims.strcat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____29
-let infix_prim_ops: (FStar_Ident.lident* Prims.string) Prims.list =
-  [(FStar_Syntax_Const.op_Addition, "+");
-  (FStar_Syntax_Const.op_Subtraction, "-");
-  (FStar_Syntax_Const.op_Multiply, "*");
-  (FStar_Syntax_Const.op_Division, "/");
-  (FStar_Syntax_Const.op_Eq, "=");
-  (FStar_Syntax_Const.op_ColonEq, ":=");
-  (FStar_Syntax_Const.op_notEq, "<>");
-  (FStar_Syntax_Const.op_And, "&&");
-  (FStar_Syntax_Const.op_Or, "||");
-  (FStar_Syntax_Const.op_LTE, "<=");
-  (FStar_Syntax_Const.op_GTE, ">=");
-  (FStar_Syntax_Const.op_LT, "<");
-  (FStar_Syntax_Const.op_GT, ">");
-  (FStar_Syntax_Const.op_Modulus, "mod");
-  (FStar_Syntax_Const.and_lid, "/\\");
-  (FStar_Syntax_Const.or_lid, "\\/");
-  (FStar_Syntax_Const.imp_lid, "==>");
-  (FStar_Syntax_Const.iff_lid, "<==>");
-  (FStar_Syntax_Const.precedes_lid, "<<");
-  (FStar_Syntax_Const.eq2_lid, "==");
-  (FStar_Syntax_Const.eq3_lid, "===")]
-let unary_prim_ops: (FStar_Ident.lident* Prims.string) Prims.list =
-  [(FStar_Syntax_Const.op_Negation, "not");
-  (FStar_Syntax_Const.op_Minus, "-");
-  (FStar_Syntax_Const.not_lid, "~")]
-let is_prim_op ps f =
-  match f.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_fvar fv ->
-      FStar_All.pipe_right ps
-        (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
-  | uu____109 -> false
-let get_lid f =
-  match f.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_fvar fv ->
-      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-  | uu____126 -> failwith "get_lid"
-let is_infix_prim_op: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun e  -> is_prim_op (Prims.fst (FStar_List.split infix_prim_ops)) e
-let is_unary_prim_op: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun e  -> is_prim_op (Prims.fst (FStar_List.split unary_prim_ops)) e
-let quants: (FStar_Ident.lident* Prims.string) Prims.list =
-  [(FStar_Syntax_Const.forall_lid, "forall");
-  (FStar_Syntax_Const.exists_lid, "exists")]
-type exp = FStar_Syntax_Syntax.term
-let is_b2t: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  -> is_prim_op [FStar_Syntax_Const.b2t_lid] t
-let is_quant: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  -> is_prim_op (Prims.fst (FStar_List.split quants)) t
-let is_ite: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  -> is_prim_op [FStar_Syntax_Const.ite_lid] t
-let is_lex_cons: exp -> Prims.bool =
-  fun f  -> is_prim_op [FStar_Syntax_Const.lexcons_lid] f
-let is_lex_top: exp -> Prims.bool =
-  fun f  -> is_prim_op [FStar_Syntax_Const.lextop_lid] f
-let is_inr uu___182_173 =
-  match uu___182_173 with
-  | FStar_Util.Inl uu____176 -> false
-  | FStar_Util.Inr uu____177 -> true
-let filter_imp a =
-  FStar_All.pipe_right a
-    (FStar_List.filter
-       (fun uu___183_208  ->
-          match uu___183_208 with
-          | (uu____212,Some (FStar_Syntax_Syntax.Implicit uu____213)) ->
-              false
-          | uu____215 -> true))
-let rec reconstruct_lex:
-  exp ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax Prims.list Prims.option
-  =
-  fun e  ->
-    let uu____226 =
-      let uu____227 = FStar_Syntax_Subst.compress e in
-      uu____227.FStar_Syntax_Syntax.n in
-    match uu____226 with
-    | FStar_Syntax_Syntax.Tm_app (f,args) ->
-        let args1 = filter_imp args in
-        let exps = FStar_List.map Prims.fst args1 in
-        let uu____273 =
-          (is_lex_cons f) &&
-            ((FStar_List.length exps) = (Prims.parse_int "2")) in
-        if uu____273
-        then
-          let uu____282 =
-            let uu____287 = FStar_List.nth exps (Prims.parse_int "1") in
-            reconstruct_lex uu____287 in
-          (match uu____282 with
-           | Some xs ->
-               let uu____301 =
-                 let uu____305 = FStar_List.nth exps (Prims.parse_int "0") in
-                 uu____305 :: xs in
-               Some uu____301
-           | None  -> None)
-        else None
-    | uu____325 ->
-        let uu____326 = is_lex_top e in if uu____326 then Some [] else None
-let rec find f l =
-  match l with
-  | [] -> failwith "blah"
-  | hd1::tl1 ->
-      let uu____362 = f hd1 in if uu____362 then hd1 else find f tl1
-let find_lid:
-  FStar_Ident.lident ->
-    (FStar_Ident.lident* Prims.string) Prims.list -> Prims.string
-  =
-  fun x  ->
-    fun xs  ->
-      let uu____376 =
-        find (fun p  -> FStar_Ident.lid_equals x (Prims.fst p)) xs in
-      Prims.snd uu____376
-let infix_prim_op_to_string e =
-  let uu____395 = get_lid e in find_lid uu____395 infix_prim_ops
-let unary_prim_op_to_string e =
-  let uu____407 = get_lid e in find_lid uu____407 unary_prim_ops
-let quant_to_string t =
-  let uu____419 = get_lid t in find_lid uu____419 quants
-let const_to_string: FStar_Const.sconst -> Prims.string =
-  fun x  ->
-    match x with
-    | FStar_Const.Const_effect  -> "Effect"
-    | FStar_Const.Const_unit  -> "()"
-    | FStar_Const.Const_bool b -> if b then "true" else "false"
-    | FStar_Const.Const_float x1 -> FStar_Util.string_of_float x1
-    | FStar_Const.Const_string (bytes,uu____427) ->
-        FStar_Util.format1 "\"%s\"" (FStar_Util.string_of_bytes bytes)
-    | FStar_Const.Const_bytearray uu____430 -> "<bytearray>"
-    | FStar_Const.Const_int (x1,uu____435) -> x1
-    | FStar_Const.Const_char c ->
-        Prims.strcat "'" (Prims.strcat (FStar_Util.string_of_char c) "'")
-    | FStar_Const.Const_range r -> FStar_Range.string_of_range r
-    | FStar_Const.Const_reify  -> "reify"
-    | FStar_Const.Const_reflect l ->
-        let uu____445 = sli l in
-        FStar_Util.format1 "[[%s.reflect]]" uu____445
-let lbname_to_string: FStar_Syntax_Syntax.lbname -> Prims.string =
-  fun uu___184_448  ->
-    match uu___184_448 with
-    | FStar_Util.Inl l -> bv_to_string l
-    | FStar_Util.Inr l ->
-        lid_to_string (l.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-let tag_of_term: FStar_Syntax_Syntax.term -> Prims.string =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar x ->
-        let uu____459 = db_to_string x in Prims.strcat "Tm_bvar: " uu____459
-    | FStar_Syntax_Syntax.Tm_name x ->
-        let uu____461 = nm_to_string x in Prims.strcat "Tm_name: " uu____461
-    | FStar_Syntax_Syntax.Tm_fvar x ->
-        let uu____463 =
-          lid_to_string (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        Prims.strcat "Tm_fvar: " uu____463
-    | FStar_Syntax_Syntax.Tm_uinst uu____468 -> "Tm_uinst"
-    | FStar_Syntax_Syntax.Tm_constant uu____473 -> "Tm_constant"
-    | FStar_Syntax_Syntax.Tm_type uu____474 -> "Tm_type"
-    | FStar_Syntax_Syntax.Tm_abs uu____475 -> "Tm_abs"
-    | FStar_Syntax_Syntax.Tm_arrow uu____490 -> "Tm_arrow"
-    | FStar_Syntax_Syntax.Tm_refine uu____498 -> "Tm_refine"
-    | FStar_Syntax_Syntax.Tm_app uu____503 -> "Tm_app"
-    | FStar_Syntax_Syntax.Tm_match uu____513 -> "Tm_match"
-    | FStar_Syntax_Syntax.Tm_ascribed uu____529 -> "Tm_ascribed"
-    | FStar_Syntax_Syntax.Tm_let uu____547 -> "Tm_let"
-    | FStar_Syntax_Syntax.Tm_uvar uu____555 -> "Tm_uvar"
-    | FStar_Syntax_Syntax.Tm_delayed (uu____564,m) ->
-        let uu____602 = FStar_ST.read m in
-        (match uu____602 with
-         | None  -> "Tm_delayed"
-         | Some uu____613 -> "Tm_delayed-resolved")
-    | FStar_Syntax_Syntax.Tm_meta uu____618 -> "Tm_meta"
-    | FStar_Syntax_Syntax.Tm_unknown  -> "Tm_unknown"
-let uvar_to_string u =
-  let uu____632 = FStar_Options.hide_uvar_nums () in
-  if uu____632
-  then "?"
-  else
-    (let uu____634 =
-       let uu____635 = FStar_Unionfind.uvar_id u in
-       FStar_All.pipe_right uu____635 FStar_Util.string_of_int in
-     Prims.strcat "?" uu____634)
-let rec int_of_univ:
-  Prims.int ->
-    FStar_Syntax_Syntax.universe ->
-      (Prims.int* FStar_Syntax_Syntax.universe Prims.option)
-  =
-  fun n1  ->
-    fun u  ->
-      let uu____645 = FStar_Syntax_Subst.compress_univ u in
-      match uu____645 with
-      | FStar_Syntax_Syntax.U_zero  -> (n1, None)
-      | FStar_Syntax_Syntax.U_succ u1 ->
-          int_of_univ (n1 + (Prims.parse_int "1")) u1
-      | uu____651 -> (n1, (Some u))
-let rec univ_to_string: FStar_Syntax_Syntax.universe -> Prims.string =
-  fun u  ->
-    let uu____656 = FStar_Syntax_Subst.compress_univ u in
-    match uu____656 with
-    | FStar_Syntax_Syntax.U_unif u1 -> uvar_to_string u1
-    | FStar_Syntax_Syntax.U_name x -> x.FStar_Ident.idText
-    | FStar_Syntax_Syntax.U_bvar x ->
-        let uu____663 = FStar_Util.string_of_int x in
-        Prims.strcat "@" uu____663
-    | FStar_Syntax_Syntax.U_zero  -> "0"
-    | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____665 = int_of_univ (Prims.parse_int "1") u1 in
-        (match uu____665 with
-         | (n1,None ) -> FStar_Util.string_of_int n1
-         | (n1,Some u2) ->
-             let uu____674 = univ_to_string u2 in
-             let uu____675 = FStar_Util.string_of_int n1 in
-             FStar_Util.format2 "(%s + %s)" uu____674 uu____675)
-    | FStar_Syntax_Syntax.U_max us ->
-        let uu____678 =
-          let uu____679 = FStar_List.map univ_to_string us in
-          FStar_All.pipe_right uu____679 (FStar_String.concat ", ") in
-        FStar_Util.format1 "(max %s)" uu____678
-    | FStar_Syntax_Syntax.U_unknown  -> "unknown"
-let univs_to_string: FStar_Syntax_Syntax.universe Prims.list -> Prims.string
-  =
-  fun us  ->
-    let uu____687 = FStar_List.map univ_to_string us in
-    FStar_All.pipe_right uu____687 (FStar_String.concat ", ")
-let univ_names_to_string: FStar_Ident.ident Prims.list -> Prims.string =
-  fun us  ->
-    let uu____695 = FStar_List.map (fun x  -> x.FStar_Ident.idText) us in
-    FStar_All.pipe_right uu____695 (FStar_String.concat ", ")
-let qual_to_string: FStar_Syntax_Syntax.qualifier -> Prims.string =
-  fun uu___185_701  ->
-    match uu___185_701 with
-    | FStar_Syntax_Syntax.Assumption  -> "assume"
-    | FStar_Syntax_Syntax.New  -> "new"
-    | FStar_Syntax_Syntax.Private  -> "private"
-    | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen  -> "unfold"
-    | FStar_Syntax_Syntax.Inline_for_extraction  -> "inline"
-    | FStar_Syntax_Syntax.NoExtract  -> "noextract"
-    | FStar_Syntax_Syntax.Visible_default  -> "visible"
-    | FStar_Syntax_Syntax.Irreducible  -> "irreducible"
-    | FStar_Syntax_Syntax.Abstract  -> "abstract"
-    | FStar_Syntax_Syntax.Noeq  -> "noeq"
-    | FStar_Syntax_Syntax.Unopteq  -> "unopteq"
-    | FStar_Syntax_Syntax.Logic  -> "logic"
-    | FStar_Syntax_Syntax.TotalEffect  -> "total"
-    | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____703 = lid_to_string l in
-        FStar_Util.format1 "(Discriminator %s)" uu____703
-    | FStar_Syntax_Syntax.Projector (l,x) ->
-        let uu____706 = lid_to_string l in
-        FStar_Util.format2 "(Projector %s %s)" uu____706 x.FStar_Ident.idText
-    | FStar_Syntax_Syntax.RecordType (ns,fns) ->
-        let uu____713 =
-          let uu____714 = FStar_Ident.path_of_ns ns in
-          FStar_Ident.text_of_path uu____714 in
-        let uu____716 =
-          let uu____717 =
-            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id) in
-          FStar_All.pipe_right uu____717 (FStar_String.concat ", ") in
-        FStar_Util.format2 "(RecordType %s %s)" uu____713 uu____716
-    | FStar_Syntax_Syntax.RecordConstructor (ns,fns) ->
-        let uu____728 =
-          let uu____729 = FStar_Ident.path_of_ns ns in
-          FStar_Ident.text_of_path uu____729 in
-        let uu____731 =
-          let uu____732 =
-            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id) in
-          FStar_All.pipe_right uu____732 (FStar_String.concat ", ") in
-        FStar_Util.format2 "(RecordConstructor %s %s)" uu____728 uu____731
-    | FStar_Syntax_Syntax.Action eff_lid ->
-        let uu____738 = lid_to_string eff_lid in
-        FStar_Util.format1 "(Action %s)" uu____738
-    | FStar_Syntax_Syntax.ExceptionConstructor  -> "ExceptionConstructor"
-    | FStar_Syntax_Syntax.HasMaskedEffect  -> "HasMaskedEffect"
-    | FStar_Syntax_Syntax.Effect  -> "Effect"
-    | FStar_Syntax_Syntax.Reifiable  -> "reify"
-    | FStar_Syntax_Syntax.Reflectable l ->
-        FStar_Util.format1 "(reflect %s)" l.FStar_Ident.str
-    | FStar_Syntax_Syntax.OnlyName  -> "OnlyName"
-let quals_to_string: FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string
-  =
-  fun quals  ->
-    match quals with
-    | [] -> ""
-    | uu____745 ->
-        let uu____747 =
-          FStar_All.pipe_right quals (FStar_List.map qual_to_string) in
-        FStar_All.pipe_right uu____747 (FStar_String.concat " ")
-let quals_to_string':
-  FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string =
-  fun quals  ->
-    match quals with
-    | [] -> ""
-    | uu____757 ->
-        let uu____759 = quals_to_string quals in Prims.strcat uu____759 " "
-let rec term_to_string: FStar_Syntax_Syntax.term -> Prims.string =
-  fun x  ->
-    let x1 = FStar_Syntax_Subst.compress x in
-    let x2 =
-      let uu____815 = FStar_Options.print_implicits () in
-      if uu____815 then x1 else FStar_Syntax_Util.unmeta x1 in
-    match x2.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____817 -> failwith "impossible"
-    | FStar_Syntax_Syntax.Tm_app (uu____838,[]) -> failwith "Empty args!"
-    | FStar_Syntax_Syntax.Tm_meta (t,FStar_Syntax_Syntax.Meta_pattern ps) ->
-        let pats =
-          let uu____865 =
-            FStar_All.pipe_right ps
-              (FStar_List.map
-                 (fun args  ->
-                    let uu____881 =
-                      FStar_All.pipe_right args
-                        (FStar_List.map
-                           (fun uu____889  ->
-                              match uu____889 with
-                              | (t1,uu____893) -> term_to_string t1)) in
-                    FStar_All.pipe_right uu____881 (FStar_String.concat "; "))) in
-          FStar_All.pipe_right uu____865 (FStar_String.concat "\\/") in
-        let uu____896 = term_to_string t in
-        FStar_Util.format2 "{:pattern %s} %s" pats uu____896
-    | FStar_Syntax_Syntax.Tm_meta (t,FStar_Syntax_Syntax.Meta_monadic (m,t'))
-        ->
-        let uu____908 = tag_of_term t in
-        let uu____909 = sli m in
-        let uu____910 = term_to_string t' in
-        let uu____911 = term_to_string t in
-        FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____908 uu____909
-          uu____910 uu____911
-    | FStar_Syntax_Syntax.Tm_meta
-        (t,FStar_Syntax_Syntax.Meta_monadic_lift (m0,m1,t')) ->
-        let uu____924 = tag_of_term t in
-        let uu____925 = term_to_string t' in
-        let uu____926 = sli m0 in
-        let uu____927 = sli m1 in
-        let uu____928 = term_to_string t in
-        FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____924
-          uu____925 uu____926 uu____927 uu____928
-    | FStar_Syntax_Syntax.Tm_meta
-        (t,FStar_Syntax_Syntax.Meta_labeled (l,r,b)) when
-        FStar_Options.print_implicits () ->
-        let uu____937 = FStar_Range.string_of_range r in
-        let uu____938 = term_to_string t in
-        FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____937 uu____938
-    | FStar_Syntax_Syntax.Tm_meta (t,uu____940) -> term_to_string t
-    | FStar_Syntax_Syntax.Tm_bvar x3 -> db_to_string x3
-    | FStar_Syntax_Syntax.Tm_name x3 -> nm_to_string x3
-    | FStar_Syntax_Syntax.Tm_fvar f -> fv_to_string f
-    | FStar_Syntax_Syntax.Tm_uvar (u,uu____949) -> uvar_to_string u
-    | FStar_Syntax_Syntax.Tm_constant c -> const_to_string c
-    | FStar_Syntax_Syntax.Tm_type u ->
-        let uu____967 = FStar_Options.print_universes () in
-        if uu____967
-        then
-          let uu____968 = univ_to_string u in
-          FStar_Util.format1 "Type u#(%s)" uu____968
-        else "Type"
-    | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____982 = binders_to_string " -> " bs in
-        let uu____983 = comp_to_string c in
-        FStar_Util.format2 "(%s -> %s)" uu____982 uu____983
-    | FStar_Syntax_Syntax.Tm_abs (bs,t2,lc) ->
-        (match lc with
-         | Some (FStar_Util.Inl l) when FStar_Options.print_implicits () ->
-             let uu____1018 = binders_to_string " " bs in
-             let uu____1019 = term_to_string t2 in
-             let uu____1020 =
-               let uu____1021 = l.FStar_Syntax_Syntax.comp () in
-               FStar_All.pipe_left comp_to_string uu____1021 in
-             FStar_Util.format3 "(fun %s -> (%s $$ %s))" uu____1018
-               uu____1019 uu____1020
-         | Some (FStar_Util.Inr (l,flags)) when
-             FStar_Options.print_implicits () ->
-             let uu____1034 = binders_to_string " " bs in
-             let uu____1035 = term_to_string t2 in
-             FStar_Util.format3 "(fun %s -> (%s $$ (name only) %s))"
-               uu____1034 uu____1035 l.FStar_Ident.str
-         | uu____1036 ->
-             let uu____1043 = binders_to_string " " bs in
-             let uu____1044 = term_to_string t2 in
-             FStar_Util.format2 "(fun %s -> %s)" uu____1043 uu____1044)
-    | FStar_Syntax_Syntax.Tm_refine (xt,f) ->
-        let uu____1051 = bv_to_string xt in
-        let uu____1052 =
-          FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string in
-        let uu____1055 = FStar_All.pipe_right f formula_to_string in
-        FStar_Util.format3 "(%s:%s{%s})" uu____1051 uu____1052 uu____1055
-    | FStar_Syntax_Syntax.Tm_app (t,args) ->
-        let uu____1074 = term_to_string t in
-        let uu____1075 = args_to_string args in
-        FStar_Util.format2 "(%s %s)" uu____1074 uu____1075
-    | FStar_Syntax_Syntax.Tm_let (lbs,e) ->
-        let uu____1088 = lbs_to_string [] lbs in
-        let uu____1089 = term_to_string e in
-        FStar_Util.format2 "%s\nin\n%s" uu____1088 uu____1089
-    | FStar_Syntax_Syntax.Tm_ascribed (e,(annot,topt),eff_name) ->
-        let annot1 =
-          match annot with
-          | FStar_Util.Inl t ->
-              let uu____1137 =
-                let uu____1138 =
-                  FStar_Util.map_opt eff_name FStar_Ident.text_of_lid in
-                FStar_All.pipe_right uu____1138 (FStar_Util.dflt "default") in
-              let uu____1141 = term_to_string t in
-              FStar_Util.format2 "[%s] %s" uu____1137 uu____1141
-          | FStar_Util.Inr c -> comp_to_string c in
-        let topt1 =
-          match topt with
-          | None  -> ""
-          | Some t ->
-              let uu____1157 = term_to_string t in
-              FStar_Util.format1 "by %s" uu____1157 in
-        let uu____1158 = term_to_string e in
-        FStar_Util.format3 "(%s <: %s %s)" uu____1158 annot1 topt1
-    | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
-        let uu____1187 = term_to_string head1 in
-        let uu____1188 =
-          let uu____1189 =
-            FStar_All.pipe_right branches
-              (FStar_List.map
-                 (fun uu____1207  ->
-                    match uu____1207 with
-                    | (p,wopt,e) ->
-                        let uu____1217 = FStar_All.pipe_right p pat_to_string in
-                        let uu____1218 =
-                          match wopt with
-                          | None  -> ""
-                          | Some w ->
-                              let uu____1220 =
-                                FStar_All.pipe_right w term_to_string in
-                              FStar_Util.format1 "when %s" uu____1220 in
-                        let uu____1221 =
-                          FStar_All.pipe_right e term_to_string in
-                        FStar_Util.format3 "%s %s -> %s" uu____1217
-                          uu____1218 uu____1221)) in
-          FStar_Util.concat_l "\n\t|" uu____1189 in
-        FStar_Util.format2 "(match %s with\n\t| %s)" uu____1187 uu____1188
-    | FStar_Syntax_Syntax.Tm_uinst (t,us) ->
-        let uu____1228 = FStar_Options.print_universes () in
-        if uu____1228
-        then
-          let uu____1229 = term_to_string t in
-          let uu____1230 = univs_to_string us in
-          FStar_Util.format2 "%s<%s>" uu____1229 uu____1230
-        else term_to_string t
-    | uu____1232 -> tag_of_term x2
-and pat_to_string: FStar_Syntax_Syntax.pat -> Prims.string =
-  fun x  ->
-    match x.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_cons (l,pats) ->
-        let uu____1246 = fv_to_string l in
-        let uu____1247 =
-          let uu____1248 =
-            FStar_List.map
-              (fun uu____1252  ->
-                 match uu____1252 with
-                 | (x1,b) ->
-                     let p = pat_to_string x1 in
-                     if b then Prims.strcat "#" p else p) pats in
-          FStar_All.pipe_right uu____1248 (FStar_String.concat " ") in
-        FStar_Util.format2 "(%s %s)" uu____1246 uu____1247
-    | FStar_Syntax_Syntax.Pat_dot_term (x1,uu____1261) ->
-        let uu____1266 = FStar_Options.print_bound_var_types () in
-        if uu____1266
-        then
-          let uu____1267 = bv_to_string x1 in
-          let uu____1268 = term_to_string x1.FStar_Syntax_Syntax.sort in
-          FStar_Util.format2 ".%s:%s" uu____1267 uu____1268
-        else
-          (let uu____1270 = bv_to_string x1 in
-           FStar_Util.format1 ".%s" uu____1270)
-    | FStar_Syntax_Syntax.Pat_var x1 ->
-        let uu____1272 = FStar_Options.print_bound_var_types () in
-        if uu____1272
-        then
-          let uu____1273 = bv_to_string x1 in
-          let uu____1274 = term_to_string x1.FStar_Syntax_Syntax.sort in
-          FStar_Util.format2 "%s:%s" uu____1273 uu____1274
-        else bv_to_string x1
-    | FStar_Syntax_Syntax.Pat_constant c -> const_to_string c
-    | FStar_Syntax_Syntax.Pat_wild x1 ->
-        let uu____1278 = FStar_Options.print_real_names () in
-        if uu____1278
-        then
-          let uu____1279 = bv_to_string x1 in
-          Prims.strcat "Pat_wild " uu____1279
-        else "_"
-    | FStar_Syntax_Syntax.Pat_disj ps ->
-        let uu____1285 = FStar_List.map pat_to_string ps in
-        FStar_Util.concat_l " | " uu____1285
-and lbs_to_string:
-  FStar_Syntax_Syntax.qualifier Prims.list ->
-    (Prims.bool* FStar_Syntax_Syntax.letbinding Prims.list) -> Prims.string
-  =
-  fun quals  ->
-    fun lbs  ->
-      let lbs1 =
-        let uu____1297 = FStar_Options.print_universes () in
-        if uu____1297
-        then
-          let uu____1301 =
-            FStar_All.pipe_right (Prims.snd lbs)
-              (FStar_List.map
-                 (fun lb  ->
-                    let uu____1307 =
-                      let uu____1310 =
-                        FStar_Syntax_Util.mk_conj
-                          lb.FStar_Syntax_Syntax.lbtyp
-                          lb.FStar_Syntax_Syntax.lbdef in
-                      FStar_Syntax_Subst.open_univ_vars
-                        lb.FStar_Syntax_Syntax.lbunivs uu____1310 in
-                    match uu____1307 with
-                    | (us,td) ->
-                        let uu____1313 =
-                          let uu____1320 =
-                            let uu____1321 = FStar_Syntax_Subst.compress td in
-                            uu____1321.FStar_Syntax_Syntax.n in
-                          match uu____1320 with
-                          | FStar_Syntax_Syntax.Tm_app
-                              (uu____1330,(t,uu____1332)::(d,uu____1334)::[])
-                              -> (t, d)
-                          | uu____1368 -> failwith "Impossibe" in
-                        (match uu____1313 with
-                         | (t,d) ->
-                             let uu___192_1385 = lb in
-                             {
-                               FStar_Syntax_Syntax.lbname =
-                                 (uu___192_1385.FStar_Syntax_Syntax.lbname);
-                               FStar_Syntax_Syntax.lbunivs = us;
-                               FStar_Syntax_Syntax.lbtyp = t;
-                               FStar_Syntax_Syntax.lbeff =
-                                 (uu___192_1385.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = d
-                             }))) in
-          ((Prims.fst lbs), uu____1301)
-        else lbs in
-      let uu____1389 = quals_to_string' quals in
-      let uu____1390 =
-        let uu____1391 =
-          FStar_All.pipe_right (Prims.snd lbs1)
-            (FStar_List.map
-               (fun lb  ->
-                  let uu____1397 =
-                    lbname_to_string lb.FStar_Syntax_Syntax.lbname in
-                  let uu____1398 =
-                    let uu____1399 = FStar_Options.print_universes () in
-                    if uu____1399
-                    then
-                      let uu____1400 =
-                        let uu____1401 =
-                          univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs in
-                        Prims.strcat uu____1401 ">" in
-                      Prims.strcat "<" uu____1400
-                    else "" in
-                  let uu____1403 =
-                    term_to_string lb.FStar_Syntax_Syntax.lbtyp in
-                  let uu____1404 =
-                    FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbdef
-                      term_to_string in
-                  FStar_Util.format4 "%s %s : %s = %s" uu____1397 uu____1398
-                    uu____1403 uu____1404)) in
-        FStar_Util.concat_l "\n and " uu____1391 in
-      FStar_Util.format3 "%slet %s %s" uu____1389
-        (if Prims.fst lbs1 then "rec" else "") uu____1390
-and lcomp_to_string: FStar_Syntax_Syntax.lcomp -> Prims.string =
-  fun lc  ->
-    let uu____1410 = FStar_Options.print_effect_args () in
-    if uu____1410
-    then
-      let uu____1411 = lc.FStar_Syntax_Syntax.comp () in
-      comp_to_string uu____1411
-    else
-      (let uu____1413 = sli lc.FStar_Syntax_Syntax.eff_name in
-       let uu____1414 = term_to_string lc.FStar_Syntax_Syntax.res_typ in
-       FStar_Util.format2 "%s %s" uu____1413 uu____1414)
-and imp_to_string:
-  Prims.string ->
-    FStar_Syntax_Syntax.arg_qualifier Prims.option -> Prims.string
-  =
-  fun s  ->
-    fun uu___186_1416  ->
-      match uu___186_1416 with
-      | Some (FStar_Syntax_Syntax.Implicit (false )) -> Prims.strcat "#" s
-      | Some (FStar_Syntax_Syntax.Implicit (true )) -> Prims.strcat "#." s
-      | Some (FStar_Syntax_Syntax.Equality ) -> Prims.strcat "$" s
-      | uu____1418 -> s
-and binder_to_string':
-  Prims.bool ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) -> Prims.string
-  =
-  fun is_arrow  ->
-    fun b  ->
-      let uu____1424 = b in
-      match uu____1424 with
-      | (a,imp) ->
-          let uu____1429 = FStar_Syntax_Syntax.is_null_binder b in
-          if uu____1429
-          then
-            let uu____1430 = term_to_string a.FStar_Syntax_Syntax.sort in
-            Prims.strcat "_:" uu____1430
-          else
-            (let uu____1432 =
-               (Prims.op_Negation is_arrow) &&
-                 (let uu____1433 = FStar_Options.print_bound_var_types () in
-                  Prims.op_Negation uu____1433) in
-             if uu____1432
-             then
-               let uu____1434 = nm_to_string a in
-               imp_to_string uu____1434 imp
-             else
-               (let uu____1436 =
-                  let uu____1437 = nm_to_string a in
-                  let uu____1438 =
-                    let uu____1439 =
-                      term_to_string a.FStar_Syntax_Syntax.sort in
-                    Prims.strcat ":" uu____1439 in
-                  Prims.strcat uu____1437 uu____1438 in
-                imp_to_string uu____1436 imp))
-and binder_to_string:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) -> Prims.string =
-  fun b  -> binder_to_string' false b
-and arrow_binder_to_string:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) -> Prims.string =
-  fun b  -> binder_to_string' true b
-and binders_to_string:
-  Prims.string -> FStar_Syntax_Syntax.binders -> Prims.string =
-  fun sep  ->
-    fun bs  ->
-      let bs1 =
-        let uu____1449 = FStar_Options.print_implicits () in
-        if uu____1449 then bs else filter_imp bs in
-      if sep = " -> "
-      then
-        let uu____1451 =
-          FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string) in
-        FStar_All.pipe_right uu____1451 (FStar_String.concat sep)
-      else
-        (let uu____1458 =
-           FStar_All.pipe_right bs1 (FStar_List.map binder_to_string) in
-         FStar_All.pipe_right uu____1458 (FStar_String.concat sep))
-and arg_to_string:
-  (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.arg_qualifier Prims.option)
-    -> Prims.string
-  =
-  fun uu___187_1464  ->
-    match uu___187_1464 with
-    | (a,imp) ->
-        let uu____1472 = term_to_string a in imp_to_string uu____1472 imp
-and args_to_string: FStar_Syntax_Syntax.args -> Prims.string =
-  fun args  ->
-    let args1 =
-      let uu____1475 = FStar_Options.print_implicits () in
-      if uu____1475 then args else filter_imp args in
-    let uu____1479 =
-      FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
-    FStar_All.pipe_right uu____1479 (FStar_String.concat " ")
-and comp_to_string: FStar_Syntax_Syntax.comp -> Prims.string =
-  fun c  ->
-    match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____1488) ->
-        let uu____1495 =
-          let uu____1496 = FStar_Syntax_Subst.compress t in
-          uu____1496.FStar_Syntax_Syntax.n in
-        (match uu____1495 with
-         | FStar_Syntax_Syntax.Tm_type uu____1499 when
-             let uu____1500 = FStar_Options.print_implicits () in
-             Prims.op_Negation uu____1500 -> term_to_string t
-         | uu____1501 ->
-             let uu____1502 = term_to_string t in
-             FStar_Util.format1 "Tot %s" uu____1502)
-    | FStar_Syntax_Syntax.GTotal (t,uu____1504) ->
-        let uu____1511 =
-          let uu____1512 = FStar_Syntax_Subst.compress t in
-          uu____1512.FStar_Syntax_Syntax.n in
-        (match uu____1511 with
-         | FStar_Syntax_Syntax.Tm_type uu____1515 when
-             let uu____1516 = FStar_Options.print_implicits () in
-             Prims.op_Negation uu____1516 -> term_to_string t
-         | uu____1517 ->
-             let uu____1518 = term_to_string t in
-             FStar_Util.format1 "GTot %s" uu____1518)
-    | FStar_Syntax_Syntax.Comp c1 ->
-        let basic =
-          let uu____1521 = FStar_Options.print_effect_args () in
-          if uu____1521
-          then
-            let uu____1522 = sli c1.FStar_Syntax_Syntax.effect_name in
-            let uu____1523 = term_to_string c1.FStar_Syntax_Syntax.result_typ in
-            let uu____1524 =
-              let uu____1525 =
-                FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
-                  (FStar_List.map arg_to_string) in
-              FStar_All.pipe_right uu____1525 (FStar_String.concat ", ") in
-            let uu____1537 =
-              let uu____1538 =
-                FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-                  (FStar_List.map cflags_to_string) in
-              FStar_All.pipe_right uu____1538 (FStar_String.concat " ") in
-            FStar_Util.format4 "%s (%s) %s (attributes %s)" uu____1522
-              uu____1523 uu____1524 uu____1537
-          else
-            (let uu____1544 =
-               (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-                  (FStar_Util.for_some
-                     (fun uu___188_1546  ->
-                        match uu___188_1546 with
-                        | FStar_Syntax_Syntax.TOTAL  -> true
-                        | uu____1547 -> false)))
-                 &&
-                 (let uu____1548 = FStar_Options.print_effect_args () in
-                  Prims.op_Negation uu____1548) in
-             if uu____1544
-             then
-               let uu____1549 =
-                 term_to_string c1.FStar_Syntax_Syntax.result_typ in
-               FStar_Util.format1 "Tot %s" uu____1549
-             else
-               (let uu____1551 =
-                  ((let uu____1552 = FStar_Options.print_effect_args () in
-                    Prims.op_Negation uu____1552) &&
-                     (let uu____1553 = FStar_Options.print_implicits () in
-                      Prims.op_Negation uu____1553))
-                    &&
-                    (FStar_Ident.lid_equals
-                       c1.FStar_Syntax_Syntax.effect_name
-                       FStar_Syntax_Const.effect_ML_lid) in
-                if uu____1551
-                then term_to_string c1.FStar_Syntax_Syntax.result_typ
-                else
-                  (let uu____1555 =
-                     (let uu____1556 = FStar_Options.print_effect_args () in
-                      Prims.op_Negation uu____1556) &&
-                       (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-                          (FStar_Util.for_some
-                             (fun uu___189_1558  ->
-                                match uu___189_1558 with
-                                | FStar_Syntax_Syntax.MLEFFECT  -> true
-                                | uu____1559 -> false))) in
-                   if uu____1555
-                   then
-                     let uu____1560 =
-                       term_to_string c1.FStar_Syntax_Syntax.result_typ in
-                     FStar_Util.format1 "ALL %s" uu____1560
-                   else
-                     (let uu____1562 = sli c1.FStar_Syntax_Syntax.effect_name in
-                      let uu____1563 =
-                        term_to_string c1.FStar_Syntax_Syntax.result_typ in
-                      FStar_Util.format2 "%s (%s)" uu____1562 uu____1563)))) in
-        let dec =
-          let uu____1565 =
-            FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-              (FStar_List.collect
-                 (fun uu___190_1569  ->
-                    match uu___190_1569 with
-                    | FStar_Syntax_Syntax.DECREASES e ->
-                        let uu____1574 =
-                          let uu____1575 = term_to_string e in
-                          FStar_Util.format1 " (decreases %s)" uu____1575 in
-                        [uu____1574]
-                    | uu____1576 -> [])) in
-          FStar_All.pipe_right uu____1565 (FStar_String.concat " ") in
-        FStar_Util.format2 "%s%s" basic dec
-and cflags_to_string: FStar_Syntax_Syntax.cflags -> Prims.string =
-  fun c  ->
-    match c with
-    | FStar_Syntax_Syntax.TOTAL  -> "total"
-    | FStar_Syntax_Syntax.MLEFFECT  -> "ml"
-    | FStar_Syntax_Syntax.RETURN  -> "return"
-    | FStar_Syntax_Syntax.PARTIAL_RETURN  -> "partial_return"
-    | FStar_Syntax_Syntax.SOMETRIVIAL  -> "sometrivial"
-    | FStar_Syntax_Syntax.LEMMA  -> "lemma"
-    | FStar_Syntax_Syntax.CPS  -> "cps"
-    | FStar_Syntax_Syntax.DECREASES uu____1579 -> ""
-and formula_to_string:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax -> Prims.string
-  = fun phi  -> term_to_string phi
-let enclose_universes: Prims.string -> Prims.string =
-  fun s  ->
-    let uu____1588 = FStar_Options.print_universes () in
-    if uu____1588 then Prims.strcat "<" (Prims.strcat s ">") else ""
-let tscheme_to_string: FStar_Syntax_Syntax.tscheme -> Prims.string =
-  fun uu____1592  ->
-    match uu____1592 with
-    | (us,t) ->
-        let uu____1597 =
-          let uu____1598 = univ_names_to_string us in
-          FStar_All.pipe_left enclose_universes uu____1598 in
-        let uu____1599 = term_to_string t in
-        FStar_Util.format2 "%s%s" uu____1597 uu____1599
-let eff_decl_to_string:
-  Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string =
-  fun for_free  ->
-    fun ed  ->
-      let actions_to_string actions =
-        let uu____1612 =
-          FStar_All.pipe_right actions
-            (FStar_List.map
-               (fun a  ->
-                  let uu____1617 = sli a.FStar_Syntax_Syntax.action_name in
-                  let uu____1618 =
-                    let uu____1619 =
-                      univ_names_to_string a.FStar_Syntax_Syntax.action_univs in
-                    FStar_All.pipe_left enclose_universes uu____1619 in
-                  let uu____1620 =
-                    term_to_string a.FStar_Syntax_Syntax.action_typ in
-                  let uu____1621 =
-                    term_to_string a.FStar_Syntax_Syntax.action_defn in
-                  FStar_Util.format4 "%s%s : %s = %s" uu____1617 uu____1618
-                    uu____1620 uu____1621)) in
-        FStar_All.pipe_right uu____1612 (FStar_String.concat ",\n\t") in
-      let uu____1623 =
-        let uu____1625 =
-          let uu____1627 = lid_to_string ed.FStar_Syntax_Syntax.mname in
-          let uu____1628 =
-            let uu____1630 =
-              let uu____1631 =
-                univ_names_to_string ed.FStar_Syntax_Syntax.univs in
-              FStar_All.pipe_left enclose_universes uu____1631 in
-            let uu____1632 =
-              let uu____1634 =
-                binders_to_string " " ed.FStar_Syntax_Syntax.binders in
-              let uu____1635 =
-                let uu____1637 =
-                  term_to_string ed.FStar_Syntax_Syntax.signature in
-                let uu____1638 =
-                  let uu____1640 =
-                    tscheme_to_string ed.FStar_Syntax_Syntax.ret_wp in
-                  let uu____1641 =
-                    let uu____1643 =
-                      tscheme_to_string ed.FStar_Syntax_Syntax.bind_wp in
-                    let uu____1644 =
-                      let uu____1646 =
-                        tscheme_to_string ed.FStar_Syntax_Syntax.if_then_else in
-                      let uu____1647 =
-                        let uu____1649 =
-                          tscheme_to_string ed.FStar_Syntax_Syntax.ite_wp in
-                        let uu____1650 =
-                          let uu____1652 =
-                            tscheme_to_string ed.FStar_Syntax_Syntax.stronger in
-                          let uu____1653 =
-                            let uu____1655 =
-                              tscheme_to_string
-                                ed.FStar_Syntax_Syntax.close_wp in
-                            let uu____1656 =
-                              let uu____1658 =
-                                tscheme_to_string
-                                  ed.FStar_Syntax_Syntax.assert_p in
-                              let uu____1659 =
-                                let uu____1661 =
-                                  tscheme_to_string
-                                    ed.FStar_Syntax_Syntax.assume_p in
-                                let uu____1662 =
-                                  let uu____1664 =
-                                    tscheme_to_string
-                                      ed.FStar_Syntax_Syntax.null_wp in
-                                  let uu____1665 =
-                                    let uu____1667 =
-                                      tscheme_to_string
-                                        ed.FStar_Syntax_Syntax.trivial in
-                                    let uu____1668 =
-                                      let uu____1670 =
-                                        term_to_string
-                                          ed.FStar_Syntax_Syntax.repr in
-                                      let uu____1671 =
-                                        let uu____1673 =
-                                          tscheme_to_string
-                                            ed.FStar_Syntax_Syntax.bind_repr in
-                                        let uu____1674 =
-                                          let uu____1676 =
-                                            tscheme_to_string
-                                              ed.FStar_Syntax_Syntax.return_repr in
-                                          let uu____1677 =
-                                            let uu____1679 =
-                                              actions_to_string
-                                                ed.FStar_Syntax_Syntax.actions in
-                                            [uu____1679] in
-                                          uu____1676 :: uu____1677 in
-                                        uu____1673 :: uu____1674 in
-                                      uu____1670 :: uu____1671 in
-                                    uu____1667 :: uu____1668 in
-                                  uu____1664 :: uu____1665 in
-                                uu____1661 :: uu____1662 in
-                              uu____1658 :: uu____1659 in
-                            uu____1655 :: uu____1656 in
-                          uu____1652 :: uu____1653 in
-                        uu____1649 :: uu____1650 in
-                      uu____1646 :: uu____1647 in
-                    uu____1643 :: uu____1644 in
-                  uu____1640 :: uu____1641 in
-                uu____1637 :: uu____1638 in
-              uu____1634 :: uu____1635 in
-            uu____1630 :: uu____1632 in
-          uu____1627 :: uu____1628 in
-        (if for_free then "_for_free " else "") :: uu____1625 in
-      FStar_Util.format
-        "new_effect%s { %s%s %s : %s \n  return_wp   = %s\n; bind_wp     = %s\n; if_then_else= %s\n; ite_wp      = %s\n; stronger    = %s\n; close_wp    = %s\n; assert_p    = %s\n; assume_p    = %s\n; null_wp     = %s\n; trivial     = %s\n; repr        = %s\n; bind_repr   = %s\n; return_repr = %s\nand effect_actions\n\t%s\n}\n"
-        uu____1623
-let rec sigelt_to_string: FStar_Syntax_Syntax.sigelt -> Prims.string =
-  fun x  ->
-    match x with
-    | FStar_Syntax_Syntax.Sig_pragma
-        (FStar_Syntax_Syntax.LightOff ,uu____1684) -> "#light \"off\""
-    | FStar_Syntax_Syntax.Sig_pragma
-        (FStar_Syntax_Syntax.ResetOptions (None ),uu____1685) ->
-        "#reset-options"
-    | FStar_Syntax_Syntax.Sig_pragma
-        (FStar_Syntax_Syntax.ResetOptions (Some s),uu____1687) ->
-        FStar_Util.format1 "#reset-options \"%s\"" s
-    | FStar_Syntax_Syntax.Sig_pragma
-        (FStar_Syntax_Syntax.SetOptions s,uu____1689) ->
-        FStar_Util.format1 "#set-options \"%s\"" s
-    | FStar_Syntax_Syntax.Sig_pragma
-        (FStar_Syntax_Syntax.LightOff ,uu____1690) -> "#light \"off\""
-    | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,univs,tps,k,uu____1695,uu____1696,quals,uu____1698) ->
-        let uu____1705 = quals_to_string' quals in
-        let uu____1706 = binders_to_string " " tps in
-        let uu____1707 = term_to_string k in
-        FStar_Util.format4 "%stype %s %s : %s" uu____1705 lid.FStar_Ident.str
-          uu____1706 uu____1707
-    | FStar_Syntax_Syntax.Sig_datacon
-        (lid,univs,t,uu____1711,uu____1712,uu____1713,uu____1714,uu____1715)
-        ->
-        let uu____1720 = FStar_Options.print_universes () in
-        if uu____1720
-        then
-          let uu____1721 = FStar_Syntax_Subst.open_univ_vars univs t in
-          (match uu____1721 with
-           | (univs1,t1) ->
-               let uu____1726 = univ_names_to_string univs1 in
-               let uu____1727 = term_to_string t1 in
-               FStar_Util.format3 "datacon<%s> %s : %s" uu____1726
-                 lid.FStar_Ident.str uu____1727)
-        else
-          (let uu____1729 = term_to_string t in
-           FStar_Util.format2 "datacon %s : %s" lid.FStar_Ident.str
-             uu____1729)
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs,t,quals,uu____1734) ->
-        let uu____1737 = FStar_Syntax_Subst.open_univ_vars univs t in
-        (match uu____1737 with
-         | (univs1,t1) ->
-             let uu____1742 = quals_to_string' quals in
-             let uu____1743 =
-               let uu____1744 = FStar_Options.print_universes () in
-               if uu____1744
-               then
-                 let uu____1745 = univ_names_to_string univs1 in
-                 FStar_Util.format1 "<%s>" uu____1745
-               else "" in
-             let uu____1747 = term_to_string t1 in
-             FStar_Util.format4 "%sval %s %s : %s" uu____1742
-               lid.FStar_Ident.str uu____1743 uu____1747)
-    | FStar_Syntax_Syntax.Sig_assume (lid,f,uu____1750,uu____1751) ->
-        let uu____1754 = term_to_string f in
-        FStar_Util.format2 "val %s : %s" lid.FStar_Ident.str uu____1754
-    | FStar_Syntax_Syntax.Sig_let (lbs,uu____1756,uu____1757,qs,uu____1759)
-        -> lbs_to_string qs lbs
-    | FStar_Syntax_Syntax.Sig_main (e,uu____1767) ->
-        let uu____1768 = term_to_string e in
-        FStar_Util.format1 "let _ = %s" uu____1768
-    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____1770,uu____1771,uu____1772)
-        ->
-        let uu____1779 = FStar_List.map sigelt_to_string ses in
-        FStar_All.pipe_right uu____1779 (FStar_String.concat "\n")
-    | FStar_Syntax_Syntax.Sig_new_effect (ed,uu____1783) ->
-        eff_decl_to_string false ed
-    | FStar_Syntax_Syntax.Sig_new_effect_for_free (ed,uu____1785) ->
-        eff_decl_to_string true ed
-    | FStar_Syntax_Syntax.Sig_sub_effect (se,r) ->
-        let lift_wp =
-          match ((se.FStar_Syntax_Syntax.lift_wp),
-                  (se.FStar_Syntax_Syntax.lift))
-          with
-          | (None ,None ) -> failwith "impossible"
-          | (Some lift_wp,uu____1794) -> lift_wp
-          | (uu____1798,Some lift) -> lift in
-        let uu____1803 =
-          FStar_Syntax_Subst.open_univ_vars (Prims.fst lift_wp)
-            (Prims.snd lift_wp) in
-        (match uu____1803 with
-         | (us,t) ->
-             let uu____1810 = lid_to_string se.FStar_Syntax_Syntax.source in
-             let uu____1811 = lid_to_string se.FStar_Syntax_Syntax.target in
-             let uu____1812 = univ_names_to_string us in
-             let uu____1813 = term_to_string t in
-             FStar_Util.format4 "sub_effect %s ~> %s : <%s> %s" uu____1810
-               uu____1811 uu____1812 uu____1813)
-    | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (l,univs,tps,c,uu____1818,flags,uu____1820) ->
-        let uu____1825 = FStar_Options.print_universes () in
-        if uu____1825
-        then
-          let uu____1826 =
-            let uu____1829 =
-              (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (tps, c)))
-                None FStar_Range.dummyRange in
-            FStar_Syntax_Subst.open_univ_vars univs uu____1829 in
-          (match uu____1826 with
-           | (univs1,t) ->
-               let uu____1840 =
-                 let uu____1848 =
-                   let uu____1849 = FStar_Syntax_Subst.compress t in
-                   uu____1849.FStar_Syntax_Syntax.n in
-                 match uu____1848 with
-                 | FStar_Syntax_Syntax.Tm_arrow (bs,c1) -> (bs, c1)
-                 | uu____1876 -> failwith "impossible" in
-               (match uu____1840 with
-                | (tps1,c1) ->
-                    let uu____1896 = sli l in
-                    let uu____1897 = univ_names_to_string univs1 in
-                    let uu____1898 = binders_to_string " " tps1 in
-                    let uu____1899 = comp_to_string c1 in
-                    FStar_Util.format4 "effect %s<%s> %s = %s" uu____1896
-                      uu____1897 uu____1898 uu____1899))
-        else
-          (let uu____1901 = sli l in
-           let uu____1902 = binders_to_string " " tps in
-           let uu____1903 = comp_to_string c in
-           FStar_Util.format3 "effect %s %s = %s" uu____1901 uu____1902
-             uu____1903)
-let format_error: FStar_Range.range -> Prims.string -> Prims.string =
-  fun r  ->
-    fun msg  ->
-      let uu____1910 = FStar_Range.string_of_range r in
-      FStar_Util.format2 "%s: %s\n" uu____1910 msg
-let rec sigelt_to_string_short: FStar_Syntax_Syntax.sigelt -> Prims.string =
-  fun x  ->
-    match x with
-    | FStar_Syntax_Syntax.Sig_let
-        ((uu____1914,{ FStar_Syntax_Syntax.lbname = lb;
-                       FStar_Syntax_Syntax.lbunivs = uu____1916;
-                       FStar_Syntax_Syntax.lbtyp = t;
-                       FStar_Syntax_Syntax.lbeff = uu____1918;
-                       FStar_Syntax_Syntax.lbdef = uu____1919;_}::[]),uu____1920,uu____1921,uu____1922,uu____1923)
-        ->
-        let uu____1941 = lbname_to_string lb in
-        let uu____1942 = term_to_string t in
-        FStar_Util.format2 "let %s : %s" uu____1941 uu____1942
-    | uu____1943 ->
-        let uu____1944 =
-          FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x)
-            (FStar_List.map (fun l  -> l.FStar_Ident.str)) in
-        FStar_All.pipe_right uu____1944 (FStar_String.concat ", ")
-let rec modul_to_string: FStar_Syntax_Syntax.modul -> Prims.string =
-  fun m  ->
-    let uu____1953 = sli m.FStar_Syntax_Syntax.name in
-    let uu____1954 =
-      let uu____1955 =
-        FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations in
-      FStar_All.pipe_right uu____1955 (FStar_String.concat "\n") in
-    FStar_Util.format2 "module %s\n%s" uu____1953 uu____1954
-let subst_elt_to_string: FStar_Syntax_Syntax.subst_elt -> Prims.string =
-  fun uu___191_1960  ->
-    match uu___191_1960 with
-    | FStar_Syntax_Syntax.DB (i,x) ->
-        let uu____1963 = FStar_Util.string_of_int i in
-        let uu____1964 = bv_to_string x in
-        FStar_Util.format2 "DB (%s, %s)" uu____1963 uu____1964
-    | FStar_Syntax_Syntax.NM (x,i) ->
-        let uu____1967 = bv_to_string x in
-        let uu____1968 = FStar_Util.string_of_int i in
-        FStar_Util.format2 "NM (%s, %s)" uu____1967 uu____1968
-    | FStar_Syntax_Syntax.NT (x,t) ->
-        let uu____1975 = bv_to_string x in
-        let uu____1976 = term_to_string t in
-        FStar_Util.format2 "DB (%s, %s)" uu____1975 uu____1976
-    | FStar_Syntax_Syntax.UN (i,u) ->
-        let uu____1979 = FStar_Util.string_of_int i in
-        let uu____1980 = univ_to_string u in
-        FStar_Util.format2 "UN (%s, %s)" uu____1979 uu____1980
-    | FStar_Syntax_Syntax.UD (u,i) ->
-        let uu____1983 = FStar_Util.string_of_int i in
-        FStar_Util.format2 "UD (%s, %s)" u.FStar_Ident.idText uu____1983
-let subst_to_string: FStar_Syntax_Syntax.subst_t -> Prims.string =
-  fun s  ->
-    let uu____1987 =
-      FStar_All.pipe_right s (FStar_List.map subst_elt_to_string) in
-    FStar_All.pipe_right uu____1987 (FStar_String.concat "; ")
-let abs_ascription_to_string:
-  (FStar_Syntax_Syntax.lcomp,FStar_Ident.lident) FStar_Util.either
-    Prims.option -> Prims.string
-  =
-  fun ascription  ->
-    let strb = FStar_Util.new_string_builder () in
-    (match ascription with
-     | None  -> FStar_Util.string_builder_append strb "None"
-     | Some (FStar_Util.Inl lc) ->
-         (FStar_Util.string_builder_append strb "Some Inr ";
-          FStar_Util.string_builder_append strb
-            (FStar_Ident.text_of_lid lc.FStar_Syntax_Syntax.eff_name))
-     | Some (FStar_Util.Inr lid) ->
-         (FStar_Util.string_builder_append strb "Some Inr ";
-          FStar_Util.string_builder_append strb (FStar_Ident.text_of_lid lid)));
-    FStar_Util.string_of_string_builder strb
-let list_to_string f elts =
-  match elts with
-  | [] -> "[]"
-  | x::xs ->
-      let strb = FStar_Util.new_string_builder () in
-      (FStar_Util.string_builder_append strb "[";
-       (let uu____2037 = f x in
-        FStar_Util.string_builder_append strb uu____2037);
-       FStar_List.iter
-         (fun x1  ->
-            FStar_Util.string_builder_append strb "; ";
-            (let uu____2041 = f x1 in
-             FStar_Util.string_builder_append strb uu____2041)) xs;
-       FStar_Util.string_builder_append strb "]";
-       FStar_Util.string_of_string_builder strb)
-let set_to_string f s =
-  let elts = FStar_Util.set_elements s in
-  match elts with
-  | [] -> "{}"
-  | x::xs ->
-      let strb = FStar_Util.new_string_builder () in
-      (FStar_Util.string_builder_append strb "{";
-       (let uu____2070 = f x in
-        FStar_Util.string_builder_append strb uu____2070);
-       FStar_List.iter
-         (fun x1  ->
-            FStar_Util.string_builder_append strb ", ";
-            (let uu____2074 = f x1 in
-             FStar_Util.string_builder_append strb uu____2074)) xs;
-       FStar_Util.string_builder_append strb "}";
-       FStar_Util.string_of_string_builder strb)
+
+let sli : FStar_Ident.lident  ->  Prims.string = (fun l -> (
+
+let uu____4 = (FStar_Options.print_real_names ())
+in (match (uu____4) with
+| true -> begin
+l.FStar_Ident.str
+end
+| uu____5 -> begin
+l.FStar_Ident.ident.FStar_Ident.idText
+end)))
+
+
+let lid_to_string : FStar_Ident.lid  ->  Prims.string = (fun l -> (sli l))
+
+
+let fv_to_string : FStar_Syntax_Syntax.fv  ->  Prims.string = (fun fv -> (lid_to_string fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v))
+
+
+let bv_to_string : FStar_Syntax_Syntax.bv  ->  Prims.string = (fun bv -> (
+
+let uu____19 = (
+
+let uu____20 = (FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index)
+in (Prims.strcat "#" uu____20))
+in (Prims.strcat bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText uu____19)))
+
+
+let nm_to_string : FStar_Syntax_Syntax.bv  ->  Prims.string = (fun bv -> (
+
+let uu____24 = (FStar_Options.print_real_names ())
+in (match (uu____24) with
+| true -> begin
+(bv_to_string bv)
+end
+| uu____25 -> begin
+bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText
+end)))
+
+
+let db_to_string : FStar_Syntax_Syntax.bv  ->  Prims.string = (fun bv -> (
+
+let uu____29 = (
+
+let uu____30 = (FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index)
+in (Prims.strcat "@" uu____30))
+in (Prims.strcat bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText uu____29)))
+
+
+let infix_prim_ops : (FStar_Ident.lident * Prims.string) Prims.list = (((FStar_Syntax_Const.op_Addition), ("+")))::(((FStar_Syntax_Const.op_Subtraction), ("-")))::(((FStar_Syntax_Const.op_Multiply), ("*")))::(((FStar_Syntax_Const.op_Division), ("/")))::(((FStar_Syntax_Const.op_Eq), ("=")))::(((FStar_Syntax_Const.op_ColonEq), (":=")))::(((FStar_Syntax_Const.op_notEq), ("<>")))::(((FStar_Syntax_Const.op_And), ("&&")))::(((FStar_Syntax_Const.op_Or), ("||")))::(((FStar_Syntax_Const.op_LTE), ("<=")))::(((FStar_Syntax_Const.op_GTE), (">=")))::(((FStar_Syntax_Const.op_LT), ("<")))::(((FStar_Syntax_Const.op_GT), (">")))::(((FStar_Syntax_Const.op_Modulus), ("mod")))::(((FStar_Syntax_Const.and_lid), ("/\\")))::(((FStar_Syntax_Const.or_lid), ("\\/")))::(((FStar_Syntax_Const.imp_lid), ("==>")))::(((FStar_Syntax_Const.iff_lid), ("<==>")))::(((FStar_Syntax_Const.precedes_lid), ("<<")))::(((FStar_Syntax_Const.eq2_lid), ("==")))::(((FStar_Syntax_Const.eq3_lid), ("===")))::[]
+
+
+let unary_prim_ops : (FStar_Ident.lident * Prims.string) Prims.list = (((FStar_Syntax_Const.op_Negation), ("not")))::(((FStar_Syntax_Const.op_Minus), ("-")))::(((FStar_Syntax_Const.not_lid), ("~")))::[]
+
+
+let is_prim_op = (fun ps f -> (match (f.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_All.pipe_right ps (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)))
+end
+| uu____109 -> begin
+false
+end))
+
+
+let get_lid = (fun f -> (match (f.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+end
+| uu____126 -> begin
+(failwith "get_lid")
+end))
+
+
+let is_infix_prim_op : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun e -> (is_prim_op (Prims.fst (FStar_List.split infix_prim_ops)) e))
+
+
+let is_unary_prim_op : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun e -> (is_prim_op (Prims.fst (FStar_List.split unary_prim_ops)) e))
+
+
+let quants : (FStar_Ident.lident * Prims.string) Prims.list = (((FStar_Syntax_Const.forall_lid), ("forall")))::(((FStar_Syntax_Const.exists_lid), ("exists")))::[]
+
+
+type exp =
+FStar_Syntax_Syntax.term
+
+
+let is_b2t : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (is_prim_op ((FStar_Syntax_Const.b2t_lid)::[]) t))
+
+
+let is_quant : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (is_prim_op (Prims.fst (FStar_List.split quants)) t))
+
+
+let is_ite : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (is_prim_op ((FStar_Syntax_Const.ite_lid)::[]) t))
+
+
+let is_lex_cons : exp  ->  Prims.bool = (fun f -> (is_prim_op ((FStar_Syntax_Const.lexcons_lid)::[]) f))
+
+
+let is_lex_top : exp  ->  Prims.bool = (fun f -> (is_prim_op ((FStar_Syntax_Const.lextop_lid)::[]) f))
+
+
+let is_inr = (fun uu___178_173 -> (match (uu___178_173) with
+| FStar_Util.Inl (uu____176) -> begin
+false
+end
+| FStar_Util.Inr (uu____177) -> begin
+true
+end))
+
+
+let filter_imp = (fun a -> (FStar_All.pipe_right a (FStar_List.filter (fun uu___179_208 -> (match (uu___179_208) with
+| (uu____212, Some (FStar_Syntax_Syntax.Implicit (uu____213))) -> begin
+false
+end
+| uu____215 -> begin
+true
+end)))))
+
+
+let rec reconstruct_lex : exp  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.list Prims.option = (fun e -> (
+
+let uu____226 = (
+
+let uu____227 = (FStar_Syntax_Subst.compress e)
+in uu____227.FStar_Syntax_Syntax.n)
+in (match (uu____226) with
+| FStar_Syntax_Syntax.Tm_app (f, args) -> begin
+(
+
+let args1 = (filter_imp args)
+in (
+
+let exps = (FStar_List.map Prims.fst args1)
+in (
+
+let uu____273 = ((is_lex_cons f) && ((FStar_List.length exps) = (Prims.parse_int "2")))
+in (match (uu____273) with
+| true -> begin
+(
+
+let uu____282 = (
+
+let uu____287 = (FStar_List.nth exps (Prims.parse_int "1"))
+in (reconstruct_lex uu____287))
+in (match (uu____282) with
+| Some (xs) -> begin
+(
+
+let uu____301 = (
+
+let uu____305 = (FStar_List.nth exps (Prims.parse_int "0"))
+in (uu____305)::xs)
+in Some (uu____301))
+end
+| None -> begin
+None
+end))
+end
+| uu____321 -> begin
+None
+end))))
+end
+| uu____325 -> begin
+(
+
+let uu____326 = (is_lex_top e)
+in (match (uu____326) with
+| true -> begin
+Some ([])
+end
+| uu____336 -> begin
+None
+end))
+end)))
+
+
+let rec find = (fun f l -> (match (l) with
+| [] -> begin
+(failwith "blah")
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____362 = (f hd1)
+in (match (uu____362) with
+| true -> begin
+hd1
+end
+| uu____363 -> begin
+(find f tl1)
+end))
+end))
+
+
+let find_lid : FStar_Ident.lident  ->  (FStar_Ident.lident * Prims.string) Prims.list  ->  Prims.string = (fun x xs -> (
+
+let uu____376 = (find (fun p -> (FStar_Ident.lid_equals x (Prims.fst p))) xs)
+in (Prims.snd uu____376)))
+
+
+let infix_prim_op_to_string = (fun e -> (
+
+let uu____395 = (get_lid e)
+in (find_lid uu____395 infix_prim_ops)))
+
+
+let unary_prim_op_to_string = (fun e -> (
+
+let uu____407 = (get_lid e)
+in (find_lid uu____407 unary_prim_ops)))
+
+
+let quant_to_string = (fun t -> (
+
+let uu____419 = (get_lid t)
+in (find_lid uu____419 quants)))
+
+
+let const_to_string : FStar_Const.sconst  ->  Prims.string = (fun x -> (match (x) with
+| FStar_Const.Const_effect -> begin
+"Effect"
+end
+| FStar_Const.Const_unit -> begin
+"()"
+end
+| FStar_Const.Const_bool (b) -> begin
+(match (b) with
+| true -> begin
+"true"
+end
+| uu____424 -> begin
+"false"
+end)
+end
+| FStar_Const.Const_float (x1) -> begin
+(FStar_Util.string_of_float x1)
+end
+| FStar_Const.Const_string (bytes, uu____427) -> begin
+(FStar_Util.format1 "\"%s\"" (FStar_Util.string_of_bytes bytes))
+end
+| FStar_Const.Const_bytearray (uu____430) -> begin
+"<bytearray>"
+end
+| FStar_Const.Const_int (x1, uu____435) -> begin
+x1
+end
+| FStar_Const.Const_char (c) -> begin
+(Prims.strcat "\'" (Prims.strcat (FStar_Util.string_of_char c) "\'"))
+end
+| FStar_Const.Const_range (r) -> begin
+(FStar_Range.string_of_range r)
+end
+| FStar_Const.Const_reify -> begin
+"reify"
+end
+| FStar_Const.Const_reflect (l) -> begin
+(
+
+let uu____445 = (sli l)
+in (FStar_Util.format1 "[[%s.reflect]]" uu____445))
+end))
+
+
+let lbname_to_string : FStar_Syntax_Syntax.lbname  ->  Prims.string = (fun uu___180_448 -> (match (uu___180_448) with
+| FStar_Util.Inl (l) -> begin
+(bv_to_string l)
+end
+| FStar_Util.Inr (l) -> begin
+(lid_to_string l.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end))
+
+
+let tag_of_term : FStar_Syntax_Syntax.term  ->  Prims.string = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_bvar (x) -> begin
+(
+
+let uu____459 = (db_to_string x)
+in (Prims.strcat "Tm_bvar: " uu____459))
+end
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+(
+
+let uu____461 = (nm_to_string x)
+in (Prims.strcat "Tm_name: " uu____461))
+end
+| FStar_Syntax_Syntax.Tm_fvar (x) -> begin
+(
+
+let uu____463 = (lid_to_string x.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (Prims.strcat "Tm_fvar: " uu____463))
+end
+| FStar_Syntax_Syntax.Tm_uinst (uu____468) -> begin
+"Tm_uinst"
+end
+| FStar_Syntax_Syntax.Tm_constant (uu____473) -> begin
+"Tm_constant"
+end
+| FStar_Syntax_Syntax.Tm_type (uu____474) -> begin
+"Tm_type"
+end
+| FStar_Syntax_Syntax.Tm_abs (uu____475) -> begin
+"Tm_abs"
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____490) -> begin
+"Tm_arrow"
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____498) -> begin
+"Tm_refine"
+end
+| FStar_Syntax_Syntax.Tm_app (uu____503) -> begin
+"Tm_app"
+end
+| FStar_Syntax_Syntax.Tm_match (uu____513) -> begin
+"Tm_match"
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____529) -> begin
+"Tm_ascribed"
+end
+| FStar_Syntax_Syntax.Tm_let (uu____547) -> begin
+"Tm_let"
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____555) -> begin
+"Tm_uvar"
+end
+| FStar_Syntax_Syntax.Tm_delayed (uu____564, m) -> begin
+(
+
+let uu____602 = (FStar_ST.read m)
+in (match (uu____602) with
+| None -> begin
+"Tm_delayed"
+end
+| Some (uu____613) -> begin
+"Tm_delayed-resolved"
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (uu____618) -> begin
+"Tm_meta"
+end
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+"Tm_unknown"
+end))
+
+
+let uvar_to_string = (fun u -> (
+
+let uu____632 = (FStar_Options.hide_uvar_nums ())
+in (match (uu____632) with
+| true -> begin
+"?"
+end
+| uu____633 -> begin
+(
+
+let uu____634 = (
+
+let uu____635 = (FStar_Unionfind.uvar_id u)
+in (FStar_All.pipe_right uu____635 FStar_Util.string_of_int))
+in (Prims.strcat "?" uu____634))
+end)))
+
+
+let rec int_of_univ : Prims.int  ->  FStar_Syntax_Syntax.universe  ->  (Prims.int * FStar_Syntax_Syntax.universe Prims.option) = (fun n1 u -> (
+
+let uu____645 = (FStar_Syntax_Subst.compress_univ u)
+in (match (uu____645) with
+| FStar_Syntax_Syntax.U_zero -> begin
+((n1), (None))
+end
+| FStar_Syntax_Syntax.U_succ (u1) -> begin
+(int_of_univ (n1 + (Prims.parse_int "1")) u1)
+end
+| uu____651 -> begin
+((n1), (Some (u)))
+end)))
+
+
+let rec univ_to_string : FStar_Syntax_Syntax.universe  ->  Prims.string = (fun u -> (
+
+let uu____656 = (FStar_Syntax_Subst.compress_univ u)
+in (match (uu____656) with
+| FStar_Syntax_Syntax.U_unif (u1) -> begin
+(uvar_to_string u1)
+end
+| FStar_Syntax_Syntax.U_name (x) -> begin
+x.FStar_Ident.idText
+end
+| FStar_Syntax_Syntax.U_bvar (x) -> begin
+(
+
+let uu____663 = (FStar_Util.string_of_int x)
+in (Prims.strcat "@" uu____663))
+end
+| FStar_Syntax_Syntax.U_zero -> begin
+"0"
+end
+| FStar_Syntax_Syntax.U_succ (u1) -> begin
+(
+
+let uu____665 = (int_of_univ (Prims.parse_int "1") u1)
+in (match (uu____665) with
+| (n1, None) -> begin
+(FStar_Util.string_of_int n1)
+end
+| (n1, Some (u2)) -> begin
+(
+
+let uu____674 = (univ_to_string u2)
+in (
+
+let uu____675 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format2 "(%s + %s)" uu____674 uu____675)))
+end))
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(
+
+let uu____678 = (
+
+let uu____679 = (FStar_List.map univ_to_string us)
+in (FStar_All.pipe_right uu____679 (FStar_String.concat ", ")))
+in (FStar_Util.format1 "(max %s)" uu____678))
+end
+| FStar_Syntax_Syntax.U_unknown -> begin
+"unknown"
+end)))
+
+
+let univs_to_string : FStar_Syntax_Syntax.universe Prims.list  ->  Prims.string = (fun us -> (
+
+let uu____687 = (FStar_List.map univ_to_string us)
+in (FStar_All.pipe_right uu____687 (FStar_String.concat ", "))))
+
+
+let univ_names_to_string : FStar_Ident.ident Prims.list  ->  Prims.string = (fun us -> (
+
+let uu____695 = (FStar_List.map (fun x -> x.FStar_Ident.idText) us)
+in (FStar_All.pipe_right uu____695 (FStar_String.concat ", "))))
+
+
+let qual_to_string : FStar_Syntax_Syntax.qualifier  ->  Prims.string = (fun uu___181_701 -> (match (uu___181_701) with
+| FStar_Syntax_Syntax.Assumption -> begin
+"assume"
+end
+| FStar_Syntax_Syntax.New -> begin
+"new"
+end
+| FStar_Syntax_Syntax.Private -> begin
+"private"
+end
+| FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen -> begin
+"unfold"
+end
+| FStar_Syntax_Syntax.Inline_for_extraction -> begin
+"inline"
+end
+| FStar_Syntax_Syntax.NoExtract -> begin
+"noextract"
+end
+| FStar_Syntax_Syntax.Visible_default -> begin
+"visible"
+end
+| FStar_Syntax_Syntax.Irreducible -> begin
+"irreducible"
+end
+| FStar_Syntax_Syntax.Abstract -> begin
+"abstract"
+end
+| FStar_Syntax_Syntax.Noeq -> begin
+"noeq"
+end
+| FStar_Syntax_Syntax.Unopteq -> begin
+"unopteq"
+end
+| FStar_Syntax_Syntax.Logic -> begin
+"logic"
+end
+| FStar_Syntax_Syntax.TotalEffect -> begin
+"total"
+end
+| FStar_Syntax_Syntax.Discriminator (l) -> begin
+(
+
+let uu____703 = (lid_to_string l)
+in (FStar_Util.format1 "(Discriminator %s)" uu____703))
+end
+| FStar_Syntax_Syntax.Projector (l, x) -> begin
+(
+
+let uu____706 = (lid_to_string l)
+in (FStar_Util.format2 "(Projector %s %s)" uu____706 x.FStar_Ident.idText))
+end
+| FStar_Syntax_Syntax.RecordType (ns, fns) -> begin
+(
+
+let uu____713 = (
+
+let uu____714 = (FStar_Ident.path_of_ns ns)
+in (FStar_Ident.text_of_path uu____714))
+in (
+
+let uu____716 = (
+
+let uu____717 = (FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id))
+in (FStar_All.pipe_right uu____717 (FStar_String.concat ", ")))
+in (FStar_Util.format2 "(RecordType %s %s)" uu____713 uu____716)))
+end
+| FStar_Syntax_Syntax.RecordConstructor (ns, fns) -> begin
+(
+
+let uu____728 = (
+
+let uu____729 = (FStar_Ident.path_of_ns ns)
+in (FStar_Ident.text_of_path uu____729))
+in (
+
+let uu____731 = (
+
+let uu____732 = (FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id))
+in (FStar_All.pipe_right uu____732 (FStar_String.concat ", ")))
+in (FStar_Util.format2 "(RecordConstructor %s %s)" uu____728 uu____731)))
+end
+| FStar_Syntax_Syntax.Action (eff_lid) -> begin
+(
+
+let uu____738 = (lid_to_string eff_lid)
+in (FStar_Util.format1 "(Action %s)" uu____738))
+end
+| FStar_Syntax_Syntax.ExceptionConstructor -> begin
+"ExceptionConstructor"
+end
+| FStar_Syntax_Syntax.HasMaskedEffect -> begin
+"HasMaskedEffect"
+end
+| FStar_Syntax_Syntax.Effect -> begin
+"Effect"
+end
+| FStar_Syntax_Syntax.Reifiable -> begin
+"reify"
+end
+| FStar_Syntax_Syntax.Reflectable (l) -> begin
+(FStar_Util.format1 "(reflect %s)" l.FStar_Ident.str)
+end
+| FStar_Syntax_Syntax.OnlyName -> begin
+"OnlyName"
+end))
+
+
+let quals_to_string : FStar_Syntax_Syntax.qualifier Prims.list  ->  Prims.string = (fun quals -> (match (quals) with
+| [] -> begin
+""
+end
+| uu____745 -> begin
+(
+
+let uu____747 = (FStar_All.pipe_right quals (FStar_List.map qual_to_string))
+in (FStar_All.pipe_right uu____747 (FStar_String.concat " ")))
+end))
+
+
+let quals_to_string' : FStar_Syntax_Syntax.qualifier Prims.list  ->  Prims.string = (fun quals -> (match (quals) with
+| [] -> begin
+""
+end
+| uu____757 -> begin
+(
+
+let uu____759 = (quals_to_string quals)
+in (Prims.strcat uu____759 " "))
+end))
+
+
+let rec term_to_string : FStar_Syntax_Syntax.term  ->  Prims.string = (fun x -> (
+
+let x1 = (FStar_Syntax_Subst.compress x)
+in (
+
+let x2 = (
+
+let uu____815 = (FStar_Options.print_implicits ())
+in (match (uu____815) with
+| true -> begin
+x1
+end
+| uu____816 -> begin
+(FStar_Syntax_Util.unmeta x1)
+end))
+in (match (x2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____817) -> begin
+(failwith "impossible")
+end
+| FStar_Syntax_Syntax.Tm_app (uu____838, []) -> begin
+(failwith "Empty args!")
+end
+| FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_pattern (ps)) -> begin
+(
+
+let pats = (
+
+let uu____865 = (FStar_All.pipe_right ps (FStar_List.map (fun args -> (
+
+let uu____881 = (FStar_All.pipe_right args (FStar_List.map (fun uu____889 -> (match (uu____889) with
+| (t1, uu____893) -> begin
+(term_to_string t1)
+end))))
+in (FStar_All.pipe_right uu____881 (FStar_String.concat "; "))))))
+in (FStar_All.pipe_right uu____865 (FStar_String.concat "\\/")))
+in (
+
+let uu____896 = (term_to_string t)
+in (FStar_Util.format2 "{:pattern %s} %s" pats uu____896)))
+end
+| FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_monadic (m, t')) -> begin
+(
+
+let uu____908 = (tag_of_term t)
+in (
+
+let uu____909 = (sli m)
+in (
+
+let uu____910 = (term_to_string t')
+in (
+
+let uu____911 = (term_to_string t)
+in (FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____908 uu____909 uu____910 uu____911)))))
+end
+| FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_monadic_lift (m0, m1, t')) -> begin
+(
+
+let uu____924 = (tag_of_term t)
+in (
+
+let uu____925 = (term_to_string t')
+in (
+
+let uu____926 = (sli m0)
+in (
+
+let uu____927 = (sli m1)
+in (
+
+let uu____928 = (term_to_string t)
+in (FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____924 uu____925 uu____926 uu____927 uu____928))))))
+end
+| FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_labeled (l, r, b)) when (FStar_Options.print_implicits ()) -> begin
+(
+
+let uu____937 = (FStar_Range.string_of_range r)
+in (
+
+let uu____938 = (term_to_string t)
+in (FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____937 uu____938)))
+end
+| FStar_Syntax_Syntax.Tm_meta (t, uu____940) -> begin
+(term_to_string t)
+end
+| FStar_Syntax_Syntax.Tm_bvar (x3) -> begin
+(db_to_string x3)
+end
+| FStar_Syntax_Syntax.Tm_name (x3) -> begin
+(nm_to_string x3)
+end
+| FStar_Syntax_Syntax.Tm_fvar (f) -> begin
+(fv_to_string f)
+end
+| FStar_Syntax_Syntax.Tm_uvar (u, uu____949) -> begin
+(uvar_to_string u)
+end
+| FStar_Syntax_Syntax.Tm_constant (c) -> begin
+(const_to_string c)
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(
+
+let uu____967 = (FStar_Options.print_universes ())
+in (match (uu____967) with
+| true -> begin
+(
+
+let uu____968 = (univ_to_string u)
+in (FStar_Util.format1 "Type u#(%s)" uu____968))
+end
+| uu____969 -> begin
+"Type"
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____982 = (binders_to_string " -> " bs)
+in (
+
+let uu____983 = (comp_to_string c)
+in (FStar_Util.format2 "(%s -> %s)" uu____982 uu____983)))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, t2, lc) -> begin
+(match (lc) with
+| Some (FStar_Util.Inl (l)) when (FStar_Options.print_implicits ()) -> begin
+(
+
+let uu____1018 = (binders_to_string " " bs)
+in (
+
+let uu____1019 = (term_to_string t2)
+in (
+
+let uu____1020 = (
+
+let uu____1021 = (l.FStar_Syntax_Syntax.comp ())
+in (FStar_All.pipe_left comp_to_string uu____1021))
+in (FStar_Util.format3 "(fun %s -> (%s $$ %s))" uu____1018 uu____1019 uu____1020))))
+end
+| Some (FStar_Util.Inr (l, flags)) when (FStar_Options.print_implicits ()) -> begin
+(
+
+let uu____1034 = (binders_to_string " " bs)
+in (
+
+let uu____1035 = (term_to_string t2)
+in (FStar_Util.format3 "(fun %s -> (%s $$ (name only) %s))" uu____1034 uu____1035 l.FStar_Ident.str)))
+end
+| uu____1036 -> begin
+(
+
+let uu____1043 = (binders_to_string " " bs)
+in (
+
+let uu____1044 = (term_to_string t2)
+in (FStar_Util.format2 "(fun %s -> %s)" uu____1043 uu____1044)))
+end)
+end
+| FStar_Syntax_Syntax.Tm_refine (xt, f) -> begin
+(
+
+let uu____1051 = (bv_to_string xt)
+in (
+
+let uu____1052 = (FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string)
+in (
+
+let uu____1055 = (FStar_All.pipe_right f formula_to_string)
+in (FStar_Util.format3 "(%s:%s{%s})" uu____1051 uu____1052 uu____1055))))
+end
+| FStar_Syntax_Syntax.Tm_app (t, args) -> begin
+(
+
+let uu____1074 = (term_to_string t)
+in (
+
+let uu____1075 = (args_to_string args)
+in (FStar_Util.format2 "(%s %s)" uu____1074 uu____1075)))
+end
+| FStar_Syntax_Syntax.Tm_let (lbs, e) -> begin
+(
+
+let uu____1088 = (lbs_to_string [] lbs)
+in (
+
+let uu____1089 = (term_to_string e)
+in (FStar_Util.format2 "%s\nin\n%s" uu____1088 uu____1089)))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e, (annot, topt), eff_name) -> begin
+(
+
+let annot1 = (match (annot) with
+| FStar_Util.Inl (t) -> begin
+(
+
+let uu____1137 = (
+
+let uu____1138 = (FStar_Util.map_opt eff_name FStar_Ident.text_of_lid)
+in (FStar_All.pipe_right uu____1138 (FStar_Util.dflt "default")))
+in (
+
+let uu____1141 = (term_to_string t)
+in (FStar_Util.format2 "[%s] %s" uu____1137 uu____1141)))
+end
+| FStar_Util.Inr (c) -> begin
+(comp_to_string c)
+end)
+in (
+
+let topt1 = (match (topt) with
+| None -> begin
+""
+end
+| Some (t) -> begin
+(
+
+let uu____1157 = (term_to_string t)
+in (FStar_Util.format1 "by %s" uu____1157))
+end)
+in (
+
+let uu____1158 = (term_to_string e)
+in (FStar_Util.format3 "(%s <: %s %s)" uu____1158 annot1 topt1))))
+end
+| FStar_Syntax_Syntax.Tm_match (head1, branches) -> begin
+(
+
+let uu____1187 = (term_to_string head1)
+in (
+
+let uu____1188 = (
+
+let uu____1189 = (FStar_All.pipe_right branches (FStar_List.map (fun uu____1207 -> (match (uu____1207) with
+| (p, wopt, e) -> begin
+(
+
+let uu____1217 = (FStar_All.pipe_right p pat_to_string)
+in (
+
+let uu____1218 = (match (wopt) with
+| None -> begin
+""
+end
+| Some (w) -> begin
+(
+
+let uu____1220 = (FStar_All.pipe_right w term_to_string)
+in (FStar_Util.format1 "when %s" uu____1220))
+end)
+in (
+
+let uu____1221 = (FStar_All.pipe_right e term_to_string)
+in (FStar_Util.format3 "%s %s -> %s" uu____1217 uu____1218 uu____1221))))
+end))))
+in (FStar_Util.concat_l "\n\t|" uu____1189))
+in (FStar_Util.format2 "(match %s with\n\t| %s)" uu____1187 uu____1188)))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t, us) -> begin
+(
+
+let uu____1228 = (FStar_Options.print_universes ())
+in (match (uu____1228) with
+| true -> begin
+(
+
+let uu____1229 = (term_to_string t)
+in (
+
+let uu____1230 = (univs_to_string us)
+in (FStar_Util.format2 "%s<%s>" uu____1229 uu____1230)))
+end
+| uu____1231 -> begin
+(term_to_string t)
+end))
+end
+| uu____1232 -> begin
+(tag_of_term x2)
+end))))
+and pat_to_string : FStar_Syntax_Syntax.pat  ->  Prims.string = (fun x -> (match (x.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_cons (l, pats) -> begin
+(
+
+let uu____1246 = (fv_to_string l)
+in (
+
+let uu____1247 = (
+
+let uu____1248 = (FStar_List.map (fun uu____1252 -> (match (uu____1252) with
+| (x1, b) -> begin
+(
+
+let p = (pat_to_string x1)
+in (match (b) with
+| true -> begin
+(Prims.strcat "#" p)
+end
+| uu____1258 -> begin
+p
+end))
+end)) pats)
+in (FStar_All.pipe_right uu____1248 (FStar_String.concat " ")))
+in (FStar_Util.format2 "(%s %s)" uu____1246 uu____1247)))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x1, uu____1261) -> begin
+(
+
+let uu____1266 = (FStar_Options.print_bound_var_types ())
+in (match (uu____1266) with
+| true -> begin
+(
+
+let uu____1267 = (bv_to_string x1)
+in (
+
+let uu____1268 = (term_to_string x1.FStar_Syntax_Syntax.sort)
+in (FStar_Util.format2 ".%s:%s" uu____1267 uu____1268)))
+end
+| uu____1269 -> begin
+(
+
+let uu____1270 = (bv_to_string x1)
+in (FStar_Util.format1 ".%s" uu____1270))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x1) -> begin
+(
+
+let uu____1272 = (FStar_Options.print_bound_var_types ())
+in (match (uu____1272) with
+| true -> begin
+(
+
+let uu____1273 = (bv_to_string x1)
+in (
+
+let uu____1274 = (term_to_string x1.FStar_Syntax_Syntax.sort)
+in (FStar_Util.format2 "%s:%s" uu____1273 uu____1274)))
+end
+| uu____1275 -> begin
+(bv_to_string x1)
+end))
+end
+| FStar_Syntax_Syntax.Pat_constant (c) -> begin
+(const_to_string c)
+end
+| FStar_Syntax_Syntax.Pat_wild (x1) -> begin
+(
+
+let uu____1278 = (FStar_Options.print_real_names ())
+in (match (uu____1278) with
+| true -> begin
+(
+
+let uu____1279 = (bv_to_string x1)
+in (Prims.strcat "Pat_wild " uu____1279))
+end
+| uu____1280 -> begin
+"_"
+end))
+end
+| FStar_Syntax_Syntax.Pat_disj (ps) -> begin
+(
+
+let uu____1285 = (FStar_List.map pat_to_string ps)
+in (FStar_Util.concat_l " | " uu____1285))
+end))
+and lbs_to_string : FStar_Syntax_Syntax.qualifier Prims.list  ->  (Prims.bool * FStar_Syntax_Syntax.letbinding Prims.list)  ->  Prims.string = (fun quals lbs -> (
+
+let lbs1 = (
+
+let uu____1297 = (FStar_Options.print_universes ())
+in (match (uu____1297) with
+| true -> begin
+(
+
+let uu____1301 = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.map (fun lb -> (
+
+let uu____1307 = (
+
+let uu____1310 = (FStar_Syntax_Util.mk_conj lb.FStar_Syntax_Syntax.lbtyp lb.FStar_Syntax_Syntax.lbdef)
+in (FStar_Syntax_Subst.open_univ_vars lb.FStar_Syntax_Syntax.lbunivs uu____1310))
+in (match (uu____1307) with
+| (us, td) -> begin
+(
+
+let uu____1313 = (
+
+let uu____1320 = (
+
+let uu____1321 = (FStar_Syntax_Subst.compress td)
+in uu____1321.FStar_Syntax_Syntax.n)
+in (match (uu____1320) with
+| FStar_Syntax_Syntax.Tm_app (uu____1330, ((t, uu____1332))::((d, uu____1334))::[]) -> begin
+((t), (d))
+end
+| uu____1368 -> begin
+(failwith "Impossibe")
+end))
+in (match (uu____1313) with
+| (t, d) -> begin
+(
+
+let uu___188_1385 = lb
+in {FStar_Syntax_Syntax.lbname = uu___188_1385.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = us; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = uu___188_1385.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = d})
+end))
+end)))))
+in (((Prims.fst lbs)), (uu____1301)))
+end
+| uu____1388 -> begin
+lbs
+end))
+in (
+
+let uu____1389 = (quals_to_string' quals)
+in (
+
+let uu____1390 = (
+
+let uu____1391 = (FStar_All.pipe_right (Prims.snd lbs1) (FStar_List.map (fun lb -> (
+
+let uu____1397 = (lbname_to_string lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____1398 = (
+
+let uu____1399 = (FStar_Options.print_universes ())
+in (match (uu____1399) with
+| true -> begin
+(
+
+let uu____1400 = (
+
+let uu____1401 = (univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs)
+in (Prims.strcat uu____1401 ">"))
+in (Prims.strcat "<" uu____1400))
+end
+| uu____1402 -> begin
+""
+end))
+in (
+
+let uu____1403 = (term_to_string lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____1404 = (FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbdef term_to_string)
+in (FStar_Util.format4 "%s %s : %s = %s" uu____1397 uu____1398 uu____1403 uu____1404))))))))
+in (FStar_Util.concat_l "\n and " uu____1391))
+in (FStar_Util.format3 "%slet %s %s" uu____1389 (match ((Prims.fst lbs1)) with
+| true -> begin
+"rec"
+end
+| uu____1408 -> begin
+""
+end) uu____1390)))))
+and lcomp_to_string : FStar_Syntax_Syntax.lcomp  ->  Prims.string = (fun lc -> (
+
+let uu____1410 = (FStar_Options.print_effect_args ())
+in (match (uu____1410) with
+| true -> begin
+(
+
+let uu____1411 = (lc.FStar_Syntax_Syntax.comp ())
+in (comp_to_string uu____1411))
+end
+| uu____1412 -> begin
+(
+
+let uu____1413 = (sli lc.FStar_Syntax_Syntax.eff_name)
+in (
+
+let uu____1414 = (term_to_string lc.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.format2 "%s %s" uu____1413 uu____1414)))
+end)))
+and imp_to_string : Prims.string  ->  FStar_Syntax_Syntax.arg_qualifier Prims.option  ->  Prims.string = (fun s uu___182_1416 -> (match (uu___182_1416) with
+| Some (FStar_Syntax_Syntax.Implicit (false)) -> begin
+(Prims.strcat "#" s)
+end
+| Some (FStar_Syntax_Syntax.Implicit (true)) -> begin
+(Prims.strcat "#." s)
+end
+| Some (FStar_Syntax_Syntax.Equality) -> begin
+(Prims.strcat "$" s)
+end
+| uu____1418 -> begin
+s
+end))
+and binder_to_string' : Prims.bool  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)  ->  Prims.string = (fun is_arrow b -> (
+
+let uu____1424 = b
+in (match (uu____1424) with
+| (a, imp) -> begin
+(
+
+let uu____1429 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____1429) with
+| true -> begin
+(
+
+let uu____1430 = (term_to_string a.FStar_Syntax_Syntax.sort)
+in (Prims.strcat "_:" uu____1430))
+end
+| uu____1431 -> begin
+(
+
+let uu____1432 = ((not (is_arrow)) && (
+
+let uu____1433 = (FStar_Options.print_bound_var_types ())
+in (not (uu____1433))))
+in (match (uu____1432) with
+| true -> begin
+(
+
+let uu____1434 = (nm_to_string a)
+in (imp_to_string uu____1434 imp))
+end
+| uu____1435 -> begin
+(
+
+let uu____1436 = (
+
+let uu____1437 = (nm_to_string a)
+in (
+
+let uu____1438 = (
+
+let uu____1439 = (term_to_string a.FStar_Syntax_Syntax.sort)
+in (Prims.strcat ":" uu____1439))
+in (Prims.strcat uu____1437 uu____1438)))
+in (imp_to_string uu____1436 imp))
+end))
+end))
+end)))
+and binder_to_string : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)  ->  Prims.string = (fun b -> (binder_to_string' false b))
+and arrow_binder_to_string : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)  ->  Prims.string = (fun b -> (binder_to_string' true b))
+and binders_to_string : Prims.string  ->  FStar_Syntax_Syntax.binders  ->  Prims.string = (fun sep bs -> (
+
+let bs1 = (
+
+let uu____1449 = (FStar_Options.print_implicits ())
+in (match (uu____1449) with
+| true -> begin
+bs
+end
+| uu____1450 -> begin
+(filter_imp bs)
+end))
+in (match ((sep = " -> ")) with
+| true -> begin
+(
+
+let uu____1451 = (FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string))
+in (FStar_All.pipe_right uu____1451 (FStar_String.concat sep)))
+end
+| uu____1457 -> begin
+(
+
+let uu____1458 = (FStar_All.pipe_right bs1 (FStar_List.map binder_to_string))
+in (FStar_All.pipe_right uu____1458 (FStar_String.concat sep)))
+end)))
+and arg_to_string : (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier Prims.option)  ->  Prims.string = (fun uu___183_1464 -> (match (uu___183_1464) with
+| (a, imp) -> begin
+(
+
+let uu____1472 = (term_to_string a)
+in (imp_to_string uu____1472 imp))
+end))
+and args_to_string : FStar_Syntax_Syntax.args  ->  Prims.string = (fun args -> (
+
+let args1 = (
+
+let uu____1475 = (FStar_Options.print_implicits ())
+in (match (uu____1475) with
+| true -> begin
+args
+end
+| uu____1476 -> begin
+(filter_imp args)
+end))
+in (
+
+let uu____1479 = (FStar_All.pipe_right args1 (FStar_List.map arg_to_string))
+in (FStar_All.pipe_right uu____1479 (FStar_String.concat " ")))))
+and comp_to_string : FStar_Syntax_Syntax.comp  ->  Prims.string = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uu____1488) -> begin
+(
+
+let uu____1495 = (
+
+let uu____1496 = (FStar_Syntax_Subst.compress t)
+in uu____1496.FStar_Syntax_Syntax.n)
+in (match (uu____1495) with
+| FStar_Syntax_Syntax.Tm_type (uu____1499) when (
+
+let uu____1500 = (FStar_Options.print_implicits ())
+in (not (uu____1500))) -> begin
+(term_to_string t)
+end
+| uu____1501 -> begin
+(
+
+let uu____1502 = (term_to_string t)
+in (FStar_Util.format1 "Tot %s" uu____1502))
+end))
+end
+| FStar_Syntax_Syntax.GTotal (t, uu____1504) -> begin
+(
+
+let uu____1511 = (
+
+let uu____1512 = (FStar_Syntax_Subst.compress t)
+in uu____1512.FStar_Syntax_Syntax.n)
+in (match (uu____1511) with
+| FStar_Syntax_Syntax.Tm_type (uu____1515) when (
+
+let uu____1516 = (FStar_Options.print_implicits ())
+in (not (uu____1516))) -> begin
+(term_to_string t)
+end
+| uu____1517 -> begin
+(
+
+let uu____1518 = (term_to_string t)
+in (FStar_Util.format1 "GTot %s" uu____1518))
+end))
+end
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+(
+
+let basic = (
+
+let uu____1521 = (FStar_Options.print_effect_args ())
+in (match (uu____1521) with
+| true -> begin
+(
+
+let uu____1522 = (sli c1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____1523 = (term_to_string c1.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____1524 = (
+
+let uu____1525 = (FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args (FStar_List.map arg_to_string))
+in (FStar_All.pipe_right uu____1525 (FStar_String.concat ", ")))
+in (
+
+let uu____1537 = (
+
+let uu____1538 = (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_List.map cflags_to_string))
+in (FStar_All.pipe_right uu____1538 (FStar_String.concat " ")))
+in (FStar_Util.format4 "%s (%s) %s (attributes %s)" uu____1522 uu____1523 uu____1524 uu____1537)))))
+end
+| uu____1543 -> begin
+(
+
+let uu____1544 = ((FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___184_1546 -> (match (uu___184_1546) with
+| FStar_Syntax_Syntax.TOTAL -> begin
+true
+end
+| uu____1547 -> begin
+false
+end)))) && (
+
+let uu____1548 = (FStar_Options.print_effect_args ())
+in (not (uu____1548))))
+in (match (uu____1544) with
+| true -> begin
+(
+
+let uu____1549 = (term_to_string c1.FStar_Syntax_Syntax.result_typ)
+in (FStar_Util.format1 "Tot %s" uu____1549))
+end
+| uu____1550 -> begin
+(
+
+let uu____1551 = (((
+
+let uu____1552 = (FStar_Options.print_effect_args ())
+in (not (uu____1552))) && (
+
+let uu____1553 = (FStar_Options.print_implicits ())
+in (not (uu____1553)))) && (FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_ML_lid))
+in (match (uu____1551) with
+| true -> begin
+(term_to_string c1.FStar_Syntax_Syntax.result_typ)
+end
+| uu____1554 -> begin
+(
+
+let uu____1555 = ((
+
+let uu____1556 = (FStar_Options.print_effect_args ())
+in (not (uu____1556))) && (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___185_1558 -> (match (uu___185_1558) with
+| FStar_Syntax_Syntax.MLEFFECT -> begin
+true
+end
+| uu____1559 -> begin
+false
+end)))))
+in (match (uu____1555) with
+| true -> begin
+(
+
+let uu____1560 = (term_to_string c1.FStar_Syntax_Syntax.result_typ)
+in (FStar_Util.format1 "ALL %s" uu____1560))
+end
+| uu____1561 -> begin
+(
+
+let uu____1562 = (sli c1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____1563 = (term_to_string c1.FStar_Syntax_Syntax.result_typ)
+in (FStar_Util.format2 "%s (%s)" uu____1562 uu____1563)))
+end))
+end))
+end))
+end))
+in (
+
+let dec = (
+
+let uu____1565 = (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_List.collect (fun uu___186_1569 -> (match (uu___186_1569) with
+| FStar_Syntax_Syntax.DECREASES (e) -> begin
+(
+
+let uu____1574 = (
+
+let uu____1575 = (term_to_string e)
+in (FStar_Util.format1 " (decreases %s)" uu____1575))
+in (uu____1574)::[])
+end
+| uu____1576 -> begin
+[]
+end))))
+in (FStar_All.pipe_right uu____1565 (FStar_String.concat " ")))
+in (FStar_Util.format2 "%s%s" basic dec)))
+end))
+and cflags_to_string : FStar_Syntax_Syntax.cflags  ->  Prims.string = (fun c -> (match (c) with
+| FStar_Syntax_Syntax.TOTAL -> begin
+"total"
+end
+| FStar_Syntax_Syntax.MLEFFECT -> begin
+"ml"
+end
+| FStar_Syntax_Syntax.RETURN -> begin
+"return"
+end
+| FStar_Syntax_Syntax.PARTIAL_RETURN -> begin
+"partial_return"
+end
+| FStar_Syntax_Syntax.SOMETRIVIAL -> begin
+"sometrivial"
+end
+| FStar_Syntax_Syntax.LEMMA -> begin
+"lemma"
+end
+| FStar_Syntax_Syntax.CPS -> begin
+"cps"
+end
+| FStar_Syntax_Syntax.DECREASES (uu____1579) -> begin
+""
+end))
+and formula_to_string : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  Prims.string = (fun phi -> (term_to_string phi))
+
+
+let enclose_universes : Prims.string  ->  Prims.string = (fun s -> (
+
+let uu____1588 = (FStar_Options.print_universes ())
+in (match (uu____1588) with
+| true -> begin
+(Prims.strcat "<" (Prims.strcat s ">"))
+end
+| uu____1589 -> begin
+""
+end)))
+
+
+let tscheme_to_string : FStar_Syntax_Syntax.tscheme  ->  Prims.string = (fun uu____1592 -> (match (uu____1592) with
+| (us, t) -> begin
+(
+
+let uu____1597 = (
+
+let uu____1598 = (univ_names_to_string us)
+in (FStar_All.pipe_left enclose_universes uu____1598))
+in (
+
+let uu____1599 = (term_to_string t)
+in (FStar_Util.format2 "%s%s" uu____1597 uu____1599)))
+end))
+
+
+let eff_decl_to_string : Prims.bool  ->  FStar_Syntax_Syntax.eff_decl  ->  Prims.string = (fun for_free ed -> (
+
+let actions_to_string = (fun actions -> (
+
+let uu____1612 = (FStar_All.pipe_right actions (FStar_List.map (fun a -> (
+
+let uu____1617 = (sli a.FStar_Syntax_Syntax.action_name)
+in (
+
+let uu____1618 = (
+
+let uu____1619 = (univ_names_to_string a.FStar_Syntax_Syntax.action_univs)
+in (FStar_All.pipe_left enclose_universes uu____1619))
+in (
+
+let uu____1620 = (term_to_string a.FStar_Syntax_Syntax.action_typ)
+in (
+
+let uu____1621 = (term_to_string a.FStar_Syntax_Syntax.action_defn)
+in (FStar_Util.format4 "%s%s : %s = %s" uu____1617 uu____1618 uu____1620 uu____1621))))))))
+in (FStar_All.pipe_right uu____1612 (FStar_String.concat ",\n\t"))))
+in (
+
+let uu____1623 = (
+
+let uu____1625 = (
+
+let uu____1627 = (lid_to_string ed.FStar_Syntax_Syntax.mname)
+in (
+
+let uu____1628 = (
+
+let uu____1630 = (
+
+let uu____1631 = (univ_names_to_string ed.FStar_Syntax_Syntax.univs)
+in (FStar_All.pipe_left enclose_universes uu____1631))
+in (
+
+let uu____1632 = (
+
+let uu____1634 = (binders_to_string " " ed.FStar_Syntax_Syntax.binders)
+in (
+
+let uu____1635 = (
+
+let uu____1637 = (term_to_string ed.FStar_Syntax_Syntax.signature)
+in (
+
+let uu____1638 = (
+
+let uu____1640 = (tscheme_to_string ed.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____1641 = (
+
+let uu____1643 = (tscheme_to_string ed.FStar_Syntax_Syntax.bind_wp)
+in (
+
+let uu____1644 = (
+
+let uu____1646 = (tscheme_to_string ed.FStar_Syntax_Syntax.if_then_else)
+in (
+
+let uu____1647 = (
+
+let uu____1649 = (tscheme_to_string ed.FStar_Syntax_Syntax.ite_wp)
+in (
+
+let uu____1650 = (
+
+let uu____1652 = (tscheme_to_string ed.FStar_Syntax_Syntax.stronger)
+in (
+
+let uu____1653 = (
+
+let uu____1655 = (tscheme_to_string ed.FStar_Syntax_Syntax.close_wp)
+in (
+
+let uu____1656 = (
+
+let uu____1658 = (tscheme_to_string ed.FStar_Syntax_Syntax.assert_p)
+in (
+
+let uu____1659 = (
+
+let uu____1661 = (tscheme_to_string ed.FStar_Syntax_Syntax.assume_p)
+in (
+
+let uu____1662 = (
+
+let uu____1664 = (tscheme_to_string ed.FStar_Syntax_Syntax.null_wp)
+in (
+
+let uu____1665 = (
+
+let uu____1667 = (tscheme_to_string ed.FStar_Syntax_Syntax.trivial)
+in (
+
+let uu____1668 = (
+
+let uu____1670 = (term_to_string ed.FStar_Syntax_Syntax.repr)
+in (
+
+let uu____1671 = (
+
+let uu____1673 = (tscheme_to_string ed.FStar_Syntax_Syntax.bind_repr)
+in (
+
+let uu____1674 = (
+
+let uu____1676 = (tscheme_to_string ed.FStar_Syntax_Syntax.return_repr)
+in (
+
+let uu____1677 = (
+
+let uu____1679 = (actions_to_string ed.FStar_Syntax_Syntax.actions)
+in (uu____1679)::[])
+in (uu____1676)::uu____1677))
+in (uu____1673)::uu____1674))
+in (uu____1670)::uu____1671))
+in (uu____1667)::uu____1668))
+in (uu____1664)::uu____1665))
+in (uu____1661)::uu____1662))
+in (uu____1658)::uu____1659))
+in (uu____1655)::uu____1656))
+in (uu____1652)::uu____1653))
+in (uu____1649)::uu____1650))
+in (uu____1646)::uu____1647))
+in (uu____1643)::uu____1644))
+in (uu____1640)::uu____1641))
+in (uu____1637)::uu____1638))
+in (uu____1634)::uu____1635))
+in (uu____1630)::uu____1632))
+in (uu____1627)::uu____1628))
+in ((match (for_free) with
+| true -> begin
+"_for_free "
+end
+| uu____1680 -> begin
+""
+end))::uu____1625)
+in (FStar_Util.format "new_effect%s { %s%s %s : %s \n  return_wp   = %s\n; bind_wp     = %s\n; if_then_else= %s\n; ite_wp      = %s\n; stronger    = %s\n; close_wp    = %s\n; assert_p    = %s\n; assume_p    = %s\n; null_wp     = %s\n; trivial     = %s\n; repr        = %s\n; bind_repr   = %s\n; return_repr = %s\nand effect_actions\n\t%s\n}\n" uu____1623))))
+
+
+let rec sigelt_to_string : FStar_Syntax_Syntax.sigelt  ->  Prims.string = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.LightOff) -> begin
+"#light \"off\""
+end
+| FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.ResetOptions (None)) -> begin
+"#reset-options"
+end
+| FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.ResetOptions (Some (s))) -> begin
+(FStar_Util.format1 "#reset-options \"%s\"" s)
+end
+| FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.SetOptions (s)) -> begin
+(FStar_Util.format1 "#set-options \"%s\"" s)
+end
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, univs, tps, k, uu____1690, uu____1691, quals) -> begin
+(
+
+let uu____1699 = (quals_to_string' quals)
+in (
+
+let uu____1700 = (binders_to_string " " tps)
+in (
+
+let uu____1701 = (term_to_string k)
+in (FStar_Util.format4 "%stype %s %s : %s" uu____1699 lid.FStar_Ident.str uu____1700 uu____1701))))
+end
+| FStar_Syntax_Syntax.Sig_datacon (lid, univs, t, uu____1705, uu____1706, uu____1707, uu____1708) -> begin
+(
+
+let uu____1713 = (FStar_Options.print_universes ())
+in (match (uu____1713) with
+| true -> begin
+(
+
+let uu____1714 = (FStar_Syntax_Subst.open_univ_vars univs t)
+in (match (uu____1714) with
+| (univs1, t1) -> begin
+(
+
+let uu____1719 = (univ_names_to_string univs1)
+in (
+
+let uu____1720 = (term_to_string t1)
+in (FStar_Util.format3 "datacon<%s> %s : %s" uu____1719 lid.FStar_Ident.str uu____1720)))
+end))
+end
+| uu____1721 -> begin
+(
+
+let uu____1722 = (term_to_string t)
+in (FStar_Util.format2 "datacon %s : %s" lid.FStar_Ident.str uu____1722))
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t, quals) -> begin
+(
+
+let uu____1729 = (FStar_Syntax_Subst.open_univ_vars univs t)
+in (match (uu____1729) with
+| (univs1, t1) -> begin
+(
+
+let uu____1734 = (quals_to_string' quals)
+in (
+
+let uu____1735 = (
+
+let uu____1736 = (FStar_Options.print_universes ())
+in (match (uu____1736) with
+| true -> begin
+(
+
+let uu____1737 = (univ_names_to_string univs1)
+in (FStar_Util.format1 "<%s>" uu____1737))
+end
+| uu____1738 -> begin
+""
+end))
+in (
+
+let uu____1739 = (term_to_string t1)
+in (FStar_Util.format4 "%sval %s %s : %s" uu____1734 lid.FStar_Ident.str uu____1735 uu____1739))))
+end))
+end
+| FStar_Syntax_Syntax.Sig_assume (lid, f, uu____1742) -> begin
+(
+
+let uu____1745 = (term_to_string f)
+in (FStar_Util.format2 "val %s : %s" lid.FStar_Ident.str uu____1745))
+end
+| FStar_Syntax_Syntax.Sig_let (lbs, uu____1747, qs, uu____1749) -> begin
+(lbs_to_string qs lbs)
+end
+| FStar_Syntax_Syntax.Sig_main (e) -> begin
+(
+
+let uu____1757 = (term_to_string e)
+in (FStar_Util.format1 "let _ = %s" uu____1757))
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, uu____1759, uu____1760) -> begin
+(
+
+let uu____1767 = (FStar_List.map sigelt_to_string ses)
+in (FStar_All.pipe_right uu____1767 (FStar_String.concat "\n")))
+end
+| FStar_Syntax_Syntax.Sig_new_effect (ed) -> begin
+(eff_decl_to_string false ed)
+end
+| FStar_Syntax_Syntax.Sig_new_effect_for_free (ed) -> begin
+(eff_decl_to_string true ed)
+end
+| FStar_Syntax_Syntax.Sig_sub_effect (se) -> begin
+(
+
+let lift_wp = (match (((se.FStar_Syntax_Syntax.lift_wp), (se.FStar_Syntax_Syntax.lift))) with
+| (None, None) -> begin
+(failwith "impossible")
+end
+| (Some (lift_wp), uu____1779) -> begin
+lift_wp
+end
+| (uu____1783, Some (lift)) -> begin
+lift
+end)
+in (
+
+let uu____1788 = (FStar_Syntax_Subst.open_univ_vars (Prims.fst lift_wp) (Prims.snd lift_wp))
+in (match (uu____1788) with
+| (us, t) -> begin
+(
+
+let uu____1795 = (lid_to_string se.FStar_Syntax_Syntax.source)
+in (
+
+let uu____1796 = (lid_to_string se.FStar_Syntax_Syntax.target)
+in (
+
+let uu____1797 = (univ_names_to_string us)
+in (
+
+let uu____1798 = (term_to_string t)
+in (FStar_Util.format4 "sub_effect %s ~> %s : <%s> %s" uu____1795 uu____1796 uu____1797 uu____1798)))))
+end)))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (l, univs, tps, c, uu____1803, flags) -> begin
+(
+
+let uu____1809 = (FStar_Options.print_universes ())
+in (match (uu____1809) with
+| true -> begin
+(
+
+let uu____1810 = (
+
+let uu____1813 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((tps), (c))))) None FStar_Range.dummyRange)
+in (FStar_Syntax_Subst.open_univ_vars univs uu____1813))
+in (match (uu____1810) with
+| (univs1, t) -> begin
+(
+
+let uu____1824 = (
+
+let uu____1832 = (
+
+let uu____1833 = (FStar_Syntax_Subst.compress t)
+in uu____1833.FStar_Syntax_Syntax.n)
+in (match (uu____1832) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c1) -> begin
+((bs), (c1))
+end
+| uu____1860 -> begin
+(failwith "impossible")
+end))
+in (match (uu____1824) with
+| (tps1, c1) -> begin
+(
+
+let uu____1880 = (sli l)
+in (
+
+let uu____1881 = (univ_names_to_string univs1)
+in (
+
+let uu____1882 = (binders_to_string " " tps1)
+in (
+
+let uu____1883 = (comp_to_string c1)
+in (FStar_Util.format4 "effect %s<%s> %s = %s" uu____1880 uu____1881 uu____1882 uu____1883)))))
+end))
+end))
+end
+| uu____1884 -> begin
+(
+
+let uu____1885 = (sli l)
+in (
+
+let uu____1886 = (binders_to_string " " tps)
+in (
+
+let uu____1887 = (comp_to_string c)
+in (FStar_Util.format3 "effect %s %s = %s" uu____1885 uu____1886 uu____1887))))
+end))
+end))
+
+
+let format_error : FStar_Range.range  ->  Prims.string  ->  Prims.string = (fun r msg -> (
+
+let uu____1894 = (FStar_Range.string_of_range r)
+in (FStar_Util.format2 "%s: %s\n" uu____1894 msg)))
+
+
+let rec sigelt_to_string_short : FStar_Syntax_Syntax.sigelt  ->  Prims.string = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____1898, ({FStar_Syntax_Syntax.lbname = lb; FStar_Syntax_Syntax.lbunivs = uu____1900; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = uu____1902; FStar_Syntax_Syntax.lbdef = uu____1903})::[]), uu____1904, uu____1905, uu____1906) -> begin
+(
+
+let uu____1924 = (lbname_to_string lb)
+in (
+
+let uu____1925 = (term_to_string t)
+in (FStar_Util.format2 "let %s : %s" uu____1924 uu____1925)))
+end
+| uu____1926 -> begin
+(
+
+let uu____1927 = (FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x) (FStar_List.map (fun l -> l.FStar_Ident.str)))
+in (FStar_All.pipe_right uu____1927 (FStar_String.concat ", ")))
+end))
+
+
+let rec modul_to_string : FStar_Syntax_Syntax.modul  ->  Prims.string = (fun m -> (
+
+let uu____1936 = (sli m.FStar_Syntax_Syntax.name)
+in (
+
+let uu____1937 = (
+
+let uu____1938 = (FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations)
+in (FStar_All.pipe_right uu____1938 (FStar_String.concat "\n")))
+in (FStar_Util.format2 "module %s\n%s" uu____1936 uu____1937))))
+
+
+let subst_elt_to_string : FStar_Syntax_Syntax.subst_elt  ->  Prims.string = (fun uu___187_1943 -> (match (uu___187_1943) with
+| FStar_Syntax_Syntax.DB (i, x) -> begin
+(
+
+let uu____1946 = (FStar_Util.string_of_int i)
+in (
+
+let uu____1947 = (bv_to_string x)
+in (FStar_Util.format2 "DB (%s, %s)" uu____1946 uu____1947)))
+end
+| FStar_Syntax_Syntax.NM (x, i) -> begin
+(
+
+let uu____1950 = (bv_to_string x)
+in (
+
+let uu____1951 = (FStar_Util.string_of_int i)
+in (FStar_Util.format2 "NM (%s, %s)" uu____1950 uu____1951)))
+end
+| FStar_Syntax_Syntax.NT (x, t) -> begin
+(
+
+let uu____1958 = (bv_to_string x)
+in (
+
+let uu____1959 = (term_to_string t)
+in (FStar_Util.format2 "DB (%s, %s)" uu____1958 uu____1959)))
+end
+| FStar_Syntax_Syntax.UN (i, u) -> begin
+(
+
+let uu____1962 = (FStar_Util.string_of_int i)
+in (
+
+let uu____1963 = (univ_to_string u)
+in (FStar_Util.format2 "UN (%s, %s)" uu____1962 uu____1963)))
+end
+| FStar_Syntax_Syntax.UD (u, i) -> begin
+(
+
+let uu____1966 = (FStar_Util.string_of_int i)
+in (FStar_Util.format2 "UD (%s, %s)" u.FStar_Ident.idText uu____1966))
+end))
+
+
+let subst_to_string : FStar_Syntax_Syntax.subst_t  ->  Prims.string = (fun s -> (
+
+let uu____1970 = (FStar_All.pipe_right s (FStar_List.map subst_elt_to_string))
+in (FStar_All.pipe_right uu____1970 (FStar_String.concat "; "))))
+
+
+let abs_ascription_to_string : (FStar_Syntax_Syntax.lcomp, FStar_Ident.lident) FStar_Util.either Prims.option  ->  Prims.string = (fun ascription -> (
+
+let strb = (FStar_Util.new_string_builder ())
+in ((match (ascription) with
+| None -> begin
+(FStar_Util.string_builder_append strb "None")
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+((FStar_Util.string_builder_append strb "Some Inr ");
+(FStar_Util.string_builder_append strb (FStar_Ident.text_of_lid lc.FStar_Syntax_Syntax.eff_name));
+)
+end
+| Some (FStar_Util.Inr (lid)) -> begin
+((FStar_Util.string_builder_append strb "Some Inr ");
+(FStar_Util.string_builder_append strb (FStar_Ident.text_of_lid lid));
+)
+end);
+(FStar_Util.string_of_string_builder strb);
+)))
+
+
+let list_to_string = (fun f elts -> (match (elts) with
+| [] -> begin
+"[]"
+end
+| (x)::xs -> begin
+(
+
+let strb = (FStar_Util.new_string_builder ())
+in ((FStar_Util.string_builder_append strb "[");
+(
+
+let uu____2020 = (f x)
+in (FStar_Util.string_builder_append strb uu____2020));
+(FStar_List.iter (fun x1 -> ((FStar_Util.string_builder_append strb "; ");
+(
+
+let uu____2024 = (f x1)
+in (FStar_Util.string_builder_append strb uu____2024));
+)) xs);
+(FStar_Util.string_builder_append strb "]");
+(FStar_Util.string_of_string_builder strb);
+))
+end))
+
+
+let set_to_string = (fun f s -> (
+
+let elts = (FStar_Util.set_elements s)
+in (match (elts) with
+| [] -> begin
+"{}"
+end
+| (x)::xs -> begin
+(
+
+let strb = (FStar_Util.new_string_builder ())
+in ((FStar_Util.string_builder_append strb "{");
+(
+
+let uu____2053 = (f x)
+in (FStar_Util.string_builder_append strb uu____2053));
+(FStar_List.iter (fun x1 -> ((FStar_Util.string_builder_append strb ", ");
+(
+
+let uu____2057 = (f x1)
+in (FStar_Util.string_builder_append strb uu____2057));
+)) xs);
+(FStar_Util.string_builder_append strb "}");
+(FStar_Util.string_of_string_builder strb);
+))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -1,1507 +1,1700 @@
+
 open Prims
-let subst_to_string s =
-  let uu____14 =
-    FStar_All.pipe_right s
-      (FStar_List.map
-         (fun uu____22  ->
-            match uu____22 with
-            | (b,uu____26) ->
-                (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)) in
-  FStar_All.pipe_right uu____14 (FStar_String.concat ", ")
-let rec apply_until_some f s =
-  match s with
-  | [] -> None
-  | s0::rest ->
-      let uu____61 = f s0 in
-      (match uu____61 with
-       | None  -> apply_until_some f rest
-       | Some st -> Some (rest, st))
-let map_some_curry f x uu___102_101 =
-  match uu___102_101 with | None  -> x | Some (a,b) -> f a b
-let apply_until_some_then_map f s g t =
-  let uu____162 = apply_until_some f s in
-  FStar_All.pipe_right uu____162 (map_some_curry g t)
-let compose_subst s1 s2 =
-  let s = FStar_List.append (Prims.fst s1) (Prims.fst s2) in
-  let ropt =
-    match Prims.snd s2 with
-    | Some uu____217 -> Prims.snd s2
-    | uu____220 -> Prims.snd s1 in
-  (s, ropt)
-let delay:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list* FStar_Range.range
-      Prims.option) -> FStar_Syntax_Syntax.term
-  =
-  fun t  ->
-    fun s  ->
-      match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t',s'),m) ->
-          FStar_Syntax_Syntax.mk_Tm_delayed
-            (FStar_Util.Inl (t', (compose_subst s' s)))
-            t.FStar_Syntax_Syntax.pos
-      | uu____316 ->
-          FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (t, s))
-            t.FStar_Syntax_Syntax.pos
-let rec force_uvar':
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_uvar (uv,uu____347) ->
-        let uu____360 = FStar_Unionfind.find uv in
-        (match uu____360 with
-         | FStar_Syntax_Syntax.Fixed t' -> force_uvar' t'
-         | uu____374 -> t)
-    | uu____378 -> t
-let force_uvar:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun t  ->
-    let t' = force_uvar' t in
-    let uu____391 = FStar_Util.physical_equality t t' in
-    if uu____391
-    then t
-    else delay t' ([], (Some (t.FStar_Syntax_Syntax.pos)))
-let rec force_delayed_thunk:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed (f,m) ->
-        let uu____450 = FStar_ST.read m in
-        (match uu____450 with
-         | None  ->
-             (match f with
-              | FStar_Util.Inr c ->
-                  let t' =
-                    let uu____486 = c () in force_delayed_thunk uu____486 in
-                  (FStar_ST.write m (Some t'); t')
-              | uu____497 -> t)
-         | Some t' ->
-             let t'1 = force_delayed_thunk t' in
-             (FStar_ST.write m (Some t'1); t'1))
-    | uu____529 -> t
-let rec compress_univ:
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe =
-  fun u  ->
-    match u with
-    | FStar_Syntax_Syntax.U_unif u' ->
-        let uu____536 = FStar_Unionfind.find u' in
-        (match uu____536 with | Some u1 -> compress_univ u1 | uu____540 -> u)
-    | uu____542 -> u
-let subst_bv:
-  FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.term Prims.option
-  =
-  fun a  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___103_552  ->
-           match uu___103_552 with
-           | FStar_Syntax_Syntax.DB (i,x) when
-               i = a.FStar_Syntax_Syntax.index ->
-               let uu____556 =
-                 let uu____557 =
-                   let uu____558 = FStar_Syntax_Syntax.range_of_bv a in
-                   FStar_Syntax_Syntax.set_range_of_bv x uu____558 in
-                 FStar_Syntax_Syntax.bv_to_name uu____557 in
-               Some uu____556
-           | uu____559 -> None)
-let subst_nm:
-  FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.term Prims.option
-  =
-  fun a  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___104_569  ->
-           match uu___104_569 with
-           | FStar_Syntax_Syntax.NM (x,i) when FStar_Syntax_Syntax.bv_eq a x
-               ->
-               let uu____573 =
-                 FStar_Syntax_Syntax.bv_to_tm
-                   (let uu___109_574 = a in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___109_574.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index = i;
-                      FStar_Syntax_Syntax.sort =
-                        (uu___109_574.FStar_Syntax_Syntax.sort)
-                    }) in
-               Some uu____573
-           | FStar_Syntax_Syntax.NT (x,t) when FStar_Syntax_Syntax.bv_eq a x
-               -> Some t
-           | uu____583 -> None)
-let subst_univ_bv:
-  Prims.int ->
-    FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.universe Prims.option
-  =
-  fun x  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___105_593  ->
-           match uu___105_593 with
-           | FStar_Syntax_Syntax.UN (y,t) when x = y -> Some t
-           | uu____597 -> None)
-let subst_univ_nm:
-  FStar_Syntax_Syntax.univ_name ->
-    FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.universe Prims.option
-  =
-  fun x  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___106_607  ->
-           match uu___106_607 with
-           | FStar_Syntax_Syntax.UD (y,i) when
-               x.FStar_Ident.idText = y.FStar_Ident.idText ->
-               Some (FStar_Syntax_Syntax.U_bvar i)
-           | uu____611 -> None)
-let rec subst_univ:
-  FStar_Syntax_Syntax.subst_elt Prims.list Prims.list ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
-  =
-  fun s  ->
-    fun u  ->
-      let u1 = compress_univ u in
-      match u1 with
-      | FStar_Syntax_Syntax.U_bvar x ->
-          apply_until_some_then_map (subst_univ_bv x) s subst_univ u1
-      | FStar_Syntax_Syntax.U_name x ->
-          apply_until_some_then_map (subst_univ_nm x) s subst_univ u1
-      | FStar_Syntax_Syntax.U_zero 
-        |FStar_Syntax_Syntax.U_unknown |FStar_Syntax_Syntax.U_unif _ -> u1
-      | FStar_Syntax_Syntax.U_succ u2 ->
-          let uu____629 = subst_univ s u2 in
-          FStar_Syntax_Syntax.U_succ uu____629
-      | FStar_Syntax_Syntax.U_max us ->
-          let uu____632 = FStar_List.map (subst_univ s) us in
-          FStar_Syntax_Syntax.U_max uu____632
-let tag_with_range t s =
-  match Prims.snd s with
-  | None  -> t
-  | Some r ->
-      let r1 = FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos r in
-      let t' =
-        match t.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_bvar bv ->
-            let uu____665 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
-            FStar_Syntax_Syntax.Tm_bvar uu____665
-        | FStar_Syntax_Syntax.Tm_name bv ->
-            let uu____667 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
-            FStar_Syntax_Syntax.Tm_name uu____667
-        | FStar_Syntax_Syntax.Tm_fvar fv ->
-            let l = FStar_Syntax_Syntax.lid_of_fv fv in
-            let v1 =
-              let uu___110_675 = fv.FStar_Syntax_Syntax.fv_name in
-              {
-                FStar_Syntax_Syntax.v = (FStar_Ident.set_lid_range l r1);
-                FStar_Syntax_Syntax.ty =
-                  (uu___110_675.FStar_Syntax_Syntax.ty);
-                FStar_Syntax_Syntax.p = (uu___110_675.FStar_Syntax_Syntax.p)
-              } in
-            let fv1 =
-              let uu___111_691 = fv in
-              {
-                FStar_Syntax_Syntax.fv_name = v1;
-                FStar_Syntax_Syntax.fv_delta =
-                  (uu___111_691.FStar_Syntax_Syntax.fv_delta);
-                FStar_Syntax_Syntax.fv_qual =
-                  (uu___111_691.FStar_Syntax_Syntax.fv_qual)
-              } in
-            FStar_Syntax_Syntax.Tm_fvar fv1
-        | t' -> t' in
-      let uu___112_693 = t in
-      {
-        FStar_Syntax_Syntax.n = t';
-        FStar_Syntax_Syntax.tk = (uu___112_693.FStar_Syntax_Syntax.tk);
-        FStar_Syntax_Syntax.pos = r1;
-        FStar_Syntax_Syntax.vars = (uu___112_693.FStar_Syntax_Syntax.vars)
-      }
-let tag_lid_with_range l s =
-  match Prims.snd s with
-  | None  -> l
-  | Some r ->
-      let uu____720 =
-        FStar_Range.set_use_range (FStar_Ident.range_of_lid l) r in
-      FStar_Ident.set_lid_range l uu____720
-let mk_range:
-  FStar_Range.range -> FStar_Syntax_Syntax.subst_ts -> FStar_Range.range =
-  fun r  ->
-    fun s  ->
-      match Prims.snd s with
-      | None  -> r
-      | Some r' -> FStar_Range.set_use_range r r'
-let rec subst':
-  FStar_Syntax_Syntax.subst_ts ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun s  ->
-    fun t  ->
-      let subst_tail tl1 = subst' (tl1, (Prims.snd s)) in
-      match s with
-      | ([],None )|([]::[],None ) -> t
-      | uu____802 ->
-          let t0 = force_delayed_thunk t in
-          (match t0.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_unknown 
-             |FStar_Syntax_Syntax.Tm_constant _
-              |FStar_Syntax_Syntax.Tm_fvar _|FStar_Syntax_Syntax.Tm_uvar _ ->
-               tag_with_range t0 s
-           | FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t',s'),m) ->
-               FStar_Syntax_Syntax.mk_Tm_delayed
-                 (FStar_Util.Inl (t', (compose_subst s' s)))
-                 t.FStar_Syntax_Syntax.pos
-           | FStar_Syntax_Syntax.Tm_delayed
-               (FStar_Util.Inr uu____883,uu____884) ->
-               failwith
-                 "Impossible: force_delayed_thunk removes lazy delayed nodes"
-           | FStar_Syntax_Syntax.Tm_bvar a ->
-               apply_until_some_then_map (subst_bv a) (Prims.fst s)
-                 subst_tail t0
-           | FStar_Syntax_Syntax.Tm_name a ->
-               apply_until_some_then_map (subst_nm a) (Prims.fst s)
-                 subst_tail t0
-           | FStar_Syntax_Syntax.Tm_type u ->
-               let uu____940 = mk_range t0.FStar_Syntax_Syntax.pos s in
-               let uu____941 =
-                 let uu____944 =
-                   let uu____945 = subst_univ (Prims.fst s) u in
-                   FStar_Syntax_Syntax.Tm_type uu____945 in
-                 FStar_Syntax_Syntax.mk uu____944 in
-               uu____941 None uu____940
-           | uu____957 ->
-               let uu____958 = mk_range t.FStar_Syntax_Syntax.pos s in
-               FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (t0, s))
-                 uu____958)
-and subst_flags':
-  FStar_Syntax_Syntax.subst_ts ->
-    FStar_Syntax_Syntax.cflags Prims.list ->
-      FStar_Syntax_Syntax.cflags Prims.list
-  =
-  fun s  ->
-    fun flags  ->
-      FStar_All.pipe_right flags
-        (FStar_List.map
-           (fun uu___107_972  ->
-              match uu___107_972 with
-              | FStar_Syntax_Syntax.DECREASES a ->
-                  let uu____976 = subst' s a in
-                  FStar_Syntax_Syntax.DECREASES uu____976
-              | f -> f))
-and subst_comp_typ':
-  (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list* FStar_Range.range
-    Prims.option) ->
-    FStar_Syntax_Syntax.comp_typ -> FStar_Syntax_Syntax.comp_typ
-  =
-  fun s  ->
-    fun t  ->
-      match s with
-      | ([],None )|([]::[],None ) -> t
-      | uu____996 ->
-          let uu___113_1002 = t in
-          let uu____1003 =
-            FStar_List.map (subst_univ (Prims.fst s))
-              t.FStar_Syntax_Syntax.comp_univs in
-          let uu____1007 =
-            tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s in
-          let uu____1010 = subst' s t.FStar_Syntax_Syntax.result_typ in
-          let uu____1013 =
-            FStar_List.map
-              (fun uu____1027  ->
-                 match uu____1027 with
-                 | (t1,imp) ->
-                     let uu____1042 = subst' s t1 in (uu____1042, imp))
-              t.FStar_Syntax_Syntax.effect_args in
-          let uu____1047 = subst_flags' s t.FStar_Syntax_Syntax.flags in
-          {
-            FStar_Syntax_Syntax.comp_univs = uu____1003;
-            FStar_Syntax_Syntax.effect_name = uu____1007;
-            FStar_Syntax_Syntax.result_typ = uu____1010;
-            FStar_Syntax_Syntax.effect_args = uu____1013;
-            FStar_Syntax_Syntax.flags = uu____1047
-          }
-and subst_comp':
-  (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list* FStar_Range.range
-    Prims.option) ->
-    (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun s  ->
-    fun t  ->
-      match s with
-      | ([],None )|([]::[],None ) -> t
-      | uu____1069 ->
-          (match t.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (t1,uopt) ->
-               let uu____1085 = subst' s t1 in
-               let uu____1086 =
-                 FStar_Option.map (subst_univ (Prims.fst s)) uopt in
-               FStar_Syntax_Syntax.mk_Total' uu____1085 uu____1086
-           | FStar_Syntax_Syntax.GTotal (t1,uopt) ->
-               let uu____1099 = subst' s t1 in
-               let uu____1100 =
-                 FStar_Option.map (subst_univ (Prims.fst s)) uopt in
-               FStar_Syntax_Syntax.mk_GTotal' uu____1099 uu____1100
-           | FStar_Syntax_Syntax.Comp ct ->
-               let uu____1106 = subst_comp_typ' s ct in
-               FStar_Syntax_Syntax.mk_Comp uu____1106)
-let shift:
-  Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt
-  =
-  fun n1  ->
-    fun s  ->
-      match s with
-      | FStar_Syntax_Syntax.DB (i,t) -> FStar_Syntax_Syntax.DB ((i + n1), t)
-      | FStar_Syntax_Syntax.UN (i,t) -> FStar_Syntax_Syntax.UN ((i + n1), t)
-      | FStar_Syntax_Syntax.NM (x,i) -> FStar_Syntax_Syntax.NM (x, (i + n1))
-      | FStar_Syntax_Syntax.UD (x,i) -> FStar_Syntax_Syntax.UD (x, (i + n1))
-      | FStar_Syntax_Syntax.NT uu____1121 -> s
-let shift_subst:
-  Prims.int ->
-    FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_elt Prims.list
-  = fun n1  -> fun s  -> FStar_List.map (shift n1) s
-let shift_subst' n1 s =
-  let uu____1153 =
-    FStar_All.pipe_right (Prims.fst s) (FStar_List.map (shift_subst n1)) in
-  (uu____1153, (Prims.snd s))
-let subst_binder' s uu____1175 =
-  match uu____1175 with
-  | (x,imp) ->
-      let uu____1180 =
-        let uu___114_1181 = x in
-        let uu____1182 = subst' s x.FStar_Syntax_Syntax.sort in
-        {
-          FStar_Syntax_Syntax.ppname =
-            (uu___114_1181.FStar_Syntax_Syntax.ppname);
-          FStar_Syntax_Syntax.index =
-            (uu___114_1181.FStar_Syntax_Syntax.index);
-          FStar_Syntax_Syntax.sort = uu____1182
-        } in
-      (uu____1180, imp)
-let subst_binders' s bs =
-  FStar_All.pipe_right bs
-    (FStar_List.mapi
-       (fun i  ->
-          fun b  ->
-            if i = (Prims.parse_int "0")
-            then subst_binder' s b
-            else
-              (let uu____1223 = shift_subst' i s in
-               subst_binder' uu____1223 b)))
-let subst_binders:
-  FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.binders ->
-      (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  = fun s  -> fun bs  -> subst_binders' ([s], None) bs
-let subst_arg' s uu____1257 =
-  match uu____1257 with
-  | (t,imp) -> let uu____1268 = subst' s t in (uu____1268, imp)
-let subst_args' s = FStar_List.map (subst_arg' s)
-let subst_pat':
-  (FStar_Syntax_Syntax.subst_t Prims.list* FStar_Range.range Prims.option) ->
-    (FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.withinfo_t -> (FStar_Syntax_Syntax.pat* Prims.int)
-  =
-  fun s  ->
-    fun p  ->
-      let rec aux n1 p1 =
-        match p1.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_disj [] ->
-            failwith "Impossible: empty disjunction"
-        | FStar_Syntax_Syntax.Pat_constant uu____1343 -> (p1, n1)
-        | FStar_Syntax_Syntax.Pat_disj (p2::ps) ->
-            let uu____1355 = aux n1 p2 in
-            (match uu____1355 with
-             | (p3,m) ->
-                 let ps1 =
-                   FStar_List.map
-                     (fun p4  ->
-                        let uu____1369 = aux n1 p4 in Prims.fst uu____1369)
-                     ps in
-                 ((let uu___115_1374 = p3 in
-                   {
-                     FStar_Syntax_Syntax.v =
-                       (FStar_Syntax_Syntax.Pat_disj (p3 :: ps1));
-                     FStar_Syntax_Syntax.ty =
-                       (uu___115_1374.FStar_Syntax_Syntax.ty);
-                     FStar_Syntax_Syntax.p =
-                       (uu___115_1374.FStar_Syntax_Syntax.p)
-                   }), m))
-        | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-            let uu____1387 =
-              FStar_All.pipe_right pats
-                (FStar_List.fold_left
-                   (fun uu____1412  ->
-                      fun uu____1413  ->
-                        match (uu____1412, uu____1413) with
-                        | ((pats1,n2),(p2,imp)) ->
-                            let uu____1460 = aux n2 p2 in
-                            (match uu____1460 with
-                             | (p3,m) -> (((p3, imp) :: pats1), m))) 
-                   ([], n1)) in
-            (match uu____1387 with
-             | (pats1,n2) ->
-                 ((let uu___116_1492 = p1 in
-                   {
-                     FStar_Syntax_Syntax.v =
-                       (FStar_Syntax_Syntax.Pat_cons
-                          (fv, (FStar_List.rev pats1)));
-                     FStar_Syntax_Syntax.ty =
-                       (uu___116_1492.FStar_Syntax_Syntax.ty);
-                     FStar_Syntax_Syntax.p =
-                       (uu___116_1492.FStar_Syntax_Syntax.p)
-                   }), n2))
-        | FStar_Syntax_Syntax.Pat_var x ->
-            let s1 = shift_subst' n1 s in
-            let x1 =
-              let uu___117_1508 = x in
-              let uu____1509 = subst' s1 x.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname =
-                  (uu___117_1508.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___117_1508.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1509
-              } in
-            ((let uu___118_1514 = p1 in
-              {
-                FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-                FStar_Syntax_Syntax.ty =
-                  (uu___118_1514.FStar_Syntax_Syntax.ty);
-                FStar_Syntax_Syntax.p = (uu___118_1514.FStar_Syntax_Syntax.p)
-              }), (n1 + (Prims.parse_int "1")))
-        | FStar_Syntax_Syntax.Pat_wild x ->
-            let s1 = shift_subst' n1 s in
-            let x1 =
-              let uu___119_1525 = x in
-              let uu____1526 = subst' s1 x.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname =
-                  (uu___119_1525.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___119_1525.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1526
-              } in
-            ((let uu___120_1531 = p1 in
-              {
-                FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-                FStar_Syntax_Syntax.ty =
-                  (uu___120_1531.FStar_Syntax_Syntax.ty);
-                FStar_Syntax_Syntax.p = (uu___120_1531.FStar_Syntax_Syntax.p)
-              }), (n1 + (Prims.parse_int "1")))
-        | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-            let s1 = shift_subst' n1 s in
-            let x1 =
-              let uu___121_1547 = x in
-              let uu____1548 = subst' s1 x.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname =
-                  (uu___121_1547.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___121_1547.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1548
-              } in
-            let t01 = subst' s1 t0 in
-            ((let uu___122_1556 = p1 in
-              {
-                FStar_Syntax_Syntax.v =
-                  (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-                FStar_Syntax_Syntax.ty =
-                  (uu___122_1556.FStar_Syntax_Syntax.ty);
-                FStar_Syntax_Syntax.p = (uu___122_1556.FStar_Syntax_Syntax.p)
-              }), n1) in
-      aux (Prims.parse_int "0") p
-let push_subst_lcomp s lopt =
-  match lopt with
-  | None |Some (FStar_Util.Inr _) -> lopt
-  | Some (FStar_Util.Inl l) ->
-      let uu____1590 =
-        let uu____1593 =
-          let uu___123_1594 = l in
-          let uu____1595 = subst' s l.FStar_Syntax_Syntax.res_typ in
-          {
-            FStar_Syntax_Syntax.eff_name =
-              (uu___123_1594.FStar_Syntax_Syntax.eff_name);
-            FStar_Syntax_Syntax.res_typ = uu____1595;
-            FStar_Syntax_Syntax.cflags =
-              (uu___123_1594.FStar_Syntax_Syntax.cflags);
-            FStar_Syntax_Syntax.comp =
-              (fun uu____1598  ->
-                 let uu____1599 = l.FStar_Syntax_Syntax.comp () in
-                 subst_comp' s uu____1599)
-          } in
-        FStar_Util.Inl uu____1593 in
-      Some uu____1590
-let push_subst:
-  FStar_Syntax_Syntax.subst_ts ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun s  ->
-    fun t  ->
-      let mk1 t' =
-        let uu____1622 = mk_range t.FStar_Syntax_Syntax.pos s in
-        (FStar_Syntax_Syntax.mk t') None uu____1622 in
-      match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____1633 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_constant _
-        |FStar_Syntax_Syntax.Tm_fvar _
-         |FStar_Syntax_Syntax.Tm_unknown |FStar_Syntax_Syntax.Tm_uvar _ ->
-          tag_with_range t s
-      | FStar_Syntax_Syntax.Tm_type _
-        |FStar_Syntax_Syntax.Tm_bvar _|FStar_Syntax_Syntax.Tm_name _ ->
-          subst' s t
-      | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
-          let us1 = FStar_List.map (subst_univ (Prims.fst s)) us in
-          let uu____1675 = FStar_Syntax_Syntax.mk_Tm_uinst t' us1 in
-          tag_with_range uu____1675 s
-      | FStar_Syntax_Syntax.Tm_app (t0,args) ->
-          let uu____1696 =
-            let uu____1697 =
-              let uu____1707 = subst' s t0 in
-              let uu____1710 = (subst_args' s) args in
-              (uu____1707, uu____1710) in
-            FStar_Syntax_Syntax.Tm_app uu____1697 in
-          mk1 uu____1696
-      | FStar_Syntax_Syntax.Tm_ascribed (t0,(annot,topt),lopt) ->
-          let annot1 =
-            match annot with
-            | FStar_Util.Inl t1 ->
-                let uu____1782 = subst' s t1 in FStar_Util.Inl uu____1782
-            | FStar_Util.Inr c ->
-                let uu____1796 = subst_comp' s c in FStar_Util.Inr uu____1796 in
-          let uu____1803 =
-            let uu____1804 =
-              let uu____1822 = subst' s t0 in
-              let uu____1825 =
-                let uu____1837 = FStar_Util.map_opt topt (subst' s) in
-                (annot1, uu____1837) in
-              (uu____1822, uu____1825, lopt) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____1804 in
-          mk1 uu____1803
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-          let n1 = FStar_List.length bs in
-          let s' = shift_subst' n1 s in
-          let uu____1905 =
-            let uu____1906 =
-              let uu____1921 = subst_binders' s bs in
-              let uu____1925 = subst' s' body in
-              let uu____1928 = push_subst_lcomp s' lopt in
-              (uu____1921, uu____1925, uu____1928) in
-            FStar_Syntax_Syntax.Tm_abs uu____1906 in
-          mk1 uu____1905
-      | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
-          let n1 = FStar_List.length bs in
-          let uu____1965 =
-            let uu____1966 =
-              let uu____1974 = subst_binders' s bs in
-              let uu____1978 =
-                let uu____1981 = shift_subst' n1 s in
-                subst_comp' uu____1981 comp in
-              (uu____1974, uu____1978) in
-            FStar_Syntax_Syntax.Tm_arrow uu____1966 in
-          mk1 uu____1965
-      | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let x1 =
-            let uu___124_2002 = x in
-            let uu____2003 = subst' s x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___124_2002.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___124_2002.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2003
-            } in
-          let phi1 =
-            let uu____2009 = shift_subst' (Prims.parse_int "1") s in
-            subst' uu____2009 phi in
-          mk1 (FStar_Syntax_Syntax.Tm_refine (x1, phi1))
-      | FStar_Syntax_Syntax.Tm_match (t0,pats) ->
-          let t01 = subst' s t0 in
-          let pats1 =
-            FStar_All.pipe_right pats
-              (FStar_List.map
-                 (fun uu____2092  ->
-                    match uu____2092 with
-                    | (pat,wopt,branch) ->
-                        let uu____2128 = subst_pat' s pat in
-                        (match uu____2128 with
-                         | (pat1,n1) ->
-                             let s1 = shift_subst' n1 s in
-                             let wopt1 =
-                               match wopt with
-                               | None  -> None
-                               | Some w ->
-                                   let uu____2163 = subst' s1 w in
-                                   Some uu____2163 in
-                             let branch1 = subst' s1 branch in
-                             (pat1, wopt1, branch1)))) in
-          mk1 (FStar_Syntax_Syntax.Tm_match (t01, pats1))
-      | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),body) ->
-          let n1 = FStar_List.length lbs in
-          let sn = shift_subst' n1 s in
-          let body1 = subst' sn body in
-          let lbs1 =
-            FStar_All.pipe_right lbs
-              (FStar_List.map
-                 (fun lb  ->
-                    let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp in
-                    let lbd =
-                      let uu____2223 =
-                        is_rec &&
-                          (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname) in
-                      if uu____2223
-                      then subst' sn lb.FStar_Syntax_Syntax.lbdef
-                      else subst' s lb.FStar_Syntax_Syntax.lbdef in
-                    let lbname =
-                      match lb.FStar_Syntax_Syntax.lbname with
-                      | FStar_Util.Inl x ->
-                          FStar_Util.Inl
-                            (let uu___125_2233 = x in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (uu___125_2233.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (uu___125_2233.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = lbt
-                             })
-                      | FStar_Util.Inr fv ->
-                          FStar_Util.Inr
-                            (let uu___126_2235 = fv in
-                             {
-                               FStar_Syntax_Syntax.fv_name =
-                                 (let uu___127_2236 =
-                                    fv.FStar_Syntax_Syntax.fv_name in
-                                  {
-                                    FStar_Syntax_Syntax.v =
-                                      (uu___127_2236.FStar_Syntax_Syntax.v);
-                                    FStar_Syntax_Syntax.ty = lbt;
-                                    FStar_Syntax_Syntax.p =
-                                      (uu___127_2236.FStar_Syntax_Syntax.p)
-                                  });
-                               FStar_Syntax_Syntax.fv_delta =
-                                 (uu___126_2235.FStar_Syntax_Syntax.fv_delta);
-                               FStar_Syntax_Syntax.fv_qual =
-                                 (uu___126_2235.FStar_Syntax_Syntax.fv_qual)
-                             }) in
-                    let uu___128_2251 = lb in
-                    {
-                      FStar_Syntax_Syntax.lbname = lbname;
-                      FStar_Syntax_Syntax.lbunivs =
-                        (uu___128_2251.FStar_Syntax_Syntax.lbunivs);
-                      FStar_Syntax_Syntax.lbtyp = lbt;
-                      FStar_Syntax_Syntax.lbeff =
-                        (uu___128_2251.FStar_Syntax_Syntax.lbeff);
-                      FStar_Syntax_Syntax.lbdef = lbd
-                    })) in
-          mk1 (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs1), body1))
-      | FStar_Syntax_Syntax.Tm_meta (t0,FStar_Syntax_Syntax.Meta_pattern ps)
-          ->
-          let uu____2270 =
-            let uu____2271 =
-              let uu____2276 = subst' s t0 in
-              let uu____2279 =
-                let uu____2280 =
-                  FStar_All.pipe_right ps (FStar_List.map (subst_args' s)) in
-                FStar_Syntax_Syntax.Meta_pattern uu____2280 in
-              (uu____2276, uu____2279) in
-            FStar_Syntax_Syntax.Tm_meta uu____2271 in
-          mk1 uu____2270
-      | FStar_Syntax_Syntax.Tm_meta
-          (t0,FStar_Syntax_Syntax.Meta_monadic (m,t1)) ->
-          let uu____2322 =
-            let uu____2323 =
-              let uu____2328 = subst' s t0 in
-              let uu____2331 =
-                let uu____2332 =
-                  let uu____2337 = subst' s t1 in (m, uu____2337) in
-                FStar_Syntax_Syntax.Meta_monadic uu____2332 in
-              (uu____2328, uu____2331) in
-            FStar_Syntax_Syntax.Tm_meta uu____2323 in
-          mk1 uu____2322
-      | FStar_Syntax_Syntax.Tm_meta
-          (t0,FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t1)) ->
-          let uu____2356 =
-            let uu____2357 =
-              let uu____2362 = subst' s t0 in
-              let uu____2365 =
-                let uu____2366 =
-                  let uu____2372 = subst' s t1 in (m1, m2, uu____2372) in
-                FStar_Syntax_Syntax.Meta_monadic_lift uu____2366 in
-              (uu____2362, uu____2365) in
-            FStar_Syntax_Syntax.Tm_meta uu____2357 in
-          mk1 uu____2356
-      | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-          let uu____2385 =
-            let uu____2386 = let uu____2391 = subst' s t1 in (uu____2391, m) in
-            FStar_Syntax_Syntax.Tm_meta uu____2386 in
-          mk1 uu____2385
-let rec compress: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  ->
-    let t1 = force_delayed_thunk t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t2,s),memo) ->
-        let t' = let uu____2454 = push_subst s t2 in compress uu____2454 in
-        (FStar_Unionfind.update_in_tx memo (Some t'); t')
-    | uu____2461 ->
-        let t' = force_uvar t1 in
-        (match t'.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_delayed uu____2465 -> compress t'
-         | uu____2486 -> t')
-let subst:
-  FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  = fun s  -> fun t  -> subst' ([s], None) t
-let set_use_range:
-  FStar_Range.range ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun r  ->
-    fun t  ->
-      subst'
-        ([],
-          (Some
-             (let uu___129_2510 = r in
-              {
-                FStar_Range.def_range = (r.FStar_Range.use_range);
-                FStar_Range.use_range = (uu___129_2510.FStar_Range.use_range)
-              }))) t
-let subst_comp:
-  FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  = fun s  -> fun t  -> subst_comp' ([s], None) t
-let closing_subst bs =
-  let uu____2538 =
-    FStar_List.fold_right
-      (fun uu____2547  ->
-         fun uu____2548  ->
-           match (uu____2547, uu____2548) with
-           | ((x,uu____2563),(subst1,n1)) ->
-               (((FStar_Syntax_Syntax.NM (x, n1)) :: subst1),
-                 (n1 + (Prims.parse_int "1")))) bs
-      ([], (Prims.parse_int "0")) in
-  FStar_All.pipe_right uu____2538 Prims.fst
-let open_binders' bs =
-  let rec aux bs1 o =
-    match bs1 with
-    | [] -> ([], o)
-    | (x,imp)::bs' ->
-        let x' =
-          let uu___130_2643 = FStar_Syntax_Syntax.freshen_bv x in
-          let uu____2644 = subst o x.FStar_Syntax_Syntax.sort in
-          {
-            FStar_Syntax_Syntax.ppname =
-              (uu___130_2643.FStar_Syntax_Syntax.ppname);
-            FStar_Syntax_Syntax.index =
-              (uu___130_2643.FStar_Syntax_Syntax.index);
-            FStar_Syntax_Syntax.sort = uu____2644
-          } in
-        let o1 =
-          let uu____2649 = shift_subst (Prims.parse_int "1") o in
-          (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) :: uu____2649 in
-        let uu____2651 = aux bs' o1 in
-        (match uu____2651 with | (bs'1,o2) -> (((x', imp) :: bs'1), o2)) in
-  aux bs []
-let open_binders:
-  FStar_Syntax_Syntax.binders ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  = fun bs  -> let uu____2683 = open_binders' bs in Prims.fst uu____2683
-let open_term':
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.term*
-        FStar_Syntax_Syntax.subst_t)
-  =
-  fun bs  ->
-    fun t  ->
-      let uu____2703 = open_binders' bs in
-      match uu____2703 with
-      | (bs',opening) ->
-          let uu____2723 = subst opening t in (bs', uu____2723, opening)
-let open_term:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.term)
-  =
-  fun bs  ->
-    fun t  ->
-      let uu____2736 = open_term' bs t in
-      match uu____2736 with | (b,t1,uu____2744) -> (b, t1)
-let open_comp:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.comp)
-  =
-  fun bs  ->
-    fun t  ->
-      let uu____2753 = open_binders' bs in
-      match uu____2753 with
-      | (bs',opening) ->
-          let uu____2772 = subst_comp opening t in (bs', uu____2772)
-let open_pat:
-  FStar_Syntax_Syntax.pat ->
-    (FStar_Syntax_Syntax.pat* FStar_Syntax_Syntax.subst_t)
-  =
-  fun p  ->
-    let rec aux_disj sub1 renaming p1 =
-      match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_disj uu____2809 -> failwith "impossible"
-      | FStar_Syntax_Syntax.Pat_constant uu____2815 -> p1
-      | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu___131_2828 = p1 in
-          let uu____2831 =
-            let uu____2832 =
-              let uu____2840 =
-                FStar_All.pipe_right pats
-                  (FStar_List.map
-                     (fun uu____2864  ->
-                        match uu____2864 with
-                        | (p2,b) ->
-                            let uu____2879 = aux_disj sub1 renaming p2 in
-                            (uu____2879, b))) in
-              (fv, uu____2840) in
-            FStar_Syntax_Syntax.Pat_cons uu____2832 in
-          {
-            FStar_Syntax_Syntax.v = uu____2831;
-            FStar_Syntax_Syntax.ty = (uu___131_2828.FStar_Syntax_Syntax.ty);
-            FStar_Syntax_Syntax.p = (uu___131_2828.FStar_Syntax_Syntax.p)
-          }
-      | FStar_Syntax_Syntax.Pat_var x ->
-          let yopt =
-            FStar_Util.find_map renaming
-              (fun uu___108_2894  ->
-                 match uu___108_2894 with
-                 | (x',y) when
-                     (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText =
-                       (x'.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                     -> Some y
-                 | uu____2900 -> None) in
-          let y =
-            match yopt with
-            | None  ->
-                let uu___132_2904 = FStar_Syntax_Syntax.freshen_bv x in
-                let uu____2905 = subst sub1 x.FStar_Syntax_Syntax.sort in
-                {
-                  FStar_Syntax_Syntax.ppname =
-                    (uu___132_2904.FStar_Syntax_Syntax.ppname);
-                  FStar_Syntax_Syntax.index =
-                    (uu___132_2904.FStar_Syntax_Syntax.index);
-                  FStar_Syntax_Syntax.sort = uu____2905
-                }
-            | Some y -> y in
-          let uu___133_2909 = p1 in
-          {
-            FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var y);
-            FStar_Syntax_Syntax.ty = (uu___133_2909.FStar_Syntax_Syntax.ty);
-            FStar_Syntax_Syntax.p = (uu___133_2909.FStar_Syntax_Syntax.p)
-          }
-      | FStar_Syntax_Syntax.Pat_wild x ->
-          let x' =
-            let uu___134_2914 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____2915 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___134_2914.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___134_2914.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2915
-            } in
-          let uu___135_2918 = p1 in
-          {
-            FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
-            FStar_Syntax_Syntax.ty = (uu___135_2918.FStar_Syntax_Syntax.ty);
-            FStar_Syntax_Syntax.p = (uu___135_2918.FStar_Syntax_Syntax.p)
-          }
-      | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-          let x1 =
-            let uu___136_2928 = x in
-            let uu____2929 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___136_2928.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___136_2928.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2929
-            } in
-          let t01 = subst sub1 t0 in
-          let uu___137_2933 = p1 in
-          {
-            FStar_Syntax_Syntax.v =
-              (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-            FStar_Syntax_Syntax.ty = (uu___137_2933.FStar_Syntax_Syntax.ty);
-            FStar_Syntax_Syntax.p = (uu___137_2933.FStar_Syntax_Syntax.p)
-          } in
-    let rec aux sub1 renaming p1 =
-      match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_disj [] ->
-          failwith "Impossible: empty disjunction"
-      | FStar_Syntax_Syntax.Pat_constant uu____2987 -> (p1, sub1, renaming)
-      | FStar_Syntax_Syntax.Pat_disj (p2::ps) ->
-          let uu____3003 = aux sub1 renaming p2 in
-          (match uu____3003 with
-           | (p3,sub2,renaming1) ->
-               let ps1 = FStar_List.map (aux_disj sub2 renaming1) ps in
-               ((let uu___138_3051 = p3 in
-                 {
-                   FStar_Syntax_Syntax.v =
-                     (FStar_Syntax_Syntax.Pat_disj (p3 :: ps1));
-                   FStar_Syntax_Syntax.ty =
-                     (uu___138_3051.FStar_Syntax_Syntax.ty);
-                   FStar_Syntax_Syntax.p =
-                     (uu___138_3051.FStar_Syntax_Syntax.p)
-                 }), sub2, renaming1))
-      | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____3068 =
-            FStar_All.pipe_right pats
-              (FStar_List.fold_left
-                 (fun uu____3114  ->
-                    fun uu____3115  ->
-                      match (uu____3114, uu____3115) with
-                      | ((pats1,sub2,renaming1),(p2,imp)) ->
-                          let uu____3203 = aux sub2 renaming1 p2 in
-                          (match uu____3203 with
-                           | (p3,sub3,renaming2) ->
-                               (((p3, imp) :: pats1), sub3, renaming2)))
-                 ([], sub1, renaming)) in
-          (match uu____3068 with
-           | (pats1,sub2,renaming1) ->
-               ((let uu___139_3304 = p1 in
-                 {
-                   FStar_Syntax_Syntax.v =
-                     (FStar_Syntax_Syntax.Pat_cons
-                        (fv, (FStar_List.rev pats1)));
-                   FStar_Syntax_Syntax.ty =
-                     (uu___139_3304.FStar_Syntax_Syntax.ty);
-                   FStar_Syntax_Syntax.p =
-                     (uu___139_3304.FStar_Syntax_Syntax.p)
-                 }), sub2, renaming1))
-      | FStar_Syntax_Syntax.Pat_var x ->
-          let x' =
-            let uu___140_3318 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____3319 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___140_3318.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___140_3318.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3319
-            } in
-          let sub2 =
-            let uu____3324 = shift_subst (Prims.parse_int "1") sub1 in
-            (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) ::
-              uu____3324 in
-          ((let uu___141_3332 = p1 in
-            {
-              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x');
-              FStar_Syntax_Syntax.ty = (uu___141_3332.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___141_3332.FStar_Syntax_Syntax.p)
-            }), sub2, ((x, x') :: renaming))
-      | FStar_Syntax_Syntax.Pat_wild x ->
-          let x' =
-            let uu___142_3339 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____3340 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___142_3339.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___142_3339.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3340
-            } in
-          let sub2 =
-            let uu____3345 = shift_subst (Prims.parse_int "1") sub1 in
-            (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) ::
-              uu____3345 in
-          ((let uu___143_3353 = p1 in
-            {
-              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
-              FStar_Syntax_Syntax.ty = (uu___143_3353.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___143_3353.FStar_Syntax_Syntax.p)
-            }), sub2, ((x, x') :: renaming))
-      | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-          let x1 =
-            let uu___144_3365 = x in
-            let uu____3366 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___144_3365.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___144_3365.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3366
-            } in
-          let t01 = subst sub1 t0 in
-          ((let uu___145_3376 = p1 in
-            {
-              FStar_Syntax_Syntax.v =
-                (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.ty = (uu___145_3376.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___145_3376.FStar_Syntax_Syntax.p)
-            }), sub1, renaming) in
-    let uu____3379 = aux [] [] p in
-    match uu____3379 with | (p1,sub1,uu____3395) -> (p1, sub1)
-let open_branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
-  fun uu____3413  ->
-    match uu____3413 with
-    | (p,wopt,e) ->
-        let uu____3431 = open_pat p in
-        (match uu____3431 with
-         | (p1,opening) ->
-             let wopt1 =
-               match wopt with
-               | None  -> None
-               | Some w ->
-                   let uu____3446 = subst opening w in Some uu____3446 in
-             let e1 = subst opening e in (p1, wopt1, e1))
-let close:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun bs  ->
-    fun t  -> let uu____3455 = closing_subst bs in subst uu____3455 t
-let close_comp:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
-  =
-  fun bs  ->
-    fun c  -> let uu____3463 = closing_subst bs in subst_comp uu____3463 c
-let close_binders:
-  FStar_Syntax_Syntax.binders ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun bs  ->
-    let rec aux s bs1 =
-      match bs1 with
-      | [] -> []
-      | (x,imp)::tl1 ->
-          let x1 =
-            let uu___146_3496 = x in
-            let uu____3497 = subst s x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___146_3496.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___146_3496.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3497
-            } in
-          let s' =
-            let uu____3502 = shift_subst (Prims.parse_int "1") s in
-            (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____3502 in
-          let uu____3504 = aux s' tl1 in (x1, imp) :: uu____3504 in
-    aux [] bs
-let close_lcomp:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun bs  ->
-    fun lc  ->
-      let s = closing_subst bs in
-      let uu___147_3518 = lc in
-      let uu____3519 = subst s lc.FStar_Syntax_Syntax.res_typ in
-      {
-        FStar_Syntax_Syntax.eff_name =
-          (uu___147_3518.FStar_Syntax_Syntax.eff_name);
-        FStar_Syntax_Syntax.res_typ = uu____3519;
-        FStar_Syntax_Syntax.cflags =
-          (uu___147_3518.FStar_Syntax_Syntax.cflags);
-        FStar_Syntax_Syntax.comp =
-          (fun uu____3522  ->
-             let uu____3523 = lc.FStar_Syntax_Syntax.comp () in
-             subst_comp s uu____3523)
-      }
-let close_pat:
-  (FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.withinfo_t ->
-    ((FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.withinfo_t* FStar_Syntax_Syntax.subst_elt
-      Prims.list)
-  =
-  fun p  ->
-    let rec aux sub1 p1 =
-      match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_disj [] ->
-          failwith "Impossible: empty disjunction"
-      | FStar_Syntax_Syntax.Pat_constant uu____3566 -> (p1, sub1)
-      | FStar_Syntax_Syntax.Pat_disj (p2::ps) ->
-          let uu____3579 = aux sub1 p2 in
-          (match uu____3579 with
-           | (p3,sub2) ->
-               let ps1 =
-                 FStar_List.map
-                   (fun p4  ->
-                      let uu____3609 = aux sub2 p4 in Prims.fst uu____3609)
-                   ps in
-               ((let uu___148_3621 = p3 in
-                 {
-                   FStar_Syntax_Syntax.v =
-                     (FStar_Syntax_Syntax.Pat_disj (p3 :: ps1));
-                   FStar_Syntax_Syntax.ty =
-                     (uu___148_3621.FStar_Syntax_Syntax.ty);
-                   FStar_Syntax_Syntax.p =
-                     (uu___148_3621.FStar_Syntax_Syntax.p)
-                 }), sub2))
-      | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____3638 =
-            FStar_All.pipe_right pats
-              (FStar_List.fold_left
-                 (fun uu____3672  ->
-                    fun uu____3673  ->
-                      match (uu____3672, uu____3673) with
-                      | ((pats1,sub2),(p2,imp)) ->
-                          let uu____3738 = aux sub2 p2 in
-                          (match uu____3738 with
-                           | (p3,sub3) -> (((p3, imp) :: pats1), sub3)))
-                 ([], sub1)) in
-          (match uu____3638 with
-           | (pats1,sub2) ->
-               ((let uu___149_3804 = p1 in
-                 {
-                   FStar_Syntax_Syntax.v =
-                     (FStar_Syntax_Syntax.Pat_cons
-                        (fv, (FStar_List.rev pats1)));
-                   FStar_Syntax_Syntax.ty =
-                     (uu___149_3804.FStar_Syntax_Syntax.ty);
-                   FStar_Syntax_Syntax.p =
-                     (uu___149_3804.FStar_Syntax_Syntax.p)
-                 }), sub2))
-      | FStar_Syntax_Syntax.Pat_var x ->
-          let x1 =
-            let uu___150_3818 = x in
-            let uu____3819 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___150_3818.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___150_3818.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3819
-            } in
-          let sub2 =
-            let uu____3824 = shift_subst (Prims.parse_int "1") sub1 in
-            (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____3824 in
-          ((let uu___151_3829 = p1 in
-            {
-              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-              FStar_Syntax_Syntax.ty = (uu___151_3829.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___151_3829.FStar_Syntax_Syntax.p)
-            }), sub2)
-      | FStar_Syntax_Syntax.Pat_wild x ->
-          let x1 =
-            let uu___152_3834 = x in
-            let uu____3835 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___152_3834.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___152_3834.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3835
-            } in
-          let sub2 =
-            let uu____3840 = shift_subst (Prims.parse_int "1") sub1 in
-            (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____3840 in
-          ((let uu___153_3845 = p1 in
-            {
-              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-              FStar_Syntax_Syntax.ty = (uu___153_3845.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___153_3845.FStar_Syntax_Syntax.p)
-            }), sub2)
-      | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-          let x1 =
-            let uu___154_3855 = x in
-            let uu____3856 = subst sub1 x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___154_3855.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___154_3855.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3856
-            } in
-          let t01 = subst sub1 t0 in
-          ((let uu___155_3863 = p1 in
-            {
-              FStar_Syntax_Syntax.v =
-                (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.ty = (uu___155_3863.FStar_Syntax_Syntax.ty);
-              FStar_Syntax_Syntax.p = (uu___155_3863.FStar_Syntax_Syntax.p)
-            }), sub1) in
-    aux [] p
-let close_branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
-  fun uu____3868  ->
-    match uu____3868 with
-    | (p,wopt,e) ->
-        let uu____3886 = close_pat p in
-        (match uu____3886 with
-         | (p1,closing) ->
-             let wopt1 =
-               match wopt with
-               | None  -> None
-               | Some w ->
-                   let uu____3910 = subst closing w in Some uu____3910 in
-             let e1 = subst closing e in (p1, wopt1, e1))
-let univ_var_opening:
-  FStar_Syntax_Syntax.univ_names ->
-    (FStar_Syntax_Syntax.subst_elt Prims.list* FStar_Syntax_Syntax.univ_name
-      Prims.list)
-  =
-  fun us  ->
-    let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
-    let uu____3926 =
-      let uu____3931 =
-        FStar_All.pipe_right us
-          (FStar_List.mapi
-             (fun i  ->
-                fun u  ->
-                  let u' =
-                    FStar_Syntax_Syntax.new_univ_name
-                      (Some (u.FStar_Ident.idRange)) in
-                  ((FStar_Syntax_Syntax.UN
-                      ((n1 - i), (FStar_Syntax_Syntax.U_name u'))), u'))) in
-      FStar_All.pipe_right uu____3931 FStar_List.unzip in
-    match uu____3926 with | (s,us') -> (s, us')
-let open_univ_vars:
-  FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.univ_names* FStar_Syntax_Syntax.term)
-  =
-  fun us  ->
-    fun t  ->
-      let uu____3972 = univ_var_opening us in
-      match uu____3972 with | (s,us') -> let t1 = subst s t in (us', t1)
-let open_univ_vars_comp:
-  FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.univ_names* FStar_Syntax_Syntax.comp)
-  =
-  fun us  ->
-    fun c  ->
-      let uu____3997 = univ_var_opening us in
-      match uu____3997 with
-      | (s,us') -> let uu____4010 = subst_comp s c in (us', uu____4010)
-let close_univ_vars:
-  FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun us  ->
-    fun t  ->
-      let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
-      let s =
-        FStar_All.pipe_right us
-          (FStar_List.mapi
-             (fun i  -> fun u  -> FStar_Syntax_Syntax.UD (u, (n1 - i)))) in
-      subst s t
-let close_univ_vars_comp:
-  FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
-  =
-  fun us  ->
-    fun c  ->
-      let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
-      let s =
-        FStar_All.pipe_right us
-          (FStar_List.mapi
-             (fun i  -> fun u  -> FStar_Syntax_Syntax.UD (u, (n1 - i)))) in
-      subst_comp s c
-let open_let_rec:
-  FStar_Syntax_Syntax.letbinding Prims.list ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.letbinding Prims.list* FStar_Syntax_Syntax.term)
-  =
-  fun lbs  ->
-    fun t  ->
-      let uu____4053 = FStar_Syntax_Syntax.is_top_level lbs in
-      if uu____4053
-      then (lbs, t)
-      else
-        (let uu____4059 =
-           FStar_List.fold_right
-             (fun lb  ->
-                fun uu____4071  ->
-                  match uu____4071 with
-                  | (i,lbs1,out) ->
-                      let x =
-                        let uu____4090 =
-                          FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                        FStar_Syntax_Syntax.freshen_bv uu____4090 in
-                      ((i + (Prims.parse_int "1")),
-                        ((let uu___156_4093 = lb in
-                          {
-                            FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
-                            FStar_Syntax_Syntax.lbunivs =
-                              (uu___156_4093.FStar_Syntax_Syntax.lbunivs);
-                            FStar_Syntax_Syntax.lbtyp =
-                              (uu___156_4093.FStar_Syntax_Syntax.lbtyp);
-                            FStar_Syntax_Syntax.lbeff =
-                              (uu___156_4093.FStar_Syntax_Syntax.lbeff);
-                            FStar_Syntax_Syntax.lbdef =
-                              (uu___156_4093.FStar_Syntax_Syntax.lbdef)
-                          }) :: lbs1), ((FStar_Syntax_Syntax.DB (i, x)) ::
-                        out))) lbs ((Prims.parse_int "0"), [], []) in
-         match uu____4059 with
-         | (n_let_recs,lbs1,let_rec_opening) ->
-             let lbs2 =
-               FStar_All.pipe_right lbs1
-                 (FStar_List.map
-                    (fun lb  ->
-                       let uu____4111 =
-                         FStar_List.fold_right
-                           (fun u  ->
-                              fun uu____4123  ->
-                                match uu____4123 with
-                                | (i,us,out) ->
-                                    let u1 =
-                                      FStar_Syntax_Syntax.new_univ_name None in
-                                    ((i + (Prims.parse_int "1")), (u1 :: us),
-                                      ((FStar_Syntax_Syntax.UN
-                                          (i,
-                                            (FStar_Syntax_Syntax.U_name u1)))
-                                      :: out)))
-                           lb.FStar_Syntax_Syntax.lbunivs
-                           (n_let_recs, [], let_rec_opening) in
-                       match uu____4111 with
-                       | (uu____4146,us,u_let_rec_opening) ->
-                           let uu___157_4153 = lb in
-                           let uu____4154 =
-                             subst u_let_rec_opening
-                               lb.FStar_Syntax_Syntax.lbdef in
-                           {
-                             FStar_Syntax_Syntax.lbname =
-                               (uu___157_4153.FStar_Syntax_Syntax.lbname);
-                             FStar_Syntax_Syntax.lbunivs = us;
-                             FStar_Syntax_Syntax.lbtyp =
-                               (uu___157_4153.FStar_Syntax_Syntax.lbtyp);
-                             FStar_Syntax_Syntax.lbeff =
-                               (uu___157_4153.FStar_Syntax_Syntax.lbeff);
-                             FStar_Syntax_Syntax.lbdef = uu____4154
-                           })) in
-             let t1 = subst let_rec_opening t in (lbs2, t1))
-let close_let_rec:
-  FStar_Syntax_Syntax.letbinding Prims.list ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.letbinding Prims.list* FStar_Syntax_Syntax.term)
-  =
-  fun lbs  ->
-    fun t  ->
-      let uu____4170 = FStar_Syntax_Syntax.is_top_level lbs in
-      if uu____4170
-      then (lbs, t)
-      else
-        (let uu____4176 =
-           FStar_List.fold_right
-             (fun lb  ->
-                fun uu____4184  ->
-                  match uu____4184 with
-                  | (i,out) ->
-                      let uu____4195 =
-                        let uu____4197 =
-                          let uu____4198 =
-                            let uu____4201 =
-                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                            (uu____4201, i) in
-                          FStar_Syntax_Syntax.NM uu____4198 in
-                        uu____4197 :: out in
-                      ((i + (Prims.parse_int "1")), uu____4195)) lbs
-             ((Prims.parse_int "0"), []) in
-         match uu____4176 with
-         | (n_let_recs,let_rec_closing) ->
-             let lbs1 =
-               FStar_All.pipe_right lbs
-                 (FStar_List.map
-                    (fun lb  ->
-                       let uu____4216 =
-                         FStar_List.fold_right
-                           (fun u  ->
-                              fun uu____4224  ->
-                                match uu____4224 with
-                                | (i,out) ->
-                                    ((i + (Prims.parse_int "1")),
-                                      ((FStar_Syntax_Syntax.UD (u, i)) ::
-                                      out))) lb.FStar_Syntax_Syntax.lbunivs
-                           (n_let_recs, let_rec_closing) in
-                       match uu____4216 with
-                       | (uu____4237,u_let_rec_closing) ->
-                           let uu___158_4241 = lb in
-                           let uu____4242 =
-                             subst u_let_rec_closing
-                               lb.FStar_Syntax_Syntax.lbdef in
-                           {
-                             FStar_Syntax_Syntax.lbname =
-                               (uu___158_4241.FStar_Syntax_Syntax.lbname);
-                             FStar_Syntax_Syntax.lbunivs =
-                               (uu___158_4241.FStar_Syntax_Syntax.lbunivs);
-                             FStar_Syntax_Syntax.lbtyp =
-                               (uu___158_4241.FStar_Syntax_Syntax.lbtyp);
-                             FStar_Syntax_Syntax.lbeff =
-                               (uu___158_4241.FStar_Syntax_Syntax.lbeff);
-                             FStar_Syntax_Syntax.lbdef = uu____4242
-                           })) in
-             let t1 = subst let_rec_closing t in (lbs1, t1))
-let close_tscheme:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.tscheme ->
-      (FStar_Syntax_Syntax.univ_name Prims.list* FStar_Syntax_Syntax.term)
-  =
-  fun binders  ->
-    fun uu____4252  ->
-      match uu____4252 with
-      | (us,t) ->
-          let n1 = (FStar_List.length binders) - (Prims.parse_int "1") in
-          let k = FStar_List.length us in
-          let s =
-            FStar_List.mapi
-              (fun i  ->
-                 fun uu____4270  ->
-                   match uu____4270 with
-                   | (x,uu____4274) ->
-                       FStar_Syntax_Syntax.NM (x, (k + (n1 - i)))) binders in
-          let t1 = subst s t in (us, t1)
-let close_univ_vars_tscheme:
-  FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.tscheme ->
-      (FStar_Syntax_Syntax.univ_name Prims.list* FStar_Syntax_Syntax.term)
-  =
-  fun us  ->
-    fun uu____4285  ->
-      match uu____4285 with
-      | (us',t) ->
-          let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
-          let k = FStar_List.length us' in
-          let s =
-            FStar_List.mapi
-              (fun i  -> fun x  -> FStar_Syntax_Syntax.UD (x, (k + (n1 - i))))
-              us in
-          let uu____4303 = subst s t in (us', uu____4303)
-let opening_of_binders:
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list =
-  fun bs  ->
-    let n1 = (FStar_List.length bs) - (Prims.parse_int "1") in
-    FStar_All.pipe_right bs
-      (FStar_List.mapi
-         (fun i  ->
-            fun uu____4318  ->
-              match uu____4318 with
-              | (x,uu____4322) -> FStar_Syntax_Syntax.DB ((n1 - i), x)))
+
+let subst_to_string = (fun s -> (
+
+let uu____14 = (FStar_All.pipe_right s (FStar_List.map (fun uu____22 -> (match (uu____22) with
+| (b, uu____26) -> begin
+b.FStar_Syntax_Syntax.ppname.FStar_Ident.idText
+end))))
+in (FStar_All.pipe_right uu____14 (FStar_String.concat ", "))))
+
+
+let rec apply_until_some = (fun f s -> (match (s) with
+| [] -> begin
+None
+end
+| (s0)::rest -> begin
+(
+
+let uu____61 = (f s0)
+in (match (uu____61) with
+| None -> begin
+(apply_until_some f rest)
+end
+| Some (st) -> begin
+Some (((rest), (st)))
+end))
+end))
+
+
+let map_some_curry = (fun f x uu___98_101 -> (match (uu___98_101) with
+| None -> begin
+x
+end
+| Some (a, b) -> begin
+(f a b)
+end))
+
+
+let apply_until_some_then_map = (fun f s g t -> (
+
+let uu____162 = (apply_until_some f s)
+in (FStar_All.pipe_right uu____162 (map_some_curry g t))))
+
+
+let compose_subst = (fun s1 s2 -> (
+
+let s = (FStar_List.append (Prims.fst s1) (Prims.fst s2))
+in (
+
+let ropt = (match ((Prims.snd s2)) with
+| Some (uu____217) -> begin
+(Prims.snd s2)
+end
+| uu____220 -> begin
+(Prims.snd s1)
+end)
+in ((s), (ropt)))))
+
+
+let delay : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)  ->  FStar_Syntax_Syntax.term = (fun t s -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t', s'), m) -> begin
+(FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (((t'), ((compose_subst s' s))))) t.FStar_Syntax_Syntax.pos)
+end
+| uu____316 -> begin
+(FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (((t), (s)))) t.FStar_Syntax_Syntax.pos)
+end))
+
+
+let rec force_uvar' : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uvar (uv, uu____347) -> begin
+(
+
+let uu____360 = (FStar_Unionfind.find uv)
+in (match (uu____360) with
+| FStar_Syntax_Syntax.Fixed (t') -> begin
+(force_uvar' t')
+end
+| uu____374 -> begin
+t
+end))
+end
+| uu____378 -> begin
+t
+end))
+
+
+let force_uvar : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun t -> (
+
+let t' = (force_uvar' t)
+in (
+
+let uu____391 = (FStar_Util.physical_equality t t')
+in (match (uu____391) with
+| true -> begin
+t
+end
+| uu____396 -> begin
+(delay t' (([]), (Some (t.FStar_Syntax_Syntax.pos))))
+end))))
+
+
+let rec force_delayed_thunk : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (f, m) -> begin
+(
+
+let uu____450 = (FStar_ST.read m)
+in (match (uu____450) with
+| None -> begin
+(match (f) with
+| FStar_Util.Inr (c) -> begin
+(
+
+let t' = (
+
+let uu____486 = (c ())
+in (force_delayed_thunk uu____486))
+in ((FStar_ST.write m (Some (t')));
+t';
+))
+end
+| uu____497 -> begin
+t
+end)
+end
+| Some (t') -> begin
+(
+
+let t'1 = (force_delayed_thunk t')
+in ((FStar_ST.write m (Some (t'1)));
+t'1;
+))
+end))
+end
+| uu____529 -> begin
+t
+end))
+
+
+let rec compress_univ : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun u -> (match (u) with
+| FStar_Syntax_Syntax.U_unif (u') -> begin
+(
+
+let uu____536 = (FStar_Unionfind.find u')
+in (match (uu____536) with
+| Some (u1) -> begin
+(compress_univ u1)
+end
+| uu____540 -> begin
+u
+end))
+end
+| uu____542 -> begin
+u
+end))
+
+
+let subst_bv : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.term Prims.option = (fun a s -> (FStar_Util.find_map s (fun uu___99_552 -> (match (uu___99_552) with
+| FStar_Syntax_Syntax.DB (i, x) when (i = a.FStar_Syntax_Syntax.index) -> begin
+(
+
+let uu____556 = (
+
+let uu____557 = (
+
+let uu____558 = (FStar_Syntax_Syntax.range_of_bv a)
+in (FStar_Syntax_Syntax.set_range_of_bv x uu____558))
+in (FStar_Syntax_Syntax.bv_to_name uu____557))
+in Some (uu____556))
+end
+| uu____559 -> begin
+None
+end))))
+
+
+let subst_nm : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.term Prims.option = (fun a s -> (FStar_Util.find_map s (fun uu___100_569 -> (match (uu___100_569) with
+| FStar_Syntax_Syntax.NM (x, i) when (FStar_Syntax_Syntax.bv_eq a x) -> begin
+(
+
+let uu____573 = (FStar_Syntax_Syntax.bv_to_tm (
+
+let uu___105_574 = a
+in {FStar_Syntax_Syntax.ppname = uu___105_574.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = i; FStar_Syntax_Syntax.sort = uu___105_574.FStar_Syntax_Syntax.sort}))
+in Some (uu____573))
+end
+| FStar_Syntax_Syntax.NT (x, t) when (FStar_Syntax_Syntax.bv_eq a x) -> begin
+Some (t)
+end
+| uu____583 -> begin
+None
+end))))
+
+
+let subst_univ_bv : Prims.int  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.universe Prims.option = (fun x s -> (FStar_Util.find_map s (fun uu___101_593 -> (match (uu___101_593) with
+| FStar_Syntax_Syntax.UN (y, t) when (x = y) -> begin
+Some (t)
+end
+| uu____597 -> begin
+None
+end))))
+
+
+let subst_univ_nm : FStar_Syntax_Syntax.univ_name  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.universe Prims.option = (fun x s -> (FStar_Util.find_map s (fun uu___102_607 -> (match (uu___102_607) with
+| FStar_Syntax_Syntax.UD (y, i) when (x.FStar_Ident.idText = y.FStar_Ident.idText) -> begin
+Some (FStar_Syntax_Syntax.U_bvar (i))
+end
+| uu____611 -> begin
+None
+end))))
+
+
+let rec subst_univ : FStar_Syntax_Syntax.subst_elt Prims.list Prims.list  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun s u -> (
+
+let u1 = (compress_univ u)
+in (match (u1) with
+| FStar_Syntax_Syntax.U_bvar (x) -> begin
+(apply_until_some_then_map (subst_univ_bv x) s subst_univ u1)
+end
+| FStar_Syntax_Syntax.U_name (x) -> begin
+(apply_until_some_then_map (subst_univ_nm x) s subst_univ u1)
+end
+| (FStar_Syntax_Syntax.U_zero) | (FStar_Syntax_Syntax.U_unknown) | (FStar_Syntax_Syntax.U_unif (_)) -> begin
+u1
+end
+| FStar_Syntax_Syntax.U_succ (u2) -> begin
+(
+
+let uu____629 = (subst_univ s u2)
+in FStar_Syntax_Syntax.U_succ (uu____629))
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(
+
+let uu____632 = (FStar_List.map (subst_univ s) us)
+in FStar_Syntax_Syntax.U_max (uu____632))
+end)))
+
+
+let tag_with_range = (fun t s -> (match ((Prims.snd s)) with
+| None -> begin
+t
+end
+| Some (r) -> begin
+(
+
+let r1 = (FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos r)
+in (
+
+let t' = (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_bvar (bv) -> begin
+(
+
+let uu____665 = (FStar_Syntax_Syntax.set_range_of_bv bv r1)
+in FStar_Syntax_Syntax.Tm_bvar (uu____665))
+end
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+(
+
+let uu____667 = (FStar_Syntax_Syntax.set_range_of_bv bv r1)
+in FStar_Syntax_Syntax.Tm_name (uu____667))
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let l = (FStar_Syntax_Syntax.lid_of_fv fv)
+in (
+
+let v1 = (
+
+let uu___106_675 = fv.FStar_Syntax_Syntax.fv_name
+in {FStar_Syntax_Syntax.v = (FStar_Ident.set_lid_range l r1); FStar_Syntax_Syntax.ty = uu___106_675.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___106_675.FStar_Syntax_Syntax.p})
+in (
+
+let fv1 = (
+
+let uu___107_691 = fv
+in {FStar_Syntax_Syntax.fv_name = v1; FStar_Syntax_Syntax.fv_delta = uu___107_691.FStar_Syntax_Syntax.fv_delta; FStar_Syntax_Syntax.fv_qual = uu___107_691.FStar_Syntax_Syntax.fv_qual})
+in FStar_Syntax_Syntax.Tm_fvar (fv1))))
+end
+| t' -> begin
+t'
+end)
+in (
+
+let uu___108_693 = t
+in {FStar_Syntax_Syntax.n = t'; FStar_Syntax_Syntax.tk = uu___108_693.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = r1; FStar_Syntax_Syntax.vars = uu___108_693.FStar_Syntax_Syntax.vars})))
+end))
+
+
+let tag_lid_with_range = (fun l s -> (match ((Prims.snd s)) with
+| None -> begin
+l
+end
+| Some (r) -> begin
+(
+
+let uu____720 = (FStar_Range.set_use_range (FStar_Ident.range_of_lid l) r)
+in (FStar_Ident.set_lid_range l uu____720))
+end))
+
+
+let mk_range : FStar_Range.range  ->  FStar_Syntax_Syntax.subst_ts  ->  FStar_Range.range = (fun r s -> (match ((Prims.snd s)) with
+| None -> begin
+r
+end
+| Some (r') -> begin
+(FStar_Range.set_use_range r r')
+end))
+
+
+let rec subst' : FStar_Syntax_Syntax.subst_ts  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun s t -> (
+
+let subst_tail = (fun tl1 -> (subst' ((tl1), ((Prims.snd s)))))
+in (match (s) with
+| (([], None)) | ((([])::[], None)) -> begin
+t
+end
+| uu____802 -> begin
+(
+
+let t0 = (force_delayed_thunk t)
+in (match (t0.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) -> begin
+(tag_with_range t0 s)
+end
+| FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t', s'), m) -> begin
+(FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (((t'), ((compose_subst s' s))))) t.FStar_Syntax_Syntax.pos)
+end
+| FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inr (uu____883), uu____884) -> begin
+(failwith "Impossible: force_delayed_thunk removes lazy delayed nodes")
+end
+| FStar_Syntax_Syntax.Tm_bvar (a) -> begin
+(apply_until_some_then_map (subst_bv a) (Prims.fst s) subst_tail t0)
+end
+| FStar_Syntax_Syntax.Tm_name (a) -> begin
+(apply_until_some_then_map (subst_nm a) (Prims.fst s) subst_tail t0)
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(
+
+let uu____940 = (mk_range t0.FStar_Syntax_Syntax.pos s)
+in (
+
+let uu____941 = (
+
+let uu____944 = (
+
+let uu____945 = (subst_univ (Prims.fst s) u)
+in FStar_Syntax_Syntax.Tm_type (uu____945))
+in (FStar_Syntax_Syntax.mk uu____944))
+in (uu____941 None uu____940)))
+end
+| uu____957 -> begin
+(
+
+let uu____958 = (mk_range t.FStar_Syntax_Syntax.pos s)
+in (FStar_Syntax_Syntax.mk_Tm_delayed (FStar_Util.Inl (((t0), (s)))) uu____958))
+end))
+end)))
+and subst_flags' : FStar_Syntax_Syntax.subst_ts  ->  FStar_Syntax_Syntax.cflags Prims.list  ->  FStar_Syntax_Syntax.cflags Prims.list = (fun s flags -> (FStar_All.pipe_right flags (FStar_List.map (fun uu___103_972 -> (match (uu___103_972) with
+| FStar_Syntax_Syntax.DECREASES (a) -> begin
+(
+
+let uu____976 = (subst' s a)
+in FStar_Syntax_Syntax.DECREASES (uu____976))
+end
+| f -> begin
+f
+end)))))
+and subst_comp_typ' : (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)  ->  FStar_Syntax_Syntax.comp_typ  ->  FStar_Syntax_Syntax.comp_typ = (fun s t -> (match (s) with
+| (([], None)) | ((([])::[], None)) -> begin
+t
+end
+| uu____996 -> begin
+(
+
+let uu___109_1002 = t
+in (
+
+let uu____1003 = (FStar_List.map (subst_univ (Prims.fst s)) t.FStar_Syntax_Syntax.comp_univs)
+in (
+
+let uu____1007 = (tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s)
+in (
+
+let uu____1010 = (subst' s t.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____1013 = (FStar_List.map (fun uu____1027 -> (match (uu____1027) with
+| (t1, imp) -> begin
+(
+
+let uu____1042 = (subst' s t1)
+in ((uu____1042), (imp)))
+end)) t.FStar_Syntax_Syntax.effect_args)
+in (
+
+let uu____1047 = (subst_flags' s t.FStar_Syntax_Syntax.flags)
+in {FStar_Syntax_Syntax.comp_univs = uu____1003; FStar_Syntax_Syntax.effect_name = uu____1007; FStar_Syntax_Syntax.result_typ = uu____1010; FStar_Syntax_Syntax.effect_args = uu____1013; FStar_Syntax_Syntax.flags = uu____1047}))))))
+end))
+and subst_comp' : (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun s t -> (match (s) with
+| (([], None)) | ((([])::[], None)) -> begin
+t
+end
+| uu____1069 -> begin
+(match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t1, uopt) -> begin
+(
+
+let uu____1085 = (subst' s t1)
+in (
+
+let uu____1086 = (FStar_Option.map (subst_univ (Prims.fst s)) uopt)
+in (FStar_Syntax_Syntax.mk_Total' uu____1085 uu____1086)))
+end
+| FStar_Syntax_Syntax.GTotal (t1, uopt) -> begin
+(
+
+let uu____1099 = (subst' s t1)
+in (
+
+let uu____1100 = (FStar_Option.map (subst_univ (Prims.fst s)) uopt)
+in (FStar_Syntax_Syntax.mk_GTotal' uu____1099 uu____1100)))
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let uu____1106 = (subst_comp_typ' s ct)
+in (FStar_Syntax_Syntax.mk_Comp uu____1106))
+end)
+end))
+
+
+let shift : Prims.int  ->  FStar_Syntax_Syntax.subst_elt  ->  FStar_Syntax_Syntax.subst_elt = (fun n1 s -> (match (s) with
+| FStar_Syntax_Syntax.DB (i, t) -> begin
+FStar_Syntax_Syntax.DB ((((i + n1)), (t)))
+end
+| FStar_Syntax_Syntax.UN (i, t) -> begin
+FStar_Syntax_Syntax.UN ((((i + n1)), (t)))
+end
+| FStar_Syntax_Syntax.NM (x, i) -> begin
+FStar_Syntax_Syntax.NM (((x), ((i + n1))))
+end
+| FStar_Syntax_Syntax.UD (x, i) -> begin
+FStar_Syntax_Syntax.UD (((x), ((i + n1))))
+end
+| FStar_Syntax_Syntax.NT (uu____1121) -> begin
+s
+end))
+
+
+let shift_subst : Prims.int  ->  FStar_Syntax_Syntax.subst_t  ->  FStar_Syntax_Syntax.subst_t = (fun n1 s -> (FStar_List.map (shift n1) s))
+
+
+let shift_subst' = (fun n1 s -> (
+
+let uu____1153 = (FStar_All.pipe_right (Prims.fst s) (FStar_List.map (shift_subst n1)))
+in ((uu____1153), ((Prims.snd s)))))
+
+
+let subst_binder' = (fun s uu____1175 -> (match (uu____1175) with
+| (x, imp) -> begin
+(
+
+let uu____1180 = (
+
+let uu___110_1181 = x
+in (
+
+let uu____1182 = (subst' s x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___110_1181.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___110_1181.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1182}))
+in ((uu____1180), (imp)))
+end))
+
+
+let subst_binders' = (fun s bs -> (FStar_All.pipe_right bs (FStar_List.mapi (fun i b -> (match ((i = (Prims.parse_int "0"))) with
+| true -> begin
+(subst_binder' s b)
+end
+| uu____1222 -> begin
+(
+
+let uu____1223 = (shift_subst' i s)
+in (subst_binder' uu____1223 b))
+end)))))
+
+
+let subst_binders : FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun s bs -> (subst_binders' (((s)::[]), (None)) bs))
+
+
+let subst_arg' = (fun s uu____1257 -> (match (uu____1257) with
+| (t, imp) -> begin
+(
+
+let uu____1268 = (subst' s t)
+in ((uu____1268), (imp)))
+end))
+
+
+let subst_args' = (fun s -> (FStar_List.map (subst_arg' s)))
+
+
+let subst_pat' : (FStar_Syntax_Syntax.subst_t Prims.list * FStar_Range.range Prims.option)  ->  (FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t  ->  (FStar_Syntax_Syntax.pat * Prims.int) = (fun s p -> (
+
+let rec aux = (fun n1 p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible: empty disjunction")
+end
+| FStar_Syntax_Syntax.Pat_constant (uu____1343) -> begin
+((p1), (n1))
+end
+| FStar_Syntax_Syntax.Pat_disj ((p2)::ps) -> begin
+(
+
+let uu____1355 = (aux n1 p2)
+in (match (uu____1355) with
+| (p3, m) -> begin
+(
+
+let ps1 = (FStar_List.map (fun p4 -> (
+
+let uu____1369 = (aux n1 p4)
+in (Prims.fst uu____1369))) ps)
+in (((
+
+let uu___111_1374 = p3
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((p3)::ps1); FStar_Syntax_Syntax.ty = uu___111_1374.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___111_1374.FStar_Syntax_Syntax.p})), (m)))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____1387 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____1412 uu____1413 -> (match (((uu____1412), (uu____1413))) with
+| ((pats1, n2), (p2, imp)) -> begin
+(
+
+let uu____1460 = (aux n2 p2)
+in (match (uu____1460) with
+| (p3, m) -> begin
+(((((p3), (imp)))::pats1), (m))
+end))
+end)) (([]), (n1))))
+in (match (uu____1387) with
+| (pats1, n2) -> begin
+(((
+
+let uu___112_1492 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___112_1492.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___112_1492.FStar_Syntax_Syntax.p})), (n2))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let s1 = (shift_subst' n1 s)
+in (
+
+let x1 = (
+
+let uu___113_1508 = x
+in (
+
+let uu____1509 = (subst' s1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___113_1508.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___113_1508.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1509}))
+in (((
+
+let uu___114_1514 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (x1); FStar_Syntax_Syntax.ty = uu___114_1514.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___114_1514.FStar_Syntax_Syntax.p})), ((n1 + (Prims.parse_int "1"))))))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let s1 = (shift_subst' n1 s)
+in (
+
+let x1 = (
+
+let uu___115_1525 = x
+in (
+
+let uu____1526 = (subst' s1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___115_1525.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___115_1525.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1526}))
+in (((
+
+let uu___116_1531 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x1); FStar_Syntax_Syntax.ty = uu___116_1531.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___116_1531.FStar_Syntax_Syntax.p})), ((n1 + (Prims.parse_int "1"))))))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t0) -> begin
+(
+
+let s1 = (shift_subst' n1 s)
+in (
+
+let x1 = (
+
+let uu___117_1547 = x
+in (
+
+let uu____1548 = (subst' s1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___117_1547.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___117_1547.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1548}))
+in (
+
+let t01 = (subst' s1 t0)
+in (((
+
+let uu___118_1556 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t01))); FStar_Syntax_Syntax.ty = uu___118_1556.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___118_1556.FStar_Syntax_Syntax.p})), (n1)))))
+end))
+in (aux (Prims.parse_int "0") p)))
+
+
+let push_subst_lcomp = (fun s lopt -> (match (lopt) with
+| (None) | (Some (FStar_Util.Inr (_))) -> begin
+lopt
+end
+| Some (FStar_Util.Inl (l)) -> begin
+(
+
+let uu____1590 = (
+
+let uu____1593 = (
+
+let uu___119_1594 = l
+in (
+
+let uu____1595 = (subst' s l.FStar_Syntax_Syntax.res_typ)
+in {FStar_Syntax_Syntax.eff_name = uu___119_1594.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu____1595; FStar_Syntax_Syntax.cflags = uu___119_1594.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____1598 -> (
+
+let uu____1599 = (l.FStar_Syntax_Syntax.comp ())
+in (subst_comp' s uu____1599)))}))
+in FStar_Util.Inl (uu____1593))
+in Some (uu____1590))
+end))
+
+
+let push_subst : FStar_Syntax_Syntax.subst_ts  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun s t -> (
+
+let mk1 = (fun t' -> (
+
+let uu____1622 = (mk_range t.FStar_Syntax_Syntax.pos s)
+in ((FStar_Syntax_Syntax.mk t') None uu____1622)))
+in (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____1633) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_uvar (_)) -> begin
+(tag_with_range t s)
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) -> begin
+(subst' s t)
+end
+| FStar_Syntax_Syntax.Tm_uinst (t', us) -> begin
+(
+
+let us1 = (FStar_List.map (subst_univ (Prims.fst s)) us)
+in (
+
+let uu____1675 = (FStar_Syntax_Syntax.mk_Tm_uinst t' us1)
+in (tag_with_range uu____1675 s)))
+end
+| FStar_Syntax_Syntax.Tm_app (t0, args) -> begin
+(
+
+let uu____1696 = (
+
+let uu____1697 = (
+
+let uu____1707 = (subst' s t0)
+in (
+
+let uu____1710 = ((subst_args' s) args)
+in ((uu____1707), (uu____1710))))
+in FStar_Syntax_Syntax.Tm_app (uu____1697))
+in (mk1 uu____1696))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t0, (annot, topt), lopt) -> begin
+(
+
+let annot1 = (match (annot) with
+| FStar_Util.Inl (t1) -> begin
+(
+
+let uu____1782 = (subst' s t1)
+in FStar_Util.Inl (uu____1782))
+end
+| FStar_Util.Inr (c) -> begin
+(
+
+let uu____1796 = (subst_comp' s c)
+in FStar_Util.Inr (uu____1796))
+end)
+in (
+
+let uu____1803 = (
+
+let uu____1804 = (
+
+let uu____1822 = (subst' s t0)
+in (
+
+let uu____1825 = (
+
+let uu____1837 = (FStar_Util.map_opt topt (subst' s))
+in ((annot1), (uu____1837)))
+in ((uu____1822), (uu____1825), (lopt))))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____1804))
+in (mk1 uu____1803)))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) -> begin
+(
+
+let n1 = (FStar_List.length bs)
+in (
+
+let s' = (shift_subst' n1 s)
+in (
+
+let uu____1905 = (
+
+let uu____1906 = (
+
+let uu____1921 = (subst_binders' s bs)
+in (
+
+let uu____1925 = (subst' s' body)
+in (
+
+let uu____1928 = (push_subst_lcomp s' lopt)
+in ((uu____1921), (uu____1925), (uu____1928)))))
+in FStar_Syntax_Syntax.Tm_abs (uu____1906))
+in (mk1 uu____1905))))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, comp) -> begin
+(
+
+let n1 = (FStar_List.length bs)
+in (
+
+let uu____1965 = (
+
+let uu____1966 = (
+
+let uu____1974 = (subst_binders' s bs)
+in (
+
+let uu____1978 = (
+
+let uu____1981 = (shift_subst' n1 s)
+in (subst_comp' uu____1981 comp))
+in ((uu____1974), (uu____1978))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____1966))
+in (mk1 uu____1965)))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, phi) -> begin
+(
+
+let x1 = (
+
+let uu___120_2002 = x
+in (
+
+let uu____2003 = (subst' s x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___120_2002.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___120_2002.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2003}))
+in (
+
+let phi1 = (
+
+let uu____2009 = (shift_subst' (Prims.parse_int "1") s)
+in (subst' uu____2009 phi))
+in (mk1 (FStar_Syntax_Syntax.Tm_refine (((x1), (phi1)))))))
+end
+| FStar_Syntax_Syntax.Tm_match (t0, pats) -> begin
+(
+
+let t01 = (subst' s t0)
+in (
+
+let pats1 = (FStar_All.pipe_right pats (FStar_List.map (fun uu____2092 -> (match (uu____2092) with
+| (pat, wopt, branch) -> begin
+(
+
+let uu____2128 = (subst_pat' s pat)
+in (match (uu____2128) with
+| (pat1, n1) -> begin
+(
+
+let s1 = (shift_subst' n1 s)
+in (
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____2163 = (subst' s1 w)
+in Some (uu____2163))
+end)
+in (
+
+let branch1 = (subst' s1 branch)
+in ((pat1), (wopt1), (branch1)))))
+end))
+end))))
+in (mk1 (FStar_Syntax_Syntax.Tm_match (((t01), (pats1)))))))
+end
+| FStar_Syntax_Syntax.Tm_let ((is_rec, lbs), body) -> begin
+(
+
+let n1 = (FStar_List.length lbs)
+in (
+
+let sn = (shift_subst' n1 s)
+in (
+
+let body1 = (subst' sn body)
+in (
+
+let lbs1 = (FStar_All.pipe_right lbs (FStar_List.map (fun lb -> (
+
+let lbt = (subst' s lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let lbd = (
+
+let uu____2223 = (is_rec && (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname))
+in (match (uu____2223) with
+| true -> begin
+(subst' sn lb.FStar_Syntax_Syntax.lbdef)
+end
+| uu____2226 -> begin
+(subst' s lb.FStar_Syntax_Syntax.lbdef)
+end))
+in (
+
+let lbname = (match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inl (x) -> begin
+FStar_Util.Inl ((
+
+let uu___121_2233 = x
+in {FStar_Syntax_Syntax.ppname = uu___121_2233.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___121_2233.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = lbt}))
+end
+| FStar_Util.Inr (fv) -> begin
+FStar_Util.Inr ((
+
+let uu___122_2235 = fv
+in {FStar_Syntax_Syntax.fv_name = (
+
+let uu___123_2236 = fv.FStar_Syntax_Syntax.fv_name
+in {FStar_Syntax_Syntax.v = uu___123_2236.FStar_Syntax_Syntax.v; FStar_Syntax_Syntax.ty = lbt; FStar_Syntax_Syntax.p = uu___123_2236.FStar_Syntax_Syntax.p}); FStar_Syntax_Syntax.fv_delta = uu___122_2235.FStar_Syntax_Syntax.fv_delta; FStar_Syntax_Syntax.fv_qual = uu___122_2235.FStar_Syntax_Syntax.fv_qual}))
+end)
+in (
+
+let uu___124_2251 = lb
+in {FStar_Syntax_Syntax.lbname = lbname; FStar_Syntax_Syntax.lbunivs = uu___124_2251.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = lbt; FStar_Syntax_Syntax.lbeff = uu___124_2251.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = lbd})))))))
+in (mk1 (FStar_Syntax_Syntax.Tm_let (((((is_rec), (lbs1))), (body1)))))))))
+end
+| FStar_Syntax_Syntax.Tm_meta (t0, FStar_Syntax_Syntax.Meta_pattern (ps)) -> begin
+(
+
+let uu____2270 = (
+
+let uu____2271 = (
+
+let uu____2276 = (subst' s t0)
+in (
+
+let uu____2279 = (
+
+let uu____2280 = (FStar_All.pipe_right ps (FStar_List.map (subst_args' s)))
+in FStar_Syntax_Syntax.Meta_pattern (uu____2280))
+in ((uu____2276), (uu____2279))))
+in FStar_Syntax_Syntax.Tm_meta (uu____2271))
+in (mk1 uu____2270))
+end
+| FStar_Syntax_Syntax.Tm_meta (t0, FStar_Syntax_Syntax.Meta_monadic (m, t1)) -> begin
+(
+
+let uu____2322 = (
+
+let uu____2323 = (
+
+let uu____2328 = (subst' s t0)
+in (
+
+let uu____2331 = (
+
+let uu____2332 = (
+
+let uu____2337 = (subst' s t1)
+in ((m), (uu____2337)))
+in FStar_Syntax_Syntax.Meta_monadic (uu____2332))
+in ((uu____2328), (uu____2331))))
+in FStar_Syntax_Syntax.Tm_meta (uu____2323))
+in (mk1 uu____2322))
+end
+| FStar_Syntax_Syntax.Tm_meta (t0, FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t1)) -> begin
+(
+
+let uu____2356 = (
+
+let uu____2357 = (
+
+let uu____2362 = (subst' s t0)
+in (
+
+let uu____2365 = (
+
+let uu____2366 = (
+
+let uu____2372 = (subst' s t1)
+in ((m1), (m2), (uu____2372)))
+in FStar_Syntax_Syntax.Meta_monadic_lift (uu____2366))
+in ((uu____2362), (uu____2365))))
+in FStar_Syntax_Syntax.Tm_meta (uu____2357))
+in (mk1 uu____2356))
+end
+| FStar_Syntax_Syntax.Tm_meta (t1, m) -> begin
+(
+
+let uu____2385 = (
+
+let uu____2386 = (
+
+let uu____2391 = (subst' s t1)
+in ((uu____2391), (m)))
+in FStar_Syntax_Syntax.Tm_meta (uu____2386))
+in (mk1 uu____2385))
+end)))
+
+
+let rec compress : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (
+
+let t1 = (force_delayed_thunk t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (FStar_Util.Inl (t2, s), memo) -> begin
+(
+
+let t' = (
+
+let uu____2454 = (push_subst s t2)
+in (compress uu____2454))
+in ((FStar_Unionfind.update_in_tx memo (Some (t')));
+t';
+))
+end
+| uu____2461 -> begin
+(
+
+let t' = (force_uvar t1)
+in (match (t'.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____2465) -> begin
+(compress t')
+end
+| uu____2486 -> begin
+t'
+end))
+end)))
+
+
+let subst : FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun s t -> (subst' (((s)::[]), (None)) t))
+
+
+let set_use_range : FStar_Range.range  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun r t -> (subst' (([]), (Some ((
+
+let uu___125_2510 = r
+in {FStar_Range.def_range = r.FStar_Range.use_range; FStar_Range.use_range = uu___125_2510.FStar_Range.use_range})))) t))
+
+
+let subst_comp : FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun s t -> (subst_comp' (((s)::[]), (None)) t))
+
+
+let closing_subst = (fun bs -> (
+
+let uu____2538 = (FStar_List.fold_right (fun uu____2547 uu____2548 -> (match (((uu____2547), (uu____2548))) with
+| ((x, uu____2563), (subst1, n1)) -> begin
+(((FStar_Syntax_Syntax.NM (((x), (n1))))::subst1), ((n1 + (Prims.parse_int "1"))))
+end)) bs (([]), ((Prims.parse_int "0"))))
+in (FStar_All.pipe_right uu____2538 Prims.fst)))
+
+
+let open_binders' = (fun bs -> (
+
+let rec aux = (fun bs1 o -> (match (bs1) with
+| [] -> begin
+(([]), (o))
+end
+| ((x, imp))::bs' -> begin
+(
+
+let x' = (
+
+let uu___126_2643 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let uu____2644 = (subst o x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___126_2643.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___126_2643.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2644}))
+in (
+
+let o1 = (
+
+let uu____2649 = (shift_subst (Prims.parse_int "1") o)
+in (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x'))))::uu____2649)
+in (
+
+let uu____2651 = (aux bs' o1)
+in (match (uu____2651) with
+| (bs'1, o2) -> begin
+(((((x'), (imp)))::bs'1), (o2))
+end))))
+end))
+in (aux bs [])))
+
+
+let open_binders : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun bs -> (
+
+let uu____2683 = (open_binders' bs)
+in (Prims.fst uu____2683)))
+
+
+let open_term' : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.subst_t) = (fun bs t -> (
+
+let uu____2703 = (open_binders' bs)
+in (match (uu____2703) with
+| (bs', opening) -> begin
+(
+
+let uu____2723 = (subst opening t)
+in ((bs'), (uu____2723), (opening)))
+end)))
+
+
+let open_term : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.term) = (fun bs t -> (
+
+let uu____2736 = (open_term' bs t)
+in (match (uu____2736) with
+| (b, t1, uu____2744) -> begin
+((b), (t1))
+end)))
+
+
+let open_comp : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp) = (fun bs t -> (
+
+let uu____2753 = (open_binders' bs)
+in (match (uu____2753) with
+| (bs', opening) -> begin
+(
+
+let uu____2772 = (subst_comp opening t)
+in ((bs'), (uu____2772)))
+end)))
+
+
+let open_pat : FStar_Syntax_Syntax.pat  ->  (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.subst_t) = (fun p -> (
+
+let rec aux_disj = (fun sub1 renaming p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (uu____2809) -> begin
+(failwith "impossible")
+end
+| FStar_Syntax_Syntax.Pat_constant (uu____2815) -> begin
+p1
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu___127_2828 = p1
+in (
+
+let uu____2831 = (
+
+let uu____2832 = (
+
+let uu____2840 = (FStar_All.pipe_right pats (FStar_List.map (fun uu____2864 -> (match (uu____2864) with
+| (p2, b) -> begin
+(
+
+let uu____2879 = (aux_disj sub1 renaming p2)
+in ((uu____2879), (b)))
+end))))
+in ((fv), (uu____2840)))
+in FStar_Syntax_Syntax.Pat_cons (uu____2832))
+in {FStar_Syntax_Syntax.v = uu____2831; FStar_Syntax_Syntax.ty = uu___127_2828.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___127_2828.FStar_Syntax_Syntax.p}))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let yopt = (FStar_Util.find_map renaming (fun uu___104_2894 -> (match (uu___104_2894) with
+| (x', y) when (x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText = x'.FStar_Syntax_Syntax.ppname.FStar_Ident.idText) -> begin
+Some (y)
+end
+| uu____2900 -> begin
+None
+end)))
+in (
+
+let y = (match (yopt) with
+| None -> begin
+(
+
+let uu___128_2904 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let uu____2905 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___128_2904.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___128_2904.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2905}))
+end
+| Some (y) -> begin
+y
+end)
+in (
+
+let uu___129_2909 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (y); FStar_Syntax_Syntax.ty = uu___129_2909.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___129_2909.FStar_Syntax_Syntax.p})))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let x' = (
+
+let uu___130_2914 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let uu____2915 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___130_2914.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___130_2914.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2915}))
+in (
+
+let uu___131_2918 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x'); FStar_Syntax_Syntax.ty = uu___131_2918.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___131_2918.FStar_Syntax_Syntax.p}))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t0) -> begin
+(
+
+let x1 = (
+
+let uu___132_2928 = x
+in (
+
+let uu____2929 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___132_2928.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___132_2928.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2929}))
+in (
+
+let t01 = (subst sub1 t0)
+in (
+
+let uu___133_2933 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t01))); FStar_Syntax_Syntax.ty = uu___133_2933.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___133_2933.FStar_Syntax_Syntax.p})))
+end))
+in (
+
+let rec aux = (fun sub1 renaming p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible: empty disjunction")
+end
+| FStar_Syntax_Syntax.Pat_constant (uu____2987) -> begin
+((p1), (sub1), (renaming))
+end
+| FStar_Syntax_Syntax.Pat_disj ((p2)::ps) -> begin
+(
+
+let uu____3003 = (aux sub1 renaming p2)
+in (match (uu____3003) with
+| (p3, sub2, renaming1) -> begin
+(
+
+let ps1 = (FStar_List.map (aux_disj sub2 renaming1) ps)
+in (((
+
+let uu___134_3051 = p3
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((p3)::ps1); FStar_Syntax_Syntax.ty = uu___134_3051.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___134_3051.FStar_Syntax_Syntax.p})), (sub2), (renaming1)))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____3068 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____3114 uu____3115 -> (match (((uu____3114), (uu____3115))) with
+| ((pats1, sub2, renaming1), (p2, imp)) -> begin
+(
+
+let uu____3203 = (aux sub2 renaming1 p2)
+in (match (uu____3203) with
+| (p3, sub3, renaming2) -> begin
+(((((p3), (imp)))::pats1), (sub3), (renaming2))
+end))
+end)) (([]), (sub1), (renaming))))
+in (match (uu____3068) with
+| (pats1, sub2, renaming1) -> begin
+(((
+
+let uu___135_3304 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___135_3304.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___135_3304.FStar_Syntax_Syntax.p})), (sub2), (renaming1))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let x' = (
+
+let uu___136_3318 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let uu____3319 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___136_3318.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___136_3318.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3319}))
+in (
+
+let sub2 = (
+
+let uu____3324 = (shift_subst (Prims.parse_int "1") sub1)
+in (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x'))))::uu____3324)
+in (((
+
+let uu___137_3332 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (x'); FStar_Syntax_Syntax.ty = uu___137_3332.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___137_3332.FStar_Syntax_Syntax.p})), (sub2), ((((x), (x')))::renaming))))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let x' = (
+
+let uu___138_3339 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let uu____3340 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___138_3339.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___138_3339.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3340}))
+in (
+
+let sub2 = (
+
+let uu____3345 = (shift_subst (Prims.parse_int "1") sub1)
+in (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x'))))::uu____3345)
+in (((
+
+let uu___139_3353 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x'); FStar_Syntax_Syntax.ty = uu___139_3353.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___139_3353.FStar_Syntax_Syntax.p})), (sub2), ((((x), (x')))::renaming))))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t0) -> begin
+(
+
+let x1 = (
+
+let uu___140_3365 = x
+in (
+
+let uu____3366 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___140_3365.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___140_3365.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3366}))
+in (
+
+let t01 = (subst sub1 t0)
+in (((
+
+let uu___141_3376 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t01))); FStar_Syntax_Syntax.ty = uu___141_3376.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___141_3376.FStar_Syntax_Syntax.p})), (sub1), (renaming))))
+end))
+in (
+
+let uu____3379 = (aux [] [] p)
+in (match (uu____3379) with
+| (p1, sub1, uu____3395) -> begin
+((p1), (sub1))
+end)))))
+
+
+let open_branch : FStar_Syntax_Syntax.branch  ->  FStar_Syntax_Syntax.branch = (fun uu____3413 -> (match (uu____3413) with
+| (p, wopt, e) -> begin
+(
+
+let uu____3431 = (open_pat p)
+in (match (uu____3431) with
+| (p1, opening) -> begin
+(
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____3446 = (subst opening w)
+in Some (uu____3446))
+end)
+in (
+
+let e1 = (subst opening e)
+in ((p1), (wopt1), (e1))))
+end))
+end))
+
+
+let close : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun bs t -> (
+
+let uu____3455 = (closing_subst bs)
+in (subst uu____3455 t)))
+
+
+let close_comp : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun bs c -> (
+
+let uu____3463 = (closing_subst bs)
+in (subst_comp uu____3463 c)))
+
+
+let close_binders : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun bs -> (
+
+let rec aux = (fun s bs1 -> (match (bs1) with
+| [] -> begin
+[]
+end
+| ((x, imp))::tl1 -> begin
+(
+
+let x1 = (
+
+let uu___142_3496 = x
+in (
+
+let uu____3497 = (subst s x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___142_3496.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___142_3496.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3497}))
+in (
+
+let s' = (
+
+let uu____3502 = (shift_subst (Prims.parse_int "1") s)
+in (FStar_Syntax_Syntax.NM (((x1), ((Prims.parse_int "0")))))::uu____3502)
+in (
+
+let uu____3504 = (aux s' tl1)
+in (((x1), (imp)))::uu____3504)))
+end))
+in (aux [] bs)))
+
+
+let close_lcomp : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun bs lc -> (
+
+let s = (closing_subst bs)
+in (
+
+let uu___143_3518 = lc
+in (
+
+let uu____3519 = (subst s lc.FStar_Syntax_Syntax.res_typ)
+in {FStar_Syntax_Syntax.eff_name = uu___143_3518.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu____3519; FStar_Syntax_Syntax.cflags = uu___143_3518.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____3522 -> (
+
+let uu____3523 = (lc.FStar_Syntax_Syntax.comp ())
+in (subst_comp s uu____3523)))}))))
+
+
+let close_pat : (FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t  ->  ((FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t * FStar_Syntax_Syntax.subst_elt Prims.list) = (fun p -> (
+
+let rec aux = (fun sub1 p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible: empty disjunction")
+end
+| FStar_Syntax_Syntax.Pat_constant (uu____3566) -> begin
+((p1), (sub1))
+end
+| FStar_Syntax_Syntax.Pat_disj ((p2)::ps) -> begin
+(
+
+let uu____3579 = (aux sub1 p2)
+in (match (uu____3579) with
+| (p3, sub2) -> begin
+(
+
+let ps1 = (FStar_List.map (fun p4 -> (
+
+let uu____3609 = (aux sub2 p4)
+in (Prims.fst uu____3609))) ps)
+in (((
+
+let uu___144_3621 = p3
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((p3)::ps1); FStar_Syntax_Syntax.ty = uu___144_3621.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___144_3621.FStar_Syntax_Syntax.p})), (sub2)))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____3638 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____3672 uu____3673 -> (match (((uu____3672), (uu____3673))) with
+| ((pats1, sub2), (p2, imp)) -> begin
+(
+
+let uu____3738 = (aux sub2 p2)
+in (match (uu____3738) with
+| (p3, sub3) -> begin
+(((((p3), (imp)))::pats1), (sub3))
+end))
+end)) (([]), (sub1))))
+in (match (uu____3638) with
+| (pats1, sub2) -> begin
+(((
+
+let uu___145_3804 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___145_3804.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___145_3804.FStar_Syntax_Syntax.p})), (sub2))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let x1 = (
+
+let uu___146_3818 = x
+in (
+
+let uu____3819 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___146_3818.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___146_3818.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3819}))
+in (
+
+let sub2 = (
+
+let uu____3824 = (shift_subst (Prims.parse_int "1") sub1)
+in (FStar_Syntax_Syntax.NM (((x1), ((Prims.parse_int "0")))))::uu____3824)
+in (((
+
+let uu___147_3829 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (x1); FStar_Syntax_Syntax.ty = uu___147_3829.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___147_3829.FStar_Syntax_Syntax.p})), (sub2))))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let x1 = (
+
+let uu___148_3834 = x
+in (
+
+let uu____3835 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___148_3834.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___148_3834.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3835}))
+in (
+
+let sub2 = (
+
+let uu____3840 = (shift_subst (Prims.parse_int "1") sub1)
+in (FStar_Syntax_Syntax.NM (((x1), ((Prims.parse_int "0")))))::uu____3840)
+in (((
+
+let uu___149_3845 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x1); FStar_Syntax_Syntax.ty = uu___149_3845.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___149_3845.FStar_Syntax_Syntax.p})), (sub2))))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t0) -> begin
+(
+
+let x1 = (
+
+let uu___150_3855 = x
+in (
+
+let uu____3856 = (subst sub1 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___150_3855.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___150_3855.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3856}))
+in (
+
+let t01 = (subst sub1 t0)
+in (((
+
+let uu___151_3863 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t01))); FStar_Syntax_Syntax.ty = uu___151_3863.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___151_3863.FStar_Syntax_Syntax.p})), (sub1))))
+end))
+in (aux [] p)))
+
+
+let close_branch : FStar_Syntax_Syntax.branch  ->  FStar_Syntax_Syntax.branch = (fun uu____3868 -> (match (uu____3868) with
+| (p, wopt, e) -> begin
+(
+
+let uu____3886 = (close_pat p)
+in (match (uu____3886) with
+| (p1, closing) -> begin
+(
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____3910 = (subst closing w)
+in Some (uu____3910))
+end)
+in (
+
+let e1 = (subst closing e)
+in ((p1), (wopt1), (e1))))
+end))
+end))
+
+
+let univ_var_opening : FStar_Syntax_Syntax.univ_names  ->  (FStar_Syntax_Syntax.subst_elt Prims.list * FStar_Syntax_Syntax.univ_name Prims.list) = (fun us -> (
+
+let n1 = ((FStar_List.length us) - (Prims.parse_int "1"))
+in (
+
+let uu____3926 = (
+
+let uu____3931 = (FStar_All.pipe_right us (FStar_List.mapi (fun i u -> (
+
+let u' = (FStar_Syntax_Syntax.new_univ_name (Some (u.FStar_Ident.idRange)))
+in ((FStar_Syntax_Syntax.UN ((((n1 - i)), (FStar_Syntax_Syntax.U_name (u'))))), (u'))))))
+in (FStar_All.pipe_right uu____3931 FStar_List.unzip))
+in (match (uu____3926) with
+| (s, us') -> begin
+((s), (us'))
+end))))
+
+
+let open_univ_vars : FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.term) = (fun us t -> (
+
+let uu____3972 = (univ_var_opening us)
+in (match (uu____3972) with
+| (s, us') -> begin
+(
+
+let t1 = (subst s t)
+in ((us'), (t1)))
+end)))
+
+
+let open_univ_vars_comp : FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.comp) = (fun us c -> (
+
+let uu____3997 = (univ_var_opening us)
+in (match (uu____3997) with
+| (s, us') -> begin
+(
+
+let uu____4010 = (subst_comp s c)
+in ((us'), (uu____4010)))
+end)))
+
+
+let close_univ_vars : FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun us t -> (
+
+let n1 = ((FStar_List.length us) - (Prims.parse_int "1"))
+in (
+
+let s = (FStar_All.pipe_right us (FStar_List.mapi (fun i u -> FStar_Syntax_Syntax.UD (((u), ((n1 - i)))))))
+in (subst s t))))
+
+
+let close_univ_vars_comp : FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun us c -> (
+
+let n1 = ((FStar_List.length us) - (Prims.parse_int "1"))
+in (
+
+let s = (FStar_All.pipe_right us (FStar_List.mapi (fun i u -> FStar_Syntax_Syntax.UD (((u), ((n1 - i)))))))
+in (subst_comp s c))))
+
+
+let open_let_rec : FStar_Syntax_Syntax.letbinding Prims.list  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.letbinding Prims.list * FStar_Syntax_Syntax.term) = (fun lbs t -> (
+
+let uu____4053 = (FStar_Syntax_Syntax.is_top_level lbs)
+in (match (uu____4053) with
+| true -> begin
+((lbs), (t))
+end
+| uu____4058 -> begin
+(
+
+let uu____4059 = (FStar_List.fold_right (fun lb uu____4071 -> (match (uu____4071) with
+| (i, lbs1, out) -> begin
+(
+
+let x = (
+
+let uu____4090 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in (FStar_Syntax_Syntax.freshen_bv uu____4090))
+in (((i + (Prims.parse_int "1"))), (((
+
+let uu___152_4093 = lb
+in {FStar_Syntax_Syntax.lbname = FStar_Util.Inl (x); FStar_Syntax_Syntax.lbunivs = uu___152_4093.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___152_4093.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___152_4093.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___152_4093.FStar_Syntax_Syntax.lbdef}))::lbs1), ((FStar_Syntax_Syntax.DB (((i), (x))))::out)))
+end)) lbs (((Prims.parse_int "0")), ([]), ([])))
+in (match (uu____4059) with
+| (n_let_recs, lbs1, let_rec_opening) -> begin
+(
+
+let lbs2 = (FStar_All.pipe_right lbs1 (FStar_List.map (fun lb -> (
+
+let uu____4111 = (FStar_List.fold_right (fun u uu____4123 -> (match (uu____4123) with
+| (i, us, out) -> begin
+(
+
+let u1 = (FStar_Syntax_Syntax.new_univ_name None)
+in (((i + (Prims.parse_int "1"))), ((u1)::us), ((FStar_Syntax_Syntax.UN (((i), (FStar_Syntax_Syntax.U_name (u1)))))::out)))
+end)) lb.FStar_Syntax_Syntax.lbunivs ((n_let_recs), ([]), (let_rec_opening)))
+in (match (uu____4111) with
+| (uu____4146, us, u_let_rec_opening) -> begin
+(
+
+let uu___153_4153 = lb
+in (
+
+let uu____4154 = (subst u_let_rec_opening lb.FStar_Syntax_Syntax.lbdef)
+in {FStar_Syntax_Syntax.lbname = uu___153_4153.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = us; FStar_Syntax_Syntax.lbtyp = uu___153_4153.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___153_4153.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____4154}))
+end)))))
+in (
+
+let t1 = (subst let_rec_opening t)
+in ((lbs2), (t1))))
+end))
+end)))
+
+
+let close_let_rec : FStar_Syntax_Syntax.letbinding Prims.list  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.letbinding Prims.list * FStar_Syntax_Syntax.term) = (fun lbs t -> (
+
+let uu____4170 = (FStar_Syntax_Syntax.is_top_level lbs)
+in (match (uu____4170) with
+| true -> begin
+((lbs), (t))
+end
+| uu____4175 -> begin
+(
+
+let uu____4176 = (FStar_List.fold_right (fun lb uu____4184 -> (match (uu____4184) with
+| (i, out) -> begin
+(
+
+let uu____4195 = (
+
+let uu____4197 = (
+
+let uu____4198 = (
+
+let uu____4201 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in ((uu____4201), (i)))
+in FStar_Syntax_Syntax.NM (uu____4198))
+in (uu____4197)::out)
+in (((i + (Prims.parse_int "1"))), (uu____4195)))
+end)) lbs (((Prims.parse_int "0")), ([])))
+in (match (uu____4176) with
+| (n_let_recs, let_rec_closing) -> begin
+(
+
+let lbs1 = (FStar_All.pipe_right lbs (FStar_List.map (fun lb -> (
+
+let uu____4216 = (FStar_List.fold_right (fun u uu____4224 -> (match (uu____4224) with
+| (i, out) -> begin
+(((i + (Prims.parse_int "1"))), ((FStar_Syntax_Syntax.UD (((u), (i))))::out))
+end)) lb.FStar_Syntax_Syntax.lbunivs ((n_let_recs), (let_rec_closing)))
+in (match (uu____4216) with
+| (uu____4237, u_let_rec_closing) -> begin
+(
+
+let uu___154_4241 = lb
+in (
+
+let uu____4242 = (subst u_let_rec_closing lb.FStar_Syntax_Syntax.lbdef)
+in {FStar_Syntax_Syntax.lbname = uu___154_4241.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___154_4241.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___154_4241.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___154_4241.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____4242}))
+end)))))
+in (
+
+let t1 = (subst let_rec_closing t)
+in ((lbs1), (t1))))
+end))
+end)))
+
+
+let close_tscheme : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.tscheme  ->  FStar_Syntax_Syntax.tscheme = (fun binders uu____4252 -> (match (uu____4252) with
+| (us, t) -> begin
+(
+
+let n1 = ((FStar_List.length binders) - (Prims.parse_int "1"))
+in (
+
+let k = (FStar_List.length us)
+in (
+
+let s = (FStar_List.mapi (fun i uu____4270 -> (match (uu____4270) with
+| (x, uu____4274) -> begin
+FStar_Syntax_Syntax.NM (((x), ((k + (n1 - i)))))
+end)) binders)
+in (
+
+let t1 = (subst s t)
+in ((us), (t1))))))
+end))
+
+
+let close_univ_vars_tscheme : FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.tscheme  ->  FStar_Syntax_Syntax.tscheme = (fun us uu____4285 -> (match (uu____4285) with
+| (us', t) -> begin
+(
+
+let n1 = ((FStar_List.length us) - (Prims.parse_int "1"))
+in (
+
+let k = (FStar_List.length us')
+in (
+
+let s = (FStar_List.mapi (fun i x -> FStar_Syntax_Syntax.UD (((x), ((k + (n1 - i)))))) us)
+in (
+
+let uu____4303 = (subst s t)
+in ((us'), (uu____4303))))))
+end))
+
+
+let opening_of_binders : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.subst_t = (fun bs -> (
+
+let n1 = ((FStar_List.length bs) - (Prims.parse_int "1"))
+in (FStar_All.pipe_right bs (FStar_List.mapi (fun i uu____4318 -> (match (uu____4318) with
+| (x, uu____4322) -> begin
+FStar_Syntax_Syntax.DB ((((n1 - i)), (x)))
+end))))))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1,1176 +1,2234 @@
+
 open Prims
-type ('a,'t) withinfo_t = {
-  v: 'a;
-  ty: 't;
-  p: FStar_Range.range;}
-type 't var = (FStar_Ident.lident,'t) withinfo_t
-type sconst = FStar_Const.sconst
+type ('a, 't) withinfo_t =
+{v : 'a; ty : 't; p : FStar_Range.range}
+
+
+type fsdoc =
+(Prims.string * (Prims.string * Prims.string) Prims.list)
+
+
+let string_of_fsdoc : fsdoc  ->  Prims.string = (fun uu____71 -> (match (uu____71) with
+| (comment, keywords) -> begin
+(
+
+let uu____80 = (
+
+let uu____81 = (FStar_List.map (fun uu____85 -> (match (uu____85) with
+| (k, v1) -> begin
+(Prims.strcat k (Prims.strcat "->" v1))
+end)) keywords)
+in (FStar_String.concat "," uu____81))
+in (Prims.strcat comment uu____80))
+end))
+
+
+type 't var =
+(FStar_Ident.lident, 't) withinfo_t
+
+
+type sconst =
+FStar_Const.sconst
+
 type pragma =
-  | SetOptions of Prims.string
-  | ResetOptions of Prims.string Prims.option
-  | LightOff
-let uu___is_SetOptions: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SetOptions _0 -> true | uu____78 -> false
-let __proj__SetOptions__item___0: pragma -> Prims.string =
-  fun projectee  -> match projectee with | SetOptions _0 -> _0
-let uu___is_ResetOptions: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ResetOptions _0 -> true | uu____91 -> false
-let __proj__ResetOptions__item___0: pragma -> Prims.string Prims.option =
-  fun projectee  -> match projectee with | ResetOptions _0 -> _0
-let uu___is_LightOff: pragma -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LightOff  -> true | uu____105 -> false
-type 'a memo = 'a Prims.option FStar_ST.ref
+| SetOptions of Prims.string
+| ResetOptions of Prims.string Prims.option
+| LightOff
+
+
+let uu___is_SetOptions : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SetOptions (_0) -> begin
+true
+end
+| uu____104 -> begin
+false
+end))
+
+
+let __proj__SetOptions__item___0 : pragma  ->  Prims.string = (fun projectee -> (match (projectee) with
+| SetOptions (_0) -> begin
+_0
+end))
+
+
+let uu___is_ResetOptions : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ResetOptions (_0) -> begin
+true
+end
+| uu____117 -> begin
+false
+end))
+
+
+let __proj__ResetOptions__item___0 : pragma  ->  Prims.string Prims.option = (fun projectee -> (match (projectee) with
+| ResetOptions (_0) -> begin
+_0
+end))
+
+
+let uu___is_LightOff : pragma  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LightOff -> begin
+true
+end
+| uu____131 -> begin
+false
+end))
+
+
+type 'a memo =
+'a Prims.option FStar_ST.ref
+
 type arg_qualifier =
-  | Implicit of Prims.bool
-  | Equality
-let uu___is_Implicit: arg_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Implicit _0 -> true | uu____116 -> false
-let __proj__Implicit__item___0: arg_qualifier -> Prims.bool =
-  fun projectee  -> match projectee with | Implicit _0 -> _0
-let uu___is_Equality: arg_qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Equality  -> true | uu____127 -> false
-type aqual = arg_qualifier Prims.option
+| Implicit of Prims.bool
+| Equality
+
+
+let uu___is_Implicit : arg_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Implicit (_0) -> begin
+true
+end
+| uu____142 -> begin
+false
+end))
+
+
+let __proj__Implicit__item___0 : arg_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Implicit (_0) -> begin
+_0
+end))
+
+
+let uu___is_Equality : arg_qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Equality -> begin
+true
+end
+| uu____153 -> begin
+false
+end))
+
+
+type aqual =
+arg_qualifier Prims.option
+
 type universe =
-  | U_zero
-  | U_succ of universe
-  | U_max of universe Prims.list
-  | U_bvar of Prims.int
-  | U_name of FStar_Ident.ident
-  | U_unif of universe Prims.option FStar_Unionfind.uvar
-  | U_unknown
-let uu___is_U_zero: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_zero  -> true | uu____150 -> false
-let uu___is_U_succ: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_succ _0 -> true | uu____155 -> false
-let __proj__U_succ__item___0: universe -> universe =
-  fun projectee  -> match projectee with | U_succ _0 -> _0
-let uu___is_U_max: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_max _0 -> true | uu____168 -> false
-let __proj__U_max__item___0: universe -> universe Prims.list =
-  fun projectee  -> match projectee with | U_max _0 -> _0
-let uu___is_U_bvar: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_bvar _0 -> true | uu____183 -> false
-let __proj__U_bvar__item___0: universe -> Prims.int =
-  fun projectee  -> match projectee with | U_bvar _0 -> _0
-let uu___is_U_name: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_name _0 -> true | uu____195 -> false
-let __proj__U_name__item___0: universe -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | U_name _0 -> _0
-let uu___is_U_unif: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_unif _0 -> true | uu____209 -> false
-let __proj__U_unif__item___0:
-  universe -> universe Prims.option FStar_Unionfind.uvar =
-  fun projectee  -> match projectee with | U_unif _0 -> _0
-let uu___is_U_unknown: universe -> Prims.bool =
-  fun projectee  ->
-    match projectee with | U_unknown  -> true | uu____226 -> false
-type univ_name = FStar_Ident.ident
-type universe_uvar = universe Prims.option FStar_Unionfind.uvar
-type univ_names = univ_name Prims.list
-type universes = universe Prims.list
-type monad_name = FStar_Ident.lident
+| U_zero
+| U_succ of universe
+| U_max of universe Prims.list
+| U_bvar of Prims.int
+| U_name of FStar_Ident.ident
+| U_unif of universe Prims.option FStar_Unionfind.uvar
+| U_unknown
+
+
+let uu___is_U_zero : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_zero -> begin
+true
+end
+| uu____176 -> begin
+false
+end))
+
+
+let uu___is_U_succ : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_succ (_0) -> begin
+true
+end
+| uu____181 -> begin
+false
+end))
+
+
+let __proj__U_succ__item___0 : universe  ->  universe = (fun projectee -> (match (projectee) with
+| U_succ (_0) -> begin
+_0
+end))
+
+
+let uu___is_U_max : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_max (_0) -> begin
+true
+end
+| uu____194 -> begin
+false
+end))
+
+
+let __proj__U_max__item___0 : universe  ->  universe Prims.list = (fun projectee -> (match (projectee) with
+| U_max (_0) -> begin
+_0
+end))
+
+
+let uu___is_U_bvar : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_bvar (_0) -> begin
+true
+end
+| uu____209 -> begin
+false
+end))
+
+
+let __proj__U_bvar__item___0 : universe  ->  Prims.int = (fun projectee -> (match (projectee) with
+| U_bvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_U_name : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_name (_0) -> begin
+true
+end
+| uu____221 -> begin
+false
+end))
+
+
+let __proj__U_name__item___0 : universe  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| U_name (_0) -> begin
+_0
+end))
+
+
+let uu___is_U_unif : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_unif (_0) -> begin
+true
+end
+| uu____235 -> begin
+false
+end))
+
+
+let __proj__U_unif__item___0 : universe  ->  universe Prims.option FStar_Unionfind.uvar = (fun projectee -> (match (projectee) with
+| U_unif (_0) -> begin
+_0
+end))
+
+
+let uu___is_U_unknown : universe  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| U_unknown -> begin
+true
+end
+| uu____252 -> begin
+false
+end))
+
+
+type univ_name =
+FStar_Ident.ident
+
+
+type universe_uvar =
+universe Prims.option FStar_Unionfind.uvar
+
+
+type univ_names =
+univ_name Prims.list
+
+
+type universes =
+universe Prims.list
+
+
+type monad_name =
+FStar_Ident.lident
+
 type delta_depth =
-  | Delta_constant
-  | Delta_defined_at_level of Prims.int
-  | Delta_equational
-  | Delta_abstract of delta_depth
-let uu___is_Delta_constant: delta_depth -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Delta_constant  -> true | uu____240 -> false
-let uu___is_Delta_defined_at_level: delta_depth -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Delta_defined_at_level _0 -> true
-    | uu____245 -> false
-let __proj__Delta_defined_at_level__item___0: delta_depth -> Prims.int =
-  fun projectee  -> match projectee with | Delta_defined_at_level _0 -> _0
-let uu___is_Delta_equational: delta_depth -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Delta_equational  -> true | uu____256 -> false
-let uu___is_Delta_abstract: delta_depth -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Delta_abstract _0 -> true | uu____261 -> false
-let __proj__Delta_abstract__item___0: delta_depth -> delta_depth =
-  fun projectee  -> match projectee with | Delta_abstract _0 -> _0
+| Delta_constant
+| Delta_defined_at_level of Prims.int
+| Delta_equational
+| Delta_abstract of delta_depth
+
+
+let uu___is_Delta_constant : delta_depth  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Delta_constant -> begin
+true
+end
+| uu____266 -> begin
+false
+end))
+
+
+let uu___is_Delta_defined_at_level : delta_depth  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Delta_defined_at_level (_0) -> begin
+true
+end
+| uu____271 -> begin
+false
+end))
+
+
+let __proj__Delta_defined_at_level__item___0 : delta_depth  ->  Prims.int = (fun projectee -> (match (projectee) with
+| Delta_defined_at_level (_0) -> begin
+_0
+end))
+
+
+let uu___is_Delta_equational : delta_depth  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Delta_equational -> begin
+true
+end
+| uu____282 -> begin
+false
+end))
+
+
+let uu___is_Delta_abstract : delta_depth  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Delta_abstract (_0) -> begin
+true
+end
+| uu____287 -> begin
+false
+end))
+
+
+let __proj__Delta_abstract__item___0 : delta_depth  ->  delta_depth = (fun projectee -> (match (projectee) with
+| Delta_abstract (_0) -> begin
+_0
+end))
+
 type term' =
-  | Tm_bvar of bv
-  | Tm_name of bv
-  | Tm_fvar of fv
-  | Tm_uinst of ((term',term') syntax* universes)
-  | Tm_constant of sconst
-  | Tm_type of universe
-  | Tm_abs of ((bv* aqual) Prims.list* (term',term') syntax*
-  (lcomp,(FStar_Ident.lident* cflags Prims.list)) FStar_Util.either
-  Prims.option)
-  | Tm_arrow of ((bv* aqual) Prims.list* (comp',Prims.unit) syntax)
-  | Tm_refine of (bv* (term',term') syntax)
-  | Tm_app of ((term',term') syntax* ((term',term') syntax* aqual)
-  Prims.list)
-  | Tm_match of ((term',term') syntax* ((pat',term') withinfo_t*
-  (term',term') syntax Prims.option* (term',term') syntax) Prims.list)
-  | Tm_ascribed of ((term',term') syntax*
-  (((term',term') syntax,(comp',Prims.unit) syntax) FStar_Util.either*
-  (term',term') syntax Prims.option)* FStar_Ident.lident Prims.option)
-  | Tm_let of ((Prims.bool* letbinding Prims.list)* (term',term') syntax)
-  | Tm_uvar of ((term',term') syntax uvar_basis FStar_Unionfind.uvar*
-  (term',term') syntax)
-  | Tm_delayed of
-  ((((term',term') syntax* (subst_elt Prims.list Prims.list*
-      FStar_Range.range Prims.option)),Prims.unit -> (term',term') syntax)
-  FStar_Util.either* (term',term') syntax memo)
-  | Tm_meta of ((term',term') syntax* metadata)
-  | Tm_unknown
-and pat' =
-  | Pat_constant of sconst
-  | Pat_disj of (pat',term') withinfo_t Prims.list
-  | Pat_cons of (fv* ((pat',term') withinfo_t* Prims.bool) Prims.list)
-  | Pat_var of bv
-  | Pat_wild of bv
-  | Pat_dot_term of (bv* (term',term') syntax)
-and letbinding =
-  {
-  lbname: (bv,fv) FStar_Util.either;
-  lbunivs: univ_name Prims.list;
-  lbtyp: (term',term') syntax;
-  lbeff: FStar_Ident.lident;
-  lbdef: (term',term') syntax;}
-and comp_typ =
-  {
-  comp_univs: universes;
-  effect_name: FStar_Ident.lident;
-  result_typ: (term',term') syntax;
-  effect_args: ((term',term') syntax* aqual) Prims.list;
-  flags: cflags Prims.list;}
-and comp' =
-  | Total of ((term',term') syntax* universe Prims.option)
-  | GTotal of ((term',term') syntax* universe Prims.option)
-  | Comp of comp_typ
-and cflags =
-  | TOTAL
-  | MLEFFECT
-  | RETURN
-  | PARTIAL_RETURN
-  | SOMETRIVIAL
-  | LEMMA
-  | CPS
-  | DECREASES of (term',term') syntax
-and metadata =
-  | Meta_pattern of ((term',term') syntax* aqual) Prims.list Prims.list
-  | Meta_named of FStar_Ident.lident
-  | Meta_labeled of (Prims.string* FStar_Range.range* Prims.bool)
-  | Meta_desugared of meta_source_info
-  | Meta_monadic of (monad_name* (term',term') syntax)
-  | Meta_monadic_lift of (monad_name* monad_name* (term',term') syntax)
-and 'a uvar_basis =
-  | Uvar
-  | Fixed of 'a
-and meta_source_info =
-  | Data_app
-  | Sequence
-  | Primop
-  | Masked_effect
-  | Meta_smt_pat
-  | Mutable_alloc
-  | Mutable_rval
-and fv_qual =
-  | Data_ctor
-  | Record_projector of (FStar_Ident.lident* FStar_Ident.ident)
-  | Record_ctor of (FStar_Ident.lident* FStar_Ident.ident Prims.list)
-and subst_elt =
-  | DB of (Prims.int* bv)
-  | NM of (bv* Prims.int)
-  | NT of (bv* (term',term') syntax)
-  | UN of (Prims.int* universe)
-  | UD of (univ_name* Prims.int)
-and ('a,'b) syntax =
-  {
-  n: 'a;
-  tk: 'b memo;
-  pos: FStar_Range.range;
-  vars: free_vars memo;}
-and bv =
-  {
-  ppname: FStar_Ident.ident;
-  index: Prims.int;
-  sort: (term',term') syntax;}
-and fv =
-  {
-  fv_name: (term',term') syntax var;
-  fv_delta: delta_depth;
-  fv_qual: fv_qual Prims.option;}
-and free_vars =
-  {
-  free_names: bv FStar_Util.set;
-  free_uvars:
-    ((term',term') syntax uvar_basis FStar_Unionfind.uvar* (term',term')
-      syntax) FStar_Util.set;
-  free_univs: universe_uvar FStar_Util.set;
-  free_univ_names: univ_name FStar_Util.fifo_set;}
-and lcomp =
-  {
-  eff_name: FStar_Ident.lident;
-  res_typ: (term',term') syntax;
-  cflags: cflags Prims.list;
-  comp: Prims.unit -> (comp',Prims.unit) syntax;}
-let uu___is_Tm_bvar: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_bvar _0 -> true | uu____706 -> false
-let __proj__Tm_bvar__item___0: term' -> bv =
-  fun projectee  -> match projectee with | Tm_bvar _0 -> _0
-let uu___is_Tm_name: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_name _0 -> true | uu____718 -> false
-let __proj__Tm_name__item___0: term' -> bv =
-  fun projectee  -> match projectee with | Tm_name _0 -> _0
-let uu___is_Tm_fvar: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_fvar _0 -> true | uu____730 -> false
-let __proj__Tm_fvar__item___0: term' -> fv =
-  fun projectee  -> match projectee with | Tm_fvar _0 -> _0
-let uu___is_Tm_uinst: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_uinst _0 -> true | uu____746 -> false
-let __proj__Tm_uinst__item___0: term' -> ((term',term') syntax* universes) =
-  fun projectee  -> match projectee with | Tm_uinst _0 -> _0
-let uu___is_Tm_constant: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_constant _0 -> true | uu____770 -> false
-let __proj__Tm_constant__item___0: term' -> sconst =
-  fun projectee  -> match projectee with | Tm_constant _0 -> _0
-let uu___is_Tm_type: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_type _0 -> true | uu____782 -> false
-let __proj__Tm_type__item___0: term' -> universe =
-  fun projectee  -> match projectee with | Tm_type _0 -> _0
-let uu___is_Tm_abs: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_abs _0 -> true | uu____808 -> false
-let __proj__Tm_abs__item___0:
-  term' ->
-    ((bv* aqual) Prims.list* (term',term') syntax*
-      (lcomp,(FStar_Ident.lident* cflags Prims.list)) FStar_Util.either
-      Prims.option)
-  = fun projectee  -> match projectee with | Tm_abs _0 -> _0
-let uu___is_Tm_arrow: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_arrow _0 -> true | uu____869 -> false
-let __proj__Tm_arrow__item___0:
-  term' -> ((bv* aqual) Prims.list* (comp',Prims.unit) syntax) =
-  fun projectee  -> match projectee with | Tm_arrow _0 -> _0
-let uu___is_Tm_refine: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_refine _0 -> true | uu____906 -> false
-let __proj__Tm_refine__item___0: term' -> (bv* (term',term') syntax) =
-  fun projectee  -> match projectee with | Tm_refine _0 -> _0
-let uu___is_Tm_app: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_app _0 -> true | uu____939 -> false
-let __proj__Tm_app__item___0:
-  term' -> ((term',term') syntax* ((term',term') syntax* aqual) Prims.list) =
-  fun projectee  -> match projectee with | Tm_app _0 -> _0
-let uu___is_Tm_match: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_match _0 -> true | uu____993 -> false
-let __proj__Tm_match__item___0:
-  term' ->
-    ((term',term') syntax* ((pat',term') withinfo_t* (term',term') syntax
-      Prims.option* (term',term') syntax) Prims.list)
-  = fun projectee  -> match projectee with | Tm_match _0 -> _0
-let uu___is_Tm_ascribed: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_ascribed _0 -> true | uu____1067 -> false
-let __proj__Tm_ascribed__item___0:
-  term' ->
-    ((term',term') syntax* (((term',term') syntax,(comp',Prims.unit) syntax)
-      FStar_Util.either* (term',term') syntax Prims.option)*
-      FStar_Ident.lident Prims.option)
-  = fun projectee  -> match projectee with | Tm_ascribed _0 -> _0
-let uu___is_Tm_let: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_let _0 -> true | uu____1137 -> false
-let __proj__Tm_let__item___0:
-  term' -> ((Prims.bool* letbinding Prims.list)* (term',term') syntax) =
-  fun projectee  -> match projectee with | Tm_let _0 -> _0
-let uu___is_Tm_uvar: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_uvar _0 -> true | uu____1178 -> false
-let __proj__Tm_uvar__item___0:
-  term' ->
-    ((term',term') syntax uvar_basis FStar_Unionfind.uvar* (term',term')
-      syntax)
-  = fun projectee  -> match projectee with | Tm_uvar _0 -> _0
-let uu___is_Tm_delayed: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_delayed _0 -> true | uu____1234 -> false
-let __proj__Tm_delayed__item___0:
-  term' ->
-    ((((term',term') syntax* (subst_elt Prims.list Prims.list*
-        FStar_Range.range Prims.option)),Prims.unit -> (term',term') syntax)
-      FStar_Util.either* (term',term') syntax memo)
-  = fun projectee  -> match projectee with | Tm_delayed _0 -> _0
-let uu___is_Tm_meta: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_meta _0 -> true | uu____1310 -> false
-let __proj__Tm_meta__item___0: term' -> ((term',term') syntax* metadata) =
-  fun projectee  -> match projectee with | Tm_meta _0 -> _0
-let uu___is_Tm_unknown: term' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Tm_unknown  -> true | uu____1333 -> false
-let uu___is_Pat_constant: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_constant _0 -> true | uu____1338 -> false
-let __proj__Pat_constant__item___0: pat' -> sconst =
-  fun projectee  -> match projectee with | Pat_constant _0 -> _0
-let uu___is_Pat_disj: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_disj _0 -> true | uu____1353 -> false
-let __proj__Pat_disj__item___0: pat' -> (pat',term') withinfo_t Prims.list =
-  fun projectee  -> match projectee with | Pat_disj _0 -> _0
-let uu___is_Pat_cons: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_cons _0 -> true | uu____1381 -> false
-let __proj__Pat_cons__item___0:
-  pat' -> (fv* ((pat',term') withinfo_t* Prims.bool) Prims.list) =
-  fun projectee  -> match projectee with | Pat_cons _0 -> _0
-let uu___is_Pat_var: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_var _0 -> true | uu____1414 -> false
-let __proj__Pat_var__item___0: pat' -> bv =
-  fun projectee  -> match projectee with | Pat_var _0 -> _0
-let uu___is_Pat_wild: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_wild _0 -> true | uu____1426 -> false
-let __proj__Pat_wild__item___0: pat' -> bv =
-  fun projectee  -> match projectee with | Pat_wild _0 -> _0
-let uu___is_Pat_dot_term: pat' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Pat_dot_term _0 -> true | uu____1442 -> false
-let __proj__Pat_dot_term__item___0: pat' -> (bv* (term',term') syntax) =
-  fun projectee  -> match projectee with | Pat_dot_term _0 -> _0
-let uu___is_Total: comp' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Total _0 -> true | uu____1541 -> false
-let __proj__Total__item___0:
-  comp' -> ((term',term') syntax* universe Prims.option) =
-  fun projectee  -> match projectee with | Total _0 -> _0
-let uu___is_GTotal: comp' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | GTotal _0 -> true | uu____1573 -> false
-let __proj__GTotal__item___0:
-  comp' -> ((term',term') syntax* universe Prims.option) =
-  fun projectee  -> match projectee with | GTotal _0 -> _0
-let uu___is_Comp: comp' -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Comp _0 -> true | uu____1600 -> false
-let __proj__Comp__item___0: comp' -> comp_typ =
-  fun projectee  -> match projectee with | Comp _0 -> _0
-let uu___is_TOTAL: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TOTAL  -> true | uu____1611 -> false
-let uu___is_MLEFFECT: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MLEFFECT  -> true | uu____1615 -> false
-let uu___is_RETURN: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | RETURN  -> true | uu____1619 -> false
-let uu___is_PARTIAL_RETURN: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PARTIAL_RETURN  -> true | uu____1623 -> false
-let uu___is_SOMETRIVIAL: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SOMETRIVIAL  -> true | uu____1627 -> false
-let uu___is_LEMMA: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LEMMA  -> true | uu____1631 -> false
-let uu___is_CPS: cflags -> Prims.bool =
-  fun projectee  -> match projectee with | CPS  -> true | uu____1635 -> false
-let uu___is_DECREASES: cflags -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DECREASES _0 -> true | uu____1642 -> false
-let __proj__DECREASES__item___0: cflags -> (term',term') syntax =
-  fun projectee  -> match projectee with | DECREASES _0 -> _0
-let uu___is_Meta_pattern: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_pattern _0 -> true | uu____1666 -> false
-let __proj__Meta_pattern__item___0:
-  metadata -> ((term',term') syntax* aqual) Prims.list Prims.list =
-  fun projectee  -> match projectee with | Meta_pattern _0 -> _0
-let uu___is_Meta_named: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_named _0 -> true | uu____1696 -> false
-let __proj__Meta_named__item___0: metadata -> FStar_Ident.lident =
-  fun projectee  -> match projectee with | Meta_named _0 -> _0
-let uu___is_Meta_labeled: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_labeled _0 -> true | uu____1711 -> false
-let __proj__Meta_labeled__item___0:
-  metadata -> (Prims.string* FStar_Range.range* Prims.bool) =
-  fun projectee  -> match projectee with | Meta_labeled _0 -> _0
-let uu___is_Meta_desugared: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_desugared _0 -> true | uu____1732 -> false
-let __proj__Meta_desugared__item___0: metadata -> meta_source_info =
-  fun projectee  -> match projectee with | Meta_desugared _0 -> _0
-let uu___is_Meta_monadic: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_monadic _0 -> true | uu____1748 -> false
-let __proj__Meta_monadic__item___0:
-  metadata -> (monad_name* (term',term') syntax) =
-  fun projectee  -> match projectee with | Meta_monadic _0 -> _0
-let uu___is_Meta_monadic_lift: metadata -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_monadic_lift _0 -> true | uu____1777 -> false
-let __proj__Meta_monadic_lift__item___0:
-  metadata -> (monad_name* monad_name* (term',term') syntax) =
-  fun projectee  -> match projectee with | Meta_monadic_lift _0 -> _0
-let uu___is_Uvar projectee =
-  match projectee with | Uvar  -> true | uu____1809 -> false
-let uu___is_Fixed projectee =
-  match projectee with | Fixed _0 -> true | uu____1821 -> false
-let __proj__Fixed__item___0 projectee = match projectee with | Fixed _0 -> _0
-let uu___is_Data_app: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Data_app  -> true | uu____1839 -> false
-let uu___is_Sequence: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sequence  -> true | uu____1843 -> false
-let uu___is_Primop: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Primop  -> true | uu____1847 -> false
-let uu___is_Masked_effect: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Masked_effect  -> true | uu____1851 -> false
-let uu___is_Meta_smt_pat: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta_smt_pat  -> true | uu____1855 -> false
-let uu___is_Mutable_alloc: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mutable_alloc  -> true | uu____1859 -> false
-let uu___is_Mutable_rval: meta_source_info -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mutable_rval  -> true | uu____1863 -> false
-let uu___is_Data_ctor: fv_qual -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Data_ctor  -> true | uu____1867 -> false
-let uu___is_Record_projector: fv_qual -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Record_projector _0 -> true | uu____1874 -> false
-let __proj__Record_projector__item___0:
-  fv_qual -> (FStar_Ident.lident* FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Record_projector _0 -> _0
-let uu___is_Record_ctor: fv_qual -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Record_ctor _0 -> true | uu____1895 -> false
-let __proj__Record_ctor__item___0:
-  fv_qual -> (FStar_Ident.lident* FStar_Ident.ident Prims.list) =
-  fun projectee  -> match projectee with | Record_ctor _0 -> _0
-let uu___is_DB: subst_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DB _0 -> true | uu____1918 -> false
-let __proj__DB__item___0: subst_elt -> (Prims.int* bv) =
-  fun projectee  -> match projectee with | DB _0 -> _0
-let uu___is_NM: subst_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NM _0 -> true | uu____1938 -> false
-let __proj__NM__item___0: subst_elt -> (bv* Prims.int) =
-  fun projectee  -> match projectee with | NM _0 -> _0
-let uu___is_NT: subst_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NT _0 -> true | uu____1960 -> false
-let __proj__NT__item___0: subst_elt -> (bv* (term',term') syntax) =
-  fun projectee  -> match projectee with | NT _0 -> _0
-let uu___is_UN: subst_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UN _0 -> true | uu____1986 -> false
-let __proj__UN__item___0: subst_elt -> (Prims.int* universe) =
-  fun projectee  -> match projectee with | UN _0 -> _0
-let uu___is_UD: subst_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UD _0 -> true | uu____2006 -> false
-let __proj__UD__item___0: subst_elt -> (univ_name* Prims.int) =
-  fun projectee  -> match projectee with | UD _0 -> _0
-type pat = (pat',term') withinfo_t
-type term = (term',term') syntax
+| Tm_bvar of bv
+| Tm_name of bv
+| Tm_fvar of fv
+| Tm_uinst of ((term', term') syntax * universes)
+| Tm_constant of sconst
+| Tm_type of universe
+| Tm_abs of ((bv * aqual) Prims.list * (term', term') syntax * (lcomp, (FStar_Ident.lident * cflags Prims.list)) FStar_Util.either Prims.option)
+| Tm_arrow of ((bv * aqual) Prims.list * (comp', Prims.unit) syntax)
+| Tm_refine of (bv * (term', term') syntax)
+| Tm_app of ((term', term') syntax * ((term', term') syntax * aqual) Prims.list)
+| Tm_match of ((term', term') syntax * ((pat', term') withinfo_t * (term', term') syntax Prims.option * (term', term') syntax) Prims.list)
+| Tm_ascribed of ((term', term') syntax * (((term', term') syntax, (comp', Prims.unit) syntax) FStar_Util.either * (term', term') syntax Prims.option) * FStar_Ident.lident Prims.option)
+| Tm_let of ((Prims.bool * letbinding Prims.list) * (term', term') syntax)
+| Tm_uvar of ((term', term') syntax uvar_basis FStar_Unionfind.uvar * (term', term') syntax)
+| Tm_delayed of ((((term', term') syntax * (subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)), Prims.unit  ->  (term', term') syntax) FStar_Util.either * (term', term') syntax memo)
+| Tm_meta of ((term', term') syntax * metadata)
+| Tm_unknown 
+ and pat' =
+| Pat_constant of sconst
+| Pat_disj of (pat', term') withinfo_t Prims.list
+| Pat_cons of (fv * ((pat', term') withinfo_t * Prims.bool) Prims.list)
+| Pat_var of bv
+| Pat_wild of bv
+| Pat_dot_term of (bv * (term', term') syntax) 
+ and letbinding =
+{lbname : (bv, fv) FStar_Util.either; lbunivs : univ_name Prims.list; lbtyp : (term', term') syntax; lbeff : FStar_Ident.lident; lbdef : (term', term') syntax} 
+ and comp_typ =
+{comp_univs : universes; effect_name : FStar_Ident.lident; result_typ : (term', term') syntax; effect_args : ((term', term') syntax * aqual) Prims.list; flags : cflags Prims.list} 
+ and comp' =
+| Total of ((term', term') syntax * universe Prims.option)
+| GTotal of ((term', term') syntax * universe Prims.option)
+| Comp of comp_typ 
+ and cflags =
+| TOTAL
+| MLEFFECT
+| RETURN
+| PARTIAL_RETURN
+| SOMETRIVIAL
+| LEMMA
+| CPS
+| DECREASES of (term', term') syntax 
+ and metadata =
+| Meta_pattern of ((term', term') syntax * aqual) Prims.list Prims.list
+| Meta_named of FStar_Ident.lident
+| Meta_labeled of (Prims.string * FStar_Range.range * Prims.bool)
+| Meta_desugared of meta_source_info
+| Meta_monadic of (monad_name * (term', term') syntax)
+| Meta_monadic_lift of (monad_name * monad_name * (term', term') syntax) 
+ and 'a uvar_basis =
+| Uvar
+| Fixed of 'a 
+ and meta_source_info =
+| Data_app
+| Sequence
+| Primop
+| Masked_effect
+| Meta_smt_pat
+| Mutable_alloc
+| Mutable_rval 
+ and fv_qual =
+| Data_ctor
+| Record_projector of (FStar_Ident.lident * FStar_Ident.ident)
+| Record_ctor of (FStar_Ident.lident * FStar_Ident.ident Prims.list) 
+ and subst_elt =
+| DB of (Prims.int * bv)
+| NM of (bv * Prims.int)
+| NT of (bv * (term', term') syntax)
+| UN of (Prims.int * universe)
+| UD of (univ_name * Prims.int) 
+ and ('a, 'b) syntax =
+{n : 'a; tk : 'b memo; pos : FStar_Range.range; vars : free_vars memo} 
+ and bv =
+{ppname : FStar_Ident.ident; index : Prims.int; sort : (term', term') syntax} 
+ and fv =
+{fv_name : (term', term') syntax var; fv_delta : delta_depth; fv_qual : fv_qual Prims.option} 
+ and free_vars =
+{free_names : bv FStar_Util.set; free_uvars : ((term', term') syntax uvar_basis FStar_Unionfind.uvar * (term', term') syntax) FStar_Util.set; free_univs : universe_uvar FStar_Util.set; free_univ_names : univ_name FStar_Util.fifo_set} 
+ and lcomp =
+{eff_name : FStar_Ident.lident; res_typ : (term', term') syntax; cflags : cflags Prims.list; comp : Prims.unit  ->  (comp', Prims.unit) syntax}
+
+
+let uu___is_Tm_bvar : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_bvar (_0) -> begin
+true
+end
+| uu____732 -> begin
+false
+end))
+
+
+let __proj__Tm_bvar__item___0 : term'  ->  bv = (fun projectee -> (match (projectee) with
+| Tm_bvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_name : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_name (_0) -> begin
+true
+end
+| uu____744 -> begin
+false
+end))
+
+
+let __proj__Tm_name__item___0 : term'  ->  bv = (fun projectee -> (match (projectee) with
+| Tm_name (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_fvar : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_fvar (_0) -> begin
+true
+end
+| uu____756 -> begin
+false
+end))
+
+
+let __proj__Tm_fvar__item___0 : term'  ->  fv = (fun projectee -> (match (projectee) with
+| Tm_fvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_uinst : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_uinst (_0) -> begin
+true
+end
+| uu____772 -> begin
+false
+end))
+
+
+let __proj__Tm_uinst__item___0 : term'  ->  ((term', term') syntax * universes) = (fun projectee -> (match (projectee) with
+| Tm_uinst (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_constant : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_constant (_0) -> begin
+true
+end
+| uu____796 -> begin
+false
+end))
+
+
+let __proj__Tm_constant__item___0 : term'  ->  sconst = (fun projectee -> (match (projectee) with
+| Tm_constant (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_type : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_type (_0) -> begin
+true
+end
+| uu____808 -> begin
+false
+end))
+
+
+let __proj__Tm_type__item___0 : term'  ->  universe = (fun projectee -> (match (projectee) with
+| Tm_type (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_abs : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_abs (_0) -> begin
+true
+end
+| uu____834 -> begin
+false
+end))
+
+
+let __proj__Tm_abs__item___0 : term'  ->  ((bv * aqual) Prims.list * (term', term') syntax * (lcomp, (FStar_Ident.lident * cflags Prims.list)) FStar_Util.either Prims.option) = (fun projectee -> (match (projectee) with
+| Tm_abs (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_arrow : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_arrow (_0) -> begin
+true
+end
+| uu____895 -> begin
+false
+end))
+
+
+let __proj__Tm_arrow__item___0 : term'  ->  ((bv * aqual) Prims.list * (comp', Prims.unit) syntax) = (fun projectee -> (match (projectee) with
+| Tm_arrow (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_refine : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_refine (_0) -> begin
+true
+end
+| uu____932 -> begin
+false
+end))
+
+
+let __proj__Tm_refine__item___0 : term'  ->  (bv * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Tm_refine (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_app : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_app (_0) -> begin
+true
+end
+| uu____965 -> begin
+false
+end))
+
+
+let __proj__Tm_app__item___0 : term'  ->  ((term', term') syntax * ((term', term') syntax * aqual) Prims.list) = (fun projectee -> (match (projectee) with
+| Tm_app (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_match : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_match (_0) -> begin
+true
+end
+| uu____1019 -> begin
+false
+end))
+
+
+let __proj__Tm_match__item___0 : term'  ->  ((term', term') syntax * ((pat', term') withinfo_t * (term', term') syntax Prims.option * (term', term') syntax) Prims.list) = (fun projectee -> (match (projectee) with
+| Tm_match (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_ascribed : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_ascribed (_0) -> begin
+true
+end
+| uu____1093 -> begin
+false
+end))
+
+
+let __proj__Tm_ascribed__item___0 : term'  ->  ((term', term') syntax * (((term', term') syntax, (comp', Prims.unit) syntax) FStar_Util.either * (term', term') syntax Prims.option) * FStar_Ident.lident Prims.option) = (fun projectee -> (match (projectee) with
+| Tm_ascribed (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_let : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_let (_0) -> begin
+true
+end
+| uu____1163 -> begin
+false
+end))
+
+
+let __proj__Tm_let__item___0 : term'  ->  ((Prims.bool * letbinding Prims.list) * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Tm_let (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_uvar : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_uvar (_0) -> begin
+true
+end
+| uu____1204 -> begin
+false
+end))
+
+
+let __proj__Tm_uvar__item___0 : term'  ->  ((term', term') syntax uvar_basis FStar_Unionfind.uvar * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Tm_uvar (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_delayed : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_delayed (_0) -> begin
+true
+end
+| uu____1260 -> begin
+false
+end))
+
+
+let __proj__Tm_delayed__item___0 : term'  ->  ((((term', term') syntax * (subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)), Prims.unit  ->  (term', term') syntax) FStar_Util.either * (term', term') syntax memo) = (fun projectee -> (match (projectee) with
+| Tm_delayed (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_meta : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_meta (_0) -> begin
+true
+end
+| uu____1336 -> begin
+false
+end))
+
+
+let __proj__Tm_meta__item___0 : term'  ->  ((term', term') syntax * metadata) = (fun projectee -> (match (projectee) with
+| Tm_meta (_0) -> begin
+_0
+end))
+
+
+let uu___is_Tm_unknown : term'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Tm_unknown -> begin
+true
+end
+| uu____1359 -> begin
+false
+end))
+
+
+let uu___is_Pat_constant : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_constant (_0) -> begin
+true
+end
+| uu____1364 -> begin
+false
+end))
+
+
+let __proj__Pat_constant__item___0 : pat'  ->  sconst = (fun projectee -> (match (projectee) with
+| Pat_constant (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pat_disj : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_disj (_0) -> begin
+true
+end
+| uu____1379 -> begin
+false
+end))
+
+
+let __proj__Pat_disj__item___0 : pat'  ->  (pat', term') withinfo_t Prims.list = (fun projectee -> (match (projectee) with
+| Pat_disj (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pat_cons : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_cons (_0) -> begin
+true
+end
+| uu____1407 -> begin
+false
+end))
+
+
+let __proj__Pat_cons__item___0 : pat'  ->  (fv * ((pat', term') withinfo_t * Prims.bool) Prims.list) = (fun projectee -> (match (projectee) with
+| Pat_cons (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pat_var : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_var (_0) -> begin
+true
+end
+| uu____1440 -> begin
+false
+end))
+
+
+let __proj__Pat_var__item___0 : pat'  ->  bv = (fun projectee -> (match (projectee) with
+| Pat_var (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pat_wild : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_wild (_0) -> begin
+true
+end
+| uu____1452 -> begin
+false
+end))
+
+
+let __proj__Pat_wild__item___0 : pat'  ->  bv = (fun projectee -> (match (projectee) with
+| Pat_wild (_0) -> begin
+_0
+end))
+
+
+let uu___is_Pat_dot_term : pat'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Pat_dot_term (_0) -> begin
+true
+end
+| uu____1468 -> begin
+false
+end))
+
+
+let __proj__Pat_dot_term__item___0 : pat'  ->  (bv * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Pat_dot_term (_0) -> begin
+_0
+end))
+
+
+let uu___is_Total : comp'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Total (_0) -> begin
+true
+end
+| uu____1567 -> begin
+false
+end))
+
+
+let __proj__Total__item___0 : comp'  ->  ((term', term') syntax * universe Prims.option) = (fun projectee -> (match (projectee) with
+| Total (_0) -> begin
+_0
+end))
+
+
+let uu___is_GTotal : comp'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| GTotal (_0) -> begin
+true
+end
+| uu____1599 -> begin
+false
+end))
+
+
+let __proj__GTotal__item___0 : comp'  ->  ((term', term') syntax * universe Prims.option) = (fun projectee -> (match (projectee) with
+| GTotal (_0) -> begin
+_0
+end))
+
+
+let uu___is_Comp : comp'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Comp (_0) -> begin
+true
+end
+| uu____1626 -> begin
+false
+end))
+
+
+let __proj__Comp__item___0 : comp'  ->  comp_typ = (fun projectee -> (match (projectee) with
+| Comp (_0) -> begin
+_0
+end))
+
+
+let uu___is_TOTAL : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TOTAL -> begin
+true
+end
+| uu____1637 -> begin
+false
+end))
+
+
+let uu___is_MLEFFECT : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MLEFFECT -> begin
+true
+end
+| uu____1641 -> begin
+false
+end))
+
+
+let uu___is_RETURN : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| RETURN -> begin
+true
+end
+| uu____1645 -> begin
+false
+end))
+
+
+let uu___is_PARTIAL_RETURN : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PARTIAL_RETURN -> begin
+true
+end
+| uu____1649 -> begin
+false
+end))
+
+
+let uu___is_SOMETRIVIAL : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SOMETRIVIAL -> begin
+true
+end
+| uu____1653 -> begin
+false
+end))
+
+
+let uu___is_LEMMA : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LEMMA -> begin
+true
+end
+| uu____1657 -> begin
+false
+end))
+
+
+let uu___is_CPS : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CPS -> begin
+true
+end
+| uu____1661 -> begin
+false
+end))
+
+
+let uu___is_DECREASES : cflags  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DECREASES (_0) -> begin
+true
+end
+| uu____1668 -> begin
+false
+end))
+
+
+let __proj__DECREASES__item___0 : cflags  ->  (term', term') syntax = (fun projectee -> (match (projectee) with
+| DECREASES (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_pattern : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_pattern (_0) -> begin
+true
+end
+| uu____1692 -> begin
+false
+end))
+
+
+let __proj__Meta_pattern__item___0 : metadata  ->  ((term', term') syntax * aqual) Prims.list Prims.list = (fun projectee -> (match (projectee) with
+| Meta_pattern (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_named : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_named (_0) -> begin
+true
+end
+| uu____1722 -> begin
+false
+end))
+
+
+let __proj__Meta_named__item___0 : metadata  ->  FStar_Ident.lident = (fun projectee -> (match (projectee) with
+| Meta_named (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_labeled : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_labeled (_0) -> begin
+true
+end
+| uu____1737 -> begin
+false
+end))
+
+
+let __proj__Meta_labeled__item___0 : metadata  ->  (Prims.string * FStar_Range.range * Prims.bool) = (fun projectee -> (match (projectee) with
+| Meta_labeled (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_desugared : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_desugared (_0) -> begin
+true
+end
+| uu____1758 -> begin
+false
+end))
+
+
+let __proj__Meta_desugared__item___0 : metadata  ->  meta_source_info = (fun projectee -> (match (projectee) with
+| Meta_desugared (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_monadic : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_monadic (_0) -> begin
+true
+end
+| uu____1774 -> begin
+false
+end))
+
+
+let __proj__Meta_monadic__item___0 : metadata  ->  (monad_name * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Meta_monadic (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta_monadic_lift : metadata  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_monadic_lift (_0) -> begin
+true
+end
+| uu____1803 -> begin
+false
+end))
+
+
+let __proj__Meta_monadic_lift__item___0 : metadata  ->  (monad_name * monad_name * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| Meta_monadic_lift (_0) -> begin
+_0
+end))
+
+
+let uu___is_Uvar = (fun projectee -> (match (projectee) with
+| Uvar -> begin
+true
+end
+| uu____1835 -> begin
+false
+end))
+
+
+let uu___is_Fixed = (fun projectee -> (match (projectee) with
+| Fixed (_0) -> begin
+true
+end
+| uu____1847 -> begin
+false
+end))
+
+
+let __proj__Fixed__item___0 = (fun projectee -> (match (projectee) with
+| Fixed (_0) -> begin
+_0
+end))
+
+
+let uu___is_Data_app : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Data_app -> begin
+true
+end
+| uu____1865 -> begin
+false
+end))
+
+
+let uu___is_Sequence : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sequence -> begin
+true
+end
+| uu____1869 -> begin
+false
+end))
+
+
+let uu___is_Primop : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Primop -> begin
+true
+end
+| uu____1873 -> begin
+false
+end))
+
+
+let uu___is_Masked_effect : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Masked_effect -> begin
+true
+end
+| uu____1877 -> begin
+false
+end))
+
+
+let uu___is_Meta_smt_pat : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta_smt_pat -> begin
+true
+end
+| uu____1881 -> begin
+false
+end))
+
+
+let uu___is_Mutable_alloc : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mutable_alloc -> begin
+true
+end
+| uu____1885 -> begin
+false
+end))
+
+
+let uu___is_Mutable_rval : meta_source_info  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Mutable_rval -> begin
+true
+end
+| uu____1889 -> begin
+false
+end))
+
+
+let uu___is_Data_ctor : fv_qual  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Data_ctor -> begin
+true
+end
+| uu____1893 -> begin
+false
+end))
+
+
+let uu___is_Record_projector : fv_qual  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Record_projector (_0) -> begin
+true
+end
+| uu____1900 -> begin
+false
+end))
+
+
+let __proj__Record_projector__item___0 : fv_qual  ->  (FStar_Ident.lident * FStar_Ident.ident) = (fun projectee -> (match (projectee) with
+| Record_projector (_0) -> begin
+_0
+end))
+
+
+let uu___is_Record_ctor : fv_qual  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Record_ctor (_0) -> begin
+true
+end
+| uu____1921 -> begin
+false
+end))
+
+
+let __proj__Record_ctor__item___0 : fv_qual  ->  (FStar_Ident.lident * FStar_Ident.ident Prims.list) = (fun projectee -> (match (projectee) with
+| Record_ctor (_0) -> begin
+_0
+end))
+
+
+let uu___is_DB : subst_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| DB (_0) -> begin
+true
+end
+| uu____1944 -> begin
+false
+end))
+
+
+let __proj__DB__item___0 : subst_elt  ->  (Prims.int * bv) = (fun projectee -> (match (projectee) with
+| DB (_0) -> begin
+_0
+end))
+
+
+let uu___is_NM : subst_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NM (_0) -> begin
+true
+end
+| uu____1964 -> begin
+false
+end))
+
+
+let __proj__NM__item___0 : subst_elt  ->  (bv * Prims.int) = (fun projectee -> (match (projectee) with
+| NM (_0) -> begin
+_0
+end))
+
+
+let uu___is_NT : subst_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NT (_0) -> begin
+true
+end
+| uu____1986 -> begin
+false
+end))
+
+
+let __proj__NT__item___0 : subst_elt  ->  (bv * (term', term') syntax) = (fun projectee -> (match (projectee) with
+| NT (_0) -> begin
+_0
+end))
+
+
+let uu___is_UN : subst_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UN (_0) -> begin
+true
+end
+| uu____2012 -> begin
+false
+end))
+
+
+let __proj__UN__item___0 : subst_elt  ->  (Prims.int * universe) = (fun projectee -> (match (projectee) with
+| UN (_0) -> begin
+_0
+end))
+
+
+let uu___is_UD : subst_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UD (_0) -> begin
+true
+end
+| uu____2032 -> begin
+false
+end))
+
+
+let __proj__UD__item___0 : subst_elt  ->  (univ_name * Prims.int) = (fun projectee -> (match (projectee) with
+| UD (_0) -> begin
+_0
+end))
+
+
+type pat =
+(pat', term') withinfo_t
+
+
+type term =
+(term', term') syntax
+
+
 type branch =
-  ((pat',term') withinfo_t* (term',term') syntax Prims.option* (term',
-    term') syntax)
-type comp = (comp',Prims.unit) syntax
+((pat', term') withinfo_t * (term', term') syntax Prims.option * (term', term') syntax)
+
+
+type comp =
+(comp', Prims.unit) syntax
+
+
 type ascription =
-  (((term',term') syntax,(comp',Prims.unit) syntax) FStar_Util.either*
-    (term',term') syntax Prims.option)
-type typ = (term',term') syntax
-type arg = ((term',term') syntax* aqual)
-type args = ((term',term') syntax* aqual) Prims.list
-type binder = (bv* aqual)
-type binders = (bv* aqual) Prims.list
-type uvar = (term',term') syntax uvar_basis FStar_Unionfind.uvar
-type lbname = (bv,fv) FStar_Util.either
-type letbindings = (Prims.bool* letbinding Prims.list)
+(((term', term') syntax, (comp', Prims.unit) syntax) FStar_Util.either * (term', term') syntax Prims.option)
+
+
+type typ =
+(term', term') syntax
+
+
+type arg =
+((term', term') syntax * aqual)
+
+
+type args =
+((term', term') syntax * aqual) Prims.list
+
+
+type binder =
+(bv * aqual)
+
+
+type binders =
+(bv * aqual) Prims.list
+
+
+type uvar =
+(term', term') syntax uvar_basis FStar_Unionfind.uvar
+
+
+type lbname =
+(bv, fv) FStar_Util.either
+
+
+type letbindings =
+(Prims.bool * letbinding Prims.list)
+
+
 type subst_ts =
-  (subst_elt Prims.list Prims.list* FStar_Range.range Prims.option)
-type freenames = bv FStar_Util.set
+(subst_elt Prims.list Prims.list * FStar_Range.range Prims.option)
+
+
+type freenames =
+bv FStar_Util.set
+
+
 type uvars =
-  ((term',term') syntax uvar_basis FStar_Unionfind.uvar* (term',term')
-    syntax) FStar_Util.set
-type residual_comp = (FStar_Ident.lident* cflags Prims.list)
-type tscheme = (univ_name Prims.list* typ)
-type freenames_l = bv Prims.list
-type formula = typ
-type formulae = typ Prims.list
+((term', term') syntax uvar_basis FStar_Unionfind.uvar * (term', term') syntax) FStar_Util.set
+
+
+type residual_comp =
+(FStar_Ident.lident * cflags Prims.list)
+
+
+type tscheme =
+(univ_name Prims.list * typ)
+
+
+type freenames_l =
+bv Prims.list
+
+
+type formula =
+typ
+
+
+type formulae =
+typ Prims.list
+
 type qualifier =
-  | Assumption
-  | New
-  | Private
-  | Unfold_for_unification_and_vcgen
-  | Visible_default
-  | Irreducible
-  | Abstract
-  | Inline_for_extraction
-  | NoExtract
-  | Noeq
-  | Unopteq
-  | TotalEffect
-  | Logic
-  | Reifiable
-  | Reflectable of FStar_Ident.lident
-  | Discriminator of FStar_Ident.lident
-  | Projector of (FStar_Ident.lident* FStar_Ident.ident)
-  | RecordType of (FStar_Ident.ident Prims.list* FStar_Ident.ident
-  Prims.list)
-  | RecordConstructor of (FStar_Ident.ident Prims.list* FStar_Ident.ident
-  Prims.list)
-  | Action of FStar_Ident.lident
-  | ExceptionConstructor
-  | HasMaskedEffect
-  | Effect
-  | OnlyName
-let uu___is_Assumption: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Assumption  -> true | uu____2308 -> false
-let uu___is_New: qualifier -> Prims.bool =
-  fun projectee  -> match projectee with | New  -> true | uu____2312 -> false
-let uu___is_Private: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Private  -> true | uu____2316 -> false
-let uu___is_Unfold_for_unification_and_vcgen: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Unfold_for_unification_and_vcgen  -> true
-    | uu____2320 -> false
-let uu___is_Visible_default: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Visible_default  -> true | uu____2324 -> false
-let uu___is_Irreducible: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Irreducible  -> true | uu____2328 -> false
-let uu___is_Abstract: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Abstract  -> true | uu____2332 -> false
-let uu___is_Inline_for_extraction: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Inline_for_extraction  -> true
-    | uu____2336 -> false
-let uu___is_NoExtract: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____2340 -> false
-let uu___is_Noeq: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Noeq  -> true | uu____2344 -> false
-let uu___is_Unopteq: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unopteq  -> true | uu____2348 -> false
-let uu___is_TotalEffect: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TotalEffect  -> true | uu____2352 -> false
-let uu___is_Logic: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Logic  -> true | uu____2356 -> false
-let uu___is_Reifiable: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Reifiable  -> true | uu____2360 -> false
-let uu___is_Reflectable: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Reflectable _0 -> true | uu____2365 -> false
-let __proj__Reflectable__item___0: qualifier -> FStar_Ident.lident =
-  fun projectee  -> match projectee with | Reflectable _0 -> _0
-let uu___is_Discriminator: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Discriminator _0 -> true | uu____2377 -> false
-let __proj__Discriminator__item___0: qualifier -> FStar_Ident.lident =
-  fun projectee  -> match projectee with | Discriminator _0 -> _0
-let uu___is_Projector: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Projector _0 -> true | uu____2391 -> false
-let __proj__Projector__item___0:
-  qualifier -> (FStar_Ident.lident* FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Projector _0 -> _0
-let uu___is_RecordType: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | RecordType _0 -> true | uu____2413 -> false
-let __proj__RecordType__item___0:
-  qualifier -> (FStar_Ident.ident Prims.list* FStar_Ident.ident Prims.list) =
-  fun projectee  -> match projectee with | RecordType _0 -> _0
-let uu___is_RecordConstructor: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | RecordConstructor _0 -> true | uu____2441 -> false
-let __proj__RecordConstructor__item___0:
-  qualifier -> (FStar_Ident.ident Prims.list* FStar_Ident.ident Prims.list) =
-  fun projectee  -> match projectee with | RecordConstructor _0 -> _0
-let uu___is_Action: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Action _0 -> true | uu____2465 -> false
-let __proj__Action__item___0: qualifier -> FStar_Ident.lident =
-  fun projectee  -> match projectee with | Action _0 -> _0
-let uu___is_ExceptionConstructor: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | ExceptionConstructor  -> true
-    | uu____2476 -> false
-let uu___is_HasMaskedEffect: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | HasMaskedEffect  -> true | uu____2480 -> false
-let uu___is_Effect: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Effect  -> true | uu____2484 -> false
-let uu___is_OnlyName: qualifier -> Prims.bool =
-  fun projectee  ->
-    match projectee with | OnlyName  -> true | uu____2488 -> false
-type attribute = term
-type tycon = (FStar_Ident.lident* binders* typ)
-type monad_abbrev = {
-  mabbrev: FStar_Ident.lident;
-  parms: binders;
-  def: typ;}
+| Assumption
+| New
+| Private
+| Unfold_for_unification_and_vcgen
+| Visible_default
+| Irreducible
+| Abstract
+| Inline_for_extraction
+| NoExtract
+| Noeq
+| Unopteq
+| TotalEffect
+| Logic
+| Reifiable
+| Reflectable of FStar_Ident.lident
+| Discriminator of FStar_Ident.lident
+| Projector of (FStar_Ident.lident * FStar_Ident.ident)
+| RecordType of (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list)
+| RecordConstructor of (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list)
+| Action of FStar_Ident.lident
+| ExceptionConstructor
+| HasMaskedEffect
+| Effect
+| OnlyName
+
+
+let uu___is_Assumption : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Assumption -> begin
+true
+end
+| uu____2334 -> begin
+false
+end))
+
+
+let uu___is_New : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| New -> begin
+true
+end
+| uu____2338 -> begin
+false
+end))
+
+
+let uu___is_Private : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Private -> begin
+true
+end
+| uu____2342 -> begin
+false
+end))
+
+
+let uu___is_Unfold_for_unification_and_vcgen : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unfold_for_unification_and_vcgen -> begin
+true
+end
+| uu____2346 -> begin
+false
+end))
+
+
+let uu___is_Visible_default : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Visible_default -> begin
+true
+end
+| uu____2350 -> begin
+false
+end))
+
+
+let uu___is_Irreducible : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Irreducible -> begin
+true
+end
+| uu____2354 -> begin
+false
+end))
+
+
+let uu___is_Abstract : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Abstract -> begin
+true
+end
+| uu____2358 -> begin
+false
+end))
+
+
+let uu___is_Inline_for_extraction : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Inline_for_extraction -> begin
+true
+end
+| uu____2362 -> begin
+false
+end))
+
+
+let uu___is_NoExtract : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoExtract -> begin
+true
+end
+| uu____2366 -> begin
+false
+end))
+
+
+let uu___is_Noeq : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Noeq -> begin
+true
+end
+| uu____2370 -> begin
+false
+end))
+
+
+let uu___is_Unopteq : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unopteq -> begin
+true
+end
+| uu____2374 -> begin
+false
+end))
+
+
+let uu___is_TotalEffect : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TotalEffect -> begin
+true
+end
+| uu____2378 -> begin
+false
+end))
+
+
+let uu___is_Logic : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Logic -> begin
+true
+end
+| uu____2382 -> begin
+false
+end))
+
+
+let uu___is_Reifiable : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reifiable -> begin
+true
+end
+| uu____2386 -> begin
+false
+end))
+
+
+let uu___is_Reflectable : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reflectable (_0) -> begin
+true
+end
+| uu____2391 -> begin
+false
+end))
+
+
+let __proj__Reflectable__item___0 : qualifier  ->  FStar_Ident.lident = (fun projectee -> (match (projectee) with
+| Reflectable (_0) -> begin
+_0
+end))
+
+
+let uu___is_Discriminator : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Discriminator (_0) -> begin
+true
+end
+| uu____2403 -> begin
+false
+end))
+
+
+let __proj__Discriminator__item___0 : qualifier  ->  FStar_Ident.lident = (fun projectee -> (match (projectee) with
+| Discriminator (_0) -> begin
+_0
+end))
+
+
+let uu___is_Projector : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Projector (_0) -> begin
+true
+end
+| uu____2417 -> begin
+false
+end))
+
+
+let __proj__Projector__item___0 : qualifier  ->  (FStar_Ident.lident * FStar_Ident.ident) = (fun projectee -> (match (projectee) with
+| Projector (_0) -> begin
+_0
+end))
+
+
+let uu___is_RecordType : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| RecordType (_0) -> begin
+true
+end
+| uu____2439 -> begin
+false
+end))
+
+
+let __proj__RecordType__item___0 : qualifier  ->  (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list) = (fun projectee -> (match (projectee) with
+| RecordType (_0) -> begin
+_0
+end))
+
+
+let uu___is_RecordConstructor : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| RecordConstructor (_0) -> begin
+true
+end
+| uu____2467 -> begin
+false
+end))
+
+
+let __proj__RecordConstructor__item___0 : qualifier  ->  (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list) = (fun projectee -> (match (projectee) with
+| RecordConstructor (_0) -> begin
+_0
+end))
+
+
+let uu___is_Action : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Action (_0) -> begin
+true
+end
+| uu____2491 -> begin
+false
+end))
+
+
+let __proj__Action__item___0 : qualifier  ->  FStar_Ident.lident = (fun projectee -> (match (projectee) with
+| Action (_0) -> begin
+_0
+end))
+
+
+let uu___is_ExceptionConstructor : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| ExceptionConstructor -> begin
+true
+end
+| uu____2502 -> begin
+false
+end))
+
+
+let uu___is_HasMaskedEffect : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| HasMaskedEffect -> begin
+true
+end
+| uu____2506 -> begin
+false
+end))
+
+
+let uu___is_Effect : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Effect -> begin
+true
+end
+| uu____2510 -> begin
+false
+end))
+
+
+let uu___is_OnlyName : qualifier  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| OnlyName -> begin
+true
+end
+| uu____2514 -> begin
+false
+end))
+
+
+type attribute =
+term
+
+
+type tycon =
+(FStar_Ident.lident * binders * typ)
+
+type monad_abbrev =
+{mabbrev : FStar_Ident.lident; parms : binders; def : typ}
+
 type sub_eff =
-  {
-  source: FStar_Ident.lident;
-  target: FStar_Ident.lident;
-  lift_wp: tscheme Prims.option;
-  lift: tscheme Prims.option;}
+{source : FStar_Ident.lident; target : FStar_Ident.lident; lift_wp : tscheme Prims.option; lift : tscheme Prims.option}
+
 type action =
-  {
-  action_name: FStar_Ident.lident;
-  action_unqualified_name: FStar_Ident.ident;
-  action_univs: univ_names;
-  action_defn: term;
-  action_typ: typ;}
+{action_name : FStar_Ident.lident; action_unqualified_name : FStar_Ident.ident; action_univs : univ_names; action_defn : term; action_typ : typ}
+
 type eff_decl =
-  {
-  qualifiers: qualifier Prims.list;
-  cattributes: cflags Prims.list;
-  mname: FStar_Ident.lident;
-  univs: univ_names;
-  binders: binders;
-  signature: term;
-  ret_wp: tscheme;
-  bind_wp: tscheme;
-  if_then_else: tscheme;
-  ite_wp: tscheme;
-  stronger: tscheme;
-  close_wp: tscheme;
-  assert_p: tscheme;
-  assume_p: tscheme;
-  null_wp: tscheme;
-  trivial: tscheme;
-  repr: term;
-  return_repr: tscheme;
-  bind_repr: tscheme;
-  actions: action Prims.list;}
-and sigelt =
-  | Sig_inductive_typ of (FStar_Ident.lident* univ_names* binders* typ*
-  FStar_Ident.lident Prims.list* FStar_Ident.lident Prims.list* qualifier
-  Prims.list* FStar_Range.range)
-  | Sig_bundle of (sigelt Prims.list* qualifier Prims.list*
-  FStar_Ident.lident Prims.list* FStar_Range.range)
-  | Sig_datacon of (FStar_Ident.lident* univ_names* typ* FStar_Ident.lident*
-  Prims.int* qualifier Prims.list* FStar_Ident.lident Prims.list*
-  FStar_Range.range)
-  | Sig_declare_typ of (FStar_Ident.lident* univ_names* typ* qualifier
-  Prims.list* FStar_Range.range)
-  | Sig_let of (letbindings* FStar_Range.range* FStar_Ident.lident
-  Prims.list* qualifier Prims.list* attribute Prims.list)
-  | Sig_main of (term* FStar_Range.range)
-  | Sig_assume of (FStar_Ident.lident* formula* qualifier Prims.list*
-  FStar_Range.range)
-  | Sig_new_effect of (eff_decl* FStar_Range.range)
-  | Sig_new_effect_for_free of (eff_decl* FStar_Range.range)
-  | Sig_sub_effect of (sub_eff* FStar_Range.range)
-  | Sig_effect_abbrev of (FStar_Ident.lident* univ_names* binders* comp*
-  qualifier Prims.list* cflags Prims.list* FStar_Range.range)
-  | Sig_pragma of (pragma* FStar_Range.range)
-let uu___is_Sig_inductive_typ: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_inductive_typ _0 -> true | uu____2848 -> false
-let __proj__Sig_inductive_typ__item___0:
-  sigelt ->
-    (FStar_Ident.lident* univ_names* binders* typ* FStar_Ident.lident
-      Prims.list* FStar_Ident.lident Prims.list* qualifier Prims.list*
-      FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_inductive_typ _0 -> _0
-let uu___is_Sig_bundle: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_bundle _0 -> true | uu____2900 -> false
-let __proj__Sig_bundle__item___0:
-  sigelt ->
-    (sigelt Prims.list* qualifier Prims.list* FStar_Ident.lident Prims.list*
-      FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_bundle _0 -> _0
-let uu___is_Sig_datacon: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_datacon _0 -> true | uu____2943 -> false
-let __proj__Sig_datacon__item___0:
-  sigelt ->
-    (FStar_Ident.lident* univ_names* typ* FStar_Ident.lident* Prims.int*
-      qualifier Prims.list* FStar_Ident.lident Prims.list* FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_datacon _0 -> _0
-let uu___is_Sig_declare_typ: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_declare_typ _0 -> true | uu____2991 -> false
-let __proj__Sig_declare_typ__item___0:
-  sigelt ->
-    (FStar_Ident.lident* univ_names* typ* qualifier Prims.list*
-      FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_declare_typ _0 -> _0
-let uu___is_Sig_let: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_let _0 -> true | uu____3029 -> false
-let __proj__Sig_let__item___0:
-  sigelt ->
-    (letbindings* FStar_Range.range* FStar_Ident.lident Prims.list* qualifier
-      Prims.list* attribute Prims.list)
-  = fun projectee  -> match projectee with | Sig_let _0 -> _0
-let uu___is_Sig_main: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_main _0 -> true | uu____3067 -> false
-let __proj__Sig_main__item___0: sigelt -> (term* FStar_Range.range) =
-  fun projectee  -> match projectee with | Sig_main _0 -> _0
-let uu___is_Sig_assume: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_assume _0 -> true | uu____3090 -> false
-let __proj__Sig_assume__item___0:
-  sigelt ->
-    (FStar_Ident.lident* formula* qualifier Prims.list* FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_assume _0 -> _0
-let uu___is_Sig_new_effect: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_new_effect _0 -> true | uu____3119 -> false
-let __proj__Sig_new_effect__item___0: sigelt -> (eff_decl* FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_new_effect _0 -> _0
-let uu___is_Sig_new_effect_for_free: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Sig_new_effect_for_free _0 -> true
-    | uu____3139 -> false
-let __proj__Sig_new_effect_for_free__item___0:
-  sigelt -> (eff_decl* FStar_Range.range) =
-  fun projectee  -> match projectee with | Sig_new_effect_for_free _0 -> _0
-let uu___is_Sig_sub_effect: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_sub_effect _0 -> true | uu____3159 -> false
-let __proj__Sig_sub_effect__item___0: sigelt -> (sub_eff* FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_sub_effect _0 -> _0
-let uu___is_Sig_effect_abbrev: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_effect_abbrev _0 -> true | uu____3186 -> false
-let __proj__Sig_effect_abbrev__item___0:
-  sigelt ->
-    (FStar_Ident.lident* univ_names* binders* comp* qualifier Prims.list*
-      cflags Prims.list* FStar_Range.range)
-  = fun projectee  -> match projectee with | Sig_effect_abbrev _0 -> _0
-let uu___is_Sig_pragma: sigelt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Sig_pragma _0 -> true | uu____3227 -> false
-let __proj__Sig_pragma__item___0: sigelt -> (pragma* FStar_Range.range) =
-  fun projectee  -> match projectee with | Sig_pragma _0 -> _0
-type sigelts = sigelt Prims.list
+{qualifiers : qualifier Prims.list; cattributes : cflags Prims.list; mname : FStar_Ident.lident; univs : univ_names; binders : binders; signature : term; ret_wp : tscheme; bind_wp : tscheme; if_then_else : tscheme; ite_wp : tscheme; stronger : tscheme; close_wp : tscheme; assert_p : tscheme; assume_p : tscheme; null_wp : tscheme; trivial : tscheme; repr : term; return_repr : tscheme; bind_repr : tscheme; actions : action Prims.list} 
+ and sigelt' =
+| Sig_inductive_typ of (FStar_Ident.lident * univ_names * binders * typ * FStar_Ident.lident Prims.list * FStar_Ident.lident Prims.list * qualifier Prims.list)
+| Sig_bundle of (sigelt Prims.list * qualifier Prims.list * FStar_Ident.lident Prims.list)
+| Sig_datacon of (FStar_Ident.lident * univ_names * typ * FStar_Ident.lident * Prims.int * qualifier Prims.list * FStar_Ident.lident Prims.list)
+| Sig_declare_typ of (FStar_Ident.lident * univ_names * typ * qualifier Prims.list)
+| Sig_let of (letbindings * FStar_Ident.lident Prims.list * qualifier Prims.list * attribute Prims.list)
+| Sig_main of term
+| Sig_assume of (FStar_Ident.lident * formula * qualifier Prims.list)
+| Sig_new_effect of eff_decl
+| Sig_new_effect_for_free of eff_decl
+| Sig_sub_effect of sub_eff
+| Sig_effect_abbrev of (FStar_Ident.lident * univ_names * binders * comp * qualifier Prims.list * cflags Prims.list)
+| Sig_pragma of pragma 
+ and sigelt =
+{sigel : sigelt'; sigdoc : fsdoc Prims.option; sigrng : FStar_Range.range}
+
+
+let uu___is_Sig_inductive_typ : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_inductive_typ (_0) -> begin
+true
+end
+| uu____2866 -> begin
+false
+end))
+
+
+let __proj__Sig_inductive_typ__item___0 : sigelt'  ->  (FStar_Ident.lident * univ_names * binders * typ * FStar_Ident.lident Prims.list * FStar_Ident.lident Prims.list * qualifier Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_inductive_typ (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_bundle : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_bundle (_0) -> begin
+true
+end
+| uu____2914 -> begin
+false
+end))
+
+
+let __proj__Sig_bundle__item___0 : sigelt'  ->  (sigelt Prims.list * qualifier Prims.list * FStar_Ident.lident Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_bundle (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_datacon : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_datacon (_0) -> begin
+true
+end
+| uu____2953 -> begin
+false
+end))
+
+
+let __proj__Sig_datacon__item___0 : sigelt'  ->  (FStar_Ident.lident * univ_names * typ * FStar_Ident.lident * Prims.int * qualifier Prims.list * FStar_Ident.lident Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_datacon (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_declare_typ : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_declare_typ (_0) -> begin
+true
+end
+| uu____2997 -> begin
+false
+end))
+
+
+let __proj__Sig_declare_typ__item___0 : sigelt'  ->  (FStar_Ident.lident * univ_names * typ * qualifier Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_declare_typ (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_let : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_let (_0) -> begin
+true
+end
+| uu____3031 -> begin
+false
+end))
+
+
+let __proj__Sig_let__item___0 : sigelt'  ->  (letbindings * FStar_Ident.lident Prims.list * qualifier Prims.list * attribute Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_let (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_main : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_main (_0) -> begin
+true
+end
+| uu____3064 -> begin
+false
+end))
+
+
+let __proj__Sig_main__item___0 : sigelt'  ->  term = (fun projectee -> (match (projectee) with
+| Sig_main (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_assume : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_assume (_0) -> begin
+true
+end
+| uu____3080 -> begin
+false
+end))
+
+
+let __proj__Sig_assume__item___0 : sigelt'  ->  (FStar_Ident.lident * formula * qualifier Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_assume (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_new_effect : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_new_effect (_0) -> begin
+true
+end
+| uu____3104 -> begin
+false
+end))
+
+
+let __proj__Sig_new_effect__item___0 : sigelt'  ->  eff_decl = (fun projectee -> (match (projectee) with
+| Sig_new_effect (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_new_effect_for_free : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_new_effect_for_free (_0) -> begin
+true
+end
+| uu____3116 -> begin
+false
+end))
+
+
+let __proj__Sig_new_effect_for_free__item___0 : sigelt'  ->  eff_decl = (fun projectee -> (match (projectee) with
+| Sig_new_effect_for_free (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_sub_effect : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_sub_effect (_0) -> begin
+true
+end
+| uu____3128 -> begin
+false
+end))
+
+
+let __proj__Sig_sub_effect__item___0 : sigelt'  ->  sub_eff = (fun projectee -> (match (projectee) with
+| Sig_sub_effect (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_effect_abbrev : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_effect_abbrev (_0) -> begin
+true
+end
+| uu____3148 -> begin
+false
+end))
+
+
+let __proj__Sig_effect_abbrev__item___0 : sigelt'  ->  (FStar_Ident.lident * univ_names * binders * comp * qualifier Prims.list * cflags Prims.list) = (fun projectee -> (match (projectee) with
+| Sig_effect_abbrev (_0) -> begin
+_0
+end))
+
+
+let uu___is_Sig_pragma : sigelt'  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Sig_pragma (_0) -> begin
+true
+end
+| uu____3184 -> begin
+false
+end))
+
+
+let __proj__Sig_pragma__item___0 : sigelt'  ->  pragma = (fun projectee -> (match (projectee) with
+| Sig_pragma (_0) -> begin
+_0
+end))
+
+
+type sigelts =
+sigelt Prims.list
+
 type modul =
-  {
-  name: FStar_Ident.lident;
-  declarations: sigelts;
-  exports: sigelts;
-  is_interface: Prims.bool;}
-type path = Prims.string Prims.list
-type subst_t = subst_elt Prims.list
-type ('a,'b) mk_t_a = 'b Prims.option -> FStar_Range.range -> ('a,'b) syntax
-type mk_t = (term',term') mk_t_a
-let contains_reflectable: qualifier Prims.list -> Prims.bool =
-  fun l  ->
-    FStar_Util.for_some
-      (fun uu___90_3288  ->
-         match uu___90_3288 with
-         | Reflectable uu____3289 -> true
-         | uu____3290 -> false) l
-let withinfo v1 s r = { v = v1; ty = s; p = r }
-let withsort v1 s = withinfo v1 s FStar_Range.dummyRange
-let bv_eq: bv -> bv -> Prims.bool =
-  fun bv1  ->
-    fun bv2  ->
-      ((bv1.ppname).FStar_Ident.idText = (bv2.ppname).FStar_Ident.idText) &&
-        (bv1.index = bv2.index)
-let order_bv: bv -> bv -> Prims.int =
-  fun x  ->
-    fun y  ->
-      let i =
-        FStar_String.compare (x.ppname).FStar_Ident.idText
-          (y.ppname).FStar_Ident.idText in
-      if i = (Prims.parse_int "0") then x.index - y.index else i
-let order_fv: FStar_Ident.lident -> FStar_Ident.lident -> Prims.int =
-  fun x  ->
-    fun y  -> FStar_String.compare x.FStar_Ident.str y.FStar_Ident.str
-let range_of_lbname: lbname -> FStar_Range.range =
-  fun l  ->
-    match l with
-    | FStar_Util.Inl x -> (x.ppname).FStar_Ident.idRange
-    | FStar_Util.Inr fv -> FStar_Ident.range_of_lid (fv.fv_name).v
-let range_of_bv: bv -> FStar_Range.range =
-  fun x  -> (x.ppname).FStar_Ident.idRange
-let set_range_of_bv: bv -> FStar_Range.range -> bv =
-  fun x  ->
-    fun r  ->
-      let uu___97_3366 = x in
-      {
-        ppname = (FStar_Ident.mk_ident (((x.ppname).FStar_Ident.idText), r));
-        index = (uu___97_3366.index);
-        sort = (uu___97_3366.sort)
-      }
-let syn p k f = f k p
-let mk_fvs uu____3407 = FStar_Util.mk_ref None
-let mk_uvs uu____3419 = FStar_Util.mk_ref None
-let new_bv_set: Prims.unit -> bv FStar_Util.set =
-  fun uu____3425  ->
-    FStar_Util.new_set order_bv
-      (fun x  ->
-         x.index + (FStar_Util.hashcode (x.ppname).FStar_Ident.idText))
-let new_fv_set: Prims.unit -> FStar_Ident.lident FStar_Util.set =
-  fun uu____3431  ->
-    FStar_Util.new_set order_fv
-      (fun x  -> FStar_Util.hashcode x.FStar_Ident.str)
-let new_uv_set:
-  Prims.unit ->
-    ((term',term') syntax uvar_basis FStar_Unionfind.uvar* (term',term')
-      syntax) FStar_Util.set
-  =
-  fun uu____3436  ->
-    FStar_Util.new_set
-      (fun uu____3445  ->
-         fun uu____3446  ->
-           match (uu____3445, uu____3446) with
-           | ((x,uu____3480),(y,uu____3482)) ->
-               let uu____3523 = FStar_Unionfind.uvar_id x in
-               let uu____3527 = FStar_Unionfind.uvar_id y in
-               uu____3523 - uu____3527)
-      (fun uu____3531  ->
-         match uu____3531 with | (x,uu____3541) -> FStar_Unionfind.uvar_id x)
-let new_universe_uvar_set:
-  Prims.unit -> universe Prims.option FStar_Unionfind.uvar FStar_Util.set =
-  fun uu____3560  ->
-    FStar_Util.new_set
-      (fun x  ->
-         fun y  ->
-           let uu____3570 = FStar_Unionfind.uvar_id x in
-           let uu____3572 = FStar_Unionfind.uvar_id y in
-           uu____3570 - uu____3572) (fun x  -> FStar_Unionfind.uvar_id x)
-let new_universe_names_fifo_set:
-  Prims.unit -> FStar_Ident.ident FStar_Util.fifo_set =
-  fun uu____3583  ->
-    FStar_Util.new_fifo_set
-      (fun x  ->
-         fun y  ->
-           FStar_String.compare (FStar_Ident.text_of_id x)
-             (FStar_Ident.text_of_id y))
-      (fun x  -> FStar_Util.hashcode (FStar_Ident.text_of_id x))
-let no_names: bv FStar_Util.set = new_bv_set ()
-let no_fvars: FStar_Ident.lident FStar_Util.set = new_fv_set ()
-let no_uvs: uvars = new_uv_set ()
-let no_universe_uvars: universe_uvar FStar_Util.set =
-  new_universe_uvar_set ()
-let no_universe_names: univ_name FStar_Util.fifo_set =
-  new_universe_names_fifo_set ()
-let empty_free_vars: free_vars =
-  {
-    free_names = no_names;
-    free_uvars = no_uvs;
-    free_univs = no_universe_uvars;
-    free_univ_names = no_universe_names
-  }
-let memo_no_uvs: uvars Prims.option FStar_ST.ref =
-  FStar_Util.mk_ref (Some no_uvs)
-let memo_no_names: bv FStar_Util.set Prims.option FStar_ST.ref =
-  FStar_Util.mk_ref (Some no_names)
-let freenames_of_list: bv Prims.list -> bv FStar_Util.set =
-  fun l  -> FStar_List.fold_right FStar_Util.set_add l no_names
-let list_of_freenames: freenames -> bv Prims.list =
-  fun fvs  -> FStar_Util.set_elements fvs
-let mk t topt r =
-  let uu____3645 = FStar_Util.mk_ref topt in
-  let uu____3649 = FStar_Util.mk_ref None in
-  { n = t; tk = uu____3645; pos = r; vars = uu____3649 }
-let bv_to_tm: bv -> (term',term') syntax =
-  fun bv  ->
-    let uu____3660 = range_of_bv bv in
-    (mk (Tm_bvar bv)) (Some ((bv.sort).n)) uu____3660
-let bv_to_name: bv -> (term',term') syntax =
-  fun bv  ->
-    let uu____3672 = range_of_bv bv in
-    (mk (Tm_name bv)) (Some ((bv.sort).n)) uu____3672
-let mk_Tm_app:
-  typ ->
-    arg Prims.list ->
-      term' Prims.option -> FStar_Range.range -> (term',term') syntax
-  =
-  fun t1  ->
-    fun args  ->
-      fun k  ->
-        fun p  ->
-          match args with
-          | [] -> t1
-          | uu____3697 -> (mk (Tm_app (t1, args))) k p
-let mk_Tm_uinst: term -> universes -> term =
-  fun t  ->
-    fun uu___91_3713  ->
-      match uu___91_3713 with
-      | [] -> t
-      | us ->
-          (match t.n with
-           | Tm_fvar uu____3715 -> (mk (Tm_uinst (t, us))) None t.pos
-           | uu____3724 -> failwith "Unexpected universe instantiation")
-let extend_app_n:
-  term ->
-    args -> term' Prims.option -> FStar_Range.range -> (term',term') syntax
-  =
-  fun t  ->
-    fun args'  ->
-      fun kopt  ->
-        fun r  ->
-          match t.n with
-          | Tm_app (head1,args) ->
-              (mk_Tm_app head1 (FStar_List.append args args')) kopt r
-          | uu____3764 -> (mk_Tm_app t args') kopt r
-let extend_app:
-  term ->
-    arg -> term' Prims.option -> FStar_Range.range -> (term',term') syntax
-  =
-  fun t  -> fun arg  -> fun kopt  -> fun r  -> (extend_app_n t [arg]) kopt r
-let mk_Tm_delayed:
-  ((term* subst_ts),Prims.unit -> term) FStar_Util.either ->
-    FStar_Range.range -> (term',term') syntax
-  =
-  fun lr  ->
-    fun pos  ->
-      let uu____3805 =
-        let uu____3808 =
-          let uu____3809 =
-            let uu____3830 = FStar_Util.mk_ref None in (lr, uu____3830) in
-          Tm_delayed uu____3809 in
-        mk uu____3808 in
-      uu____3805 None pos
-let mk_Total': typ -> universe Prims.option -> (comp',Prims.unit) syntax =
-  fun t  -> fun u  -> (mk (Total (t, u))) None t.pos
-let mk_GTotal': typ -> universe Prims.option -> (comp',Prims.unit) syntax =
-  fun t  -> fun u  -> (mk (GTotal (t, u))) None t.pos
-let mk_Total: typ -> comp = fun t  -> mk_Total' t None
-let mk_GTotal: typ -> comp = fun t  -> mk_GTotal' t None
-let mk_Comp: comp_typ -> (comp',Prims.unit) syntax =
-  fun ct  -> (mk (Comp ct)) None (ct.result_typ).pos
-let mk_lb:
-  (lbname* univ_name Prims.list* FStar_Ident.lident* typ* term) -> letbinding
-  =
-  fun uu____3920  ->
-    match uu____3920 with
-    | (x,univs,eff,t,e) ->
-        { lbname = x; lbunivs = univs; lbtyp = t; lbeff = eff; lbdef = e }
-let mk_subst: subst_t -> subst_t = fun s  -> s
-let extend_subst: subst_elt -> subst_elt Prims.list -> subst_elt Prims.list =
-  fun x  -> fun s  -> x :: s
-let argpos: arg -> FStar_Range.range = fun x  -> (Prims.fst x).pos
-let tun: (term',term') syntax = (mk Tm_unknown) None FStar_Range.dummyRange
-let teff: (term',term') syntax =
-  (mk (Tm_constant FStar_Const.Const_effect)) (Some Tm_unknown)
-    FStar_Range.dummyRange
-let is_teff: term -> Prims.bool =
-  fun t  ->
-    match t.n with
-    | Tm_constant (FStar_Const.Const_effect ) -> true
-    | uu____3973 -> false
-let is_type: term -> Prims.bool =
-  fun t  -> match t.n with | Tm_type uu____3977 -> true | uu____3978 -> false
-let null_id: FStar_Ident.ident =
-  FStar_Ident.mk_ident ("_", FStar_Range.dummyRange)
-let null_bv: term -> bv =
-  fun k  -> { ppname = null_id; index = (Prims.parse_int "0"); sort = k }
-let mk_binder: bv -> (bv* arg_qualifier Prims.option) = fun a  -> (a, None)
-let null_binder: term -> (bv* arg_qualifier Prims.option) =
-  fun t  -> let uu____3989 = null_bv t in (uu____3989, None)
-let imp_tag: arg_qualifier = Implicit false
-let iarg: term -> (term* arg_qualifier Prims.option) =
-  fun t  -> (t, (Some imp_tag))
-let as_arg: term -> (term* arg_qualifier Prims.option) = fun t  -> (t, None)
-let is_null_bv: bv -> Prims.bool =
-  fun b  -> (b.ppname).FStar_Ident.idText = null_id.FStar_Ident.idText
-let is_null_binder: binder -> Prims.bool = fun b  -> is_null_bv (Prims.fst b)
-let is_top_level: letbinding Prims.list -> Prims.bool =
-  fun uu___92_4008  ->
-    match uu___92_4008 with
-    | { lbname = FStar_Util.Inr uu____4010; lbunivs = uu____4011;
-        lbtyp = uu____4012; lbeff = uu____4013; lbdef = uu____4014;_}::uu____4015
-        -> true
-    | uu____4022 -> false
-let freenames_of_binders: binders -> bv FStar_Util.set =
-  fun bs  ->
-    FStar_List.fold_right
-      (fun uu____4030  ->
-         fun out  ->
-           match uu____4030 with | (x,uu____4037) -> FStar_Util.set_add x out)
-      bs no_names
-let binders_of_list:
-  bv Prims.list -> (bv* arg_qualifier Prims.option) Prims.list =
-  fun fvs  -> FStar_All.pipe_right fvs (FStar_List.map (fun t  -> (t, None)))
-let binders_of_freenames: freenames -> binders =
-  fun fvs  ->
-    let uu____4056 = FStar_Util.set_elements fvs in
-    FStar_All.pipe_right uu____4056 binders_of_list
-let is_implicit: aqual -> Prims.bool =
-  fun uu___93_4061  ->
-    match uu___93_4061 with
-    | Some (Implicit uu____4062) -> true
-    | uu____4063 -> false
-let as_implicit: Prims.bool -> arg_qualifier Prims.option =
-  fun uu___94_4066  -> if uu___94_4066 then Some imp_tag else None
-let pat_bvs: pat -> bv Prims.list =
-  fun p  ->
-    let rec aux b p1 =
-      match p1.v with
-      | Pat_dot_term _|Pat_constant _ -> b
-      | Pat_wild x|Pat_var x -> x :: b
-      | Pat_cons (uu____4091,pats) ->
-          FStar_List.fold_left
-            (fun b1  ->
-               fun uu____4109  ->
-                 match uu____4109 with | (p2,uu____4117) -> aux b1 p2) b pats
-      | Pat_disj (p2::uu____4123) -> aux b p2
-      | Pat_disj [] -> failwith "impossible" in
-    let uu____4134 = aux [] p in
-    FStar_All.pipe_left FStar_List.rev uu____4134
-let gen_reset: ((Prims.unit -> Prims.int)* (Prims.unit -> Prims.unit)) =
-  let x = FStar_Util.mk_ref (Prims.parse_int "0") in
-  let gen1 uu____4150 = FStar_Util.incr x; FStar_ST.read x in
-  let reset uu____4160 = FStar_ST.write x (Prims.parse_int "0") in
-  (gen1, reset)
-let next_id: Prims.unit -> Prims.int = Prims.fst gen_reset
-let reset_gensym: Prims.unit -> Prims.unit = Prims.snd gen_reset
-let range_of_ropt: FStar_Range.range Prims.option -> FStar_Range.range =
-  fun uu___95_4182  ->
-    match uu___95_4182 with | None  -> FStar_Range.dummyRange | Some r -> r
-let gen_bv: Prims.string -> FStar_Range.range Prims.option -> typ -> bv =
-  fun s  ->
-    fun r  ->
-      fun t  ->
-        let id = FStar_Ident.mk_ident (s, (range_of_ropt r)) in
-        let uu____4197 = next_id () in
-        { ppname = id; index = uu____4197; sort = t }
-let new_bv: FStar_Range.range Prims.option -> typ -> bv =
-  fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t
-let freshen_bv: bv -> bv =
-  fun bv  ->
-    let uu____4209 = is_null_bv bv in
-    if uu____4209
-    then
-      let uu____4210 = let uu____4212 = range_of_bv bv in Some uu____4212 in
-      new_bv uu____4210 bv.sort
-    else
-      (let uu___98_4214 = bv in
-       let uu____4215 = next_id () in
-       {
-         ppname = (uu___98_4214.ppname);
-         index = uu____4215;
-         sort = (uu___98_4214.sort)
-       })
-let new_univ_name: FStar_Range.range Prims.option -> FStar_Ident.ident =
-  fun ropt  ->
-    let id = next_id () in
-    let uu____4222 =
-      let uu____4225 =
-        let uu____4226 = FStar_Util.string_of_int id in
-        Prims.strcat FStar_Ident.reserved_prefix uu____4226 in
-      (uu____4225, (range_of_ropt ropt)) in
-    FStar_Ident.mk_ident uu____4222
-let mkbv: FStar_Ident.ident -> Prims.int -> (term',term') syntax -> bv =
-  fun x  -> fun y  -> fun t  -> { ppname = x; index = y; sort = t }
-let lbname_eq:
-  (bv,FStar_Ident.lident) FStar_Util.either ->
-    (bv,FStar_Ident.lident) FStar_Util.either -> Prims.bool
-  =
-  fun l1  ->
-    fun l2  ->
-      match (l1, l2) with
-      | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
-      | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____4270 -> false
-let fv_eq: fv -> fv -> Prims.bool =
-  fun fv1  ->
-    fun fv2  -> FStar_Ident.lid_equals (fv1.fv_name).v (fv2.fv_name).v
-let fv_eq_lid: fv -> FStar_Ident.lident -> Prims.bool =
-  fun fv  -> fun lid  -> FStar_Ident.lid_equals (fv.fv_name).v lid
-let set_bv_range: bv -> FStar_Range.range -> bv =
-  fun bv  ->
-    fun r  ->
-      let uu___99_4307 = bv in
-      {
-        ppname = (FStar_Ident.mk_ident (((bv.ppname).FStar_Ident.idText), r));
-        index = (uu___99_4307.index);
-        sort = (uu___99_4307.sort)
-      }
-let lid_as_fv:
-  FStar_Ident.lident -> delta_depth -> fv_qual Prims.option -> fv =
-  fun l  ->
-    fun dd  ->
-      fun dq  ->
-        let uu____4319 = withinfo l tun (FStar_Ident.range_of_lid l) in
-        { fv_name = uu____4319; fv_delta = dd; fv_qual = dq }
-let fv_to_tm: fv -> (term',term') syntax =
-  fun fv  -> (mk (Tm_fvar fv)) None (FStar_Ident.range_of_lid (fv.fv_name).v)
-let fvar: FStar_Ident.lident -> delta_depth -> fv_qual Prims.option -> term =
-  fun l  ->
-    fun dd  ->
-      fun dq  -> let uu____4354 = lid_as_fv l dd dq in fv_to_tm uu____4354
-let lid_of_fv: fv -> FStar_Ident.lident = fun fv  -> (fv.fv_name).v
-let range_of_fv: fv -> FStar_Range.range =
-  fun fv  ->
-    let uu____4365 = lid_of_fv fv in FStar_Ident.range_of_lid uu____4365
-let set_range_of_fv: fv -> FStar_Range.range -> fv =
-  fun fv  ->
-    fun r  ->
-      let uu___100_4372 = fv in
-      let uu____4373 =
-        let uu___101_4377 = fv.fv_name in
-        let uu____4382 =
-          let uu____4383 = lid_of_fv fv in
-          FStar_Ident.set_lid_range uu____4383 r in
-        { v = uu____4382; ty = (uu___101_4377.ty); p = (uu___101_4377.p) } in
-      {
-        fv_name = uu____4373;
-        fv_delta = (uu___100_4372.fv_delta);
-        fv_qual = (uu___100_4372.fv_qual)
-      }
-let has_simple_attribute: term Prims.list -> Prims.string -> Prims.bool =
-  fun l  ->
-    fun s  ->
-      FStar_List.existsb
-        (fun uu___96_4407  ->
-           match uu___96_4407 with
-           | { n = Tm_constant (FStar_Const.Const_string (data,uu____4411));
-               tk = uu____4412; pos = uu____4413; vars = uu____4414;_} when
-               (FStar_Util.string_of_unicode data) = s -> true
-           | uu____4419 -> false) l
+{name : FStar_Ident.lident; declarations : sigelts; exports : sigelts; is_interface : Prims.bool}
+
+
+type path =
+Prims.string Prims.list
+
+
+type subst_t =
+subst_elt Prims.list
+
+
+type ('a, 'b) mk_t_a =
+'b Prims.option  ->  FStar_Range.range  ->  ('a, 'b) syntax
+
+
+type mk_t =
+(term', term') mk_t_a
+
+
+let contains_reflectable : qualifier Prims.list  ->  Prims.bool = (fun l -> (FStar_Util.for_some (fun uu___86_3253 -> (match (uu___86_3253) with
+| Reflectable (uu____3254) -> begin
+true
+end
+| uu____3255 -> begin
+false
+end)) l))
+
+
+let withinfo = (fun v1 s r -> {v = v1; ty = s; p = r})
+
+
+let withsort = (fun v1 s -> (withinfo v1 s FStar_Range.dummyRange))
+
+
+let bv_eq : bv  ->  bv  ->  Prims.bool = (fun bv1 bv2 -> ((bv1.ppname.FStar_Ident.idText = bv2.ppname.FStar_Ident.idText) && (bv1.index = bv2.index)))
+
+
+let order_bv : bv  ->  bv  ->  Prims.int = (fun x y -> (
+
+let i = (FStar_String.compare x.ppname.FStar_Ident.idText y.ppname.FStar_Ident.idText)
+in (match ((i = (Prims.parse_int "0"))) with
+| true -> begin
+(x.index - y.index)
+end
+| uu____3306 -> begin
+i
+end)))
+
+
+let order_fv : FStar_Ident.lident  ->  FStar_Ident.lident  ->  Prims.int = (fun x y -> (FStar_String.compare x.FStar_Ident.str y.FStar_Ident.str))
+
+
+let range_of_lbname : lbname  ->  FStar_Range.range = (fun l -> (match (l) with
+| FStar_Util.Inl (x) -> begin
+x.ppname.FStar_Ident.idRange
+end
+| FStar_Util.Inr (fv) -> begin
+(FStar_Ident.range_of_lid fv.fv_name.v)
+end))
+
+
+let range_of_bv : bv  ->  FStar_Range.range = (fun x -> x.ppname.FStar_Ident.idRange)
+
+
+let set_range_of_bv : bv  ->  FStar_Range.range  ->  bv = (fun x r -> (
+
+let uu___93_3331 = x
+in {ppname = (FStar_Ident.mk_ident ((x.ppname.FStar_Ident.idText), (r))); index = uu___93_3331.index; sort = uu___93_3331.sort}))
+
+
+let syn = (fun p k f -> (f k p))
+
+
+let mk_fvs = (fun uu____3372 -> (FStar_Util.mk_ref None))
+
+
+let mk_uvs = (fun uu____3384 -> (FStar_Util.mk_ref None))
+
+
+let new_bv_set : Prims.unit  ->  bv FStar_Util.set = (fun uu____3390 -> (FStar_Util.new_set order_bv (fun x -> (x.index + (FStar_Util.hashcode x.ppname.FStar_Ident.idText)))))
+
+
+let new_fv_set : Prims.unit  ->  FStar_Ident.lident FStar_Util.set = (fun uu____3396 -> (FStar_Util.new_set order_fv (fun x -> (FStar_Util.hashcode x.FStar_Ident.str))))
+
+
+let new_uv_set : Prims.unit  ->  uvars = (fun uu____3401 -> (FStar_Util.new_set (fun uu____3410 uu____3411 -> (match (((uu____3410), (uu____3411))) with
+| ((x, uu____3445), (y, uu____3447)) -> begin
+(
+
+let uu____3488 = (FStar_Unionfind.uvar_id x)
+in (
+
+let uu____3492 = (FStar_Unionfind.uvar_id y)
+in (uu____3488 - uu____3492)))
+end)) (fun uu____3496 -> (match (uu____3496) with
+| (x, uu____3506) -> begin
+(FStar_Unionfind.uvar_id x)
+end))))
+
+
+let new_universe_uvar_set : Prims.unit  ->  universe_uvar FStar_Util.set = (fun uu____3525 -> (FStar_Util.new_set (fun x y -> (
+
+let uu____3535 = (FStar_Unionfind.uvar_id x)
+in (
+
+let uu____3537 = (FStar_Unionfind.uvar_id y)
+in (uu____3535 - uu____3537)))) (fun x -> (FStar_Unionfind.uvar_id x))))
+
+
+let new_universe_names_fifo_set : Prims.unit  ->  univ_name FStar_Util.fifo_set = (fun uu____3548 -> (FStar_Util.new_fifo_set (fun x y -> (FStar_String.compare (FStar_Ident.text_of_id x) (FStar_Ident.text_of_id y))) (fun x -> (FStar_Util.hashcode (FStar_Ident.text_of_id x)))))
+
+
+let no_names : bv FStar_Util.set = (new_bv_set ())
+
+
+let no_fvars : FStar_Ident.lident FStar_Util.set = (new_fv_set ())
+
+
+let no_uvs : uvars = (new_uv_set ())
+
+
+let no_universe_uvars : universe_uvar FStar_Util.set = (new_universe_uvar_set ())
+
+
+let no_universe_names : univ_name FStar_Util.fifo_set = (new_universe_names_fifo_set ())
+
+
+let empty_free_vars : free_vars = {free_names = no_names; free_uvars = no_uvs; free_univs = no_universe_uvars; free_univ_names = no_universe_names}
+
+
+let memo_no_uvs : uvars Prims.option FStar_ST.ref = (FStar_Util.mk_ref (Some (no_uvs)))
+
+
+let memo_no_names : bv FStar_Util.set Prims.option FStar_ST.ref = (FStar_Util.mk_ref (Some (no_names)))
+
+
+let freenames_of_list : bv Prims.list  ->  freenames = (fun l -> (FStar_List.fold_right FStar_Util.set_add l no_names))
+
+
+let list_of_freenames : freenames  ->  bv Prims.list = (fun fvs -> (FStar_Util.set_elements fvs))
+
+
+let mk = (fun t topt r -> (
+
+let uu____3610 = (FStar_Util.mk_ref topt)
+in (
+
+let uu____3614 = (FStar_Util.mk_ref None)
+in {n = t; tk = uu____3610; pos = r; vars = uu____3614})))
+
+
+let bv_to_tm : bv  ->  term = (fun bv -> (
+
+let uu____3625 = (range_of_bv bv)
+in ((mk (Tm_bvar (bv))) (Some (bv.sort.n)) uu____3625)))
+
+
+let bv_to_name : bv  ->  term = (fun bv -> (
+
+let uu____3637 = (range_of_bv bv)
+in ((mk (Tm_name (bv))) (Some (bv.sort.n)) uu____3637)))
+
+
+let mk_Tm_app : term  ->  args  ->  mk_t = (fun t1 args k p -> (match (args) with
+| [] -> begin
+t1
+end
+| uu____3662 -> begin
+((mk (Tm_app (((t1), (args))))) k p)
+end))
+
+
+let mk_Tm_uinst : term  ->  universes  ->  term = (fun t uu___87_3678 -> (match (uu___87_3678) with
+| [] -> begin
+t
+end
+| us -> begin
+(match (t.n) with
+| Tm_fvar (uu____3680) -> begin
+((mk (Tm_uinst (((t), (us))))) None t.pos)
+end
+| uu____3689 -> begin
+(failwith "Unexpected universe instantiation")
+end)
+end))
+
+
+let extend_app_n : term  ->  args  ->  mk_t = (fun t args' kopt r -> (match (t.n) with
+| Tm_app (head1, args) -> begin
+((mk_Tm_app head1 (FStar_List.append args args')) kopt r)
+end
+| uu____3729 -> begin
+((mk_Tm_app t args') kopt r)
+end))
+
+
+let extend_app : term  ->  arg  ->  mk_t = (fun t arg kopt r -> ((extend_app_n t ((arg)::[])) kopt r))
+
+
+let mk_Tm_delayed : ((term * subst_ts), Prims.unit  ->  term) FStar_Util.either  ->  FStar_Range.range  ->  term = (fun lr pos -> (
+
+let uu____3770 = (
+
+let uu____3773 = (
+
+let uu____3774 = (
+
+let uu____3795 = (FStar_Util.mk_ref None)
+in ((lr), (uu____3795)))
+in Tm_delayed (uu____3774))
+in (mk uu____3773))
+in (uu____3770 None pos)))
+
+
+let mk_Total' : typ  ->  universe Prims.option  ->  comp = (fun t u -> ((mk (Total (((t), (u))))) None t.pos))
+
+
+let mk_GTotal' : typ  ->  universe Prims.option  ->  comp = (fun t u -> ((mk (GTotal (((t), (u))))) None t.pos))
+
+
+let mk_Total : typ  ->  comp = (fun t -> (mk_Total' t None))
+
+
+let mk_GTotal : typ  ->  comp = (fun t -> (mk_GTotal' t None))
+
+
+let mk_Comp : comp_typ  ->  comp = (fun ct -> ((mk (Comp (ct))) None ct.result_typ.pos))
+
+
+let mk_lb : (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term)  ->  letbinding = (fun uu____3885 -> (match (uu____3885) with
+| (x, univs, eff, t, e) -> begin
+{lbname = x; lbunivs = univs; lbtyp = t; lbeff = eff; lbdef = e}
+end))
+
+
+let mk_sigelt : sigelt'  ->  sigelt = (fun e -> {sigel = e; sigdoc = None; sigrng = FStar_Range.dummyRange})
+
+
+let mk_subst : subst_t  ->  subst_t = (fun s -> s)
+
+
+let extend_subst : subst_elt  ->  subst_elt Prims.list  ->  subst_t = (fun x s -> (x)::s)
+
+
+let argpos : arg  ->  FStar_Range.range = (fun x -> (Prims.fst x).pos)
+
+
+let tun : (term', term') syntax = ((mk Tm_unknown) None FStar_Range.dummyRange)
+
+
+let teff : (term', term') syntax = ((mk (Tm_constant (FStar_Const.Const_effect))) (Some (Tm_unknown)) FStar_Range.dummyRange)
+
+
+let is_teff : term  ->  Prims.bool = (fun t -> (match (t.n) with
+| Tm_constant (FStar_Const.Const_effect) -> begin
+true
+end
+| uu____3941 -> begin
+false
+end))
+
+
+let is_type : term  ->  Prims.bool = (fun t -> (match (t.n) with
+| Tm_type (uu____3945) -> begin
+true
+end
+| uu____3946 -> begin
+false
+end))
+
+
+let null_id : FStar_Ident.ident = (FStar_Ident.mk_ident (("_"), (FStar_Range.dummyRange)))
+
+
+let null_bv : term  ->  bv = (fun k -> {ppname = null_id; index = (Prims.parse_int "0"); sort = k})
+
+
+let mk_binder : bv  ->  binder = (fun a -> ((a), (None)))
+
+
+let null_binder : term  ->  binder = (fun t -> (
+
+let uu____3957 = (null_bv t)
+in ((uu____3957), (None))))
+
+
+let imp_tag : arg_qualifier = Implicit (false)
+
+
+let iarg : term  ->  arg = (fun t -> ((t), (Some (imp_tag))))
+
+
+let as_arg : term  ->  arg = (fun t -> ((t), (None)))
+
+
+let is_null_bv : bv  ->  Prims.bool = (fun b -> (b.ppname.FStar_Ident.idText = null_id.FStar_Ident.idText))
+
+
+let is_null_binder : binder  ->  Prims.bool = (fun b -> (is_null_bv (Prims.fst b)))
+
+
+let is_top_level : letbinding Prims.list  ->  Prims.bool = (fun uu___88_3976 -> (match (uu___88_3976) with
+| ({lbname = FStar_Util.Inr (uu____3978); lbunivs = uu____3979; lbtyp = uu____3980; lbeff = uu____3981; lbdef = uu____3982})::uu____3983 -> begin
+true
+end
+| uu____3990 -> begin
+false
+end))
+
+
+let freenames_of_binders : binders  ->  freenames = (fun bs -> (FStar_List.fold_right (fun uu____3998 out -> (match (uu____3998) with
+| (x, uu____4005) -> begin
+(FStar_Util.set_add x out)
+end)) bs no_names))
+
+
+let binders_of_list : bv Prims.list  ->  binders = (fun fvs -> (FStar_All.pipe_right fvs (FStar_List.map (fun t -> ((t), (None))))))
+
+
+let binders_of_freenames : freenames  ->  binders = (fun fvs -> (
+
+let uu____4024 = (FStar_Util.set_elements fvs)
+in (FStar_All.pipe_right uu____4024 binders_of_list)))
+
+
+let is_implicit : aqual  ->  Prims.bool = (fun uu___89_4029 -> (match (uu___89_4029) with
+| Some (Implicit (uu____4030)) -> begin
+true
+end
+| uu____4031 -> begin
+false
+end))
+
+
+let as_implicit : Prims.bool  ->  aqual = (fun uu___90_4034 -> (match (uu___90_4034) with
+| true -> begin
+Some (imp_tag)
+end
+| uu____4035 -> begin
+None
+end))
+
+
+let pat_bvs : pat  ->  bv Prims.list = (fun p -> (
+
+let rec aux = (fun b p1 -> (match (p1.v) with
+| (Pat_dot_term (_)) | (Pat_constant (_)) -> begin
+b
+end
+| (Pat_wild (x)) | (Pat_var (x)) -> begin
+(x)::b
+end
+| Pat_cons (uu____4059, pats) -> begin
+(FStar_List.fold_left (fun b1 uu____4077 -> (match (uu____4077) with
+| (p2, uu____4085) -> begin
+(aux b1 p2)
+end)) b pats)
+end
+| Pat_disj ((p2)::uu____4091) -> begin
+(aux b p2)
+end
+| Pat_disj ([]) -> begin
+(failwith "impossible")
+end))
+in (
+
+let uu____4102 = (aux [] p)
+in (FStar_All.pipe_left FStar_List.rev uu____4102))))
+
+
+let gen_reset : ((Prims.unit  ->  Prims.int) * (Prims.unit  ->  Prims.unit)) = (
+
+let x = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (
+
+let gen1 = (fun uu____4118 -> ((FStar_Util.incr x);
+(FStar_ST.read x);
+))
+in (
+
+let reset = (fun uu____4128 -> (FStar_ST.write x (Prims.parse_int "0")))
+in ((gen1), (reset)))))
+
+
+let next_id : Prims.unit  ->  Prims.int = (Prims.fst gen_reset)
+
+
+let reset_gensym : Prims.unit  ->  Prims.unit = (Prims.snd gen_reset)
+
+
+let range_of_ropt : FStar_Range.range Prims.option  ->  FStar_Range.range = (fun uu___91_4150 -> (match (uu___91_4150) with
+| None -> begin
+FStar_Range.dummyRange
+end
+| Some (r) -> begin
+r
+end))
+
+
+let gen_bv : Prims.string  ->  FStar_Range.range Prims.option  ->  typ  ->  bv = (fun s r t -> (
+
+let id = (FStar_Ident.mk_ident ((s), ((range_of_ropt r))))
+in (
+
+let uu____4165 = (next_id ())
+in {ppname = id; index = uu____4165; sort = t})))
+
+
+let new_bv : FStar_Range.range Prims.option  ->  typ  ->  bv = (fun ropt t -> (gen_bv FStar_Ident.reserved_prefix ropt t))
+
+
+let freshen_bv : bv  ->  bv = (fun bv -> (
+
+let uu____4177 = (is_null_bv bv)
+in (match (uu____4177) with
+| true -> begin
+(
+
+let uu____4178 = (
+
+let uu____4180 = (range_of_bv bv)
+in Some (uu____4180))
+in (new_bv uu____4178 bv.sort))
+end
+| uu____4181 -> begin
+(
+
+let uu___94_4182 = bv
+in (
+
+let uu____4183 = (next_id ())
+in {ppname = uu___94_4182.ppname; index = uu____4183; sort = uu___94_4182.sort}))
+end)))
+
+
+let new_univ_name : FStar_Range.range Prims.option  ->  univ_name = (fun ropt -> (
+
+let id = (next_id ())
+in (
+
+let uu____4190 = (
+
+let uu____4193 = (
+
+let uu____4194 = (FStar_Util.string_of_int id)
+in (Prims.strcat FStar_Ident.reserved_prefix uu____4194))
+in ((uu____4193), ((range_of_ropt ropt))))
+in (FStar_Ident.mk_ident uu____4190))))
+
+
+let mkbv : FStar_Ident.ident  ->  Prims.int  ->  (term', term') syntax  ->  bv = (fun x y t -> {ppname = x; index = y; sort = t})
+
+
+let lbname_eq : (bv, FStar_Ident.lident) FStar_Util.either  ->  (bv, FStar_Ident.lident) FStar_Util.either  ->  Prims.bool = (fun l1 l2 -> (match (((l1), (l2))) with
+| (FStar_Util.Inl (x), FStar_Util.Inl (y)) -> begin
+(bv_eq x y)
+end
+| (FStar_Util.Inr (l), FStar_Util.Inr (m)) -> begin
+(FStar_Ident.lid_equals l m)
+end
+| uu____4238 -> begin
+false
+end))
+
+
+let fv_eq : fv  ->  fv  ->  Prims.bool = (fun fv1 fv2 -> (FStar_Ident.lid_equals fv1.fv_name.v fv2.fv_name.v))
+
+
+let fv_eq_lid : fv  ->  FStar_Ident.lident  ->  Prims.bool = (fun fv lid -> (FStar_Ident.lid_equals fv.fv_name.v lid))
+
+
+let set_bv_range : bv  ->  FStar_Range.range  ->  bv = (fun bv r -> (
+
+let uu___95_4275 = bv
+in {ppname = (FStar_Ident.mk_ident ((bv.ppname.FStar_Ident.idText), (r))); index = uu___95_4275.index; sort = uu___95_4275.sort}))
+
+
+let lid_as_fv : FStar_Ident.lident  ->  delta_depth  ->  fv_qual Prims.option  ->  fv = (fun l dd dq -> (
+
+let uu____4287 = (withinfo l tun (FStar_Ident.range_of_lid l))
+in {fv_name = uu____4287; fv_delta = dd; fv_qual = dq}))
+
+
+let fv_to_tm : fv  ->  term = (fun fv -> ((mk (Tm_fvar (fv))) None (FStar_Ident.range_of_lid fv.fv_name.v)))
+
+
+let fvar : FStar_Ident.lident  ->  delta_depth  ->  fv_qual Prims.option  ->  term = (fun l dd dq -> (
+
+let uu____4322 = (lid_as_fv l dd dq)
+in (fv_to_tm uu____4322)))
+
+
+let lid_of_fv : fv  ->  FStar_Ident.lid = (fun fv -> fv.fv_name.v)
+
+
+let range_of_fv : fv  ->  FStar_Range.range = (fun fv -> (
+
+let uu____4333 = (lid_of_fv fv)
+in (FStar_Ident.range_of_lid uu____4333)))
+
+
+let set_range_of_fv : fv  ->  FStar_Range.range  ->  fv = (fun fv r -> (
+
+let uu___96_4340 = fv
+in (
+
+let uu____4341 = (
+
+let uu___97_4345 = fv.fv_name
+in (
+
+let uu____4350 = (
+
+let uu____4351 = (lid_of_fv fv)
+in (FStar_Ident.set_lid_range uu____4351 r))
+in {v = uu____4350; ty = uu___97_4345.ty; p = uu___97_4345.p}))
+in {fv_name = uu____4341; fv_delta = uu___96_4340.fv_delta; fv_qual = uu___96_4340.fv_qual})))
+
+
+let has_simple_attribute : term Prims.list  ->  Prims.string  ->  Prims.bool = (fun l s -> (FStar_List.existsb (fun uu___92_4375 -> (match (uu___92_4375) with
+| {n = Tm_constant (FStar_Const.Const_string (data, uu____4379)); tk = uu____4380; pos = uu____4381; vars = uu____4382} when ((FStar_Util.string_of_unicode data) = s) -> begin
+true
+end
+| uu____4387 -> begin
+false
+end)) l))
+
+
+
+

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -1,2034 +1,2460 @@
+
 open Prims
-let qual_id: FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
-  fun lid  ->
-    fun id  ->
-      let uu____7 =
-        FStar_Ident.lid_of_ids
-          (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident; id]) in
-      FStar_Ident.set_lid_range uu____7 id.FStar_Ident.idRange
-let mk_discriminator: FStar_Ident.lident -> FStar_Ident.lident =
-  fun lid  ->
-    FStar_Ident.lid_of_ids
-      (FStar_List.append lid.FStar_Ident.ns
-         [FStar_Ident.mk_ident
-            ((Prims.strcat FStar_Ident.reserved_prefix
-                (Prims.strcat "is_"
-                   (lid.FStar_Ident.ident).FStar_Ident.idText)),
-              ((lid.FStar_Ident.ident).FStar_Ident.idRange))])
-let is_name: FStar_Ident.lident -> Prims.bool =
-  fun lid  ->
-    let c =
-      FStar_Util.char_at (lid.FStar_Ident.ident).FStar_Ident.idText
-        (Prims.parse_int "0") in
-    FStar_Util.is_upper c
-let arg_of_non_null_binder uu____25 =
-  match uu____25 with
-  | (b,imp) ->
-      let uu____30 = FStar_Syntax_Syntax.bv_to_name b in (uu____30, imp)
-let args_of_non_null_binders:
-  FStar_Syntax_Syntax.binders ->
-    (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun binders  ->
-    FStar_All.pipe_right binders
-      (FStar_List.collect
-         (fun b  ->
-            let uu____43 = FStar_Syntax_Syntax.is_null_binder b in
-            if uu____43
-            then []
-            else (let uu____50 = arg_of_non_null_binder b in [uu____50])))
-let args_of_binders:
-  FStar_Syntax_Syntax.binders ->
-    ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list*
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) Prims.list)
-  =
-  fun binders  ->
-    let uu____64 =
-      FStar_All.pipe_right binders
-        (FStar_List.map
-           (fun b  ->
-              let uu____86 = FStar_Syntax_Syntax.is_null_binder b in
-              if uu____86
-              then
-                let b1 =
-                  let uu____96 =
-                    FStar_Syntax_Syntax.new_bv None
-                      (Prims.fst b).FStar_Syntax_Syntax.sort in
-                  (uu____96, (Prims.snd b)) in
-                let uu____97 = arg_of_non_null_binder b1 in (b1, uu____97)
-              else
-                (let uu____105 = arg_of_non_null_binder b in (b, uu____105)))) in
-    FStar_All.pipe_right uu____64 FStar_List.unzip
-let name_binders:
-  FStar_Syntax_Syntax.binder Prims.list ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun binders  ->
-    FStar_All.pipe_right binders
-      (FStar_List.mapi
-         (fun i  ->
-            fun b  ->
-              let uu____145 = FStar_Syntax_Syntax.is_null_binder b in
-              if uu____145
-              then
-                let uu____148 = b in
-                match uu____148 with
-                | (a,imp) ->
-                    let b1 =
-                      let uu____154 =
-                        let uu____155 = FStar_Util.string_of_int i in
-                        Prims.strcat "_" uu____155 in
-                      FStar_Ident.id_of_text uu____154 in
-                    let b2 =
-                      {
-                        FStar_Syntax_Syntax.ppname = b1;
-                        FStar_Syntax_Syntax.index = (Prims.parse_int "0");
-                        FStar_Syntax_Syntax.sort =
-                          (a.FStar_Syntax_Syntax.sort)
-                      } in
-                    (b2, imp)
-              else b))
-let name_function_binders t =
-  match t.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-      let uu____183 =
-        let uu____186 =
-          let uu____187 =
-            let uu____195 = name_binders binders in (uu____195, comp) in
-          FStar_Syntax_Syntax.Tm_arrow uu____187 in
-        FStar_Syntax_Syntax.mk uu____186 in
-      uu____183 None t.FStar_Syntax_Syntax.pos
-  | uu____212 -> t
-let null_binders_of_tks:
-  (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.aqual) Prims.list ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun tks  ->
-    FStar_All.pipe_right tks
-      (FStar_List.map
-         (fun uu____232  ->
-            match uu____232 with
-            | (t,imp) ->
-                let uu____239 =
-                  let uu____240 = FStar_Syntax_Syntax.null_binder t in
-                  FStar_All.pipe_left Prims.fst uu____240 in
-                (uu____239, imp)))
-let binders_of_tks:
-  (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.aqual) Prims.list ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun tks  ->
-    FStar_All.pipe_right tks
-      (FStar_List.map
-         (fun uu____266  ->
-            match uu____266 with
-            | (t,imp) ->
-                let uu____279 =
-                  FStar_Syntax_Syntax.new_bv
-                    (Some (t.FStar_Syntax_Syntax.pos)) t in
-                (uu____279, imp)))
-let binders_of_freevars:
-  FStar_Syntax_Syntax.bv FStar_Util.set ->
-    FStar_Syntax_Syntax.binder Prims.list
-  =
-  fun fvs  ->
-    let uu____286 = FStar_Util.set_elements fvs in
-    FStar_All.pipe_right uu____286
-      (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-let mk_subst s = [s]
-let subst_of_list:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.subst_t
-  =
-  fun formals  ->
-    fun actuals  ->
-      if (FStar_List.length formals) = (FStar_List.length actuals)
-      then
-        FStar_List.fold_right2
-          (fun f  ->
-             fun a  ->
-               fun out  ->
-                 (FStar_Syntax_Syntax.NT ((Prims.fst f), (Prims.fst a))) ::
-                 out) formals actuals []
-      else failwith "Ill-formed substitution"
-let rename_binders:
-  FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t
-  =
-  fun replace_xs  ->
-    fun with_ys  ->
-      if (FStar_List.length replace_xs) = (FStar_List.length with_ys)
-      then
-        FStar_List.map2
-          (fun uu____354  ->
-             fun uu____355  ->
-               match (uu____354, uu____355) with
-               | ((x,uu____365),(y,uu____367)) ->
-                   let uu____372 =
-                     let uu____377 = FStar_Syntax_Syntax.bv_to_name y in
-                     (x, uu____377) in
-                   FStar_Syntax_Syntax.NT uu____372) replace_xs with_ys
-      else failwith "Ill-formed substitution"
-let rec unmeta: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun e  ->
-    let e1 = FStar_Syntax_Subst.compress e in
-    match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_meta (e2,_)|FStar_Syntax_Syntax.Tm_ascribed
-      (e2,_,_) -> unmeta e2
-    | uu____407 -> e1
-let rec univ_kernel:
-  FStar_Syntax_Syntax.universe -> (FStar_Syntax_Syntax.universe* Prims.int) =
-  fun u  ->
-    match u with
-    | FStar_Syntax_Syntax.U_unknown 
-      |FStar_Syntax_Syntax.U_name _
-       |FStar_Syntax_Syntax.U_unif _|FStar_Syntax_Syntax.U_zero  ->
-        (u, (Prims.parse_int "0"))
-    | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____418 = univ_kernel u1 in
-        (match uu____418 with | (k,n1) -> (k, (n1 + (Prims.parse_int "1"))))
-    | FStar_Syntax_Syntax.U_max uu____425 ->
-        failwith "Imposible: univ_kernel (U_max _)"
-    | FStar_Syntax_Syntax.U_bvar uu____429 ->
-        failwith "Imposible: univ_kernel (U_bvar _)"
-let constant_univ_as_nat: FStar_Syntax_Syntax.universe -> Prims.int =
-  fun u  -> let uu____435 = univ_kernel u in Prims.snd uu____435
-let rec compare_univs:
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int =
-  fun u1  ->
-    fun u2  ->
-      match (u1, u2) with
-      | (FStar_Syntax_Syntax.U_bvar _,_)|(_,FStar_Syntax_Syntax.U_bvar _) ->
-          failwith "Impossible: compare_univs"
-      | (FStar_Syntax_Syntax.U_unknown ,FStar_Syntax_Syntax.U_unknown ) ->
-          Prims.parse_int "0"
-      | (FStar_Syntax_Syntax.U_unknown ,uu____448) -> - (Prims.parse_int "1")
-      | (uu____449,FStar_Syntax_Syntax.U_unknown ) -> Prims.parse_int "1"
-      | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
-          Prims.parse_int "0"
-      | (FStar_Syntax_Syntax.U_zero ,uu____450) -> - (Prims.parse_int "1")
-      | (uu____451,FStar_Syntax_Syntax.U_zero ) -> Prims.parse_int "1"
-      | (FStar_Syntax_Syntax.U_name u11,FStar_Syntax_Syntax.U_name u21) ->
-          FStar_String.compare u11.FStar_Ident.idText u21.FStar_Ident.idText
-      | (FStar_Syntax_Syntax.U_name uu____454,FStar_Syntax_Syntax.U_unif
-         uu____455) -> - (Prims.parse_int "1")
-      | (FStar_Syntax_Syntax.U_unif uu____458,FStar_Syntax_Syntax.U_name
-         uu____459) -> Prims.parse_int "1"
-      | (FStar_Syntax_Syntax.U_unif u11,FStar_Syntax_Syntax.U_unif u21) ->
-          let uu____468 = FStar_Unionfind.uvar_id u11 in
-          let uu____470 = FStar_Unionfind.uvar_id u21 in
-          uu____468 - uu____470
-      | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2) ->
-          let n1 = FStar_List.length us1 in
-          let n2 = FStar_List.length us2 in
-          if n1 <> n2
-          then n1 - n2
-          else
-            (let copt =
-               let uu____492 = FStar_List.zip us1 us2 in
-               FStar_Util.find_map uu____492
-                 (fun uu____498  ->
-                    match uu____498 with
-                    | (u11,u21) ->
-                        let c = compare_univs u11 u21 in
-                        if c <> (Prims.parse_int "0") then Some c else None) in
-             match copt with | None  -> Prims.parse_int "0" | Some c -> c)
-      | (FStar_Syntax_Syntax.U_max uu____508,uu____509) ->
-          - (Prims.parse_int "1")
-      | (uu____511,FStar_Syntax_Syntax.U_max uu____512) ->
-          Prims.parse_int "1"
-      | uu____514 ->
-          let uu____517 = univ_kernel u1 in
-          (match uu____517 with
-           | (k1,n1) ->
-               let uu____522 = univ_kernel u2 in
-               (match uu____522 with
-                | (k2,n2) ->
-                    let r = compare_univs k1 k2 in
-                    if r = (Prims.parse_int "0") then n1 - n2 else r))
-let eq_univs:
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.bool
-  =
-  fun u1  ->
-    fun u2  ->
-      let uu____535 = compare_univs u1 u2 in
-      uu____535 = (Prims.parse_int "0")
-let ml_comp:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax ->
-    FStar_Range.range -> FStar_Syntax_Syntax.comp
-  =
-  fun t  ->
-    fun r  ->
-      FStar_Syntax_Syntax.mk_Comp
-        {
-          FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_unknown];
-          FStar_Syntax_Syntax.effect_name =
-            (FStar_Ident.set_lid_range FStar_Syntax_Const.effect_ML_lid r);
-          FStar_Syntax_Syntax.result_typ = t;
-          FStar_Syntax_Syntax.effect_args = [];
-          FStar_Syntax_Syntax.flags = [FStar_Syntax_Syntax.MLEFFECT]
-        }
-let comp_effect_name c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-  | FStar_Syntax_Syntax.Total uu____562 -> FStar_Syntax_Const.effect_Tot_lid
-  | FStar_Syntax_Syntax.GTotal uu____568 ->
-      FStar_Syntax_Const.effect_GTot_lid
-let comp_flags c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Total uu____586 -> [FStar_Syntax_Syntax.TOTAL]
-  | FStar_Syntax_Syntax.GTotal uu____592 -> [FStar_Syntax_Syntax.SOMETRIVIAL]
-  | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.flags
-let comp_set_flags:
-  FStar_Syntax_Syntax.comp ->
-    FStar_Syntax_Syntax.cflags Prims.list ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun c  ->
-    fun f  ->
-      let comp_to_comp_typ c1 =
-        match c1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Comp c2 -> c2
-        | FStar_Syntax_Syntax.Total (t,u_opt)|FStar_Syntax_Syntax.GTotal
-          (t,u_opt) ->
-            let uu____628 =
-              let uu____629 = FStar_Util.map_opt u_opt (fun x  -> [x]) in
-              FStar_Util.dflt [] uu____629 in
-            {
-              FStar_Syntax_Syntax.comp_univs = uu____628;
-              FStar_Syntax_Syntax.effect_name = (comp_effect_name c1);
-              FStar_Syntax_Syntax.result_typ = t;
-              FStar_Syntax_Syntax.effect_args = [];
-              FStar_Syntax_Syntax.flags = (comp_flags c1)
-            } in
-      let uu___177_639 = c in
-      let uu____640 =
-        let uu____641 =
-          let uu___178_642 = comp_to_comp_typ c in
-          {
-            FStar_Syntax_Syntax.comp_univs =
-              (uu___178_642.FStar_Syntax_Syntax.comp_univs);
-            FStar_Syntax_Syntax.effect_name =
-              (uu___178_642.FStar_Syntax_Syntax.effect_name);
-            FStar_Syntax_Syntax.result_typ =
-              (uu___178_642.FStar_Syntax_Syntax.result_typ);
-            FStar_Syntax_Syntax.effect_args =
-              (uu___178_642.FStar_Syntax_Syntax.effect_args);
-            FStar_Syntax_Syntax.flags = f
-          } in
-        FStar_Syntax_Syntax.Comp uu____641 in
-      {
-        FStar_Syntax_Syntax.n = uu____640;
-        FStar_Syntax_Syntax.tk = (uu___177_639.FStar_Syntax_Syntax.tk);
-        FStar_Syntax_Syntax.pos = (uu___177_639.FStar_Syntax_Syntax.pos);
-        FStar_Syntax_Syntax.vars = (uu___177_639.FStar_Syntax_Syntax.vars)
-      }
-let comp_to_comp_typ:
-  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
-  fun c  ->
-    match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Comp c1 -> c1
-    | FStar_Syntax_Syntax.Total (t,Some u)|FStar_Syntax_Syntax.GTotal
-      (t,Some u) ->
-        {
-          FStar_Syntax_Syntax.comp_univs = [u];
-          FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
-          FStar_Syntax_Syntax.result_typ = t;
-          FStar_Syntax_Syntax.effect_args = [];
-          FStar_Syntax_Syntax.flags = (comp_flags c)
-        }
-    | uu____667 ->
-        failwith "Assertion failed: Computation type without universe"
-let is_named_tot c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Comp c1 ->
-      FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
-        FStar_Syntax_Const.effect_Tot_lid
-  | FStar_Syntax_Syntax.Total uu____680 -> true
-  | FStar_Syntax_Syntax.GTotal uu____686 -> false
-let is_total_comp c =
-  FStar_All.pipe_right (comp_flags c)
-    (FStar_Util.for_some
-       (fun uu___165_704  ->
-          match uu___165_704 with
-          | FStar_Syntax_Syntax.TOTAL |FStar_Syntax_Syntax.RETURN  -> true
-          | uu____705 -> false))
-let is_total_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
-  fun c  ->
-    (FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
-       FStar_Syntax_Const.effect_Tot_lid)
-      ||
-      (FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags
-         (FStar_Util.for_some
-            (fun uu___166_710  ->
-               match uu___166_710 with
-               | FStar_Syntax_Syntax.TOTAL |FStar_Syntax_Syntax.RETURN  ->
-                   true
-               | uu____711 -> false)))
-let is_tot_or_gtot_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
-  fun c  ->
-    ((FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
-        FStar_Syntax_Const.effect_Tot_lid)
-       ||
-       (FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
-          FStar_Syntax_Const.effect_GTot_lid))
-      ||
-      (FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags
-         (FStar_Util.for_some
-            (fun uu___167_716  ->
-               match uu___167_716 with
-               | FStar_Syntax_Syntax.TOTAL |FStar_Syntax_Syntax.RETURN  ->
-                   true
-               | uu____717 -> false)))
-let is_partial_return c =
-  FStar_All.pipe_right (comp_flags c)
-    (FStar_Util.for_some
-       (fun uu___168_730  ->
-          match uu___168_730 with
-          | FStar_Syntax_Syntax.RETURN |FStar_Syntax_Syntax.PARTIAL_RETURN 
-              -> true
-          | uu____731 -> false))
-let is_lcomp_partial_return: FStar_Syntax_Syntax.lcomp -> Prims.bool =
-  fun c  ->
-    FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags
-      (FStar_Util.for_some
-         (fun uu___169_736  ->
-            match uu___169_736 with
-            | FStar_Syntax_Syntax.RETURN |FStar_Syntax_Syntax.PARTIAL_RETURN 
-                -> true
-            | uu____737 -> false))
-let is_tot_or_gtot_comp c =
-  (is_total_comp c) ||
-    (FStar_Ident.lid_equals FStar_Syntax_Const.effect_GTot_lid
-       (comp_effect_name c))
-let is_pure_effect: FStar_Ident.lident -> Prims.bool =
-  fun l  ->
-    ((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) ||
-       (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_PURE_lid))
-      || (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Pure_lid)
-let is_pure_comp c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Total uu____763 -> true
-  | FStar_Syntax_Syntax.GTotal uu____769 -> false
-  | FStar_Syntax_Syntax.Comp ct ->
-      ((is_total_comp c) ||
-         (is_pure_effect ct.FStar_Syntax_Syntax.effect_name))
-        ||
-        (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
-           (FStar_Util.for_some
-              (fun uu___170_777  ->
-                 match uu___170_777 with
-                 | FStar_Syntax_Syntax.LEMMA  -> true
-                 | uu____778 -> false)))
-let is_ghost_effect: FStar_Ident.lident -> Prims.bool =
-  fun l  ->
-    ((FStar_Ident.lid_equals FStar_Syntax_Const.effect_GTot_lid l) ||
-       (FStar_Ident.lid_equals FStar_Syntax_Const.effect_GHOST_lid l))
-      || (FStar_Ident.lid_equals FStar_Syntax_Const.effect_Ghost_lid l)
-let is_pure_or_ghost_comp c =
-  (is_pure_comp c) || (is_ghost_effect (comp_effect_name c))
-let is_pure_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
-  fun lc  ->
-    ((is_total_lcomp lc) || (is_pure_effect lc.FStar_Syntax_Syntax.eff_name))
-      ||
-      (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
-         (FStar_Util.for_some
-            (fun uu___171_797  ->
-               match uu___171_797 with
-               | FStar_Syntax_Syntax.LEMMA  -> true
-               | uu____798 -> false)))
-let is_pure_or_ghost_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
-  fun lc  ->
-    (is_pure_lcomp lc) || (is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
-let is_pure_or_ghost_function: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____805 =
-      let uu____806 = FStar_Syntax_Subst.compress t in
-      uu____806.FStar_Syntax_Syntax.n in
-    match uu____805 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____809,c) -> is_pure_or_ghost_comp c
-    | uu____821 -> true
-let is_lemma: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____825 =
-      let uu____826 = FStar_Syntax_Subst.compress t in
-      uu____826.FStar_Syntax_Syntax.n in
-    match uu____825 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____829,c) ->
-        (match c.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Comp ct ->
-             FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
-               FStar_Syntax_Const.effect_Lemma_lid
-         | uu____842 -> false)
-    | uu____843 -> false
-let head_and_args:
-  FStar_Syntax_Syntax.term ->
-    ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax*
-      ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list)
-  =
-  fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_app (head1,args) -> (head1, args)
-    | uu____889 -> (t1, [])
-let un_uinst: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____904) ->
-        FStar_Syntax_Subst.compress t2
-    | uu____909 -> t1
-let is_smt_lemma: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____913 =
-      let uu____914 = FStar_Syntax_Subst.compress t in
-      uu____914.FStar_Syntax_Syntax.n in
-    match uu____913 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____917,c) ->
-        (match c.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Comp ct when
-             FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
-               FStar_Syntax_Const.effect_Lemma_lid
-             ->
-             (match ct.FStar_Syntax_Syntax.effect_args with
-              | _req::_ens::(pats,uu____933)::uu____934 ->
-                  let pats' = unmeta pats in
-                  let uu____965 = head_and_args pats' in
-                  (match uu____965 with
-                   | (head1,uu____976) ->
-                       let uu____991 =
-                         let uu____992 = un_uinst head1 in
-                         uu____992.FStar_Syntax_Syntax.n in
-                       (match uu____991 with
-                        | FStar_Syntax_Syntax.Tm_fvar fv ->
-                            FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Syntax_Const.cons_lid
-                        | uu____996 -> false))
-              | uu____997 -> false)
-         | uu____1003 -> false)
-    | uu____1004 -> false
-let is_ml_comp c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Comp c1 ->
-      (FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
-         FStar_Syntax_Const.effect_ML_lid)
-        ||
-        (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-           (FStar_Util.for_some
-              (fun uu___172_1018  ->
-                 match uu___172_1018 with
-                 | FStar_Syntax_Syntax.MLEFFECT  -> true
-                 | uu____1019 -> false)))
-  | uu____1020 -> false
-let comp_result c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Total (t,_)|FStar_Syntax_Syntax.GTotal (t,_) -> t
-  | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
-let set_result_typ c t =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Total uu____1064 -> FStar_Syntax_Syntax.mk_Total t
-  | FStar_Syntax_Syntax.GTotal uu____1070 -> FStar_Syntax_Syntax.mk_GTotal t
-  | FStar_Syntax_Syntax.Comp ct ->
-      FStar_Syntax_Syntax.mk_Comp
-        (let uu___179_1077 = ct in
-         {
-           FStar_Syntax_Syntax.comp_univs =
-             (uu___179_1077.FStar_Syntax_Syntax.comp_univs);
-           FStar_Syntax_Syntax.effect_name =
-             (uu___179_1077.FStar_Syntax_Syntax.effect_name);
-           FStar_Syntax_Syntax.result_typ = t;
-           FStar_Syntax_Syntax.effect_args =
-             (uu___179_1077.FStar_Syntax_Syntax.effect_args);
-           FStar_Syntax_Syntax.flags =
-             (uu___179_1077.FStar_Syntax_Syntax.flags)
-         })
-let is_trivial_wp c =
-  FStar_All.pipe_right (comp_flags c)
-    (FStar_Util.for_some
-       (fun uu___173_1090  ->
-          match uu___173_1090 with
-          | FStar_Syntax_Syntax.TOTAL |FStar_Syntax_Syntax.RETURN  -> true
-          | uu____1091 -> false))
-let primops: FStar_Ident.lident Prims.list =
-  [FStar_Syntax_Const.op_Eq;
-  FStar_Syntax_Const.op_notEq;
-  FStar_Syntax_Const.op_LT;
-  FStar_Syntax_Const.op_LTE;
-  FStar_Syntax_Const.op_GT;
-  FStar_Syntax_Const.op_GTE;
-  FStar_Syntax_Const.op_Subtraction;
-  FStar_Syntax_Const.op_Minus;
-  FStar_Syntax_Const.op_Addition;
-  FStar_Syntax_Const.op_Multiply;
-  FStar_Syntax_Const.op_Division;
-  FStar_Syntax_Const.op_Modulus;
-  FStar_Syntax_Const.op_And;
-  FStar_Syntax_Const.op_Or;
-  FStar_Syntax_Const.op_Negation]
-let is_primop_lid: FStar_Ident.lident -> Prims.bool =
-  fun l  ->
-    FStar_All.pipe_right primops
-      (FStar_Util.for_some (FStar_Ident.lid_equals l))
-let is_primop f =
-  match f.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_fvar fv ->
-      is_primop_lid (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-  | uu____1113 -> false
-let rec unascribe: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun e  ->
-    let e1 = FStar_Syntax_Subst.compress e in
-    match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1119,uu____1120) ->
-        unascribe e2
-    | uu____1149 -> e1
-let rec ascribe t k =
-  match t.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_ascribed (t',uu____1191,uu____1192) ->
-      ascribe t' k
-  | uu____1221 ->
-      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_ascribed (t, k, None))
-        None t.FStar_Syntax_Syntax.pos
+
+let qual_id : FStar_Ident.lident  ->  FStar_Ident.ident  ->  FStar_Ident.lident = (fun lid id -> (
+
+let uu____7 = (FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns ((lid.FStar_Ident.ident)::(id)::[])))
+in (FStar_Ident.set_lid_range uu____7 id.FStar_Ident.idRange)))
+
+
+let mk_discriminator : FStar_Ident.lident  ->  FStar_Ident.lident = (fun lid -> (FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns (((FStar_Ident.mk_ident (((Prims.strcat FStar_Ident.reserved_prefix (Prims.strcat "is_" lid.FStar_Ident.ident.FStar_Ident.idText))), (lid.FStar_Ident.ident.FStar_Ident.idRange))))::[]))))
+
+
+let is_name : FStar_Ident.lident  ->  Prims.bool = (fun lid -> (
+
+let c = (FStar_Util.char_at lid.FStar_Ident.ident.FStar_Ident.idText (Prims.parse_int "0"))
+in (FStar_Util.is_upper c)))
+
+
+let arg_of_non_null_binder = (fun uu____25 -> (match (uu____25) with
+| (b, imp) -> begin
+(
+
+let uu____30 = (FStar_Syntax_Syntax.bv_to_name b)
+in ((uu____30), (imp)))
+end))
+
+
+let args_of_non_null_binders : FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual) Prims.list = (fun binders -> (FStar_All.pipe_right binders (FStar_List.collect (fun b -> (
+
+let uu____43 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____43) with
+| true -> begin
+[]
+end
+| uu____49 -> begin
+(
+
+let uu____50 = (arg_of_non_null_binder b)
+in (uu____50)::[])
+end))))))
+
+
+let args_of_binders : FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.args) = (fun binders -> (
+
+let uu____64 = (FStar_All.pipe_right binders (FStar_List.map (fun b -> (
+
+let uu____86 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____86) with
+| true -> begin
+(
+
+let b1 = (
+
+let uu____96 = (FStar_Syntax_Syntax.new_bv None (Prims.fst b).FStar_Syntax_Syntax.sort)
+in ((uu____96), ((Prims.snd b))))
+in (
+
+let uu____97 = (arg_of_non_null_binder b1)
+in ((b1), (uu____97))))
+end
+| uu____104 -> begin
+(
+
+let uu____105 = (arg_of_non_null_binder b)
+in ((b), (uu____105)))
+end)))))
+in (FStar_All.pipe_right uu____64 FStar_List.unzip)))
+
+
+let name_binders : FStar_Syntax_Syntax.binder Prims.list  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list = (fun binders -> (FStar_All.pipe_right binders (FStar_List.mapi (fun i b -> (
+
+let uu____145 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____145) with
+| true -> begin
+(
+
+let uu____148 = b
+in (match (uu____148) with
+| (a, imp) -> begin
+(
+
+let b1 = (
+
+let uu____154 = (
+
+let uu____155 = (FStar_Util.string_of_int i)
+in (Prims.strcat "_" uu____155))
+in (FStar_Ident.id_of_text uu____154))
+in (
+
+let b2 = {FStar_Syntax_Syntax.ppname = b1; FStar_Syntax_Syntax.index = (Prims.parse_int "0"); FStar_Syntax_Syntax.sort = a.FStar_Syntax_Syntax.sort}
+in ((b2), (imp))))
+end))
+end
+| uu____157 -> begin
+b
+end))))))
+
+
+let name_function_binders = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, comp) -> begin
+(
+
+let uu____183 = (
+
+let uu____186 = (
+
+let uu____187 = (
+
+let uu____195 = (name_binders binders)
+in ((uu____195), (comp)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____187))
+in (FStar_Syntax_Syntax.mk uu____186))
+in (uu____183 None t.FStar_Syntax_Syntax.pos))
+end
+| uu____212 -> begin
+t
+end))
+
+
+let null_binders_of_tks : (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.binders = (fun tks -> (FStar_All.pipe_right tks (FStar_List.map (fun uu____232 -> (match (uu____232) with
+| (t, imp) -> begin
+(
+
+let uu____239 = (
+
+let uu____240 = (FStar_Syntax_Syntax.null_binder t)
+in (FStar_All.pipe_left Prims.fst uu____240))
+in ((uu____239), (imp)))
+end)))))
+
+
+let binders_of_tks : (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.binders = (fun tks -> (FStar_All.pipe_right tks (FStar_List.map (fun uu____266 -> (match (uu____266) with
+| (t, imp) -> begin
+(
+
+let uu____279 = (FStar_Syntax_Syntax.new_bv (Some (t.FStar_Syntax_Syntax.pos)) t)
+in ((uu____279), (imp)))
+end)))))
+
+
+let binders_of_freevars : FStar_Syntax_Syntax.bv FStar_Util.set  ->  FStar_Syntax_Syntax.binder Prims.list = (fun fvs -> (
+
+let uu____286 = (FStar_Util.set_elements fvs)
+in (FStar_All.pipe_right uu____286 (FStar_List.map FStar_Syntax_Syntax.mk_binder))))
+
+
+let mk_subst = (fun s -> (s)::[])
+
+
+let subst_of_list : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.subst_t = (fun formals actuals -> (match (((FStar_List.length formals) = (FStar_List.length actuals))) with
+| true -> begin
+(FStar_List.fold_right2 (fun f a out -> (FStar_Syntax_Syntax.NT ((((Prims.fst f)), ((Prims.fst a)))))::out) formals actuals [])
+end
+| uu____335 -> begin
+(failwith "Ill-formed substitution")
+end))
+
+
+let rename_binders : FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.subst_t = (fun replace_xs with_ys -> (match (((FStar_List.length replace_xs) = (FStar_List.length with_ys))) with
+| true -> begin
+(FStar_List.map2 (fun uu____354 uu____355 -> (match (((uu____354), (uu____355))) with
+| ((x, uu____365), (y, uu____367)) -> begin
+(
+
+let uu____372 = (
+
+let uu____377 = (FStar_Syntax_Syntax.bv_to_name y)
+in ((x), (uu____377)))
+in FStar_Syntax_Syntax.NT (uu____372))
+end)) replace_xs with_ys)
+end
+| uu____378 -> begin
+(failwith "Ill-formed substitution")
+end))
+
+
+let rec unmeta : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun e -> (
+
+let e1 = (FStar_Syntax_Subst.compress e)
+in (match (e1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_meta (e2, _)) | (FStar_Syntax_Syntax.Tm_ascribed (e2, _, _)) -> begin
+(unmeta e2)
+end
+| uu____407 -> begin
+e1
+end)))
+
+
+let rec univ_kernel : FStar_Syntax_Syntax.universe  ->  (FStar_Syntax_Syntax.universe * Prims.int) = (fun u -> (match (u) with
+| (FStar_Syntax_Syntax.U_unknown) | (FStar_Syntax_Syntax.U_name (_)) | (FStar_Syntax_Syntax.U_unif (_)) | (FStar_Syntax_Syntax.U_zero) -> begin
+((u), ((Prims.parse_int "0")))
+end
+| FStar_Syntax_Syntax.U_succ (u1) -> begin
+(
+
+let uu____418 = (univ_kernel u1)
+in (match (uu____418) with
+| (k, n1) -> begin
+((k), ((n1 + (Prims.parse_int "1"))))
+end))
+end
+| FStar_Syntax_Syntax.U_max (uu____425) -> begin
+(failwith "Imposible: univ_kernel (U_max _)")
+end
+| FStar_Syntax_Syntax.U_bvar (uu____429) -> begin
+(failwith "Imposible: univ_kernel (U_bvar _)")
+end))
+
+
+let constant_univ_as_nat : FStar_Syntax_Syntax.universe  ->  Prims.int = (fun u -> (
+
+let uu____435 = (univ_kernel u)
+in (Prims.snd uu____435)))
+
+
+let rec compare_univs : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  Prims.int = (fun u1 u2 -> (match (((u1), (u2))) with
+| ((FStar_Syntax_Syntax.U_bvar (_), _)) | ((_, FStar_Syntax_Syntax.U_bvar (_))) -> begin
+(failwith "Impossible: compare_univs")
+end
+| (FStar_Syntax_Syntax.U_unknown, FStar_Syntax_Syntax.U_unknown) -> begin
+(Prims.parse_int "0")
+end
+| (FStar_Syntax_Syntax.U_unknown, uu____448) -> begin
+(~- ((Prims.parse_int "1")))
+end
+| (uu____449, FStar_Syntax_Syntax.U_unknown) -> begin
+(Prims.parse_int "1")
+end
+| (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) -> begin
+(Prims.parse_int "0")
+end
+| (FStar_Syntax_Syntax.U_zero, uu____450) -> begin
+(~- ((Prims.parse_int "1")))
+end
+| (uu____451, FStar_Syntax_Syntax.U_zero) -> begin
+(Prims.parse_int "1")
+end
+| (FStar_Syntax_Syntax.U_name (u11), FStar_Syntax_Syntax.U_name (u21)) -> begin
+(FStar_String.compare u11.FStar_Ident.idText u21.FStar_Ident.idText)
+end
+| (FStar_Syntax_Syntax.U_name (uu____454), FStar_Syntax_Syntax.U_unif (uu____455)) -> begin
+(~- ((Prims.parse_int "1")))
+end
+| (FStar_Syntax_Syntax.U_unif (uu____458), FStar_Syntax_Syntax.U_name (uu____459)) -> begin
+(Prims.parse_int "1")
+end
+| (FStar_Syntax_Syntax.U_unif (u11), FStar_Syntax_Syntax.U_unif (u21)) -> begin
+(
+
+let uu____468 = (FStar_Unionfind.uvar_id u11)
+in (
+
+let uu____470 = (FStar_Unionfind.uvar_id u21)
+in (uu____468 - uu____470)))
+end
+| (FStar_Syntax_Syntax.U_max (us1), FStar_Syntax_Syntax.U_max (us2)) -> begin
+(
+
+let n1 = (FStar_List.length us1)
+in (
+
+let n2 = (FStar_List.length us2)
+in (match ((n1 <> n2)) with
+| true -> begin
+(n1 - n2)
+end
+| uu____489 -> begin
+(
+
+let copt = (
+
+let uu____492 = (FStar_List.zip us1 us2)
+in (FStar_Util.find_map uu____492 (fun uu____498 -> (match (uu____498) with
+| (u11, u21) -> begin
+(
+
+let c = (compare_univs u11 u21)
+in (match ((c <> (Prims.parse_int "0"))) with
+| true -> begin
+Some (c)
+end
+| uu____506 -> begin
+None
+end))
+end))))
+in (match (copt) with
+| None -> begin
+(Prims.parse_int "0")
+end
+| Some (c) -> begin
+c
+end))
+end)))
+end
+| (FStar_Syntax_Syntax.U_max (uu____508), uu____509) -> begin
+(~- ((Prims.parse_int "1")))
+end
+| (uu____511, FStar_Syntax_Syntax.U_max (uu____512)) -> begin
+(Prims.parse_int "1")
+end
+| uu____514 -> begin
+(
+
+let uu____517 = (univ_kernel u1)
+in (match (uu____517) with
+| (k1, n1) -> begin
+(
+
+let uu____522 = (univ_kernel u2)
+in (match (uu____522) with
+| (k2, n2) -> begin
+(
+
+let r = (compare_univs k1 k2)
+in (match ((r = (Prims.parse_int "0"))) with
+| true -> begin
+(n1 - n2)
+end
+| uu____528 -> begin
+r
+end))
+end))
+end))
+end))
+
+
+let eq_univs : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  Prims.bool = (fun u1 u2 -> (
+
+let uu____535 = (compare_univs u1 u2)
+in (uu____535 = (Prims.parse_int "0"))))
+
+
+let ml_comp : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.comp = (fun t r -> (FStar_Syntax_Syntax.mk_Comp {FStar_Syntax_Syntax.comp_univs = (FStar_Syntax_Syntax.U_unknown)::[]; FStar_Syntax_Syntax.effect_name = (FStar_Ident.set_lid_range FStar_Syntax_Const.effect_ML_lid r); FStar_Syntax_Syntax.result_typ = t; FStar_Syntax_Syntax.effect_args = []; FStar_Syntax_Syntax.flags = (FStar_Syntax_Syntax.MLEFFECT)::[]}))
+
+
+let comp_effect_name = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+c1.FStar_Syntax_Syntax.effect_name
+end
+| FStar_Syntax_Syntax.Total (uu____562) -> begin
+FStar_Syntax_Const.effect_Tot_lid
+end
+| FStar_Syntax_Syntax.GTotal (uu____568) -> begin
+FStar_Syntax_Const.effect_GTot_lid
+end))
+
+
+let comp_flags = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (uu____586) -> begin
+(FStar_Syntax_Syntax.TOTAL)::[]
+end
+| FStar_Syntax_Syntax.GTotal (uu____592) -> begin
+(FStar_Syntax_Syntax.SOMETRIVIAL)::[]
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+ct.FStar_Syntax_Syntax.flags
+end))
+
+
+let comp_set_flags : FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.cflags Prims.list  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun c f -> (
+
+let comp_to_comp_typ = (fun c1 -> (match (c1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (c2) -> begin
+c2
+end
+| (FStar_Syntax_Syntax.Total (t, u_opt)) | (FStar_Syntax_Syntax.GTotal (t, u_opt)) -> begin
+(
+
+let uu____628 = (
+
+let uu____629 = (FStar_Util.map_opt u_opt (fun x -> (x)::[]))
+in (FStar_Util.dflt [] uu____629))
+in {FStar_Syntax_Syntax.comp_univs = uu____628; FStar_Syntax_Syntax.effect_name = (comp_effect_name c1); FStar_Syntax_Syntax.result_typ = t; FStar_Syntax_Syntax.effect_args = []; FStar_Syntax_Syntax.flags = (comp_flags c1)})
+end))
+in (
+
+let uu___173_639 = c
+in (
+
+let uu____640 = (
+
+let uu____641 = (
+
+let uu___174_642 = (comp_to_comp_typ c)
+in {FStar_Syntax_Syntax.comp_univs = uu___174_642.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = uu___174_642.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = uu___174_642.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu___174_642.FStar_Syntax_Syntax.effect_args; FStar_Syntax_Syntax.flags = f})
+in FStar_Syntax_Syntax.Comp (uu____641))
+in {FStar_Syntax_Syntax.n = uu____640; FStar_Syntax_Syntax.tk = uu___173_639.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___173_639.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___173_639.FStar_Syntax_Syntax.vars}))))
+
+
+let comp_to_comp_typ : FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp_typ = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+c1
+end
+| (FStar_Syntax_Syntax.Total (t, Some (u))) | (FStar_Syntax_Syntax.GTotal (t, Some (u))) -> begin
+{FStar_Syntax_Syntax.comp_univs = (u)::[]; FStar_Syntax_Syntax.effect_name = (comp_effect_name c); FStar_Syntax_Syntax.result_typ = t; FStar_Syntax_Syntax.effect_args = []; FStar_Syntax_Syntax.flags = (comp_flags c)}
+end
+| uu____667 -> begin
+(failwith "Assertion failed: Computation type without universe")
+end))
+
+
+let is_named_tot = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+(FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_Tot_lid)
+end
+| FStar_Syntax_Syntax.Total (uu____680) -> begin
+true
+end
+| FStar_Syntax_Syntax.GTotal (uu____686) -> begin
+false
+end))
+
+
+let is_total_comp = (fun c -> (FStar_All.pipe_right (comp_flags c) (FStar_Util.for_some (fun uu___161_704 -> (match (uu___161_704) with
+| (FStar_Syntax_Syntax.TOTAL) | (FStar_Syntax_Syntax.RETURN) -> begin
+true
+end
+| uu____705 -> begin
+false
+end)))))
+
+
+let is_total_lcomp : FStar_Syntax_Syntax.lcomp  ->  Prims.bool = (fun c -> ((FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name FStar_Syntax_Const.effect_Tot_lid) || (FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags (FStar_Util.for_some (fun uu___162_710 -> (match (uu___162_710) with
+| (FStar_Syntax_Syntax.TOTAL) | (FStar_Syntax_Syntax.RETURN) -> begin
+true
+end
+| uu____711 -> begin
+false
+end))))))
+
+
+let is_tot_or_gtot_lcomp : FStar_Syntax_Syntax.lcomp  ->  Prims.bool = (fun c -> (((FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name FStar_Syntax_Const.effect_Tot_lid) || (FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name FStar_Syntax_Const.effect_GTot_lid)) || (FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags (FStar_Util.for_some (fun uu___163_716 -> (match (uu___163_716) with
+| (FStar_Syntax_Syntax.TOTAL) | (FStar_Syntax_Syntax.RETURN) -> begin
+true
+end
+| uu____717 -> begin
+false
+end))))))
+
+
+let is_partial_return = (fun c -> (FStar_All.pipe_right (comp_flags c) (FStar_Util.for_some (fun uu___164_730 -> (match (uu___164_730) with
+| (FStar_Syntax_Syntax.RETURN) | (FStar_Syntax_Syntax.PARTIAL_RETURN) -> begin
+true
+end
+| uu____731 -> begin
+false
+end)))))
+
+
+let is_lcomp_partial_return : FStar_Syntax_Syntax.lcomp  ->  Prims.bool = (fun c -> (FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags (FStar_Util.for_some (fun uu___165_736 -> (match (uu___165_736) with
+| (FStar_Syntax_Syntax.RETURN) | (FStar_Syntax_Syntax.PARTIAL_RETURN) -> begin
+true
+end
+| uu____737 -> begin
+false
+end)))))
+
+
+let is_tot_or_gtot_comp = (fun c -> ((is_total_comp c) || (FStar_Ident.lid_equals FStar_Syntax_Const.effect_GTot_lid (comp_effect_name c))))
+
+
+let is_pure_effect : FStar_Ident.lident  ->  Prims.bool = (fun l -> (((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) || (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_PURE_lid)) || (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Pure_lid)))
+
+
+let is_pure_comp = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (uu____763) -> begin
+true
+end
+| FStar_Syntax_Syntax.GTotal (uu____769) -> begin
+false
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(((is_total_comp c) || (is_pure_effect ct.FStar_Syntax_Syntax.effect_name)) || (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___166_777 -> (match (uu___166_777) with
+| FStar_Syntax_Syntax.LEMMA -> begin
+true
+end
+| uu____778 -> begin
+false
+end)))))
+end))
+
+
+let is_ghost_effect : FStar_Ident.lident  ->  Prims.bool = (fun l -> (((FStar_Ident.lid_equals FStar_Syntax_Const.effect_GTot_lid l) || (FStar_Ident.lid_equals FStar_Syntax_Const.effect_GHOST_lid l)) || (FStar_Ident.lid_equals FStar_Syntax_Const.effect_Ghost_lid l)))
+
+
+let is_pure_or_ghost_comp = (fun c -> ((is_pure_comp c) || (is_ghost_effect (comp_effect_name c))))
+
+
+let is_pure_lcomp : FStar_Syntax_Syntax.lcomp  ->  Prims.bool = (fun lc -> (((is_total_lcomp lc) || (is_pure_effect lc.FStar_Syntax_Syntax.eff_name)) || (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags (FStar_Util.for_some (fun uu___167_797 -> (match (uu___167_797) with
+| FStar_Syntax_Syntax.LEMMA -> begin
+true
+end
+| uu____798 -> begin
+false
+end))))))
+
+
+let is_pure_or_ghost_lcomp : FStar_Syntax_Syntax.lcomp  ->  Prims.bool = (fun lc -> ((is_pure_lcomp lc) || (is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)))
+
+
+let is_pure_or_ghost_function : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____805 = (
+
+let uu____806 = (FStar_Syntax_Subst.compress t)
+in uu____806.FStar_Syntax_Syntax.n)
+in (match (uu____805) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____809, c) -> begin
+(is_pure_or_ghost_comp c)
+end
+| uu____821 -> begin
+true
+end)))
+
+
+let is_lemma : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____825 = (
+
+let uu____826 = (FStar_Syntax_Subst.compress t)
+in uu____826.FStar_Syntax_Syntax.n)
+in (match (uu____825) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____829, c) -> begin
+(match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_Lemma_lid)
+end
+| uu____842 -> begin
+false
+end)
+end
+| uu____843 -> begin
+false
+end)))
+
+
+let head_and_args : FStar_Syntax_Syntax.term  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list) = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+((head1), (args))
+end
+| uu____889 -> begin
+((t1), ([]))
+end)))
+
+
+let un_uinst : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uinst (t2, uu____904) -> begin
+(FStar_Syntax_Subst.compress t2)
+end
+| uu____909 -> begin
+t1
+end)))
+
+
+let is_smt_lemma : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____913 = (
+
+let uu____914 = (FStar_Syntax_Subst.compress t)
+in uu____914.FStar_Syntax_Syntax.n)
+in (match (uu____913) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____917, c) -> begin
+(match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (ct) when (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_Lemma_lid) -> begin
+(match (ct.FStar_Syntax_Syntax.effect_args) with
+| (_req)::(_ens)::((pats, uu____933))::uu____934 -> begin
+(
+
+let pats' = (unmeta pats)
+in (
+
+let uu____965 = (head_and_args pats')
+in (match (uu____965) with
+| (head1, uu____976) -> begin
+(
+
+let uu____991 = (
+
+let uu____992 = (un_uinst head1)
+in uu____992.FStar_Syntax_Syntax.n)
+in (match (uu____991) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.cons_lid)
+end
+| uu____996 -> begin
+false
+end))
+end)))
+end
+| uu____997 -> begin
+false
+end)
+end
+| uu____1003 -> begin
+false
+end)
+end
+| uu____1004 -> begin
+false
+end)))
+
+
+let is_ml_comp = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+((FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_ML_lid) || (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___168_1018 -> (match (uu___168_1018) with
+| FStar_Syntax_Syntax.MLEFFECT -> begin
+true
+end
+| uu____1019 -> begin
+false
+end)))))
+end
+| uu____1020 -> begin
+false
+end))
+
+
+let comp_result = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Total (t, _)) | (FStar_Syntax_Syntax.GTotal (t, _)) -> begin
+t
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+ct.FStar_Syntax_Syntax.result_typ
+end))
+
+
+let set_result_typ = (fun c t -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (uu____1064) -> begin
+(FStar_Syntax_Syntax.mk_Total t)
+end
+| FStar_Syntax_Syntax.GTotal (uu____1070) -> begin
+(FStar_Syntax_Syntax.mk_GTotal t)
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(FStar_Syntax_Syntax.mk_Comp (
+
+let uu___175_1077 = ct
+in {FStar_Syntax_Syntax.comp_univs = uu___175_1077.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = uu___175_1077.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = t; FStar_Syntax_Syntax.effect_args = uu___175_1077.FStar_Syntax_Syntax.effect_args; FStar_Syntax_Syntax.flags = uu___175_1077.FStar_Syntax_Syntax.flags}))
+end))
+
+
+let is_trivial_wp = (fun c -> (FStar_All.pipe_right (comp_flags c) (FStar_Util.for_some (fun uu___169_1090 -> (match (uu___169_1090) with
+| (FStar_Syntax_Syntax.TOTAL) | (FStar_Syntax_Syntax.RETURN) -> begin
+true
+end
+| uu____1091 -> begin
+false
+end)))))
+
+
+let primops : FStar_Ident.lident Prims.list = (FStar_Syntax_Const.op_Eq)::(FStar_Syntax_Const.op_notEq)::(FStar_Syntax_Const.op_LT)::(FStar_Syntax_Const.op_LTE)::(FStar_Syntax_Const.op_GT)::(FStar_Syntax_Const.op_GTE)::(FStar_Syntax_Const.op_Subtraction)::(FStar_Syntax_Const.op_Minus)::(FStar_Syntax_Const.op_Addition)::(FStar_Syntax_Const.op_Multiply)::(FStar_Syntax_Const.op_Division)::(FStar_Syntax_Const.op_Modulus)::(FStar_Syntax_Const.op_And)::(FStar_Syntax_Const.op_Or)::(FStar_Syntax_Const.op_Negation)::[]
+
+
+let is_primop_lid : FStar_Ident.lident  ->  Prims.bool = (fun l -> (FStar_All.pipe_right primops (FStar_Util.for_some (FStar_Ident.lid_equals l))))
+
+
+let is_primop = (fun f -> (match (f.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(is_primop_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end
+| uu____1113 -> begin
+false
+end))
+
+
+let rec unascribe : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun e -> (
+
+let e1 = (FStar_Syntax_Subst.compress e)
+in (match (e1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_ascribed (e2, uu____1119, uu____1120) -> begin
+(unascribe e2)
+end
+| uu____1149 -> begin
+e1
+end)))
+
+
+let rec ascribe = (fun t k -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_ascribed (t', uu____1191, uu____1192) -> begin
+(ascribe t' k)
+end
+| uu____1221 -> begin
+(FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_ascribed (((t), (k), (None)))) None t.FStar_Syntax_Syntax.pos)
+end))
+
 type eq_result =
-  | Equal
-  | NotEqual
-  | Unknown
-let uu___is_Equal: eq_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Equal  -> true | uu____1243 -> false
-let uu___is_NotEqual: eq_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NotEqual  -> true | uu____1247 -> false
-let uu___is_Unknown: eq_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unknown  -> true | uu____1251 -> false
-let rec eq_tm:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result =
-  fun t1  ->
-    fun t2  ->
-      let t11 = unascribe t1 in
-      let t21 = unascribe t2 in
-      let equal_if uu___174_1271 = if uu___174_1271 then Equal else Unknown in
-      let equal_iff uu___175_1276 = if uu___175_1276 then Equal else NotEqual in
-      let eq_and f g = match f with | Equal  -> g () | uu____1290 -> Unknown in
-      match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
-      | (FStar_Syntax_Syntax.Tm_name a,FStar_Syntax_Syntax.Tm_name b) ->
-          equal_if (FStar_Syntax_Syntax.bv_eq a b)
-      | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-          let uu____1295 = FStar_Syntax_Syntax.fv_eq f g in
-          equal_if uu____1295
-      | (FStar_Syntax_Syntax.Tm_uinst (f,us),FStar_Syntax_Syntax.Tm_uinst
-         (g,vs)) ->
-          let uu____1308 = eq_tm f g in
-          eq_and uu____1308
-            (fun uu____1309  ->
-               let uu____1310 = eq_univs_list us vs in equal_if uu____1310)
-      | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant d)
-          ->
-          let uu____1313 = FStar_Const.eq_const c d in equal_iff uu____1313
-      | (FStar_Syntax_Syntax.Tm_uvar
-         (u1,uu____1315),FStar_Syntax_Syntax.Tm_uvar (u2,uu____1317)) ->
-          let uu____1342 = FStar_Unionfind.equivalent u1 u2 in
-          equal_if uu____1342
-      | (FStar_Syntax_Syntax.Tm_app (h1,args1),FStar_Syntax_Syntax.Tm_app
-         (h2,args2)) ->
-          let uu____1378 = eq_tm h1 h2 in
-          eq_and uu____1378 (fun uu____1379  -> eq_args args1 args2)
-      | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v1) ->
-          let uu____1382 = eq_univs u v1 in equal_if uu____1382
-      | (FStar_Syntax_Syntax.Tm_meta (t12,uu____1384),uu____1385) ->
-          eq_tm t12 t21
-      | (uu____1390,FStar_Syntax_Syntax.Tm_meta (t22,uu____1392)) ->
-          eq_tm t11 t22
-      | uu____1397 -> Unknown
-and eq_args:
-  FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.args -> eq_result =
-  fun a1  ->
-    fun a2  ->
-      match (a1, a2) with
-      | ([],[]) -> Equal
-      | ((a,uu____1421)::a11,(b,uu____1424)::b1) ->
-          let uu____1462 = eq_tm a b in
-          (match uu____1462 with
-           | Equal  -> eq_args a11 b1
-           | uu____1463 -> Unknown)
-      | uu____1464 -> Unknown
-and eq_univs_list:
-  FStar_Syntax_Syntax.universes ->
-    FStar_Syntax_Syntax.universes -> Prims.bool
-  =
-  fun us  ->
-    fun vs  ->
-      ((FStar_List.length us) = (FStar_List.length vs)) &&
-        (FStar_List.forall2 eq_univs us vs)
-let rec unrefine: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____1478) ->
-        unrefine x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____1484,uu____1485) ->
-        unrefine t2
-    | uu____1514 -> t1
-let rec is_unit: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____1518 =
-      let uu____1519 = unrefine t in uu____1519.FStar_Syntax_Syntax.n in
-    match uu____1518 with
-    | FStar_Syntax_Syntax.Tm_type uu____1522 -> true
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) ||
-          (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid)
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____1525) -> is_unit t1
-    | uu____1530 -> false
-let rec non_informative: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____1534 =
-      let uu____1535 = unrefine t in uu____1535.FStar_Syntax_Syntax.n in
-    match uu____1534 with
-    | FStar_Syntax_Syntax.Tm_type uu____1538 -> true
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) ||
-           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid))
-          || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.erased_lid)
-    | FStar_Syntax_Syntax.Tm_app (head1,uu____1541) -> non_informative head1
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____1557) -> non_informative t1
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1562,c) ->
-        (is_tot_or_gtot_comp c) && (non_informative (comp_result c))
-    | uu____1574 -> false
-let is_fun: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun e  ->
-    let uu____1578 =
-      let uu____1579 = FStar_Syntax_Subst.compress e in
-      uu____1579.FStar_Syntax_Syntax.n in
-    match uu____1578 with
-    | FStar_Syntax_Syntax.Tm_abs uu____1582 -> true
-    | uu____1597 -> false
-let is_function_typ: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____1601 =
-      let uu____1602 = FStar_Syntax_Subst.compress t in
-      uu____1602.FStar_Syntax_Syntax.n in
-    match uu____1601 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____1605 -> true
-    | uu____1613 -> false
-let rec pre_typ: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____1619) ->
-        pre_typ x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____1625,uu____1626) ->
-        pre_typ t2
-    | uu____1655 -> t1
-let destruct:
-  FStar_Syntax_Syntax.term ->
-    FStar_Ident.lident ->
-      ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-        Prims.option
-  =
-  fun typ  ->
-    fun lid  ->
-      let typ1 = FStar_Syntax_Subst.compress typ in
-      let uu____1669 =
-        let uu____1670 = un_uinst typ1 in uu____1670.FStar_Syntax_Syntax.n in
-      match uu____1669 with
-      | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let head2 = un_uinst head1 in
-          (match head2.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_fvar tc when
-               FStar_Syntax_Syntax.fv_eq_lid tc lid -> Some args
-           | uu____1708 -> None)
-      | FStar_Syntax_Syntax.Tm_fvar tc when
-          FStar_Syntax_Syntax.fv_eq_lid tc lid -> Some []
-      | uu____1724 -> None
-let lids_of_sigelt:
-  FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list =
-  fun se  ->
-    match se with
-    | FStar_Syntax_Syntax.Sig_let (_,_,lids,_,_)
-      |FStar_Syntax_Syntax.Sig_bundle (_,_,lids,_) -> lids
-    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,_,_,_,_,_,_,_)
-      |FStar_Syntax_Syntax.Sig_effect_abbrev (lid,_,_,_,_,_,_)
-       |FStar_Syntax_Syntax.Sig_datacon (lid,_,_,_,_,_,_,_)
-        |FStar_Syntax_Syntax.Sig_declare_typ (lid,_,_,_,_)
-         |FStar_Syntax_Syntax.Sig_assume (lid,_,_,_)
-        -> [lid]
-    | FStar_Syntax_Syntax.Sig_new_effect_for_free (n1,_)
-      |FStar_Syntax_Syntax.Sig_new_effect (n1,_) ->
-        [n1.FStar_Syntax_Syntax.mname]
-    | FStar_Syntax_Syntax.Sig_sub_effect _
-      |FStar_Syntax_Syntax.Sig_pragma _|FStar_Syntax_Syntax.Sig_main _ -> []
-let lid_of_sigelt:
-  FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.option =
-  fun se  ->
-    match lids_of_sigelt se with | l::[] -> Some l | uu____1801 -> None
-let quals_of_sigelt:
-  FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list =
-  fun x  ->
-    match x with
-    | FStar_Syntax_Syntax.Sig_bundle (_,quals,_,_)
-      |FStar_Syntax_Syntax.Sig_inductive_typ (_,_,_,_,_,_,quals,_)
-       |FStar_Syntax_Syntax.Sig_effect_abbrev (_,_,_,_,quals,_,_)
-        |FStar_Syntax_Syntax.Sig_datacon (_,_,_,_,_,quals,_,_)
-         |FStar_Syntax_Syntax.Sig_declare_typ (_,_,_,quals,_)
-          |FStar_Syntax_Syntax.Sig_assume (_,_,quals,_)
-           |FStar_Syntax_Syntax.Sig_let (_,_,_,quals,_)
-            |FStar_Syntax_Syntax.Sig_new_effect
-             ({ FStar_Syntax_Syntax.qualifiers = quals;
-                FStar_Syntax_Syntax.cattributes = _;
-                FStar_Syntax_Syntax.mname = _; FStar_Syntax_Syntax.univs = _;
-                FStar_Syntax_Syntax.binders = _;
-                FStar_Syntax_Syntax.signature = _;
-                FStar_Syntax_Syntax.ret_wp = _;
-                FStar_Syntax_Syntax.bind_wp = _;
-                FStar_Syntax_Syntax.if_then_else = _;
-                FStar_Syntax_Syntax.ite_wp = _;
-                FStar_Syntax_Syntax.stronger = _;
-                FStar_Syntax_Syntax.close_wp = _;
-                FStar_Syntax_Syntax.assert_p = _;
-                FStar_Syntax_Syntax.assume_p = _;
-                FStar_Syntax_Syntax.null_wp = _;
-                FStar_Syntax_Syntax.trivial = _;
-                FStar_Syntax_Syntax.repr = _;
-                FStar_Syntax_Syntax.return_repr = _;
-                FStar_Syntax_Syntax.bind_repr = _;
-                FStar_Syntax_Syntax.actions = _;_},_)
-             |FStar_Syntax_Syntax.Sig_new_effect_for_free
-             ({ FStar_Syntax_Syntax.qualifiers = quals;
-                FStar_Syntax_Syntax.cattributes = _;
-                FStar_Syntax_Syntax.mname = _; FStar_Syntax_Syntax.univs = _;
-                FStar_Syntax_Syntax.binders = _;
-                FStar_Syntax_Syntax.signature = _;
-                FStar_Syntax_Syntax.ret_wp = _;
-                FStar_Syntax_Syntax.bind_wp = _;
-                FStar_Syntax_Syntax.if_then_else = _;
-                FStar_Syntax_Syntax.ite_wp = _;
-                FStar_Syntax_Syntax.stronger = _;
-                FStar_Syntax_Syntax.close_wp = _;
-                FStar_Syntax_Syntax.assert_p = _;
-                FStar_Syntax_Syntax.assume_p = _;
-                FStar_Syntax_Syntax.null_wp = _;
-                FStar_Syntax_Syntax.trivial = _;
-                FStar_Syntax_Syntax.repr = _;
-                FStar_Syntax_Syntax.return_repr = _;
-                FStar_Syntax_Syntax.bind_repr = _;
-                FStar_Syntax_Syntax.actions = _;_},_)
-        -> quals
-    | FStar_Syntax_Syntax.Sig_sub_effect (_,_)
-      |FStar_Syntax_Syntax.Sig_pragma (_,_)|FStar_Syntax_Syntax.Sig_main
-       (_,_) -> []
-let range_of_sigelt: FStar_Syntax_Syntax.sigelt -> FStar_Range.range =
-  fun x  ->
-    match x with
-    | FStar_Syntax_Syntax.Sig_bundle (_,_,_,r)
-      |FStar_Syntax_Syntax.Sig_inductive_typ (_,_,_,_,_,_,_,r)
-       |FStar_Syntax_Syntax.Sig_effect_abbrev (_,_,_,_,_,_,r)
-        |FStar_Syntax_Syntax.Sig_datacon (_,_,_,_,_,_,_,r)
-         |FStar_Syntax_Syntax.Sig_declare_typ (_,_,_,_,r)
-          |FStar_Syntax_Syntax.Sig_assume (_,_,_,r)
-           |FStar_Syntax_Syntax.Sig_let (_,r,_,_,_)
-            |FStar_Syntax_Syntax.Sig_main (_,r)
-             |FStar_Syntax_Syntax.Sig_pragma (_,r)
-              |FStar_Syntax_Syntax.Sig_new_effect (_,r)
-               |FStar_Syntax_Syntax.Sig_new_effect_for_free (_,r)
-                |FStar_Syntax_Syntax.Sig_sub_effect (_,r)
-        -> r
-let range_of_lb uu___176_1984 =
-  match uu___176_1984 with
-  | (FStar_Util.Inl x,uu____1991,uu____1992) ->
-      FStar_Syntax_Syntax.range_of_bv x
-  | (FStar_Util.Inr l,uu____1996,uu____1997) -> FStar_Ident.range_of_lid l
-let range_of_arg uu____2014 =
-  match uu____2014 with | (hd1,uu____2020) -> hd1.FStar_Syntax_Syntax.pos
-let range_of_args args r =
-  FStar_All.pipe_right args
-    (FStar_List.fold_left
-       (fun r1  -> fun a  -> FStar_Range.union_ranges r1 (range_of_arg a)) r)
-let mk_app f args =
-  let r = range_of_args args f.FStar_Syntax_Syntax.pos in
-  FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args)) None r
-let mk_data l args =
-  match args with
-  | [] ->
-      let uu____2134 =
-        let uu____2137 =
-          let uu____2138 =
-            let uu____2143 =
-              FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant
-                (Some FStar_Syntax_Syntax.Data_ctor) in
-            (uu____2143,
-              (FStar_Syntax_Syntax.Meta_desugared
-                 FStar_Syntax_Syntax.Data_app)) in
-          FStar_Syntax_Syntax.Tm_meta uu____2138 in
-        FStar_Syntax_Syntax.mk uu____2137 in
-      uu____2134 None (FStar_Ident.range_of_lid l)
-  | uu____2152 ->
-      let e =
-        let uu____2161 =
-          FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant
-            (Some FStar_Syntax_Syntax.Data_ctor) in
-        mk_app uu____2161 args in
-      FStar_Syntax_Syntax.mk
-        (FStar_Syntax_Syntax.Tm_meta
-           (e,
-             (FStar_Syntax_Syntax.Meta_desugared FStar_Syntax_Syntax.Data_app)))
-        None e.FStar_Syntax_Syntax.pos
-let mangle_field_name: FStar_Ident.ident -> FStar_Ident.ident =
-  fun x  ->
-    FStar_Ident.mk_ident
-      ((Prims.strcat "^fname^" x.FStar_Ident.idText),
-        (x.FStar_Ident.idRange))
-let unmangle_field_name: FStar_Ident.ident -> FStar_Ident.ident =
-  fun x  ->
-    if FStar_Util.starts_with x.FStar_Ident.idText "^fname^"
-    then
-      let uu____2176 =
-        let uu____2179 =
-          FStar_Util.substring_from x.FStar_Ident.idText
-            (Prims.parse_int "7") in
-        (uu____2179, (x.FStar_Ident.idRange)) in
-      FStar_Ident.mk_ident uu____2176
-    else x
-let field_projector_prefix: Prims.string = "__proj__"
-let field_projector_sep: Prims.string = "__item__"
-let field_projector_contains_constructor: Prims.string -> Prims.bool =
-  fun s  -> FStar_Util.starts_with s field_projector_prefix
-let mk_field_projector_name_from_string:
-  Prims.string -> Prims.string -> Prims.string =
-  fun constr  ->
-    fun field  ->
-      Prims.strcat field_projector_prefix
-        (Prims.strcat constr (Prims.strcat field_projector_sep field))
-let mk_field_projector_name_from_ident:
-  FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
-  fun lid  ->
-    fun i  ->
-      let j = unmangle_field_name i in
-      let jtext = j.FStar_Ident.idText in
-      let newi =
-        if field_projector_contains_constructor jtext
-        then j
-        else
-          FStar_Ident.mk_ident
-            ((mk_field_projector_name_from_string
-                (lid.FStar_Ident.ident).FStar_Ident.idText jtext),
-              (i.FStar_Ident.idRange)) in
-      FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns [newi])
-let mk_field_projector_name:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.bv ->
-      Prims.int -> (FStar_Ident.lident* FStar_Syntax_Syntax.bv)
-  =
-  fun lid  ->
-    fun x  ->
-      fun i  ->
-        let nm =
-          let uu____2212 = FStar_Syntax_Syntax.is_null_bv x in
-          if uu____2212
-          then
-            let uu____2213 =
-              let uu____2216 =
-                let uu____2217 = FStar_Util.string_of_int i in
-                Prims.strcat "_" uu____2217 in
-              let uu____2218 = FStar_Syntax_Syntax.range_of_bv x in
-              (uu____2216, uu____2218) in
-            FStar_Ident.mk_ident uu____2213
-          else x.FStar_Syntax_Syntax.ppname in
-        let y =
-          let uu___180_2221 = x in
-          {
-            FStar_Syntax_Syntax.ppname = nm;
-            FStar_Syntax_Syntax.index =
-              (uu___180_2221.FStar_Syntax_Syntax.index);
-            FStar_Syntax_Syntax.sort =
-              (uu___180_2221.FStar_Syntax_Syntax.sort)
-          } in
-        let uu____2222 = mk_field_projector_name_from_ident lid nm in
-        (uu____2222, y)
-let set_uvar uv t =
-  let uu____2239 = FStar_Unionfind.find uv in
-  match uu____2239 with
-  | FStar_Syntax_Syntax.Fixed uu____2242 ->
-      let uu____2243 =
-        let uu____2244 =
-          let uu____2245 = FStar_Unionfind.uvar_id uv in
-          FStar_All.pipe_left FStar_Util.string_of_int uu____2245 in
-        FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____2244 in
-      failwith uu____2243
-  | uu____2247 -> FStar_Unionfind.change uv (FStar_Syntax_Syntax.Fixed t)
-let qualifier_equal:
-  FStar_Syntax_Syntax.qualifier ->
-    FStar_Syntax_Syntax.qualifier -> Prims.bool
-  =
-  fun q1  ->
-    fun q2  ->
-      match (q1, q2) with
-      | (FStar_Syntax_Syntax.Discriminator
-         l1,FStar_Syntax_Syntax.Discriminator l2) ->
-          FStar_Ident.lid_equals l1 l2
-      | (FStar_Syntax_Syntax.Projector
-         (l1a,l1b),FStar_Syntax_Syntax.Projector (l2a,l2b)) ->
-          (FStar_Ident.lid_equals l1a l2a) &&
-            (l1b.FStar_Ident.idText = l2b.FStar_Ident.idText)
-      | (FStar_Syntax_Syntax.RecordType
-         (ns1,f1),FStar_Syntax_Syntax.RecordType (ns2,f2))
-        |(FStar_Syntax_Syntax.RecordConstructor
-          (ns1,f1),FStar_Syntax_Syntax.RecordConstructor (ns2,f2)) ->
-          ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
-              (FStar_List.forall2
-                 (fun x1  ->
-                    fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-                 f1 f2))
-             && ((FStar_List.length f1) = (FStar_List.length f2)))
-            &&
-            (FStar_List.forall2
-               (fun x1  ->
-                  fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-               f1 f2)
-      | uu____2294 -> q1 = q2
-let abs:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                   FStar_Syntax_Syntax.cflags Prims.list))
-        FStar_Util.either Prims.option -> FStar_Syntax_Syntax.term
-  =
-  fun bs  ->
-    fun t  ->
-      fun lopt  ->
-        if (FStar_List.length bs) = (Prims.parse_int "0")
-        then t
-        else
-          (let close_lopt lopt1 =
-             match lopt1 with
-             | None |Some (FStar_Util.Inr _) -> lopt1
-             | Some (FStar_Util.Inl lc) ->
-                 let uu____2380 =
-                   let uu____2386 = FStar_Syntax_Subst.close_lcomp bs lc in
-                   FStar_Util.Inl uu____2386 in
-                 Some uu____2380 in
-           match bs with
-           | [] -> t
-           | uu____2397 ->
-               let body =
-                 let uu____2402 = FStar_Syntax_Subst.close bs t in
-                 FStar_Syntax_Subst.compress uu____2402 in
-               (match ((body.FStar_Syntax_Syntax.n), lopt) with
-                | (FStar_Syntax_Syntax.Tm_abs (bs',t1,lopt'),None ) ->
-                    let uu____2445 =
-                      let uu____2448 =
-                        let uu____2449 =
-                          let uu____2464 =
-                            let uu____2468 =
-                              FStar_Syntax_Subst.close_binders bs in
-                            FStar_List.append uu____2468 bs' in
-                          let uu____2474 = close_lopt lopt' in
-                          (uu____2464, t1, uu____2474) in
-                        FStar_Syntax_Syntax.Tm_abs uu____2449 in
-                      FStar_Syntax_Syntax.mk uu____2448 in
-                    uu____2445 None t1.FStar_Syntax_Syntax.pos
-                | uu____2500 ->
-                    let uu____2509 =
-                      let uu____2512 =
-                        let uu____2513 =
-                          let uu____2528 =
-                            FStar_Syntax_Subst.close_binders bs in
-                          let uu____2529 = close_lopt lopt in
-                          (uu____2528, body, uu____2529) in
-                        FStar_Syntax_Syntax.Tm_abs uu____2513 in
-                      FStar_Syntax_Syntax.mk uu____2512 in
-                    uu____2509 None t.FStar_Syntax_Syntax.pos))
-let arrow:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-    (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun bs  ->
-    fun c  ->
-      match bs with
-      | [] -> comp_result c
-      | uu____2572 ->
-          let uu____2576 =
-            let uu____2579 =
-              let uu____2580 =
-                let uu____2588 = FStar_Syntax_Subst.close_binders bs in
-                let uu____2589 = FStar_Syntax_Subst.close_comp bs c in
-                (uu____2588, uu____2589) in
-              FStar_Syntax_Syntax.Tm_arrow uu____2580 in
-            FStar_Syntax_Syntax.mk uu____2579 in
-          uu____2576 None c.FStar_Syntax_Syntax.pos
-let flat_arrow:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-    (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun bs  ->
-    fun c  ->
-      let t = arrow bs c in
-      let uu____2619 =
-        let uu____2620 = FStar_Syntax_Subst.compress t in
-        uu____2620.FStar_Syntax_Syntax.n in
-      match uu____2619 with
-      | FStar_Syntax_Syntax.Tm_arrow (bs1,c1) ->
-          (match c1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (tres,uu____2640) ->
-               let uu____2647 =
-                 let uu____2648 = FStar_Syntax_Subst.compress tres in
-                 uu____2648.FStar_Syntax_Syntax.n in
-               (match uu____2647 with
-                | FStar_Syntax_Syntax.Tm_arrow (bs',c') ->
-                    let uu____2665 = FStar_ST.read t.FStar_Syntax_Syntax.tk in
-                    (FStar_Syntax_Syntax.mk
-                       (FStar_Syntax_Syntax.Tm_arrow
-                          ((FStar_List.append bs1 bs'), c'))) uu____2665
-                      t.FStar_Syntax_Syntax.pos
-                | uu____2685 -> t)
-           | uu____2686 -> t)
-      | uu____2687 -> t
-let refine:
-  FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun b  ->
-    fun t  ->
-      let uu____2696 =
-        FStar_ST.read (b.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.tk in
-      let uu____2701 =
-        let uu____2702 = FStar_Syntax_Syntax.range_of_bv b in
-        FStar_Range.union_ranges uu____2702 t.FStar_Syntax_Syntax.pos in
-      let uu____2703 =
-        let uu____2706 =
-          let uu____2707 =
-            let uu____2712 =
-              let uu____2713 =
-                let uu____2714 = FStar_Syntax_Syntax.mk_binder b in
-                [uu____2714] in
-              FStar_Syntax_Subst.close uu____2713 t in
-            (b, uu____2712) in
-          FStar_Syntax_Syntax.Tm_refine uu____2707 in
-        FStar_Syntax_Syntax.mk uu____2706 in
-      uu____2703 uu____2696 uu____2701
-let branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
-  fun b  -> FStar_Syntax_Subst.close_branch b
-let rec arrow_formals_comp:
-  FStar_Syntax_Syntax.term ->
-    ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list*
-      FStar_Syntax_Syntax.comp)
-  =
-  fun k  ->
-    let k1 = FStar_Syntax_Subst.compress k in
-    match k1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____2752 = FStar_Syntax_Subst.open_comp bs c in
-        (match uu____2752 with
-         | (bs1,c1) ->
-             let uu____2762 = is_tot_or_gtot_comp c1 in
-             if uu____2762
-             then
-               let uu____2768 = arrow_formals_comp (comp_result c1) in
-               (match uu____2768 with
-                | (bs',k2) -> ((FStar_List.append bs1 bs'), k2))
-             else (bs1, c1))
-    | uu____2793 ->
-        let uu____2794 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____2794)
-let rec arrow_formals:
-  FStar_Syntax_Syntax.term ->
-    ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax)
-  =
-  fun k  ->
-    let uu____2810 = arrow_formals_comp k in
-    match uu____2810 with | (bs,c) -> (bs, (comp_result c))
-let abs_formals:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.term*
-      (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                   FStar_Syntax_Syntax.cflags Prims.list))
-      FStar_Util.either Prims.option)
-  =
-  fun t  ->
-    let subst_lcomp_opt s l =
-      match l with
-      | Some (FStar_Util.Inl l1) ->
-          let l2 =
-            let uu___181_2891 = l1 in
-            let uu____2892 =
-              FStar_Syntax_Subst.subst s l1.FStar_Syntax_Syntax.res_typ in
-            {
-              FStar_Syntax_Syntax.eff_name =
-                (uu___181_2891.FStar_Syntax_Syntax.eff_name);
-              FStar_Syntax_Syntax.res_typ = uu____2892;
-              FStar_Syntax_Syntax.cflags =
-                (uu___181_2891.FStar_Syntax_Syntax.cflags);
-              FStar_Syntax_Syntax.comp =
-                (fun uu____2895  ->
-                   let uu____2896 = l1.FStar_Syntax_Syntax.comp () in
-                   FStar_Syntax_Subst.subst_comp s uu____2896)
-            } in
-          Some (FStar_Util.Inl l2)
-      | uu____2905 -> l in
-    let rec aux t1 abs_body_lcomp =
-      let uu____2943 =
-        let uu____2944 =
-          let uu____2947 = FStar_Syntax_Subst.compress t1 in
-          FStar_All.pipe_left unascribe uu____2947 in
-        uu____2944.FStar_Syntax_Syntax.n in
-      match uu____2943 with
-      | FStar_Syntax_Syntax.Tm_abs (bs,t2,what) ->
-          let uu____2985 = aux t2 what in
-          (match uu____2985 with
-           | (bs',t3,what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____3042 -> ([], t1, abs_body_lcomp) in
-    let uu____3054 = aux t None in
-    match uu____3054 with
-    | (bs,t1,abs_body_lcomp) ->
-        let uu____3102 = FStar_Syntax_Subst.open_term' bs t1 in
-        (match uu____3102 with
-         | (bs1,t2,opening) ->
-             let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp in
-             (bs1, t2, abs_body_lcomp1))
-let mk_letbinding:
-  (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-    FStar_Syntax_Syntax.univ_name Prims.list ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax ->
-        FStar_Ident.lident ->
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.letbinding
-  =
-  fun lbname  ->
-    fun univ_vars  ->
-      fun typ  ->
-        fun eff  ->
-          fun def  ->
-            {
-              FStar_Syntax_Syntax.lbname = lbname;
-              FStar_Syntax_Syntax.lbunivs = univ_vars;
-              FStar_Syntax_Syntax.lbtyp = typ;
-              FStar_Syntax_Syntax.lbeff = eff;
-              FStar_Syntax_Syntax.lbdef = def
-            }
-let close_univs_and_mk_letbinding:
-  FStar_Syntax_Syntax.fv Prims.list Prims.option ->
-    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-      FStar_Ident.ident Prims.list ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Ident.lident ->
-            FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.letbinding
-  =
-  fun recs  ->
-    fun lbname  ->
-      fun univ_vars  ->
-        fun typ  ->
-          fun eff  ->
-            fun def  ->
-              let def1 =
-                match (recs, univ_vars) with
-                | (None ,_)|(_,[]) -> def
-                | (Some fvs,uu____3202) ->
-                    let universes =
-                      FStar_All.pipe_right univ_vars
-                        (FStar_List.map
-                           (fun _0_25  -> FStar_Syntax_Syntax.U_name _0_25)) in
-                    let inst1 =
-                      FStar_All.pipe_right fvs
-                        (FStar_List.map
-                           (fun fv  ->
-                              (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
-                                universes))) in
-                    FStar_Syntax_InstFV.instantiate inst1 def in
-              let typ1 = FStar_Syntax_Subst.close_univ_vars univ_vars typ in
-              let def2 = FStar_Syntax_Subst.close_univ_vars univ_vars def1 in
-              mk_letbinding lbname univ_vars typ1 eff def2
-let open_univ_vars_binders_and_comp:
-  FStar_Syntax_Syntax.univ_names ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-      FStar_Syntax_Syntax.comp ->
-        (FStar_Syntax_Syntax.univ_names* (FStar_Syntax_Syntax.bv*
-          FStar_Syntax_Syntax.aqual) Prims.list* FStar_Syntax_Syntax.comp)
-  =
-  fun uvs  ->
-    fun binders  ->
-      fun c  ->
-        match binders with
-        | [] ->
-            let uu____3263 = FStar_Syntax_Subst.open_univ_vars_comp uvs c in
-            (match uu____3263 with | (uvs1,c1) -> (uvs1, [], c1))
-        | uu____3279 ->
-            let t' = arrow binders c in
-            let uu____3286 = FStar_Syntax_Subst.open_univ_vars uvs t' in
-            (match uu____3286 with
-             | (uvs1,t'1) ->
-                 let uu____3297 =
-                   let uu____3298 = FStar_Syntax_Subst.compress t'1 in
-                   uu____3298.FStar_Syntax_Syntax.n in
-                 (match uu____3297 with
-                  | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
-                      (uvs1, binders1, c1)
-                  | uu____3324 -> failwith "Impossible"))
-let is_tuple_constructor: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        FStar_Util.starts_with
-          ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-          "Prims.tuple"
-    | uu____3339 -> false
-let mk_tuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____3347 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "tuple%s" uu____3347 in
-      let uu____3348 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____3348 r
-let mk_tuple_data_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____3356 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "Mktuple%s" uu____3356 in
-      let uu____3357 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____3357 r
-let is_tuple_data_lid: FStar_Ident.lident -> Prims.int -> Prims.bool =
-  fun f  ->
-    fun n1  ->
-      let uu____3364 = mk_tuple_data_lid n1 FStar_Range.dummyRange in
-      FStar_Ident.lid_equals f uu____3364
-let is_tuple_data_lid': FStar_Ident.lident -> Prims.bool =
-  fun f  ->
-    (f.FStar_Ident.nsstr = "Prims") &&
-      (FStar_Util.starts_with (f.FStar_Ident.ident).FStar_Ident.idText
-         "Mktuple")
-let is_tuple_constructor_lid: FStar_Ident.lident -> Prims.bool =
-  fun lid  ->
-    FStar_Util.starts_with (FStar_Ident.text_of_lid lid) "Prims.tuple"
-let is_dtuple_constructor_lid: FStar_Ident.lident -> Prims.bool =
-  fun lid  ->
-    (lid.FStar_Ident.nsstr = "Prims") &&
-      (FStar_Util.starts_with (lid.FStar_Ident.ident).FStar_Ident.idText
-         "Prims.dtuple")
-let is_dtuple_constructor: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        is_dtuple_constructor_lid
-          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____3382 -> false
-let mk_dtuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____3390 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "dtuple%s" uu____3390 in
-      let uu____3391 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____3391 r
-let mk_dtuple_data_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident
-  =
-  fun n1  ->
-    fun r  ->
-      let t =
-        let uu____3399 = FStar_Util.string_of_int n1 in
-        FStar_Util.format1 "Mkdtuple%s" uu____3399 in
-      let uu____3400 = FStar_Syntax_Const.pconst t in
-      FStar_Ident.set_lid_range uu____3400 r
-let is_dtuple_data_lid': FStar_Ident.lident -> Prims.bool =
-  fun f  -> FStar_Util.starts_with (FStar_Ident.text_of_lid f) "Mkdtuple"
-let is_lid_equality: FStar_Ident.lident -> Prims.bool =
-  fun x  -> FStar_Ident.lid_equals x FStar_Syntax_Const.eq2_lid
-let is_forall: FStar_Ident.lident -> Prims.bool =
-  fun lid  -> FStar_Ident.lid_equals lid FStar_Syntax_Const.forall_lid
-let is_exists: FStar_Ident.lident -> Prims.bool =
-  fun lid  -> FStar_Ident.lid_equals lid FStar_Syntax_Const.exists_lid
-let is_qlid: FStar_Ident.lident -> Prims.bool =
-  fun lid  -> (is_forall lid) || (is_exists lid)
-let is_equality x = is_lid_equality x.FStar_Syntax_Syntax.v
-let lid_is_connective: FStar_Ident.lident -> Prims.bool =
-  let lst =
-    [FStar_Syntax_Const.and_lid;
-    FStar_Syntax_Const.or_lid;
-    FStar_Syntax_Const.not_lid;
-    FStar_Syntax_Const.iff_lid;
-    FStar_Syntax_Const.imp_lid] in
-  fun lid  -> FStar_Util.for_some (FStar_Ident.lid_equals lid) lst
-let is_constructor:
-  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool =
-  fun t  ->
-    fun lid  ->
-      let uu____3438 =
-        let uu____3439 = pre_typ t in uu____3439.FStar_Syntax_Syntax.n in
-      match uu____3438 with
-      | FStar_Syntax_Syntax.Tm_fvar tc ->
-          FStar_Ident.lid_equals
-            (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
-      | uu____3447 -> false
-let rec is_constructed_typ:
-  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool =
-  fun t  ->
-    fun lid  ->
-      let uu____3454 =
-        let uu____3455 = pre_typ t in uu____3455.FStar_Syntax_Syntax.n in
-      match uu____3454 with
-      | FStar_Syntax_Syntax.Tm_fvar uu____3458 -> is_constructor t lid
-      | FStar_Syntax_Syntax.Tm_app (t1,uu____3460) ->
-          is_constructed_typ t1 lid
-      | uu____3475 -> false
-let rec get_tycon:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term Prims.option =
-  fun t  ->
-    let t1 = pre_typ t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar _
-      |FStar_Syntax_Syntax.Tm_name _|FStar_Syntax_Syntax.Tm_fvar _ -> 
-        Some t1
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____3486) -> get_tycon t2
-    | uu____3501 -> None
-let is_interpreted: FStar_Ident.lident -> Prims.bool =
-  fun l  ->
-    let theory_syms =
-      [FStar_Syntax_Const.op_Eq;
-      FStar_Syntax_Const.op_notEq;
-      FStar_Syntax_Const.op_LT;
-      FStar_Syntax_Const.op_LTE;
-      FStar_Syntax_Const.op_GT;
-      FStar_Syntax_Const.op_GTE;
-      FStar_Syntax_Const.op_Subtraction;
-      FStar_Syntax_Const.op_Minus;
-      FStar_Syntax_Const.op_Addition;
-      FStar_Syntax_Const.op_Multiply;
-      FStar_Syntax_Const.op_Division;
-      FStar_Syntax_Const.op_Modulus;
-      FStar_Syntax_Const.op_And;
-      FStar_Syntax_Const.op_Or;
-      FStar_Syntax_Const.op_Negation] in
-    FStar_Util.for_some (FStar_Ident.lid_equals l) theory_syms
-let ktype:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  =
-  (FStar_Syntax_Syntax.mk
-     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)) None
-    FStar_Range.dummyRange
-let ktype0:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  =
-  (FStar_Syntax_Syntax.mk
-     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)) None
-    FStar_Range.dummyRange
-let type_u:
-  Prims.unit ->
-    ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.universe)
-  =
-  fun uu____3531  ->
-    let u =
-      let uu____3535 = FStar_Unionfind.fresh None in
-      FStar_All.pipe_left (fun _0_26  -> FStar_Syntax_Syntax.U_unif _0_26)
-        uu____3535 in
-    let uu____3541 =
-      (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)) None
-        FStar_Range.dummyRange in
-    (uu____3541, u)
-let kt_kt: FStar_Syntax_Syntax.term = FStar_Syntax_Const.kunary ktype0 ktype0
-let kt_kt_kt: FStar_Syntax_Syntax.term =
-  FStar_Syntax_Const.kbin ktype0 ktype0 ktype0
-let fvar_const: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
-  fun l  ->
-    FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant None
-let tand: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.and_lid
-let tor: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.or_lid
-let timp: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.imp_lid
-let tiff: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.iff_lid
-let t_bool: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.bool_lid
-let t_false: FStar_Syntax_Syntax.term =
-  fvar_const FStar_Syntax_Const.false_lid
-let t_true: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.true_lid
-let b2t_v: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.b2t_lid
-let t_not: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.not_lid
-let mk_conj_opt:
-  FStar_Syntax_Syntax.term Prims.option ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax Prims.option
-  =
-  fun phi1  ->
-    fun phi2  ->
-      match phi1 with
-      | None  -> Some phi2
-      | Some phi11 ->
-          let uu____3568 =
-            let uu____3571 =
-              FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
-                phi2.FStar_Syntax_Syntax.pos in
-            let uu____3572 =
-              let uu____3575 =
-                let uu____3576 =
-                  let uu____3586 =
-                    let uu____3588 = FStar_Syntax_Syntax.as_arg phi11 in
-                    let uu____3589 =
-                      let uu____3591 = FStar_Syntax_Syntax.as_arg phi2 in
-                      [uu____3591] in
-                    uu____3588 :: uu____3589 in
-                  (tand, uu____3586) in
-                FStar_Syntax_Syntax.Tm_app uu____3576 in
-              FStar_Syntax_Syntax.mk uu____3575 in
-            uu____3572 None uu____3571 in
-          Some uu____3568
-let mk_binop op_t phi1 phi2 =
-  let uu____3626 =
-    FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
-      phi2.FStar_Syntax_Syntax.pos in
-  let uu____3627 =
-    let uu____3630 =
-      let uu____3631 =
-        let uu____3641 =
-          let uu____3643 = FStar_Syntax_Syntax.as_arg phi1 in
-          let uu____3644 =
-            let uu____3646 = FStar_Syntax_Syntax.as_arg phi2 in [uu____3646] in
-          uu____3643 :: uu____3644 in
-        (op_t, uu____3641) in
-      FStar_Syntax_Syntax.Tm_app uu____3631 in
-    FStar_Syntax_Syntax.mk uu____3630 in
-  uu____3627 None uu____3626
-let mk_neg phi =
-  let uu____3667 =
-    let uu____3670 =
-      let uu____3671 =
-        let uu____3681 =
-          let uu____3683 = FStar_Syntax_Syntax.as_arg phi in [uu____3683] in
-        (t_not, uu____3681) in
-      FStar_Syntax_Syntax.Tm_app uu____3671 in
-    FStar_Syntax_Syntax.mk uu____3670 in
-  uu____3667 None phi.FStar_Syntax_Syntax.pos
-let mk_conj phi1 phi2 = mk_binop tand phi1 phi2
-let mk_conj_l:
-  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term =
-  fun phi  ->
-    match phi with
-    | [] ->
-        FStar_Syntax_Syntax.fvar FStar_Syntax_Const.true_lid
-          FStar_Syntax_Syntax.Delta_constant None
-    | hd1::tl1 -> FStar_List.fold_right mk_conj tl1 hd1
-let mk_disj phi1 phi2 = mk_binop tor phi1 phi2
-let mk_disj_l:
-  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term =
-  fun phi  ->
-    match phi with
-    | [] -> t_false
-    | hd1::tl1 -> FStar_List.fold_right mk_disj tl1 hd1
-let mk_imp:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun phi1  ->
-    fun phi2  ->
-      let uu____3743 =
-        let uu____3744 = FStar_Syntax_Subst.compress phi1 in
-        uu____3744.FStar_Syntax_Syntax.n in
-      match uu____3743 with
-      | FStar_Syntax_Syntax.Tm_fvar tc when
-          FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.false_lid ->
-          t_true
-      | FStar_Syntax_Syntax.Tm_fvar tc when
-          FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid ->
-          phi2
-      | uu____3749 ->
-          let uu____3750 =
-            let uu____3751 = FStar_Syntax_Subst.compress phi2 in
-            uu____3751.FStar_Syntax_Syntax.n in
-          (match uu____3750 with
-           | FStar_Syntax_Syntax.Tm_fvar tc when
-               (FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid)
-                 ||
-                 (FStar_Syntax_Syntax.fv_eq_lid tc
-                    FStar_Syntax_Const.false_lid)
-               -> phi2
-           | uu____3755 -> mk_binop timp phi1 phi2)
-let mk_iff phi1 phi2 = mk_binop tiff phi1 phi2
-let b2t e =
-  let uu____3779 =
-    let uu____3782 =
-      let uu____3783 =
-        let uu____3793 =
-          let uu____3795 = FStar_Syntax_Syntax.as_arg e in [uu____3795] in
-        (b2t_v, uu____3793) in
-      FStar_Syntax_Syntax.Tm_app uu____3783 in
-    FStar_Syntax_Syntax.mk uu____3782 in
-  uu____3779 None e.FStar_Syntax_Syntax.pos
-let teq: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.eq2_lid
-let mk_untyped_eq2 e1 e2 =
-  let uu____3819 =
-    FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
-      e2.FStar_Syntax_Syntax.pos in
-  let uu____3820 =
-    let uu____3823 =
-      let uu____3824 =
-        let uu____3834 =
-          let uu____3836 = FStar_Syntax_Syntax.as_arg e1 in
-          let uu____3837 =
-            let uu____3839 = FStar_Syntax_Syntax.as_arg e2 in [uu____3839] in
-          uu____3836 :: uu____3837 in
-        (teq, uu____3834) in
-      FStar_Syntax_Syntax.Tm_app uu____3824 in
-    FStar_Syntax_Syntax.mk uu____3823 in
-  uu____3820 None uu____3819
-let mk_eq2:
-  FStar_Syntax_Syntax.universe ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term ->
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax
-  =
-  fun u  ->
-    fun t  ->
-      fun e1  ->
-        fun e2  ->
-          let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u] in
-          let uu____3862 =
-            FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
-              e2.FStar_Syntax_Syntax.pos in
-          let uu____3863 =
-            let uu____3866 =
-              let uu____3867 =
-                let uu____3877 =
-                  let uu____3879 = FStar_Syntax_Syntax.iarg t in
-                  let uu____3880 =
-                    let uu____3882 = FStar_Syntax_Syntax.as_arg e1 in
-                    let uu____3883 =
-                      let uu____3885 = FStar_Syntax_Syntax.as_arg e2 in
-                      [uu____3885] in
-                    uu____3882 :: uu____3883 in
-                  uu____3879 :: uu____3880 in
-                (eq_inst, uu____3877) in
-              FStar_Syntax_Syntax.Tm_app uu____3867 in
-            FStar_Syntax_Syntax.mk uu____3866 in
-          uu____3863 None uu____3862
-let mk_has_type t x t' =
-  let t_has_type = fvar_const FStar_Syntax_Const.has_type_lid in
-  let t_has_type1 =
-    FStar_Syntax_Syntax.mk
-      (FStar_Syntax_Syntax.Tm_uinst
-         (t_has_type,
-           [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero])) None
-      FStar_Range.dummyRange in
-  let uu____3923 =
-    let uu____3926 =
-      let uu____3927 =
-        let uu____3937 =
-          let uu____3939 = FStar_Syntax_Syntax.iarg t in
-          let uu____3940 =
-            let uu____3942 = FStar_Syntax_Syntax.as_arg x in
-            let uu____3943 =
-              let uu____3945 = FStar_Syntax_Syntax.as_arg t' in [uu____3945] in
-            uu____3942 :: uu____3943 in
-          uu____3939 :: uu____3940 in
-        (t_has_type1, uu____3937) in
-      FStar_Syntax_Syntax.Tm_app uu____3927 in
-    FStar_Syntax_Syntax.mk uu____3926 in
-  uu____3923 None FStar_Range.dummyRange
-let lex_t: FStar_Syntax_Syntax.term = fvar_const FStar_Syntax_Const.lex_t_lid
-let lex_top: FStar_Syntax_Syntax.term =
-  FStar_Syntax_Syntax.fvar FStar_Syntax_Const.lextop_lid
-    FStar_Syntax_Syntax.Delta_constant (Some FStar_Syntax_Syntax.Data_ctor)
-let lex_pair: FStar_Syntax_Syntax.term =
-  FStar_Syntax_Syntax.fvar FStar_Syntax_Const.lexcons_lid
-    FStar_Syntax_Syntax.Delta_constant (Some FStar_Syntax_Syntax.Data_ctor)
-let tforall: FStar_Syntax_Syntax.term =
-  FStar_Syntax_Syntax.fvar FStar_Syntax_Const.forall_lid
-    (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1")) None
-let t_haseq: FStar_Syntax_Syntax.term =
-  FStar_Syntax_Syntax.fvar FStar_Syntax_Const.haseq_lid
-    FStar_Syntax_Syntax.Delta_constant None
-let lcomp_of_comp:
-  (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.lcomp
-  =
-  fun c0  ->
-    let uu____3964 =
-      match c0.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____3971 ->
-          (FStar_Syntax_Const.effect_Tot_lid, [FStar_Syntax_Syntax.TOTAL])
-      | FStar_Syntax_Syntax.GTotal uu____3978 ->
-          (FStar_Syntax_Const.effect_GTot_lid,
-            [FStar_Syntax_Syntax.SOMETRIVIAL])
-      | FStar_Syntax_Syntax.Comp c ->
-          ((c.FStar_Syntax_Syntax.effect_name),
-            (c.FStar_Syntax_Syntax.flags)) in
-    match uu____3964 with
-    | (eff_name,flags) ->
-        {
-          FStar_Syntax_Syntax.eff_name = eff_name;
-          FStar_Syntax_Syntax.res_typ = (comp_result c0);
-          FStar_Syntax_Syntax.cflags = flags;
-          FStar_Syntax_Syntax.comp = ((fun uu____3991  -> c0))
-        }
-let mk_forall_aux fa x body =
-  let uu____4015 =
-    let uu____4018 =
-      let uu____4019 =
-        let uu____4029 =
-          let uu____4031 =
-            FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort in
-          let uu____4032 =
-            let uu____4034 =
-              let uu____4035 =
-                let uu____4036 =
-                  let uu____4040 = FStar_Syntax_Syntax.mk_binder x in
-                  [uu____4040] in
-                let uu____4041 =
-                  let uu____4048 =
-                    let uu____4054 =
-                      let uu____4055 = FStar_Syntax_Syntax.mk_Total ktype0 in
-                      FStar_All.pipe_left lcomp_of_comp uu____4055 in
-                    FStar_Util.Inl uu____4054 in
-                  Some uu____4048 in
-                abs uu____4036 body uu____4041 in
-              FStar_Syntax_Syntax.as_arg uu____4035 in
-            [uu____4034] in
-          uu____4031 :: uu____4032 in
-        (fa, uu____4029) in
-      FStar_Syntax_Syntax.Tm_app uu____4019 in
-    FStar_Syntax_Syntax.mk uu____4018 in
-  uu____4015 None FStar_Range.dummyRange
-let mk_forall_no_univ:
-  FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.typ ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  = fun x  -> fun body  -> mk_forall_aux tforall x body
-let mk_forall:
-  FStar_Syntax_Syntax.universe ->
-    FStar_Syntax_Syntax.bv ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax
-  =
-  fun u  ->
-    fun x  ->
-      fun body  ->
-        let tforall1 = FStar_Syntax_Syntax.mk_Tm_uinst tforall [u] in
-        mk_forall_aux tforall1 x body
-let close_forall_no_univs:
-  FStar_Syntax_Syntax.binder Prims.list ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-  =
-  fun bs  ->
-    fun f  ->
-      FStar_List.fold_right
-        (fun b  ->
-           fun f1  ->
-             let uu____4105 = FStar_Syntax_Syntax.is_null_binder b in
-             if uu____4105 then f1 else mk_forall_no_univ (Prims.fst b) f1)
-        bs f
-let rec is_wild_pat p =
-  match p.FStar_Syntax_Syntax.v with
-  | FStar_Syntax_Syntax.Pat_wild uu____4118 -> true
-  | uu____4119 -> false
-let if_then_else b t1 t2 =
-  let then_branch =
-    let uu____4162 =
-      FStar_Syntax_Syntax.withinfo
-        (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
-        FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-        t1.FStar_Syntax_Syntax.pos in
-    (uu____4162, None, t1) in
-  let else_branch =
-    let uu____4185 =
-      FStar_Syntax_Syntax.withinfo
-        (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool false))
-        FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-        t2.FStar_Syntax_Syntax.pos in
-    (uu____4185, None, t2) in
-  let uu____4197 =
-    let uu____4198 =
-      FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
-        t2.FStar_Syntax_Syntax.pos in
-    FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____4198 in
-  FStar_Syntax_Syntax.mk
-    (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch])) None
-    uu____4197
-type qpats = FStar_Syntax_Syntax.args Prims.list
+| Equal
+| NotEqual
+| Unknown
+
+
+let uu___is_Equal : eq_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Equal -> begin
+true
+end
+| uu____1243 -> begin
+false
+end))
+
+
+let uu___is_NotEqual : eq_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NotEqual -> begin
+true
+end
+| uu____1247 -> begin
+false
+end))
+
+
+let uu___is_Unknown : eq_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unknown -> begin
+true
+end
+| uu____1251 -> begin
+false
+end))
+
+
+let rec eq_tm : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  eq_result = (fun t1 t2 -> (
+
+let t11 = (unascribe t1)
+in (
+
+let t21 = (unascribe t2)
+in (
+
+let equal_if = (fun uu___170_1271 -> (match (uu___170_1271) with
+| true -> begin
+Equal
+end
+| uu____1272 -> begin
+Unknown
+end))
+in (
+
+let equal_iff = (fun uu___171_1276 -> (match (uu___171_1276) with
+| true -> begin
+Equal
+end
+| uu____1277 -> begin
+NotEqual
+end))
+in (
+
+let eq_and = (fun f g -> (match (f) with
+| Equal -> begin
+(g ())
+end
+| uu____1290 -> begin
+Unknown
+end))
+in (match (((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_name (a), FStar_Syntax_Syntax.Tm_name (b)) -> begin
+(equal_if (FStar_Syntax_Syntax.bv_eq a b))
+end
+| (FStar_Syntax_Syntax.Tm_fvar (f), FStar_Syntax_Syntax.Tm_fvar (g)) -> begin
+(
+
+let uu____1295 = (FStar_Syntax_Syntax.fv_eq f g)
+in (equal_if uu____1295))
+end
+| (FStar_Syntax_Syntax.Tm_uinst (f, us), FStar_Syntax_Syntax.Tm_uinst (g, vs)) -> begin
+(
+
+let uu____1308 = (eq_tm f g)
+in (eq_and uu____1308 (fun uu____1309 -> (
+
+let uu____1310 = (eq_univs_list us vs)
+in (equal_if uu____1310)))))
+end
+| (FStar_Syntax_Syntax.Tm_constant (c), FStar_Syntax_Syntax.Tm_constant (d)) -> begin
+(
+
+let uu____1313 = (FStar_Const.eq_const c d)
+in (equal_iff uu____1313))
+end
+| (FStar_Syntax_Syntax.Tm_uvar (u1, uu____1315), FStar_Syntax_Syntax.Tm_uvar (u2, uu____1317)) -> begin
+(
+
+let uu____1342 = (FStar_Unionfind.equivalent u1 u2)
+in (equal_if uu____1342))
+end
+| (FStar_Syntax_Syntax.Tm_app (h1, args1), FStar_Syntax_Syntax.Tm_app (h2, args2)) -> begin
+(
+
+let uu____1378 = (eq_tm h1 h2)
+in (eq_and uu____1378 (fun uu____1379 -> (eq_args args1 args2))))
+end
+| (FStar_Syntax_Syntax.Tm_type (u), FStar_Syntax_Syntax.Tm_type (v1)) -> begin
+(
+
+let uu____1382 = (eq_univs u v1)
+in (equal_if uu____1382))
+end
+| (FStar_Syntax_Syntax.Tm_meta (t12, uu____1384), uu____1385) -> begin
+(eq_tm t12 t21)
+end
+| (uu____1390, FStar_Syntax_Syntax.Tm_meta (t22, uu____1392)) -> begin
+(eq_tm t11 t22)
+end
+| uu____1397 -> begin
+Unknown
+end)))))))
+and eq_args : FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.args  ->  eq_result = (fun a1 a2 -> (match (((a1), (a2))) with
+| ([], []) -> begin
+Equal
+end
+| (((a, uu____1421))::a11, ((b, uu____1424))::b1) -> begin
+(
+
+let uu____1462 = (eq_tm a b)
+in (match (uu____1462) with
+| Equal -> begin
+(eq_args a11 b1)
+end
+| uu____1463 -> begin
+Unknown
+end))
+end
+| uu____1464 -> begin
+Unknown
+end))
+and eq_univs_list : FStar_Syntax_Syntax.universes  ->  FStar_Syntax_Syntax.universes  ->  Prims.bool = (fun us vs -> (((FStar_List.length us) = (FStar_List.length vs)) && (FStar_List.forall2 eq_univs us vs)))
+
+
+let rec unrefine : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_refine (x, uu____1478) -> begin
+(unrefine x.FStar_Syntax_Syntax.sort)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t2, uu____1484, uu____1485) -> begin
+(unrefine t2)
+end
+| uu____1514 -> begin
+t1
+end)))
+
+
+let rec is_unit : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____1518 = (
+
+let uu____1519 = (unrefine t)
+in uu____1519.FStar_Syntax_Syntax.n)
+in (match (uu____1518) with
+| FStar_Syntax_Syntax.Tm_type (uu____1522) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, uu____1525) -> begin
+(is_unit t1)
+end
+| uu____1530 -> begin
+false
+end)))
+
+
+let rec non_informative : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____1534 = (
+
+let uu____1535 = (unrefine t)
+in uu____1535.FStar_Syntax_Syntax.n)
+in (match (uu____1534) with
+| FStar_Syntax_Syntax.Tm_type (uu____1538) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid)) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.erased_lid))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, uu____1541) -> begin
+(non_informative head1)
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, uu____1557) -> begin
+(non_informative t1)
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____1562, c) -> begin
+((is_tot_or_gtot_comp c) && (non_informative (comp_result c)))
+end
+| uu____1574 -> begin
+false
+end)))
+
+
+let is_fun : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun e -> (
+
+let uu____1578 = (
+
+let uu____1579 = (FStar_Syntax_Subst.compress e)
+in uu____1579.FStar_Syntax_Syntax.n)
+in (match (uu____1578) with
+| FStar_Syntax_Syntax.Tm_abs (uu____1582) -> begin
+true
+end
+| uu____1597 -> begin
+false
+end)))
+
+
+let is_function_typ : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____1601 = (
+
+let uu____1602 = (FStar_Syntax_Subst.compress t)
+in uu____1602.FStar_Syntax_Syntax.n)
+in (match (uu____1601) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____1605) -> begin
+true
+end
+| uu____1613 -> begin
+false
+end)))
+
+
+let rec pre_typ : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_refine (x, uu____1619) -> begin
+(pre_typ x.FStar_Syntax_Syntax.sort)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t2, uu____1625, uu____1626) -> begin
+(pre_typ t2)
+end
+| uu____1655 -> begin
+t1
+end)))
+
+
+let destruct : FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list Prims.option = (fun typ lid -> (
+
+let typ1 = (FStar_Syntax_Subst.compress typ)
+in (
+
+let uu____1669 = (
+
+let uu____1670 = (un_uinst typ1)
+in uu____1670.FStar_Syntax_Syntax.n)
+in (match (uu____1669) with
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let head2 = (un_uinst head1)
+in (match (head2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (tc) when (FStar_Syntax_Syntax.fv_eq_lid tc lid) -> begin
+Some (args)
+end
+| uu____1708 -> begin
+None
+end))
+end
+| FStar_Syntax_Syntax.Tm_fvar (tc) when (FStar_Syntax_Syntax.fv_eq_lid tc lid) -> begin
+Some ([])
+end
+| uu____1724 -> begin
+None
+end))))
+
+
+let lids_of_sigelt : FStar_Syntax_Syntax.sigelt  ->  FStar_Ident.lident Prims.list = (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| (FStar_Syntax_Syntax.Sig_let (_, lids, _, _)) | (FStar_Syntax_Syntax.Sig_bundle (_, _, lids)) -> begin
+lids
+end
+| (FStar_Syntax_Syntax.Sig_inductive_typ (lid, _, _, _, _, _, _)) | (FStar_Syntax_Syntax.Sig_effect_abbrev (lid, _, _, _, _, _)) | (FStar_Syntax_Syntax.Sig_datacon (lid, _, _, _, _, _, _)) | (FStar_Syntax_Syntax.Sig_declare_typ (lid, _, _, _)) | (FStar_Syntax_Syntax.Sig_assume (lid, _, _)) -> begin
+(lid)::[]
+end
+| (FStar_Syntax_Syntax.Sig_new_effect_for_free (n1)) | (FStar_Syntax_Syntax.Sig_new_effect (n1)) -> begin
+(n1.FStar_Syntax_Syntax.mname)::[]
+end
+| (FStar_Syntax_Syntax.Sig_sub_effect (_)) | (FStar_Syntax_Syntax.Sig_pragma (_)) | (FStar_Syntax_Syntax.Sig_main (_)) -> begin
+[]
+end))
+
+
+let lid_of_sigelt : FStar_Syntax_Syntax.sigelt  ->  FStar_Ident.lident Prims.option = (fun se -> (match ((lids_of_sigelt se)) with
+| (l)::[] -> begin
+Some (l)
+end
+| uu____1792 -> begin
+None
+end))
+
+
+let quals_of_sigelt : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.qualifier Prims.list = (fun x -> (match (x.FStar_Syntax_Syntax.sigel) with
+| (FStar_Syntax_Syntax.Sig_bundle (_, quals, _)) | (FStar_Syntax_Syntax.Sig_inductive_typ (_, _, _, _, _, _, quals)) | (FStar_Syntax_Syntax.Sig_effect_abbrev (_, _, _, _, quals, _)) | (FStar_Syntax_Syntax.Sig_datacon (_, _, _, _, _, quals, _)) | (FStar_Syntax_Syntax.Sig_declare_typ (_, _, _, quals)) | (FStar_Syntax_Syntax.Sig_assume (_, _, quals)) | (FStar_Syntax_Syntax.Sig_let (_, _, quals, _)) | (FStar_Syntax_Syntax.Sig_new_effect ({FStar_Syntax_Syntax.qualifiers = quals; FStar_Syntax_Syntax.cattributes = _; FStar_Syntax_Syntax.mname = _; FStar_Syntax_Syntax.univs = _; FStar_Syntax_Syntax.binders = _; FStar_Syntax_Syntax.signature = _; FStar_Syntax_Syntax.ret_wp = _; FStar_Syntax_Syntax.bind_wp = _; FStar_Syntax_Syntax.if_then_else = _; FStar_Syntax_Syntax.ite_wp = _; FStar_Syntax_Syntax.stronger = _; FStar_Syntax_Syntax.close_wp = _; FStar_Syntax_Syntax.assert_p = _; FStar_Syntax_Syntax.assume_p = _; FStar_Syntax_Syntax.null_wp = _; FStar_Syntax_Syntax.trivial = _; FStar_Syntax_Syntax.repr = _; FStar_Syntax_Syntax.return_repr = _; FStar_Syntax_Syntax.bind_repr = _; FStar_Syntax_Syntax.actions = _})) | (FStar_Syntax_Syntax.Sig_new_effect_for_free ({FStar_Syntax_Syntax.qualifiers = quals; FStar_Syntax_Syntax.cattributes = _; FStar_Syntax_Syntax.mname = _; FStar_Syntax_Syntax.univs = _; FStar_Syntax_Syntax.binders = _; FStar_Syntax_Syntax.signature = _; FStar_Syntax_Syntax.ret_wp = _; FStar_Syntax_Syntax.bind_wp = _; FStar_Syntax_Syntax.if_then_else = _; FStar_Syntax_Syntax.ite_wp = _; FStar_Syntax_Syntax.stronger = _; FStar_Syntax_Syntax.close_wp = _; FStar_Syntax_Syntax.assert_p = _; FStar_Syntax_Syntax.assume_p = _; FStar_Syntax_Syntax.null_wp = _; FStar_Syntax_Syntax.trivial = _; FStar_Syntax_Syntax.repr = _; FStar_Syntax_Syntax.return_repr = _; FStar_Syntax_Syntax.bind_repr = _; FStar_Syntax_Syntax.actions = _})) -> begin
+quals
+end
+| (FStar_Syntax_Syntax.Sig_sub_effect (_)) | (FStar_Syntax_Syntax.Sig_pragma (_)) | (FStar_Syntax_Syntax.Sig_main (_)) -> begin
+[]
+end))
+
+
+let range_of_sigelt : FStar_Syntax_Syntax.sigelt  ->  FStar_Range.range = (fun x -> x.FStar_Syntax_Syntax.sigrng)
+
+
+let docs_of_sigelt : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.fsdoc Prims.option = (fun x -> x.FStar_Syntax_Syntax.sigdoc)
+
+
+let range_of_lb = (fun uu___172_1912 -> (match (uu___172_1912) with
+| (FStar_Util.Inl (x), uu____1919, uu____1920) -> begin
+(FStar_Syntax_Syntax.range_of_bv x)
+end
+| (FStar_Util.Inr (l), uu____1924, uu____1925) -> begin
+(FStar_Ident.range_of_lid l)
+end))
+
+
+let range_of_arg = (fun uu____1942 -> (match (uu____1942) with
+| (hd1, uu____1948) -> begin
+hd1.FStar_Syntax_Syntax.pos
+end))
+
+
+let range_of_args = (fun args r -> (FStar_All.pipe_right args (FStar_List.fold_left (fun r1 a -> (FStar_Range.union_ranges r1 (range_of_arg a))) r)))
+
+
+let mk_app = (fun f args -> (
+
+let r = (range_of_args args f.FStar_Syntax_Syntax.pos)
+in (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((f), (args)))) None r)))
+
+
+let mk_data = (fun l args -> (match (args) with
+| [] -> begin
+(
+
+let uu____2062 = (
+
+let uu____2065 = (
+
+let uu____2066 = (
+
+let uu____2071 = (FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in ((uu____2071), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app))))
+in FStar_Syntax_Syntax.Tm_meta (uu____2066))
+in (FStar_Syntax_Syntax.mk uu____2065))
+in (uu____2062 None (FStar_Ident.range_of_lid l)))
+end
+| uu____2080 -> begin
+(
+
+let e = (
+
+let uu____2089 = (FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in (mk_app uu____2089 args))
+in (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app))))) None e.FStar_Syntax_Syntax.pos))
+end))
+
+
+let mangle_field_name : FStar_Ident.ident  ->  FStar_Ident.ident = (fun x -> (FStar_Ident.mk_ident (((Prims.strcat "^fname^" x.FStar_Ident.idText)), (x.FStar_Ident.idRange))))
+
+
+let unmangle_field_name : FStar_Ident.ident  ->  FStar_Ident.ident = (fun x -> (match ((FStar_Util.starts_with x.FStar_Ident.idText "^fname^")) with
+| true -> begin
+(
+
+let uu____2104 = (
+
+let uu____2107 = (FStar_Util.substring_from x.FStar_Ident.idText (Prims.parse_int "7"))
+in ((uu____2107), (x.FStar_Ident.idRange)))
+in (FStar_Ident.mk_ident uu____2104))
+end
+| uu____2108 -> begin
+x
+end))
+
+
+let field_projector_prefix : Prims.string = "__proj__"
+
+
+let field_projector_sep : Prims.string = "__item__"
+
+
+let field_projector_contains_constructor : Prims.string  ->  Prims.bool = (fun s -> (FStar_Util.starts_with s field_projector_prefix))
+
+
+let mk_field_projector_name_from_string : Prims.string  ->  Prims.string  ->  Prims.string = (fun constr field -> (Prims.strcat field_projector_prefix (Prims.strcat constr (Prims.strcat field_projector_sep field))))
+
+
+let mk_field_projector_name_from_ident : FStar_Ident.lident  ->  FStar_Ident.ident  ->  FStar_Ident.lident = (fun lid i -> (
+
+let j = (unmangle_field_name i)
+in (
+
+let jtext = j.FStar_Ident.idText
+in (
+
+let newi = (match ((field_projector_contains_constructor jtext)) with
+| true -> begin
+j
+end
+| uu____2127 -> begin
+(FStar_Ident.mk_ident (((mk_field_projector_name_from_string lid.FStar_Ident.ident.FStar_Ident.idText jtext)), (i.FStar_Ident.idRange)))
+end)
+in (FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns ((newi)::[])))))))
+
+
+let mk_field_projector_name : FStar_Ident.lident  ->  FStar_Syntax_Syntax.bv  ->  Prims.int  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.bv) = (fun lid x i -> (
+
+let nm = (
+
+let uu____2140 = (FStar_Syntax_Syntax.is_null_bv x)
+in (match (uu____2140) with
+| true -> begin
+(
+
+let uu____2141 = (
+
+let uu____2144 = (
+
+let uu____2145 = (FStar_Util.string_of_int i)
+in (Prims.strcat "_" uu____2145))
+in (
+
+let uu____2146 = (FStar_Syntax_Syntax.range_of_bv x)
+in ((uu____2144), (uu____2146))))
+in (FStar_Ident.mk_ident uu____2141))
+end
+| uu____2147 -> begin
+x.FStar_Syntax_Syntax.ppname
+end))
+in (
+
+let y = (
+
+let uu___176_2149 = x
+in {FStar_Syntax_Syntax.ppname = nm; FStar_Syntax_Syntax.index = uu___176_2149.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu___176_2149.FStar_Syntax_Syntax.sort})
+in (
+
+let uu____2150 = (mk_field_projector_name_from_ident lid nm)
+in ((uu____2150), (y))))))
+
+
+let set_uvar = (fun uv t -> (
+
+let uu____2167 = (FStar_Unionfind.find uv)
+in (match (uu____2167) with
+| FStar_Syntax_Syntax.Fixed (uu____2170) -> begin
+(
+
+let uu____2171 = (
+
+let uu____2172 = (
+
+let uu____2173 = (FStar_Unionfind.uvar_id uv)
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____2173))
+in (FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____2172))
+in (failwith uu____2171))
+end
+| uu____2175 -> begin
+(FStar_Unionfind.change uv (FStar_Syntax_Syntax.Fixed (t)))
+end)))
+
+
+let qualifier_equal : FStar_Syntax_Syntax.qualifier  ->  FStar_Syntax_Syntax.qualifier  ->  Prims.bool = (fun q1 q2 -> (match (((q1), (q2))) with
+| (FStar_Syntax_Syntax.Discriminator (l1), FStar_Syntax_Syntax.Discriminator (l2)) -> begin
+(FStar_Ident.lid_equals l1 l2)
+end
+| (FStar_Syntax_Syntax.Projector (l1a, l1b), FStar_Syntax_Syntax.Projector (l2a, l2b)) -> begin
+((FStar_Ident.lid_equals l1a l2a) && (l1b.FStar_Ident.idText = l2b.FStar_Ident.idText))
+end
+| ((FStar_Syntax_Syntax.RecordType (ns1, f1), FStar_Syntax_Syntax.RecordType (ns2, f2))) | ((FStar_Syntax_Syntax.RecordConstructor (ns1, f1), FStar_Syntax_Syntax.RecordConstructor (ns2, f2))) -> begin
+(((((FStar_List.length ns1) = (FStar_List.length ns2)) && (FStar_List.forall2 (fun x1 x2 -> (x1.FStar_Ident.idText = x2.FStar_Ident.idText)) f1 f2)) && ((FStar_List.length f1) = (FStar_List.length f2))) && (FStar_List.forall2 (fun x1 x2 -> (x1.FStar_Ident.idText = x2.FStar_Ident.idText)) f1 f2))
+end
+| uu____2222 -> begin
+(q1 = q2)
+end))
+
+
+let abs : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option  ->  FStar_Syntax_Syntax.term = (fun bs t lopt -> (match (((FStar_List.length bs) = (Prims.parse_int "0"))) with
+| true -> begin
+t
+end
+| uu____2256 -> begin
+(
+
+let close_lopt = (fun lopt1 -> (match (lopt1) with
+| (None) | (Some (FStar_Util.Inr (_))) -> begin
+lopt1
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let uu____2308 = (
+
+let uu____2314 = (FStar_Syntax_Subst.close_lcomp bs lc)
+in FStar_Util.Inl (uu____2314))
+in Some (uu____2308))
+end))
+in (match (bs) with
+| [] -> begin
+t
+end
+| uu____2325 -> begin
+(
+
+let body = (
+
+let uu____2330 = (FStar_Syntax_Subst.close bs t)
+in (FStar_Syntax_Subst.compress uu____2330))
+in (match (((body.FStar_Syntax_Syntax.n), (lopt))) with
+| (FStar_Syntax_Syntax.Tm_abs (bs', t1, lopt'), None) -> begin
+(
+
+let uu____2373 = (
+
+let uu____2376 = (
+
+let uu____2377 = (
+
+let uu____2392 = (
+
+let uu____2396 = (FStar_Syntax_Subst.close_binders bs)
+in (FStar_List.append uu____2396 bs'))
+in (
+
+let uu____2402 = (close_lopt lopt')
+in ((uu____2392), (t1), (uu____2402))))
+in FStar_Syntax_Syntax.Tm_abs (uu____2377))
+in (FStar_Syntax_Syntax.mk uu____2376))
+in (uu____2373 None t1.FStar_Syntax_Syntax.pos))
+end
+| uu____2428 -> begin
+(
+
+let uu____2437 = (
+
+let uu____2440 = (
+
+let uu____2441 = (
+
+let uu____2456 = (FStar_Syntax_Subst.close_binders bs)
+in (
+
+let uu____2457 = (close_lopt lopt)
+in ((uu____2456), (body), (uu____2457))))
+in FStar_Syntax_Syntax.Tm_abs (uu____2441))
+in (FStar_Syntax_Syntax.mk uu____2440))
+in (uu____2437 None t.FStar_Syntax_Syntax.pos))
+end))
+end))
+end))
+
+
+let arrow : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun bs c -> (match (bs) with
+| [] -> begin
+(comp_result c)
+end
+| uu____2500 -> begin
+(
+
+let uu____2504 = (
+
+let uu____2507 = (
+
+let uu____2508 = (
+
+let uu____2516 = (FStar_Syntax_Subst.close_binders bs)
+in (
+
+let uu____2517 = (FStar_Syntax_Subst.close_comp bs c)
+in ((uu____2516), (uu____2517))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____2508))
+in (FStar_Syntax_Syntax.mk uu____2507))
+in (uu____2504 None c.FStar_Syntax_Syntax.pos))
+end))
+
+
+let flat_arrow : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun bs c -> (
+
+let t = (arrow bs c)
+in (
+
+let uu____2547 = (
+
+let uu____2548 = (FStar_Syntax_Subst.compress t)
+in uu____2548.FStar_Syntax_Syntax.n)
+in (match (uu____2547) with
+| FStar_Syntax_Syntax.Tm_arrow (bs1, c1) -> begin
+(match (c1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (tres, uu____2568) -> begin
+(
+
+let uu____2575 = (
+
+let uu____2576 = (FStar_Syntax_Subst.compress tres)
+in uu____2576.FStar_Syntax_Syntax.n)
+in (match (uu____2575) with
+| FStar_Syntax_Syntax.Tm_arrow (bs', c') -> begin
+(
+
+let uu____2593 = (FStar_ST.read t.FStar_Syntax_Syntax.tk)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow ((((FStar_List.append bs1 bs')), (c'))))) uu____2593 t.FStar_Syntax_Syntax.pos))
+end
+| uu____2613 -> begin
+t
+end))
+end
+| uu____2614 -> begin
+t
+end)
+end
+| uu____2615 -> begin
+t
+end))))
+
+
+let refine : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun b t -> (
+
+let uu____2624 = (FStar_ST.read b.FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.tk)
+in (
+
+let uu____2629 = (
+
+let uu____2630 = (FStar_Syntax_Syntax.range_of_bv b)
+in (FStar_Range.union_ranges uu____2630 t.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____2631 = (
+
+let uu____2634 = (
+
+let uu____2635 = (
+
+let uu____2640 = (
+
+let uu____2641 = (
+
+let uu____2642 = (FStar_Syntax_Syntax.mk_binder b)
+in (uu____2642)::[])
+in (FStar_Syntax_Subst.close uu____2641 t))
+in ((b), (uu____2640)))
+in FStar_Syntax_Syntax.Tm_refine (uu____2635))
+in (FStar_Syntax_Syntax.mk uu____2634))
+in (uu____2631 uu____2624 uu____2629)))))
+
+
+let branch : FStar_Syntax_Syntax.branch  ->  FStar_Syntax_Syntax.branch = (fun b -> (FStar_Syntax_Subst.close_branch b))
+
+
+let rec arrow_formals_comp : FStar_Syntax_Syntax.term  ->  ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list * FStar_Syntax_Syntax.comp) = (fun k -> (
+
+let k1 = (FStar_Syntax_Subst.compress k)
+in (match (k1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____2680 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____2680) with
+| (bs1, c1) -> begin
+(
+
+let uu____2690 = (is_tot_or_gtot_comp c1)
+in (match (uu____2690) with
+| true -> begin
+(
+
+let uu____2696 = (arrow_formals_comp (comp_result c1))
+in (match (uu____2696) with
+| (bs', k2) -> begin
+(((FStar_List.append bs1 bs')), (k2))
+end))
+end
+| uu____2720 -> begin
+((bs1), (c1))
+end))
+end))
+end
+| uu____2721 -> begin
+(
+
+let uu____2722 = (FStar_Syntax_Syntax.mk_Total k1)
+in (([]), (uu____2722)))
+end)))
+
+
+let rec arrow_formals : FStar_Syntax_Syntax.term  ->  ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) = (fun k -> (
+
+let uu____2738 = (arrow_formals_comp k)
+in (match (uu____2738) with
+| (bs, c) -> begin
+((bs), ((comp_result c)))
+end)))
+
+
+let abs_formals : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option) = (fun t -> (
+
+let subst_lcomp_opt = (fun s l -> (match (l) with
+| Some (FStar_Util.Inl (l1)) -> begin
+(
+
+let l2 = (
+
+let uu___177_2819 = l1
+in (
+
+let uu____2820 = (FStar_Syntax_Subst.subst s l1.FStar_Syntax_Syntax.res_typ)
+in {FStar_Syntax_Syntax.eff_name = uu___177_2819.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu____2820; FStar_Syntax_Syntax.cflags = uu___177_2819.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____2823 -> (
+
+let uu____2824 = (l1.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Subst.subst_comp s uu____2824)))}))
+in Some (FStar_Util.Inl (l2)))
+end
+| uu____2833 -> begin
+l
+end))
+in (
+
+let rec aux = (fun t1 abs_body_lcomp -> (
+
+let uu____2871 = (
+
+let uu____2872 = (
+
+let uu____2875 = (FStar_Syntax_Subst.compress t1)
+in (FStar_All.pipe_left unascribe uu____2875))
+in uu____2872.FStar_Syntax_Syntax.n)
+in (match (uu____2871) with
+| FStar_Syntax_Syntax.Tm_abs (bs, t2, what) -> begin
+(
+
+let uu____2913 = (aux t2 what)
+in (match (uu____2913) with
+| (bs', t3, what1) -> begin
+(((FStar_List.append bs bs')), (t3), (what1))
+end))
+end
+| uu____2970 -> begin
+(([]), (t1), (abs_body_lcomp))
+end)))
+in (
+
+let uu____2982 = (aux t None)
+in (match (uu____2982) with
+| (bs, t1, abs_body_lcomp) -> begin
+(
+
+let uu____3030 = (FStar_Syntax_Subst.open_term' bs t1)
+in (match (uu____3030) with
+| (bs1, t2, opening) -> begin
+(
+
+let abs_body_lcomp1 = (subst_lcomp_opt opening abs_body_lcomp)
+in ((bs1), (t2), (abs_body_lcomp1)))
+end))
+end)))))
+
+
+let mk_letbinding : (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either  ->  FStar_Syntax_Syntax.univ_name Prims.list  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.letbinding = (fun lbname univ_vars typ eff def -> {FStar_Syntax_Syntax.lbname = lbname; FStar_Syntax_Syntax.lbunivs = univ_vars; FStar_Syntax_Syntax.lbtyp = typ; FStar_Syntax_Syntax.lbeff = eff; FStar_Syntax_Syntax.lbdef = def})
+
+
+let close_univs_and_mk_letbinding : FStar_Syntax_Syntax.fv Prims.list Prims.option  ->  (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either  ->  FStar_Ident.ident Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.letbinding = (fun recs lbname univ_vars typ eff def -> (
+
+let def1 = (match (((recs), (univ_vars))) with
+| ((None, _)) | ((_, [])) -> begin
+def
+end
+| (Some (fvs), uu____3130) -> begin
+(
+
+let universes = (FStar_All.pipe_right univ_vars (FStar_List.map (fun _0_25 -> FStar_Syntax_Syntax.U_name (_0_25))))
+in (
+
+let inst1 = (FStar_All.pipe_right fvs (FStar_List.map (fun fv -> ((fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v), (universes)))))
+in (FStar_Syntax_InstFV.instantiate inst1 def)))
+end)
+in (
+
+let typ1 = (FStar_Syntax_Subst.close_univ_vars univ_vars typ)
+in (
+
+let def2 = (FStar_Syntax_Subst.close_univ_vars univ_vars def1)
+in (mk_letbinding lbname univ_vars typ1 eff def2)))))
+
+
+let open_univ_vars_binders_and_comp : FStar_Syntax_Syntax.univ_names  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.univ_names * (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list * FStar_Syntax_Syntax.comp) = (fun uvs binders c -> (match (binders) with
+| [] -> begin
+(
+
+let uu____3191 = (FStar_Syntax_Subst.open_univ_vars_comp uvs c)
+in (match (uu____3191) with
+| (uvs1, c1) -> begin
+((uvs1), ([]), (c1))
+end))
+end
+| uu____3207 -> begin
+(
+
+let t' = (arrow binders c)
+in (
+
+let uu____3214 = (FStar_Syntax_Subst.open_univ_vars uvs t')
+in (match (uu____3214) with
+| (uvs1, t'1) -> begin
+(
+
+let uu____3225 = (
+
+let uu____3226 = (FStar_Syntax_Subst.compress t'1)
+in uu____3226.FStar_Syntax_Syntax.n)
+in (match (uu____3225) with
+| FStar_Syntax_Syntax.Tm_arrow (binders1, c1) -> begin
+((uvs1), (binders1), (c1))
+end
+| uu____3252 -> begin
+(failwith "Impossible")
+end))
+end)))
+end))
+
+
+let is_tuple_constructor : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_Util.starts_with fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str "Prims.tuple")
+end
+| uu____3267 -> begin
+false
+end))
+
+
+let mk_tuple_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____3275 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "tuple%s" uu____3275))
+in (
+
+let uu____3276 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____3276 r))))
+
+
+let mk_tuple_data_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____3284 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "Mktuple%s" uu____3284))
+in (
+
+let uu____3285 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____3285 r))))
+
+
+let is_tuple_data_lid : FStar_Ident.lident  ->  Prims.int  ->  Prims.bool = (fun f n1 -> (
+
+let uu____3292 = (mk_tuple_data_lid n1 FStar_Range.dummyRange)
+in (FStar_Ident.lid_equals f uu____3292)))
+
+
+let is_tuple_data_lid' : FStar_Ident.lident  ->  Prims.bool = (fun f -> ((f.FStar_Ident.nsstr = "Prims") && (FStar_Util.starts_with f.FStar_Ident.ident.FStar_Ident.idText "Mktuple")))
+
+
+let is_tuple_constructor_lid : FStar_Ident.lident  ->  Prims.bool = (fun lid -> (FStar_Util.starts_with (FStar_Ident.text_of_lid lid) "Prims.tuple"))
+
+
+let is_dtuple_constructor_lid : FStar_Ident.lident  ->  Prims.bool = (fun lid -> ((lid.FStar_Ident.nsstr = "Prims") && (FStar_Util.starts_with lid.FStar_Ident.ident.FStar_Ident.idText "Prims.dtuple")))
+
+
+let is_dtuple_constructor : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(is_dtuple_constructor_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end
+| uu____3310 -> begin
+false
+end))
+
+
+let mk_dtuple_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____3318 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "dtuple%s" uu____3318))
+in (
+
+let uu____3319 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____3319 r))))
+
+
+let mk_dtuple_data_lid : Prims.int  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 r -> (
+
+let t = (
+
+let uu____3327 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format1 "Mkdtuple%s" uu____3327))
+in (
+
+let uu____3328 = (FStar_Syntax_Const.pconst t)
+in (FStar_Ident.set_lid_range uu____3328 r))))
+
+
+let is_dtuple_data_lid' : FStar_Ident.lident  ->  Prims.bool = (fun f -> (FStar_Util.starts_with (FStar_Ident.text_of_lid f) "Mkdtuple"))
+
+
+let is_lid_equality : FStar_Ident.lident  ->  Prims.bool = (fun x -> (FStar_Ident.lid_equals x FStar_Syntax_Const.eq2_lid))
+
+
+let is_forall : FStar_Ident.lident  ->  Prims.bool = (fun lid -> (FStar_Ident.lid_equals lid FStar_Syntax_Const.forall_lid))
+
+
+let is_exists : FStar_Ident.lident  ->  Prims.bool = (fun lid -> (FStar_Ident.lid_equals lid FStar_Syntax_Const.exists_lid))
+
+
+let is_qlid : FStar_Ident.lident  ->  Prims.bool = (fun lid -> ((is_forall lid) || (is_exists lid)))
+
+
+let is_equality = (fun x -> (is_lid_equality x.FStar_Syntax_Syntax.v))
+
+
+let lid_is_connective : FStar_Ident.lident  ->  Prims.bool = (
+
+let lst = (FStar_Syntax_Const.and_lid)::(FStar_Syntax_Const.or_lid)::(FStar_Syntax_Const.not_lid)::(FStar_Syntax_Const.iff_lid)::(FStar_Syntax_Const.imp_lid)::[]
+in (fun lid -> (FStar_Util.for_some (FStar_Ident.lid_equals lid) lst)))
+
+
+let is_constructor : FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  Prims.bool = (fun t lid -> (
+
+let uu____3366 = (
+
+let uu____3367 = (pre_typ t)
+in uu____3367.FStar_Syntax_Syntax.n)
+in (match (uu____3366) with
+| FStar_Syntax_Syntax.Tm_fvar (tc) -> begin
+(FStar_Ident.lid_equals tc.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v lid)
+end
+| uu____3375 -> begin
+false
+end)))
+
+
+let rec is_constructed_typ : FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  Prims.bool = (fun t lid -> (
+
+let uu____3382 = (
+
+let uu____3383 = (pre_typ t)
+in uu____3383.FStar_Syntax_Syntax.n)
+in (match (uu____3382) with
+| FStar_Syntax_Syntax.Tm_fvar (uu____3386) -> begin
+(is_constructor t lid)
+end
+| FStar_Syntax_Syntax.Tm_app (t1, uu____3388) -> begin
+(is_constructed_typ t1 lid)
+end
+| uu____3403 -> begin
+false
+end)))
+
+
+let rec get_tycon : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term Prims.option = (fun t -> (
+
+let t1 = (pre_typ t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+Some (t1)
+end
+| FStar_Syntax_Syntax.Tm_app (t2, uu____3414) -> begin
+(get_tycon t2)
+end
+| uu____3429 -> begin
+None
+end)))
+
+
+let is_interpreted : FStar_Ident.lident  ->  Prims.bool = (fun l -> (
+
+let theory_syms = (FStar_Syntax_Const.op_Eq)::(FStar_Syntax_Const.op_notEq)::(FStar_Syntax_Const.op_LT)::(FStar_Syntax_Const.op_LTE)::(FStar_Syntax_Const.op_GT)::(FStar_Syntax_Const.op_GTE)::(FStar_Syntax_Const.op_Subtraction)::(FStar_Syntax_Const.op_Minus)::(FStar_Syntax_Const.op_Addition)::(FStar_Syntax_Const.op_Multiply)::(FStar_Syntax_Const.op_Division)::(FStar_Syntax_Const.op_Modulus)::(FStar_Syntax_Const.op_And)::(FStar_Syntax_Const.op_Or)::(FStar_Syntax_Const.op_Negation)::[]
+in (FStar_Util.for_some (FStar_Ident.lid_equals l) theory_syms)))
+
+
+let ktype : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_unknown))) None FStar_Range.dummyRange)
+
+
+let ktype0 : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_zero))) None FStar_Range.dummyRange)
+
+
+let type_u : Prims.unit  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.universe) = (fun uu____3459 -> (
+
+let u = (
+
+let uu____3463 = (FStar_Unionfind.fresh None)
+in (FStar_All.pipe_left (fun _0_26 -> FStar_Syntax_Syntax.U_unif (_0_26)) uu____3463))
+in (
+
+let uu____3469 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (u))) None FStar_Range.dummyRange)
+in ((uu____3469), (u)))))
+
+
+let kt_kt : FStar_Syntax_Syntax.term = (FStar_Syntax_Const.kunary ktype0 ktype0)
+
+
+let kt_kt_kt : FStar_Syntax_Syntax.term = (FStar_Syntax_Const.kbin ktype0 ktype0 ktype0)
+
+
+let fvar_const : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term = (fun l -> (FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant None))
+
+
+let tand : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.and_lid)
+
+
+let tor : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.or_lid)
+
+
+let timp : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.imp_lid)
+
+
+let tiff : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.iff_lid)
+
+
+let t_bool : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.bool_lid)
+
+
+let t_false : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.false_lid)
+
+
+let t_true : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.true_lid)
+
+
+let b2t_v : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.b2t_lid)
+
+
+let t_not : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.not_lid)
+
+
+let mk_conj_opt : FStar_Syntax_Syntax.term Prims.option  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term Prims.option = (fun phi1 phi2 -> (match (phi1) with
+| None -> begin
+Some (phi2)
+end
+| Some (phi11) -> begin
+(
+
+let uu____3496 = (
+
+let uu____3499 = (FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos phi2.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3500 = (
+
+let uu____3503 = (
+
+let uu____3504 = (
+
+let uu____3514 = (
+
+let uu____3516 = (FStar_Syntax_Syntax.as_arg phi11)
+in (
+
+let uu____3517 = (
+
+let uu____3519 = (FStar_Syntax_Syntax.as_arg phi2)
+in (uu____3519)::[])
+in (uu____3516)::uu____3517))
+in ((tand), (uu____3514)))
+in FStar_Syntax_Syntax.Tm_app (uu____3504))
+in (FStar_Syntax_Syntax.mk uu____3503))
+in (uu____3500 None uu____3499)))
+in Some (uu____3496))
+end))
+
+
+let mk_binop = (fun op_t phi1 phi2 -> (
+
+let uu____3554 = (FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos phi2.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3555 = (
+
+let uu____3558 = (
+
+let uu____3559 = (
+
+let uu____3569 = (
+
+let uu____3571 = (FStar_Syntax_Syntax.as_arg phi1)
+in (
+
+let uu____3572 = (
+
+let uu____3574 = (FStar_Syntax_Syntax.as_arg phi2)
+in (uu____3574)::[])
+in (uu____3571)::uu____3572))
+in ((op_t), (uu____3569)))
+in FStar_Syntax_Syntax.Tm_app (uu____3559))
+in (FStar_Syntax_Syntax.mk uu____3558))
+in (uu____3555 None uu____3554))))
+
+
+let mk_neg = (fun phi -> (
+
+let uu____3595 = (
+
+let uu____3598 = (
+
+let uu____3599 = (
+
+let uu____3609 = (
+
+let uu____3611 = (FStar_Syntax_Syntax.as_arg phi)
+in (uu____3611)::[])
+in ((t_not), (uu____3609)))
+in FStar_Syntax_Syntax.Tm_app (uu____3599))
+in (FStar_Syntax_Syntax.mk uu____3598))
+in (uu____3595 None phi.FStar_Syntax_Syntax.pos)))
+
+
+let mk_conj = (fun phi1 phi2 -> (mk_binop tand phi1 phi2))
+
+
+let mk_conj_l : FStar_Syntax_Syntax.term Prims.list  ->  FStar_Syntax_Syntax.term = (fun phi -> (match (phi) with
+| [] -> begin
+(FStar_Syntax_Syntax.fvar FStar_Syntax_Const.true_lid FStar_Syntax_Syntax.Delta_constant None)
+end
+| (hd1)::tl1 -> begin
+(FStar_List.fold_right mk_conj tl1 hd1)
+end))
+
+
+let mk_disj = (fun phi1 phi2 -> (mk_binop tor phi1 phi2))
+
+
+let mk_disj_l : FStar_Syntax_Syntax.term Prims.list  ->  FStar_Syntax_Syntax.term = (fun phi -> (match (phi) with
+| [] -> begin
+t_false
+end
+| (hd1)::tl1 -> begin
+(FStar_List.fold_right mk_disj tl1 hd1)
+end))
+
+
+let mk_imp : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun phi1 phi2 -> (
+
+let uu____3671 = (
+
+let uu____3672 = (FStar_Syntax_Subst.compress phi1)
+in uu____3672.FStar_Syntax_Syntax.n)
+in (match (uu____3671) with
+| FStar_Syntax_Syntax.Tm_fvar (tc) when (FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.false_lid) -> begin
+t_true
+end
+| FStar_Syntax_Syntax.Tm_fvar (tc) when (FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid) -> begin
+phi2
+end
+| uu____3677 -> begin
+(
+
+let uu____3678 = (
+
+let uu____3679 = (FStar_Syntax_Subst.compress phi2)
+in uu____3679.FStar_Syntax_Syntax.n)
+in (match (uu____3678) with
+| FStar_Syntax_Syntax.Tm_fvar (tc) when ((FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid) || (FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.false_lid)) -> begin
+phi2
+end
+| uu____3683 -> begin
+(mk_binop timp phi1 phi2)
+end))
+end)))
+
+
+let mk_iff = (fun phi1 phi2 -> (mk_binop tiff phi1 phi2))
+
+
+let b2t = (fun e -> (
+
+let uu____3707 = (
+
+let uu____3710 = (
+
+let uu____3711 = (
+
+let uu____3721 = (
+
+let uu____3723 = (FStar_Syntax_Syntax.as_arg e)
+in (uu____3723)::[])
+in ((b2t_v), (uu____3721)))
+in FStar_Syntax_Syntax.Tm_app (uu____3711))
+in (FStar_Syntax_Syntax.mk uu____3710))
+in (uu____3707 None e.FStar_Syntax_Syntax.pos)))
+
+
+let teq : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.eq2_lid)
+
+
+let mk_untyped_eq2 = (fun e1 e2 -> (
+
+let uu____3747 = (FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos e2.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3748 = (
+
+let uu____3751 = (
+
+let uu____3752 = (
+
+let uu____3762 = (
+
+let uu____3764 = (FStar_Syntax_Syntax.as_arg e1)
+in (
+
+let uu____3765 = (
+
+let uu____3767 = (FStar_Syntax_Syntax.as_arg e2)
+in (uu____3767)::[])
+in (uu____3764)::uu____3765))
+in ((teq), (uu____3762)))
+in FStar_Syntax_Syntax.Tm_app (uu____3752))
+in (FStar_Syntax_Syntax.mk uu____3751))
+in (uu____3748 None uu____3747))))
+
+
+let mk_eq2 : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun u t e1 e2 -> (
+
+let eq_inst = (FStar_Syntax_Syntax.mk_Tm_uinst teq ((u)::[]))
+in (
+
+let uu____3790 = (FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos e2.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3791 = (
+
+let uu____3794 = (
+
+let uu____3795 = (
+
+let uu____3805 = (
+
+let uu____3807 = (FStar_Syntax_Syntax.iarg t)
+in (
+
+let uu____3808 = (
+
+let uu____3810 = (FStar_Syntax_Syntax.as_arg e1)
+in (
+
+let uu____3811 = (
+
+let uu____3813 = (FStar_Syntax_Syntax.as_arg e2)
+in (uu____3813)::[])
+in (uu____3810)::uu____3811))
+in (uu____3807)::uu____3808))
+in ((eq_inst), (uu____3805)))
+in FStar_Syntax_Syntax.Tm_app (uu____3795))
+in (FStar_Syntax_Syntax.mk uu____3794))
+in (uu____3791 None uu____3790)))))
+
+
+let mk_has_type = (fun t x t' -> (
+
+let t_has_type = (fvar_const FStar_Syntax_Const.has_type_lid)
+in (
+
+let t_has_type1 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uinst (((t_has_type), ((FStar_Syntax_Syntax.U_zero)::(FStar_Syntax_Syntax.U_zero)::[])))) None FStar_Range.dummyRange)
+in (
+
+let uu____3851 = (
+
+let uu____3854 = (
+
+let uu____3855 = (
+
+let uu____3865 = (
+
+let uu____3867 = (FStar_Syntax_Syntax.iarg t)
+in (
+
+let uu____3868 = (
+
+let uu____3870 = (FStar_Syntax_Syntax.as_arg x)
+in (
+
+let uu____3871 = (
+
+let uu____3873 = (FStar_Syntax_Syntax.as_arg t')
+in (uu____3873)::[])
+in (uu____3870)::uu____3871))
+in (uu____3867)::uu____3868))
+in ((t_has_type1), (uu____3865)))
+in FStar_Syntax_Syntax.Tm_app (uu____3855))
+in (FStar_Syntax_Syntax.mk uu____3854))
+in (uu____3851 None FStar_Range.dummyRange)))))
+
+
+let lex_t : FStar_Syntax_Syntax.term = (fvar_const FStar_Syntax_Const.lex_t_lid)
+
+
+let lex_top : FStar_Syntax_Syntax.term = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.lextop_lid FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+
+
+let lex_pair : FStar_Syntax_Syntax.term = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.lexcons_lid FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+
+
+let tforall : FStar_Syntax_Syntax.term = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.forall_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+
+
+let t_haseq : FStar_Syntax_Syntax.term = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.haseq_lid FStar_Syntax_Syntax.Delta_constant None)
+
+
+let lcomp_of_comp : (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.lcomp = (fun c0 -> (
+
+let uu____3892 = (match (c0.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (uu____3899) -> begin
+((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[]))
+end
+| FStar_Syntax_Syntax.GTotal (uu____3906) -> begin
+((FStar_Syntax_Const.effect_GTot_lid), ((FStar_Syntax_Syntax.SOMETRIVIAL)::[]))
+end
+| FStar_Syntax_Syntax.Comp (c) -> begin
+((c.FStar_Syntax_Syntax.effect_name), (c.FStar_Syntax_Syntax.flags))
+end)
+in (match (uu____3892) with
+| (eff_name, flags) -> begin
+{FStar_Syntax_Syntax.eff_name = eff_name; FStar_Syntax_Syntax.res_typ = (comp_result c0); FStar_Syntax_Syntax.cflags = flags; FStar_Syntax_Syntax.comp = (fun uu____3919 -> c0)}
+end)))
+
+
+let mk_forall_aux = (fun fa x body -> (
+
+let uu____3943 = (
+
+let uu____3946 = (
+
+let uu____3947 = (
+
+let uu____3957 = (
+
+let uu____3959 = (FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____3960 = (
+
+let uu____3962 = (
+
+let uu____3963 = (
+
+let uu____3964 = (
+
+let uu____3968 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____3968)::[])
+in (
+
+let uu____3969 = (
+
+let uu____3976 = (
+
+let uu____3982 = (
+
+let uu____3983 = (FStar_Syntax_Syntax.mk_Total ktype0)
+in (FStar_All.pipe_left lcomp_of_comp uu____3983))
+in FStar_Util.Inl (uu____3982))
+in Some (uu____3976))
+in (abs uu____3964 body uu____3969)))
+in (FStar_Syntax_Syntax.as_arg uu____3963))
+in (uu____3962)::[])
+in (uu____3959)::uu____3960))
+in ((fa), (uu____3957)))
+in FStar_Syntax_Syntax.Tm_app (uu____3947))
+in (FStar_Syntax_Syntax.mk uu____3946))
+in (uu____3943 None FStar_Range.dummyRange)))
+
+
+let mk_forall_no_univ : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun x body -> (mk_forall_aux tforall x body))
+
+
+let mk_forall : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun u x body -> (
+
+let tforall1 = (FStar_Syntax_Syntax.mk_Tm_uinst tforall ((u)::[]))
+in (mk_forall_aux tforall1 x body)))
+
+
+let close_forall_no_univs : FStar_Syntax_Syntax.binder Prims.list  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun bs f -> (FStar_List.fold_right (fun b f1 -> (
+
+let uu____4033 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____4033) with
+| true -> begin
+f1
+end
+| uu____4034 -> begin
+(mk_forall_no_univ (Prims.fst b) f1)
+end))) bs f))
+
+
+let rec is_wild_pat = (fun p -> (match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_wild (uu____4046) -> begin
+true
+end
+| uu____4047 -> begin
+false
+end))
+
+
+let if_then_else = (fun b t1 t2 -> (
+
+let then_branch = (
+
+let uu____4090 = (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n t1.FStar_Syntax_Syntax.pos)
+in ((uu____4090), (None), (t1)))
+in (
+
+let else_branch = (
+
+let uu____4113 = (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (false))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n t2.FStar_Syntax_Syntax.pos)
+in ((uu____4113), (None), (t2)))
+in (
+
+let uu____4125 = (
+
+let uu____4126 = (FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos t2.FStar_Syntax_Syntax.pos)
+in (FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____4126))
+in (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (((b), ((then_branch)::(else_branch)::[])))) None uu____4125)))))
+
+
+type qpats =
+FStar_Syntax_Syntax.args Prims.list
+
 type connective =
-  | QAll of (FStar_Syntax_Syntax.binders* qpats* FStar_Syntax_Syntax.typ)
-  | QEx of (FStar_Syntax_Syntax.binders* qpats* FStar_Syntax_Syntax.typ)
-  | BaseConn of (FStar_Ident.lident* FStar_Syntax_Syntax.args)
-let uu___is_QAll: connective -> Prims.bool =
-  fun projectee  ->
-    match projectee with | QAll _0 -> true | uu____4271 -> false
-let __proj__QAll__item___0:
-  connective -> (FStar_Syntax_Syntax.binders* qpats* FStar_Syntax_Syntax.typ)
-  = fun projectee  -> match projectee with | QAll _0 -> _0
-let uu___is_QEx: connective -> Prims.bool =
-  fun projectee  ->
-    match projectee with | QEx _0 -> true | uu____4295 -> false
-let __proj__QEx__item___0:
-  connective -> (FStar_Syntax_Syntax.binders* qpats* FStar_Syntax_Syntax.typ)
-  = fun projectee  -> match projectee with | QEx _0 -> _0
-let uu___is_BaseConn: connective -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BaseConn _0 -> true | uu____4318 -> false
-let __proj__BaseConn__item___0:
-  connective -> (FStar_Ident.lident* FStar_Syntax_Syntax.args) =
-  fun projectee  -> match projectee with | BaseConn _0 -> _0
-let destruct_typ_as_formula:
-  FStar_Syntax_Syntax.term -> connective Prims.option =
-  fun f  ->
-    let rec unmeta_monadic f1 =
-      let f2 = FStar_Syntax_Subst.compress f1 in
-      match f2.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta (t,FStar_Syntax_Syntax.Meta_monadic _)
-        |FStar_Syntax_Syntax.Tm_meta
-        (t,FStar_Syntax_Syntax.Meta_monadic_lift _) -> unmeta_monadic t
-      | uu____4353 -> f2 in
-    let destruct_base_conn f1 =
-      let connectives =
-        [(FStar_Syntax_Const.true_lid, (Prims.parse_int "0"));
-        (FStar_Syntax_Const.false_lid, (Prims.parse_int "0"));
-        (FStar_Syntax_Const.and_lid, (Prims.parse_int "2"));
-        (FStar_Syntax_Const.or_lid, (Prims.parse_int "2"));
-        (FStar_Syntax_Const.imp_lid, (Prims.parse_int "2"));
-        (FStar_Syntax_Const.iff_lid, (Prims.parse_int "2"));
-        (FStar_Syntax_Const.ite_lid, (Prims.parse_int "3"));
-        (FStar_Syntax_Const.not_lid, (Prims.parse_int "1"));
-        (FStar_Syntax_Const.eq2_lid, (Prims.parse_int "3"));
-        (FStar_Syntax_Const.eq2_lid, (Prims.parse_int "2"));
-        (FStar_Syntax_Const.eq3_lid, (Prims.parse_int "4"));
-        (FStar_Syntax_Const.eq3_lid, (Prims.parse_int "2"))] in
-      let rec aux f2 uu____4398 =
-        match uu____4398 with
-        | (lid,arity) ->
-            let uu____4404 =
-              let uu____4414 = unmeta_monadic f2 in head_and_args uu____4414 in
-            (match uu____4404 with
-             | (t,args) ->
-                 let t1 = un_uinst t in
-                 let uu____4433 =
-                   (is_constructor t1 lid) &&
-                     ((FStar_List.length args) = arity) in
-                 if uu____4433 then Some (BaseConn (lid, args)) else None) in
-      FStar_Util.find_map connectives (aux f1) in
-    let patterns t =
-      let t1 = FStar_Syntax_Subst.compress t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_pattern pats) ->
-          let uu____4484 = FStar_Syntax_Subst.compress t2 in
-          (pats, uu____4484)
-      | uu____4491 ->
-          let uu____4492 = FStar_Syntax_Subst.compress t1 in ([], uu____4492) in
-    let destruct_q_conn t =
-      let is_q fa fv =
-        if fa
-        then is_forall (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-        else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let flat t1 =
-        let uu____4534 = head_and_args t1 in
-        match uu____4534 with
-        | (t2,args) ->
-            let uu____4565 = un_uinst t2 in
-            let uu____4566 =
-              FStar_All.pipe_right args
-                (FStar_List.map
-                   (fun uu____4582  ->
-                      match uu____4582 with
-                      | (t3,imp) ->
-                          let uu____4589 = unascribe t3 in (uu____4589, imp))) in
-            (uu____4565, uu____4566) in
-      let rec aux qopt out t1 =
-        let uu____4612 = let uu____4621 = flat t1 in (qopt, uu____4621) in
-        match uu____4612 with
-        | (Some
-           fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                 FStar_Syntax_Syntax.vars = _;_},({
-                                                    FStar_Syntax_Syntax.n =
-                                                      FStar_Syntax_Syntax.Tm_abs
-                                                      (b::[],t2,_);
-                                                    FStar_Syntax_Syntax.tk =
-                                                      _;
-                                                    FStar_Syntax_Syntax.pos =
-                                                      _;
-                                                    FStar_Syntax_Syntax.vars
-                                                      = _;_},_)::[]))
-          |(Some
-            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                  FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                  FStar_Syntax_Syntax.vars = _;_},_::({
-                                                        FStar_Syntax_Syntax.n
-                                                          =
-                                                          FStar_Syntax_Syntax.Tm_abs
-                                                          (b::[],t2,_);
-                                                        FStar_Syntax_Syntax.tk
-                                                          = _;
-                                                        FStar_Syntax_Syntax.pos
-                                                          = _;
-                                                        FStar_Syntax_Syntax.vars
-                                                          = _;_},_)::[]))
-            when is_q fa tc -> aux qopt (b :: out) t2
-        | (None
-           ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-               FStar_Syntax_Syntax.vars = _;_},({
-                                                  FStar_Syntax_Syntax.n =
-                                                    FStar_Syntax_Syntax.Tm_abs
-                                                    (b::[],t2,_);
-                                                  FStar_Syntax_Syntax.tk = _;
-                                                  FStar_Syntax_Syntax.pos = _;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    _;_},_)::[]))
-          |(None
-            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                FStar_Syntax_Syntax.vars = _;_},_::({
-                                                      FStar_Syntax_Syntax.n =
-                                                        FStar_Syntax_Syntax.Tm_abs
-                                                        (b::[],t2,_);
-                                                      FStar_Syntax_Syntax.tk
-                                                        = _;
-                                                      FStar_Syntax_Syntax.pos
-                                                        = _;
-                                                      FStar_Syntax_Syntax.vars
-                                                        = _;_},_)::[]))
-            when
-            is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            aux
-              (Some
-                 (is_forall
-                    (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))
-              (b :: out) t2
-        | (Some b,uu____4880) ->
-            let bs = FStar_List.rev out in
-            let uu____4898 = FStar_Syntax_Subst.open_term bs t1 in
-            (match uu____4898 with
-             | (bs1,t2) ->
-                 let uu____4904 = patterns t2 in
-                 (match uu____4904 with
-                  | (pats,body) ->
-                      if b
-                      then Some (QAll (bs1, pats, body))
-                      else Some (QEx (bs1, pats, body))))
-        | uu____4942 -> None in
-      aux None [] t in
-    let phi = unmeta_monadic f in
-    let uu____4954 = destruct_base_conn phi in
-    match uu____4954 with | Some b -> Some b | None  -> destruct_q_conn phi
-let action_as_lb:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.action -> FStar_Syntax_Syntax.sigelt
-  =
-  fun eff_lid  ->
-    fun a  ->
-      let lb =
-        let uu____4965 =
-          let uu____4968 =
-            FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
-              FStar_Syntax_Syntax.Delta_equational None in
-          FStar_Util.Inr uu____4968 in
-        close_univs_and_mk_letbinding None uu____4965
-          a.FStar_Syntax_Syntax.action_univs a.FStar_Syntax_Syntax.action_typ
-          FStar_Syntax_Const.effect_Tot_lid a.FStar_Syntax_Syntax.action_defn in
-      FStar_Syntax_Syntax.Sig_let
-        ((false, [lb]),
-          ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos),
-          [a.FStar_Syntax_Syntax.action_name],
-          [FStar_Syntax_Syntax.Visible_default;
-          FStar_Syntax_Syntax.Action eff_lid], [])
-let mk_reify t =
-  let reify_ =
-    FStar_Syntax_Syntax.mk
-      (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify) None
-      t.FStar_Syntax_Syntax.pos in
-  let uu____4997 =
-    let uu____5000 =
-      let uu____5001 =
-        let uu____5011 =
-          let uu____5013 = FStar_Syntax_Syntax.as_arg t in [uu____5013] in
-        (reify_, uu____5011) in
-      FStar_Syntax_Syntax.Tm_app uu____5001 in
-    FStar_Syntax_Syntax.mk uu____5000 in
-  uu____4997 None t.FStar_Syntax_Syntax.pos
-let rec delta_qualifier:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth =
-  fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____5029 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
-    | FStar_Syntax_Syntax.Tm_bvar _
-      |FStar_Syntax_Syntax.Tm_name _
-       |FStar_Syntax_Syntax.Tm_match _
-        |FStar_Syntax_Syntax.Tm_uvar _|FStar_Syntax_Syntax.Tm_unknown  ->
-        FStar_Syntax_Syntax.Delta_equational
-    | FStar_Syntax_Syntax.Tm_type _
-      |FStar_Syntax_Syntax.Tm_constant _|FStar_Syntax_Syntax.Tm_arrow _ ->
-        FStar_Syntax_Syntax.Delta_constant
-    | FStar_Syntax_Syntax.Tm_uinst (t2,_)
-      |FStar_Syntax_Syntax.Tm_refine
-       ({ FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-          FStar_Syntax_Syntax.sort = t2;_},_)
-       |FStar_Syntax_Syntax.Tm_meta (t2,_)
-        |FStar_Syntax_Syntax.Tm_ascribed (t2,_,_)
-         |FStar_Syntax_Syntax.Tm_app (t2,_)
-          |FStar_Syntax_Syntax.Tm_abs (_,t2,_)|FStar_Syntax_Syntax.Tm_let
-           (_,t2)
-        -> delta_qualifier t2
-let incr_delta_qualifier:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth =
-  fun t  ->
-    let d = delta_qualifier t in
-    let rec aux d1 =
-      match d1 with
-      | FStar_Syntax_Syntax.Delta_equational  -> d1
-      | FStar_Syntax_Syntax.Delta_constant  ->
-          FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1")
-      | FStar_Syntax_Syntax.Delta_defined_at_level i ->
-          FStar_Syntax_Syntax.Delta_defined_at_level
-            (i + (Prims.parse_int "1"))
-      | FStar_Syntax_Syntax.Delta_abstract d2 -> aux d2 in
-    aux d
-let is_unknown: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____5140 =
-      let uu____5141 = FStar_Syntax_Subst.compress t in
-      uu____5141.FStar_Syntax_Syntax.n in
-    match uu____5140 with
-    | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____5144 -> false
-let rec list_elements:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term Prims.list Prims.option
-  =
-  fun e  ->
-    let uu____5152 = let uu____5162 = unmeta e in head_and_args uu____5162 in
-    match uu____5152 with
-    | (head1,args) ->
-        let uu____5181 =
-          let uu____5189 =
-            let uu____5190 = un_uinst head1 in
-            uu____5190.FStar_Syntax_Syntax.n in
-          (uu____5189, args) in
-        (match uu____5181 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____5201) when
-             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.nil_lid ->
-             Some []
-         | (FStar_Syntax_Syntax.Tm_fvar
-            fv,uu____5214::(hd1,uu____5216)::(tl1,uu____5218)::[]) when
-             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.cons_lid ->
-             let uu____5252 =
-               let uu____5256 =
-                 let uu____5260 = list_elements tl1 in
-                 FStar_Util.must uu____5260 in
-               hd1 :: uu____5256 in
-             Some uu____5252
-         | uu____5269 -> None)
+| QAll of (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ)
+| QEx of (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ)
+| BaseConn of (FStar_Ident.lident * FStar_Syntax_Syntax.args)
+
+
+let uu___is_QAll : connective  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| QAll (_0) -> begin
+true
+end
+| uu____4199 -> begin
+false
+end))
+
+
+let __proj__QAll__item___0 : connective  ->  (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ) = (fun projectee -> (match (projectee) with
+| QAll (_0) -> begin
+_0
+end))
+
+
+let uu___is_QEx : connective  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| QEx (_0) -> begin
+true
+end
+| uu____4223 -> begin
+false
+end))
+
+
+let __proj__QEx__item___0 : connective  ->  (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ) = (fun projectee -> (match (projectee) with
+| QEx (_0) -> begin
+_0
+end))
+
+
+let uu___is_BaseConn : connective  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| BaseConn (_0) -> begin
+true
+end
+| uu____4246 -> begin
+false
+end))
+
+
+let __proj__BaseConn__item___0 : connective  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.args) = (fun projectee -> (match (projectee) with
+| BaseConn (_0) -> begin
+_0
+end))
+
+
+let destruct_typ_as_formula : FStar_Syntax_Syntax.term  ->  connective Prims.option = (fun f -> (
+
+let rec unmeta_monadic = (fun f1 -> (
+
+let f2 = (FStar_Syntax_Subst.compress f1)
+in (match (f2.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_monadic (_))) | (FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_monadic_lift (_))) -> begin
+(unmeta_monadic t)
+end
+| uu____4281 -> begin
+f2
+end)))
+in (
+
+let destruct_base_conn = (fun f1 -> (
+
+let connectives = (((FStar_Syntax_Const.true_lid), ((Prims.parse_int "0"))))::(((FStar_Syntax_Const.false_lid), ((Prims.parse_int "0"))))::(((FStar_Syntax_Const.and_lid), ((Prims.parse_int "2"))))::(((FStar_Syntax_Const.or_lid), ((Prims.parse_int "2"))))::(((FStar_Syntax_Const.imp_lid), ((Prims.parse_int "2"))))::(((FStar_Syntax_Const.iff_lid), ((Prims.parse_int "2"))))::(((FStar_Syntax_Const.ite_lid), ((Prims.parse_int "3"))))::(((FStar_Syntax_Const.not_lid), ((Prims.parse_int "1"))))::(((FStar_Syntax_Const.eq2_lid), ((Prims.parse_int "3"))))::(((FStar_Syntax_Const.eq2_lid), ((Prims.parse_int "2"))))::(((FStar_Syntax_Const.eq3_lid), ((Prims.parse_int "4"))))::(((FStar_Syntax_Const.eq3_lid), ((Prims.parse_int "2"))))::[]
+in (
+
+let rec aux = (fun f2 uu____4326 -> (match (uu____4326) with
+| (lid, arity) -> begin
+(
+
+let uu____4332 = (
+
+let uu____4342 = (unmeta_monadic f2)
+in (head_and_args uu____4342))
+in (match (uu____4332) with
+| (t, args) -> begin
+(
+
+let t1 = (un_uinst t)
+in (
+
+let uu____4361 = ((is_constructor t1 lid) && ((FStar_List.length args) = arity))
+in (match (uu____4361) with
+| true -> begin
+Some (BaseConn (((lid), (args))))
+end
+| uu____4376 -> begin
+None
+end)))
+end))
+end))
+in (FStar_Util.find_map connectives (aux f1)))))
+in (
+
+let patterns = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_meta (t2, FStar_Syntax_Syntax.Meta_pattern (pats)) -> begin
+(
+
+let uu____4412 = (FStar_Syntax_Subst.compress t2)
+in ((pats), (uu____4412)))
+end
+| uu____4419 -> begin
+(
+
+let uu____4420 = (FStar_Syntax_Subst.compress t1)
+in (([]), (uu____4420)))
+end)))
+in (
+
+let destruct_q_conn = (fun t -> (
+
+let is_q = (fun fa fv -> (match (fa) with
+| true -> begin
+(is_forall fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end
+| uu____4448 -> begin
+(is_exists fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end))
+in (
+
+let flat = (fun t1 -> (
+
+let uu____4462 = (head_and_args t1)
+in (match (uu____4462) with
+| (t2, args) -> begin
+(
+
+let uu____4493 = (un_uinst t2)
+in (
+
+let uu____4494 = (FStar_All.pipe_right args (FStar_List.map (fun uu____4510 -> (match (uu____4510) with
+| (t3, imp) -> begin
+(
+
+let uu____4517 = (unascribe t3)
+in ((uu____4517), (imp)))
+end))))
+in ((uu____4493), (uu____4494))))
+end)))
+in (
+
+let rec aux = (fun qopt out t1 -> (
+
+let uu____4540 = (
+
+let uu____4549 = (flat t1)
+in ((qopt), (uu____4549)))
+in (match (uu____4540) with
+| ((Some (fa), ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (tc); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs ((b)::[], t2, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))::[]))) | ((Some (fa), ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (tc); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (_)::(({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs ((b)::[], t2, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))::[]))) when (is_q fa tc) -> begin
+(aux qopt ((b)::out) t2)
+end
+| ((None, ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (tc); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs ((b)::[], t2, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))::[]))) | ((None, ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (tc); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (_)::(({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs ((b)::[], t2, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))::[]))) when (is_qlid tc.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v) -> begin
+(aux (Some ((is_forall tc.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v))) ((b)::out) t2)
+end
+| (Some (b), uu____4808) -> begin
+(
+
+let bs = (FStar_List.rev out)
+in (
+
+let uu____4826 = (FStar_Syntax_Subst.open_term bs t1)
+in (match (uu____4826) with
+| (bs1, t2) -> begin
+(
+
+let uu____4832 = (patterns t2)
+in (match (uu____4832) with
+| (pats, body) -> begin
+(match (b) with
+| true -> begin
+Some (QAll (((bs1), (pats), (body))))
+end
+| uu____4863 -> begin
+Some (QEx (((bs1), (pats), (body))))
+end)
+end))
+end)))
+end
+| uu____4870 -> begin
+None
+end)))
+in (aux None [] t)))))
+in (
+
+let phi = (unmeta_monadic f)
+in (
+
+let uu____4882 = (destruct_base_conn phi)
+in (match (uu____4882) with
+| Some (b) -> begin
+Some (b)
+end
+| None -> begin
+(destruct_q_conn phi)
+end))))))))
+
+
+let action_as_lb : FStar_Ident.lident  ->  FStar_Syntax_Syntax.action  ->  FStar_Syntax_Syntax.sigelt = (fun eff_lid a -> (
+
+let lb = (
+
+let uu____4893 = (
+
+let uu____4896 = (FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name FStar_Syntax_Syntax.Delta_equational None)
+in FStar_Util.Inr (uu____4896))
+in (close_univs_and_mk_letbinding None uu____4893 a.FStar_Syntax_Syntax.action_univs a.FStar_Syntax_Syntax.action_typ FStar_Syntax_Const.effect_Tot_lid a.FStar_Syntax_Syntax.action_defn))
+in (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_let (((((false), ((lb)::[]))), ((a.FStar_Syntax_Syntax.action_name)::[]), ((FStar_Syntax_Syntax.Visible_default)::(FStar_Syntax_Syntax.Action (eff_lid))::[]), ([])))))))
+
+
+let mk_reify = (fun t -> (
+
+let reify_ = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify)) None t.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____4925 = (
+
+let uu____4928 = (
+
+let uu____4929 = (
+
+let uu____4939 = (
+
+let uu____4941 = (FStar_Syntax_Syntax.as_arg t)
+in (uu____4941)::[])
+in ((reify_), (uu____4939)))
+in FStar_Syntax_Syntax.Tm_app (uu____4929))
+in (FStar_Syntax_Syntax.mk uu____4928))
+in (uu____4925 None t.FStar_Syntax_Syntax.pos))))
+
+
+let rec delta_qualifier : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.delta_depth = (fun t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____4957) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+fv.FStar_Syntax_Syntax.fv_delta
+end
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_match (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+FStar_Syntax_Syntax.Delta_equational
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) -> begin
+FStar_Syntax_Syntax.Delta_constant
+end
+| (FStar_Syntax_Syntax.Tm_uinst (t2, _)) | (FStar_Syntax_Syntax.Tm_refine ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t2}, _)) | (FStar_Syntax_Syntax.Tm_meta (t2, _)) | (FStar_Syntax_Syntax.Tm_ascribed (t2, _, _)) | (FStar_Syntax_Syntax.Tm_app (t2, _)) | (FStar_Syntax_Syntax.Tm_abs (_, t2, _)) | (FStar_Syntax_Syntax.Tm_let (_, t2)) -> begin
+(delta_qualifier t2)
+end)))
+
+
+let incr_delta_qualifier : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.delta_depth = (fun t -> (
+
+let d = (delta_qualifier t)
+in (
+
+let rec aux = (fun d1 -> (match (d1) with
+| FStar_Syntax_Syntax.Delta_equational -> begin
+d1
+end
+| FStar_Syntax_Syntax.Delta_constant -> begin
+FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))
+end
+| FStar_Syntax_Syntax.Delta_defined_at_level (i) -> begin
+FStar_Syntax_Syntax.Delta_defined_at_level ((i + (Prims.parse_int "1")))
+end
+| FStar_Syntax_Syntax.Delta_abstract (d2) -> begin
+(aux d2)
+end))
+in (aux d))))
+
+
+let is_unknown : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____5068 = (
+
+let uu____5069 = (FStar_Syntax_Subst.compress t)
+in uu____5069.FStar_Syntax_Syntax.n)
+in (match (uu____5068) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+true
+end
+| uu____5072 -> begin
+false
+end)))
+
+
+let rec list_elements : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term Prims.list Prims.option = (fun e -> (
+
+let uu____5080 = (
+
+let uu____5090 = (unmeta e)
+in (head_and_args uu____5090))
+in (match (uu____5080) with
+| (head1, args) -> begin
+(
+
+let uu____5109 = (
+
+let uu____5117 = (
+
+let uu____5118 = (un_uinst head1)
+in uu____5118.FStar_Syntax_Syntax.n)
+in ((uu____5117), (args)))
+in (match (uu____5109) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), uu____5129) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.nil_lid) -> begin
+Some ([])
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____5142)::((hd1, uu____5144))::((tl1, uu____5146))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.cons_lid) -> begin
+(
+
+let uu____5180 = (
+
+let uu____5184 = (
+
+let uu____5188 = (list_elements tl1)
+in (FStar_Util.must uu____5188))
+in (hd1)::uu____5184)
+in Some (uu____5180))
+end
+| uu____5197 -> begin
+None
+end))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -1,1027 +1,1251 @@
+
 open Prims
-type name = FStar_Syntax_Syntax.bv
+
+type name =
+FStar_Syntax_Syntax.bv
+
 type goal =
-  {
-  context: FStar_TypeChecker_Env.env;
-  witness: FStar_Syntax_Syntax.term Prims.option;
-  goal_ty: FStar_Syntax_Syntax.term;}
+{context : FStar_TypeChecker_Env.env; witness : FStar_Syntax_Syntax.term Prims.option; goal_ty : FStar_Syntax_Syntax.term}
+
 type proofstate =
-  {
-  main_context: FStar_TypeChecker_Env.env;
-  main_goal: goal;
-  all_implicits: FStar_TypeChecker_Env.implicits;
-  goals: goal Prims.list;
-  smt_goals: goal Prims.list;
-  transaction: FStar_Unionfind.tx;}
+{main_context : FStar_TypeChecker_Env.env; main_goal : goal; all_implicits : FStar_TypeChecker_Env.implicits; goals : goal Prims.list; smt_goals : goal Prims.list; transaction : FStar_Unionfind.tx}
+
 type 'a result =
-  | Success of ('a* proofstate)
-  | Failed of (Prims.string* proofstate)
-let uu___is_Success projectee =
-  match projectee with | Success _0 -> true | uu____100 -> false
-let __proj__Success__item___0 projectee =
-  match projectee with | Success _0 -> _0
-let uu___is_Failed projectee =
-  match projectee with | Failed _0 -> true | uu____131 -> false
-let __proj__Failed__item___0 projectee =
-  match projectee with | Failed _0 -> _0
-exception Failure of Prims.string
-let uu___is_Failure: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Failure uu____155 -> true | uu____156 -> false
-let __proj__Failure__item__uu___: Prims.exn -> Prims.string =
-  fun projectee  -> match projectee with | Failure uu____163 -> uu____163
+| Success of ('a * proofstate)
+| Failed of (Prims.string * proofstate)
+
+
+let uu___is_Success = (fun projectee -> (match (projectee) with
+| Success (_0) -> begin
+true
+end
+| uu____100 -> begin
+false
+end))
+
+
+let __proj__Success__item___0 = (fun projectee -> (match (projectee) with
+| Success (_0) -> begin
+_0
+end))
+
+
+let uu___is_Failed = (fun projectee -> (match (projectee) with
+| Failed (_0) -> begin
+true
+end
+| uu____131 -> begin
+false
+end))
+
+
+let __proj__Failed__item___0 = (fun projectee -> (match (projectee) with
+| Failed (_0) -> begin
+_0
+end))
+
+exception Failure of (Prims.string)
+
+
+let uu___is_Failure : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Failure (uu____155) -> begin
+true
+end
+| uu____156 -> begin
+false
+end))
+
+
+let __proj__Failure__item__uu___ : Prims.exn  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Failure (uu____163) -> begin
+uu____163
+end))
+
 type 'a tac =
-  {
-  tac_f: proofstate -> 'a result;
-  tac_name: Prims.string;
-  kernel: Prims.bool;}
-let as_tac name b f = { tac_f = f; tac_name = name; kernel = b }
-let kernel_tac n1 t = { tac_f = t; tac_name = n1; kernel = true }
-let user_tac n1 t = { tac_f = t; tac_name = n1; kernel = false }
-let name_tac n1 t =
-  let uu___73_300 = t in
-  { tac_f = (uu___73_300.tac_f); tac_name = n1; kernel = false }
-let run t p = t.tac_f p
-let debug: proofstate -> Prims.string -> Prims.unit =
-  fun p  ->
-    fun msg  ->
-      let uu____323 = FStar_Util.string_of_int (FStar_List.length p.goals) in
-      let uu____327 =
-        match p.goals with
-        | [] -> "[]"
-        | uu____328 ->
-            let uu____330 =
-              let uu____331 = FStar_List.hd p.goals in uu____331.goal_ty in
-            FStar_Syntax_Print.term_to_string uu____330 in
-      let uu____332 =
-        match p.goals with
-        | [] -> ""
-        | uu____333 ->
-            let uu____335 =
-              let uu____337 = FStar_List.tl p.goals in
-              FStar_All.pipe_right uu____337
-                (FStar_List.map
-                   (fun x  -> FStar_Syntax_Print.term_to_string x.goal_ty)) in
-            FStar_All.pipe_right uu____335 (FStar_String.concat ";;") in
-      FStar_Util.print4
-        "TAC (ngoals=%s, maingoal=%s, rest=%s):\n\tTAC>> %s\n" uu____323
-        uu____327 uu____332 msg
-let ret a = kernel_tac "return" (fun p  -> Success (a, p))
-let bind t1 t2 =
-  kernel_tac "bind"
-    (fun p  ->
-       if Prims.op_Negation t1.kernel then debug p t1.tac_name else ();
-       (let uu____379 = t1.tac_f p in
-        match uu____379 with
-        | Success (a,q) ->
-            let t21 = t2 a in
-            (if Prims.op_Negation t21.kernel
-             then debug q t21.tac_name
-             else ();
-             t21.tac_f q)
-        | Failed (msg,q) ->
-            (if Prims.op_Negation t1.kernel
-             then
-               (let uu____391 = FStar_Util.format1 "%s failed!" t1.tac_name in
-                debug p uu____391)
-             else ();
-             Failed (msg, q))))
-let get: proofstate tac = kernel_tac "get" (fun p  -> Success (p, p))
-let fail msg =
-  kernel_tac "fail"
-    (fun p  -> FStar_Util.print1 ">>>>>%s\n" msg; Failed (msg, p))
-let show: Prims.unit tac =
-  kernel_tac "show" (fun p  -> debug p "debug"; Success ((), p))
-let set: proofstate -> Prims.unit tac =
-  fun p  -> kernel_tac "set" (fun uu____413  -> Success ((), p))
-let solve: goal -> FStar_Syntax_Syntax.typ -> Prims.unit =
-  fun goal  ->
-    fun solution  ->
-      match goal.witness with
-      | None  -> ()
-      | Some w ->
-          let uu____421 =
-            FStar_TypeChecker_Rel.teq_nosmt goal.context w solution in
-          if uu____421
-          then ()
-          else
-            (let uu____423 =
-               let uu____424 =
-                 let uu____425 = FStar_Syntax_Print.term_to_string solution in
-                 let uu____426 = FStar_Syntax_Print.term_to_string w in
-                 let uu____427 =
-                   FStar_Syntax_Print.term_to_string goal.goal_ty in
-                 FStar_Util.format3 "%s does not solve %s : %s" uu____425
-                   uu____426 uu____427 in
-               Failure uu____424 in
-             Prims.raise uu____423)
-let dismiss: Prims.unit tac =
-  bind get
-    (fun p  ->
-       let uu____430 =
-         let uu___74_431 = p in
-         let uu____432 = FStar_List.tl p.goals in
-         {
-           main_context = (uu___74_431.main_context);
-           main_goal = (uu___74_431.main_goal);
-           all_implicits = (uu___74_431.all_implicits);
-           goals = uu____432;
-           smt_goals = (uu___74_431.smt_goals);
-           transaction = (uu___74_431.transaction)
-         } in
-       set uu____430)
-let dismiss_all: Prims.unit tac =
-  bind get
-    (fun p  ->
-       set
-         (let uu___75_436 = p in
-          {
-            main_context = (uu___75_436.main_context);
-            main_goal = (uu___75_436.main_goal);
-            all_implicits = (uu___75_436.all_implicits);
-            goals = [];
-            smt_goals = (uu___75_436.smt_goals);
-            transaction = (uu___75_436.transaction)
-          }))
-let add_goals: goal Prims.list -> Prims.unit tac =
-  fun gs  ->
-    bind get
-      (fun p  ->
-         set
-           (let uu___76_445 = p in
-            {
-              main_context = (uu___76_445.main_context);
-              main_goal = (uu___76_445.main_goal);
-              all_implicits = (uu___76_445.all_implicits);
-              goals = (FStar_List.append gs p.goals);
-              smt_goals = (uu___76_445.smt_goals);
-              transaction = (uu___76_445.transaction)
-            }))
-let add_smt_goals: goal Prims.list -> Prims.unit tac =
-  fun gs  ->
-    bind get
-      (fun p  ->
-         set
-           (let uu___77_454 = p in
-            {
-              main_context = (uu___77_454.main_context);
-              main_goal = (uu___77_454.main_goal);
-              all_implicits = (uu___77_454.all_implicits);
-              goals = (uu___77_454.goals);
-              smt_goals = (FStar_List.append gs p.smt_goals);
-              transaction = (uu___77_454.transaction)
-            }))
-let replace: goal -> Prims.unit tac =
-  fun g  -> bind dismiss (fun uu____460  -> add_goals [g])
-let add_implicits: FStar_TypeChecker_Env.implicits -> Prims.unit tac =
-  fun i  ->
-    bind get
-      (fun p  ->
-         set
-           (let uu___78_467 = p in
-            {
-              main_context = (uu___78_467.main_context);
-              main_goal = (uu___78_467.main_goal);
-              all_implicits = (FStar_List.append i p.all_implicits);
-              goals = (uu___78_467.goals);
-              smt_goals = (uu___78_467.smt_goals);
-              transaction = (uu___78_467.transaction)
-            }))
-let is_true: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____477 = FStar_Syntax_Util.destruct_typ_as_formula t in
-    match uu____477 with
-    | Some (FStar_Syntax_Util.BaseConn (l,[])) ->
-        FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid
-    | uu____489 -> false
-let is_false: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____494 = FStar_Syntax_Util.destruct_typ_as_formula t in
-    match uu____494 with
-    | Some (FStar_Syntax_Util.BaseConn (l,[])) ->
-        FStar_Ident.lid_equals l FStar_Syntax_Const.false_lid
-    | uu____506 -> false
-let conj_goals: goal -> goal -> goal =
-  fun g1  ->
-    fun g2  ->
-      let t1 = g1.goal_ty in
-      let t2 = g2.goal_ty in
-      let uu____516 = (is_true t1) || (is_false t2) in
-      if uu____516
-      then g2
-      else
-        (let uu____518 = (is_true t2) || (is_false t1) in
-         if uu____518
-         then g1
-         else
-           (let uu___79_520 = g1 in
-            let uu____521 = FStar_Syntax_Util.mk_conj t1 t2 in
-            {
-              context = (uu___79_520.context);
-              witness = (uu___79_520.witness);
-              goal_ty = uu____521
-            }))
-let with_cur_goal nm f =
-  let uu____542 =
-    bind get
-      (fun p  ->
-         match p.goals with | [] -> fail "No more goals" | hd1::tl1 -> f hd1) in
-  name_tac nm uu____542
-let smt: Prims.unit tac =
-  with_cur_goal "smt"
-    (fun g  ->
-       bind dismiss
-         (fun uu____551  ->
-            let uu____552 =
-              add_goals
-                [(let uu___80_554 = g in
-                  {
-                    context = (uu___80_554.context);
-                    witness = (uu___80_554.witness);
-                    goal_ty = FStar_Syntax_Util.t_true
-                  })] in
-            bind uu____552 (fun uu____555  -> add_smt_goals [g])))
-let focus_cur_goal nm f =
-  bind get
-    (fun p  ->
-       match p.goals with
-       | [] -> fail "No more goals"
-       | hd1::tl1 ->
-           let q =
-             let uu___81_577 = p in
-             {
-               main_context = (uu___81_577.main_context);
-               main_goal = (uu___81_577.main_goal);
-               all_implicits = (uu___81_577.all_implicits);
-               goals = [hd1];
-               smt_goals = (uu___81_577.smt_goals);
-               transaction = (uu___81_577.transaction)
-             } in
-           let uu____578 = set q in
-           bind uu____578
-             (fun uu____580  ->
-                bind f
-                  (fun a  ->
-                     bind get
-                       (fun q'  ->
-                          let q2 =
-                            let uu___82_584 = q' in
-                            {
-                              main_context = (uu___82_584.main_context);
-                              main_goal = (uu___82_584.main_goal);
-                              all_implicits = (uu___82_584.all_implicits);
-                              goals = (FStar_List.append q'.goals tl1);
-                              smt_goals = (uu___82_584.smt_goals);
-                              transaction = (uu___82_584.transaction)
-                            } in
-                          let uu____585 = set q2 in
-                          bind uu____585 (fun uu____587  -> ret a)))))
-let cur_goal_and_rest f g =
-  bind get
-    (fun p  ->
-       match p.goals with
-       | [] -> fail "No more goals"
-       | uu____621::[] -> bind f (fun a  -> ret (a, None))
-       | hd1::tl1 ->
-           bind dismiss_all
-             (fun uu____636  ->
-                let uu____637 = add_goals [hd1] in
-                bind uu____637
-                  (fun uu____642  ->
-                     bind f
-                       (fun a  ->
-                          bind get
-                            (fun uu____650  ->
-                               match uu____650 with
-                               | { main_context = uu____655;
-                                   main_goal = uu____656;
-                                   all_implicits = uu____657;
-                                   goals = sub_goals_f;
-                                   smt_goals = uu____659;
-                                   transaction = uu____660;_} ->
-                                   bind dismiss_all
-                                     (fun uu____666  ->
-                                        let uu____667 = add_goals tl1 in
-                                        bind uu____667
-                                          (fun uu____672  ->
-                                             bind g
-                                               (fun b  ->
-                                                  let uu____677 =
-                                                    add_goals sub_goals_f in
-                                                  bind uu____677
-                                                    (fun uu____682  ->
-                                                       ret (a, (Some b)))))))))))
-let or_else t1 t2 =
-  kernel_tac "or_else"
-    (fun p  ->
-       (let uu____706 = FStar_Util.format1 "or_else: trying %s" t1.tac_name in
-        debug p uu____706);
-       (let uu____707 = t1.tac_f p in
-        match uu____707 with
-        | Failed uu____710 ->
-            ((let uu____714 =
-                FStar_Util.format2 "or_else: %s failed; trying %s"
-                  t1.tac_name t2.tac_name in
-              debug p uu____714);
-             t2.tac_f p)
-        | q -> q))
-let rec map t =
-  user_tac "map"
-    (fun p  ->
-       let uu____730 =
-         let uu____733 =
-           let uu____739 = map t in cur_goal_and_rest t uu____739 in
-         bind uu____733
-           (fun uu___72_748  ->
-              match uu___72_748 with
-              | (hd1,None ) -> ret [hd1]
-              | (hd1,Some tl1) -> ret (hd1 :: tl1)) in
-       run uu____730 p)
-let map_goal_term:
-  (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) -> Prims.unit tac =
-  fun f  ->
-    let aux =
-      with_cur_goal "map_goal"
-        (fun g  ->
-           let uu____781 =
-             let uu___83_782 = g in
-             let uu____783 = f g.goal_ty in
-             {
-               context = (uu___83_782.context);
-               witness = (uu___83_782.witness);
-               goal_ty = uu____783
-             } in
-           replace uu____781) in
-    let uu____784 = map aux in bind uu____784 (fun uu____788  -> ret ())
-let map_meta t =
-  with_cur_goal "map_meta"
-    (fun g  ->
-       let uu____801 =
-         let uu____802 = FStar_Syntax_Subst.compress g.goal_ty in
-         uu____802.FStar_Syntax_Syntax.n in
-       match uu____801 with
-       | FStar_Syntax_Syntax.Tm_meta (f,annot) ->
-           let uu____812 =
-             replace
-               (let uu___84_814 = g in
-                {
-                  context = (uu___84_814.context);
-                  witness = (uu___84_814.witness);
-                  goal_ty = f
-                }) in
-           bind uu____812
-             (fun uu____815  ->
-                bind t
-                  (fun a  ->
-                     let uu____817 =
-                       map_goal_term
-                         (fun tm  ->
-                            let uu____820 = is_true tm in
-                            if uu____820
-                            then tm
-                            else
-                              FStar_Syntax_Syntax.mk
-                                (FStar_Syntax_Syntax.Tm_meta (tm, annot))
-                                None tm.FStar_Syntax_Syntax.pos) in
-                     bind uu____817 (fun uu____826  -> ret a)))
-       | uu____827 -> fail "Not a meta")
-let seq: Prims.unit tac -> Prims.unit tac -> Prims.unit tac =
-  fun t1  ->
-    fun t2  ->
-      let uu____840 =
-        bind t1
-          (fun uu____842  ->
-             let uu____843 = map t2 in
-             bind uu____843 (fun uu____847  -> ret ())) in
-      focus_cur_goal "seq" uu____840
-let intros: FStar_Syntax_Syntax.binders tac =
-  with_cur_goal "intros"
-    (fun goal  ->
-       let uu____851 = FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty in
-       match uu____851 with
-       | Some (FStar_Syntax_Util.QAll (bs,pats,body)) ->
-           let new_context =
-             FStar_TypeChecker_Env.push_binders goal.context bs in
-           let new_goal =
-             { context = new_context; witness = None; goal_ty = body } in
-           bind dismiss
-             (fun uu____859  ->
-                let uu____860 = add_goals [new_goal] in
-                bind uu____860
-                  (fun uu____862  ->
-                     (let uu____864 =
-                        FStar_Syntax_Print.binders_to_string ", " bs in
-                      FStar_Util.print1 "intros: %s\n" uu____864);
-                     ret bs))
-       | uu____865 -> fail "Cannot intro this goal, expected a forall")
-let intros_no_names: Prims.unit tac = bind intros (fun uu____868  -> ret ())
-let mk_squash p =
-  let sq = FStar_Syntax_Util.fvar_const FStar_Syntax_Const.squash_lid in
-  let uu____879 = let uu____885 = FStar_Syntax_Syntax.as_arg p in [uu____885] in
-  FStar_Syntax_Util.mk_app sq uu____879
-let un_squash:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax Prims.option
-  =
-  fun t  ->
-    let uu____892 = FStar_Syntax_Util.head_and_args t in
-    match uu____892 with
-    | (head1,args) ->
-        let uu____921 =
-          let uu____929 =
-            let uu____930 = FStar_Syntax_Util.un_uinst head1 in
-            uu____930.FStar_Syntax_Syntax.n in
-          (uu____929, args) in
-        (match uu____921 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____943)::[]) when
-             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid
-             -> Some p
-         | (FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____963;
-               FStar_Syntax_Syntax.index = uu____964;
-               FStar_Syntax_Syntax.sort =
-                 { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.tk = uu____966;
-                   FStar_Syntax_Syntax.pos = uu____967;
-                   FStar_Syntax_Syntax.vars = uu____968;_};_},p),[])
-             when
-             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid ->
-             Some p
-         | uu____987 -> None)
-let imp_intro: FStar_Syntax_Syntax.binder tac =
-  with_cur_goal "imp_intro"
-    (fun goal  ->
-       let uu____999 = FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty in
-       match uu____999 with
-       | Some (FStar_Syntax_Util.BaseConn
-           (l,(lhs,uu____1004)::(rhs,uu____1006)::[])) when
-           FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid ->
-           let name = FStar_Syntax_Syntax.new_bv None lhs in
-           let new_goal =
-             let uu____1034 = FStar_TypeChecker_Env.push_bv goal.context name in
-             { context = uu____1034; witness = None; goal_ty = rhs } in
-           bind dismiss
-             (fun uu____1035  ->
-                let uu____1036 = add_goals [new_goal] in
-                bind uu____1036
-                  (fun uu____1038  ->
-                     (let uu____1040 = FStar_Syntax_Print.bv_to_string name in
-                      FStar_Util.print1 "imp_intro: %s\n" uu____1040);
-                     (let uu____1041 = FStar_Syntax_Syntax.mk_binder name in
-                      ret uu____1041)))
-       | uu____1042 -> fail "Cannot intro this goal, expected an '==>'")
-let split: Prims.unit tac =
-  with_cur_goal "split"
-    (fun goal  ->
-       let uu____1046 =
-         FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty in
-       match uu____1046 with
-       | Some (FStar_Syntax_Util.BaseConn (l,args)) when
-           FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid ->
-           let new_goals =
-             FStar_All.pipe_right args
-               (FStar_List.map
-                  (fun uu____1056  ->
-                     match uu____1056 with
-                     | (a,uu____1060) ->
-                         let uu___85_1061 = goal in
-                         {
-                           context = (uu___85_1061.context);
-                           witness = None;
-                           goal_ty = a
-                         })) in
-           bind dismiss
-             (fun uu____1062  ->
-                let uu____1063 = add_goals new_goals in
-                bind uu____1063 (fun uu____1065  -> show))
-       | uu____1066 -> fail "Cannot split this goal; expected a conjunction")
-let trivial: Prims.unit tac =
-  with_cur_goal "trivial"
-    (fun goal  ->
-       let steps =
-         [FStar_TypeChecker_Normalize.Reify;
-         FStar_TypeChecker_Normalize.Beta;
-         FStar_TypeChecker_Normalize.UnfoldUntil
-           FStar_Syntax_Syntax.Delta_constant;
-         FStar_TypeChecker_Normalize.Zeta;
-         FStar_TypeChecker_Normalize.Iota;
-         FStar_TypeChecker_Normalize.Primops] in
-       let t =
-         FStar_TypeChecker_Normalize.normalize steps goal.context
-           goal.goal_ty in
-       let uu____1073 = FStar_Syntax_Util.destruct_typ_as_formula t in
-       match uu____1073 with
-       | Some (FStar_Syntax_Util.BaseConn (l,[])) when
-           FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid ->
-           bind dismiss
-             (fun uu____1086  ->
-                add_goals
-                  [(let uu___86_1087 = goal in
-                    {
-                      context = (uu___86_1087.context);
-                      witness = (uu___86_1087.witness);
-                      goal_ty = t
-                    })])
-       | uu____1088 -> fail "Not a trivial goal")
-let apply_lemma: FStar_Syntax_Syntax.term -> Prims.unit tac =
-  fun tm  ->
-    with_cur_goal "apply_lemma"
-      (fun goal  ->
-         try
-           let uu____1099 =
-             (goal.context).FStar_TypeChecker_Env.type_of goal.context tm in
-           match uu____1099 with
-           | (tm1,t,guard) ->
-               let uu____1107 =
-                 let uu____1108 = FStar_Syntax_Util.is_lemma t in
-                 Prims.op_Negation uu____1108 in
-               if uu____1107
-               then fail "apply_lemma: not a lemma"
-               else
-                 (let uu____1111 = FStar_Syntax_Util.arrow_formals_comp t in
-                  match uu____1111 with
-                  | (bs,comp) ->
-                      let uu____1126 =
-                        FStar_List.fold_left
-                          (fun uu____1143  ->
-                             fun uu____1144  ->
-                               match (uu____1143, uu____1144) with
-                               | ((uvs,guard1,subst1),(b,aq)) ->
-                                   let b_t =
-                                     FStar_Syntax_Subst.subst subst1
-                                       b.FStar_Syntax_Syntax.sort in
-                                   let uu____1193 =
-                                     FStar_TypeChecker_Util.new_implicit_var
-                                       "apply_lemma"
-                                       (goal.goal_ty).FStar_Syntax_Syntax.pos
-                                       goal.context b_t in
-                                   (match uu____1193 with
-                                    | (u,uu____1208,g_u) ->
-                                        let uu____1216 =
-                                          FStar_TypeChecker_Rel.conj_guard
-                                            guard1 g_u in
-                                        (((u, aq) :: uvs), uu____1216,
-                                          ((FStar_Syntax_Syntax.NT (b, u)) ::
-                                          subst1)))) ([], guard, []) bs in
-                      (match uu____1126 with
-                       | (uvs,implicits,subst1) ->
-                           let uvs1 = FStar_List.rev uvs in
-                           let comp1 =
-                             FStar_Syntax_Subst.subst_comp subst1 comp in
-                           let uu____1248 =
-                             let c = FStar_Syntax_Util.comp_to_comp_typ comp1 in
-                             match c.FStar_Syntax_Syntax.effect_args with
-                             | pre::post::uu____1264 ->
-                                 ((Prims.fst pre), (Prims.fst post))
-                             | uu____1294 ->
-                                 failwith "Impossible: not a lemma" in
-                           (match uu____1248 with
-                            | (pre,post) ->
-                                let uu____1317 =
-                                  FStar_TypeChecker_Rel.try_teq false
-                                    goal.context post goal.goal_ty in
-                                (match uu____1317 with
-                                 | None  ->
-                                     fail
-                                       "apply_lemma: does not unify with goal"
-                                 | Some g ->
-                                     let g1 =
-                                       let uu____1322 =
-                                         FStar_TypeChecker_Rel.solve_deferred_constraints
-                                           goal.context g in
-                                       FStar_All.pipe_right uu____1322
-                                         FStar_TypeChecker_Rel.resolve_implicits in
-                                     let solution =
-                                       (FStar_Syntax_Syntax.mk_Tm_app tm1
-                                          uvs1) None
-                                         (goal.context).FStar_TypeChecker_Env.range in
-                                     let implicits1 =
-                                       FStar_All.pipe_right
-                                         implicits.FStar_TypeChecker_Env.implicits
-                                         (FStar_List.filter
-                                            (fun uu____1358  ->
-                                               match uu____1358 with
-                                               | (uu____1365,uu____1366,uu____1367,tm2,uu____1369,uu____1370)
-                                                   ->
-                                                   let uu____1371 =
-                                                     FStar_Syntax_Util.head_and_args
-                                                       tm2 in
-                                                   (match uu____1371 with
-                                                    | (hd1,uu____1382) ->
-                                                        let uu____1397 =
-                                                          let uu____1398 =
-                                                            FStar_Syntax_Subst.compress
-                                                              hd1 in
-                                                          uu____1398.FStar_Syntax_Syntax.n in
-                                                        (match uu____1397
-                                                         with
-                                                         | FStar_Syntax_Syntax.Tm_uvar
-                                                             uu____1401 ->
-                                                             true
-                                                         | uu____1410 ->
-                                                             false)))) in
-                                     (solve goal solution;
-                                      (let sub_goals =
-                                         let uu____1414 =
-                                           FStar_All.pipe_right implicits1
-                                             (FStar_List.map
-                                                (fun uu____1430  ->
-                                                   match uu____1430 with
-                                                   | (_msg,_env,_uvar,term,typ,uu____1442)
-                                                       ->
-                                                       {
-                                                         context =
-                                                           (goal.context);
-                                                         witness =
-                                                           (Some term);
-                                                         goal_ty = typ
-                                                       })) in
-                                         (let uu___89_1443 = goal in
-                                          {
-                                            context = (uu___89_1443.context);
-                                            witness = None;
-                                            goal_ty = pre
-                                          }) :: uu____1414 in
-                                       let uu____1444 =
-                                         add_implicits
-                                           g1.FStar_TypeChecker_Env.implicits in
-                                       bind uu____1444
-                                         (fun uu____1446  ->
-                                            bind dismiss
-                                              (fun uu____1447  ->
-                                                 add_goals sub_goals))))))))
-         with | uu____1450 -> fail "apply_lemma: ill-typed term")
-let exact: FStar_Syntax_Syntax.term -> Prims.unit tac =
-  fun tm  ->
-    with_cur_goal "exact"
-      (fun goal  ->
-         try
-           let uu____1460 =
-             (goal.context).FStar_TypeChecker_Env.type_of goal.context tm in
-           match uu____1460 with
-           | (uu____1465,t,guard) ->
-               let uu____1468 =
-                 FStar_TypeChecker_Rel.teq_nosmt goal.context t goal.goal_ty in
-               if uu____1468
-               then
-                 (solve goal tm;
-                  replace
-                    (let uu___92_1471 = goal in
-                     {
-                       context = (uu___92_1471.context);
-                       witness = None;
-                       goal_ty = FStar_Syntax_Util.t_true
-                     }))
-               else
-                 (let msg =
-                    let uu____1474 = FStar_Syntax_Print.term_to_string tm in
-                    let uu____1475 = FStar_Syntax_Print.term_to_string t in
-                    let uu____1476 =
-                      FStar_Syntax_Print.term_to_string goal.goal_ty in
-                    FStar_Util.format3
-                      "%s : %s does not exactly solve the goal %s" uu____1474
-                      uu____1475 uu____1476 in
-                  fail msg)
-         with
-         | e ->
-             let uu____1480 =
-               let uu____1481 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.format1 "Term is not typeable: %s" uu____1481 in
-             fail uu____1480)
-let rewrite: FStar_Syntax_Syntax.binder -> Prims.unit tac =
-  fun h  ->
-    with_cur_goal "rewrite"
-      (fun goal  ->
-         (let uu____1489 = FStar_Syntax_Print.bv_to_string (Prims.fst h) in
-          let uu____1490 =
-            FStar_Syntax_Print.term_to_string
-              (Prims.fst h).FStar_Syntax_Syntax.sort in
-          FStar_Util.print2 "+++Rewrite %s : %s\n" uu____1489 uu____1490);
-         (let uu____1491 =
-            let uu____1493 =
-              let uu____1494 =
-                FStar_TypeChecker_Env.lookup_bv goal.context (Prims.fst h) in
-              FStar_All.pipe_left Prims.fst uu____1494 in
-            FStar_Syntax_Util.destruct_typ_as_formula uu____1493 in
-          match uu____1491 with
-          | Some (FStar_Syntax_Util.BaseConn
-              (l,uu____1501::(x,uu____1503)::(e,uu____1505)::[])) when
-              FStar_Ident.lid_equals l FStar_Syntax_Const.eq2_lid ->
-              let uu____1539 =
-                let uu____1540 = FStar_Syntax_Subst.compress x in
-                uu____1540.FStar_Syntax_Syntax.n in
-              (match uu____1539 with
-               | FStar_Syntax_Syntax.Tm_name x1 ->
-                   let goal1 =
-                     let uu___93_1546 = goal in
-                     let uu____1547 =
-                       FStar_Syntax_Subst.subst
-                         [FStar_Syntax_Syntax.NT (x1, e)] goal.goal_ty in
-                     {
-                       context = (uu___93_1546.context);
-                       witness = (uu___93_1546.witness);
-                       goal_ty = uu____1547
-                     } in
-                   replace goal1
-               | uu____1550 ->
-                   fail
-                     "Not an equality hypothesis with a variable on the LHS")
-          | uu____1551 -> fail "Not an equality hypothesis"))
-let clear: Prims.unit tac =
-  with_cur_goal "clear"
-    (fun goal  ->
-       let uu____1555 = FStar_TypeChecker_Env.pop_bv goal.context in
-       match uu____1555 with
-       | None  -> fail "Cannot clear; empty context"
-       | Some (x,env') ->
-           let fns = FStar_Syntax_Free.names goal.goal_ty in
-           let uu____1568 = FStar_Util.set_mem x fns in
-           if uu____1568
-           then fail "Cannot clear; variable appears in goal"
-           else
-             (let new_goal =
-                let uu___94_1572 = goal in
-                {
-                  context = env';
-                  witness = (uu___94_1572.witness);
-                  goal_ty = (uu___94_1572.goal_ty)
-                } in
-              bind dismiss (fun uu____1573  -> add_goals [new_goal])))
-let clear_hd: name -> Prims.unit tac =
-  fun x  ->
-    with_cur_goal "clear_hd"
-      (fun goal  ->
-         let uu____1580 = FStar_TypeChecker_Env.pop_bv goal.context in
-         match uu____1580 with
-         | None  -> fail "Cannot clear_hd; empty context"
-         | Some (y,env') ->
-             if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x y)
-             then fail "Cannot clear_hd; head variable mismatch"
-             else clear)
-let revert: Prims.unit tac =
-  with_cur_goal "revert"
-    (fun goal  ->
-       let uu____1595 = FStar_TypeChecker_Env.pop_bv goal.context in
-       match uu____1595 with
-       | None  -> fail "Cannot clear_hd; empty context"
-       | Some (x,env') ->
-           let fns = FStar_Syntax_Free.names goal.goal_ty in
-           ((let uu____1609 = FStar_Syntax_Print.bv_to_string x in
-             FStar_Util.print1 "reverting %s\n" uu____1609);
-            (let uu____1610 =
-               let uu____1611 = FStar_Util.set_mem x fns in
-               Prims.op_Negation uu____1611 in
-             if uu____1610
-             then clear_hd x
-             else
-               (let new_goal =
-                  let uu____1615 =
-                    let uu____1624 = un_squash x.FStar_Syntax_Syntax.sort in
-                    let uu____1628 = un_squash goal.goal_ty in
-                    (uu____1624, uu____1628) in
-                  match uu____1615 with
-                  | (Some p,Some q) ->
-                      let uu___95_1654 = goal in
-                      let uu____1655 = FStar_Syntax_Util.mk_imp p q in
-                      {
-                        context = env';
-                        witness = (uu___95_1654.witness);
-                        goal_ty = uu____1655
-                      }
-                  | uu____1656 ->
-                      let uu___96_1665 = goal in
-                      let uu____1666 =
-                        let uu____1667 =
-                          FStar_TypeChecker_TcTerm.universe_of env'
-                            x.FStar_Syntax_Syntax.sort in
-                        FStar_Syntax_Util.mk_forall uu____1667 x goal.goal_ty in
-                      {
-                        context = env';
-                        witness = (uu___96_1665.witness);
-                        goal_ty = uu____1666
-                      } in
-                bind dismiss (fun uu____1668  -> add_goals [new_goal])))))
-let revert_hd: name -> Prims.unit tac =
-  fun x  ->
-    with_cur_goal "revert_hd"
-      (fun goal  ->
-         let uu____1675 = FStar_TypeChecker_Env.pop_bv goal.context in
-         match uu____1675 with
-         | None  -> fail "Cannot revert_hd; empty context"
-         | Some (y,env') ->
-             if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x y)
-             then
-               let uu____1687 =
-                 let uu____1688 = FStar_Syntax_Print.bv_to_string x in
-                 let uu____1689 = FStar_Syntax_Print.bv_to_string y in
-                 FStar_Util.format2
-                   "Cannot revert_hd %s; head variable mismatch ... egot %s"
-                   uu____1688 uu____1689 in
-               fail uu____1687
-             else revert)
-let rec revert_all_hd: name Prims.list -> Prims.unit tac =
-  fun xs  ->
-    match xs with
-    | [] -> ret ()
-    | x::xs1 ->
-        let uu____1702 = revert_all_hd xs1 in
-        bind uu____1702 (fun uu____1704  -> revert_hd x)
-let is_name: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun x  ->
-    let uu____1708 =
-      let uu____1709 = FStar_Syntax_Subst.compress x in
-      uu____1709.FStar_Syntax_Syntax.n in
-    match uu____1708 with
-    | FStar_Syntax_Syntax.Tm_name uu____1712 -> true
-    | uu____1713 -> false
-let as_name: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv =
-  fun x  ->
-    let uu____1717 =
-      let uu____1718 = FStar_Syntax_Subst.compress x in
-      uu____1718.FStar_Syntax_Syntax.n in
-    match uu____1717 with
-    | FStar_Syntax_Syntax.Tm_name x1 -> x1
-    | uu____1722 -> failwith "Not a name"
-let destruct_equality_imp:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.bv*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax) Prims.option
-  =
-  fun t  ->
-    let uu____1734 = FStar_Syntax_Util.destruct_typ_as_formula t in
-    match uu____1734 with
-    | Some (FStar_Syntax_Util.BaseConn
-        (l,(lhs,uu____1746)::(rhs,uu____1748)::[])) when
-        FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid ->
-        let uu____1774 = FStar_Syntax_Util.destruct_typ_as_formula lhs in
-        (match uu____1774 with
-         | Some (FStar_Syntax_Util.BaseConn (eq1,_::(x,_)::(e,_)::[]))|Some
-           (FStar_Syntax_Util.BaseConn (eq1,(x,_)::(e,_)::[])) when
-             (FStar_Ident.lid_equals eq1 FStar_Syntax_Const.eq2_lid) &&
-               (is_name x)
-             ->
-             let uu____1846 =
-               let uu____1854 = as_name x in (uu____1854, e, rhs) in
-             Some uu____1846
-         | uu____1866 -> None)
-    | uu____1875 -> None
-let at_most_one t =
-  bind t
-    (fun a  ->
-       bind get
-         (fun p  ->
-            match p.goals with
-            | []|_::[] -> ret a
-            | uu____1898 -> fail "expected at most one goal remaining"))
-let goal_to_string: goal -> Prims.string =
-  fun g1  ->
-    let g1_binders =
-      let uu____1904 = FStar_TypeChecker_Env.all_binders g1.context in
-      FStar_All.pipe_right uu____1904
-        (FStar_Syntax_Print.binders_to_string ", ") in
-    let uu____1905 = FStar_Syntax_Print.term_to_string g1.goal_ty in
-    FStar_Util.format2 "%s |- %s" g1_binders uu____1905
-let merge_sub_goals: Prims.unit tac =
-  let uu____1907 =
-    bind get
-      (fun p  ->
-         match p.goals with
-         | g1::g2::rest ->
-             let uu____1915 =
-               ((FStar_TypeChecker_Env.eq_gamma g1.context g2.context) &&
-                  (FStar_Option.isNone g1.witness))
-                 && (FStar_Option.isNone g2.witness) in
-             if uu____1915
-             then
-               let uu____1917 =
-                 let uu___97_1918 = p in
-                 let uu____1919 =
-                   let uu____1921 = conj_goals g1 g2 in uu____1921 :: rest in
-                 {
-                   main_context = (uu___97_1918.main_context);
-                   main_goal = (uu___97_1918.main_goal);
-                   all_implicits = (uu___97_1918.all_implicits);
-                   goals = uu____1919;
-                   smt_goals = (uu___97_1918.smt_goals);
-                   transaction = (uu___97_1918.transaction)
-                 } in
-               set uu____1917
-             else
-               (let g1_binders =
-                  let uu____1924 =
-                    FStar_TypeChecker_Env.all_binders g1.context in
-                  FStar_All.pipe_right uu____1924
-                    (FStar_Syntax_Print.binders_to_string ", ") in
-                let g2_binders =
-                  let uu____1926 =
-                    FStar_TypeChecker_Env.all_binders g2.context in
-                  FStar_All.pipe_right uu____1926
-                    (FStar_Syntax_Print.binders_to_string ", ") in
-                let uu____1927 =
-                  let uu____1928 = goal_to_string g1 in
-                  let uu____1929 = goal_to_string g2 in
-                  let uu____1930 =
-                    let uu____1931 =
-                      FStar_TypeChecker_Env.eq_gamma g1.context g2.context in
-                    FStar_All.pipe_right uu____1931 FStar_Util.string_of_bool in
-                  FStar_Util.format3
-                    "Cannot merge sub-goals: incompatible contexts:\ng1=%s\ng2=%s\neq_gamma=%s\n"
-                    uu____1928 uu____1929 uu____1930 in
-                fail uu____1927)
-         | uu____1932 ->
-             let goals =
-               let uu____1935 =
-                 FStar_All.pipe_right p.goals
-                   (FStar_List.map
-                      (fun x  -> FStar_Syntax_Print.term_to_string x.goal_ty)) in
-               FStar_All.pipe_right uu____1935 (FStar_String.concat "\n\t") in
-             let uu____1941 =
-               FStar_Util.format1
-                 "Cannot merge sub-goals: not enough sub-goals\n\tGoals are: %s"
-                 goals in
-             fail uu____1941) in
-  name_tac "merge_sub_goals" uu____1907
-let rec visit: Prims.unit tac -> Prims.unit tac =
-  fun callback  ->
-    let uu____1949 =
-      let uu____1951 =
-        with_cur_goal "visit_strengthen_else"
-          (fun goal  ->
-             let uu____1954 =
-               FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty in
-             match uu____1954 with
-             | None  ->
-                 let uu____1957 =
-                   let uu____1958 = FStar_Syntax_Subst.compress goal.goal_ty in
-                   uu____1958.FStar_Syntax_Syntax.n in
-                 (match uu____1957 with
-                  | FStar_Syntax_Syntax.Tm_meta uu____1962 ->
-                      let uu____1967 = visit callback in map_meta uu____1967
-                  | uu____1969 ->
-                      ((let uu____1971 =
-                          FStar_Syntax_Print.term_to_string goal.goal_ty in
-                        FStar_Util.print1 "Not a formula, split to smt %s\n"
-                          uu____1971);
-                       smt))
-             | Some (FStar_Syntax_Util.QEx uu____1972) ->
-                 ((let uu____1977 =
-                     FStar_Syntax_Print.term_to_string goal.goal_ty in
-                   FStar_Util.print1
-                     "Not yet handled: exists\n\tGoal is %s\n" uu____1977);
-                  ret ())
-             | Some (FStar_Syntax_Util.QAll (xs,uu____1979,uu____1980)) ->
-                 bind intros
-                   (fun binders  ->
-                      let uu____1982 = visit callback in
-                      bind uu____1982
-                        (fun uu____1984  ->
-                           let uu____1985 =
-                             let uu____1987 =
-                               FStar_List.map Prims.fst binders in
-                             revert_all_hd uu____1987 in
-                           bind uu____1985
-                             (fun uu____1991  ->
-                                with_cur_goal "inner"
-                                  (fun goal1  ->
-                                     (let uu____1994 = goal_to_string goal1 in
-                                      FStar_Util.print1
-                                        "After reverting intros, goal is %s\n"
-                                        uu____1994);
-                                     ret ()))))
-             | Some (FStar_Syntax_Util.BaseConn (l,uu____1996)) when
-                 FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid ->
-                 let uu____1997 =
-                   let uu____1999 = visit callback in seq split uu____1999 in
-                 bind uu____1997 (fun uu____2001  -> merge_sub_goals)
-             | Some (FStar_Syntax_Util.BaseConn (l,uu____2003)) when
-                 FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid ->
-                 bind imp_intro
-                   (fun h  ->
-                      let uu____2005 = visit callback in
-                      bind uu____2005 (fun uu____2007  -> revert))
-             | Some (FStar_Syntax_Util.BaseConn (l,uu____2009)) ->
-                 or_else trivial smt) in
-      or_else callback uu____1951 in
-    focus_cur_goal "visit_strengthen" uu____1949
-let proofstate_of_goal_ty:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> proofstate =
-  fun env  ->
-    fun g  ->
-      let g1 =
-        let uu____2017 =
-          FStar_TypeChecker_Normalize.normalize
-            [FStar_TypeChecker_Normalize.Beta] env g in
-        { context = env; witness = None; goal_ty = uu____2017 } in
-      let uu____2018 = FStar_Unionfind.new_transaction () in
-      {
-        main_context = env;
-        main_goal = g1;
-        all_implicits = [];
-        goals = [g1];
-        smt_goals = [];
-        transaction = uu____2018
-      }
+{tac_f : proofstate  ->  'a result; tac_name : Prims.string; kernel : Prims.bool}
+
+
+let as_tac = (fun name b f -> {tac_f = f; tac_name = name; kernel = b})
+
+
+let kernel_tac = (fun n1 t -> {tac_f = t; tac_name = n1; kernel = true})
+
+
+let user_tac = (fun n1 t -> {tac_f = t; tac_name = n1; kernel = false})
+
+
+let name_tac = (fun n1 t -> (
+
+let uu___73_300 = t
+in {tac_f = uu___73_300.tac_f; tac_name = n1; kernel = false}))
+
+
+let run = (fun t p -> (t.tac_f p))
+
+
+let debug : proofstate  ->  Prims.string  ->  Prims.unit = (fun p msg -> (
+
+let uu____323 = (FStar_Util.string_of_int (FStar_List.length p.goals))
+in (
+
+let uu____327 = (match (p.goals) with
+| [] -> begin
+"[]"
+end
+| uu____328 -> begin
+(
+
+let uu____330 = (
+
+let uu____331 = (FStar_List.hd p.goals)
+in uu____331.goal_ty)
+in (FStar_Syntax_Print.term_to_string uu____330))
+end)
+in (
+
+let uu____332 = (match (p.goals) with
+| [] -> begin
+""
+end
+| uu____333 -> begin
+(
+
+let uu____335 = (
+
+let uu____337 = (FStar_List.tl p.goals)
+in (FStar_All.pipe_right uu____337 (FStar_List.map (fun x -> (FStar_Syntax_Print.term_to_string x.goal_ty)))))
+in (FStar_All.pipe_right uu____335 (FStar_String.concat ";;")))
+end)
+in (FStar_Util.print4 "TAC (ngoals=%s, maingoal=%s, rest=%s):\n\tTAC>> %s\n" uu____323 uu____327 uu____332 msg)))))
+
+
+let ret = (fun a -> (kernel_tac "return" (fun p -> Success (((a), (p))))))
+
+
+let bind = (fun t1 t2 -> (kernel_tac "bind" (fun p -> ((match ((not (t1.kernel))) with
+| true -> begin
+(debug p t1.tac_name)
+end
+| uu____378 -> begin
+()
+end);
+(
+
+let uu____379 = (t1.tac_f p)
+in (match (uu____379) with
+| Success (a, q) -> begin
+(
+
+let t21 = (t2 a)
+in ((match ((not (t21.kernel))) with
+| true -> begin
+(debug q t21.tac_name)
+end
+| uu____387 -> begin
+()
+end);
+(t21.tac_f q);
+))
+end
+| Failed (msg, q) -> begin
+((match ((not (t1.kernel))) with
+| true -> begin
+(
+
+let uu____391 = (FStar_Util.format1 "%s failed!" t1.tac_name)
+in (debug p uu____391))
+end
+| uu____392 -> begin
+()
+end);
+Failed (((msg), (q)));
+)
+end));
+))))
+
+
+let get : proofstate tac = (kernel_tac "get" (fun p -> Success (((p), (p)))))
+
+
+let fail = (fun msg -> (kernel_tac "fail" (fun p -> ((FStar_Util.print1 ">>>>>%s\n" msg);
+Failed (((msg), (p)));
+))))
+
+
+let show : Prims.unit tac = (kernel_tac "show" (fun p -> ((debug p "debug");
+Success (((()), (p)));
+)))
+
+
+let set : proofstate  ->  Prims.unit tac = (fun p -> (kernel_tac "set" (fun uu____413 -> Success (((()), (p))))))
+
+
+let solve : goal  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit = (fun goal solution -> (match (goal.witness) with
+| None -> begin
+()
+end
+| Some (w) -> begin
+(
+
+let uu____421 = (FStar_TypeChecker_Rel.teq_nosmt goal.context w solution)
+in (match (uu____421) with
+| true -> begin
+()
+end
+| uu____422 -> begin
+(
+
+let uu____423 = (
+
+let uu____424 = (
+
+let uu____425 = (FStar_Syntax_Print.term_to_string solution)
+in (
+
+let uu____426 = (FStar_Syntax_Print.term_to_string w)
+in (
+
+let uu____427 = (FStar_Syntax_Print.term_to_string goal.goal_ty)
+in (FStar_Util.format3 "%s does not solve %s : %s" uu____425 uu____426 uu____427))))
+in Failure (uu____424))
+in (Prims.raise uu____423))
+end))
+end))
+
+
+let dismiss : Prims.unit tac = (bind get (fun p -> (
+
+let uu____430 = (
+
+let uu___74_431 = p
+in (
+
+let uu____432 = (FStar_List.tl p.goals)
+in {main_context = uu___74_431.main_context; main_goal = uu___74_431.main_goal; all_implicits = uu___74_431.all_implicits; goals = uu____432; smt_goals = uu___74_431.smt_goals; transaction = uu___74_431.transaction}))
+in (set uu____430))))
+
+
+let dismiss_all : Prims.unit tac = (bind get (fun p -> (set (
+
+let uu___75_436 = p
+in {main_context = uu___75_436.main_context; main_goal = uu___75_436.main_goal; all_implicits = uu___75_436.all_implicits; goals = []; smt_goals = uu___75_436.smt_goals; transaction = uu___75_436.transaction}))))
+
+
+let add_goals : goal Prims.list  ->  Prims.unit tac = (fun gs -> (bind get (fun p -> (set (
+
+let uu___76_445 = p
+in {main_context = uu___76_445.main_context; main_goal = uu___76_445.main_goal; all_implicits = uu___76_445.all_implicits; goals = (FStar_List.append gs p.goals); smt_goals = uu___76_445.smt_goals; transaction = uu___76_445.transaction})))))
+
+
+let add_smt_goals : goal Prims.list  ->  Prims.unit tac = (fun gs -> (bind get (fun p -> (set (
+
+let uu___77_454 = p
+in {main_context = uu___77_454.main_context; main_goal = uu___77_454.main_goal; all_implicits = uu___77_454.all_implicits; goals = uu___77_454.goals; smt_goals = (FStar_List.append gs p.smt_goals); transaction = uu___77_454.transaction})))))
+
+
+let replace : goal  ->  Prims.unit tac = (fun g -> (bind dismiss (fun uu____460 -> (add_goals ((g)::[])))))
+
+
+let add_implicits : FStar_TypeChecker_Env.implicits  ->  Prims.unit tac = (fun i -> (bind get (fun p -> (set (
+
+let uu___78_467 = p
+in {main_context = uu___78_467.main_context; main_goal = uu___78_467.main_goal; all_implicits = (FStar_List.append i p.all_implicits); goals = uu___78_467.goals; smt_goals = uu___78_467.smt_goals; transaction = uu___78_467.transaction})))))
+
+
+let is_true : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____477 = (FStar_Syntax_Util.destruct_typ_as_formula t)
+in (match (uu____477) with
+| Some (FStar_Syntax_Util.BaseConn (l, [])) -> begin
+(FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid)
+end
+| uu____489 -> begin
+false
+end)))
+
+
+let is_false : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____494 = (FStar_Syntax_Util.destruct_typ_as_formula t)
+in (match (uu____494) with
+| Some (FStar_Syntax_Util.BaseConn (l, [])) -> begin
+(FStar_Ident.lid_equals l FStar_Syntax_Const.false_lid)
+end
+| uu____506 -> begin
+false
+end)))
+
+
+let conj_goals : goal  ->  goal  ->  goal = (fun g1 g2 -> (
+
+let t1 = g1.goal_ty
+in (
+
+let t2 = g2.goal_ty
+in (
+
+let uu____516 = ((is_true t1) || (is_false t2))
+in (match (uu____516) with
+| true -> begin
+g2
+end
+| uu____517 -> begin
+(
+
+let uu____518 = ((is_true t2) || (is_false t1))
+in (match (uu____518) with
+| true -> begin
+g1
+end
+| uu____519 -> begin
+(
+
+let uu___79_520 = g1
+in (
+
+let uu____521 = (FStar_Syntax_Util.mk_conj t1 t2)
+in {context = uu___79_520.context; witness = uu___79_520.witness; goal_ty = uu____521}))
+end))
+end)))))
+
+
+let with_cur_goal = (fun nm f -> (
+
+let uu____542 = (bind get (fun p -> (match (p.goals) with
+| [] -> begin
+(fail "No more goals")
+end
+| (hd1)::tl1 -> begin
+(f hd1)
+end)))
+in (name_tac nm uu____542)))
+
+
+let smt : Prims.unit tac = (with_cur_goal "smt" (fun g -> (bind dismiss (fun uu____551 -> (
+
+let uu____552 = (add_goals (((
+
+let uu___80_554 = g
+in {context = uu___80_554.context; witness = uu___80_554.witness; goal_ty = FStar_Syntax_Util.t_true}))::[]))
+in (bind uu____552 (fun uu____555 -> (add_smt_goals ((g)::[])))))))))
+
+
+let focus_cur_goal = (fun nm f -> (bind get (fun p -> (match (p.goals) with
+| [] -> begin
+(fail "No more goals")
+end
+| (hd1)::tl1 -> begin
+(
+
+let q = (
+
+let uu___81_577 = p
+in {main_context = uu___81_577.main_context; main_goal = uu___81_577.main_goal; all_implicits = uu___81_577.all_implicits; goals = (hd1)::[]; smt_goals = uu___81_577.smt_goals; transaction = uu___81_577.transaction})
+in (
+
+let uu____578 = (set q)
+in (bind uu____578 (fun uu____580 -> (bind f (fun a -> (bind get (fun q' -> (
+
+let q2 = (
+
+let uu___82_584 = q'
+in {main_context = uu___82_584.main_context; main_goal = uu___82_584.main_goal; all_implicits = uu___82_584.all_implicits; goals = (FStar_List.append q'.goals tl1); smt_goals = uu___82_584.smt_goals; transaction = uu___82_584.transaction})
+in (
+
+let uu____585 = (set q2)
+in (bind uu____585 (fun uu____587 -> (ret a)))))))))))))
+end))))
+
+
+let cur_goal_and_rest = (fun f g -> (bind get (fun p -> (match (p.goals) with
+| [] -> begin
+(fail "No more goals")
+end
+| (uu____621)::[] -> begin
+(bind f (fun a -> (ret ((a), (None)))))
+end
+| (hd1)::tl1 -> begin
+(bind dismiss_all (fun uu____636 -> (
+
+let uu____637 = (add_goals ((hd1)::[]))
+in (bind uu____637 (fun uu____642 -> (bind f (fun a -> (bind get (fun uu____650 -> (match (uu____650) with
+| {main_context = uu____655; main_goal = uu____656; all_implicits = uu____657; goals = sub_goals_f; smt_goals = uu____659; transaction = uu____660} -> begin
+(bind dismiss_all (fun uu____666 -> (
+
+let uu____667 = (add_goals tl1)
+in (bind uu____667 (fun uu____672 -> (bind g (fun b -> (
+
+let uu____677 = (add_goals sub_goals_f)
+in (bind uu____677 (fun uu____682 -> (ret ((a), (Some (b))))))))))))))
+end))))))))))
+end))))
+
+
+let or_else = (fun t1 t2 -> (kernel_tac "or_else" (fun p -> ((
+
+let uu____706 = (FStar_Util.format1 "or_else: trying %s" t1.tac_name)
+in (debug p uu____706));
+(
+
+let uu____707 = (t1.tac_f p)
+in (match (uu____707) with
+| Failed (uu____710) -> begin
+((
+
+let uu____714 = (FStar_Util.format2 "or_else: %s failed; trying %s" t1.tac_name t2.tac_name)
+in (debug p uu____714));
+(t2.tac_f p);
+)
+end
+| q -> begin
+q
+end));
+))))
+
+
+let rec map = (fun t -> (user_tac "map" (fun p -> (
+
+let uu____730 = (
+
+let uu____733 = (
+
+let uu____739 = (map t)
+in (cur_goal_and_rest t uu____739))
+in (bind uu____733 (fun uu___72_748 -> (match (uu___72_748) with
+| (hd1, None) -> begin
+(ret ((hd1)::[]))
+end
+| (hd1, Some (tl1)) -> begin
+(ret ((hd1)::tl1))
+end))))
+in (run uu____730 p)))))
+
+
+let map_goal_term : (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term)  ->  Prims.unit tac = (fun f -> (
+
+let aux = (with_cur_goal "map_goal" (fun g -> (
+
+let uu____781 = (
+
+let uu___83_782 = g
+in (
+
+let uu____783 = (f g.goal_ty)
+in {context = uu___83_782.context; witness = uu___83_782.witness; goal_ty = uu____783}))
+in (replace uu____781))))
+in (
+
+let uu____784 = (map aux)
+in (bind uu____784 (fun uu____788 -> (ret ()))))))
+
+
+let map_meta = (fun t -> (with_cur_goal "map_meta" (fun g -> (
+
+let uu____801 = (
+
+let uu____802 = (FStar_Syntax_Subst.compress g.goal_ty)
+in uu____802.FStar_Syntax_Syntax.n)
+in (match (uu____801) with
+| FStar_Syntax_Syntax.Tm_meta (f, annot) -> begin
+(
+
+let uu____812 = (replace (
+
+let uu___84_814 = g
+in {context = uu___84_814.context; witness = uu___84_814.witness; goal_ty = f}))
+in (bind uu____812 (fun uu____815 -> (bind t (fun a -> (
+
+let uu____817 = (map_goal_term (fun tm -> (
+
+let uu____820 = (is_true tm)
+in (match (uu____820) with
+| true -> begin
+tm
+end
+| uu____821 -> begin
+(FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((tm), (annot)))) None tm.FStar_Syntax_Syntax.pos)
+end))))
+in (bind uu____817 (fun uu____826 -> (ret a)))))))))
+end
+| uu____827 -> begin
+(fail "Not a meta")
+end)))))
+
+
+let seq : Prims.unit tac  ->  Prims.unit tac  ->  Prims.unit tac = (fun t1 t2 -> (
+
+let uu____840 = (bind t1 (fun uu____842 -> (
+
+let uu____843 = (map t2)
+in (bind uu____843 (fun uu____847 -> (ret ()))))))
+in (focus_cur_goal "seq" uu____840)))
+
+
+let intros : FStar_Syntax_Syntax.binders tac = (with_cur_goal "intros" (fun goal -> (
+
+let uu____851 = (FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty)
+in (match (uu____851) with
+| Some (FStar_Syntax_Util.QAll (bs, pats, body)) -> begin
+(
+
+let new_context = (FStar_TypeChecker_Env.push_binders goal.context bs)
+in (
+
+let new_goal = {context = new_context; witness = None; goal_ty = body}
+in (bind dismiss (fun uu____859 -> (
+
+let uu____860 = (add_goals ((new_goal)::[]))
+in (bind uu____860 (fun uu____862 -> ((
+
+let uu____864 = (FStar_Syntax_Print.binders_to_string ", " bs)
+in (FStar_Util.print1 "intros: %s\n" uu____864));
+(ret bs);
+))))))))
+end
+| uu____865 -> begin
+(fail "Cannot intro this goal, expected a forall")
+end))))
+
+
+let intros_no_names : Prims.unit tac = (bind intros (fun uu____868 -> (ret ())))
+
+
+let mk_squash = (fun p -> (
+
+let sq = (FStar_Syntax_Util.fvar_const FStar_Syntax_Const.squash_lid)
+in (
+
+let uu____879 = (
+
+let uu____885 = (FStar_Syntax_Syntax.as_arg p)
+in (uu____885)::[])
+in (FStar_Syntax_Util.mk_app sq uu____879))))
+
+
+let un_squash : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.option = (fun t -> (
+
+let uu____892 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____892) with
+| (head1, args) -> begin
+(
+
+let uu____921 = (
+
+let uu____929 = (
+
+let uu____930 = (FStar_Syntax_Util.un_uinst head1)
+in uu____930.FStar_Syntax_Syntax.n)
+in ((uu____929), (args)))
+in (match (uu____921) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((p, uu____943))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.squash_lid) -> begin
+Some (p)
+end
+| (FStar_Syntax_Syntax.Tm_refine ({FStar_Syntax_Syntax.ppname = uu____963; FStar_Syntax_Syntax.index = uu____964; FStar_Syntax_Syntax.sort = {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____966; FStar_Syntax_Syntax.pos = uu____967; FStar_Syntax_Syntax.vars = uu____968}}, p), []) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) -> begin
+Some (p)
+end
+| uu____987 -> begin
+None
+end))
+end)))
+
+
+let imp_intro : FStar_Syntax_Syntax.binder tac = (with_cur_goal "imp_intro" (fun goal -> (
+
+let uu____999 = (FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty)
+in (match (uu____999) with
+| Some (FStar_Syntax_Util.BaseConn (l, ((lhs, uu____1004))::((rhs, uu____1006))::[])) when (FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid) -> begin
+(
+
+let name = (FStar_Syntax_Syntax.new_bv None lhs)
+in (
+
+let new_goal = (
+
+let uu____1034 = (FStar_TypeChecker_Env.push_bv goal.context name)
+in {context = uu____1034; witness = None; goal_ty = rhs})
+in (bind dismiss (fun uu____1035 -> (
+
+let uu____1036 = (add_goals ((new_goal)::[]))
+in (bind uu____1036 (fun uu____1038 -> ((
+
+let uu____1040 = (FStar_Syntax_Print.bv_to_string name)
+in (FStar_Util.print1 "imp_intro: %s\n" uu____1040));
+(
+
+let uu____1041 = (FStar_Syntax_Syntax.mk_binder name)
+in (ret uu____1041));
+))))))))
+end
+| uu____1042 -> begin
+(fail "Cannot intro this goal, expected an \'==>\'")
+end))))
+
+
+let split : Prims.unit tac = (with_cur_goal "split" (fun goal -> (
+
+let uu____1046 = (FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty)
+in (match (uu____1046) with
+| Some (FStar_Syntax_Util.BaseConn (l, args)) when (FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid) -> begin
+(
+
+let new_goals = (FStar_All.pipe_right args (FStar_List.map (fun uu____1056 -> (match (uu____1056) with
+| (a, uu____1060) -> begin
+(
+
+let uu___85_1061 = goal
+in {context = uu___85_1061.context; witness = None; goal_ty = a})
+end))))
+in (bind dismiss (fun uu____1062 -> (
+
+let uu____1063 = (add_goals new_goals)
+in (bind uu____1063 (fun uu____1065 -> show))))))
+end
+| uu____1066 -> begin
+(fail "Cannot split this goal; expected a conjunction")
+end))))
+
+
+let trivial : Prims.unit tac = (with_cur_goal "trivial" (fun goal -> (
+
+let steps = (FStar_TypeChecker_Normalize.Reify)::(FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Primops)::[]
+in (
+
+let t = (FStar_TypeChecker_Normalize.normalize steps goal.context goal.goal_ty)
+in (
+
+let uu____1073 = (FStar_Syntax_Util.destruct_typ_as_formula t)
+in (match (uu____1073) with
+| Some (FStar_Syntax_Util.BaseConn (l, [])) when (FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid) -> begin
+(bind dismiss (fun uu____1086 -> (add_goals (((
+
+let uu___86_1087 = goal
+in {context = uu___86_1087.context; witness = uu___86_1087.witness; goal_ty = t}))::[]))))
+end
+| uu____1088 -> begin
+(fail "Not a trivial goal")
+end))))))
+
+
+let apply_lemma : FStar_Syntax_Syntax.term  ->  Prims.unit tac = (fun tm -> (with_cur_goal "apply_lemma" (fun goal -> try
+(match (()) with
+| () -> begin
+(
+
+let uu____1099 = (goal.context.FStar_TypeChecker_Env.type_of goal.context tm)
+in (match (uu____1099) with
+| (tm1, t, guard) -> begin
+(
+
+let uu____1107 = (
+
+let uu____1108 = (FStar_Syntax_Util.is_lemma t)
+in (not (uu____1108)))
+in (match (uu____1107) with
+| true -> begin
+(fail "apply_lemma: not a lemma")
+end
+| uu____1110 -> begin
+(
+
+let uu____1111 = (FStar_Syntax_Util.arrow_formals_comp t)
+in (match (uu____1111) with
+| (bs, comp) -> begin
+(
+
+let uu____1126 = (FStar_List.fold_left (fun uu____1143 uu____1144 -> (match (((uu____1143), (uu____1144))) with
+| ((uvs, guard1, subst1), (b, aq)) -> begin
+(
+
+let b_t = (FStar_Syntax_Subst.subst subst1 b.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____1193 = (FStar_TypeChecker_Util.new_implicit_var "apply_lemma" goal.goal_ty.FStar_Syntax_Syntax.pos goal.context b_t)
+in (match (uu____1193) with
+| (u, uu____1208, g_u) -> begin
+(
+
+let uu____1216 = (FStar_TypeChecker_Rel.conj_guard guard1 g_u)
+in (((((u), (aq)))::uvs), (uu____1216), ((FStar_Syntax_Syntax.NT (((b), (u))))::subst1)))
+end)))
+end)) (([]), (guard), ([])) bs)
+in (match (uu____1126) with
+| (uvs, implicits, subst1) -> begin
+(
+
+let uvs1 = (FStar_List.rev uvs)
+in (
+
+let comp1 = (FStar_Syntax_Subst.subst_comp subst1 comp)
+in (
+
+let uu____1248 = (
+
+let c = (FStar_Syntax_Util.comp_to_comp_typ comp1)
+in (match (c.FStar_Syntax_Syntax.effect_args) with
+| (pre)::(post)::uu____1264 -> begin
+(((Prims.fst pre)), ((Prims.fst post)))
+end
+| uu____1294 -> begin
+(failwith "Impossible: not a lemma")
+end))
+in (match (uu____1248) with
+| (pre, post) -> begin
+(
+
+let uu____1317 = (FStar_TypeChecker_Rel.try_teq false goal.context post goal.goal_ty)
+in (match (uu____1317) with
+| None -> begin
+(fail "apply_lemma: does not unify with goal")
+end
+| Some (g) -> begin
+(
+
+let g1 = (
+
+let uu____1322 = (FStar_TypeChecker_Rel.solve_deferred_constraints goal.context g)
+in (FStar_All.pipe_right uu____1322 FStar_TypeChecker_Rel.resolve_implicits))
+in (
+
+let solution = ((FStar_Syntax_Syntax.mk_Tm_app tm1 uvs1) None goal.context.FStar_TypeChecker_Env.range)
+in (
+
+let implicits1 = (FStar_All.pipe_right implicits.FStar_TypeChecker_Env.implicits (FStar_List.filter (fun uu____1358 -> (match (uu____1358) with
+| (uu____1365, uu____1366, uu____1367, tm2, uu____1369, uu____1370) -> begin
+(
+
+let uu____1371 = (FStar_Syntax_Util.head_and_args tm2)
+in (match (uu____1371) with
+| (hd1, uu____1382) -> begin
+(
+
+let uu____1397 = (
+
+let uu____1398 = (FStar_Syntax_Subst.compress hd1)
+in uu____1398.FStar_Syntax_Syntax.n)
+in (match (uu____1397) with
+| FStar_Syntax_Syntax.Tm_uvar (uu____1401) -> begin
+true
+end
+| uu____1410 -> begin
+false
+end))
+end))
+end))))
+in ((solve goal solution);
+(
+
+let sub_goals = (
+
+let uu____1414 = (FStar_All.pipe_right implicits1 (FStar_List.map (fun uu____1430 -> (match (uu____1430) with
+| (_msg, _env, _uvar, term, typ, uu____1442) -> begin
+{context = goal.context; witness = Some (term); goal_ty = typ}
+end))))
+in ((
+
+let uu___89_1443 = goal
+in {context = uu___89_1443.context; witness = None; goal_ty = pre}))::uu____1414)
+in (
+
+let uu____1444 = (add_implicits g1.FStar_TypeChecker_Env.implicits)
+in (bind uu____1444 (fun uu____1446 -> (bind dismiss (fun uu____1447 -> (add_goals sub_goals)))))));
+))))
+end))
+end))))
+end))
+end))
+end))
+end))
+end)
+with
+| uu____1450 -> begin
+(fail "apply_lemma: ill-typed term")
+end)))
+
+
+let exact : FStar_Syntax_Syntax.term  ->  Prims.unit tac = (fun tm -> (with_cur_goal "exact" (fun goal -> try
+(match (()) with
+| () -> begin
+(
+
+let uu____1460 = (goal.context.FStar_TypeChecker_Env.type_of goal.context tm)
+in (match (uu____1460) with
+| (uu____1465, t, guard) -> begin
+(
+
+let uu____1468 = (FStar_TypeChecker_Rel.teq_nosmt goal.context t goal.goal_ty)
+in (match (uu____1468) with
+| true -> begin
+((solve goal tm);
+(replace (
+
+let uu___92_1471 = goal
+in {context = uu___92_1471.context; witness = None; goal_ty = FStar_Syntax_Util.t_true}));
+)
+end
+| uu____1472 -> begin
+(
+
+let msg = (
+
+let uu____1474 = (FStar_Syntax_Print.term_to_string tm)
+in (
+
+let uu____1475 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____1476 = (FStar_Syntax_Print.term_to_string goal.goal_ty)
+in (FStar_Util.format3 "%s : %s does not exactly solve the goal %s" uu____1474 uu____1475 uu____1476))))
+in (fail msg))
+end))
+end))
+end)
+with
+| e -> begin
+(
+
+let uu____1480 = (
+
+let uu____1481 = (FStar_Syntax_Print.term_to_string tm)
+in (FStar_Util.format1 "Term is not typeable: %s" uu____1481))
+in (fail uu____1480))
+end)))
+
+
+let rewrite : FStar_Syntax_Syntax.binder  ->  Prims.unit tac = (fun h -> (with_cur_goal "rewrite" (fun goal -> ((
+
+let uu____1489 = (FStar_Syntax_Print.bv_to_string (Prims.fst h))
+in (
+
+let uu____1490 = (FStar_Syntax_Print.term_to_string (Prims.fst h).FStar_Syntax_Syntax.sort)
+in (FStar_Util.print2 "+++Rewrite %s : %s\n" uu____1489 uu____1490)));
+(
+
+let uu____1491 = (
+
+let uu____1493 = (
+
+let uu____1494 = (FStar_TypeChecker_Env.lookup_bv goal.context (Prims.fst h))
+in (FStar_All.pipe_left Prims.fst uu____1494))
+in (FStar_Syntax_Util.destruct_typ_as_formula uu____1493))
+in (match (uu____1491) with
+| Some (FStar_Syntax_Util.BaseConn (l, (uu____1501)::((x, uu____1503))::((e, uu____1505))::[])) when (FStar_Ident.lid_equals l FStar_Syntax_Const.eq2_lid) -> begin
+(
+
+let uu____1539 = (
+
+let uu____1540 = (FStar_Syntax_Subst.compress x)
+in uu____1540.FStar_Syntax_Syntax.n)
+in (match (uu____1539) with
+| FStar_Syntax_Syntax.Tm_name (x1) -> begin
+(
+
+let goal1 = (
+
+let uu___93_1546 = goal
+in (
+
+let uu____1547 = (FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.NT (((x1), (e))))::[]) goal.goal_ty)
+in {context = uu___93_1546.context; witness = uu___93_1546.witness; goal_ty = uu____1547}))
+in (replace goal1))
+end
+| uu____1550 -> begin
+(fail "Not an equality hypothesis with a variable on the LHS")
+end))
+end
+| uu____1551 -> begin
+(fail "Not an equality hypothesis")
+end));
+))))
+
+
+let clear : Prims.unit tac = (with_cur_goal "clear" (fun goal -> (
+
+let uu____1555 = (FStar_TypeChecker_Env.pop_bv goal.context)
+in (match (uu____1555) with
+| None -> begin
+(fail "Cannot clear; empty context")
+end
+| Some (x, env') -> begin
+(
+
+let fns = (FStar_Syntax_Free.names goal.goal_ty)
+in (
+
+let uu____1568 = (FStar_Util.set_mem x fns)
+in (match (uu____1568) with
+| true -> begin
+(fail "Cannot clear; variable appears in goal")
+end
+| uu____1570 -> begin
+(
+
+let new_goal = (
+
+let uu___94_1572 = goal
+in {context = env'; witness = uu___94_1572.witness; goal_ty = uu___94_1572.goal_ty})
+in (bind dismiss (fun uu____1573 -> (add_goals ((new_goal)::[])))))
+end)))
+end))))
+
+
+let clear_hd : name  ->  Prims.unit tac = (fun x -> (with_cur_goal "clear_hd" (fun goal -> (
+
+let uu____1580 = (FStar_TypeChecker_Env.pop_bv goal.context)
+in (match (uu____1580) with
+| None -> begin
+(fail "Cannot clear_hd; empty context")
+end
+| Some (y, env') -> begin
+(match ((not ((FStar_Syntax_Syntax.bv_eq x y)))) with
+| true -> begin
+(fail "Cannot clear_hd; head variable mismatch")
+end
+| uu____1592 -> begin
+clear
+end)
+end)))))
+
+
+let revert : Prims.unit tac = (with_cur_goal "revert" (fun goal -> (
+
+let uu____1595 = (FStar_TypeChecker_Env.pop_bv goal.context)
+in (match (uu____1595) with
+| None -> begin
+(fail "Cannot clear_hd; empty context")
+end
+| Some (x, env') -> begin
+(
+
+let fns = (FStar_Syntax_Free.names goal.goal_ty)
+in ((
+
+let uu____1609 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.print1 "reverting %s\n" uu____1609));
+(
+
+let uu____1610 = (
+
+let uu____1611 = (FStar_Util.set_mem x fns)
+in (not (uu____1611)))
+in (match (uu____1610) with
+| true -> begin
+(clear_hd x)
+end
+| uu____1613 -> begin
+(
+
+let new_goal = (
+
+let uu____1615 = (
+
+let uu____1624 = (un_squash x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____1628 = (un_squash goal.goal_ty)
+in ((uu____1624), (uu____1628))))
+in (match (uu____1615) with
+| (Some (p), Some (q)) -> begin
+(
+
+let uu___95_1654 = goal
+in (
+
+let uu____1655 = (FStar_Syntax_Util.mk_imp p q)
+in {context = env'; witness = uu___95_1654.witness; goal_ty = uu____1655}))
+end
+| uu____1656 -> begin
+(
+
+let uu___96_1665 = goal
+in (
+
+let uu____1666 = (
+
+let uu____1667 = (FStar_TypeChecker_TcTerm.universe_of env' x.FStar_Syntax_Syntax.sort)
+in (FStar_Syntax_Util.mk_forall uu____1667 x goal.goal_ty))
+in {context = env'; witness = uu___96_1665.witness; goal_ty = uu____1666}))
+end))
+in (bind dismiss (fun uu____1668 -> (add_goals ((new_goal)::[])))))
+end));
+))
+end))))
+
+
+let revert_hd : name  ->  Prims.unit tac = (fun x -> (with_cur_goal "revert_hd" (fun goal -> (
+
+let uu____1675 = (FStar_TypeChecker_Env.pop_bv goal.context)
+in (match (uu____1675) with
+| None -> begin
+(fail "Cannot revert_hd; empty context")
+end
+| Some (y, env') -> begin
+(match ((not ((FStar_Syntax_Syntax.bv_eq x y)))) with
+| true -> begin
+(
+
+let uu____1687 = (
+
+let uu____1688 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____1689 = (FStar_Syntax_Print.bv_to_string y)
+in (FStar_Util.format2 "Cannot revert_hd %s; head variable mismatch ... egot %s" uu____1688 uu____1689)))
+in (fail uu____1687))
+end
+| uu____1690 -> begin
+revert
+end)
+end)))))
+
+
+let rec revert_all_hd : name Prims.list  ->  Prims.unit tac = (fun xs -> (match (xs) with
+| [] -> begin
+(ret ())
+end
+| (x)::xs1 -> begin
+(
+
+let uu____1702 = (revert_all_hd xs1)
+in (bind uu____1702 (fun uu____1704 -> (revert_hd x))))
+end))
+
+
+let is_name : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun x -> (
+
+let uu____1708 = (
+
+let uu____1709 = (FStar_Syntax_Subst.compress x)
+in uu____1709.FStar_Syntax_Syntax.n)
+in (match (uu____1708) with
+| FStar_Syntax_Syntax.Tm_name (uu____1712) -> begin
+true
+end
+| uu____1713 -> begin
+false
+end)))
+
+
+let as_name : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.bv = (fun x -> (
+
+let uu____1717 = (
+
+let uu____1718 = (FStar_Syntax_Subst.compress x)
+in uu____1718.FStar_Syntax_Syntax.n)
+in (match (uu____1717) with
+| FStar_Syntax_Syntax.Tm_name (x1) -> begin
+x1
+end
+| uu____1722 -> begin
+(failwith "Not a name")
+end)))
+
+
+let destruct_equality_imp : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.bv * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) Prims.option = (fun t -> (
+
+let uu____1734 = (FStar_Syntax_Util.destruct_typ_as_formula t)
+in (match (uu____1734) with
+| Some (FStar_Syntax_Util.BaseConn (l, ((lhs, uu____1746))::((rhs, uu____1748))::[])) when (FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid) -> begin
+(
+
+let uu____1774 = (FStar_Syntax_Util.destruct_typ_as_formula lhs)
+in (match (uu____1774) with
+| (Some (FStar_Syntax_Util.BaseConn (eq1, (_)::((x, _))::((e, _))::[]))) | (Some (FStar_Syntax_Util.BaseConn (eq1, ((x, _))::((e, _))::[]))) when ((FStar_Ident.lid_equals eq1 FStar_Syntax_Const.eq2_lid) && (is_name x)) -> begin
+(
+
+let uu____1846 = (
+
+let uu____1854 = (as_name x)
+in ((uu____1854), (e), (rhs)))
+in Some (uu____1846))
+end
+| uu____1866 -> begin
+None
+end))
+end
+| uu____1875 -> begin
+None
+end)))
+
+
+let at_most_one = (fun t -> (bind t (fun a -> (bind get (fun p -> (match (p.goals) with
+| ([]) | ((_)::[]) -> begin
+(ret a)
+end
+| uu____1898 -> begin
+(fail "expected at most one goal remaining")
+end))))))
+
+
+let goal_to_string : goal  ->  Prims.string = (fun g1 -> (
+
+let g1_binders = (
+
+let uu____1904 = (FStar_TypeChecker_Env.all_binders g1.context)
+in (FStar_All.pipe_right uu____1904 (FStar_Syntax_Print.binders_to_string ", ")))
+in (
+
+let uu____1905 = (FStar_Syntax_Print.term_to_string g1.goal_ty)
+in (FStar_Util.format2 "%s |- %s" g1_binders uu____1905))))
+
+
+let merge_sub_goals : Prims.unit tac = (
+
+let uu____1907 = (bind get (fun p -> (match (p.goals) with
+| (g1)::(g2)::rest -> begin
+(
+
+let uu____1915 = (((FStar_TypeChecker_Env.eq_gamma g1.context g2.context) && (FStar_Option.isNone g1.witness)) && (FStar_Option.isNone g2.witness))
+in (match (uu____1915) with
+| true -> begin
+(
+
+let uu____1917 = (
+
+let uu___97_1918 = p
+in (
+
+let uu____1919 = (
+
+let uu____1921 = (conj_goals g1 g2)
+in (uu____1921)::rest)
+in {main_context = uu___97_1918.main_context; main_goal = uu___97_1918.main_goal; all_implicits = uu___97_1918.all_implicits; goals = uu____1919; smt_goals = uu___97_1918.smt_goals; transaction = uu___97_1918.transaction}))
+in (set uu____1917))
+end
+| uu____1922 -> begin
+(
+
+let g1_binders = (
+
+let uu____1924 = (FStar_TypeChecker_Env.all_binders g1.context)
+in (FStar_All.pipe_right uu____1924 (FStar_Syntax_Print.binders_to_string ", ")))
+in (
+
+let g2_binders = (
+
+let uu____1926 = (FStar_TypeChecker_Env.all_binders g2.context)
+in (FStar_All.pipe_right uu____1926 (FStar_Syntax_Print.binders_to_string ", ")))
+in (
+
+let uu____1927 = (
+
+let uu____1928 = (goal_to_string g1)
+in (
+
+let uu____1929 = (goal_to_string g2)
+in (
+
+let uu____1930 = (
+
+let uu____1931 = (FStar_TypeChecker_Env.eq_gamma g1.context g2.context)
+in (FStar_All.pipe_right uu____1931 FStar_Util.string_of_bool))
+in (FStar_Util.format3 "Cannot merge sub-goals: incompatible contexts:\ng1=%s\ng2=%s\neq_gamma=%s\n" uu____1928 uu____1929 uu____1930))))
+in (fail uu____1927))))
+end))
+end
+| uu____1932 -> begin
+(
+
+let goals = (
+
+let uu____1935 = (FStar_All.pipe_right p.goals (FStar_List.map (fun x -> (FStar_Syntax_Print.term_to_string x.goal_ty))))
+in (FStar_All.pipe_right uu____1935 (FStar_String.concat "\n\t")))
+in (
+
+let uu____1941 = (FStar_Util.format1 "Cannot merge sub-goals: not enough sub-goals\n\tGoals are: %s" goals)
+in (fail uu____1941)))
+end)))
+in (name_tac "merge_sub_goals" uu____1907))
+
+
+let rec visit : Prims.unit tac  ->  Prims.unit tac = (fun callback -> (
+
+let uu____1949 = (
+
+let uu____1951 = (with_cur_goal "visit_strengthen_else" (fun goal -> (
+
+let uu____1954 = (FStar_Syntax_Util.destruct_typ_as_formula goal.goal_ty)
+in (match (uu____1954) with
+| None -> begin
+(
+
+let uu____1957 = (
+
+let uu____1958 = (FStar_Syntax_Subst.compress goal.goal_ty)
+in uu____1958.FStar_Syntax_Syntax.n)
+in (match (uu____1957) with
+| FStar_Syntax_Syntax.Tm_meta (uu____1962) -> begin
+(
+
+let uu____1967 = (visit callback)
+in (map_meta uu____1967))
+end
+| uu____1969 -> begin
+((
+
+let uu____1971 = (FStar_Syntax_Print.term_to_string goal.goal_ty)
+in (FStar_Util.print1 "Not a formula, split to smt %s\n" uu____1971));
+smt;
+)
+end))
+end
+| Some (FStar_Syntax_Util.QEx (uu____1972)) -> begin
+((
+
+let uu____1977 = (FStar_Syntax_Print.term_to_string goal.goal_ty)
+in (FStar_Util.print1 "Not yet handled: exists\n\tGoal is %s\n" uu____1977));
+(ret ());
+)
+end
+| Some (FStar_Syntax_Util.QAll (xs, uu____1979, uu____1980)) -> begin
+(bind intros (fun binders -> (
+
+let uu____1982 = (visit callback)
+in (bind uu____1982 (fun uu____1984 -> (
+
+let uu____1985 = (
+
+let uu____1987 = (FStar_List.map Prims.fst binders)
+in (revert_all_hd uu____1987))
+in (bind uu____1985 (fun uu____1991 -> (with_cur_goal "inner" (fun goal1 -> ((
+
+let uu____1994 = (goal_to_string goal1)
+in (FStar_Util.print1 "After reverting intros, goal is %s\n" uu____1994));
+(ret ());
+)))))))))))
+end
+| Some (FStar_Syntax_Util.BaseConn (l, uu____1996)) when (FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid) -> begin
+(
+
+let uu____1997 = (
+
+let uu____1999 = (visit callback)
+in (seq split uu____1999))
+in (bind uu____1997 (fun uu____2001 -> merge_sub_goals)))
+end
+| Some (FStar_Syntax_Util.BaseConn (l, uu____2003)) when (FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid) -> begin
+(bind imp_intro (fun h -> (
+
+let uu____2005 = (visit callback)
+in (bind uu____2005 (fun uu____2007 -> revert)))))
+end
+| Some (FStar_Syntax_Util.BaseConn (l, uu____2009)) -> begin
+(or_else trivial smt)
+end))))
+in (or_else callback uu____1951))
+in (focus_cur_goal "visit_strengthen" uu____1949)))
+
+
+let proofstate_of_goal_ty : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  proofstate = (fun env g -> (
+
+let g1 = (
+
+let uu____2017 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env g)
+in {context = env; witness = None; goal_ty = uu____2017})
+in (
+
+let uu____2018 = (FStar_Unionfind.new_transaction ())
+in {main_context = env; main_goal = g1; all_implicits = []; goals = (g1)::[]; smt_goals = []; transaction = uu____2018})))
+
+
+
+

--- a/src/ocaml-output/FStar_Tactics_Embedding.ml
+++ b/src/ocaml-output/FStar_Tactics_Embedding.ml
@@ -1,616 +1,967 @@
+
 open Prims
-type name = FStar_Syntax_Syntax.bv
-let fstar_tactics_lid: Prims.string -> FStar_Ident.lident =
-  fun s  ->
-    FStar_Ident.lid_of_path (FStar_List.append ["FStar"; "Tactics"] [s])
-      FStar_Range.dummyRange
-let by_tactic_lid: FStar_Ident.lident = fstar_tactics_lid "by_tactic"
-let lid_as_tm: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
-  fun l  ->
-    let uu____7 =
-      FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None in
-    FStar_All.pipe_right uu____7 FStar_Syntax_Syntax.fv_to_tm
-let mk_tactic_lid_as_term: Prims.string -> FStar_Syntax_Syntax.term =
-  fun s  -> let uu____11 = fstar_tactics_lid s in lid_as_tm uu____11
-let fstar_tactics_term: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "term"
-let fstar_tactics_env: FStar_Syntax_Syntax.term = mk_tactic_lid_as_term "env"
-let fstar_tactics_binder: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "binder"
-let fstar_tactics_binders: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "binders"
-let fstar_tactics_goal: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "goal"
-let fstar_tactics_goals: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "goals"
-let fstar_tactics_formula: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "formula"
-let fstar_tactics_embed: FStar_Syntax_Syntax.term =
-  mk_tactic_lid_as_term "embed"
-let lid_as_data_tm: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
-  fun l  ->
-    let uu____15 =
-      FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-        (Some FStar_Syntax_Syntax.Data_ctor) in
-    FStar_Syntax_Syntax.fv_to_tm uu____15
-let fstar_tactics_lid_as_data_tm: Prims.string -> FStar_Syntax_Syntax.term =
-  fun s  -> let uu____19 = fstar_tactics_lid s in lid_as_data_tm uu____19
-let fstar_tactics_Failed: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Failed"
-let fstar_tactics_Success: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Success"
-let fstar_tactics_True_: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "True_"
-let fstar_tactics_False_: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "False_"
-let fstar_tactics_Eq: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Eq"
-let fstar_tactics_And: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "And"
-let fstar_tactics_Or: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Or"
-let fstar_tactics_Not: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Not"
-let fstar_tactics_Implies: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Implies"
-let fstar_tactics_Iff: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Iff"
-let fstar_tactics_Forall: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Forall"
-let fstar_tactics_Exists: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Exists"
-let fstar_tactics_App: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "App"
-let fstar_tactics_Name: FStar_Syntax_Syntax.term =
-  fstar_tactics_lid_as_data_tm "Name"
-let lid_Mktuple2: FStar_Ident.lident =
-  FStar_Syntax_Util.mk_tuple_data_lid (Prims.parse_int "2")
-    FStar_Range.dummyRange
-let protect_embedded_term:
-  FStar_Syntax_Syntax.typ ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun t  ->
-    fun x  ->
-      let uu____28 =
-        let uu____29 =
-          let uu____30 = FStar_Syntax_Syntax.iarg t in
-          let uu____31 =
-            let uu____33 = FStar_Syntax_Syntax.as_arg x in [uu____33] in
-          uu____30 :: uu____31 in
-        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_embed uu____29 in
-      uu____28 None x.FStar_Syntax_Syntax.pos
-let un_protect_embedded_term:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  let embed_lid = fstar_tactics_lid "embed" in
-  fun t  ->
-    let uu____42 = FStar_Syntax_Util.head_and_args t in
-    match uu____42 with
-    | (head1,args) ->
-        let uu____68 =
-          let uu____76 =
-            let uu____77 = FStar_Syntax_Subst.compress head1 in
-            uu____77.FStar_Syntax_Syntax.n in
-          (uu____76, args) in
-        (match uu____68 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____86::(x,uu____88)::[]) when
-             FStar_Syntax_Syntax.fv_eq_lid fv embed_lid -> x
-         | uu____114 ->
-             let uu____122 =
-               let uu____123 = FStar_Syntax_Print.term_to_string t in
-               FStar_Util.format1 "Not a protected embedded term: %s"
-                 uu____123 in
-             failwith uu____122)
-exception Unembed_failed of Prims.string
-let uu___is_Unembed_failed: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Unembed_failed uu____129 -> true
-    | uu____130 -> false
-let __proj__Unembed_failed__item__uu___: Prims.exn -> Prims.string =
-  fun projectee  ->
-    match projectee with | Unembed_failed uu____137 -> uu____137
-let embed_binder:
-  FStar_Syntax_Syntax.binder ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun b  ->
-    let uu____141 = FStar_Syntax_Syntax.bv_to_name (Prims.fst b) in
-    protect_embedded_term fstar_tactics_binder uu____141
-let unembed_binder: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.binder =
-  fun t  ->
-    let t1 = un_protect_embedded_term t in
-    let t2 = FStar_Syntax_Util.unascribe t1 in
-    match t2.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_name bv -> FStar_Syntax_Syntax.mk_binder bv
-    | uu____148 -> failwith "Not an embedded binder"
-let embed_pair x embed_a t_a embed_b t_b =
-  let uu____192 =
-    let uu____193 =
-      let uu____194 = lid_as_data_tm lid_Mktuple2 in
-      FStar_Syntax_Syntax.mk_Tm_uinst uu____194
-        [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] in
-    let uu____195 =
-      let uu____196 = FStar_Syntax_Syntax.iarg t_a in
-      let uu____197 =
-        let uu____199 = FStar_Syntax_Syntax.iarg t_b in
-        let uu____200 =
-          let uu____202 =
-            let uu____203 = embed_a (Prims.fst x) in
-            FStar_Syntax_Syntax.as_arg uu____203 in
-          let uu____204 =
-            let uu____206 =
-              let uu____207 = embed_b (Prims.snd x) in
-              FStar_Syntax_Syntax.as_arg uu____207 in
-            [uu____206] in
-          uu____202 :: uu____204 in
-        uu____199 :: uu____200 in
-      uu____196 :: uu____197 in
-    FStar_Syntax_Syntax.mk_Tm_app uu____193 uu____195 in
-  uu____192 None FStar_Range.dummyRange
-let unembed_pair pair unembed_a unembed_b =
-  let pairs = FStar_Syntax_Util.unascribe pair in
-  let uu____244 = FStar_Syntax_Util.head_and_args pair in
-  match uu____244 with
-  | (hd1,args) ->
-      let uu____272 =
-        let uu____280 =
-          let uu____281 = FStar_Syntax_Util.un_uinst hd1 in
-          uu____281.FStar_Syntax_Syntax.n in
-        (uu____280, args) in
-      (match uu____272 with
-       | (FStar_Syntax_Syntax.Tm_fvar
-          fv,uu____292::uu____293::(a,uu____295)::(b,uu____297)::[]) when
-           FStar_Syntax_Syntax.fv_eq_lid fv lid_Mktuple2 ->
-           let uu____339 = unembed_a a in
-           let uu____340 = unembed_b b in (uu____339, uu____340)
-       | uu____341 -> failwith "Not an embedded pair")
-let embed_option embed_a typ o =
-  match o with
-  | None  ->
-      let uu____375 =
-        let uu____376 =
-          let uu____377 = lid_as_data_tm FStar_Syntax_Const.none_lid in
-          FStar_Syntax_Syntax.mk_Tm_uinst uu____377
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____378 =
-          let uu____379 = FStar_Syntax_Syntax.iarg typ in [uu____379] in
-        FStar_Syntax_Syntax.mk_Tm_app uu____376 uu____378 in
-      uu____375 None FStar_Range.dummyRange
-  | Some a ->
-      let uu____385 =
-        let uu____386 =
-          let uu____387 = lid_as_data_tm FStar_Syntax_Const.some_lid in
-          FStar_Syntax_Syntax.mk_Tm_uinst uu____387
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____388 =
-          let uu____389 = FStar_Syntax_Syntax.iarg typ in
-          let uu____390 =
-            let uu____392 =
-              let uu____393 = embed_a a in
-              FStar_Syntax_Syntax.as_arg uu____393 in
-            [uu____392] in
-          uu____389 :: uu____390 in
-        FStar_Syntax_Syntax.mk_Tm_app uu____386 uu____388 in
-      uu____385 None FStar_Range.dummyRange
-let unembed_option unembed_a o =
-  let uu____416 = FStar_Syntax_Util.head_and_args o in
-  match uu____416 with
-  | (hd1,args) ->
-      let uu____443 =
-        let uu____451 =
-          let uu____452 = FStar_Syntax_Util.un_uinst hd1 in
-          uu____452.FStar_Syntax_Syntax.n in
-        (uu____451, args) in
-      (match uu____443 with
-       | (FStar_Syntax_Syntax.Tm_fvar fv,uu____462) when
-           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.none_lid ->
-           None
-       | (FStar_Syntax_Syntax.Tm_fvar fv,uu____474::(a,uu____476)::[]) when
-           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.some_lid ->
-           let uu____502 = unembed_a a in Some uu____502
-       | uu____503 -> failwith "Not an embedded option")
-let rec embed_list l embed_a t_a =
-  match l with
-  | [] ->
-      let uu____536 =
-        let uu____537 =
-          let uu____538 = lid_as_data_tm FStar_Syntax_Const.nil_lid in
-          FStar_Syntax_Syntax.mk_Tm_uinst uu____538
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____539 =
-          let uu____540 = FStar_Syntax_Syntax.iarg t_a in [uu____540] in
-        FStar_Syntax_Syntax.mk_Tm_app uu____537 uu____539 in
-      uu____536 None FStar_Range.dummyRange
-  | hd1::tl1 ->
-      let uu____548 =
-        let uu____549 =
-          let uu____550 = lid_as_data_tm FStar_Syntax_Const.cons_lid in
-          FStar_Syntax_Syntax.mk_Tm_uinst uu____550
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____551 =
-          let uu____552 = FStar_Syntax_Syntax.iarg t_a in
-          let uu____553 =
-            let uu____555 =
-              let uu____556 = embed_a hd1 in
-              FStar_Syntax_Syntax.as_arg uu____556 in
-            let uu____557 =
-              let uu____559 =
-                let uu____560 = embed_list tl1 embed_a t_a in
-                FStar_Syntax_Syntax.as_arg uu____560 in
-              [uu____559] in
-            uu____555 :: uu____557 in
-          uu____552 :: uu____553 in
-        FStar_Syntax_Syntax.mk_Tm_app uu____549 uu____551 in
-      uu____548 None FStar_Range.dummyRange
-let rec unembed_list l unembed_a =
-  let l1 = FStar_Syntax_Util.unascribe l in
-  let uu____584 = FStar_Syntax_Util.head_and_args l1 in
-  match uu____584 with
-  | (hd1,args) ->
-      let uu____611 =
-        let uu____619 =
-          let uu____620 = FStar_Syntax_Util.un_uinst hd1 in
-          uu____620.FStar_Syntax_Syntax.n in
-        (uu____619, args) in
-      (match uu____611 with
-       | (FStar_Syntax_Syntax.Tm_fvar fv,uu____630) when
-           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.nil_lid -> []
-       | (FStar_Syntax_Syntax.Tm_fvar
-          fv,_t::(hd2,uu____644)::(tl1,uu____646)::[]) when
-           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.cons_lid ->
-           let uu____680 = unembed_a hd2 in
-           let uu____681 = unembed_list tl1 unembed_a in uu____680 ::
-             uu____681
-       | uu____683 ->
-           let uu____691 =
-             let uu____692 = FStar_Syntax_Print.term_to_string l1 in
-             FStar_Util.format1 "Not an embedded list: %s" uu____692 in
-           failwith uu____691)
-let embed_binders:
-  FStar_Syntax_Syntax.binder Prims.list -> FStar_Syntax_Syntax.term =
-  fun l  -> embed_list l embed_binder fstar_tactics_binder
-let unembed_binders:
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.binder Prims.list =
-  fun t  -> unembed_list t unembed_binder
-let embed_env:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    let uu____706 =
-      let uu____707 = FStar_TypeChecker_Env.all_binders env in
-      embed_list uu____707 embed_binder fstar_tactics_binder in
-    protect_embedded_term fstar_tactics_env uu____706
-let unembed_env:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_TypeChecker_Env.env
-  =
-  fun env  ->
-    fun protected_embedded_env  ->
-      let embedded_env = un_protect_embedded_term protected_embedded_env in
-      let binders = unembed_list embedded_env unembed_binder in
-      (let uu____723 = FStar_Syntax_Print.binders_to_string ", " binders in
-       FStar_Util.print1 "Unembedding environment: %s\n" uu____723);
-      FStar_List.fold_left
-        (fun env1  ->
-           fun b  ->
-             let uu____730 =
-               FStar_TypeChecker_Env.try_lookup_bv env1 (Prims.fst b) in
-             match uu____730 with
-             | None  -> FStar_TypeChecker_Env.push_binders env1 [b]
-             | uu____740 -> env1) env binders
-let embed_term:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  = fun t  -> protect_embedded_term fstar_tactics_term t
-let unembed_term: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun t  -> un_protect_embedded_term t
-let embed_goal: FStar_Tactics_Basic.goal -> FStar_Syntax_Syntax.term =
-  fun g  ->
-    embed_pair
-      ((g.FStar_Tactics_Basic.context), (g.FStar_Tactics_Basic.goal_ty))
-      embed_env fstar_tactics_env embed_term fstar_tactics_term
-let unembed_goal:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Tactics_Basic.goal
-  =
-  fun env  ->
-    fun t  ->
-      let uu____759 = unembed_pair t (unembed_env env) unembed_term in
-      match uu____759 with
-      | (env1,goal_ty) ->
-          {
-            FStar_Tactics_Basic.context = env1;
-            FStar_Tactics_Basic.witness = None;
-            FStar_Tactics_Basic.goal_ty = goal_ty
-          }
-let embed_goals:
-  FStar_Tactics_Basic.goal Prims.list -> FStar_Syntax_Syntax.term =
-  fun l  -> embed_list l embed_goal fstar_tactics_goal
-let unembed_goals:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Tactics_Basic.goal Prims.list
-  = fun env  -> fun egs  -> unembed_list egs (unembed_goal env)
+
+type name =
+FStar_Syntax_Syntax.bv
+
+
+let fstar_tactics_lid : Prims.string  ->  FStar_Ident.lident = (fun s -> (FStar_Ident.lid_of_path (FStar_List.append (("FStar")::("Tactics")::[]) ((s)::[])) FStar_Range.dummyRange))
+
+
+let by_tactic_lid : FStar_Ident.lident = (fstar_tactics_lid "by_tactic")
+
+
+let lid_as_tm : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term = (fun l -> (
+
+let uu____7 = (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_All.pipe_right uu____7 FStar_Syntax_Syntax.fv_to_tm)))
+
+
+let mk_tactic_lid_as_term : Prims.string  ->  FStar_Syntax_Syntax.term = (fun s -> (
+
+let uu____11 = (fstar_tactics_lid s)
+in (lid_as_tm uu____11)))
+
+
+let fstar_tactics_term : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "term")
+
+
+let fstar_tactics_env : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "env")
+
+
+let fstar_tactics_binder : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "binder")
+
+
+let fstar_tactics_binders : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "binders")
+
+
+let fstar_tactics_goal : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "goal")
+
+
+let fstar_tactics_goals : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "goals")
+
+
+let fstar_tactics_formula : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "formula")
+
+
+let fstar_tactics_embed : FStar_Syntax_Syntax.term = (mk_tactic_lid_as_term "embed")
+
+
+let lid_as_data_tm : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term = (fun l -> (
+
+let uu____15 = (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in (FStar_Syntax_Syntax.fv_to_tm uu____15)))
+
+
+let fstar_tactics_lid_as_data_tm : Prims.string  ->  FStar_Syntax_Syntax.term = (fun s -> (
+
+let uu____19 = (fstar_tactics_lid s)
+in (lid_as_data_tm uu____19)))
+
+
+let fstar_tactics_Failed : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Failed")
+
+
+let fstar_tactics_Success : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Success")
+
+
+let fstar_tactics_True_ : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "True_")
+
+
+let fstar_tactics_False_ : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "False_")
+
+
+let fstar_tactics_Eq : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Eq")
+
+
+let fstar_tactics_And : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "And")
+
+
+let fstar_tactics_Or : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Or")
+
+
+let fstar_tactics_Not : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Not")
+
+
+let fstar_tactics_Implies : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Implies")
+
+
+let fstar_tactics_Iff : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Iff")
+
+
+let fstar_tactics_Forall : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Forall")
+
+
+let fstar_tactics_Exists : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Exists")
+
+
+let fstar_tactics_App : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "App")
+
+
+let fstar_tactics_Name : FStar_Syntax_Syntax.term = (fstar_tactics_lid_as_data_tm "Name")
+
+
+let lid_Mktuple2 : FStar_Ident.lident = (FStar_Syntax_Util.mk_tuple_data_lid (Prims.parse_int "2") FStar_Range.dummyRange)
+
+
+let protect_embedded_term : FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun t x -> (
+
+let uu____28 = (
+
+let uu____29 = (
+
+let uu____30 = (FStar_Syntax_Syntax.iarg t)
+in (
+
+let uu____31 = (
+
+let uu____33 = (FStar_Syntax_Syntax.as_arg x)
+in (uu____33)::[])
+in (uu____30)::uu____31))
+in (FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_embed uu____29))
+in (uu____28 None x.FStar_Syntax_Syntax.pos)))
+
+
+let un_protect_embedded_term : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (
+
+let embed_lid = (fstar_tactics_lid "embed")
+in (fun t -> (
+
+let uu____42 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____42) with
+| (head1, args) -> begin
+(
+
+let uu____68 = (
+
+let uu____76 = (
+
+let uu____77 = (FStar_Syntax_Subst.compress head1)
+in uu____77.FStar_Syntax_Syntax.n)
+in ((uu____76), (args)))
+in (match (uu____68) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____86)::((x, uu____88))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv embed_lid) -> begin
+x
+end
+| uu____114 -> begin
+(
+
+let uu____122 = (
+
+let uu____123 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format1 "Not a protected embedded term: %s" uu____123))
+in (failwith uu____122))
+end))
+end))))
+
+exception Unembed_failed of (Prims.string)
+
+
+let uu___is_Unembed_failed : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unembed_failed (uu____129) -> begin
+true
+end
+| uu____130 -> begin
+false
+end))
+
+
+let __proj__Unembed_failed__item__uu___ : Prims.exn  ->  Prims.string = (fun projectee -> (match (projectee) with
+| Unembed_failed (uu____137) -> begin
+uu____137
+end))
+
+
+let embed_binder : FStar_Syntax_Syntax.binder  ->  FStar_Syntax_Syntax.term = (fun b -> (
+
+let uu____141 = (FStar_Syntax_Syntax.bv_to_name (Prims.fst b))
+in (protect_embedded_term fstar_tactics_binder uu____141)))
+
+
+let unembed_binder : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.binder = (fun t -> (
+
+let t1 = (un_protect_embedded_term t)
+in (
+
+let t2 = (FStar_Syntax_Util.unascribe t1)
+in (match (t2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+(FStar_Syntax_Syntax.mk_binder bv)
+end
+| uu____148 -> begin
+(failwith "Not an embedded binder")
+end))))
+
+
+let embed_pair = (fun x embed_a t_a embed_b t_b -> (
+
+let uu____192 = (
+
+let uu____193 = (
+
+let uu____194 = (lid_as_data_tm lid_Mktuple2)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____194 ((FStar_Syntax_Syntax.U_zero)::(FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____195 = (
+
+let uu____196 = (FStar_Syntax_Syntax.iarg t_a)
+in (
+
+let uu____197 = (
+
+let uu____199 = (FStar_Syntax_Syntax.iarg t_b)
+in (
+
+let uu____200 = (
+
+let uu____202 = (
+
+let uu____203 = (embed_a (Prims.fst x))
+in (FStar_Syntax_Syntax.as_arg uu____203))
+in (
+
+let uu____204 = (
+
+let uu____206 = (
+
+let uu____207 = (embed_b (Prims.snd x))
+in (FStar_Syntax_Syntax.as_arg uu____207))
+in (uu____206)::[])
+in (uu____202)::uu____204))
+in (uu____199)::uu____200))
+in (uu____196)::uu____197))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____193 uu____195)))
+in (uu____192 None FStar_Range.dummyRange)))
+
+
+let unembed_pair = (fun pair unembed_a unembed_b -> (
+
+let pairs = (FStar_Syntax_Util.unascribe pair)
+in (
+
+let uu____244 = (FStar_Syntax_Util.head_and_args pair)
+in (match (uu____244) with
+| (hd1, args) -> begin
+(
+
+let uu____272 = (
+
+let uu____280 = (
+
+let uu____281 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____281.FStar_Syntax_Syntax.n)
+in ((uu____280), (args)))
+in (match (uu____272) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____292)::(uu____293)::((a, uu____295))::((b, uu____297))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv lid_Mktuple2) -> begin
+(
+
+let uu____339 = (unembed_a a)
+in (
+
+let uu____340 = (unembed_b b)
+in ((uu____339), (uu____340))))
+end
+| uu____341 -> begin
+(failwith "Not an embedded pair")
+end))
+end))))
+
+
+let embed_option = (fun embed_a typ o -> (match (o) with
+| None -> begin
+(
+
+let uu____375 = (
+
+let uu____376 = (
+
+let uu____377 = (lid_as_data_tm FStar_Syntax_Const.none_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____377 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____378 = (
+
+let uu____379 = (FStar_Syntax_Syntax.iarg typ)
+in (uu____379)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____376 uu____378)))
+in (uu____375 None FStar_Range.dummyRange))
+end
+| Some (a) -> begin
+(
+
+let uu____385 = (
+
+let uu____386 = (
+
+let uu____387 = (lid_as_data_tm FStar_Syntax_Const.some_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____387 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____388 = (
+
+let uu____389 = (FStar_Syntax_Syntax.iarg typ)
+in (
+
+let uu____390 = (
+
+let uu____392 = (
+
+let uu____393 = (embed_a a)
+in (FStar_Syntax_Syntax.as_arg uu____393))
+in (uu____392)::[])
+in (uu____389)::uu____390))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____386 uu____388)))
+in (uu____385 None FStar_Range.dummyRange))
+end))
+
+
+let unembed_option = (fun unembed_a o -> (
+
+let uu____416 = (FStar_Syntax_Util.head_and_args o)
+in (match (uu____416) with
+| (hd1, args) -> begin
+(
+
+let uu____443 = (
+
+let uu____451 = (
+
+let uu____452 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____452.FStar_Syntax_Syntax.n)
+in ((uu____451), (args)))
+in (match (uu____443) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), uu____462) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.none_lid) -> begin
+None
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____474)::((a, uu____476))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.some_lid) -> begin
+(
+
+let uu____502 = (unembed_a a)
+in Some (uu____502))
+end
+| uu____503 -> begin
+(failwith "Not an embedded option")
+end))
+end)))
+
+
+let rec embed_list = (fun l embed_a t_a -> (match (l) with
+| [] -> begin
+(
+
+let uu____536 = (
+
+let uu____537 = (
+
+let uu____538 = (lid_as_data_tm FStar_Syntax_Const.nil_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____538 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____539 = (
+
+let uu____540 = (FStar_Syntax_Syntax.iarg t_a)
+in (uu____540)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____537 uu____539)))
+in (uu____536 None FStar_Range.dummyRange))
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____548 = (
+
+let uu____549 = (
+
+let uu____550 = (lid_as_data_tm FStar_Syntax_Const.cons_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____550 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____551 = (
+
+let uu____552 = (FStar_Syntax_Syntax.iarg t_a)
+in (
+
+let uu____553 = (
+
+let uu____555 = (
+
+let uu____556 = (embed_a hd1)
+in (FStar_Syntax_Syntax.as_arg uu____556))
+in (
+
+let uu____557 = (
+
+let uu____559 = (
+
+let uu____560 = (embed_list tl1 embed_a t_a)
+in (FStar_Syntax_Syntax.as_arg uu____560))
+in (uu____559)::[])
+in (uu____555)::uu____557))
+in (uu____552)::uu____553))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____549 uu____551)))
+in (uu____548 None FStar_Range.dummyRange))
+end))
+
+
+let rec unembed_list = (fun l unembed_a -> (
+
+let l1 = (FStar_Syntax_Util.unascribe l)
+in (
+
+let uu____584 = (FStar_Syntax_Util.head_and_args l1)
+in (match (uu____584) with
+| (hd1, args) -> begin
+(
+
+let uu____611 = (
+
+let uu____619 = (
+
+let uu____620 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____620.FStar_Syntax_Syntax.n)
+in ((uu____619), (args)))
+in (match (uu____611) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), uu____630) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.nil_lid) -> begin
+[]
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (_t)::((hd2, uu____644))::((tl1, uu____646))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.cons_lid) -> begin
+(
+
+let uu____680 = (unembed_a hd2)
+in (
+
+let uu____681 = (unembed_list tl1 unembed_a)
+in (uu____680)::uu____681))
+end
+| uu____683 -> begin
+(
+
+let uu____691 = (
+
+let uu____692 = (FStar_Syntax_Print.term_to_string l1)
+in (FStar_Util.format1 "Not an embedded list: %s" uu____692))
+in (failwith uu____691))
+end))
+end))))
+
+
+let embed_binders : FStar_Syntax_Syntax.binder Prims.list  ->  FStar_Syntax_Syntax.term = (fun l -> (embed_list l embed_binder fstar_tactics_binder))
+
+
+let unembed_binders : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.binder Prims.list = (fun t -> (unembed_list t unembed_binder))
+
+
+let embed_env : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term = (fun env -> (
+
+let uu____706 = (
+
+let uu____707 = (FStar_TypeChecker_Env.all_binders env)
+in (embed_list uu____707 embed_binder fstar_tactics_binder))
+in (protect_embedded_term fstar_tactics_env uu____706)))
+
+
+let unembed_env : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_TypeChecker_Env.env = (fun env protected_embedded_env -> (
+
+let embedded_env = (un_protect_embedded_term protected_embedded_env)
+in (
+
+let binders = (unembed_list embedded_env unembed_binder)
+in ((
+
+let uu____723 = (FStar_Syntax_Print.binders_to_string ", " binders)
+in (FStar_Util.print1 "Unembedding environment: %s\n" uu____723));
+(FStar_List.fold_left (fun env1 b -> (
+
+let uu____730 = (FStar_TypeChecker_Env.try_lookup_bv env1 (Prims.fst b))
+in (match (uu____730) with
+| None -> begin
+(FStar_TypeChecker_Env.push_binders env1 ((b)::[]))
+end
+| uu____740 -> begin
+env1
+end))) env binders);
+))))
+
+
+let embed_term : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (protect_embedded_term fstar_tactics_term t))
+
+
+let unembed_term : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun t -> (un_protect_embedded_term t))
+
+
+let embed_goal : FStar_Tactics_Basic.goal  ->  FStar_Syntax_Syntax.term = (fun g -> (embed_pair ((g.FStar_Tactics_Basic.context), (g.FStar_Tactics_Basic.goal_ty)) embed_env fstar_tactics_env embed_term fstar_tactics_term))
+
+
+let unembed_goal : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Tactics_Basic.goal = (fun env t -> (
+
+let uu____759 = (unembed_pair t (unembed_env env) unembed_term)
+in (match (uu____759) with
+| (env1, goal_ty) -> begin
+{FStar_Tactics_Basic.context = env1; FStar_Tactics_Basic.witness = None; FStar_Tactics_Basic.goal_ty = goal_ty}
+end)))
+
+
+let embed_goals : FStar_Tactics_Basic.goal Prims.list  ->  FStar_Syntax_Syntax.term = (fun l -> (embed_list l embed_goal fstar_tactics_goal))
+
+
+let unembed_goals : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Tactics_Basic.goal Prims.list = (fun env egs -> (unembed_list egs (unembed_goal env)))
+
+
 type state =
-  (FStar_Tactics_Basic.goal Prims.list* FStar_Tactics_Basic.goal Prims.list)
-let embed_state: state -> FStar_Syntax_Syntax.term =
-  fun s  ->
-    embed_pair s embed_goals fstar_tactics_goals embed_goals
-      fstar_tactics_goals
-let unembed_state:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Tactics_Basic.goal Prims.list* FStar_Tactics_Basic.goal
-        Prims.list)
-  =
-  fun env  ->
-    fun s  ->
-      let s1 = FStar_Syntax_Util.unascribe s in
-      unembed_pair s1 (unembed_goals env) (unembed_goals env)
-let embed_unit: Prims.unit -> FStar_Syntax_Syntax.term =
-  fun u  -> FStar_Syntax_Const.exp_unit
-let unembed_unit: FStar_Syntax_Syntax.term -> Prims.unit =
-  fun uu____800  -> ()
-let embed_bool: Prims.bool -> FStar_Syntax_Syntax.term =
-  fun b  ->
-    if b
-    then FStar_Syntax_Const.exp_true_bool
-    else FStar_Syntax_Const.exp_false_bool
-let unembed_bool: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____808 =
-      let uu____809 = FStar_Syntax_Subst.compress t in
-      uu____809.FStar_Syntax_Syntax.n in
-    match uu____808 with
-    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool b) -> b
-    | uu____813 -> failwith "Not an embedded bool"
-let embed_string:
-  Prims.string ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun s  ->
-    let bytes = FStar_Util.unicode_of_string s in
-    (FStar_Syntax_Syntax.mk
-       (FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string (bytes, FStar_Range.dummyRange)))) None
-      FStar_Range.dummyRange
-let unembed_string: FStar_Syntax_Syntax.term -> Prims.string =
-  fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t in
-    match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-        (bytes,uu____833)) -> FStar_Util.string_of_unicode bytes
-    | uu____836 -> failwith "Not an embedded string"
-let embed_result res embed_a t_a =
-  match res with
-  | FStar_Tactics_Basic.Failed (msg,ps) ->
-      let uu____863 =
-        let uu____864 =
-          FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____865 =
-          let uu____866 = FStar_Syntax_Syntax.iarg t_a in
-          let uu____867 =
-            let uu____869 =
-              let uu____870 = embed_string msg in
-              FStar_Syntax_Syntax.as_arg uu____870 in
-            let uu____871 =
-              let uu____873 =
-                let uu____874 =
-                  embed_state
-                    ((ps.FStar_Tactics_Basic.goals),
-                      (ps.FStar_Tactics_Basic.smt_goals)) in
-                FStar_Syntax_Syntax.as_arg uu____874 in
-              [uu____873] in
-            uu____869 :: uu____871 in
-          uu____866 :: uu____867 in
-        FStar_Syntax_Syntax.mk_Tm_app uu____864 uu____865 in
-      uu____863 None FStar_Range.dummyRange
-  | FStar_Tactics_Basic.Success (a,ps) ->
-      let uu____883 =
-        let uu____884 =
-          FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success
-            [FStar_Syntax_Syntax.U_zero] in
-        let uu____885 =
-          let uu____886 = FStar_Syntax_Syntax.iarg t_a in
-          let uu____887 =
-            let uu____889 =
-              let uu____890 = embed_a a in
-              FStar_Syntax_Syntax.as_arg uu____890 in
-            let uu____891 =
-              let uu____893 =
-                let uu____894 =
-                  embed_state
-                    ((ps.FStar_Tactics_Basic.goals),
-                      (ps.FStar_Tactics_Basic.smt_goals)) in
-                FStar_Syntax_Syntax.as_arg uu____894 in
-              [uu____893] in
-            uu____889 :: uu____891 in
-          uu____886 :: uu____887 in
-        FStar_Syntax_Syntax.mk_Tm_app uu____884 uu____885 in
-      uu____883 None FStar_Range.dummyRange
-let unembed_result env res unembed_a =
-  let res1 = FStar_Syntax_Util.unascribe res in
-  let uu____930 = FStar_Syntax_Util.head_and_args res1 in
-  match uu____930 with
-  | (hd1,args) ->
-      let uu____962 =
-        let uu____970 =
-          let uu____971 = FStar_Syntax_Util.un_uinst hd1 in
-          uu____971.FStar_Syntax_Syntax.n in
-        (uu____970, args) in
-      (match uu____962 with
-       | (FStar_Syntax_Syntax.Tm_fvar
-          fv,_t::(a,uu____988)::(embedded_state,uu____990)::[]) when
-           let uu____1024 = fstar_tactics_lid "Success" in
-           FStar_Syntax_Syntax.fv_eq_lid fv uu____1024 ->
-           let uu____1025 =
-             let uu____1028 = unembed_a a in
-             let uu____1029 = unembed_state env embedded_state in
-             (uu____1028, uu____1029) in
-           FStar_Util.Inl uu____1025
-       | (FStar_Syntax_Syntax.Tm_fvar
-          fv,_t::(embedded_string,uu____1037)::(embedded_state,uu____1039)::[])
-           when
-           let uu____1073 = fstar_tactics_lid "Failed" in
-           FStar_Syntax_Syntax.fv_eq_lid fv uu____1073 ->
-           let uu____1074 =
-             let uu____1077 = unembed_string embedded_string in
-             let uu____1078 = unembed_state env embedded_state in
-             (uu____1077, uu____1078) in
-           FStar_Util.Inr uu____1074
-       | uu____1083 ->
-           let uu____1091 =
-             let uu____1092 = FStar_Syntax_Print.term_to_string res1 in
-             FStar_Util.format1 "Not an embedded result: %s" uu____1092 in
-           failwith uu____1091)
+(FStar_Tactics_Basic.goal Prims.list * FStar_Tactics_Basic.goal Prims.list)
+
+
+let embed_state : state  ->  FStar_Syntax_Syntax.term = (fun s -> (embed_pair s embed_goals fstar_tactics_goals embed_goals fstar_tactics_goals))
+
+
+let unembed_state : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  state = (fun env s -> (
+
+let s1 = (FStar_Syntax_Util.unascribe s)
+in (unembed_pair s1 (unembed_goals env) (unembed_goals env))))
+
+
+let embed_unit : Prims.unit  ->  FStar_Syntax_Syntax.term = (fun u -> FStar_Syntax_Const.exp_unit)
+
+
+let unembed_unit : FStar_Syntax_Syntax.term  ->  Prims.unit = (fun uu____800 -> ())
+
+
+let embed_bool : Prims.bool  ->  FStar_Syntax_Syntax.term = (fun b -> (match (b) with
+| true -> begin
+FStar_Syntax_Const.exp_true_bool
+end
+| uu____804 -> begin
+FStar_Syntax_Const.exp_false_bool
+end))
+
+
+let unembed_bool : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____808 = (
+
+let uu____809 = (FStar_Syntax_Subst.compress t)
+in uu____809.FStar_Syntax_Syntax.n)
+in (match (uu____808) with
+| FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool (b)) -> begin
+b
+end
+| uu____813 -> begin
+(failwith "Not an embedded bool")
+end)))
+
+
+let embed_string : Prims.string  ->  FStar_Syntax_Syntax.term = (fun s -> (
+
+let bytes = (FStar_Util.unicode_of_string s)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (((bytes), (FStar_Range.dummyRange)))))) None FStar_Range.dummyRange)))
+
+
+let unembed_string : FStar_Syntax_Syntax.term  ->  Prims.string = (fun t -> (
+
+let t1 = (FStar_Syntax_Util.unascribe t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (bytes, uu____833)) -> begin
+(FStar_Util.string_of_unicode bytes)
+end
+| uu____836 -> begin
+(failwith "Not an embedded string")
+end)))
+
+
+let embed_result = (fun res embed_a t_a -> (match (res) with
+| FStar_Tactics_Basic.Failed (msg, ps) -> begin
+(
+
+let uu____863 = (
+
+let uu____864 = (FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed ((FStar_Syntax_Syntax.U_zero)::[]))
+in (
+
+let uu____865 = (
+
+let uu____866 = (FStar_Syntax_Syntax.iarg t_a)
+in (
+
+let uu____867 = (
+
+let uu____869 = (
+
+let uu____870 = (embed_string msg)
+in (FStar_Syntax_Syntax.as_arg uu____870))
+in (
+
+let uu____871 = (
+
+let uu____873 = (
+
+let uu____874 = (embed_state ((ps.FStar_Tactics_Basic.goals), (ps.FStar_Tactics_Basic.smt_goals)))
+in (FStar_Syntax_Syntax.as_arg uu____874))
+in (uu____873)::[])
+in (uu____869)::uu____871))
+in (uu____866)::uu____867))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____864 uu____865)))
+in (uu____863 None FStar_Range.dummyRange))
+end
+| FStar_Tactics_Basic.Success (a, ps) -> begin
+(
+
+let uu____883 = (
+
+let uu____884 = (FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success ((FStar_Syntax_Syntax.U_zero)::[]))
+in (
+
+let uu____885 = (
+
+let uu____886 = (FStar_Syntax_Syntax.iarg t_a)
+in (
+
+let uu____887 = (
+
+let uu____889 = (
+
+let uu____890 = (embed_a a)
+in (FStar_Syntax_Syntax.as_arg uu____890))
+in (
+
+let uu____891 = (
+
+let uu____893 = (
+
+let uu____894 = (embed_state ((ps.FStar_Tactics_Basic.goals), (ps.FStar_Tactics_Basic.smt_goals)))
+in (FStar_Syntax_Syntax.as_arg uu____894))
+in (uu____893)::[])
+in (uu____889)::uu____891))
+in (uu____886)::uu____887))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____884 uu____885)))
+in (uu____883 None FStar_Range.dummyRange))
+end))
+
+
+let unembed_result = (fun env res unembed_a -> (
+
+let res1 = (FStar_Syntax_Util.unascribe res)
+in (
+
+let uu____930 = (FStar_Syntax_Util.head_and_args res1)
+in (match (uu____930) with
+| (hd1, args) -> begin
+(
+
+let uu____962 = (
+
+let uu____970 = (
+
+let uu____971 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____971.FStar_Syntax_Syntax.n)
+in ((uu____970), (args)))
+in (match (uu____962) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (_t)::((a, uu____988))::((embedded_state, uu____990))::[]) when (
+
+let uu____1024 = (fstar_tactics_lid "Success")
+in (FStar_Syntax_Syntax.fv_eq_lid fv uu____1024)) -> begin
+(
+
+let uu____1025 = (
+
+let uu____1028 = (unembed_a a)
+in (
+
+let uu____1029 = (unembed_state env embedded_state)
+in ((uu____1028), (uu____1029))))
+in FStar_Util.Inl (uu____1025))
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (_t)::((embedded_string, uu____1037))::((embedded_state, uu____1039))::[]) when (
+
+let uu____1073 = (fstar_tactics_lid "Failed")
+in (FStar_Syntax_Syntax.fv_eq_lid fv uu____1073)) -> begin
+(
+
+let uu____1074 = (
+
+let uu____1077 = (unembed_string embedded_string)
+in (
+
+let uu____1078 = (unembed_state env embedded_state)
+in ((uu____1077), (uu____1078))))
+in FStar_Util.Inr (uu____1074))
+end
+| uu____1083 -> begin
+(
+
+let uu____1091 = (
+
+let uu____1092 = (FStar_Syntax_Print.term_to_string res1)
+in (FStar_Util.format1 "Not an embedded result: %s" uu____1092))
+in (failwith uu____1091))
+end))
+end))))
+
 type formula =
-  | Connective of FStar_Syntax_Util.connective
-  | App of (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term Prims.list)
-  | Name of FStar_Syntax_Syntax.bv
-let uu___is_Connective: formula -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Connective _0 -> true | uu____1115 -> false
-let __proj__Connective__item___0: formula -> FStar_Syntax_Util.connective =
-  fun projectee  -> match projectee with | Connective _0 -> _0
-let uu___is_App: formula -> Prims.bool =
-  fun projectee  ->
-    match projectee with | App _0 -> true | uu____1130 -> false
-let __proj__App__item___0:
-  formula -> (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term Prims.list)
-  = fun projectee  -> match projectee with | App _0 -> _0
-let uu___is_Name: formula -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Name _0 -> true | uu____1151 -> false
-let __proj__Name__item___0: formula -> FStar_Syntax_Syntax.bv =
-  fun projectee  -> match projectee with | Name _0 -> _0
-let embed_formula: formula -> FStar_Syntax_Syntax.term =
-  fun f  ->
-    let encode_app l args =
-      let hd1 =
-        if FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid
-        then fstar_tactics_True_
-        else
-          if FStar_Ident.lid_equals l FStar_Syntax_Const.false_lid
-          then fstar_tactics_False_
-          else
-            if FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid
-            then fstar_tactics_And
-            else
-              if FStar_Ident.lid_equals l FStar_Syntax_Const.or_lid
-              then fstar_tactics_Or
-              else
-                if FStar_Ident.lid_equals l FStar_Syntax_Const.not_lid
-                then fstar_tactics_Not
-                else
-                  if FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid
-                  then fstar_tactics_Implies
-                  else
-                    if FStar_Ident.lid_equals l FStar_Syntax_Const.iff_lid
-                    then fstar_tactics_Iff
-                    else
-                      if FStar_Ident.lid_equals l FStar_Syntax_Const.eq2_lid
-                      then fstar_tactics_Eq
-                      else
-                        (let uu____1178 =
-                           let uu____1179 = FStar_Ident.string_of_lid l in
-                           Prims.strcat "Unrecognized connective" uu____1179 in
-                         failwith uu____1178) in
-      match args with
-      | [] -> hd1
-      | uu____1184 ->
-          let uu____1185 =
-            let uu____1186 =
-              FStar_List.map
-                (fun uu____1189  ->
-                   match uu____1189 with
-                   | (x,uu____1193) ->
-                       let uu____1194 = embed_term x in
-                       FStar_Syntax_Syntax.as_arg uu____1194) args in
-            FStar_Syntax_Syntax.mk_Tm_app hd1 uu____1186 in
-          uu____1185 None FStar_Range.dummyRange in
-    match f with
-    | Connective (FStar_Syntax_Util.QAll (binders,qpats,typ)) ->
-        let uu____1202 =
-          let uu____1203 =
-            let uu____1204 =
-              let uu____1205 = embed_binders binders in
-              FStar_Syntax_Syntax.as_arg uu____1205 in
-            let uu____1206 =
-              let uu____1208 =
-                let uu____1209 = embed_term typ in
-                FStar_Syntax_Syntax.as_arg uu____1209 in
-              [uu____1208] in
-            uu____1204 :: uu____1206 in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Forall uu____1203 in
-        uu____1202 None FStar_Range.dummyRange
-    | Connective (FStar_Syntax_Util.QEx (binders,qpats,typ)) ->
-        let uu____1217 =
-          let uu____1218 =
-            let uu____1219 =
-              let uu____1220 = embed_binders binders in
-              FStar_Syntax_Syntax.as_arg uu____1220 in
-            let uu____1221 =
-              let uu____1223 =
-                let uu____1224 = embed_term typ in
-                FStar_Syntax_Syntax.as_arg uu____1224 in
-              [uu____1223] in
-            uu____1219 :: uu____1221 in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Exists uu____1218 in
-        uu____1217 None FStar_Range.dummyRange
-    | Connective (FStar_Syntax_Util.BaseConn (lid,args)) ->
-        encode_app lid args
-    | App (t,ts) ->
-        let uu____1235 =
-          let uu____1236 =
-            let uu____1237 =
-              let uu____1238 = embed_term t in
-              FStar_Syntax_Syntax.as_arg uu____1238 in
-            let uu____1239 =
-              let uu____1241 =
-                let uu____1242 = embed_list ts embed_term fstar_tactics_term in
-                FStar_Syntax_Syntax.as_arg uu____1242 in
-              [uu____1241] in
-            uu____1237 :: uu____1239 in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_App uu____1236 in
-        uu____1235 None FStar_Range.dummyRange
-    | Name bv ->
-        let uu____1248 =
-          let uu____1249 =
-            let uu____1250 =
-              let uu____1251 =
-                let uu____1252 = FStar_Syntax_Syntax.mk_binder bv in
-                embed_binder uu____1252 in
-              FStar_Syntax_Syntax.as_arg uu____1251 in
-            [uu____1250] in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Name uu____1249 in
-        uu____1248 None FStar_Range.dummyRange
-let term_as_formula: FStar_Syntax_Syntax.term -> formula Prims.option =
-  fun t  ->
-    let uu____1262 = FStar_Syntax_Util.destruct_typ_as_formula t in
-    match uu____1262 with
-    | Some c -> Some (Connective c)
-    | uu____1266 ->
-        let uu____1268 =
-          let uu____1269 = FStar_Syntax_Subst.compress t in
-          uu____1269.FStar_Syntax_Syntax.n in
-        (match uu____1268 with
-         | FStar_Syntax_Syntax.Tm_app uu____1273 ->
-             let uu____1283 = FStar_Syntax_Util.head_and_args t in
-             (match uu____1283 with
-              | (hd1,args) ->
-                  let uu____1310 =
-                    let uu____1311 =
-                      let uu____1315 = FStar_List.map Prims.fst args in
-                      (hd1, uu____1315) in
-                    App uu____1311 in
-                  Some uu____1310)
-         | FStar_Syntax_Syntax.Tm_name bv -> Some (Name bv)
-         | uu____1333 -> None)
+| Connective of FStar_Syntax_Util.connective
+| App of (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term Prims.list)
+| Name of FStar_Syntax_Syntax.bv
+
+
+let uu___is_Connective : formula  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Connective (_0) -> begin
+true
+end
+| uu____1115 -> begin
+false
+end))
+
+
+let __proj__Connective__item___0 : formula  ->  FStar_Syntax_Util.connective = (fun projectee -> (match (projectee) with
+| Connective (_0) -> begin
+_0
+end))
+
+
+let uu___is_App : formula  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+true
+end
+| uu____1130 -> begin
+false
+end))
+
+
+let __proj__App__item___0 : formula  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term Prims.list) = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+_0
+end))
+
+
+let uu___is_Name : formula  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Name (_0) -> begin
+true
+end
+| uu____1151 -> begin
+false
+end))
+
+
+let __proj__Name__item___0 : formula  ->  FStar_Syntax_Syntax.bv = (fun projectee -> (match (projectee) with
+| Name (_0) -> begin
+_0
+end))
+
+
+let embed_formula : formula  ->  FStar_Syntax_Syntax.term = (fun f -> (
+
+let encode_app = (fun l args -> (
+
+let hd1 = (match ((FStar_Ident.lid_equals l FStar_Syntax_Const.true_lid)) with
+| true -> begin
+fstar_tactics_True_
+end
+| uu____1170 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.false_lid)) with
+| true -> begin
+fstar_tactics_False_
+end
+| uu____1171 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.and_lid)) with
+| true -> begin
+fstar_tactics_And
+end
+| uu____1172 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.or_lid)) with
+| true -> begin
+fstar_tactics_Or
+end
+| uu____1173 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.not_lid)) with
+| true -> begin
+fstar_tactics_Not
+end
+| uu____1174 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.imp_lid)) with
+| true -> begin
+fstar_tactics_Implies
+end
+| uu____1175 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.iff_lid)) with
+| true -> begin
+fstar_tactics_Iff
+end
+| uu____1176 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.eq2_lid)) with
+| true -> begin
+fstar_tactics_Eq
+end
+| uu____1177 -> begin
+(
+
+let uu____1178 = (
+
+let uu____1179 = (FStar_Ident.string_of_lid l)
+in (Prims.strcat "Unrecognized connective" uu____1179))
+in (failwith uu____1178))
+end)
+end)
+end)
+end)
+end)
+end)
+end)
+end)
+in (match (args) with
+| [] -> begin
+hd1
+end
+| uu____1184 -> begin
+(
+
+let uu____1185 = (
+
+let uu____1186 = (FStar_List.map (fun uu____1189 -> (match (uu____1189) with
+| (x, uu____1193) -> begin
+(
+
+let uu____1194 = (embed_term x)
+in (FStar_Syntax_Syntax.as_arg uu____1194))
+end)) args)
+in (FStar_Syntax_Syntax.mk_Tm_app hd1 uu____1186))
+in (uu____1185 None FStar_Range.dummyRange))
+end)))
+in (match (f) with
+| Connective (FStar_Syntax_Util.QAll (binders, qpats, typ)) -> begin
+(
+
+let uu____1202 = (
+
+let uu____1203 = (
+
+let uu____1204 = (
+
+let uu____1205 = (embed_binders binders)
+in (FStar_Syntax_Syntax.as_arg uu____1205))
+in (
+
+let uu____1206 = (
+
+let uu____1208 = (
+
+let uu____1209 = (embed_term typ)
+in (FStar_Syntax_Syntax.as_arg uu____1209))
+in (uu____1208)::[])
+in (uu____1204)::uu____1206))
+in (FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Forall uu____1203))
+in (uu____1202 None FStar_Range.dummyRange))
+end
+| Connective (FStar_Syntax_Util.QEx (binders, qpats, typ)) -> begin
+(
+
+let uu____1217 = (
+
+let uu____1218 = (
+
+let uu____1219 = (
+
+let uu____1220 = (embed_binders binders)
+in (FStar_Syntax_Syntax.as_arg uu____1220))
+in (
+
+let uu____1221 = (
+
+let uu____1223 = (
+
+let uu____1224 = (embed_term typ)
+in (FStar_Syntax_Syntax.as_arg uu____1224))
+in (uu____1223)::[])
+in (uu____1219)::uu____1221))
+in (FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Exists uu____1218))
+in (uu____1217 None FStar_Range.dummyRange))
+end
+| Connective (FStar_Syntax_Util.BaseConn (lid, args)) -> begin
+(encode_app lid args)
+end
+| App (t, ts) -> begin
+(
+
+let uu____1235 = (
+
+let uu____1236 = (
+
+let uu____1237 = (
+
+let uu____1238 = (embed_term t)
+in (FStar_Syntax_Syntax.as_arg uu____1238))
+in (
+
+let uu____1239 = (
+
+let uu____1241 = (
+
+let uu____1242 = (embed_list ts embed_term fstar_tactics_term)
+in (FStar_Syntax_Syntax.as_arg uu____1242))
+in (uu____1241)::[])
+in (uu____1237)::uu____1239))
+in (FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_App uu____1236))
+in (uu____1235 None FStar_Range.dummyRange))
+end
+| Name (bv) -> begin
+(
+
+let uu____1248 = (
+
+let uu____1249 = (
+
+let uu____1250 = (
+
+let uu____1251 = (
+
+let uu____1252 = (FStar_Syntax_Syntax.mk_binder bv)
+in (embed_binder uu____1252))
+in (FStar_Syntax_Syntax.as_arg uu____1251))
+in (uu____1250)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_Name uu____1249))
+in (uu____1248 None FStar_Range.dummyRange))
+end)))
+
+
+let term_as_formula : FStar_Syntax_Syntax.term  ->  formula Prims.option = (fun t -> (
+
+let uu____1262 = (FStar_Syntax_Util.destruct_typ_as_formula t)
+in (match (uu____1262) with
+| Some (c) -> begin
+Some (Connective (c))
+end
+| uu____1266 -> begin
+(
+
+let uu____1268 = (
+
+let uu____1269 = (FStar_Syntax_Subst.compress t)
+in uu____1269.FStar_Syntax_Syntax.n)
+in (match (uu____1268) with
+| FStar_Syntax_Syntax.Tm_app (uu____1273) -> begin
+(
+
+let uu____1283 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____1283) with
+| (hd1, args) -> begin
+(
+
+let uu____1310 = (
+
+let uu____1311 = (
+
+let uu____1315 = (FStar_List.map Prims.fst args)
+in ((hd1), (uu____1315)))
+in App (uu____1311))
+in Some (uu____1310))
+end))
+end
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+Some (Name (bv))
+end
+| uu____1333 -> begin
+None
+end))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1,491 +1,520 @@
+
 open Prims
-type name = FStar_Syntax_Syntax.bv
-let remove_unit f x = f x ()
-let quote:
-  FStar_Ident.lid ->
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun nm  ->
-    fun args  ->
-      match args with
-      | uu____33::(y,uu____35)::[] ->
-          let uu____56 = FStar_Tactics_Embedding.embed_term y in
-          Some uu____56
-      | uu____57 -> None
-let binders_of_env:
-  FStar_Tactics_Basic.proofstate ->
-    FStar_Ident.lid ->
-      FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun ps  ->
-    fun nm  ->
-      fun args  ->
-        match args with
-        | (embedded_env,uu____70)::[] ->
-            let env =
-              FStar_Tactics_Embedding.unembed_env
-                ps.FStar_Tactics_Basic.main_context embedded_env in
-            let uu____84 =
-              let uu____85 = FStar_TypeChecker_Env.all_binders env in
-              FStar_Tactics_Embedding.embed_binders uu____85 in
-            Some uu____84
-        | uu____87 -> None
-let type_of_binder:
-  FStar_Ident.lid ->
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun nm  ->
-    fun args  ->
-      match args with
-      | (embedded_binder,uu____97)::[] ->
-          let uu____110 =
-            FStar_Tactics_Embedding.unembed_binder embedded_binder in
-          (match uu____110 with
-           | (b,uu____113) ->
-               let uu____114 =
-                 FStar_Tactics_Embedding.embed_term
-                   b.FStar_Syntax_Syntax.sort in
-               Some uu____114)
-      | uu____115 -> None
-let term_eq:
-  FStar_Ident.lid ->
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun nm  ->
-    fun args  ->
-      match args with
-      | (embedded_t1,uu____125)::(embedded_t2,uu____127)::[] ->
-          let t1 = FStar_Tactics_Embedding.unembed_term embedded_t1 in
-          let t2 = FStar_Tactics_Embedding.unembed_term embedded_t2 in
-          let uu____150 = FStar_Syntax_Util.eq_tm t1 t2 in
-          (match uu____150 with
-           | FStar_Syntax_Util.Equal  ->
-               let uu____152 = FStar_Tactics_Embedding.embed_bool true in
-               Some uu____152
-           | uu____153 ->
-               let uu____154 = FStar_Tactics_Embedding.embed_bool false in
-               Some uu____154)
-      | uu____155 -> None
-let mk_pure_interpretation_1 f unembed_a embed_b nm args =
-  (let uu____202 = FStar_Ident.string_of_lid nm in
-   let uu____203 = FStar_Syntax_Print.args_to_string args in
-   FStar_Util.print2 "Reached %s, args are: %s\n" uu____202 uu____203);
-  (match args with
-   | a::[] ->
-       let uu____218 =
-         let uu____219 =
-           let uu____220 = unembed_a (Prims.fst a) in f uu____220 in
-         embed_b uu____219 in
-       Some uu____218
-   | uu____223 -> failwith "Unexpected interpretation of pure primitive")
-let mk_tactic_interpretation_0 ps t embed_a t_a nm args =
-  match args with
-  | (embedded_state,uu____266)::[] ->
-      ((let uu____280 = FStar_Ident.string_of_lid nm in
-        let uu____281 = FStar_Syntax_Print.args_to_string args in
-        FStar_Util.print2 "Reached %s, args are: %s\n" uu____280 uu____281);
-       (let uu____282 =
-          FStar_Tactics_Embedding.unembed_state
-            ps.FStar_Tactics_Basic.main_context embedded_state in
-        match uu____282 with
-        | (goals,smt_goals) ->
-            let ps1 =
-              let uu___98_291 = ps in
-              {
-                FStar_Tactics_Basic.main_context =
-                  (uu___98_291.FStar_Tactics_Basic.main_context);
-                FStar_Tactics_Basic.main_goal =
-                  (uu___98_291.FStar_Tactics_Basic.main_goal);
-                FStar_Tactics_Basic.all_implicits =
-                  (uu___98_291.FStar_Tactics_Basic.all_implicits);
-                FStar_Tactics_Basic.goals = goals;
-                FStar_Tactics_Basic.smt_goals = smt_goals;
-                FStar_Tactics_Basic.transaction =
-                  (uu___98_291.FStar_Tactics_Basic.transaction)
-              } in
-            let res = FStar_Tactics_Basic.run t ps1 in
-            let uu____294 =
-              FStar_Tactics_Embedding.embed_result res embed_a t_a in
-            Some uu____294))
-  | uu____295 -> failwith "Unexpected application of tactic primitive"
-let mk_tactic_interpretation_1 ps t unembed_b embed_a t_a nm args =
-  match args with
-  | (b,uu____355)::(embedded_state,uu____357)::[] ->
-      ((let uu____379 = FStar_Ident.string_of_lid nm in
-        let uu____380 = FStar_Syntax_Print.term_to_string embedded_state in
-        FStar_Util.print2 "Reached %s, goals are: %s\n" uu____379 uu____380);
-       (let uu____381 =
-          FStar_Tactics_Embedding.unembed_state
-            ps.FStar_Tactics_Basic.main_context embedded_state in
-        match uu____381 with
-        | (goals,smt_goals) ->
-            let ps1 =
-              let uu___99_390 = ps in
-              {
-                FStar_Tactics_Basic.main_context =
-                  (uu___99_390.FStar_Tactics_Basic.main_context);
-                FStar_Tactics_Basic.main_goal =
-                  (uu___99_390.FStar_Tactics_Basic.main_goal);
-                FStar_Tactics_Basic.all_implicits =
-                  (uu___99_390.FStar_Tactics_Basic.all_implicits);
-                FStar_Tactics_Basic.goals = goals;
-                FStar_Tactics_Basic.smt_goals = smt_goals;
-                FStar_Tactics_Basic.transaction =
-                  (uu___99_390.FStar_Tactics_Basic.transaction)
-              } in
-            let res =
-              let uu____393 = let uu____395 = unembed_b b in t uu____395 in
-              FStar_Tactics_Basic.run uu____393 ps1 in
-            let uu____396 =
-              FStar_Tactics_Embedding.embed_result res embed_a t_a in
-            Some uu____396))
-  | uu____397 ->
-      let uu____398 =
-        let uu____399 = FStar_Ident.string_of_lid nm in
-        let uu____400 = FStar_Syntax_Print.args_to_string args in
-        FStar_Util.format2 "Unexpected application of tactic primitive %s %s"
-          uu____399 uu____400 in
-      failwith uu____398
-let mk_tactic_interpretation_2 ps t unembed_a unembed_b embed_c t_c nm args =
-  match args with
-  | (a,uu____477)::(b,uu____479)::(embedded_state,uu____481)::[] ->
-      ((let uu____511 = FStar_Ident.string_of_lid nm in
-        let uu____512 = FStar_Syntax_Print.term_to_string embedded_state in
-        FStar_Util.print2 "Reached %s, goals are: %s\n" uu____511 uu____512);
-       (let uu____513 =
-          FStar_Tactics_Embedding.unembed_state
-            ps.FStar_Tactics_Basic.main_context embedded_state in
-        match uu____513 with
-        | (goals,smt_goals) ->
-            let ps1 =
-              let uu___100_522 = ps in
-              {
-                FStar_Tactics_Basic.main_context =
-                  (uu___100_522.FStar_Tactics_Basic.main_context);
-                FStar_Tactics_Basic.main_goal =
-                  (uu___100_522.FStar_Tactics_Basic.main_goal);
-                FStar_Tactics_Basic.all_implicits =
-                  (uu___100_522.FStar_Tactics_Basic.all_implicits);
-                FStar_Tactics_Basic.goals = goals;
-                FStar_Tactics_Basic.smt_goals = smt_goals;
-                FStar_Tactics_Basic.transaction =
-                  (uu___100_522.FStar_Tactics_Basic.transaction)
-              } in
-            let res =
-              let uu____525 =
-                let uu____527 = unembed_a a in
-                let uu____528 = unembed_b b in t uu____527 uu____528 in
-              FStar_Tactics_Basic.run uu____525 ps1 in
-            let uu____529 =
-              FStar_Tactics_Embedding.embed_result res embed_c t_c in
-            Some uu____529))
-  | uu____530 ->
-      let uu____531 =
-        let uu____532 = FStar_Ident.string_of_lid nm in
-        let uu____533 = FStar_Syntax_Print.args_to_string args in
-        FStar_Util.format2 "Unexpected application of tactic primitive %s %s"
-          uu____532 uu____533 in
-      failwith uu____531
-let rec primitive_steps:
-  FStar_Tactics_Basic.proofstate ->
-    FStar_TypeChecker_Normalize.primitive_step Prims.list
-  =
-  fun ps  ->
-    let mk1 nm arity interpretation =
-      let nm1 = FStar_Tactics_Embedding.fstar_tactics_lid nm in
-      let uu____577 = interpretation nm1 in
-      {
-        FStar_TypeChecker_Normalize.name = nm1;
-        FStar_TypeChecker_Normalize.arity = arity;
-        FStar_TypeChecker_Normalize.strong_reduction_ok = false;
-        FStar_TypeChecker_Normalize.interpretation = uu____577
-      } in
-    let uu____581 =
-      mk1 "forall_intros_" (Prims.parse_int "1")
-        (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.intros
-           FStar_Tactics_Embedding.embed_binders
-           FStar_Tactics_Embedding.fstar_tactics_binders) in
-    let uu____582 =
-      let uu____584 =
-        mk1 "implies_intro_" (Prims.parse_int "1")
-          (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.imp_intro
-             FStar_Tactics_Embedding.embed_binder
-             FStar_Tactics_Embedding.fstar_tactics_binder) in
-      let uu____585 =
-        let uu____587 =
-          mk1 "trivial_" (Prims.parse_int "1")
-            (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.trivial
-               FStar_Tactics_Embedding.embed_unit
-               FStar_TypeChecker_Common.t_unit) in
-        let uu____588 =
-          let uu____590 =
-            mk1 "revert_" (Prims.parse_int "1")
-              (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.revert
-                 FStar_Tactics_Embedding.embed_unit
-                 FStar_TypeChecker_Common.t_unit) in
-          let uu____591 =
-            let uu____593 =
-              mk1 "clear_" (Prims.parse_int "1")
-                (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.clear
-                   FStar_Tactics_Embedding.embed_unit
-                   FStar_TypeChecker_Common.t_unit) in
-            let uu____594 =
-              let uu____596 =
-                mk1 "split_" (Prims.parse_int "1")
-                  (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.split
-                     FStar_Tactics_Embedding.embed_unit
-                     FStar_TypeChecker_Common.t_unit) in
-              let uu____597 =
-                let uu____599 =
-                  mk1 "merge_" (Prims.parse_int "1")
-                    (mk_tactic_interpretation_0 ps
-                       FStar_Tactics_Basic.merge_sub_goals
-                       FStar_Tactics_Embedding.embed_unit
-                       FStar_TypeChecker_Common.t_unit) in
-                let uu____600 =
-                  let uu____602 =
-                    mk1 "rewrite_" (Prims.parse_int "2")
-                      (mk_tactic_interpretation_1 ps
-                         FStar_Tactics_Basic.rewrite
-                         FStar_Tactics_Embedding.unembed_binder
-                         FStar_Tactics_Embedding.embed_unit
-                         FStar_TypeChecker_Common.t_unit) in
-                  let uu____603 =
-                    let uu____605 =
-                      mk1 "smt_" (Prims.parse_int "1")
-                        (mk_tactic_interpretation_0 ps
-                           FStar_Tactics_Basic.smt
-                           FStar_Tactics_Embedding.embed_unit
-                           FStar_TypeChecker_Common.t_unit) in
-                    let uu____606 =
-                      let uu____608 =
-                        mk1 "exact_" (Prims.parse_int "2")
-                          (mk_tactic_interpretation_1 ps
-                             FStar_Tactics_Basic.exact
-                             FStar_Tactics_Embedding.unembed_term
-                             FStar_Tactics_Embedding.embed_unit
-                             FStar_TypeChecker_Common.t_unit) in
-                      let uu____609 =
-                        let uu____611 =
-                          mk1 "apply_lemma_" (Prims.parse_int "2")
-                            (mk_tactic_interpretation_1 ps
-                               FStar_Tactics_Basic.apply_lemma
-                               FStar_Tactics_Embedding.unembed_term
-                               FStar_Tactics_Embedding.embed_unit
-                               FStar_TypeChecker_Common.t_unit) in
-                        let uu____612 =
-                          let uu____614 =
-                            mk1 "visit_" (Prims.parse_int "2")
-                              (mk_tactic_interpretation_1 ps
-                                 FStar_Tactics_Basic.visit
-                                 (unembed_tactic_0
-                                    FStar_Tactics_Embedding.unembed_unit)
-                                 FStar_Tactics_Embedding.embed_unit
-                                 FStar_TypeChecker_Common.t_unit) in
-                          let uu____616 =
-                            let uu____618 =
-                              mk1 "focus_" (Prims.parse_int "2")
-                                (mk_tactic_interpretation_1 ps
-                                   (FStar_Tactics_Basic.focus_cur_goal
-                                      "user_tactic")
-                                   (unembed_tactic_0
-                                      FStar_Tactics_Embedding.unembed_unit)
-                                   FStar_Tactics_Embedding.embed_unit
-                                   FStar_TypeChecker_Common.t_unit) in
-                            let uu____620 =
-                              let uu____622 =
-                                mk1 "seq_" (Prims.parse_int "3")
-                                  (mk_tactic_interpretation_2 ps
-                                     FStar_Tactics_Basic.seq
-                                     (unembed_tactic_0
-                                        FStar_Tactics_Embedding.unembed_unit)
-                                     (unembed_tactic_0
-                                        FStar_Tactics_Embedding.unembed_unit)
-                                     FStar_Tactics_Embedding.embed_unit
-                                     FStar_TypeChecker_Common.t_unit) in
-                              let uu____625 =
-                                let uu____627 =
-                                  mk1 "term_as_formula" (Prims.parse_int "1")
-                                    (mk_pure_interpretation_1
-                                       FStar_Tactics_Embedding.term_as_formula
-                                       FStar_Tactics_Embedding.unembed_term
-                                       (FStar_Tactics_Embedding.embed_option
-                                          FStar_Tactics_Embedding.embed_formula
-                                          FStar_Tactics_Embedding.fstar_tactics_formula)) in
-                                let uu____629 =
-                                  let uu____631 =
-                                    mk1 "quote" (Prims.parse_int "2") quote in
-                                  let uu____632 =
-                                    let uu____634 =
-                                      mk1 "binders_of_env"
-                                        (Prims.parse_int "1")
-                                        (binders_of_env ps) in
-                                    let uu____635 =
-                                      let uu____637 =
-                                        mk1 "type_of_binder"
-                                          (Prims.parse_int "1")
-                                          type_of_binder in
-                                      let uu____638 =
-                                        let uu____640 =
-                                          mk1 "term_eq" (Prims.parse_int "2")
-                                            term_eq in
-                                        [uu____640] in
-                                      uu____637 :: uu____638 in
-                                    uu____634 :: uu____635 in
-                                  uu____631 :: uu____632 in
-                                uu____627 :: uu____629 in
-                              uu____622 :: uu____625 in
-                            uu____618 :: uu____620 in
-                          uu____614 :: uu____616 in
-                        uu____611 :: uu____612 in
-                      uu____608 :: uu____609 in
-                    uu____605 :: uu____606 in
-                  uu____602 :: uu____603 in
-                uu____599 :: uu____600 in
-              uu____596 :: uu____597 in
-            uu____593 :: uu____594 in
-          uu____590 :: uu____591 in
-        uu____587 :: uu____588 in
-      uu____584 :: uu____585 in
-    uu____581 :: uu____582
-and unembed_tactic_0 unembed_b embedded_tac_b =
-  FStar_Tactics_Basic.bind FStar_Tactics_Basic.get
-    (fun proof_state  ->
-       let tm =
-         let uu____649 =
-           let uu____650 =
-             let uu____651 =
-               let uu____652 =
-                 FStar_Tactics_Embedding.embed_state
-                   ((proof_state.FStar_Tactics_Basic.goals), []) in
-               FStar_Syntax_Syntax.as_arg uu____652 in
-             [uu____651] in
-           FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____650 in
-         uu____649 None FStar_Range.dummyRange in
-       let steps =
-         [FStar_TypeChecker_Normalize.Reify;
-         FStar_TypeChecker_Normalize.Beta;
-         FStar_TypeChecker_Normalize.UnfoldUntil
-           FStar_Syntax_Syntax.Delta_constant;
-         FStar_TypeChecker_Normalize.Zeta;
-         FStar_TypeChecker_Normalize.Iota;
-         FStar_TypeChecker_Normalize.Primops] in
-       (let uu____662 = FStar_Syntax_Print.term_to_string tm in
-        FStar_Util.print1 "Starting normalizer with %s\n" uu____662);
-       FStar_Options.set_option "debug_level"
-         (FStar_Options.List [FStar_Options.String "Norm"]);
-       (let result =
-          let uu____665 = primitive_steps proof_state in
-          FStar_TypeChecker_Normalize.normalize_with_primitive_steps
-            uu____665 steps proof_state.FStar_Tactics_Basic.main_context tm in
-        FStar_Options.set_option "debug_level" (FStar_Options.List []);
-        (let uu____669 = FStar_Syntax_Print.term_to_string result in
-         FStar_Util.print1 "Reduced tactic: got %s\n" uu____669);
-        (let uu____670 =
-           FStar_Tactics_Embedding.unembed_result
-             proof_state.FStar_Tactics_Basic.main_context result unembed_b in
-         match uu____670 with
-         | FStar_Util.Inl (b,(goals,smt_goals)) ->
-             FStar_Tactics_Basic.bind FStar_Tactics_Basic.dismiss
-               (fun uu____697  ->
-                  let uu____698 = FStar_Tactics_Basic.add_goals goals in
-                  FStar_Tactics_Basic.bind uu____698
-                    (fun uu____700  ->
-                       let uu____701 =
-                         FStar_Tactics_Basic.add_smt_goals smt_goals in
-                       FStar_Tactics_Basic.bind uu____701
-                         (fun uu____703  -> FStar_Tactics_Basic.ret b)))
-         | FStar_Util.Inr (msg,(goals,smt_goals)) ->
-             FStar_Tactics_Basic.bind FStar_Tactics_Basic.dismiss
-               (fun uu____723  ->
-                  let uu____724 = FStar_Tactics_Basic.add_goals goals in
-                  FStar_Tactics_Basic.bind uu____724
-                    (fun uu____726  ->
-                       let uu____727 =
-                         FStar_Tactics_Basic.add_smt_goals smt_goals in
-                       FStar_Tactics_Basic.bind uu____727
-                         (fun uu____729  -> FStar_Tactics_Basic.fail msg))))))
-let evaluate_user_tactic: Prims.unit FStar_Tactics_Basic.tac =
-  FStar_Tactics_Basic.with_cur_goal "evaluate_user_tactic"
-    (fun goal  ->
-       FStar_Tactics_Basic.bind FStar_Tactics_Basic.get
-         (fun proof_state  ->
-            let uu____733 =
-              FStar_Syntax_Util.head_and_args
-                goal.FStar_Tactics_Basic.goal_ty in
-            match uu____733 with
-            | (hd1,args) ->
-                let uu____760 =
-                  let uu____768 =
-                    let uu____769 = FStar_Syntax_Util.un_uinst hd1 in
-                    uu____769.FStar_Syntax_Syntax.n in
-                  (uu____768, args) in
-                (match uu____760 with
-                 | (FStar_Syntax_Syntax.Tm_fvar
-                    fv,(tactic,uu____780)::(assertion,uu____782)::[]) when
-                     FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Tactics_Embedding.by_tactic_lid
-                     ->
-                     let uu____808 =
-                       let uu____810 =
-                         FStar_Tactics_Basic.replace
-                           (let uu___101_812 = goal in
-                            {
-                              FStar_Tactics_Basic.context =
-                                (uu___101_812.FStar_Tactics_Basic.context);
-                              FStar_Tactics_Basic.witness =
-                                (uu___101_812.FStar_Tactics_Basic.witness);
-                              FStar_Tactics_Basic.goal_ty = assertion
-                            }) in
-                       FStar_Tactics_Basic.bind uu____810
-                         (fun uu____813  ->
-                            unembed_tactic_0
-                              FStar_Tactics_Embedding.unembed_unit tactic) in
-                     FStar_Tactics_Basic.focus_cur_goal "user tactic"
-                       uu____808
-                 | uu____814 -> FStar_Tactics_Basic.fail "Not a user tactic")))
-let preprocess:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_TypeChecker_Env.env* FStar_Syntax_Syntax.term) Prims.list
-  =
-  fun env  ->
-    fun goal  ->
-      let uu____834 =
-        (let uu____835 = FStar_TypeChecker_Env.current_module env in
-         FStar_Ident.lid_equals uu____835 FStar_Syntax_Const.prims_lid) ||
-          (let uu____836 =
-             let uu____837 = FStar_TypeChecker_Env.current_module env in
-             FStar_Ident.string_of_lid uu____837 in
-           FStar_Util.starts_with uu____836 "FStar.") in
-      if uu____834
-      then [(env, goal)]
-      else
-        ((let uu____847 = FStar_Syntax_Print.term_to_string goal in
-          FStar_Util.print1 "About to preprocess %s\n" uu____847);
-         (let p = FStar_Tactics_Basic.proofstate_of_goal_ty env goal in
-          let uu____849 =
-            let uu____851 = FStar_Tactics_Basic.visit evaluate_user_tactic in
-            FStar_Tactics_Basic.run uu____851 p in
-          match uu____849 with
-          | FStar_Tactics_Basic.Success (uu____856,p2) ->
-              FStar_All.pipe_right
-                (FStar_List.append p2.FStar_Tactics_Basic.goals
-                   p2.FStar_Tactics_Basic.smt_goals)
-                (FStar_List.map
-                   (fun g  ->
-                      (let uu____866 = FStar_Tactics_Basic.goal_to_string g in
-                       FStar_Util.print1 "Got goal: %s\n" uu____866);
-                      ((g.FStar_Tactics_Basic.context),
-                        (g.FStar_Tactics_Basic.goal_ty))))
-          | FStar_Tactics_Basic.Failed (msg,uu____868) ->
-              (FStar_Util.print1 "Tactic failed: %s\n" msg;
-               (let uu____871 =
-                  FStar_Tactics_Basic.goal_to_string
-                    {
-                      FStar_Tactics_Basic.context = env;
-                      FStar_Tactics_Basic.witness = None;
-                      FStar_Tactics_Basic.goal_ty = goal
-                    } in
-                FStar_Util.print1 "Got goal: %s\n" uu____871);
-               [(env, goal)])))
+
+type name =
+FStar_Syntax_Syntax.bv
+
+
+let remove_unit = (fun f x -> (f x ()))
+
+
+let quote : FStar_Ident.lid  ->  FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.term Prims.option = (fun nm args -> (match (args) with
+| (uu____33)::((y, uu____35))::[] -> begin
+(
+
+let uu____56 = (FStar_Tactics_Embedding.embed_term y)
+in Some (uu____56))
+end
+| uu____57 -> begin
+None
+end))
+
+
+let binders_of_env : FStar_Tactics_Basic.proofstate  ->  FStar_Ident.lid  ->  FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.term Prims.option = (fun ps nm args -> (match (args) with
+| ((embedded_env, uu____70))::[] -> begin
+(
+
+let env = (FStar_Tactics_Embedding.unembed_env ps.FStar_Tactics_Basic.main_context embedded_env)
+in (
+
+let uu____84 = (
+
+let uu____85 = (FStar_TypeChecker_Env.all_binders env)
+in (FStar_Tactics_Embedding.embed_binders uu____85))
+in Some (uu____84)))
+end
+| uu____87 -> begin
+None
+end))
+
+
+let type_of_binder : FStar_Ident.lid  ->  FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.term Prims.option = (fun nm args -> (match (args) with
+| ((embedded_binder, uu____97))::[] -> begin
+(
+
+let uu____110 = (FStar_Tactics_Embedding.unembed_binder embedded_binder)
+in (match (uu____110) with
+| (b, uu____113) -> begin
+(
+
+let uu____114 = (FStar_Tactics_Embedding.embed_term b.FStar_Syntax_Syntax.sort)
+in Some (uu____114))
+end))
+end
+| uu____115 -> begin
+None
+end))
+
+
+let term_eq : FStar_Ident.lid  ->  FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.term Prims.option = (fun nm args -> (match (args) with
+| ((embedded_t1, uu____125))::((embedded_t2, uu____127))::[] -> begin
+(
+
+let t1 = (FStar_Tactics_Embedding.unembed_term embedded_t1)
+in (
+
+let t2 = (FStar_Tactics_Embedding.unembed_term embedded_t2)
+in (
+
+let uu____150 = (FStar_Syntax_Util.eq_tm t1 t2)
+in (match (uu____150) with
+| FStar_Syntax_Util.Equal -> begin
+(
+
+let uu____152 = (FStar_Tactics_Embedding.embed_bool true)
+in Some (uu____152))
+end
+| uu____153 -> begin
+(
+
+let uu____154 = (FStar_Tactics_Embedding.embed_bool false)
+in Some (uu____154))
+end))))
+end
+| uu____155 -> begin
+None
+end))
+
+
+let mk_pure_interpretation_1 = (fun f unembed_a embed_b nm args -> ((
+
+let uu____202 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____203 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.print2 "Reached %s, args are: %s\n" uu____202 uu____203)));
+(match (args) with
+| (a)::[] -> begin
+(
+
+let uu____218 = (
+
+let uu____219 = (
+
+let uu____220 = (unembed_a (Prims.fst a))
+in (f uu____220))
+in (embed_b uu____219))
+in Some (uu____218))
+end
+| uu____223 -> begin
+(failwith "Unexpected interpretation of pure primitive")
+end);
+))
+
+
+let mk_tactic_interpretation_0 = (fun ps t embed_a t_a nm args -> (match (args) with
+| ((embedded_state, uu____266))::[] -> begin
+((
+
+let uu____280 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____281 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.print2 "Reached %s, args are: %s\n" uu____280 uu____281)));
+(
+
+let uu____282 = (FStar_Tactics_Embedding.unembed_state ps.FStar_Tactics_Basic.main_context embedded_state)
+in (match (uu____282) with
+| (goals, smt_goals) -> begin
+(
+
+let ps1 = (
+
+let uu___98_291 = ps
+in {FStar_Tactics_Basic.main_context = uu___98_291.FStar_Tactics_Basic.main_context; FStar_Tactics_Basic.main_goal = uu___98_291.FStar_Tactics_Basic.main_goal; FStar_Tactics_Basic.all_implicits = uu___98_291.FStar_Tactics_Basic.all_implicits; FStar_Tactics_Basic.goals = goals; FStar_Tactics_Basic.smt_goals = smt_goals; FStar_Tactics_Basic.transaction = uu___98_291.FStar_Tactics_Basic.transaction})
+in (
+
+let res = (FStar_Tactics_Basic.run t ps1)
+in (
+
+let uu____294 = (FStar_Tactics_Embedding.embed_result res embed_a t_a)
+in Some (uu____294))))
+end));
+)
+end
+| uu____295 -> begin
+(failwith "Unexpected application of tactic primitive")
+end))
+
+
+let mk_tactic_interpretation_1 = (fun ps t unembed_b embed_a t_a nm args -> (match (args) with
+| ((b, uu____355))::((embedded_state, uu____357))::[] -> begin
+((
+
+let uu____379 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____380 = (FStar_Syntax_Print.term_to_string embedded_state)
+in (FStar_Util.print2 "Reached %s, goals are: %s\n" uu____379 uu____380)));
+(
+
+let uu____381 = (FStar_Tactics_Embedding.unembed_state ps.FStar_Tactics_Basic.main_context embedded_state)
+in (match (uu____381) with
+| (goals, smt_goals) -> begin
+(
+
+let ps1 = (
+
+let uu___99_390 = ps
+in {FStar_Tactics_Basic.main_context = uu___99_390.FStar_Tactics_Basic.main_context; FStar_Tactics_Basic.main_goal = uu___99_390.FStar_Tactics_Basic.main_goal; FStar_Tactics_Basic.all_implicits = uu___99_390.FStar_Tactics_Basic.all_implicits; FStar_Tactics_Basic.goals = goals; FStar_Tactics_Basic.smt_goals = smt_goals; FStar_Tactics_Basic.transaction = uu___99_390.FStar_Tactics_Basic.transaction})
+in (
+
+let res = (
+
+let uu____393 = (
+
+let uu____395 = (unembed_b b)
+in (t uu____395))
+in (FStar_Tactics_Basic.run uu____393 ps1))
+in (
+
+let uu____396 = (FStar_Tactics_Embedding.embed_result res embed_a t_a)
+in Some (uu____396))))
+end));
+)
+end
+| uu____397 -> begin
+(
+
+let uu____398 = (
+
+let uu____399 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____400 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.format2 "Unexpected application of tactic primitive %s %s" uu____399 uu____400)))
+in (failwith uu____398))
+end))
+
+
+let mk_tactic_interpretation_2 = (fun ps t unembed_a unembed_b embed_c t_c nm args -> (match (args) with
+| ((a, uu____477))::((b, uu____479))::((embedded_state, uu____481))::[] -> begin
+((
+
+let uu____511 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____512 = (FStar_Syntax_Print.term_to_string embedded_state)
+in (FStar_Util.print2 "Reached %s, goals are: %s\n" uu____511 uu____512)));
+(
+
+let uu____513 = (FStar_Tactics_Embedding.unembed_state ps.FStar_Tactics_Basic.main_context embedded_state)
+in (match (uu____513) with
+| (goals, smt_goals) -> begin
+(
+
+let ps1 = (
+
+let uu___100_522 = ps
+in {FStar_Tactics_Basic.main_context = uu___100_522.FStar_Tactics_Basic.main_context; FStar_Tactics_Basic.main_goal = uu___100_522.FStar_Tactics_Basic.main_goal; FStar_Tactics_Basic.all_implicits = uu___100_522.FStar_Tactics_Basic.all_implicits; FStar_Tactics_Basic.goals = goals; FStar_Tactics_Basic.smt_goals = smt_goals; FStar_Tactics_Basic.transaction = uu___100_522.FStar_Tactics_Basic.transaction})
+in (
+
+let res = (
+
+let uu____525 = (
+
+let uu____527 = (unembed_a a)
+in (
+
+let uu____528 = (unembed_b b)
+in (t uu____527 uu____528)))
+in (FStar_Tactics_Basic.run uu____525 ps1))
+in (
+
+let uu____529 = (FStar_Tactics_Embedding.embed_result res embed_c t_c)
+in Some (uu____529))))
+end));
+)
+end
+| uu____530 -> begin
+(
+
+let uu____531 = (
+
+let uu____532 = (FStar_Ident.string_of_lid nm)
+in (
+
+let uu____533 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.format2 "Unexpected application of tactic primitive %s %s" uu____532 uu____533)))
+in (failwith uu____531))
+end))
+
+
+let rec primitive_steps : FStar_Tactics_Basic.proofstate  ->  FStar_TypeChecker_Normalize.primitive_step Prims.list = (fun ps -> (
+
+let mk1 = (fun nm arity interpretation -> (
+
+let nm1 = (FStar_Tactics_Embedding.fstar_tactics_lid nm)
+in (
+
+let uu____577 = (interpretation nm1)
+in {FStar_TypeChecker_Normalize.name = nm1; FStar_TypeChecker_Normalize.arity = arity; FStar_TypeChecker_Normalize.strong_reduction_ok = false; FStar_TypeChecker_Normalize.interpretation = uu____577})))
+in (
+
+let uu____581 = (mk1 "forall_intros_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.intros FStar_Tactics_Embedding.embed_binders FStar_Tactics_Embedding.fstar_tactics_binders))
+in (
+
+let uu____582 = (
+
+let uu____584 = (mk1 "implies_intro_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.imp_intro FStar_Tactics_Embedding.embed_binder FStar_Tactics_Embedding.fstar_tactics_binder))
+in (
+
+let uu____585 = (
+
+let uu____587 = (mk1 "trivial_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.trivial FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____588 = (
+
+let uu____590 = (mk1 "revert_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.revert FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____591 = (
+
+let uu____593 = (mk1 "clear_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.clear FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____594 = (
+
+let uu____596 = (mk1 "split_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.split FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____597 = (
+
+let uu____599 = (mk1 "merge_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.merge_sub_goals FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____600 = (
+
+let uu____602 = (mk1 "rewrite_" (Prims.parse_int "2") (mk_tactic_interpretation_1 ps FStar_Tactics_Basic.rewrite FStar_Tactics_Embedding.unembed_binder FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____603 = (
+
+let uu____605 = (mk1 "smt_" (Prims.parse_int "1") (mk_tactic_interpretation_0 ps FStar_Tactics_Basic.smt FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____606 = (
+
+let uu____608 = (mk1 "exact_" (Prims.parse_int "2") (mk_tactic_interpretation_1 ps FStar_Tactics_Basic.exact FStar_Tactics_Embedding.unembed_term FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____609 = (
+
+let uu____611 = (mk1 "apply_lemma_" (Prims.parse_int "2") (mk_tactic_interpretation_1 ps FStar_Tactics_Basic.apply_lemma FStar_Tactics_Embedding.unembed_term FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____612 = (
+
+let uu____614 = (mk1 "visit_" (Prims.parse_int "2") (mk_tactic_interpretation_1 ps FStar_Tactics_Basic.visit (unembed_tactic_0 FStar_Tactics_Embedding.unembed_unit) FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____616 = (
+
+let uu____618 = (mk1 "focus_" (Prims.parse_int "2") (mk_tactic_interpretation_1 ps (FStar_Tactics_Basic.focus_cur_goal "user_tactic") (unembed_tactic_0 FStar_Tactics_Embedding.unembed_unit) FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____620 = (
+
+let uu____622 = (mk1 "seq_" (Prims.parse_int "3") (mk_tactic_interpretation_2 ps FStar_Tactics_Basic.seq (unembed_tactic_0 FStar_Tactics_Embedding.unembed_unit) (unembed_tactic_0 FStar_Tactics_Embedding.unembed_unit) FStar_Tactics_Embedding.embed_unit FStar_TypeChecker_Common.t_unit))
+in (
+
+let uu____625 = (
+
+let uu____627 = (mk1 "term_as_formula" (Prims.parse_int "1") (mk_pure_interpretation_1 FStar_Tactics_Embedding.term_as_formula FStar_Tactics_Embedding.unembed_term (FStar_Tactics_Embedding.embed_option FStar_Tactics_Embedding.embed_formula FStar_Tactics_Embedding.fstar_tactics_formula)))
+in (
+
+let uu____629 = (
+
+let uu____631 = (mk1 "quote" (Prims.parse_int "2") quote)
+in (
+
+let uu____632 = (
+
+let uu____634 = (mk1 "binders_of_env" (Prims.parse_int "1") (binders_of_env ps))
+in (
+
+let uu____635 = (
+
+let uu____637 = (mk1 "type_of_binder" (Prims.parse_int "1") type_of_binder)
+in (
+
+let uu____638 = (
+
+let uu____640 = (mk1 "term_eq" (Prims.parse_int "2") term_eq)
+in (uu____640)::[])
+in (uu____637)::uu____638))
+in (uu____634)::uu____635))
+in (uu____631)::uu____632))
+in (uu____627)::uu____629))
+in (uu____622)::uu____625))
+in (uu____618)::uu____620))
+in (uu____614)::uu____616))
+in (uu____611)::uu____612))
+in (uu____608)::uu____609))
+in (uu____605)::uu____606))
+in (uu____602)::uu____603))
+in (uu____599)::uu____600))
+in (uu____596)::uu____597))
+in (uu____593)::uu____594))
+in (uu____590)::uu____591))
+in (uu____587)::uu____588))
+in (uu____584)::uu____585))
+in (uu____581)::uu____582))))
+and unembed_tactic_0 = (fun unembed_b embedded_tac_b -> (FStar_Tactics_Basic.bind FStar_Tactics_Basic.get (fun proof_state -> (
+
+let tm = (
+
+let uu____649 = (
+
+let uu____650 = (
+
+let uu____651 = (
+
+let uu____652 = (FStar_Tactics_Embedding.embed_state ((proof_state.FStar_Tactics_Basic.goals), ([])))
+in (FStar_Syntax_Syntax.as_arg uu____652))
+in (uu____651)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____650))
+in (uu____649 None FStar_Range.dummyRange))
+in (
+
+let steps = (FStar_TypeChecker_Normalize.Reify)::(FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Primops)::[]
+in ((
+
+let uu____662 = (FStar_Syntax_Print.term_to_string tm)
+in (FStar_Util.print1 "Starting normalizer with %s\n" uu____662));
+(FStar_Options.set_option "debug_level" (FStar_Options.List ((FStar_Options.String ("Norm"))::[])));
+(
+
+let result = (
+
+let uu____665 = (primitive_steps proof_state)
+in (FStar_TypeChecker_Normalize.normalize_with_primitive_steps uu____665 steps proof_state.FStar_Tactics_Basic.main_context tm))
+in ((FStar_Options.set_option "debug_level" (FStar_Options.List ([])));
+(
+
+let uu____669 = (FStar_Syntax_Print.term_to_string result)
+in (FStar_Util.print1 "Reduced tactic: got %s\n" uu____669));
+(
+
+let uu____670 = (FStar_Tactics_Embedding.unembed_result proof_state.FStar_Tactics_Basic.main_context result unembed_b)
+in (match (uu____670) with
+| FStar_Util.Inl (b, (goals, smt_goals)) -> begin
+(FStar_Tactics_Basic.bind FStar_Tactics_Basic.dismiss (fun uu____697 -> (
+
+let uu____698 = (FStar_Tactics_Basic.add_goals goals)
+in (FStar_Tactics_Basic.bind uu____698 (fun uu____700 -> (
+
+let uu____701 = (FStar_Tactics_Basic.add_smt_goals smt_goals)
+in (FStar_Tactics_Basic.bind uu____701 (fun uu____703 -> (FStar_Tactics_Basic.ret b)))))))))
+end
+| FStar_Util.Inr (msg, (goals, smt_goals)) -> begin
+(FStar_Tactics_Basic.bind FStar_Tactics_Basic.dismiss (fun uu____723 -> (
+
+let uu____724 = (FStar_Tactics_Basic.add_goals goals)
+in (FStar_Tactics_Basic.bind uu____724 (fun uu____726 -> (
+
+let uu____727 = (FStar_Tactics_Basic.add_smt_goals smt_goals)
+in (FStar_Tactics_Basic.bind uu____727 (fun uu____729 -> (FStar_Tactics_Basic.fail msg)))))))))
+end));
+));
+))))))
+
+
+let evaluate_user_tactic : Prims.unit FStar_Tactics_Basic.tac = (FStar_Tactics_Basic.with_cur_goal "evaluate_user_tactic" (fun goal -> (FStar_Tactics_Basic.bind FStar_Tactics_Basic.get (fun proof_state -> (
+
+let uu____733 = (FStar_Syntax_Util.head_and_args goal.FStar_Tactics_Basic.goal_ty)
+in (match (uu____733) with
+| (hd1, args) -> begin
+(
+
+let uu____760 = (
+
+let uu____768 = (
+
+let uu____769 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____769.FStar_Syntax_Syntax.n)
+in ((uu____768), (args)))
+in (match (uu____760) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), ((tactic, uu____780))::((assertion, uu____782))::[]) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Tactics_Embedding.by_tactic_lid) -> begin
+(
+
+let uu____808 = (
+
+let uu____810 = (FStar_Tactics_Basic.replace (
+
+let uu___101_812 = goal
+in {FStar_Tactics_Basic.context = uu___101_812.FStar_Tactics_Basic.context; FStar_Tactics_Basic.witness = uu___101_812.FStar_Tactics_Basic.witness; FStar_Tactics_Basic.goal_ty = assertion}))
+in (FStar_Tactics_Basic.bind uu____810 (fun uu____813 -> (unembed_tactic_0 FStar_Tactics_Embedding.unembed_unit tactic))))
+in (FStar_Tactics_Basic.focus_cur_goal "user tactic" uu____808))
+end
+| uu____814 -> begin
+(FStar_Tactics_Basic.fail "Not a user tactic")
+end))
+end))))))
+
+
+let preprocess : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_TypeChecker_Env.env * FStar_Syntax_Syntax.term) Prims.list = (fun env goal -> (
+
+let uu____834 = ((
+
+let uu____835 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_equals uu____835 FStar_Syntax_Const.prims_lid)) || (
+
+let uu____836 = (
+
+let uu____837 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.string_of_lid uu____837))
+in (FStar_Util.starts_with uu____836 "FStar.")))
+in (match (uu____834) with
+| true -> begin
+(((env), (goal)))::[]
+end
+| uu____845 -> begin
+((
+
+let uu____847 = (FStar_Syntax_Print.term_to_string goal)
+in (FStar_Util.print1 "About to preprocess %s\n" uu____847));
+(
+
+let p = (FStar_Tactics_Basic.proofstate_of_goal_ty env goal)
+in (
+
+let uu____849 = (
+
+let uu____851 = (FStar_Tactics_Basic.visit evaluate_user_tactic)
+in (FStar_Tactics_Basic.run uu____851 p))
+in (match (uu____849) with
+| FStar_Tactics_Basic.Success (uu____856, p2) -> begin
+(FStar_All.pipe_right (FStar_List.append p2.FStar_Tactics_Basic.goals p2.FStar_Tactics_Basic.smt_goals) (FStar_List.map (fun g -> ((
+
+let uu____866 = (FStar_Tactics_Basic.goal_to_string g)
+in (FStar_Util.print1 "Got goal: %s\n" uu____866));
+((g.FStar_Tactics_Basic.context), (g.FStar_Tactics_Basic.goal_ty));
+))))
+end
+| FStar_Tactics_Basic.Failed (msg, uu____868) -> begin
+((FStar_Util.print1 "Tactic failed: %s\n" msg);
+(
+
+let uu____871 = (FStar_Tactics_Basic.goal_to_string {FStar_Tactics_Basic.context = env; FStar_Tactics_Basic.witness = None; FStar_Tactics_Basic.goal_ty = goal})
+in (FStar_Util.print1 "Got goal: %s\n" uu____871));
+(((env), (goal)))::[];
+)
+end)));
+)
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_ToSyntax_Env.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Env.ml
@@ -1,2015 +1,2660 @@
+
 open Prims
-type local_binding = (FStar_Ident.ident* FStar_Syntax_Syntax.bv* Prims.bool)
+
+type local_binding =
+(FStar_Ident.ident * FStar_Syntax_Syntax.bv * Prims.bool)
+
+
 type rec_binding =
-  (FStar_Ident.ident* FStar_Ident.lid* FStar_Syntax_Syntax.delta_depth)
-type module_abbrev = (FStar_Ident.ident* FStar_Ident.lident)
+(FStar_Ident.ident * FStar_Ident.lid * FStar_Syntax_Syntax.delta_depth)
+
+
+type module_abbrev =
+(FStar_Ident.ident * FStar_Ident.lident)
+
 type open_kind =
-  | Open_module
-  | Open_namespace
-let uu___is_Open_module: open_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Open_module  -> true | uu____12 -> false
-let uu___is_Open_namespace: open_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Open_namespace  -> true | uu____16 -> false
-type open_module_or_namespace = (FStar_Ident.lident* open_kind)
+| Open_module
+| Open_namespace
+
+
+let uu___is_Open_module : open_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Open_module -> begin
+true
+end
+| uu____12 -> begin
+false
+end))
+
+
+let uu___is_Open_namespace : open_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Open_namespace -> begin
+true
+end
+| uu____16 -> begin
+false
+end))
+
+
+type open_module_or_namespace =
+(FStar_Ident.lident * open_kind)
+
 type record_or_dc =
-  {
-  typename: FStar_Ident.lident;
-  constrname: FStar_Ident.ident;
-  parms: FStar_Syntax_Syntax.binders;
-  fields: (FStar_Ident.ident* FStar_Syntax_Syntax.typ) Prims.list;
-  is_private_or_abstract: Prims.bool;
-  is_record: Prims.bool;}
+{typename : FStar_Ident.lident; constrname : FStar_Ident.ident; parms : FStar_Syntax_Syntax.binders; fields : (FStar_Ident.ident * FStar_Syntax_Syntax.typ) Prims.list; is_private_or_abstract : Prims.bool; is_record : Prims.bool}
+
 type scope_mod =
-  | Local_binding of local_binding
-  | Rec_binding of rec_binding
-  | Module_abbrev of module_abbrev
-  | Open_module_or_namespace of open_module_or_namespace
-  | Top_level_def of FStar_Ident.ident
-  | Record_or_dc of record_or_dc
-let uu___is_Local_binding: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Local_binding _0 -> true | uu____92 -> false
-let __proj__Local_binding__item___0: scope_mod -> local_binding =
-  fun projectee  -> match projectee with | Local_binding _0 -> _0
-let uu___is_Rec_binding: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Rec_binding _0 -> true | uu____104 -> false
-let __proj__Rec_binding__item___0: scope_mod -> rec_binding =
-  fun projectee  -> match projectee with | Rec_binding _0 -> _0
-let uu___is_Module_abbrev: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Module_abbrev _0 -> true | uu____116 -> false
-let __proj__Module_abbrev__item___0: scope_mod -> module_abbrev =
-  fun projectee  -> match projectee with | Module_abbrev _0 -> _0
-let uu___is_Open_module_or_namespace: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Open_module_or_namespace _0 -> true
-    | uu____128 -> false
-let __proj__Open_module_or_namespace__item___0:
-  scope_mod -> open_module_or_namespace =
-  fun projectee  -> match projectee with | Open_module_or_namespace _0 -> _0
-let uu___is_Top_level_def: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Top_level_def _0 -> true | uu____140 -> false
-let __proj__Top_level_def__item___0: scope_mod -> FStar_Ident.ident =
-  fun projectee  -> match projectee with | Top_level_def _0 -> _0
-let uu___is_Record_or_dc: scope_mod -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Record_or_dc _0 -> true | uu____152 -> false
-let __proj__Record_or_dc__item___0: scope_mod -> record_or_dc =
-  fun projectee  -> match projectee with | Record_or_dc _0 -> _0
-type string_set = Prims.string FStar_Util.set
+| Local_binding of local_binding
+| Rec_binding of rec_binding
+| Module_abbrev of module_abbrev
+| Open_module_or_namespace of open_module_or_namespace
+| Top_level_def of FStar_Ident.ident
+| Record_or_dc of record_or_dc
+
+
+let uu___is_Local_binding : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Local_binding (_0) -> begin
+true
+end
+| uu____92 -> begin
+false
+end))
+
+
+let __proj__Local_binding__item___0 : scope_mod  ->  local_binding = (fun projectee -> (match (projectee) with
+| Local_binding (_0) -> begin
+_0
+end))
+
+
+let uu___is_Rec_binding : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Rec_binding (_0) -> begin
+true
+end
+| uu____104 -> begin
+false
+end))
+
+
+let __proj__Rec_binding__item___0 : scope_mod  ->  rec_binding = (fun projectee -> (match (projectee) with
+| Rec_binding (_0) -> begin
+_0
+end))
+
+
+let uu___is_Module_abbrev : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Module_abbrev (_0) -> begin
+true
+end
+| uu____116 -> begin
+false
+end))
+
+
+let __proj__Module_abbrev__item___0 : scope_mod  ->  module_abbrev = (fun projectee -> (match (projectee) with
+| Module_abbrev (_0) -> begin
+_0
+end))
+
+
+let uu___is_Open_module_or_namespace : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Open_module_or_namespace (_0) -> begin
+true
+end
+| uu____128 -> begin
+false
+end))
+
+
+let __proj__Open_module_or_namespace__item___0 : scope_mod  ->  open_module_or_namespace = (fun projectee -> (match (projectee) with
+| Open_module_or_namespace (_0) -> begin
+_0
+end))
+
+
+let uu___is_Top_level_def : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Top_level_def (_0) -> begin
+true
+end
+| uu____140 -> begin
+false
+end))
+
+
+let __proj__Top_level_def__item___0 : scope_mod  ->  FStar_Ident.ident = (fun projectee -> (match (projectee) with
+| Top_level_def (_0) -> begin
+_0
+end))
+
+
+let uu___is_Record_or_dc : scope_mod  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Record_or_dc (_0) -> begin
+true
+end
+| uu____152 -> begin
+false
+end))
+
+
+let __proj__Record_or_dc__item___0 : scope_mod  ->  record_or_dc = (fun projectee -> (match (projectee) with
+| Record_or_dc (_0) -> begin
+_0
+end))
+
+
+type string_set =
+Prims.string FStar_Util.set
+
 type exported_id_kind =
-  | Exported_id_term_type
-  | Exported_id_field
-let uu___is_Exported_id_term_type: exported_id_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | Exported_id_term_type  -> true
-    | uu____164 -> false
-let uu___is_Exported_id_field: exported_id_kind -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Exported_id_field  -> true | uu____168 -> false
-type exported_id_set = exported_id_kind -> string_set FStar_ST.ref
+| Exported_id_term_type
+| Exported_id_field
+
+
+let uu___is_Exported_id_term_type : exported_id_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exported_id_term_type -> begin
+true
+end
+| uu____164 -> begin
+false
+end))
+
+
+let uu___is_Exported_id_field : exported_id_kind  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exported_id_field -> begin
+true
+end
+| uu____168 -> begin
+false
+end))
+
+
+type exported_id_set =
+exported_id_kind  ->  string_set FStar_ST.ref
+
 type env =
-  {
-  curmodule: FStar_Ident.lident Prims.option;
-  curmonad: FStar_Ident.ident Prims.option;
-  modules: (FStar_Ident.lident* FStar_Syntax_Syntax.modul) Prims.list;
-  scope_mods: scope_mod Prims.list;
-  exported_ids: exported_id_set FStar_Util.smap;
-  trans_exported_ids: exported_id_set FStar_Util.smap;
-  includes: FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap;
-  sigaccum: FStar_Syntax_Syntax.sigelts;
-  sigmap: (FStar_Syntax_Syntax.sigelt* Prims.bool) FStar_Util.smap;
-  iface: Prims.bool;
-  admitted_iface: Prims.bool;
-  expect_typ: Prims.bool;}
+{curmodule : FStar_Ident.lident Prims.option; curmonad : FStar_Ident.ident Prims.option; modules : (FStar_Ident.lident * FStar_Syntax_Syntax.modul) Prims.list; scope_mods : scope_mod Prims.list; exported_ids : exported_id_set FStar_Util.smap; trans_exported_ids : exported_id_set FStar_Util.smap; includes : FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap; sigaccum : FStar_Syntax_Syntax.sigelts; sigmap : (FStar_Syntax_Syntax.sigelt * Prims.bool) FStar_Util.smap; iface : Prims.bool; admitted_iface : Prims.bool; expect_typ : Prims.bool}
+
 type foundname =
-  | Term_name of (FStar_Syntax_Syntax.typ* Prims.bool)
-  | Eff_name of (FStar_Syntax_Syntax.sigelt* FStar_Ident.lident)
-let uu___is_Term_name: foundname -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Term_name _0 -> true | uu____314 -> false
-let __proj__Term_name__item___0:
-  foundname -> (FStar_Syntax_Syntax.typ* Prims.bool) =
-  fun projectee  -> match projectee with | Term_name _0 -> _0
-let uu___is_Eff_name: foundname -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eff_name _0 -> true | uu____334 -> false
-let __proj__Eff_name__item___0:
-  foundname -> (FStar_Syntax_Syntax.sigelt* FStar_Ident.lident) =
-  fun projectee  -> match projectee with | Eff_name _0 -> _0
-let all_exported_id_kinds: exported_id_kind Prims.list =
-  [Exported_id_field; Exported_id_term_type]
-let transitive_exported_ids:
-  env -> FStar_Ident.lident -> Prims.string Prims.list =
-  fun env  ->
-    fun lid  ->
-      let module_name = FStar_Ident.string_of_lid lid in
-      let uu____357 =
-        FStar_Util.smap_try_find env.trans_exported_ids module_name in
-      match uu____357 with
-      | None  -> []
-      | Some exported_id_set ->
-          let uu____361 =
-            let uu____362 = exported_id_set Exported_id_term_type in
-            FStar_ST.read uu____362 in
-          FStar_All.pipe_right uu____361 FStar_Util.set_elements
-let open_modules:
-  env -> (FStar_Ident.lident* FStar_Syntax_Syntax.modul) Prims.list =
-  fun e  -> e.modules
-let current_module: env -> FStar_Ident.lident =
-  fun env  ->
-    match env.curmodule with
-    | None  -> failwith "Unset current module"
-    | Some m -> m
-let qual: FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
-  FStar_Syntax_Util.qual_id
-let qualify: env -> FStar_Ident.ident -> FStar_Ident.lident =
-  fun env  ->
-    fun id  ->
-      match env.curmonad with
-      | None  -> let uu____388 = current_module env in qual uu____388 id
-      | Some monad ->
-          let uu____390 =
-            let uu____391 = current_module env in qual uu____391 monad in
-          FStar_Syntax_Util.mk_field_projector_name_from_ident uu____390 id
-let new_sigmap uu____399 = FStar_Util.smap_create (Prims.parse_int "100")
-let empty_env: Prims.unit -> env =
-  fun uu____402  ->
-    let uu____403 = new_sigmap () in
-    let uu____405 = new_sigmap () in
-    let uu____407 = new_sigmap () in
-    let uu____413 = new_sigmap () in
-    {
-      curmodule = None;
-      curmonad = None;
-      modules = [];
-      scope_mods = [];
-      exported_ids = uu____403;
-      trans_exported_ids = uu____405;
-      includes = uu____407;
-      sigaccum = [];
-      sigmap = uu____413;
-      iface = false;
-      admitted_iface = false;
-      expect_typ = false
-    }
-let sigmap: env -> (FStar_Syntax_Syntax.sigelt* Prims.bool) FStar_Util.smap =
-  fun env  -> env.sigmap
-let has_all_in_scope: env -> Prims.bool =
-  fun env  ->
-    FStar_List.existsb
-      (fun uu____432  ->
-         match uu____432 with
-         | (m,uu____436) ->
-             FStar_Ident.lid_equals m FStar_Syntax_Const.all_lid) env.modules
-let set_bv_range:
-  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.bv =
-  fun bv  ->
-    fun r  ->
-      let id =
-        let uu___175_444 = bv.FStar_Syntax_Syntax.ppname in
-        {
-          FStar_Ident.idText = (uu___175_444.FStar_Ident.idText);
-          FStar_Ident.idRange = r
-        } in
-      let uu___176_445 = bv in
-      {
-        FStar_Syntax_Syntax.ppname = id;
-        FStar_Syntax_Syntax.index = (uu___176_445.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = (uu___176_445.FStar_Syntax_Syntax.sort)
-      }
-let bv_to_name:
-  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.term =
-  fun bv  -> fun r  -> FStar_Syntax_Syntax.bv_to_name (set_bv_range bv r)
-let unmangleMap:
-  (Prims.string* Prims.string* FStar_Syntax_Syntax.delta_depth*
-    FStar_Syntax_Syntax.fv_qual Prims.option) Prims.list
-  =
-  [("op_ColonColon", "Cons", FStar_Syntax_Syntax.Delta_constant,
-     (Some FStar_Syntax_Syntax.Data_ctor));
-  ("not", "op_Negation", FStar_Syntax_Syntax.Delta_equational, None)]
-let unmangleOpName:
-  FStar_Ident.ident -> (FStar_Syntax_Syntax.term* Prims.bool) Prims.option =
-  fun id  ->
-    let t =
-      FStar_Util.find_map unmangleMap
-        (fun uu____491  ->
-           match uu____491 with
-           | (x,y,dd,dq) ->
-               if id.FStar_Ident.idText = x
-               then
-                 let uu____505 =
-                   let uu____506 =
-                     FStar_Ident.lid_of_path ["Prims"; y]
-                       id.FStar_Ident.idRange in
-                   FStar_Syntax_Syntax.fvar uu____506 dd dq in
-                 Some uu____505
-               else None) in
-    match t with | Some v1 -> Some (v1, false) | None  -> None
+| Term_name of (FStar_Syntax_Syntax.typ * Prims.bool)
+| Eff_name of (FStar_Syntax_Syntax.sigelt * FStar_Ident.lident)
+
+
+let uu___is_Term_name : foundname  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Term_name (_0) -> begin
+true
+end
+| uu____314 -> begin
+false
+end))
+
+
+let __proj__Term_name__item___0 : foundname  ->  (FStar_Syntax_Syntax.typ * Prims.bool) = (fun projectee -> (match (projectee) with
+| Term_name (_0) -> begin
+_0
+end))
+
+
+let uu___is_Eff_name : foundname  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eff_name (_0) -> begin
+true
+end
+| uu____334 -> begin
+false
+end))
+
+
+let __proj__Eff_name__item___0 : foundname  ->  (FStar_Syntax_Syntax.sigelt * FStar_Ident.lident) = (fun projectee -> (match (projectee) with
+| Eff_name (_0) -> begin
+_0
+end))
+
+
+let all_exported_id_kinds : exported_id_kind Prims.list = (Exported_id_field)::(Exported_id_term_type)::[]
+
+
+let transitive_exported_ids : env  ->  FStar_Ident.lident  ->  Prims.string Prims.list = (fun env lid -> (
+
+let module_name = (FStar_Ident.string_of_lid lid)
+in (
+
+let uu____357 = (FStar_Util.smap_try_find env.trans_exported_ids module_name)
+in (match (uu____357) with
+| None -> begin
+[]
+end
+| Some (exported_id_set) -> begin
+(
+
+let uu____361 = (
+
+let uu____362 = (exported_id_set Exported_id_term_type)
+in (FStar_ST.read uu____362))
+in (FStar_All.pipe_right uu____361 FStar_Util.set_elements))
+end))))
+
+
+let open_modules : env  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.modul) Prims.list = (fun e -> e.modules)
+
+
+let current_module : env  ->  FStar_Ident.lident = (fun env -> (match (env.curmodule) with
+| None -> begin
+(failwith "Unset current module")
+end
+| Some (m) -> begin
+m
+end))
+
+
+let qual : FStar_Ident.lident  ->  FStar_Ident.ident  ->  FStar_Ident.lident = FStar_Syntax_Util.qual_id
+
+
+let qualify : env  ->  FStar_Ident.ident  ->  FStar_Ident.lident = (fun env id -> (match (env.curmonad) with
+| None -> begin
+(
+
+let uu____388 = (current_module env)
+in (qual uu____388 id))
+end
+| Some (monad) -> begin
+(
+
+let uu____390 = (
+
+let uu____391 = (current_module env)
+in (qual uu____391 monad))
+in (FStar_Syntax_Util.mk_field_projector_name_from_ident uu____390 id))
+end))
+
+
+let new_sigmap = (fun uu____399 -> (FStar_Util.smap_create (Prims.parse_int "100")))
+
+
+let empty_env : Prims.unit  ->  env = (fun uu____402 -> (
+
+let uu____403 = (new_sigmap ())
+in (
+
+let uu____405 = (new_sigmap ())
+in (
+
+let uu____407 = (new_sigmap ())
+in (
+
+let uu____413 = (new_sigmap ())
+in {curmodule = None; curmonad = None; modules = []; scope_mods = []; exported_ids = uu____403; trans_exported_ids = uu____405; includes = uu____407; sigaccum = []; sigmap = uu____413; iface = false; admitted_iface = false; expect_typ = false})))))
+
+
+let sigmap : env  ->  (FStar_Syntax_Syntax.sigelt * Prims.bool) FStar_Util.smap = (fun env -> env.sigmap)
+
+
+let has_all_in_scope : env  ->  Prims.bool = (fun env -> (FStar_List.existsb (fun uu____432 -> (match (uu____432) with
+| (m, uu____436) -> begin
+(FStar_Ident.lid_equals m FStar_Syntax_Const.all_lid)
+end)) env.modules))
+
+
+let set_bv_range : FStar_Syntax_Syntax.bv  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.bv = (fun bv r -> (
+
+let id = (
+
+let uu___166_444 = bv.FStar_Syntax_Syntax.ppname
+in {FStar_Ident.idText = uu___166_444.FStar_Ident.idText; FStar_Ident.idRange = r})
+in (
+
+let uu___167_445 = bv
+in {FStar_Syntax_Syntax.ppname = id; FStar_Syntax_Syntax.index = uu___167_445.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu___167_445.FStar_Syntax_Syntax.sort})))
+
+
+let bv_to_name : FStar_Syntax_Syntax.bv  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.term = (fun bv r -> (FStar_Syntax_Syntax.bv_to_name (set_bv_range bv r)))
+
+
+let unmangleMap : (Prims.string * Prims.string * FStar_Syntax_Syntax.delta_depth * FStar_Syntax_Syntax.fv_qual Prims.option) Prims.list = ((("op_ColonColon"), ("Cons"), (FStar_Syntax_Syntax.Delta_constant), (Some (FStar_Syntax_Syntax.Data_ctor))))::((("not"), ("op_Negation"), (FStar_Syntax_Syntax.Delta_equational), (None)))::[]
+
+
+let unmangleOpName : FStar_Ident.ident  ->  (FStar_Syntax_Syntax.term * Prims.bool) Prims.option = (fun id -> (
+
+let t = (FStar_Util.find_map unmangleMap (fun uu____491 -> (match (uu____491) with
+| (x, y, dd, dq) -> begin
+(match ((id.FStar_Ident.idText = x)) with
+| true -> begin
+(
+
+let uu____505 = (
+
+let uu____506 = (FStar_Ident.lid_of_path (("Prims")::(y)::[]) id.FStar_Ident.idRange)
+in (FStar_Syntax_Syntax.fvar uu____506 dd dq))
+in Some (uu____505))
+end
+| uu____507 -> begin
+None
+end)
+end)))
+in (match (t) with
+| Some (v1) -> begin
+Some (((v1), (false)))
+end
+| None -> begin
+None
+end)))
+
 type 'a cont_t =
-  | Cont_ok of 'a
-  | Cont_fail
-  | Cont_ignore
-let uu___is_Cont_ok projectee =
-  match projectee with | Cont_ok _0 -> true | uu____536 -> false
-let __proj__Cont_ok__item___0 projectee =
-  match projectee with | Cont_ok _0 -> _0
-let uu___is_Cont_fail projectee =
-  match projectee with | Cont_fail  -> true | uu____560 -> false
-let uu___is_Cont_ignore projectee =
-  match projectee with | Cont_ignore  -> true | uu____571 -> false
-let option_of_cont k_ignore uu___144_590 =
-  match uu___144_590 with
-  | Cont_ok a -> Some a
-  | Cont_fail  -> None
-  | Cont_ignore  -> k_ignore ()
-let find_in_record ns id record cont =
-  let typename' =
-    FStar_Ident.lid_of_ids
-      (FStar_List.append ns [(record.typename).FStar_Ident.ident]) in
-  if FStar_Ident.lid_equals typename' record.typename
-  then
-    let fname =
-      FStar_Ident.lid_of_ids
-        (FStar_List.append (record.typename).FStar_Ident.ns [id]) in
-    let find1 =
-      FStar_Util.find_map record.fields
-        (fun uu____635  ->
-           match uu____635 with
-           | (f,uu____640) ->
-               if id.FStar_Ident.idText = f.FStar_Ident.idText
-               then Some record
-               else None) in
-    match find1 with | Some r -> cont r | None  -> Cont_ignore
-  else Cont_ignore
-let get_exported_id_set: env -> Prims.string -> exported_id_set Prims.option
-  = fun e  -> fun mname  -> FStar_Util.smap_try_find e.exported_ids mname
-let get_trans_exported_id_set:
-  env -> Prims.string -> exported_id_set Prims.option =
-  fun e  -> fun mname  -> FStar_Util.smap_try_find e.trans_exported_ids mname
-let string_of_exported_id_kind: exported_id_kind -> Prims.string =
-  fun uu___145_676  ->
-    match uu___145_676 with
-    | Exported_id_field  -> "field"
-    | Exported_id_term_type  -> "term/type"
-let find_in_module_with_includes eikind find_in_module find_in_module_default
-  env ns id =
-  let idstr = id.FStar_Ident.idText in
-  let rec aux uu___146_725 =
-    match uu___146_725 with
-    | [] -> find_in_module_default
-    | modul::q ->
-        let mname = modul.FStar_Ident.str in
-        let not_shadowed =
-          let uu____733 = get_exported_id_set env mname in
-          match uu____733 with
-          | None  -> true
-          | Some mex ->
-              let mexports =
-                let uu____749 = mex eikind in FStar_ST.read uu____749 in
-              FStar_Util.set_mem idstr mexports in
-        let mincludes =
-          let uu____756 = FStar_Util.smap_try_find env.includes mname in
-          match uu____756 with
-          | None  -> []
-          | Some minc -> FStar_ST.read minc in
-        let look_into =
-          if not_shadowed
-          then let uu____776 = qual modul id in find_in_module uu____776
-          else Cont_ignore in
-        (match look_into with
-         | Cont_ignore  -> aux (FStar_List.append mincludes q)
-         | uu____779 -> look_into) in
-  aux [ns]
-let is_exported_id_field: exported_id_kind -> Prims.bool =
-  fun uu___147_783  ->
-    match uu___147_783 with | Exported_id_field  -> true | uu____784 -> false
-let try_lookup_id'' env id eikind k_local_binding k_rec_binding k_record
-  find_in_module lookup_default_id =
-  let check_local_binding_id uu___148_873 =
-    match uu___148_873 with
-    | (id',uu____875,uu____876) ->
-        id'.FStar_Ident.idText = id.FStar_Ident.idText in
-  let check_rec_binding_id uu___149_880 =
-    match uu___149_880 with
-    | (id',uu____882,uu____883) ->
-        id'.FStar_Ident.idText = id.FStar_Ident.idText in
-  let curmod_ns =
-    let uu____886 = current_module env in FStar_Ident.ids_of_lid uu____886 in
-  let proc uu___150_891 =
-    match uu___150_891 with
-    | Local_binding l when check_local_binding_id l -> k_local_binding l
-    | Rec_binding r when check_rec_binding_id r -> k_rec_binding r
-    | Open_module_or_namespace (ns,uu____896) ->
-        find_in_module_with_includes eikind find_in_module Cont_ignore env ns
-          id
-    | Top_level_def id' when id'.FStar_Ident.idText = id.FStar_Ident.idText
-        -> lookup_default_id Cont_ignore id
-    | Record_or_dc r when is_exported_id_field eikind ->
-        let uu____899 = FStar_Ident.lid_of_ids curmod_ns in
-        find_in_module_with_includes Exported_id_field
-          (fun lid  ->
-             let id1 = lid.FStar_Ident.ident in
-             find_in_record lid.FStar_Ident.ns id1 r k_record) Cont_ignore
-          env uu____899 id
-    | uu____902 -> Cont_ignore in
-  let rec aux uu___151_908 =
-    match uu___151_908 with
-    | a::q ->
-        let uu____914 = proc a in
-        option_of_cont (fun uu____916  -> aux q) uu____914
-    | [] ->
-        let uu____917 = lookup_default_id Cont_fail id in
-        option_of_cont (fun uu____919  -> None) uu____917 in
-  aux env.scope_mods
-let found_local_binding r uu____938 =
-  match uu____938 with
-  | (id',x,mut) -> let uu____945 = bv_to_name x r in (uu____945, mut)
-let find_in_module env lid k_global_def k_not_found =
-  let uu____982 = FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str in
-  match uu____982 with
-  | Some sb -> k_global_def lid sb
-  | None  -> k_not_found
-let try_lookup_id:
-  env ->
-    FStar_Ident.ident -> (FStar_Syntax_Syntax.term* Prims.bool) Prims.option
-  =
-  fun env  ->
-    fun id  ->
-      let uu____1004 = unmangleOpName id in
-      match uu____1004 with
-      | Some f -> Some f
-      | uu____1018 ->
-          try_lookup_id'' env id Exported_id_term_type
-            (fun r  ->
-               let uu____1025 = found_local_binding id.FStar_Ident.idRange r in
-               Cont_ok uu____1025) (fun uu____1030  -> Cont_fail)
-            (fun uu____1033  -> Cont_ignore)
-            (fun i  ->
-               find_in_module env i
-                 (fun uu____1040  -> fun uu____1041  -> Cont_fail)
-                 Cont_ignore)
-            (fun uu____1048  -> fun uu____1049  -> Cont_fail)
-let lookup_default_id env id k_global_def k_not_found =
-  let find_in_monad =
-    match env.curmonad with
-    | Some uu____1101 ->
-        let lid = qualify env id in
-        let uu____1103 =
-          FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str in
-        (match uu____1103 with
-         | Some r -> let uu____1116 = k_global_def lid r in Some uu____1116
-         | None  -> None)
-    | None  -> None in
-  match find_in_monad with
-  | Some v1 -> v1
-  | None  ->
-      let lid = let uu____1129 = current_module env in qual uu____1129 id in
-      find_in_module env lid k_global_def k_not_found
-let module_is_defined: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      (match env.curmodule with
-       | None  -> false
-       | Some m ->
-           let uu____1138 = current_module env in
-           FStar_Ident.lid_equals lid uu____1138)
-        ||
-        (FStar_List.existsb
-           (fun x  -> FStar_Ident.lid_equals lid (Prims.fst x)) env.modules)
-let resolve_module_name:
-  env -> FStar_Ident.lident -> Prims.bool -> FStar_Ident.lident Prims.option
-  =
-  fun env  ->
-    fun lid  ->
-      fun honor_ns  ->
-        let nslen = FStar_List.length lid.FStar_Ident.ns in
-        let rec aux uu___152_1162 =
-          match uu___152_1162 with
-          | [] ->
-              let uu____1165 = module_is_defined env lid in
-              if uu____1165 then Some lid else None
-          | (Open_module_or_namespace (ns,Open_namespace ))::q when honor_ns
-              ->
-              let new_lid =
-                let uu____1172 =
-                  let uu____1174 = FStar_Ident.path_of_lid ns in
-                  let uu____1176 = FStar_Ident.path_of_lid lid in
-                  FStar_List.append uu____1174 uu____1176 in
-                FStar_Ident.lid_of_path uu____1172
-                  (FStar_Ident.range_of_lid lid) in
-              let uu____1178 = module_is_defined env new_lid in
-              if uu____1178 then Some new_lid else aux q
-          | (Module_abbrev (name,modul))::uu____1183 when
-              (nslen = (Prims.parse_int "0")) &&
-                (name.FStar_Ident.idText =
-                   (lid.FStar_Ident.ident).FStar_Ident.idText)
-              -> Some modul
-          | uu____1187::q -> aux q in
-        aux env.scope_mods
-let namespace_is_open: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      FStar_List.existsb
-        (fun uu___153_1196  ->
-           match uu___153_1196 with
-           | Open_module_or_namespace (ns,Open_namespace ) ->
-               FStar_Ident.lid_equals lid ns
-           | uu____1198 -> false) env.scope_mods
-let shorten_module_path:
-  env ->
-    FStar_Ident.ident Prims.list ->
-      Prims.bool ->
-        (FStar_Ident.ident Prims.list* FStar_Ident.ident Prims.list)
-  =
-  fun env  ->
-    fun ids  ->
-      fun is_full_path  ->
-        let rec aux revns id =
-          let lid = FStar_Ident.lid_of_ns_and_id (FStar_List.rev revns) id in
-          if namespace_is_open env lid
-          then Some ((FStar_List.rev (id :: revns)), [])
-          else
-            (match revns with
-             | [] -> None
-             | ns_last_id::rev_ns_prefix ->
-                 let uu____1253 = aux rev_ns_prefix ns_last_id in
-                 FStar_All.pipe_right uu____1253
-                   (FStar_Util.map_option
-                      (fun uu____1277  ->
-                         match uu____1277 with
-                         | (stripped_ids,rev_kept_ids) ->
-                             (stripped_ids, (id :: rev_kept_ids))))) in
-        let uu____1294 =
-          is_full_path &&
-            (let uu____1295 = FStar_Ident.lid_of_ids ids in
-             module_is_defined env uu____1295) in
-        if uu____1294
-        then (ids, [])
-        else
-          (match FStar_List.rev ids with
-           | [] -> ([], [])
-           | ns_last_id::ns_rev_prefix ->
-               let uu____1312 = aux ns_rev_prefix ns_last_id in
-               (match uu____1312 with
-                | None  -> ([], ids)
-                | Some (stripped_ids,rev_kept_ids) ->
-                    (stripped_ids, (FStar_List.rev rev_kept_ids))))
-let resolve_in_open_namespaces'' env lid eikind k_local_binding k_rec_binding
-  k_record f_module l_default =
-  match lid.FStar_Ident.ns with
-  | uu____1425::uu____1426 ->
-      let uu____1428 =
-        let uu____1430 =
-          let uu____1431 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
-          FStar_Ident.set_lid_range uu____1431 (FStar_Ident.range_of_lid lid) in
-        resolve_module_name env uu____1430 true in
-      (match uu____1428 with
-       | None  -> None
-       | Some modul ->
-           let uu____1434 =
-             find_in_module_with_includes eikind f_module Cont_fail env modul
-               lid.FStar_Ident.ident in
-           option_of_cont (fun uu____1436  -> None) uu____1434)
-  | [] ->
-      try_lookup_id'' env lid.FStar_Ident.ident eikind k_local_binding
-        k_rec_binding k_record f_module l_default
-let cont_of_option k_none uu___154_1451 =
-  match uu___154_1451 with | Some v1 -> Cont_ok v1 | None  -> k_none
-let resolve_in_open_namespaces' env lid k_local_binding k_rec_binding
-  k_global_def =
-  let k_global_def' k lid1 def =
-    let uu____1530 = k_global_def lid1 def in cont_of_option k uu____1530 in
-  let f_module lid' =
-    let k = Cont_ignore in find_in_module env lid' (k_global_def' k) k in
-  let l_default k i = lookup_default_id env i (k_global_def' k) k in
-  resolve_in_open_namespaces'' env lid Exported_id_term_type
-    (fun l  ->
-       let uu____1551 = k_local_binding l in
-       cont_of_option Cont_fail uu____1551)
-    (fun r  ->
-       let uu____1554 = k_rec_binding r in
-       cont_of_option Cont_fail uu____1554) (fun uu____1556  -> Cont_ignore)
-    f_module l_default
-let fv_qual_of_se:
-  FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.fv_qual Prims.option =
-  fun uu___156_1560  ->
-    match uu___156_1560 with
-    | FStar_Syntax_Syntax.Sig_datacon
-        (uu____1562,uu____1563,uu____1564,l,uu____1566,quals,uu____1568,uu____1569)
-        ->
-        let qopt =
-          FStar_Util.find_map quals
-            (fun uu___155_1576  ->
-               match uu___155_1576 with
-               | FStar_Syntax_Syntax.RecordConstructor (uu____1578,fs) ->
-                   Some (FStar_Syntax_Syntax.Record_ctor (l, fs))
-               | uu____1585 -> None) in
-        (match qopt with
-         | None  -> Some FStar_Syntax_Syntax.Data_ctor
-         | x -> x)
-    | FStar_Syntax_Syntax.Sig_declare_typ
-        (uu____1589,uu____1590,uu____1591,quals,uu____1593) -> None
-    | uu____1596 -> None
-let lb_fv:
-  FStar_Syntax_Syntax.letbinding Prims.list ->
-    FStar_Ident.lident -> FStar_Syntax_Syntax.fv
-  =
-  fun lbs  ->
-    fun lid  ->
-      let uu____1605 =
-        FStar_Util.find_map lbs
-          (fun lb  ->
-             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-             let uu____1609 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
-             if uu____1609 then Some fv else None) in
-      FStar_All.pipe_right uu____1605 FStar_Util.must
-let ns_of_lid_equals: FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool
-  =
-  fun lid  ->
-    fun ns  ->
-      ((FStar_List.length lid.FStar_Ident.ns) =
-         (FStar_List.length (FStar_Ident.ids_of_lid ns)))
-        &&
-        (let uu____1623 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
-         FStar_Ident.lid_equals uu____1623 ns)
-let try_lookup_name:
-  Prims.bool ->
-    Prims.bool -> env -> FStar_Ident.lident -> foundname Prims.option
-  =
-  fun any_val  ->
-    fun exclude_interf  ->
-      fun env  ->
-        fun lid  ->
-          let occurrence_range = FStar_Ident.range_of_lid lid in
-          let k_global_def source_lid uu___160_1648 =
-            match uu___160_1648 with
-            | (uu____1652,true ) when exclude_interf -> None
-            | (se,uu____1654) ->
-                (match se with
-                 | FStar_Syntax_Syntax.Sig_inductive_typ uu____1656 ->
-                     let uu____1668 =
-                       let uu____1669 =
-                         let uu____1672 =
-                           FStar_Syntax_Syntax.fvar source_lid
-                             FStar_Syntax_Syntax.Delta_constant None in
-                         (uu____1672, false) in
-                       Term_name uu____1669 in
-                     Some uu____1668
-                 | FStar_Syntax_Syntax.Sig_datacon uu____1673 ->
-                     let uu____1684 =
-                       let uu____1685 =
-                         let uu____1688 =
-                           let uu____1689 = fv_qual_of_se se in
-                           FStar_Syntax_Syntax.fvar source_lid
-                             FStar_Syntax_Syntax.Delta_constant uu____1689 in
-                         (uu____1688, false) in
-                       Term_name uu____1685 in
-                     Some uu____1684
-                 | FStar_Syntax_Syntax.Sig_let
-                     ((uu____1691,lbs),uu____1693,uu____1694,uu____1695,uu____1696)
-                     ->
-                     let fv = lb_fv lbs source_lid in
-                     let uu____1709 =
-                       let uu____1710 =
-                         let uu____1713 =
-                           FStar_Syntax_Syntax.fvar source_lid
-                             fv.FStar_Syntax_Syntax.fv_delta
-                             fv.FStar_Syntax_Syntax.fv_qual in
-                         (uu____1713, false) in
-                       Term_name uu____1710 in
-                     Some uu____1709
-                 | FStar_Syntax_Syntax.Sig_declare_typ
-                     (lid1,uu____1715,uu____1716,quals,uu____1718) ->
-                     let uu____1721 =
-                       any_val ||
-                         (FStar_All.pipe_right quals
-                            (FStar_Util.for_some
-                               (fun uu___157_1723  ->
-                                  match uu___157_1723 with
-                                  | FStar_Syntax_Syntax.Assumption  -> true
-                                  | uu____1724 -> false))) in
-                     if uu____1721
-                     then
-                       let lid2 =
-                         FStar_Ident.set_lid_range lid1
-                           (FStar_Ident.range_of_lid source_lid) in
-                       let dd =
-                         let uu____1728 =
-                           (FStar_Syntax_Util.is_primop_lid lid2) ||
-                             ((ns_of_lid_equals lid2
-                                 FStar_Syntax_Const.prims_lid)
-                                &&
-                                (FStar_All.pipe_right quals
-                                   (FStar_Util.for_some
-                                      (fun uu___158_1730  ->
-                                         match uu___158_1730 with
-                                         | FStar_Syntax_Syntax.Projector _
-                                           |FStar_Syntax_Syntax.Discriminator
-                                           _ -> true
-                                         | uu____1733 -> false)))) in
-                         if uu____1728
-                         then FStar_Syntax_Syntax.Delta_equational
-                         else FStar_Syntax_Syntax.Delta_constant in
-                       let uu____1735 =
-                         FStar_Util.find_map quals
-                           (fun uu___159_1737  ->
-                              match uu___159_1737 with
-                              | FStar_Syntax_Syntax.Reflectable refl_monad ->
-                                  Some refl_monad
-                              | uu____1740 -> None) in
-                       (match uu____1735 with
-                        | Some refl_monad ->
-                            let refl_const =
-                              (FStar_Syntax_Syntax.mk
-                                 (FStar_Syntax_Syntax.Tm_constant
-                                    (FStar_Const.Const_reflect refl_monad)))
-                                None occurrence_range in
-                            Some (Term_name (refl_const, false))
-                        | uu____1756 ->
-                            let uu____1758 =
-                              let uu____1759 =
-                                let uu____1762 =
-                                  let uu____1763 = fv_qual_of_se se in
-                                  FStar_Syntax_Syntax.fvar lid2 dd uu____1763 in
-                                (uu____1762, false) in
-                              Term_name uu____1759 in
-                            Some uu____1758)
-                     else None
-                 | FStar_Syntax_Syntax.Sig_new_effect_for_free (ne,_)
-                   |FStar_Syntax_Syntax.Sig_new_effect (ne,_) ->
-                     Some
-                       (Eff_name
-                          (se,
-                            (FStar_Ident.set_lid_range
-                               ne.FStar_Syntax_Syntax.mname
-                               (FStar_Ident.range_of_lid source_lid))))
-                 | FStar_Syntax_Syntax.Sig_effect_abbrev uu____1769 ->
-                     Some (Eff_name (se, source_lid))
-                 | uu____1779 -> None) in
-          let k_local_binding r =
-            let uu____1791 =
-              let uu____1792 =
-                found_local_binding (FStar_Ident.range_of_lid lid) r in
-              Term_name uu____1792 in
-            Some uu____1791 in
-          let k_rec_binding uu____1802 =
-            match uu____1802 with
-            | (id,l,dd) ->
-                let uu____1810 =
-                  let uu____1811 =
-                    let uu____1814 =
-                      FStar_Syntax_Syntax.fvar
-                        (FStar_Ident.set_lid_range l
-                           (FStar_Ident.range_of_lid lid)) dd None in
-                    (uu____1814, false) in
-                  Term_name uu____1811 in
-                Some uu____1810 in
-          let found_unmangled =
-            match lid.FStar_Ident.ns with
-            | [] ->
-                let uu____1818 = unmangleOpName lid.FStar_Ident.ident in
-                (match uu____1818 with
-                 | Some f -> Some (Term_name f)
-                 | uu____1828 -> None)
-            | uu____1832 -> None in
-          match found_unmangled with
-          | None  ->
-              resolve_in_open_namespaces' env lid k_local_binding
-                k_rec_binding k_global_def
-          | x -> x
-let try_lookup_effect_name':
-  Prims.bool ->
-    env ->
-      FStar_Ident.lident ->
-        (FStar_Syntax_Syntax.sigelt* FStar_Ident.lident) Prims.option
-  =
-  fun exclude_interf  ->
-    fun env  ->
-      fun lid  ->
-        let uu____1852 = try_lookup_name true exclude_interf env lid in
-        match uu____1852 with
-        | Some (Eff_name (o,l)) -> Some (o, l)
-        | uu____1861 -> None
-let try_lookup_effect_name:
-  env -> FStar_Ident.lident -> FStar_Ident.lident Prims.option =
-  fun env  ->
-    fun l  ->
-      let uu____1872 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
-      match uu____1872 with | Some (o,l1) -> Some l1 | uu____1881 -> None
-let try_lookup_effect_name_and_attributes:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Ident.lident* FStar_Syntax_Syntax.cflags Prims.list)
-        Prims.option
-  =
-  fun env  ->
-    fun l  ->
-      let uu____1895 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
-      match uu____1895 with
-      | Some (FStar_Syntax_Syntax.Sig_new_effect (ne,uu____1904),l1) ->
-          Some (l1, (ne.FStar_Syntax_Syntax.cattributes))
-      | Some (FStar_Syntax_Syntax.Sig_new_effect_for_free (ne,uu____1913),l1)
-          -> Some (l1, (ne.FStar_Syntax_Syntax.cattributes))
-      | Some
-          (FStar_Syntax_Syntax.Sig_effect_abbrev
-           (uu____1921,uu____1922,uu____1923,uu____1924,uu____1925,cattributes,uu____1927),l1)
-          -> Some (l1, cattributes)
-      | uu____1939 -> None
-let try_lookup_effect_defn:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl Prims.option =
-  fun env  ->
-    fun l  ->
-      let uu____1953 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
-      match uu____1953 with
-      | Some (FStar_Syntax_Syntax.Sig_new_effect (ne,uu____1959),uu____1960)
-          -> Some ne
-      | Some
-          (FStar_Syntax_Syntax.Sig_new_effect_for_free
-           (ne,uu____1964),uu____1965)
-          -> Some ne
-      | uu____1968 -> None
-let is_effect_name: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      let uu____1978 = try_lookup_effect_name env lid in
-      match uu____1978 with | None  -> false | Some uu____1980 -> true
-let try_lookup_root_effect_name:
-  env -> FStar_Ident.lident -> FStar_Ident.lident Prims.option =
-  fun env  ->
-    fun l  ->
-      let uu____1988 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
-      match uu____1988 with
-      | Some
-          (FStar_Syntax_Syntax.Sig_effect_abbrev
-           (l',uu____1994,uu____1995,uu____1996,uu____1997,uu____1998,uu____1999),uu____2000)
-          ->
-          let rec aux new_name =
-            let uu____2012 =
-              FStar_Util.smap_try_find (sigmap env) new_name.FStar_Ident.str in
-            match uu____2012 with
-            | None  -> None
-            | Some (s,uu____2022) ->
-                (match s with
-                 | FStar_Syntax_Syntax.Sig_new_effect_for_free (ne,_)
-                   |FStar_Syntax_Syntax.Sig_new_effect (ne,_) ->
-                     Some
-                       (FStar_Ident.set_lid_range
-                          ne.FStar_Syntax_Syntax.mname
-                          (FStar_Ident.range_of_lid l))
-                 | FStar_Syntax_Syntax.Sig_effect_abbrev
-                     (uu____2029,uu____2030,uu____2031,cmp,uu____2033,uu____2034,uu____2035)
-                     ->
-                     let l'' = FStar_Syntax_Util.comp_effect_name cmp in
-                     aux l''
-                 | uu____2041 -> None) in
-          aux l'
-      | Some (uu____2042,l') -> Some l'
-      | uu____2046 -> None
-let lookup_letbinding_quals:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list =
-  fun env  ->
-    fun lid  ->
-      let k_global_def lid1 uu___161_2067 =
-        match uu___161_2067 with
-        | (FStar_Syntax_Syntax.Sig_declare_typ
-           (lid2,uu____2073,uu____2074,quals,uu____2076),uu____2077) ->
-            Some quals
-        | uu____2081 -> None in
-      let uu____2085 =
-        resolve_in_open_namespaces' env lid (fun uu____2089  -> None)
-          (fun uu____2091  -> None) k_global_def in
-      match uu____2085 with | Some quals -> quals | uu____2097 -> []
-let try_lookup_module:
-  env -> Prims.string Prims.list -> FStar_Syntax_Syntax.modul Prims.option =
-  fun env  ->
-    fun path  ->
-      let uu____2109 =
-        FStar_List.tryFind
-          (fun uu____2115  ->
-             match uu____2115 with
-             | (mlid,modul) ->
-                 let uu____2120 = FStar_Ident.path_of_lid mlid in
-                 uu____2120 = path) env.modules in
-      match uu____2109 with
-      | Some (uu____2124,modul) -> Some modul
-      | None  -> None
-let try_lookup_let:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term Prims.option =
-  fun env  ->
-    fun lid  ->
-      let k_global_def lid1 uu___162_2146 =
-        match uu___162_2146 with
-        | (FStar_Syntax_Syntax.Sig_let
-           ((uu____2150,lbs),uu____2152,uu____2153,uu____2154,uu____2155),uu____2156)
-            ->
-            let fv = lb_fv lbs lid1 in
-            let uu____2169 =
-              FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
-                fv.FStar_Syntax_Syntax.fv_qual in
-            Some uu____2169
-        | uu____2170 -> None in
-      resolve_in_open_namespaces' env lid (fun uu____2173  -> None)
-        (fun uu____2174  -> None) k_global_def
-let try_lookup_definition:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax Prims.option
-  =
-  fun env  ->
-    fun lid  ->
-      let k_global_def lid1 uu___163_2193 =
-        match uu___163_2193 with
-        | (FStar_Syntax_Syntax.Sig_let
-           (lbs,uu____2200,uu____2201,uu____2202,uu____2203),uu____2204) ->
-            FStar_Util.find_map (Prims.snd lbs)
-              (fun lb  ->
-                 match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Util.Inr fv when
-                     FStar_Syntax_Syntax.fv_eq_lid fv lid1 ->
-                     Some (lb.FStar_Syntax_Syntax.lbdef)
-                 | uu____2221 -> None)
-        | uu____2226 -> None in
-      resolve_in_open_namespaces' env lid (fun uu____2233  -> None)
-        (fun uu____2236  -> None) k_global_def
-let empty_include_smap:
-  FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap = new_sigmap ()
-let empty_exported_id_smap: exported_id_set FStar_Util.smap = new_sigmap ()
-let try_lookup_lid':
-  Prims.bool ->
-    Prims.bool ->
-      env ->
-        FStar_Ident.lident ->
-          (FStar_Syntax_Syntax.term* Prims.bool) Prims.option
-  =
-  fun any_val  ->
-    fun exclude_interf  ->
-      fun env  ->
-        fun lid  ->
-          let uu____2263 = try_lookup_name any_val exclude_interf env lid in
-          match uu____2263 with
-          | Some (Term_name (e,mut)) -> Some (e, mut)
-          | uu____2272 -> None
-let try_lookup_lid:
-  env ->
-    FStar_Ident.lident -> (FStar_Syntax_Syntax.term* Prims.bool) Prims.option
-  = fun env  -> fun l  -> try_lookup_lid' env.iface false env l
-let resolve_to_fully_qualified_name:
-  env -> FStar_Ident.lident -> FStar_Ident.lident Prims.option =
-  fun env  ->
-    fun l  ->
-      let uu____2292 = try_lookup_lid env l in
-      match uu____2292 with
-      | None  -> None
-      | Some (e,uu____2300) ->
-          let uu____2303 =
-            let uu____2304 = FStar_Syntax_Subst.compress e in
-            uu____2304.FStar_Syntax_Syntax.n in
-          (match uu____2303 with
-           | FStar_Syntax_Syntax.Tm_fvar fv ->
-               Some ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-           | uu____2313 -> None)
-let try_lookup_lid_no_resolve:
-  env ->
-    FStar_Ident.lident -> (FStar_Syntax_Syntax.term* Prims.bool) Prims.option
-  =
-  fun env  ->
-    fun l  ->
-      let env' =
-        let uu___177_2324 = env in
-        {
-          curmodule = (uu___177_2324.curmodule);
-          curmonad = (uu___177_2324.curmonad);
-          modules = (uu___177_2324.modules);
-          scope_mods = [];
-          exported_ids = empty_exported_id_smap;
-          trans_exported_ids = (uu___177_2324.trans_exported_ids);
-          includes = empty_include_smap;
-          sigaccum = (uu___177_2324.sigaccum);
-          sigmap = (uu___177_2324.sigmap);
-          iface = (uu___177_2324.iface);
-          admitted_iface = (uu___177_2324.admitted_iface);
-          expect_typ = (uu___177_2324.expect_typ)
-        } in
-      try_lookup_lid env' l
-let try_lookup_datacon:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.fv Prims.option =
-  fun env  ->
-    fun lid  ->
-      let k_global_def lid1 uu___165_2341 =
-        match uu___165_2341 with
-        | (FStar_Syntax_Syntax.Sig_declare_typ
-           (uu____2345,uu____2346,uu____2347,quals,uu____2349),uu____2350) ->
-            let uu____2353 =
-              FStar_All.pipe_right quals
-                (FStar_Util.for_some
-                   (fun uu___164_2355  ->
-                      match uu___164_2355 with
-                      | FStar_Syntax_Syntax.Assumption  -> true
-                      | uu____2356 -> false)) in
-            if uu____2353
-            then
-              let uu____2358 =
-                FStar_Syntax_Syntax.lid_as_fv lid1
-                  FStar_Syntax_Syntax.Delta_constant None in
-              Some uu____2358
-            else None
-        | (FStar_Syntax_Syntax.Sig_datacon uu____2360,uu____2361) ->
-            let uu____2372 =
-              FStar_Syntax_Syntax.lid_as_fv lid1
-                FStar_Syntax_Syntax.Delta_constant
-                (Some FStar_Syntax_Syntax.Data_ctor) in
-            Some uu____2372
-        | uu____2373 -> None in
-      resolve_in_open_namespaces' env lid (fun uu____2376  -> None)
-        (fun uu____2377  -> None) k_global_def
-let find_all_datacons:
-  env -> FStar_Ident.lident -> FStar_Ident.lident Prims.list Prims.option =
-  fun env  ->
-    fun lid  ->
-      let k_global_def lid1 uu___166_2396 =
-        match uu___166_2396 with
-        | (FStar_Syntax_Syntax.Sig_inductive_typ
-           (uu____2401,uu____2402,uu____2403,uu____2404,uu____2405,datas,uu____2407,uu____2408),uu____2409)
-            -> Some datas
-        | uu____2417 -> None in
-      resolve_in_open_namespaces' env lid (fun uu____2422  -> None)
-        (fun uu____2424  -> None) k_global_def
-let record_cache_aux_with_filter:
-  (((Prims.unit -> Prims.unit)* (Prims.unit -> Prims.unit)*
-    (Prims.unit -> record_or_dc Prims.list)* (record_or_dc -> Prims.unit)*
-    (Prims.unit -> Prims.unit))* (Prims.unit -> Prims.unit))
-  =
-  let record_cache = FStar_Util.mk_ref [[]] in
-  let push1 uu____2458 =
-    let uu____2459 =
-      let uu____2462 =
-        let uu____2464 = FStar_ST.read record_cache in
-        FStar_List.hd uu____2464 in
-      let uu____2472 = FStar_ST.read record_cache in uu____2462 :: uu____2472 in
-    FStar_ST.write record_cache uu____2459 in
-  let pop1 uu____2487 =
-    let uu____2488 =
-      let uu____2491 = FStar_ST.read record_cache in FStar_List.tl uu____2491 in
-    FStar_ST.write record_cache uu____2488 in
-  let peek uu____2507 =
-    let uu____2508 = FStar_ST.read record_cache in FStar_List.hd uu____2508 in
-  let insert r =
-    let uu____2520 =
-      let uu____2523 = let uu____2525 = peek () in r :: uu____2525 in
-      let uu____2527 =
-        let uu____2530 = FStar_ST.read record_cache in
-        FStar_List.tl uu____2530 in
-      uu____2523 :: uu____2527 in
-    FStar_ST.write record_cache uu____2520 in
-  let commit1 uu____2546 =
-    let uu____2547 = FStar_ST.read record_cache in
-    match uu____2547 with
-    | hd1::uu____2555::tl1 -> FStar_ST.write record_cache (hd1 :: tl1)
-    | uu____2568 -> failwith "Impossible" in
-  let filter1 uu____2574 =
-    let rc = peek () in
-    pop1 ();
-    (match () with
-     | () ->
-         let filtered =
-           FStar_List.filter
-             (fun r  -> Prims.op_Negation r.is_private_or_abstract) rc in
-         let uu____2581 =
-           let uu____2584 = FStar_ST.read record_cache in filtered ::
-             uu____2584 in
-         FStar_ST.write record_cache uu____2581) in
-  let aux = (push1, pop1, peek, insert, commit1) in (aux, filter1)
-let record_cache_aux:
-  ((Prims.unit -> Prims.unit)* (Prims.unit -> Prims.unit)*
-    (Prims.unit -> record_or_dc Prims.list)* (record_or_dc -> Prims.unit)*
-    (Prims.unit -> Prims.unit))
-  =
-  let uu____2658 = record_cache_aux_with_filter in
-  match uu____2658 with | (aux,uu____2696) -> aux
-let filter_record_cache: Prims.unit -> Prims.unit =
-  let uu____2735 = record_cache_aux_with_filter in
-  match uu____2735 with | (uu____2758,filter1) -> filter1
-let push_record_cache: Prims.unit -> Prims.unit =
-  let uu____2798 = record_cache_aux in
-  match uu____2798 with
-  | (push1,uu____2818,uu____2819,uu____2820,uu____2821) -> push1
-let pop_record_cache: Prims.unit -> Prims.unit =
-  let uu____2846 = record_cache_aux in
-  match uu____2846 with
-  | (uu____2865,pop1,uu____2867,uu____2868,uu____2869) -> pop1
-let peek_record_cache: Prims.unit -> record_or_dc Prims.list =
-  let uu____2895 = record_cache_aux in
-  match uu____2895 with
-  | (uu____2915,uu____2916,peek,uu____2918,uu____2919) -> peek
-let insert_record_cache: record_or_dc -> Prims.unit =
-  let uu____2944 = record_cache_aux in
-  match uu____2944 with
-  | (uu____2963,uu____2964,uu____2965,insert,uu____2967) -> insert
-let commit_record_cache: Prims.unit -> Prims.unit =
-  let uu____2992 = record_cache_aux in
-  match uu____2992 with
-  | (uu____3011,uu____3012,uu____3013,uu____3014,commit1) -> commit1
-let extract_record:
-  env ->
-    scope_mod Prims.list FStar_ST.ref ->
-      FStar_Syntax_Syntax.sigelt -> Prims.unit
-  =
-  fun e  ->
-    fun new_globs  ->
-      fun uu___170_3049  ->
-        match uu___170_3049 with
-        | FStar_Syntax_Syntax.Sig_bundle
-            (sigs,uu____3054,uu____3055,uu____3056) ->
-            let is_rec =
-              FStar_Util.for_some
-                (fun uu___167_3067  ->
-                   match uu___167_3067 with
-                   | FStar_Syntax_Syntax.RecordType _
-                     |FStar_Syntax_Syntax.RecordConstructor _ -> true
-                   | uu____3070 -> false) in
-            let find_dc dc =
-              FStar_All.pipe_right sigs
-                (FStar_Util.find_opt
-                   (fun uu___168_3078  ->
-                      match uu___168_3078 with
-                      | FStar_Syntax_Syntax.Sig_datacon
-                          (lid,uu____3080,uu____3081,uu____3082,uu____3083,uu____3084,uu____3085,uu____3086)
-                          -> FStar_Ident.lid_equals dc lid
-                      | uu____3091 -> false)) in
-            FStar_All.pipe_right sigs
-              (FStar_List.iter
-                 (fun uu___169_3093  ->
-                    match uu___169_3093 with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ
-                        (typename,univs,parms,uu____3097,uu____3098,dc::[],tags,uu____3101)
-                        ->
-                        let uu____3107 =
-                          let uu____3108 = find_dc dc in
-                          FStar_All.pipe_left FStar_Util.must uu____3108 in
-                        (match uu____3107 with
-                         | FStar_Syntax_Syntax.Sig_datacon
-                             (constrname,uu____3112,t,uu____3114,uu____3115,uu____3116,uu____3117,uu____3118)
-                             ->
-                             let uu____3123 =
-                               FStar_Syntax_Util.arrow_formals t in
-                             (match uu____3123 with
-                              | (formals,uu____3132) ->
-                                  let is_rec1 = is_rec tags in
-                                  let formals' =
-                                    FStar_All.pipe_right formals
-                                      (FStar_List.collect
-                                         (fun uu____3158  ->
-                                            match uu____3158 with
-                                            | (x,q) ->
-                                                let uu____3166 =
-                                                  (FStar_Syntax_Syntax.is_null_bv
-                                                     x)
-                                                    ||
-                                                    (is_rec1 &&
-                                                       (FStar_Syntax_Syntax.is_implicit
-                                                          q)) in
-                                                if uu____3166
-                                                then []
-                                                else [(x, q)])) in
-                                  let fields' =
-                                    FStar_All.pipe_right formals'
-                                      (FStar_List.map
-                                         (fun uu____3197  ->
-                                            match uu____3197 with
-                                            | (x,q) ->
-                                                let uu____3206 =
-                                                  if is_rec1
-                                                  then
-                                                    FStar_Syntax_Util.unmangle_field_name
-                                                      x.FStar_Syntax_Syntax.ppname
-                                                  else
-                                                    x.FStar_Syntax_Syntax.ppname in
-                                                (uu____3206,
-                                                  (x.FStar_Syntax_Syntax.sort)))) in
-                                  let fields = fields' in
-                                  let record =
-                                    {
-                                      typename;
-                                      constrname =
-                                        (constrname.FStar_Ident.ident);
-                                      parms;
-                                      fields;
-                                      is_private_or_abstract =
-                                        ((FStar_List.contains
-                                            FStar_Syntax_Syntax.Private tags)
-                                           ||
-                                           (FStar_List.contains
-                                              FStar_Syntax_Syntax.Abstract
-                                              tags));
-                                      is_record = is_rec1
-                                    } in
-                                  ((let uu____3218 =
-                                      let uu____3220 =
-                                        FStar_ST.read new_globs in
-                                      (Record_or_dc record) :: uu____3220 in
-                                    FStar_ST.write new_globs uu____3218);
-                                   (match () with
-                                    | () ->
-                                        ((let add_field uu____3236 =
-                                            match uu____3236 with
-                                            | (id,uu____3242) ->
-                                                let modul =
-                                                  let uu____3248 =
-                                                    FStar_Ident.lid_of_ids
-                                                      constrname.FStar_Ident.ns in
-                                                  uu____3248.FStar_Ident.str in
-                                                let uu____3249 =
-                                                  get_exported_id_set e modul in
-                                                (match uu____3249 with
-                                                 | Some my_ex ->
-                                                     let my_exported_ids =
-                                                       my_ex
-                                                         Exported_id_field in
-                                                     ((let uu____3265 =
-                                                         let uu____3266 =
-                                                           FStar_ST.read
-                                                             my_exported_ids in
-                                                         FStar_Util.set_add
-                                                           id.FStar_Ident.idText
-                                                           uu____3266 in
-                                                       FStar_ST.write
-                                                         my_exported_ids
-                                                         uu____3265);
-                                                      (match () with
-                                                       | () ->
-                                                           let projname =
-                                                             let uu____3273 =
-                                                               let uu____3274
-                                                                 =
-                                                                 FStar_Syntax_Util.mk_field_projector_name_from_ident
-                                                                   constrname
-                                                                   id in
-                                                               uu____3274.FStar_Ident.ident in
-                                                             uu____3273.FStar_Ident.idText in
-                                                           let uu____3276 =
-                                                             let uu____3277 =
-                                                               FStar_ST.read
-                                                                 my_exported_ids in
-                                                             FStar_Util.set_add
-                                                               projname
-                                                               uu____3277 in
-                                                           FStar_ST.write
-                                                             my_exported_ids
-                                                             uu____3276))
-                                                 | None  -> ()) in
-                                          FStar_List.iter add_field fields');
-                                         (match () with
-                                          | () -> insert_record_cache record)))))
-                         | uu____3290 -> ())
-                    | uu____3291 -> ()))
-        | uu____3292 -> ()
-let try_lookup_record_or_dc_by_field_name:
-  env -> FStar_Ident.lident -> record_or_dc Prims.option =
-  fun env  ->
-    fun fieldname  ->
-      let find_in_cache fieldname1 =
-        let uu____3305 =
-          ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident)) in
-        match uu____3305 with
-        | (ns,id) ->
-            let uu____3315 = peek_record_cache () in
-            FStar_Util.find_map uu____3315
-              (fun record  ->
-                 let uu____3318 =
-                   find_in_record ns id record (fun r  -> Cont_ok r) in
-                 option_of_cont (fun uu____3321  -> None) uu____3318) in
-      resolve_in_open_namespaces'' env fieldname Exported_id_field
-        (fun uu____3322  -> Cont_ignore) (fun uu____3323  -> Cont_ignore)
-        (fun r  -> Cont_ok r)
-        (fun fn  ->
-           let uu____3326 = find_in_cache fn in
-           cont_of_option Cont_ignore uu____3326)
-        (fun k  -> fun uu____3329  -> k)
-let try_lookup_record_by_field_name:
-  env -> FStar_Ident.lident -> record_or_dc Prims.option =
-  fun env  ->
-    fun fieldname  ->
-      let uu____3338 = try_lookup_record_or_dc_by_field_name env fieldname in
-      match uu____3338 with
-      | Some r when r.is_record -> Some r
-      | uu____3342 -> None
-let belongs_to_record:
-  env -> FStar_Ident.lident -> record_or_dc -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      fun record  ->
-        let uu____3353 = try_lookup_record_by_field_name env lid in
-        match uu____3353 with
-        | Some record' when
-            let uu____3356 =
-              let uu____3357 =
-                FStar_Ident.path_of_ns (record.typename).FStar_Ident.ns in
-              FStar_Ident.text_of_path uu____3357 in
-            let uu____3359 =
-              let uu____3360 =
-                FStar_Ident.path_of_ns (record'.typename).FStar_Ident.ns in
-              FStar_Ident.text_of_path uu____3360 in
-            uu____3356 = uu____3359 ->
-            let uu____3362 =
-              find_in_record (record.typename).FStar_Ident.ns
-                lid.FStar_Ident.ident record (fun uu____3364  -> Cont_ok ()) in
-            (match uu____3362 with
-             | Cont_ok uu____3365 -> true
-             | uu____3366 -> false)
-        | uu____3368 -> false
-let try_lookup_dc_by_field_name:
-  env -> FStar_Ident.lident -> (FStar_Ident.lident* Prims.bool) Prims.option
-  =
-  fun env  ->
-    fun fieldname  ->
-      let uu____3379 = try_lookup_record_or_dc_by_field_name env fieldname in
-      match uu____3379 with
-      | Some r ->
-          let uu____3385 =
-            let uu____3388 =
-              let uu____3389 =
-                FStar_Ident.lid_of_ids
-                  (FStar_List.append (r.typename).FStar_Ident.ns
-                     [r.constrname]) in
-              FStar_Ident.set_lid_range uu____3389
-                (FStar_Ident.range_of_lid fieldname) in
-            (uu____3388, (r.is_record)) in
-          Some uu____3385
-      | uu____3392 -> None
-let string_set_ref_new:
-  Prims.unit -> Prims.string FStar_Util.set FStar_ST.ref =
-  fun uu____3401  ->
-    let uu____3402 =
-      FStar_Util.new_set FStar_Util.compare FStar_Util.hashcode in
-    FStar_Util.mk_ref uu____3402
-let exported_id_set_new:
-  Prims.unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref
-  =
-  fun uu____3413  ->
-    let term_type_set = string_set_ref_new () in
-    let field_set = string_set_ref_new () in
-    fun uu___171_3422  ->
-      match uu___171_3422 with
-      | Exported_id_term_type  -> term_type_set
-      | Exported_id_field  -> field_set
-let unique:
-  Prims.bool -> Prims.bool -> env -> FStar_Ident.lident -> Prims.bool =
-  fun any_val  ->
-    fun exclude_if  ->
-      fun env  ->
-        fun lid  ->
-          let filter_scope_mods uu___172_3442 =
-            match uu___172_3442 with
-            | Rec_binding uu____3443 -> true
-            | uu____3444 -> false in
-          let this_env =
-            let uu___178_3446 = env in
-            let uu____3447 =
-              FStar_List.filter filter_scope_mods env.scope_mods in
-            {
-              curmodule = (uu___178_3446.curmodule);
-              curmonad = (uu___178_3446.curmonad);
-              modules = (uu___178_3446.modules);
-              scope_mods = uu____3447;
-              exported_ids = empty_exported_id_smap;
-              trans_exported_ids = (uu___178_3446.trans_exported_ids);
-              includes = empty_include_smap;
-              sigaccum = (uu___178_3446.sigaccum);
-              sigmap = (uu___178_3446.sigmap);
-              iface = (uu___178_3446.iface);
-              admitted_iface = (uu___178_3446.admitted_iface);
-              expect_typ = (uu___178_3446.expect_typ)
-            } in
-          let uu____3449 = try_lookup_lid' any_val exclude_if this_env lid in
-          match uu____3449 with | None  -> true | Some uu____3455 -> false
-let push_scope_mod: env -> scope_mod -> env =
-  fun env  ->
-    fun scope_mod  ->
-      let uu___179_3466 = env in
-      {
-        curmodule = (uu___179_3466.curmodule);
-        curmonad = (uu___179_3466.curmonad);
-        modules = (uu___179_3466.modules);
-        scope_mods = (scope_mod :: (env.scope_mods));
-        exported_ids = (uu___179_3466.exported_ids);
-        trans_exported_ids = (uu___179_3466.trans_exported_ids);
-        includes = (uu___179_3466.includes);
-        sigaccum = (uu___179_3466.sigaccum);
-        sigmap = (uu___179_3466.sigmap);
-        iface = (uu___179_3466.iface);
-        admitted_iface = (uu___179_3466.admitted_iface);
-        expect_typ = (uu___179_3466.expect_typ)
-      }
-let push_bv':
-  env -> FStar_Ident.ident -> Prims.bool -> (env* FStar_Syntax_Syntax.bv) =
-  fun env  ->
-    fun x  ->
-      fun is_mutable  ->
-        let bv =
-          FStar_Syntax_Syntax.gen_bv x.FStar_Ident.idText
-            (Some (x.FStar_Ident.idRange)) FStar_Syntax_Syntax.tun in
-        ((push_scope_mod env (Local_binding (x, bv, is_mutable))), bv)
-let push_bv_mutable:
-  env -> FStar_Ident.ident -> (env* FStar_Syntax_Syntax.bv) =
-  fun env  -> fun x  -> push_bv' env x true
-let push_bv: env -> FStar_Ident.ident -> (env* FStar_Syntax_Syntax.bv) =
-  fun env  -> fun x  -> push_bv' env x false
-let push_top_level_rec_binding:
-  env -> FStar_Ident.ident -> FStar_Syntax_Syntax.delta_depth -> env =
-  fun env  ->
-    fun x  ->
-      fun dd  ->
-        let l = qualify env x in
-        let uu____3505 =
-          (unique false true env l) || (FStar_Options.interactive ()) in
-        if uu____3505
-        then push_scope_mod env (Rec_binding (x, l, dd))
-        else
-          Prims.raise
-            (FStar_Errors.Error
-               ((Prims.strcat "Duplicate top-level names " l.FStar_Ident.str),
-                 (FStar_Ident.range_of_lid l)))
-let push_sigelt: env -> FStar_Syntax_Syntax.sigelt -> env =
-  fun env  ->
-    fun s  ->
-      let err l =
-        let sopt = FStar_Util.smap_try_find (sigmap env) l.FStar_Ident.str in
-        let r =
-          match sopt with
-          | Some (se,uu____3525) ->
-              let uu____3528 =
-                FStar_Util.find_opt (FStar_Ident.lid_equals l)
-                  (FStar_Syntax_Util.lids_of_sigelt se) in
-              (match uu____3528 with
-               | Some l1 ->
-                   FStar_All.pipe_left FStar_Range.string_of_range
-                     (FStar_Ident.range_of_lid l1)
-               | None  -> "<unknown>")
-          | None  -> "<unknown>" in
-        let uu____3533 =
-          let uu____3534 =
-            let uu____3537 =
-              FStar_Util.format2
-                "Duplicate top-level names [%s]; previously declared at %s"
-                (FStar_Ident.text_of_lid l) r in
-            (uu____3537, (FStar_Ident.range_of_lid l)) in
-          FStar_Errors.Error uu____3534 in
-        Prims.raise uu____3533 in
-      let globals = FStar_Util.mk_ref env.scope_mods in
-      let env1 =
-        let uu____3544 =
-          match s with
-          | FStar_Syntax_Syntax.Sig_let uu____3549 -> (false, true)
-          | FStar_Syntax_Syntax.Sig_bundle uu____3558 -> (true, true)
-          | uu____3566 -> (false, false) in
-        match uu____3544 with
-        | (any_val,exclude_if) ->
-            let lids = FStar_Syntax_Util.lids_of_sigelt s in
-            let uu____3571 =
-              FStar_Util.find_map lids
-                (fun l  ->
-                   let uu____3574 =
-                     let uu____3575 = unique any_val exclude_if env l in
-                     Prims.op_Negation uu____3575 in
-                   if uu____3574 then Some l else None) in
-            (match uu____3571 with
-             | Some l when
-                 let uu____3579 = FStar_Options.interactive () in
-                 Prims.op_Negation uu____3579 -> err l
-             | uu____3580 ->
-                 (extract_record env globals s;
-                  (let uu___180_3585 = env in
-                   {
-                     curmodule = (uu___180_3585.curmodule);
-                     curmonad = (uu___180_3585.curmonad);
-                     modules = (uu___180_3585.modules);
-                     scope_mods = (uu___180_3585.scope_mods);
-                     exported_ids = (uu___180_3585.exported_ids);
-                     trans_exported_ids = (uu___180_3585.trans_exported_ids);
-                     includes = (uu___180_3585.includes);
-                     sigaccum = (s :: (env.sigaccum));
-                     sigmap = (uu___180_3585.sigmap);
-                     iface = (uu___180_3585.iface);
-                     admitted_iface = (uu___180_3585.admitted_iface);
-                     expect_typ = (uu___180_3585.expect_typ)
-                   }))) in
-      let env2 =
-        let uu___181_3587 = env1 in
-        let uu____3588 = FStar_ST.read globals in
-        {
-          curmodule = (uu___181_3587.curmodule);
-          curmonad = (uu___181_3587.curmonad);
-          modules = (uu___181_3587.modules);
-          scope_mods = uu____3588;
-          exported_ids = (uu___181_3587.exported_ids);
-          trans_exported_ids = (uu___181_3587.trans_exported_ids);
-          includes = (uu___181_3587.includes);
-          sigaccum = (uu___181_3587.sigaccum);
-          sigmap = (uu___181_3587.sigmap);
-          iface = (uu___181_3587.iface);
-          admitted_iface = (uu___181_3587.admitted_iface);
-          expect_typ = (uu___181_3587.expect_typ)
-        } in
-      let uu____3593 =
-        match s with
-        | FStar_Syntax_Syntax.Sig_bundle
-            (ses,uu____3607,uu____3608,uu____3609) ->
-            let uu____3616 =
-              FStar_List.map
-                (fun se  -> ((FStar_Syntax_Util.lids_of_sigelt se), se)) ses in
-            (env2, uu____3616)
-        | uu____3630 -> (env2, [((FStar_Syntax_Util.lids_of_sigelt s), s)]) in
-      match uu____3593 with
-      | (env3,lss) ->
-          (FStar_All.pipe_right lss
-             (FStar_List.iter
-                (fun uu____3660  ->
-                   match uu____3660 with
-                   | (lids,se) ->
-                       FStar_All.pipe_right lids
-                         (FStar_List.iter
-                            (fun lid  ->
-                               (let uu____3671 =
-                                  let uu____3673 = FStar_ST.read globals in
-                                  (Top_level_def (lid.FStar_Ident.ident)) ::
-                                    uu____3673 in
-                                FStar_ST.write globals uu____3671);
-                               (match () with
-                                | () ->
-                                    let modul =
-                                      let uu____3682 =
-                                        FStar_Ident.lid_of_ids
-                                          lid.FStar_Ident.ns in
-                                      uu____3682.FStar_Ident.str in
-                                    ((let uu____3684 =
-                                        get_exported_id_set env3 modul in
-                                      match uu____3684 with
-                                      | Some f ->
-                                          let my_exported_ids =
-                                            f Exported_id_term_type in
-                                          let uu____3699 =
-                                            let uu____3700 =
-                                              FStar_ST.read my_exported_ids in
-                                            FStar_Util.set_add
-                                              (lid.FStar_Ident.ident).FStar_Ident.idText
-                                              uu____3700 in
-                                          FStar_ST.write my_exported_ids
-                                            uu____3699
-                                      | None  -> ());
-                                     (match () with
-                                      | () ->
-                                          FStar_Util.smap_add (sigmap env3)
-                                            lid.FStar_Ident.str
-                                            (se,
-                                              (env3.iface &&
-                                                 (Prims.op_Negation
-                                                    env3.admitted_iface))))))))));
-           (let env4 =
-              let uu___182_3712 = env3 in
-              let uu____3713 = FStar_ST.read globals in
-              {
-                curmodule = (uu___182_3712.curmodule);
-                curmonad = (uu___182_3712.curmonad);
-                modules = (uu___182_3712.modules);
-                scope_mods = uu____3713;
-                exported_ids = (uu___182_3712.exported_ids);
-                trans_exported_ids = (uu___182_3712.trans_exported_ids);
-                includes = (uu___182_3712.includes);
-                sigaccum = (uu___182_3712.sigaccum);
-                sigmap = (uu___182_3712.sigmap);
-                iface = (uu___182_3712.iface);
-                admitted_iface = (uu___182_3712.admitted_iface);
-                expect_typ = (uu___182_3712.expect_typ)
-              } in
-            env4))
-let push_namespace: env -> FStar_Ident.lident -> env =
-  fun env  ->
-    fun ns  ->
-      let uu____3724 =
-        let uu____3727 = resolve_module_name env ns false in
-        match uu____3727 with
-        | None  ->
-            let modules = env.modules in
-            let uu____3735 =
-              FStar_All.pipe_right modules
-                (FStar_Util.for_some
-                   (fun uu____3741  ->
-                      match uu____3741 with
-                      | (m,uu____3745) ->
-                          FStar_Util.starts_with
-                            (Prims.strcat (FStar_Ident.text_of_lid m) ".")
-                            (Prims.strcat (FStar_Ident.text_of_lid ns) "."))) in
-            if uu____3735
-            then (ns, Open_namespace)
-            else
-              (let uu____3749 =
-                 let uu____3750 =
-                   let uu____3753 =
-                     FStar_Util.format1 "Namespace %s cannot be found"
-                       (FStar_Ident.text_of_lid ns) in
-                   (uu____3753, (FStar_Ident.range_of_lid ns)) in
-                 FStar_Errors.Error uu____3750 in
-               Prims.raise uu____3749)
-        | Some ns' -> (ns', Open_module) in
-      match uu____3724 with
-      | (ns',kd) -> push_scope_mod env (Open_module_or_namespace (ns', kd))
-let push_include: env -> FStar_Ident.lident -> env =
-  fun env  ->
-    fun ns  ->
-      let uu____3765 = resolve_module_name env ns false in
-      match uu____3765 with
-      | Some ns1 ->
-          let env1 =
-            push_scope_mod env (Open_module_or_namespace (ns1, Open_module)) in
-          let curmod =
-            let uu____3770 = current_module env1 in
-            uu____3770.FStar_Ident.str in
-          ((let uu____3772 = FStar_Util.smap_try_find env1.includes curmod in
-            match uu____3772 with
-            | None  -> ()
-            | Some incl ->
-                let uu____3785 =
-                  let uu____3787 = FStar_ST.read incl in ns1 :: uu____3787 in
-                FStar_ST.write incl uu____3785);
-           (match () with
-            | () ->
-                let uu____3795 =
-                  get_trans_exported_id_set env1 ns1.FStar_Ident.str in
-                (match uu____3795 with
-                 | Some ns_trans_exports ->
-                     ((let uu____3808 =
-                         let uu____3819 = get_exported_id_set env1 curmod in
-                         let uu____3824 =
-                           get_trans_exported_id_set env1 curmod in
-                         (uu____3819, uu____3824) in
-                       match uu____3808 with
-                       | (Some cur_exports,Some cur_trans_exports) ->
-                           let update_exports k =
-                             let ns_ex =
-                               let uu____3864 = ns_trans_exports k in
-                               FStar_ST.read uu____3864 in
-                             let ex = cur_exports k in
-                             (let uu____3873 =
-                                let uu____3874 = FStar_ST.read ex in
-                                FStar_Util.set_difference uu____3874 ns_ex in
-                              FStar_ST.write ex uu____3873);
-                             (match () with
-                              | () ->
-                                  let trans_ex = cur_trans_exports k in
-                                  let uu____3884 =
-                                    let uu____3885 = FStar_ST.read trans_ex in
-                                    FStar_Util.set_union uu____3885 ns_ex in
-                                  FStar_ST.write trans_ex uu____3884) in
-                           FStar_List.iter update_exports
-                             all_exported_id_kinds
-                       | uu____3891 -> ());
-                      (match () with | () -> env1))
-                 | None  ->
-                     let uu____3905 =
-                       let uu____3906 =
-                         let uu____3909 =
-                           FStar_Util.format1
-                             "include: Module %s was not prepared"
-                             ns1.FStar_Ident.str in
-                         (uu____3909, (FStar_Ident.range_of_lid ns1)) in
-                       FStar_Errors.Error uu____3906 in
-                     Prims.raise uu____3905)))
-      | uu____3910 ->
-          let uu____3912 =
-            let uu____3913 =
-              let uu____3916 =
-                FStar_Util.format1 "include: Module %s cannot be found"
-                  ns.FStar_Ident.str in
-              (uu____3916, (FStar_Ident.range_of_lid ns)) in
-            FStar_Errors.Error uu____3913 in
-          Prims.raise uu____3912
-let push_module_abbrev: env -> FStar_Ident.ident -> FStar_Ident.lident -> env
-  =
-  fun env  ->
-    fun x  ->
-      fun l  ->
-        let uu____3926 = module_is_defined env l in
-        if uu____3926
-        then push_scope_mod env (Module_abbrev (x, l))
-        else
-          (let uu____3928 =
-             let uu____3929 =
-               let uu____3932 =
-                 FStar_Util.format1 "Module %s cannot be found"
-                   (FStar_Ident.text_of_lid l) in
-               (uu____3932, (FStar_Ident.range_of_lid l)) in
-             FStar_Errors.Error uu____3929 in
-           Prims.raise uu____3928)
-let check_admits: env -> Prims.unit =
-  fun env  ->
-    FStar_All.pipe_right env.sigaccum
-      (FStar_List.iter
-         (fun se  ->
-            match se with
-            | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t,quals,r) ->
-                let uu____3944 = try_lookup_lid env l in
-                (match uu____3944 with
-                 | None  ->
-                     ((let uu____3951 =
-                         let uu____3952 = FStar_Options.interactive () in
-                         Prims.op_Negation uu____3952 in
-                       if uu____3951
-                       then
-                         let uu____3953 =
-                           let uu____3954 =
-                             FStar_Range.string_of_range
-                               (FStar_Ident.range_of_lid l) in
-                           let uu____3955 =
-                             FStar_Syntax_Print.lid_to_string l in
-                           FStar_Util.format2
-                             "%s: Warning: Admitting %s without a definition\n"
-                             uu____3954 uu____3955 in
-                         FStar_Util.print_string uu____3953
-                       else ());
-                      FStar_Util.smap_add (sigmap env) l.FStar_Ident.str
-                        ((FStar_Syntax_Syntax.Sig_declare_typ
-                            (l, u, t, (FStar_Syntax_Syntax.Assumption ::
-                              quals), r)), false))
-                 | Some uu____3960 -> ())
-            | uu____3965 -> ()))
-let finish: env -> FStar_Syntax_Syntax.modul -> env =
-  fun env  ->
-    fun modul  ->
-      FStar_All.pipe_right modul.FStar_Syntax_Syntax.declarations
-        (FStar_List.iter
-           (fun uu___174_3973  ->
-              match uu___174_3973 with
-              | FStar_Syntax_Syntax.Sig_bundle
-                  (ses,quals,uu____3976,uu____3977) ->
-                  if
-                    (FStar_List.contains FStar_Syntax_Syntax.Private quals)
-                      ||
-                      (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
-                  then
-                    FStar_All.pipe_right ses
-                      (FStar_List.iter
-                         (fun uu___173_3985  ->
-                            match uu___173_3985 with
-                            | FStar_Syntax_Syntax.Sig_datacon
-                                (lid,uu____3987,uu____3988,uu____3989,uu____3990,uu____3991,uu____3992,uu____3993)
-                                ->
-                                FStar_Util.smap_remove (sigmap env)
-                                  lid.FStar_Ident.str
-                            | uu____4000 -> ()))
-                  else ()
-              | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid,uu____4003,uu____4004,quals,uu____4006) ->
-                  if FStar_List.contains FStar_Syntax_Syntax.Private quals
-                  then
-                    FStar_Util.smap_remove (sigmap env) lid.FStar_Ident.str
-                  else ()
-              | FStar_Syntax_Syntax.Sig_let
-                  ((uu____4012,lbs),r,uu____4015,quals,uu____4017) ->
-                  (if
-                     (FStar_List.contains FStar_Syntax_Syntax.Private quals)
-                       ||
-                       (FStar_List.contains FStar_Syntax_Syntax.Abstract
-                          quals)
-                   then
-                     FStar_All.pipe_right lbs
-                       (FStar_List.iter
-                          (fun lb  ->
-                             let uu____4032 =
-                               let uu____4033 =
-                                 let uu____4034 =
-                                   let uu____4039 =
-                                     FStar_Util.right
-                                       lb.FStar_Syntax_Syntax.lbname in
-                                   uu____4039.FStar_Syntax_Syntax.fv_name in
-                                 uu____4034.FStar_Syntax_Syntax.v in
-                               uu____4033.FStar_Ident.str in
-                             FStar_Util.smap_remove (sigmap env) uu____4032))
-                   else ();
-                   if
-                     (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
-                       &&
-                       (Prims.op_Negation
-                          (FStar_List.contains FStar_Syntax_Syntax.Private
-                             quals))
-                   then
-                     FStar_All.pipe_right lbs
-                       (FStar_List.iter
-                          (fun lb  ->
-                             let lid =
-                               let uu____4049 =
-                                 let uu____4054 =
-                                   FStar_Util.right
-                                     lb.FStar_Syntax_Syntax.lbname in
-                                 uu____4054.FStar_Syntax_Syntax.fv_name in
-                               uu____4049.FStar_Syntax_Syntax.v in
-                             let decl =
-                               FStar_Syntax_Syntax.Sig_declare_typ
-                                 (lid, (lb.FStar_Syntax_Syntax.lbunivs),
-                                   (lb.FStar_Syntax_Syntax.lbtyp),
-                                   (FStar_Syntax_Syntax.Assumption :: quals),
-                                   r) in
-                             FStar_Util.smap_add (sigmap env)
-                               lid.FStar_Ident.str (decl, false)))
-                   else ())
-              | uu____4066 -> ()));
-      (let curmod =
-         let uu____4068 = current_module env in uu____4068.FStar_Ident.str in
-       (let uu____4070 =
-          let uu____4081 = get_exported_id_set env curmod in
-          let uu____4086 = get_trans_exported_id_set env curmod in
-          (uu____4081, uu____4086) in
-        match uu____4070 with
-        | (Some cur_ex,Some cur_trans_ex) ->
-            let update_exports eikind =
-              let cur_ex_set =
-                let uu____4126 = cur_ex eikind in FStar_ST.read uu____4126 in
-              let cur_trans_ex_set_ref = cur_trans_ex eikind in
-              let uu____4134 =
-                let uu____4135 = FStar_ST.read cur_trans_ex_set_ref in
-                FStar_Util.set_union cur_ex_set uu____4135 in
-              FStar_ST.write cur_trans_ex_set_ref uu____4134 in
-            FStar_List.iter update_exports all_exported_id_kinds
-        | uu____4141 -> ());
-       (match () with
-        | () ->
-            (filter_record_cache ();
-             (match () with
-              | () ->
-                  let uu___183_4153 = env in
-                  {
-                    curmodule = None;
-                    curmonad = (uu___183_4153.curmonad);
-                    modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
-                      (env.modules));
-                    scope_mods = [];
-                    exported_ids = (uu___183_4153.exported_ids);
-                    trans_exported_ids = (uu___183_4153.trans_exported_ids);
-                    includes = (uu___183_4153.includes);
-                    sigaccum = [];
-                    sigmap = (uu___183_4153.sigmap);
-                    iface = (uu___183_4153.iface);
-                    admitted_iface = (uu___183_4153.admitted_iface);
-                    expect_typ = (uu___183_4153.expect_typ)
-                  }))))
-let stack: env Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let push: env -> env =
-  fun env  ->
-    push_record_cache ();
-    (let uu____4166 =
-       let uu____4168 = FStar_ST.read stack in env :: uu____4168 in
-     FStar_ST.write stack uu____4166);
-    (let uu___184_4176 = env in
-     let uu____4177 = FStar_Util.smap_copy (sigmap env) in
-     {
-       curmodule = (uu___184_4176.curmodule);
-       curmonad = (uu___184_4176.curmonad);
-       modules = (uu___184_4176.modules);
-       scope_mods = (uu___184_4176.scope_mods);
-       exported_ids = (uu___184_4176.exported_ids);
-       trans_exported_ids = (uu___184_4176.trans_exported_ids);
-       includes = (uu___184_4176.includes);
-       sigaccum = (uu___184_4176.sigaccum);
-       sigmap = uu____4177;
-       iface = (uu___184_4176.iface);
-       admitted_iface = (uu___184_4176.admitted_iface);
-       expect_typ = (uu___184_4176.expect_typ)
-     })
-let pop: Prims.unit -> env =
-  fun uu____4185  ->
-    let uu____4186 = FStar_ST.read stack in
-    match uu____4186 with
-    | env::tl1 -> (pop_record_cache (); FStar_ST.write stack tl1; env)
-    | uu____4199 -> failwith "Impossible: Too many pops"
-let commit_mark: env -> env =
-  fun env  ->
-    commit_record_cache ();
-    (let uu____4205 = FStar_ST.read stack in
-     match uu____4205 with
-     | uu____4210::tl1 -> (FStar_ST.write stack tl1; env)
-     | uu____4217 -> failwith "Impossible: Too many pops")
-let mark: env -> env = fun x  -> push x
-let reset_mark: Prims.unit -> env = fun uu____4224  -> pop ()
-let export_interface: FStar_Ident.lident -> env -> env =
-  fun m  ->
-    fun env  ->
-      let sigelt_in_m se =
-        match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____4236 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
-        | uu____4238 -> false in
-      let sm = sigmap env in
-      let env1 = pop () in
-      let keys = FStar_Util.smap_keys sm in
-      let sm' = sigmap env1 in
-      FStar_All.pipe_right keys
-        (FStar_List.iter
-           (fun k  ->
-              let uu____4256 = FStar_Util.smap_try_find sm' k in
-              match uu____4256 with
-              | Some (se,true ) when sigelt_in_m se ->
-                  (FStar_Util.smap_remove sm' k;
-                   (let se1 =
-                      match se with
-                      | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t,q,r) ->
-                          FStar_Syntax_Syntax.Sig_declare_typ
-                            (l, u, t, (FStar_Syntax_Syntax.Assumption :: q),
-                              r)
-                      | uu____4277 -> se in
-                    FStar_Util.smap_add sm' k (se1, false)))
-              | uu____4280 -> ()));
-      env1
-let finish_module_or_interface: env -> FStar_Syntax_Syntax.modul -> env =
-  fun env  ->
-    fun modul  ->
-      if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
-      then check_admits env
-      else ();
-      finish env modul
-let prepare_module_or_interface:
-  Prims.bool -> Prims.bool -> env -> FStar_Ident.lident -> (env* Prims.bool)
-  =
-  fun intf  ->
-    fun admitted  ->
-      fun env  ->
-        fun mname  ->
-          let prep env1 =
-            let open_ns =
-              if FStar_Ident.lid_equals mname FStar_Syntax_Const.prims_lid
-              then []
-              else
-                if
-                  FStar_Util.starts_with "FStar."
-                    (FStar_Ident.text_of_lid mname)
-                then
-                  [FStar_Syntax_Const.prims_lid;
-                  FStar_Syntax_Const.fstar_ns_lid]
-                else
-                  [FStar_Syntax_Const.prims_lid;
-                  FStar_Syntax_Const.st_lid;
-                  FStar_Syntax_Const.all_lid;
-                  FStar_Syntax_Const.fstar_ns_lid] in
-            let open_ns1 =
-              if
-                (FStar_List.length mname.FStar_Ident.ns) <>
-                  (Prims.parse_int "0")
-              then
-                let ns = FStar_Ident.lid_of_ids mname.FStar_Ident.ns in ns ::
-                  open_ns
-              else open_ns in
-            (let uu____4324 = exported_id_set_new () in
-             FStar_Util.smap_add env1.exported_ids mname.FStar_Ident.str
-               uu____4324);
-            (match () with
-             | () ->
-                 ((let uu____4329 = exported_id_set_new () in
-                   FStar_Util.smap_add env1.trans_exported_ids
-                     mname.FStar_Ident.str uu____4329);
-                  (match () with
-                   | () ->
-                       ((let uu____4334 = FStar_Util.mk_ref [] in
-                         FStar_Util.smap_add env1.includes
-                           mname.FStar_Ident.str uu____4334);
-                        (match () with
-                         | () ->
-                             let uu___185_4343 = env1 in
-                             let uu____4344 =
-                               FStar_List.map
-                                 (fun lid  ->
-                                    Open_module_or_namespace
-                                      (lid, Open_namespace)) open_ns1 in
-                             {
-                               curmodule = (Some mname);
-                               curmonad = (uu___185_4343.curmonad);
-                               modules = (uu___185_4343.modules);
-                               scope_mods = uu____4344;
-                               exported_ids = (uu___185_4343.exported_ids);
-                               trans_exported_ids =
-                                 (uu___185_4343.trans_exported_ids);
-                               includes = (uu___185_4343.includes);
-                               sigaccum = (uu___185_4343.sigaccum);
-                               sigmap = (env1.sigmap);
-                               iface = intf;
-                               admitted_iface = admitted;
-                               expect_typ = (uu___185_4343.expect_typ)
-                             }))))) in
-          let uu____4347 =
-            FStar_All.pipe_right env.modules
-              (FStar_Util.find_opt
-                 (fun uu____4359  ->
-                    match uu____4359 with
-                    | (l,uu____4363) -> FStar_Ident.lid_equals l mname)) in
-          match uu____4347 with
-          | None  -> let uu____4368 = prep env in (uu____4368, false)
-          | Some (uu____4369,m) ->
-              ((let uu____4374 =
-                  (let uu____4375 = FStar_Options.interactive () in
-                   Prims.op_Negation uu____4375) &&
-                    ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
-                       || intf) in
-                if uu____4374
-                then
-                  let uu____4376 =
-                    let uu____4377 =
-                      let uu____4380 =
-                        FStar_Util.format1
-                          "Duplicate module or interface name: %s"
-                          mname.FStar_Ident.str in
-                      (uu____4380, (FStar_Ident.range_of_lid mname)) in
-                    FStar_Errors.Error uu____4377 in
-                  Prims.raise uu____4376
-                else ());
-               (let uu____4382 = let uu____4383 = push env in prep uu____4383 in
-                (uu____4382, true)))
-let enter_monad_scope: env -> FStar_Ident.ident -> env =
-  fun env  ->
-    fun mname  ->
-      match env.curmonad with
-      | Some mname' ->
-          Prims.raise
-            (FStar_Errors.Error
-               ((Prims.strcat "Trying to define monad "
-                   (Prims.strcat mname.FStar_Ident.idText
-                      (Prims.strcat ", but already in monad scope "
-                         mname'.FStar_Ident.idText))),
-                 (mname.FStar_Ident.idRange)))
-      | None  ->
-          let uu___186_4391 = env in
-          {
-            curmodule = (uu___186_4391.curmodule);
-            curmonad = (Some mname);
-            modules = (uu___186_4391.modules);
-            scope_mods = (uu___186_4391.scope_mods);
-            exported_ids = (uu___186_4391.exported_ids);
-            trans_exported_ids = (uu___186_4391.trans_exported_ids);
-            includes = (uu___186_4391.includes);
-            sigaccum = (uu___186_4391.sigaccum);
-            sigmap = (uu___186_4391.sigmap);
-            iface = (uu___186_4391.iface);
-            admitted_iface = (uu___186_4391.admitted_iface);
-            expect_typ = (uu___186_4391.expect_typ)
-          }
-let fail_or env lookup lid =
-  let uu____4416 = lookup lid in
-  match uu____4416 with
-  | None  ->
-      let opened_modules =
-        FStar_List.map
-          (fun uu____4422  ->
-             match uu____4422 with
-             | (lid1,uu____4426) -> FStar_Ident.text_of_lid lid1) env.modules in
-      let msg =
-        FStar_Util.format1 "Identifier not found: [%s]"
-          (FStar_Ident.text_of_lid lid) in
-      let msg1 =
-        if (FStar_List.length lid.FStar_Ident.ns) = (Prims.parse_int "0")
-        then msg
-        else
-          (let modul =
-             let uu____4433 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
-             FStar_Ident.set_lid_range uu____4433
-               (FStar_Ident.range_of_lid lid) in
-           let uu____4434 = resolve_module_name env modul true in
-           match uu____4434 with
-           | None  ->
-               let opened_modules1 = FStar_String.concat ", " opened_modules in
-               FStar_Util.format3
-                 "%s\nModule %s does not belong to the list of modules in scope, namely %s"
-                 msg modul.FStar_Ident.str opened_modules1
-           | Some modul' when
-               Prims.op_Negation
-                 (FStar_List.existsb (fun m  -> m = modul'.FStar_Ident.str)
-                    opened_modules)
-               ->
-               let opened_modules1 = FStar_String.concat ", " opened_modules in
-               FStar_Util.format4
-                 "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s"
-                 msg modul.FStar_Ident.str modul'.FStar_Ident.str
-                 opened_modules1
-           | Some modul' ->
-               FStar_Util.format4
-                 "%s\nModule %s resolved into %s, definition %s not found"
-                 msg modul.FStar_Ident.str modul'.FStar_Ident.str
-                 (lid.FStar_Ident.ident).FStar_Ident.idText) in
-      Prims.raise (FStar_Errors.Error (msg1, (FStar_Ident.range_of_lid lid)))
-  | Some r -> r
-let fail_or2 lookup id =
-  let uu____4461 = lookup id in
-  match uu____4461 with
-  | None  ->
-      Prims.raise
-        (FStar_Errors.Error
-           ((Prims.strcat "Identifier not found ["
-               (Prims.strcat id.FStar_Ident.idText "]")),
-             (id.FStar_Ident.idRange)))
-  | Some r -> r
+| Cont_ok of 'a
+| Cont_fail
+| Cont_ignore
+
+
+let uu___is_Cont_ok = (fun projectee -> (match (projectee) with
+| Cont_ok (_0) -> begin
+true
+end
+| uu____536 -> begin
+false
+end))
+
+
+let __proj__Cont_ok__item___0 = (fun projectee -> (match (projectee) with
+| Cont_ok (_0) -> begin
+_0
+end))
+
+
+let uu___is_Cont_fail = (fun projectee -> (match (projectee) with
+| Cont_fail -> begin
+true
+end
+| uu____560 -> begin
+false
+end))
+
+
+let uu___is_Cont_ignore = (fun projectee -> (match (projectee) with
+| Cont_ignore -> begin
+true
+end
+| uu____571 -> begin
+false
+end))
+
+
+let option_of_cont = (fun k_ignore uu___139_590 -> (match (uu___139_590) with
+| Cont_ok (a) -> begin
+Some (a)
+end
+| Cont_fail -> begin
+None
+end
+| Cont_ignore -> begin
+(k_ignore ())
+end))
+
+
+let find_in_record = (fun ns id record cont -> (
+
+let typename' = (FStar_Ident.lid_of_ids (FStar_List.append ns ((record.typename.FStar_Ident.ident)::[])))
+in (match ((FStar_Ident.lid_equals typename' record.typename)) with
+| true -> begin
+(
+
+let fname = (FStar_Ident.lid_of_ids (FStar_List.append record.typename.FStar_Ident.ns ((id)::[])))
+in (
+
+let find1 = (FStar_Util.find_map record.fields (fun uu____635 -> (match (uu____635) with
+| (f, uu____640) -> begin
+(match ((id.FStar_Ident.idText = f.FStar_Ident.idText)) with
+| true -> begin
+Some (record)
+end
+| uu____642 -> begin
+None
+end)
+end)))
+in (match (find1) with
+| Some (r) -> begin
+(cont r)
+end
+| None -> begin
+Cont_ignore
+end)))
+end
+| uu____645 -> begin
+Cont_ignore
+end)))
+
+
+let get_exported_id_set : env  ->  Prims.string  ->  (exported_id_kind  ->  string_set FStar_ST.ref) Prims.option = (fun e mname -> (FStar_Util.smap_try_find e.exported_ids mname))
+
+
+let get_trans_exported_id_set : env  ->  Prims.string  ->  (exported_id_kind  ->  string_set FStar_ST.ref) Prims.option = (fun e mname -> (FStar_Util.smap_try_find e.trans_exported_ids mname))
+
+
+let string_of_exported_id_kind : exported_id_kind  ->  Prims.string = (fun uu___140_676 -> (match (uu___140_676) with
+| Exported_id_field -> begin
+"field"
+end
+| Exported_id_term_type -> begin
+"term/type"
+end))
+
+
+let find_in_module_with_includes = (fun eikind find_in_module find_in_module_default env ns id -> (
+
+let idstr = id.FStar_Ident.idText
+in (
+
+let rec aux = (fun uu___141_725 -> (match (uu___141_725) with
+| [] -> begin
+find_in_module_default
+end
+| (modul)::q -> begin
+(
+
+let mname = modul.FStar_Ident.str
+in (
+
+let not_shadowed = (
+
+let uu____733 = (get_exported_id_set env mname)
+in (match (uu____733) with
+| None -> begin
+true
+end
+| Some (mex) -> begin
+(
+
+let mexports = (
+
+let uu____749 = (mex eikind)
+in (FStar_ST.read uu____749))
+in (FStar_Util.set_mem idstr mexports))
+end))
+in (
+
+let mincludes = (
+
+let uu____756 = (FStar_Util.smap_try_find env.includes mname)
+in (match (uu____756) with
+| None -> begin
+[]
+end
+| Some (minc) -> begin
+(FStar_ST.read minc)
+end))
+in (
+
+let look_into = (match (not_shadowed) with
+| true -> begin
+(
+
+let uu____776 = (qual modul id)
+in (find_in_module uu____776))
+end
+| uu____777 -> begin
+Cont_ignore
+end)
+in (match (look_into) with
+| Cont_ignore -> begin
+(aux (FStar_List.append mincludes q))
+end
+| uu____779 -> begin
+look_into
+end)))))
+end))
+in (aux ((ns)::[])))))
+
+
+let is_exported_id_field : exported_id_kind  ->  Prims.bool = (fun uu___142_783 -> (match (uu___142_783) with
+| Exported_id_field -> begin
+true
+end
+| uu____784 -> begin
+false
+end))
+
+
+let try_lookup_id'' = (fun env id eikind k_local_binding k_rec_binding k_record find_in_module lookup_default_id -> (
+
+let check_local_binding_id = (fun uu___143_873 -> (match (uu___143_873) with
+| (id', uu____875, uu____876) -> begin
+(id'.FStar_Ident.idText = id.FStar_Ident.idText)
+end))
+in (
+
+let check_rec_binding_id = (fun uu___144_880 -> (match (uu___144_880) with
+| (id', uu____882, uu____883) -> begin
+(id'.FStar_Ident.idText = id.FStar_Ident.idText)
+end))
+in (
+
+let curmod_ns = (
+
+let uu____886 = (current_module env)
+in (FStar_Ident.ids_of_lid uu____886))
+in (
+
+let proc = (fun uu___145_891 -> (match (uu___145_891) with
+| Local_binding (l) when (check_local_binding_id l) -> begin
+(k_local_binding l)
+end
+| Rec_binding (r) when (check_rec_binding_id r) -> begin
+(k_rec_binding r)
+end
+| Open_module_or_namespace (ns, uu____896) -> begin
+(find_in_module_with_includes eikind find_in_module Cont_ignore env ns id)
+end
+| Top_level_def (id') when (id'.FStar_Ident.idText = id.FStar_Ident.idText) -> begin
+(lookup_default_id Cont_ignore id)
+end
+| Record_or_dc (r) when (is_exported_id_field eikind) -> begin
+(
+
+let uu____899 = (FStar_Ident.lid_of_ids curmod_ns)
+in (find_in_module_with_includes Exported_id_field (fun lid -> (
+
+let id1 = lid.FStar_Ident.ident
+in (find_in_record lid.FStar_Ident.ns id1 r k_record))) Cont_ignore env uu____899 id))
+end
+| uu____902 -> begin
+Cont_ignore
+end))
+in (
+
+let rec aux = (fun uu___146_908 -> (match (uu___146_908) with
+| (a)::q -> begin
+(
+
+let uu____914 = (proc a)
+in (option_of_cont (fun uu____916 -> (aux q)) uu____914))
+end
+| [] -> begin
+(
+
+let uu____917 = (lookup_default_id Cont_fail id)
+in (option_of_cont (fun uu____919 -> None) uu____917))
+end))
+in (aux env.scope_mods)))))))
+
+
+let found_local_binding = (fun r uu____938 -> (match (uu____938) with
+| (id', x, mut) -> begin
+(
+
+let uu____945 = (bv_to_name x r)
+in ((uu____945), (mut)))
+end))
+
+
+let find_in_module = (fun env lid k_global_def k_not_found -> (
+
+let uu____982 = (FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str)
+in (match (uu____982) with
+| Some (sb) -> begin
+(k_global_def lid sb)
+end
+| None -> begin
+k_not_found
+end)))
+
+
+let try_lookup_id : env  ->  FStar_Ident.ident  ->  (FStar_Syntax_Syntax.term * Prims.bool) Prims.option = (fun env id -> (
+
+let uu____1004 = (unmangleOpName id)
+in (match (uu____1004) with
+| Some (f) -> begin
+Some (f)
+end
+| uu____1018 -> begin
+(try_lookup_id'' env id Exported_id_term_type (fun r -> (
+
+let uu____1025 = (found_local_binding id.FStar_Ident.idRange r)
+in Cont_ok (uu____1025))) (fun uu____1030 -> Cont_fail) (fun uu____1033 -> Cont_ignore) (fun i -> (find_in_module env i (fun uu____1040 uu____1041 -> Cont_fail) Cont_ignore)) (fun uu____1048 uu____1049 -> Cont_fail))
+end)))
+
+
+let lookup_default_id = (fun env id k_global_def k_not_found -> (
+
+let find_in_monad = (match (env.curmonad) with
+| Some (uu____1101) -> begin
+(
+
+let lid = (qualify env id)
+in (
+
+let uu____1103 = (FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str)
+in (match (uu____1103) with
+| Some (r) -> begin
+(
+
+let uu____1116 = (k_global_def lid r)
+in Some (uu____1116))
+end
+| None -> begin
+None
+end)))
+end
+| None -> begin
+None
+end)
+in (match (find_in_monad) with
+| Some (v1) -> begin
+v1
+end
+| None -> begin
+(
+
+let lid = (
+
+let uu____1129 = (current_module env)
+in (qual uu____1129 id))
+in (find_in_module env lid k_global_def k_not_found))
+end)))
+
+
+let module_is_defined : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> ((match (env.curmodule) with
+| None -> begin
+false
+end
+| Some (m) -> begin
+(
+
+let uu____1138 = (current_module env)
+in (FStar_Ident.lid_equals lid uu____1138))
+end) || (FStar_List.existsb (fun x -> (FStar_Ident.lid_equals lid (Prims.fst x))) env.modules)))
+
+
+let resolve_module_name : env  ->  FStar_Ident.lident  ->  Prims.bool  ->  FStar_Ident.lident Prims.option = (fun env lid honor_ns -> (
+
+let nslen = (FStar_List.length lid.FStar_Ident.ns)
+in (
+
+let rec aux = (fun uu___147_1162 -> (match (uu___147_1162) with
+| [] -> begin
+(
+
+let uu____1165 = (module_is_defined env lid)
+in (match (uu____1165) with
+| true -> begin
+Some (lid)
+end
+| uu____1167 -> begin
+None
+end))
+end
+| (Open_module_or_namespace (ns, Open_namespace))::q when honor_ns -> begin
+(
+
+let new_lid = (
+
+let uu____1172 = (
+
+let uu____1174 = (FStar_Ident.path_of_lid ns)
+in (
+
+let uu____1176 = (FStar_Ident.path_of_lid lid)
+in (FStar_List.append uu____1174 uu____1176)))
+in (FStar_Ident.lid_of_path uu____1172 (FStar_Ident.range_of_lid lid)))
+in (
+
+let uu____1178 = (module_is_defined env new_lid)
+in (match (uu____1178) with
+| true -> begin
+Some (new_lid)
+end
+| uu____1180 -> begin
+(aux q)
+end)))
+end
+| (Module_abbrev (name, modul))::uu____1183 when ((nslen = (Prims.parse_int "0")) && (name.FStar_Ident.idText = lid.FStar_Ident.ident.FStar_Ident.idText)) -> begin
+Some (modul)
+end
+| (uu____1187)::q -> begin
+(aux q)
+end))
+in (aux env.scope_mods))))
+
+
+let namespace_is_open : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (FStar_List.existsb (fun uu___148_1196 -> (match (uu___148_1196) with
+| Open_module_or_namespace (ns, Open_namespace) -> begin
+(FStar_Ident.lid_equals lid ns)
+end
+| uu____1198 -> begin
+false
+end)) env.scope_mods))
+
+
+let shorten_module_path : env  ->  FStar_Ident.ident Prims.list  ->  Prims.bool  ->  (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list) = (fun env ids is_full_path -> (
+
+let rec aux = (fun revns id -> (
+
+let lid = (FStar_Ident.lid_of_ns_and_id (FStar_List.rev revns) id)
+in (match ((namespace_is_open env lid)) with
+| true -> begin
+Some ((((FStar_List.rev ((id)::revns))), ([])))
+end
+| uu____1240 -> begin
+(match (revns) with
+| [] -> begin
+None
+end
+| (ns_last_id)::rev_ns_prefix -> begin
+(
+
+let uu____1253 = (aux rev_ns_prefix ns_last_id)
+in (FStar_All.pipe_right uu____1253 (FStar_Util.map_option (fun uu____1277 -> (match (uu____1277) with
+| (stripped_ids, rev_kept_ids) -> begin
+((stripped_ids), ((id)::rev_kept_ids))
+end)))))
+end)
+end)))
+in (
+
+let uu____1294 = (is_full_path && (
+
+let uu____1295 = (FStar_Ident.lid_of_ids ids)
+in (module_is_defined env uu____1295)))
+in (match (uu____1294) with
+| true -> begin
+((ids), ([]))
+end
+| uu____1302 -> begin
+(match ((FStar_List.rev ids)) with
+| [] -> begin
+(([]), ([]))
+end
+| (ns_last_id)::ns_rev_prefix -> begin
+(
+
+let uu____1312 = (aux ns_rev_prefix ns_last_id)
+in (match (uu____1312) with
+| None -> begin
+(([]), (ids))
+end
+| Some (stripped_ids, rev_kept_ids) -> begin
+((stripped_ids), ((FStar_List.rev rev_kept_ids)))
+end))
+end)
+end))))
+
+
+let resolve_in_open_namespaces'' = (fun env lid eikind k_local_binding k_rec_binding k_record f_module l_default -> (match (lid.FStar_Ident.ns) with
+| (uu____1425)::uu____1426 -> begin
+(
+
+let uu____1428 = (
+
+let uu____1430 = (
+
+let uu____1431 = (FStar_Ident.lid_of_ids lid.FStar_Ident.ns)
+in (FStar_Ident.set_lid_range uu____1431 (FStar_Ident.range_of_lid lid)))
+in (resolve_module_name env uu____1430 true))
+in (match (uu____1428) with
+| None -> begin
+None
+end
+| Some (modul) -> begin
+(
+
+let uu____1434 = (find_in_module_with_includes eikind f_module Cont_fail env modul lid.FStar_Ident.ident)
+in (option_of_cont (fun uu____1436 -> None) uu____1434))
+end))
+end
+| [] -> begin
+(try_lookup_id'' env lid.FStar_Ident.ident eikind k_local_binding k_rec_binding k_record f_module l_default)
+end))
+
+
+let cont_of_option = (fun k_none uu___149_1451 -> (match (uu___149_1451) with
+| Some (v1) -> begin
+Cont_ok (v1)
+end
+| None -> begin
+k_none
+end))
+
+
+let resolve_in_open_namespaces' = (fun env lid k_local_binding k_rec_binding k_global_def -> (
+
+let k_global_def' = (fun k lid1 def -> (
+
+let uu____1530 = (k_global_def lid1 def)
+in (cont_of_option k uu____1530)))
+in (
+
+let f_module = (fun lid' -> (
+
+let k = Cont_ignore
+in (find_in_module env lid' (k_global_def' k) k)))
+in (
+
+let l_default = (fun k i -> (lookup_default_id env i (k_global_def' k) k))
+in (resolve_in_open_namespaces'' env lid Exported_id_term_type (fun l -> (
+
+let uu____1551 = (k_local_binding l)
+in (cont_of_option Cont_fail uu____1551))) (fun r -> (
+
+let uu____1554 = (k_rec_binding r)
+in (cont_of_option Cont_fail uu____1554))) (fun uu____1556 -> Cont_ignore) f_module l_default)))))
+
+
+let fv_qual_of_se : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.fv_qual Prims.option = (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (uu____1562, uu____1563, uu____1564, l, uu____1566, quals, uu____1568) -> begin
+(
+
+let qopt = (FStar_Util.find_map quals (fun uu___150_1575 -> (match (uu___150_1575) with
+| FStar_Syntax_Syntax.RecordConstructor (uu____1577, fs) -> begin
+Some (FStar_Syntax_Syntax.Record_ctor (((l), (fs))))
+end
+| uu____1584 -> begin
+None
+end)))
+in (match (qopt) with
+| None -> begin
+Some (FStar_Syntax_Syntax.Data_ctor)
+end
+| x -> begin
+x
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (uu____1588, uu____1589, uu____1590, quals) -> begin
+None
+end
+| uu____1594 -> begin
+None
+end))
+
+
+let lb_fv : FStar_Syntax_Syntax.letbinding Prims.list  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.fv = (fun lbs lid -> (
+
+let uu____1603 = (FStar_Util.find_map lbs (fun lb -> (
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____1607 = (FStar_Syntax_Syntax.fv_eq_lid fv lid)
+in (match (uu____1607) with
+| true -> begin
+Some (fv)
+end
+| uu____1609 -> begin
+None
+end)))))
+in (FStar_All.pipe_right uu____1603 FStar_Util.must)))
+
+
+let ns_of_lid_equals : FStar_Ident.lident  ->  FStar_Ident.lident  ->  Prims.bool = (fun lid ns -> (((FStar_List.length lid.FStar_Ident.ns) = (FStar_List.length (FStar_Ident.ids_of_lid ns))) && (
+
+let uu____1621 = (FStar_Ident.lid_of_ids lid.FStar_Ident.ns)
+in (FStar_Ident.lid_equals uu____1621 ns))))
+
+
+let try_lookup_name : Prims.bool  ->  Prims.bool  ->  env  ->  FStar_Ident.lident  ->  foundname Prims.option = (fun any_val exclude_interf env lid -> (
+
+let occurrence_range = (FStar_Ident.range_of_lid lid)
+in (
+
+let k_global_def = (fun source_lid uu___154_1646 -> (match (uu___154_1646) with
+| (uu____1650, true) when exclude_interf -> begin
+None
+end
+| (se, uu____1652) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____1654) -> begin
+(
+
+let uu____1665 = (
+
+let uu____1666 = (
+
+let uu____1669 = (FStar_Syntax_Syntax.fvar source_lid FStar_Syntax_Syntax.Delta_constant None)
+in ((uu____1669), (false)))
+in Term_name (uu____1666))
+in Some (uu____1665))
+end
+| FStar_Syntax_Syntax.Sig_datacon (uu____1670) -> begin
+(
+
+let uu____1680 = (
+
+let uu____1681 = (
+
+let uu____1684 = (
+
+let uu____1685 = (fv_qual_of_se se)
+in (FStar_Syntax_Syntax.fvar source_lid FStar_Syntax_Syntax.Delta_constant uu____1685))
+in ((uu____1684), (false)))
+in Term_name (uu____1681))
+in Some (uu____1680))
+end
+| FStar_Syntax_Syntax.Sig_let ((uu____1687, lbs), uu____1689, uu____1690, uu____1691) -> begin
+(
+
+let fv = (lb_fv lbs source_lid)
+in (
+
+let uu____1704 = (
+
+let uu____1705 = (
+
+let uu____1708 = (FStar_Syntax_Syntax.fvar source_lid fv.FStar_Syntax_Syntax.fv_delta fv.FStar_Syntax_Syntax.fv_qual)
+in ((uu____1708), (false)))
+in Term_name (uu____1705))
+in Some (uu____1704)))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid1, uu____1710, uu____1711, quals) -> begin
+(
+
+let uu____1715 = (any_val || (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___151_1717 -> (match (uu___151_1717) with
+| FStar_Syntax_Syntax.Assumption -> begin
+true
+end
+| uu____1718 -> begin
+false
+end)))))
+in (match (uu____1715) with
+| true -> begin
+(
+
+let lid2 = (FStar_Ident.set_lid_range lid1 (FStar_Ident.range_of_lid source_lid))
+in (
+
+let dd = (
+
+let uu____1722 = ((FStar_Syntax_Util.is_primop_lid lid2) || ((ns_of_lid_equals lid2 FStar_Syntax_Const.prims_lid) && (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___152_1724 -> (match (uu___152_1724) with
+| (FStar_Syntax_Syntax.Projector (_)) | (FStar_Syntax_Syntax.Discriminator (_)) -> begin
+true
+end
+| uu____1727 -> begin
+false
+end))))))
+in (match (uu____1722) with
+| true -> begin
+FStar_Syntax_Syntax.Delta_equational
+end
+| uu____1728 -> begin
+FStar_Syntax_Syntax.Delta_constant
+end))
+in (
+
+let uu____1729 = (FStar_Util.find_map quals (fun uu___153_1731 -> (match (uu___153_1731) with
+| FStar_Syntax_Syntax.Reflectable (refl_monad) -> begin
+Some (refl_monad)
+end
+| uu____1734 -> begin
+None
+end)))
+in (match (uu____1729) with
+| Some (refl_monad) -> begin
+(
+
+let refl_const = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (refl_monad)))) None occurrence_range)
+in Some (Term_name (((refl_const), (false)))))
+end
+| uu____1750 -> begin
+(
+
+let uu____1752 = (
+
+let uu____1753 = (
+
+let uu____1756 = (
+
+let uu____1757 = (fv_qual_of_se se)
+in (FStar_Syntax_Syntax.fvar lid2 dd uu____1757))
+in ((uu____1756), (false)))
+in Term_name (uu____1753))
+in Some (uu____1752))
+end))))
+end
+| uu____1759 -> begin
+None
+end))
+end
+| (FStar_Syntax_Syntax.Sig_new_effect_for_free (ne)) | (FStar_Syntax_Syntax.Sig_new_effect (ne)) -> begin
+Some (Eff_name (((se), ((FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname (FStar_Ident.range_of_lid source_lid))))))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (uu____1761) -> begin
+Some (Eff_name (((se), (source_lid))))
+end
+| uu____1770 -> begin
+None
+end)
+end))
+in (
+
+let k_local_binding = (fun r -> (
+
+let uu____1782 = (
+
+let uu____1783 = (found_local_binding (FStar_Ident.range_of_lid lid) r)
+in Term_name (uu____1783))
+in Some (uu____1782)))
+in (
+
+let k_rec_binding = (fun uu____1793 -> (match (uu____1793) with
+| (id, l, dd) -> begin
+(
+
+let uu____1801 = (
+
+let uu____1802 = (
+
+let uu____1805 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range l (FStar_Ident.range_of_lid lid)) dd None)
+in ((uu____1805), (false)))
+in Term_name (uu____1802))
+in Some (uu____1801))
+end))
+in (
+
+let found_unmangled = (match (lid.FStar_Ident.ns) with
+| [] -> begin
+(
+
+let uu____1809 = (unmangleOpName lid.FStar_Ident.ident)
+in (match (uu____1809) with
+| Some (f) -> begin
+Some (Term_name (f))
+end
+| uu____1819 -> begin
+None
+end))
+end
+| uu____1823 -> begin
+None
+end)
+in (match (found_unmangled) with
+| None -> begin
+(resolve_in_open_namespaces' env lid k_local_binding k_rec_binding k_global_def)
+end
+| x -> begin
+x
+end)))))))
+
+
+let try_lookup_effect_name' : Prims.bool  ->  env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.sigelt * FStar_Ident.lident) Prims.option = (fun exclude_interf env lid -> (
+
+let uu____1843 = (try_lookup_name true exclude_interf env lid)
+in (match (uu____1843) with
+| Some (Eff_name (o, l)) -> begin
+Some (((o), (l)))
+end
+| uu____1852 -> begin
+None
+end)))
+
+
+let try_lookup_effect_name : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident Prims.option = (fun env l -> (
+
+let uu____1863 = (try_lookup_effect_name' (not (env.iface)) env l)
+in (match (uu____1863) with
+| Some (o, l1) -> begin
+Some (l1)
+end
+| uu____1872 -> begin
+None
+end)))
+
+
+let try_lookup_effect_name_and_attributes : env  ->  FStar_Ident.lident  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list) Prims.option = (fun env l -> (
+
+let uu____1886 = (try_lookup_effect_name' (not (env.iface)) env l)
+in (match (uu____1886) with
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne); FStar_Syntax_Syntax.sigdoc = uu____1895; FStar_Syntax_Syntax.sigrng = uu____1896}, l1) -> begin
+Some (((l1), (ne.FStar_Syntax_Syntax.cattributes)))
+end
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect_for_free (ne); FStar_Syntax_Syntax.sigdoc = uu____1906; FStar_Syntax_Syntax.sigrng = uu____1907}, l1) -> begin
+Some (((l1), (ne.FStar_Syntax_Syntax.cattributes)))
+end
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_effect_abbrev (uu____1916, uu____1917, uu____1918, uu____1919, uu____1920, cattributes); FStar_Syntax_Syntax.sigdoc = uu____1922; FStar_Syntax_Syntax.sigrng = uu____1923}, l1) -> begin
+Some (((l1), (cattributes)))
+end
+| uu____1936 -> begin
+None
+end)))
+
+
+let try_lookup_effect_defn : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.eff_decl Prims.option = (fun env l -> (
+
+let uu____1950 = (try_lookup_effect_name' (not (env.iface)) env l)
+in (match (uu____1950) with
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne); FStar_Syntax_Syntax.sigdoc = uu____1956; FStar_Syntax_Syntax.sigrng = uu____1957}, uu____1958) -> begin
+Some (ne)
+end
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect_for_free (ne); FStar_Syntax_Syntax.sigdoc = uu____1963; FStar_Syntax_Syntax.sigrng = uu____1964}, uu____1965) -> begin
+Some (ne)
+end
+| uu____1969 -> begin
+None
+end)))
+
+
+let is_effect_name : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (
+
+let uu____1979 = (try_lookup_effect_name env lid)
+in (match (uu____1979) with
+| None -> begin
+false
+end
+| Some (uu____1981) -> begin
+true
+end)))
+
+
+let try_lookup_root_effect_name : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident Prims.option = (fun env l -> (
+
+let uu____1989 = (try_lookup_effect_name' (not (env.iface)) env l)
+in (match (uu____1989) with
+| Some ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_effect_abbrev (l', uu____1995, uu____1996, uu____1997, uu____1998, uu____1999); FStar_Syntax_Syntax.sigdoc = uu____2000; FStar_Syntax_Syntax.sigrng = uu____2001}, uu____2002) -> begin
+(
+
+let rec aux = (fun new_name -> (
+
+let uu____2015 = (FStar_Util.smap_try_find (sigmap env) new_name.FStar_Ident.str)
+in (match (uu____2015) with
+| None -> begin
+None
+end
+| Some (s, uu____2025) -> begin
+(match (s.FStar_Syntax_Syntax.sigel) with
+| (FStar_Syntax_Syntax.Sig_new_effect_for_free (ne)) | (FStar_Syntax_Syntax.Sig_new_effect (ne)) -> begin
+Some ((FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname (FStar_Ident.range_of_lid l)))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (uu____2030, uu____2031, uu____2032, cmp, uu____2034, uu____2035) -> begin
+(
+
+let l'' = (FStar_Syntax_Util.comp_effect_name cmp)
+in (aux l''))
+end
+| uu____2041 -> begin
+None
+end)
+end)))
+in (aux l'))
+end
+| Some (uu____2042, l') -> begin
+Some (l')
+end
+| uu____2046 -> begin
+None
+end)))
+
+
+let lookup_letbinding_quals : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.qualifier Prims.list = (fun env lid -> (
+
+let k_global_def = (fun lid1 uu___155_2067 -> (match (uu___155_2067) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (lid2, uu____2073, uu____2074, quals); FStar_Syntax_Syntax.sigdoc = uu____2076; FStar_Syntax_Syntax.sigrng = uu____2077}, uu____2078) -> begin
+Some (quals)
+end
+| uu____2083 -> begin
+None
+end))
+in (
+
+let uu____2087 = (resolve_in_open_namespaces' env lid (fun uu____2091 -> None) (fun uu____2093 -> None) k_global_def)
+in (match (uu____2087) with
+| Some (quals) -> begin
+quals
+end
+| uu____2099 -> begin
+[]
+end))))
+
+
+let try_lookup_module : env  ->  Prims.string Prims.list  ->  FStar_Syntax_Syntax.modul Prims.option = (fun env path -> (
+
+let uu____2111 = (FStar_List.tryFind (fun uu____2117 -> (match (uu____2117) with
+| (mlid, modul) -> begin
+(
+
+let uu____2122 = (FStar_Ident.path_of_lid mlid)
+in (uu____2122 = path))
+end)) env.modules)
+in (match (uu____2111) with
+| Some (uu____2126, modul) -> begin
+Some (modul)
+end
+| None -> begin
+None
+end)))
+
+
+let try_lookup_let : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term Prims.option = (fun env lid -> (
+
+let k_global_def = (fun lid1 uu___156_2148 -> (match (uu___156_2148) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let ((uu____2152, lbs), uu____2154, uu____2155, uu____2156); FStar_Syntax_Syntax.sigdoc = uu____2157; FStar_Syntax_Syntax.sigrng = uu____2158}, uu____2159) -> begin
+(
+
+let fv = (lb_fv lbs lid1)
+in (
+
+let uu____2173 = (FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta fv.FStar_Syntax_Syntax.fv_qual)
+in Some (uu____2173)))
+end
+| uu____2174 -> begin
+None
+end))
+in (resolve_in_open_namespaces' env lid (fun uu____2177 -> None) (fun uu____2178 -> None) k_global_def)))
+
+
+let try_lookup_definition : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term Prims.option = (fun env lid -> (
+
+let k_global_def = (fun lid1 uu___157_2197 -> (match (uu___157_2197) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let (lbs, uu____2204, uu____2205, uu____2206); FStar_Syntax_Syntax.sigdoc = uu____2207; FStar_Syntax_Syntax.sigrng = uu____2208}, uu____2209) -> begin
+(FStar_Util.find_map (Prims.snd lbs) (fun lb -> (match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inr (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv lid1) -> begin
+Some (lb.FStar_Syntax_Syntax.lbdef)
+end
+| uu____2227 -> begin
+None
+end)))
+end
+| uu____2232 -> begin
+None
+end))
+in (resolve_in_open_namespaces' env lid (fun uu____2239 -> None) (fun uu____2242 -> None) k_global_def)))
+
+
+let empty_include_smap : FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap = (new_sigmap ())
+
+
+let empty_exported_id_smap : exported_id_set FStar_Util.smap = (new_sigmap ())
+
+
+let try_lookup_lid' : Prims.bool  ->  Prims.bool  ->  env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term * Prims.bool) Prims.option = (fun any_val exclude_interf env lid -> (
+
+let uu____2269 = (try_lookup_name any_val exclude_interf env lid)
+in (match (uu____2269) with
+| Some (Term_name (e, mut)) -> begin
+Some (((e), (mut)))
+end
+| uu____2278 -> begin
+None
+end)))
+
+
+let try_lookup_lid : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term * Prims.bool) Prims.option = (fun env l -> (try_lookup_lid' env.iface false env l))
+
+
+let resolve_to_fully_qualified_name : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident Prims.option = (fun env l -> (
+
+let uu____2298 = (try_lookup_lid env l)
+in (match (uu____2298) with
+| None -> begin
+None
+end
+| Some (e, uu____2306) -> begin
+(
+
+let uu____2309 = (
+
+let uu____2310 = (FStar_Syntax_Subst.compress e)
+in uu____2310.FStar_Syntax_Syntax.n)
+in (match (uu____2309) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+Some (fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end
+| uu____2319 -> begin
+None
+end))
+end)))
+
+
+let try_lookup_lid_no_resolve : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term * Prims.bool) Prims.option = (fun env l -> (
+
+let env' = (
+
+let uu___168_2330 = env
+in {curmodule = uu___168_2330.curmodule; curmonad = uu___168_2330.curmonad; modules = uu___168_2330.modules; scope_mods = []; exported_ids = empty_exported_id_smap; trans_exported_ids = uu___168_2330.trans_exported_ids; includes = empty_include_smap; sigaccum = uu___168_2330.sigaccum; sigmap = uu___168_2330.sigmap; iface = uu___168_2330.iface; admitted_iface = uu___168_2330.admitted_iface; expect_typ = uu___168_2330.expect_typ})
+in (try_lookup_lid env' l)))
+
+
+let try_lookup_datacon : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.fv Prims.option = (fun env lid -> (
+
+let k_global_def = (fun lid1 uu___159_2347 -> (match (uu___159_2347) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (uu____2351, uu____2352, uu____2353, quals); FStar_Syntax_Syntax.sigdoc = uu____2355; FStar_Syntax_Syntax.sigrng = uu____2356}, uu____2357) -> begin
+(
+
+let uu____2361 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___158_2363 -> (match (uu___158_2363) with
+| FStar_Syntax_Syntax.Assumption -> begin
+true
+end
+| uu____2364 -> begin
+false
+end))))
+in (match (uu____2361) with
+| true -> begin
+(
+
+let uu____2366 = (FStar_Syntax_Syntax.lid_as_fv lid1 FStar_Syntax_Syntax.Delta_constant None)
+in Some (uu____2366))
+end
+| uu____2367 -> begin
+None
+end))
+end
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____2368); FStar_Syntax_Syntax.sigdoc = uu____2369; FStar_Syntax_Syntax.sigrng = uu____2370}, uu____2371) -> begin
+(
+
+let uu____2382 = (FStar_Syntax_Syntax.lid_as_fv lid1 FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in Some (uu____2382))
+end
+| uu____2383 -> begin
+None
+end))
+in (resolve_in_open_namespaces' env lid (fun uu____2386 -> None) (fun uu____2387 -> None) k_global_def)))
+
+
+let find_all_datacons : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident Prims.list Prims.option = (fun env lid -> (
+
+let k_global_def = (fun lid1 uu___160_2406 -> (match (uu___160_2406) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (uu____2411, uu____2412, uu____2413, uu____2414, uu____2415, datas, uu____2417); FStar_Syntax_Syntax.sigdoc = uu____2418; FStar_Syntax_Syntax.sigrng = uu____2419}, uu____2420) -> begin
+Some (datas)
+end
+| uu____2429 -> begin
+None
+end))
+in (resolve_in_open_namespaces' env lid (fun uu____2434 -> None) (fun uu____2436 -> None) k_global_def)))
+
+
+let record_cache_aux_with_filter : (((Prims.unit  ->  Prims.unit) * (Prims.unit  ->  Prims.unit) * (Prims.unit  ->  record_or_dc Prims.list) * (record_or_dc  ->  Prims.unit) * (Prims.unit  ->  Prims.unit)) * (Prims.unit  ->  Prims.unit)) = (
+
+let record_cache = (FStar_Util.mk_ref (([])::[]))
+in (
+
+let push1 = (fun uu____2470 -> (
+
+let uu____2471 = (
+
+let uu____2474 = (
+
+let uu____2476 = (FStar_ST.read record_cache)
+in (FStar_List.hd uu____2476))
+in (
+
+let uu____2484 = (FStar_ST.read record_cache)
+in (uu____2474)::uu____2484))
+in (FStar_ST.write record_cache uu____2471)))
+in (
+
+let pop1 = (fun uu____2499 -> (
+
+let uu____2500 = (
+
+let uu____2503 = (FStar_ST.read record_cache)
+in (FStar_List.tl uu____2503))
+in (FStar_ST.write record_cache uu____2500)))
+in (
+
+let peek = (fun uu____2519 -> (
+
+let uu____2520 = (FStar_ST.read record_cache)
+in (FStar_List.hd uu____2520)))
+in (
+
+let insert = (fun r -> (
+
+let uu____2532 = (
+
+let uu____2535 = (
+
+let uu____2537 = (peek ())
+in (r)::uu____2537)
+in (
+
+let uu____2539 = (
+
+let uu____2542 = (FStar_ST.read record_cache)
+in (FStar_List.tl uu____2542))
+in (uu____2535)::uu____2539))
+in (FStar_ST.write record_cache uu____2532)))
+in (
+
+let commit1 = (fun uu____2558 -> (
+
+let uu____2559 = (FStar_ST.read record_cache)
+in (match (uu____2559) with
+| (hd1)::(uu____2567)::tl1 -> begin
+(FStar_ST.write record_cache ((hd1)::tl1))
+end
+| uu____2580 -> begin
+(failwith "Impossible")
+end)))
+in (
+
+let filter1 = (fun uu____2586 -> (
+
+let rc = (peek ())
+in ((pop1 ());
+(match (()) with
+| () -> begin
+(
+
+let filtered = (FStar_List.filter (fun r -> (not (r.is_private_or_abstract))) rc)
+in (
+
+let uu____2593 = (
+
+let uu____2596 = (FStar_ST.read record_cache)
+in (filtered)::uu____2596)
+in (FStar_ST.write record_cache uu____2593)))
+end);
+)))
+in (
+
+let aux = ((push1), (pop1), (peek), (insert), (commit1))
+in ((aux), (filter1))))))))))
+
+
+let record_cache_aux : ((Prims.unit  ->  Prims.unit) * (Prims.unit  ->  Prims.unit) * (Prims.unit  ->  record_or_dc Prims.list) * (record_or_dc  ->  Prims.unit) * (Prims.unit  ->  Prims.unit)) = (
+
+let uu____2670 = record_cache_aux_with_filter
+in (match (uu____2670) with
+| (aux, uu____2708) -> begin
+aux
+end))
+
+
+let filter_record_cache : Prims.unit  ->  Prims.unit = (
+
+let uu____2747 = record_cache_aux_with_filter
+in (match (uu____2747) with
+| (uu____2770, filter1) -> begin
+filter1
+end))
+
+
+let push_record_cache : Prims.unit  ->  Prims.unit = (
+
+let uu____2810 = record_cache_aux
+in (match (uu____2810) with
+| (push1, uu____2830, uu____2831, uu____2832, uu____2833) -> begin
+push1
+end))
+
+
+let pop_record_cache : Prims.unit  ->  Prims.unit = (
+
+let uu____2858 = record_cache_aux
+in (match (uu____2858) with
+| (uu____2877, pop1, uu____2879, uu____2880, uu____2881) -> begin
+pop1
+end))
+
+
+let peek_record_cache : Prims.unit  ->  record_or_dc Prims.list = (
+
+let uu____2907 = record_cache_aux
+in (match (uu____2907) with
+| (uu____2927, uu____2928, peek, uu____2930, uu____2931) -> begin
+peek
+end))
+
+
+let insert_record_cache : record_or_dc  ->  Prims.unit = (
+
+let uu____2956 = record_cache_aux
+in (match (uu____2956) with
+| (uu____2975, uu____2976, uu____2977, insert, uu____2979) -> begin
+insert
+end))
+
+
+let commit_record_cache : Prims.unit  ->  Prims.unit = (
+
+let uu____3004 = record_cache_aux
+in (match (uu____3004) with
+| (uu____3023, uu____3024, uu____3025, uu____3026, commit1) -> begin
+commit1
+end))
+
+
+let extract_record : env  ->  scope_mod Prims.list FStar_ST.ref  ->  FStar_Syntax_Syntax.sigelt  ->  Prims.unit = (fun e new_globs se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (sigs, uu____3066, uu____3067) -> begin
+(
+
+let is_rec = (FStar_Util.for_some (fun uu___161_3078 -> (match (uu___161_3078) with
+| (FStar_Syntax_Syntax.RecordType (_)) | (FStar_Syntax_Syntax.RecordConstructor (_)) -> begin
+true
+end
+| uu____3081 -> begin
+false
+end)))
+in (
+
+let find_dc = (fun dc -> (FStar_All.pipe_right sigs (FStar_Util.find_opt (fun uu___162_3089 -> (match (uu___162_3089) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (lid, uu____3091, uu____3092, uu____3093, uu____3094, uu____3095, uu____3096); FStar_Syntax_Syntax.sigdoc = uu____3097; FStar_Syntax_Syntax.sigrng = uu____3098} -> begin
+(FStar_Ident.lid_equals dc lid)
+end
+| uu____3104 -> begin
+false
+end)))))
+in (FStar_All.pipe_right sigs (FStar_List.iter (fun uu___163_3106 -> (match (uu___163_3106) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (typename, univs, parms, uu____3110, uu____3111, (dc)::[], tags); FStar_Syntax_Syntax.sigdoc = uu____3114; FStar_Syntax_Syntax.sigrng = uu____3115} -> begin
+(
+
+let uu____3122 = (
+
+let uu____3123 = (find_dc dc)
+in (FStar_All.pipe_left FStar_Util.must uu____3123))
+in (match (uu____3122) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (constrname, uu____3127, t, uu____3129, uu____3130, uu____3131, uu____3132); FStar_Syntax_Syntax.sigdoc = uu____3133; FStar_Syntax_Syntax.sigrng = uu____3134} -> begin
+(
+
+let uu____3140 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____3140) with
+| (formals, uu____3149) -> begin
+(
+
+let is_rec1 = (is_rec tags)
+in (
+
+let formals' = (FStar_All.pipe_right formals (FStar_List.collect (fun uu____3175 -> (match (uu____3175) with
+| (x, q) -> begin
+(
+
+let uu____3183 = ((FStar_Syntax_Syntax.is_null_bv x) || (is_rec1 && (FStar_Syntax_Syntax.is_implicit q)))
+in (match (uu____3183) with
+| true -> begin
+[]
+end
+| uu____3189 -> begin
+(((x), (q)))::[]
+end))
+end))))
+in (
+
+let fields' = (FStar_All.pipe_right formals' (FStar_List.map (fun uu____3214 -> (match (uu____3214) with
+| (x, q) -> begin
+(
+
+let uu____3223 = (match (is_rec1) with
+| true -> begin
+(FStar_Syntax_Util.unmangle_field_name x.FStar_Syntax_Syntax.ppname)
+end
+| uu____3224 -> begin
+x.FStar_Syntax_Syntax.ppname
+end)
+in ((uu____3223), (x.FStar_Syntax_Syntax.sort)))
+end))))
+in (
+
+let fields = fields'
+in (
+
+let record = {typename = typename; constrname = constrname.FStar_Ident.ident; parms = parms; fields = fields; is_private_or_abstract = ((FStar_List.contains FStar_Syntax_Syntax.Private tags) || (FStar_List.contains FStar_Syntax_Syntax.Abstract tags)); is_record = is_rec1}
+in ((
+
+let uu____3235 = (
+
+let uu____3237 = (FStar_ST.read new_globs)
+in (Record_or_dc (record))::uu____3237)
+in (FStar_ST.write new_globs uu____3235));
+(match (()) with
+| () -> begin
+((
+
+let add_field = (fun uu____3253 -> (match (uu____3253) with
+| (id, uu____3259) -> begin
+(
+
+let modul = (
+
+let uu____3265 = (FStar_Ident.lid_of_ids constrname.FStar_Ident.ns)
+in uu____3265.FStar_Ident.str)
+in (
+
+let uu____3266 = (get_exported_id_set e modul)
+in (match (uu____3266) with
+| Some (my_ex) -> begin
+(
+
+let my_exported_ids = (my_ex Exported_id_field)
+in ((
+
+let uu____3282 = (
+
+let uu____3283 = (FStar_ST.read my_exported_ids)
+in (FStar_Util.set_add id.FStar_Ident.idText uu____3283))
+in (FStar_ST.write my_exported_ids uu____3282));
+(match (()) with
+| () -> begin
+(
+
+let projname = (
+
+let uu____3290 = (
+
+let uu____3291 = (FStar_Syntax_Util.mk_field_projector_name_from_ident constrname id)
+in uu____3291.FStar_Ident.ident)
+in uu____3290.FStar_Ident.idText)
+in (
+
+let uu____3293 = (
+
+let uu____3294 = (FStar_ST.read my_exported_ids)
+in (FStar_Util.set_add projname uu____3294))
+in (FStar_ST.write my_exported_ids uu____3293)))
+end);
+))
+end
+| None -> begin
+()
+end)))
+end))
+in (FStar_List.iter add_field fields'));
+(match (()) with
+| () -> begin
+(insert_record_cache record)
+end);
+)
+end);
+))))))
+end))
+end
+| uu____3307 -> begin
+()
+end))
+end
+| uu____3308 -> begin
+()
+end))))))
+end
+| uu____3309 -> begin
+()
+end))
+
+
+let try_lookup_record_or_dc_by_field_name : env  ->  FStar_Ident.lident  ->  record_or_dc Prims.option = (fun env fieldname -> (
+
+let find_in_cache = (fun fieldname1 -> (
+
+let uu____3322 = ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident))
+in (match (uu____3322) with
+| (ns, id) -> begin
+(
+
+let uu____3332 = (peek_record_cache ())
+in (FStar_Util.find_map uu____3332 (fun record -> (
+
+let uu____3335 = (find_in_record ns id record (fun r -> Cont_ok (r)))
+in (option_of_cont (fun uu____3338 -> None) uu____3335)))))
+end)))
+in (resolve_in_open_namespaces'' env fieldname Exported_id_field (fun uu____3339 -> Cont_ignore) (fun uu____3340 -> Cont_ignore) (fun r -> Cont_ok (r)) (fun fn -> (
+
+let uu____3343 = (find_in_cache fn)
+in (cont_of_option Cont_ignore uu____3343))) (fun k uu____3346 -> k))))
+
+
+let try_lookup_record_by_field_name : env  ->  FStar_Ident.lident  ->  record_or_dc Prims.option = (fun env fieldname -> (
+
+let uu____3355 = (try_lookup_record_or_dc_by_field_name env fieldname)
+in (match (uu____3355) with
+| Some (r) when r.is_record -> begin
+Some (r)
+end
+| uu____3359 -> begin
+None
+end)))
+
+
+let belongs_to_record : env  ->  FStar_Ident.lident  ->  record_or_dc  ->  Prims.bool = (fun env lid record -> (
+
+let uu____3370 = (try_lookup_record_by_field_name env lid)
+in (match (uu____3370) with
+| Some (record') when (
+
+let uu____3373 = (
+
+let uu____3374 = (FStar_Ident.path_of_ns record.typename.FStar_Ident.ns)
+in (FStar_Ident.text_of_path uu____3374))
+in (
+
+let uu____3376 = (
+
+let uu____3377 = (FStar_Ident.path_of_ns record'.typename.FStar_Ident.ns)
+in (FStar_Ident.text_of_path uu____3377))
+in (uu____3373 = uu____3376))) -> begin
+(
+
+let uu____3379 = (find_in_record record.typename.FStar_Ident.ns lid.FStar_Ident.ident record (fun uu____3381 -> Cont_ok (())))
+in (match (uu____3379) with
+| Cont_ok (uu____3382) -> begin
+true
+end
+| uu____3383 -> begin
+false
+end))
+end
+| uu____3385 -> begin
+false
+end)))
+
+
+let try_lookup_dc_by_field_name : env  ->  FStar_Ident.lident  ->  (FStar_Ident.lident * Prims.bool) Prims.option = (fun env fieldname -> (
+
+let uu____3396 = (try_lookup_record_or_dc_by_field_name env fieldname)
+in (match (uu____3396) with
+| Some (r) -> begin
+(
+
+let uu____3402 = (
+
+let uu____3405 = (
+
+let uu____3406 = (FStar_Ident.lid_of_ids (FStar_List.append r.typename.FStar_Ident.ns ((r.constrname)::[])))
+in (FStar_Ident.set_lid_range uu____3406 (FStar_Ident.range_of_lid fieldname)))
+in ((uu____3405), (r.is_record)))
+in Some (uu____3402))
+end
+| uu____3409 -> begin
+None
+end)))
+
+
+let string_set_ref_new : Prims.unit  ->  Prims.string FStar_Util.set FStar_ST.ref = (fun uu____3418 -> (
+
+let uu____3419 = (FStar_Util.new_set FStar_Util.compare FStar_Util.hashcode)
+in (FStar_Util.mk_ref uu____3419)))
+
+
+let exported_id_set_new : Prims.unit  ->  exported_id_kind  ->  Prims.string FStar_Util.set FStar_ST.ref = (fun uu____3430 -> (
+
+let term_type_set = (string_set_ref_new ())
+in (
+
+let field_set = (string_set_ref_new ())
+in (fun uu___164_3439 -> (match (uu___164_3439) with
+| Exported_id_term_type -> begin
+term_type_set
+end
+| Exported_id_field -> begin
+field_set
+end)))))
+
+
+let unique : Prims.bool  ->  Prims.bool  ->  env  ->  FStar_Ident.lident  ->  Prims.bool = (fun any_val exclude_if env lid -> (
+
+let filter_scope_mods = (fun uu___165_3459 -> (match (uu___165_3459) with
+| Rec_binding (uu____3460) -> begin
+true
+end
+| uu____3461 -> begin
+false
+end))
+in (
+
+let this_env = (
+
+let uu___169_3463 = env
+in (
+
+let uu____3464 = (FStar_List.filter filter_scope_mods env.scope_mods)
+in {curmodule = uu___169_3463.curmodule; curmonad = uu___169_3463.curmonad; modules = uu___169_3463.modules; scope_mods = uu____3464; exported_ids = empty_exported_id_smap; trans_exported_ids = uu___169_3463.trans_exported_ids; includes = empty_include_smap; sigaccum = uu___169_3463.sigaccum; sigmap = uu___169_3463.sigmap; iface = uu___169_3463.iface; admitted_iface = uu___169_3463.admitted_iface; expect_typ = uu___169_3463.expect_typ}))
+in (
+
+let uu____3466 = (try_lookup_lid' any_val exclude_if this_env lid)
+in (match (uu____3466) with
+| None -> begin
+true
+end
+| Some (uu____3472) -> begin
+false
+end)))))
+
+
+let push_scope_mod : env  ->  scope_mod  ->  env = (fun env scope_mod -> (
+
+let uu___170_3483 = env
+in {curmodule = uu___170_3483.curmodule; curmonad = uu___170_3483.curmonad; modules = uu___170_3483.modules; scope_mods = (scope_mod)::env.scope_mods; exported_ids = uu___170_3483.exported_ids; trans_exported_ids = uu___170_3483.trans_exported_ids; includes = uu___170_3483.includes; sigaccum = uu___170_3483.sigaccum; sigmap = uu___170_3483.sigmap; iface = uu___170_3483.iface; admitted_iface = uu___170_3483.admitted_iface; expect_typ = uu___170_3483.expect_typ}))
+
+
+let push_bv' : env  ->  FStar_Ident.ident  ->  Prims.bool  ->  (env * FStar_Syntax_Syntax.bv) = (fun env x is_mutable -> (
+
+let bv = (FStar_Syntax_Syntax.gen_bv x.FStar_Ident.idText (Some (x.FStar_Ident.idRange)) FStar_Syntax_Syntax.tun)
+in (((push_scope_mod env (Local_binding (((x), (bv), (is_mutable)))))), (bv))))
+
+
+let push_bv_mutable : env  ->  FStar_Ident.ident  ->  (env * FStar_Syntax_Syntax.bv) = (fun env x -> (push_bv' env x true))
+
+
+let push_bv : env  ->  FStar_Ident.ident  ->  (env * FStar_Syntax_Syntax.bv) = (fun env x -> (push_bv' env x false))
+
+
+let push_top_level_rec_binding : env  ->  FStar_Ident.ident  ->  FStar_Syntax_Syntax.delta_depth  ->  env = (fun env x dd -> (
+
+let l = (qualify env x)
+in (
+
+let uu____3522 = ((unique false true env l) || (FStar_Options.interactive ()))
+in (match (uu____3522) with
+| true -> begin
+(push_scope_mod env (Rec_binding (((x), (l), (dd)))))
+end
+| uu____3523 -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Duplicate top-level names " l.FStar_Ident.str)), ((FStar_Ident.range_of_lid l))))))
+end))))
+
+
+let push_sigelt : env  ->  FStar_Syntax_Syntax.sigelt  ->  env = (fun env s -> (
+
+let err = (fun l -> (
+
+let sopt = (FStar_Util.smap_try_find (sigmap env) l.FStar_Ident.str)
+in (
+
+let r = (match (sopt) with
+| Some (se, uu____3542) -> begin
+(
+
+let uu____3545 = (FStar_Util.find_opt (FStar_Ident.lid_equals l) (FStar_Syntax_Util.lids_of_sigelt se))
+in (match (uu____3545) with
+| Some (l1) -> begin
+(FStar_All.pipe_left FStar_Range.string_of_range (FStar_Ident.range_of_lid l1))
+end
+| None -> begin
+"<unknown>"
+end))
+end
+| None -> begin
+"<unknown>"
+end)
+in (
+
+let uu____3550 = (
+
+let uu____3551 = (
+
+let uu____3554 = (FStar_Util.format2 "Duplicate top-level names [%s]; previously declared at %s" (FStar_Ident.text_of_lid l) r)
+in ((uu____3554), ((FStar_Ident.range_of_lid l))))
+in FStar_Errors.Error (uu____3551))
+in (Prims.raise uu____3550)))))
+in (
+
+let globals = (FStar_Util.mk_ref env.scope_mods)
+in (
+
+let env1 = (
+
+let uu____3561 = (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let (uu____3566) -> begin
+((false), (true))
+end
+| FStar_Syntax_Syntax.Sig_bundle (uu____3574) -> begin
+((true), (true))
+end
+| uu____3581 -> begin
+((false), (false))
+end)
+in (match (uu____3561) with
+| (any_val, exclude_if) -> begin
+(
+
+let lids = (FStar_Syntax_Util.lids_of_sigelt s)
+in (
+
+let uu____3586 = (FStar_Util.find_map lids (fun l -> (
+
+let uu____3589 = (
+
+let uu____3590 = (unique any_val exclude_if env l)
+in (not (uu____3590)))
+in (match (uu____3589) with
+| true -> begin
+Some (l)
+end
+| uu____3592 -> begin
+None
+end))))
+in (match (uu____3586) with
+| Some (l) when (
+
+let uu____3594 = (FStar_Options.interactive ())
+in (not (uu____3594))) -> begin
+(err l)
+end
+| uu____3595 -> begin
+((extract_record env globals s);
+(
+
+let uu___171_3600 = env
+in {curmodule = uu___171_3600.curmodule; curmonad = uu___171_3600.curmonad; modules = uu___171_3600.modules; scope_mods = uu___171_3600.scope_mods; exported_ids = uu___171_3600.exported_ids; trans_exported_ids = uu___171_3600.trans_exported_ids; includes = uu___171_3600.includes; sigaccum = (s)::env.sigaccum; sigmap = uu___171_3600.sigmap; iface = uu___171_3600.iface; admitted_iface = uu___171_3600.admitted_iface; expect_typ = uu___171_3600.expect_typ});
+)
+end)))
+end))
+in (
+
+let env2 = (
+
+let uu___172_3602 = env1
+in (
+
+let uu____3603 = (FStar_ST.read globals)
+in {curmodule = uu___172_3602.curmodule; curmonad = uu___172_3602.curmonad; modules = uu___172_3602.modules; scope_mods = uu____3603; exported_ids = uu___172_3602.exported_ids; trans_exported_ids = uu___172_3602.trans_exported_ids; includes = uu___172_3602.includes; sigaccum = uu___172_3602.sigaccum; sigmap = uu___172_3602.sigmap; iface = uu___172_3602.iface; admitted_iface = uu___172_3602.admitted_iface; expect_typ = uu___172_3602.expect_typ}))
+in (
+
+let uu____3608 = (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (ses, uu____3622, uu____3623) -> begin
+(
+
+let uu____3630 = (FStar_List.map (fun se -> (((FStar_Syntax_Util.lids_of_sigelt se)), (se))) ses)
+in ((env2), (uu____3630)))
+end
+| uu____3644 -> begin
+((env2), (((((FStar_Syntax_Util.lids_of_sigelt s)), (s)))::[]))
+end)
+in (match (uu____3608) with
+| (env3, lss) -> begin
+((FStar_All.pipe_right lss (FStar_List.iter (fun uu____3674 -> (match (uu____3674) with
+| (lids, se) -> begin
+(FStar_All.pipe_right lids (FStar_List.iter (fun lid -> ((
+
+let uu____3685 = (
+
+let uu____3687 = (FStar_ST.read globals)
+in (Top_level_def (lid.FStar_Ident.ident))::uu____3687)
+in (FStar_ST.write globals uu____3685));
+(match (()) with
+| () -> begin
+(
+
+let modul = (
+
+let uu____3696 = (FStar_Ident.lid_of_ids lid.FStar_Ident.ns)
+in uu____3696.FStar_Ident.str)
+in ((
+
+let uu____3698 = (get_exported_id_set env3 modul)
+in (match (uu____3698) with
+| Some (f) -> begin
+(
+
+let my_exported_ids = (f Exported_id_term_type)
+in (
+
+let uu____3713 = (
+
+let uu____3714 = (FStar_ST.read my_exported_ids)
+in (FStar_Util.set_add lid.FStar_Ident.ident.FStar_Ident.idText uu____3714))
+in (FStar_ST.write my_exported_ids uu____3713)))
+end
+| None -> begin
+()
+end));
+(match (()) with
+| () -> begin
+(FStar_Util.smap_add (sigmap env3) lid.FStar_Ident.str ((se), ((env3.iface && (not (env3.admitted_iface))))))
+end);
+))
+end);
+))))
+end))));
+(
+
+let env4 = (
+
+let uu___173_3726 = env3
+in (
+
+let uu____3727 = (FStar_ST.read globals)
+in {curmodule = uu___173_3726.curmodule; curmonad = uu___173_3726.curmonad; modules = uu___173_3726.modules; scope_mods = uu____3727; exported_ids = uu___173_3726.exported_ids; trans_exported_ids = uu___173_3726.trans_exported_ids; includes = uu___173_3726.includes; sigaccum = uu___173_3726.sigaccum; sigmap = uu___173_3726.sigmap; iface = uu___173_3726.iface; admitted_iface = uu___173_3726.admitted_iface; expect_typ = uu___173_3726.expect_typ}))
+in env4);
+)
+end)))))))
+
+
+let push_namespace : env  ->  FStar_Ident.lident  ->  env = (fun env ns -> (
+
+let uu____3738 = (
+
+let uu____3741 = (resolve_module_name env ns false)
+in (match (uu____3741) with
+| None -> begin
+(
+
+let modules = env.modules
+in (
+
+let uu____3749 = (FStar_All.pipe_right modules (FStar_Util.for_some (fun uu____3755 -> (match (uu____3755) with
+| (m, uu____3759) -> begin
+(FStar_Util.starts_with (Prims.strcat (FStar_Ident.text_of_lid m) ".") (Prims.strcat (FStar_Ident.text_of_lid ns) "."))
+end))))
+in (match (uu____3749) with
+| true -> begin
+((ns), (Open_namespace))
+end
+| uu____3762 -> begin
+(
+
+let uu____3763 = (
+
+let uu____3764 = (
+
+let uu____3767 = (FStar_Util.format1 "Namespace %s cannot be found" (FStar_Ident.text_of_lid ns))
+in ((uu____3767), ((FStar_Ident.range_of_lid ns))))
+in FStar_Errors.Error (uu____3764))
+in (Prims.raise uu____3763))
+end)))
+end
+| Some (ns') -> begin
+((ns'), (Open_module))
+end))
+in (match (uu____3738) with
+| (ns', kd) -> begin
+(push_scope_mod env (Open_module_or_namespace (((ns'), (kd)))))
+end)))
+
+
+let push_include : env  ->  FStar_Ident.lident  ->  env = (fun env ns -> (
+
+let uu____3779 = (resolve_module_name env ns false)
+in (match (uu____3779) with
+| Some (ns1) -> begin
+(
+
+let env1 = (push_scope_mod env (Open_module_or_namespace (((ns1), (Open_module)))))
+in (
+
+let curmod = (
+
+let uu____3784 = (current_module env1)
+in uu____3784.FStar_Ident.str)
+in ((
+
+let uu____3786 = (FStar_Util.smap_try_find env1.includes curmod)
+in (match (uu____3786) with
+| None -> begin
+()
+end
+| Some (incl) -> begin
+(
+
+let uu____3799 = (
+
+let uu____3801 = (FStar_ST.read incl)
+in (ns1)::uu____3801)
+in (FStar_ST.write incl uu____3799))
+end));
+(match (()) with
+| () -> begin
+(
+
+let uu____3809 = (get_trans_exported_id_set env1 ns1.FStar_Ident.str)
+in (match (uu____3809) with
+| Some (ns_trans_exports) -> begin
+((
+
+let uu____3822 = (
+
+let uu____3833 = (get_exported_id_set env1 curmod)
+in (
+
+let uu____3838 = (get_trans_exported_id_set env1 curmod)
+in ((uu____3833), (uu____3838))))
+in (match (uu____3822) with
+| (Some (cur_exports), Some (cur_trans_exports)) -> begin
+(
+
+let update_exports = (fun k -> (
+
+let ns_ex = (
+
+let uu____3878 = (ns_trans_exports k)
+in (FStar_ST.read uu____3878))
+in (
+
+let ex = (cur_exports k)
+in ((
+
+let uu____3887 = (
+
+let uu____3888 = (FStar_ST.read ex)
+in (FStar_Util.set_difference uu____3888 ns_ex))
+in (FStar_ST.write ex uu____3887));
+(match (()) with
+| () -> begin
+(
+
+let trans_ex = (cur_trans_exports k)
+in (
+
+let uu____3898 = (
+
+let uu____3899 = (FStar_ST.read trans_ex)
+in (FStar_Util.set_union uu____3899 ns_ex))
+in (FStar_ST.write trans_ex uu____3898)))
+end);
+))))
+in (FStar_List.iter update_exports all_exported_id_kinds))
+end
+| uu____3905 -> begin
+()
+end));
+(match (()) with
+| () -> begin
+env1
+end);
+)
+end
+| None -> begin
+(
+
+let uu____3919 = (
+
+let uu____3920 = (
+
+let uu____3923 = (FStar_Util.format1 "include: Module %s was not prepared" ns1.FStar_Ident.str)
+in ((uu____3923), ((FStar_Ident.range_of_lid ns1))))
+in FStar_Errors.Error (uu____3920))
+in (Prims.raise uu____3919))
+end))
+end);
+)))
+end
+| uu____3924 -> begin
+(
+
+let uu____3926 = (
+
+let uu____3927 = (
+
+let uu____3930 = (FStar_Util.format1 "include: Module %s cannot be found" ns.FStar_Ident.str)
+in ((uu____3930), ((FStar_Ident.range_of_lid ns))))
+in FStar_Errors.Error (uu____3927))
+in (Prims.raise uu____3926))
+end)))
+
+
+let push_module_abbrev : env  ->  FStar_Ident.ident  ->  FStar_Ident.lident  ->  env = (fun env x l -> (
+
+let uu____3940 = (module_is_defined env l)
+in (match (uu____3940) with
+| true -> begin
+(push_scope_mod env (Module_abbrev (((x), (l)))))
+end
+| uu____3941 -> begin
+(
+
+let uu____3942 = (
+
+let uu____3943 = (
+
+let uu____3946 = (FStar_Util.format1 "Module %s cannot be found" (FStar_Ident.text_of_lid l))
+in ((uu____3946), ((FStar_Ident.range_of_lid l))))
+in FStar_Errors.Error (uu____3943))
+in (Prims.raise uu____3942))
+end)))
+
+
+let check_admits : env  ->  Prims.unit = (fun env -> (FStar_All.pipe_right env.sigaccum (FStar_List.iter (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_declare_typ (l, u, t, quals) -> begin
+(
+
+let uu____3957 = (try_lookup_lid env l)
+in (match (uu____3957) with
+| None -> begin
+((
+
+let uu____3964 = (
+
+let uu____3965 = (FStar_Options.interactive ())
+in (not (uu____3965)))
+in (match (uu____3964) with
+| true -> begin
+(
+
+let uu____3966 = (
+
+let uu____3967 = (FStar_Range.string_of_range (FStar_Ident.range_of_lid l))
+in (
+
+let uu____3968 = (FStar_Syntax_Print.lid_to_string l)
+in (FStar_Util.format2 "%s: Warning: Admitting %s without a definition\n" uu____3967 uu____3968)))
+in (FStar_Util.print_string uu____3966))
+end
+| uu____3969 -> begin
+()
+end));
+(FStar_Util.smap_add (sigmap env) l.FStar_Ident.str (((
+
+let uu___174_3972 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), (u), (t), ((FStar_Syntax_Syntax.Assumption)::quals))); FStar_Syntax_Syntax.sigdoc = uu___174_3972.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___174_3972.FStar_Syntax_Syntax.sigrng})), (false)));
+)
+end
+| Some (uu____3974) -> begin
+()
+end))
+end
+| uu____3979 -> begin
+()
+end)))))
+
+
+let finish : env  ->  FStar_Syntax_Syntax.modul  ->  env = (fun env modul -> ((FStar_All.pipe_right modul.FStar_Syntax_Syntax.declarations (FStar_List.iter (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, uu____3990) -> begin
+(match (((FStar_List.contains FStar_Syntax_Syntax.Private quals) || (FStar_List.contains FStar_Syntax_Syntax.Abstract quals))) with
+| true -> begin
+(FStar_All.pipe_right ses (FStar_List.iter (fun se1 -> (match (se1.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (lid, uu____4000, uu____4001, uu____4002, uu____4003, uu____4004, uu____4005) -> begin
+(FStar_Util.smap_remove (sigmap env) lid.FStar_Ident.str)
+end
+| uu____4012 -> begin
+()
+end))))
+end
+| uu____4013 -> begin
+()
+end)
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____4015, uu____4016, quals) -> begin
+(match ((FStar_List.contains FStar_Syntax_Syntax.Private quals)) with
+| true -> begin
+(FStar_Util.smap_remove (sigmap env) lid.FStar_Ident.str)
+end
+| uu____4022 -> begin
+()
+end)
+end
+| FStar_Syntax_Syntax.Sig_let ((uu____4023, lbs), uu____4025, quals, uu____4027) -> begin
+((match (((FStar_List.contains FStar_Syntax_Syntax.Private quals) || (FStar_List.contains FStar_Syntax_Syntax.Abstract quals))) with
+| true -> begin
+(FStar_All.pipe_right lbs (FStar_List.iter (fun lb -> (
+
+let uu____4042 = (
+
+let uu____4043 = (
+
+let uu____4044 = (
+
+let uu____4049 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in uu____4049.FStar_Syntax_Syntax.fv_name)
+in uu____4044.FStar_Syntax_Syntax.v)
+in uu____4043.FStar_Ident.str)
+in (FStar_Util.smap_remove (sigmap env) uu____4042)))))
+end
+| uu____4055 -> begin
+()
+end);
+(match (((FStar_List.contains FStar_Syntax_Syntax.Abstract quals) && (not ((FStar_List.contains FStar_Syntax_Syntax.Private quals))))) with
+| true -> begin
+(FStar_All.pipe_right lbs (FStar_List.iter (fun lb -> (
+
+let lid = (
+
+let uu____4059 = (
+
+let uu____4064 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in uu____4064.FStar_Syntax_Syntax.fv_name)
+in uu____4059.FStar_Syntax_Syntax.v)
+in (
+
+let decl = (
+
+let uu___175_4069 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((lid), (lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp), ((FStar_Syntax_Syntax.Assumption)::quals))); FStar_Syntax_Syntax.sigdoc = uu___175_4069.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___175_4069.FStar_Syntax_Syntax.sigrng})
+in (FStar_Util.smap_add (sigmap env) lid.FStar_Ident.str ((decl), (false))))))))
+end
+| uu____4076 -> begin
+()
+end);
+)
+end
+| uu____4077 -> begin
+()
+end))));
+(
+
+let curmod = (
+
+let uu____4079 = (current_module env)
+in uu____4079.FStar_Ident.str)
+in ((
+
+let uu____4081 = (
+
+let uu____4092 = (get_exported_id_set env curmod)
+in (
+
+let uu____4097 = (get_trans_exported_id_set env curmod)
+in ((uu____4092), (uu____4097))))
+in (match (uu____4081) with
+| (Some (cur_ex), Some (cur_trans_ex)) -> begin
+(
+
+let update_exports = (fun eikind -> (
+
+let cur_ex_set = (
+
+let uu____4137 = (cur_ex eikind)
+in (FStar_ST.read uu____4137))
+in (
+
+let cur_trans_ex_set_ref = (cur_trans_ex eikind)
+in (
+
+let uu____4145 = (
+
+let uu____4146 = (FStar_ST.read cur_trans_ex_set_ref)
+in (FStar_Util.set_union cur_ex_set uu____4146))
+in (FStar_ST.write cur_trans_ex_set_ref uu____4145)))))
+in (FStar_List.iter update_exports all_exported_id_kinds))
+end
+| uu____4152 -> begin
+()
+end));
+(match (()) with
+| () -> begin
+((filter_record_cache ());
+(match (()) with
+| () -> begin
+(
+
+let uu___176_4164 = env
+in {curmodule = None; curmonad = uu___176_4164.curmonad; modules = (((modul.FStar_Syntax_Syntax.name), (modul)))::env.modules; scope_mods = []; exported_ids = uu___176_4164.exported_ids; trans_exported_ids = uu___176_4164.trans_exported_ids; includes = uu___176_4164.includes; sigaccum = []; sigmap = uu___176_4164.sigmap; iface = uu___176_4164.iface; admitted_iface = uu___176_4164.admitted_iface; expect_typ = uu___176_4164.expect_typ})
+end);
+)
+end);
+));
+))
+
+
+let stack : env Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let push : env  ->  env = (fun env -> ((push_record_cache ());
+(
+
+let uu____4177 = (
+
+let uu____4179 = (FStar_ST.read stack)
+in (env)::uu____4179)
+in (FStar_ST.write stack uu____4177));
+(
+
+let uu___177_4187 = env
+in (
+
+let uu____4188 = (FStar_Util.smap_copy (sigmap env))
+in {curmodule = uu___177_4187.curmodule; curmonad = uu___177_4187.curmonad; modules = uu___177_4187.modules; scope_mods = uu___177_4187.scope_mods; exported_ids = uu___177_4187.exported_ids; trans_exported_ids = uu___177_4187.trans_exported_ids; includes = uu___177_4187.includes; sigaccum = uu___177_4187.sigaccum; sigmap = uu____4188; iface = uu___177_4187.iface; admitted_iface = uu___177_4187.admitted_iface; expect_typ = uu___177_4187.expect_typ}));
+))
+
+
+let pop : Prims.unit  ->  env = (fun uu____4196 -> (
+
+let uu____4197 = (FStar_ST.read stack)
+in (match (uu____4197) with
+| (env)::tl1 -> begin
+((pop_record_cache ());
+(FStar_ST.write stack tl1);
+env;
+)
+end
+| uu____4210 -> begin
+(failwith "Impossible: Too many pops")
+end)))
+
+
+let commit_mark : env  ->  env = (fun env -> ((commit_record_cache ());
+(
+
+let uu____4216 = (FStar_ST.read stack)
+in (match (uu____4216) with
+| (uu____4221)::tl1 -> begin
+((FStar_ST.write stack tl1);
+env;
+)
+end
+| uu____4228 -> begin
+(failwith "Impossible: Too many pops")
+end));
+))
+
+
+let mark : env  ->  env = (fun x -> (push x))
+
+
+let reset_mark : Prims.unit  ->  env = (fun uu____4235 -> (pop ()))
+
+
+let export_interface : FStar_Ident.lident  ->  env  ->  env = (fun m env -> (
+
+let sigelt_in_m = (fun se -> (match ((FStar_Syntax_Util.lids_of_sigelt se)) with
+| (l)::uu____4247 -> begin
+(l.FStar_Ident.nsstr = m.FStar_Ident.str)
+end
+| uu____4249 -> begin
+false
+end))
+in (
+
+let sm = (sigmap env)
+in (
+
+let env1 = (pop ())
+in (
+
+let keys = (FStar_Util.smap_keys sm)
+in (
+
+let sm' = (sigmap env1)
+in ((FStar_All.pipe_right keys (FStar_List.iter (fun k -> (
+
+let uu____4267 = (FStar_Util.smap_try_find sm' k)
+in (match (uu____4267) with
+| Some (se, true) when (sigelt_in_m se) -> begin
+((FStar_Util.smap_remove sm' k);
+(
+
+let se1 = (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_declare_typ (l, u, t, q) -> begin
+(
+
+let uu___178_4286 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), (u), (t), ((FStar_Syntax_Syntax.Assumption)::q))); FStar_Syntax_Syntax.sigdoc = uu___178_4286.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___178_4286.FStar_Syntax_Syntax.sigrng})
+end
+| uu____4288 -> begin
+se
+end)
+in (FStar_Util.smap_add sm' k ((se1), (false))));
+)
+end
+| uu____4291 -> begin
+()
+end)))));
+env1;
+)))))))
+
+
+let finish_module_or_interface : env  ->  FStar_Syntax_Syntax.modul  ->  env = (fun env modul -> ((match ((not (modul.FStar_Syntax_Syntax.is_interface))) with
+| true -> begin
+(check_admits env)
+end
+| uu____4302 -> begin
+()
+end);
+(finish env modul);
+))
+
+
+let prepare_module_or_interface : Prims.bool  ->  Prims.bool  ->  env  ->  FStar_Ident.lident  ->  (env * Prims.bool) = (fun intf admitted env mname -> (
+
+let prep = (fun env1 -> (
+
+let open_ns = (match ((FStar_Ident.lid_equals mname FStar_Syntax_Const.prims_lid)) with
+| true -> begin
+[]
+end
+| uu____4324 -> begin
+(match ((FStar_Util.starts_with "FStar." (FStar_Ident.text_of_lid mname))) with
+| true -> begin
+(FStar_Syntax_Const.prims_lid)::(FStar_Syntax_Const.fstar_ns_lid)::[]
+end
+| uu____4326 -> begin
+(FStar_Syntax_Const.prims_lid)::(FStar_Syntax_Const.st_lid)::(FStar_Syntax_Const.all_lid)::(FStar_Syntax_Const.fstar_ns_lid)::[]
+end)
+end)
+in (
+
+let open_ns1 = (match (((FStar_List.length mname.FStar_Ident.ns) <> (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let ns = (FStar_Ident.lid_of_ids mname.FStar_Ident.ns)
+in (ns)::open_ns)
+end
+| uu____4333 -> begin
+open_ns
+end)
+in ((
+
+let uu____4335 = (exported_id_set_new ())
+in (FStar_Util.smap_add env1.exported_ids mname.FStar_Ident.str uu____4335));
+(match (()) with
+| () -> begin
+((
+
+let uu____4340 = (exported_id_set_new ())
+in (FStar_Util.smap_add env1.trans_exported_ids mname.FStar_Ident.str uu____4340));
+(match (()) with
+| () -> begin
+((
+
+let uu____4345 = (FStar_Util.mk_ref [])
+in (FStar_Util.smap_add env1.includes mname.FStar_Ident.str uu____4345));
+(match (()) with
+| () -> begin
+(
+
+let uu___179_4354 = env1
+in (
+
+let uu____4355 = (FStar_List.map (fun lid -> Open_module_or_namespace (((lid), (Open_namespace)))) open_ns1)
+in {curmodule = Some (mname); curmonad = uu___179_4354.curmonad; modules = uu___179_4354.modules; scope_mods = uu____4355; exported_ids = uu___179_4354.exported_ids; trans_exported_ids = uu___179_4354.trans_exported_ids; includes = uu___179_4354.includes; sigaccum = uu___179_4354.sigaccum; sigmap = env1.sigmap; iface = intf; admitted_iface = admitted; expect_typ = uu___179_4354.expect_typ}))
+end);
+)
+end);
+)
+end);
+))))
+in (
+
+let uu____4358 = (FStar_All.pipe_right env.modules (FStar_Util.find_opt (fun uu____4370 -> (match (uu____4370) with
+| (l, uu____4374) -> begin
+(FStar_Ident.lid_equals l mname)
+end))))
+in (match (uu____4358) with
+| None -> begin
+(
+
+let uu____4379 = (prep env)
+in ((uu____4379), (false)))
+end
+| Some (uu____4380, m) -> begin
+((
+
+let uu____4385 = ((
+
+let uu____4386 = (FStar_Options.interactive ())
+in (not (uu____4386))) && ((not (m.FStar_Syntax_Syntax.is_interface)) || intf))
+in (match (uu____4385) with
+| true -> begin
+(
+
+let uu____4387 = (
+
+let uu____4388 = (
+
+let uu____4391 = (FStar_Util.format1 "Duplicate module or interface name: %s" mname.FStar_Ident.str)
+in ((uu____4391), ((FStar_Ident.range_of_lid mname))))
+in FStar_Errors.Error (uu____4388))
+in (Prims.raise uu____4387))
+end
+| uu____4392 -> begin
+()
+end));
+(
+
+let uu____4393 = (
+
+let uu____4394 = (push env)
+in (prep uu____4394))
+in ((uu____4393), (true)));
+)
+end))))
+
+
+let enter_monad_scope : env  ->  FStar_Ident.ident  ->  env = (fun env mname -> (match (env.curmonad) with
+| Some (mname') -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Trying to define monad " (Prims.strcat mname.FStar_Ident.idText (Prims.strcat ", but already in monad scope " mname'.FStar_Ident.idText)))), (mname.FStar_Ident.idRange)))))
+end
+| None -> begin
+(
+
+let uu___180_4402 = env
+in {curmodule = uu___180_4402.curmodule; curmonad = Some (mname); modules = uu___180_4402.modules; scope_mods = uu___180_4402.scope_mods; exported_ids = uu___180_4402.exported_ids; trans_exported_ids = uu___180_4402.trans_exported_ids; includes = uu___180_4402.includes; sigaccum = uu___180_4402.sigaccum; sigmap = uu___180_4402.sigmap; iface = uu___180_4402.iface; admitted_iface = uu___180_4402.admitted_iface; expect_typ = uu___180_4402.expect_typ})
+end))
+
+
+let fail_or = (fun env lookup lid -> (
+
+let uu____4427 = (lookup lid)
+in (match (uu____4427) with
+| None -> begin
+(
+
+let opened_modules = (FStar_List.map (fun uu____4433 -> (match (uu____4433) with
+| (lid1, uu____4437) -> begin
+(FStar_Ident.text_of_lid lid1)
+end)) env.modules)
+in (
+
+let msg = (FStar_Util.format1 "Identifier not found: [%s]" (FStar_Ident.text_of_lid lid))
+in (
+
+let msg1 = (match (((FStar_List.length lid.FStar_Ident.ns) = (Prims.parse_int "0"))) with
+| true -> begin
+msg
+end
+| uu____4442 -> begin
+(
+
+let modul = (
+
+let uu____4444 = (FStar_Ident.lid_of_ids lid.FStar_Ident.ns)
+in (FStar_Ident.set_lid_range uu____4444 (FStar_Ident.range_of_lid lid)))
+in (
+
+let uu____4445 = (resolve_module_name env modul true)
+in (match (uu____4445) with
+| None -> begin
+(
+
+let opened_modules1 = (FStar_String.concat ", " opened_modules)
+in (FStar_Util.format3 "%s\nModule %s does not belong to the list of modules in scope, namely %s" msg modul.FStar_Ident.str opened_modules1))
+end
+| Some (modul') when (not ((FStar_List.existsb (fun m -> (m = modul'.FStar_Ident.str)) opened_modules))) -> begin
+(
+
+let opened_modules1 = (FStar_String.concat ", " opened_modules)
+in (FStar_Util.format4 "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s" msg modul.FStar_Ident.str modul'.FStar_Ident.str opened_modules1))
+end
+| Some (modul') -> begin
+(FStar_Util.format4 "%s\nModule %s resolved into %s, definition %s not found" msg modul.FStar_Ident.str modul'.FStar_Ident.str lid.FStar_Ident.ident.FStar_Ident.idText)
+end)))
+end)
+in (Prims.raise (FStar_Errors.Error (((msg1), ((FStar_Ident.range_of_lid lid)))))))))
+end
+| Some (r) -> begin
+r
+end)))
+
+
+let fail_or2 = (fun lookup id -> (
+
+let uu____4472 = (lookup id)
+in (match (uu____4472) with
+| None -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Identifier not found [" (Prims.strcat id.FStar_Ident.idText "]"))), (id.FStar_Ident.idRange)))))
+end
+| Some (r) -> begin
+r
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -1,5188 +1,5852 @@
+
 open Prims
-let trans_aqual:
-  FStar_Parser_AST.arg_qualifier Prims.option ->
-    FStar_Syntax_Syntax.arg_qualifier Prims.option
-  =
-  fun uu___187_5  ->
-    match uu___187_5 with
-    | Some (FStar_Parser_AST.Implicit ) -> Some FStar_Syntax_Syntax.imp_tag
-    | Some (FStar_Parser_AST.Equality ) -> Some FStar_Syntax_Syntax.Equality
-    | uu____8 -> None
-let trans_qual:
-  FStar_Range.range ->
-    FStar_Ident.lident Prims.option ->
-      FStar_Parser_AST.qualifier -> FStar_Syntax_Syntax.qualifier
-  =
-  fun r  ->
-    fun maybe_effect_id  ->
-      fun uu___188_19  ->
-        match uu___188_19 with
-        | FStar_Parser_AST.Private  -> FStar_Syntax_Syntax.Private
-        | FStar_Parser_AST.Assumption  -> FStar_Syntax_Syntax.Assumption
-        | FStar_Parser_AST.Unfold_for_unification_and_vcgen  ->
-            FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
-        | FStar_Parser_AST.Inline_for_extraction  ->
-            FStar_Syntax_Syntax.Inline_for_extraction
-        | FStar_Parser_AST.NoExtract  -> FStar_Syntax_Syntax.NoExtract
-        | FStar_Parser_AST.Irreducible  -> FStar_Syntax_Syntax.Irreducible
-        | FStar_Parser_AST.Logic  -> FStar_Syntax_Syntax.Logic
-        | FStar_Parser_AST.TotalEffect  -> FStar_Syntax_Syntax.TotalEffect
-        | FStar_Parser_AST.Effect_qual  -> FStar_Syntax_Syntax.Effect
-        | FStar_Parser_AST.New  -> FStar_Syntax_Syntax.New
-        | FStar_Parser_AST.Abstract  -> FStar_Syntax_Syntax.Abstract
-        | FStar_Parser_AST.Opaque  ->
-            (FStar_Errors.warn r
-               "The 'opaque' qualifier is deprecated since its use was strangely schizophrenic. There were two overloaded uses: (1) Given 'opaque val f : t', the behavior was to exclude the definition of 'f' to the SMT solver. This corresponds roughly to the new 'irreducible' qualifier. (2) Given 'opaque type t = t'', the behavior was to provide the definition of 't' to the SMT solver, but not to inline it, unless absolutely required for unification. This corresponds roughly to the behavior of 'unfoldable' (which is currently the default).";
-             FStar_Syntax_Syntax.Visible_default)
-        | FStar_Parser_AST.Reflectable  ->
-            (match maybe_effect_id with
-             | None  ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ("Qualifier reflect only supported on effects", r))
-             | Some effect_id -> FStar_Syntax_Syntax.Reflectable effect_id)
-        | FStar_Parser_AST.Reifiable  -> FStar_Syntax_Syntax.Reifiable
-        | FStar_Parser_AST.Noeq  -> FStar_Syntax_Syntax.Noeq
-        | FStar_Parser_AST.Unopteq  -> FStar_Syntax_Syntax.Unopteq
-        | FStar_Parser_AST.DefaultEffect  ->
-            Prims.raise
-              (FStar_Errors.Error
-                 ("The 'default' qualifier on effects is no longer supported",
-                   r))
-        | FStar_Parser_AST.Inline |FStar_Parser_AST.Visible  ->
-            Prims.raise (FStar_Errors.Error ("Unsupported qualifier", r))
-let trans_pragma: FStar_Parser_AST.pragma -> FStar_Syntax_Syntax.pragma =
-  fun uu___189_25  ->
-    match uu___189_25 with
-    | FStar_Parser_AST.SetOptions s -> FStar_Syntax_Syntax.SetOptions s
-    | FStar_Parser_AST.ResetOptions sopt ->
-        FStar_Syntax_Syntax.ResetOptions sopt
-    | FStar_Parser_AST.LightOff  -> FStar_Syntax_Syntax.LightOff
-let as_imp:
-  FStar_Parser_AST.imp -> FStar_Syntax_Syntax.arg_qualifier Prims.option =
-  fun uu___190_32  ->
-    match uu___190_32 with
-    | FStar_Parser_AST.Hash  -> Some FStar_Syntax_Syntax.imp_tag
-    | uu____34 -> None
-let arg_withimp_e imp t = (t, (as_imp imp))
-let arg_withimp_t imp t =
-  match imp with
-  | FStar_Parser_AST.Hash  -> (t, (Some FStar_Syntax_Syntax.imp_tag))
-  | uu____67 -> (t, None)
-let contains_binder: FStar_Parser_AST.binder Prims.list -> Prims.bool =
-  fun binders  ->
-    FStar_All.pipe_right binders
-      (FStar_Util.for_some
-         (fun b  ->
-            match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated uu____76 -> true
-            | uu____79 -> false))
-let rec unparen: FStar_Parser_AST.term -> FStar_Parser_AST.term =
-  fun t  ->
-    match t.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Paren t1 -> unparen t1
-    | uu____84 -> t
-let tm_type_z: FStar_Range.range -> FStar_Parser_AST.term =
-  fun r  ->
-    let uu____88 =
-      let uu____89 = FStar_Ident.lid_of_path ["Type0"] r in
-      FStar_Parser_AST.Name uu____89 in
-    FStar_Parser_AST.mk_term uu____88 r FStar_Parser_AST.Kind
-let tm_type: FStar_Range.range -> FStar_Parser_AST.term =
-  fun r  ->
-    let uu____93 =
-      let uu____94 = FStar_Ident.lid_of_path ["Type"] r in
-      FStar_Parser_AST.Name uu____94 in
-    FStar_Parser_AST.mk_term uu____93 r FStar_Parser_AST.Kind
-let rec is_comp_type:
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      match t.FStar_Parser_AST.tm with
-      | FStar_Parser_AST.Name l|FStar_Parser_AST.Construct (l,_) ->
-          let uu____106 = FStar_ToSyntax_Env.try_lookup_effect_name env l in
-          FStar_All.pipe_right uu____106 FStar_Option.isSome
-      | FStar_Parser_AST.App (head1,uu____110,uu____111) ->
-          is_comp_type env head1
-      | FStar_Parser_AST.Paren t1
-        |FStar_Parser_AST.Ascribed (t1,_,_)|FStar_Parser_AST.LetOpen (_,t1)
-          -> is_comp_type env t1
-      | uu____117 -> false
-let unit_ty: FStar_Parser_AST.term =
-  FStar_Parser_AST.mk_term
-    (FStar_Parser_AST.Name FStar_Syntax_Const.unit_lid)
-    FStar_Range.dummyRange FStar_Parser_AST.Type_level
-let compile_op_lid:
-  Prims.int -> Prims.string -> FStar_Range.range -> FStar_Ident.lident =
-  fun n1  ->
-    fun s  ->
-      fun r  ->
-        let uu____127 =
-          let uu____129 =
-            let uu____130 =
-              let uu____133 = FStar_Parser_AST.compile_op n1 s in
-              (uu____133, r) in
-            FStar_Ident.mk_ident uu____130 in
-          [uu____129] in
-        FStar_All.pipe_right uu____127 FStar_Ident.lid_of_ids
-let op_as_term:
-  FStar_ToSyntax_Env.env ->
-    Prims.int ->
-      FStar_Range.range ->
-        Prims.string -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun env  ->
-    fun arity  ->
-      fun rng  ->
-        fun s  ->
-          let r l dd =
-            let uu____157 =
-              let uu____158 =
-                FStar_Syntax_Syntax.lid_as_fv
-                  (FStar_Ident.set_lid_range l rng) dd None in
-              FStar_All.pipe_right uu____158 FStar_Syntax_Syntax.fv_to_tm in
-            Some uu____157 in
-          let fallback uu____163 =
-            match s with
-            | "=" ->
-                r FStar_Syntax_Const.op_Eq
-                  FStar_Syntax_Syntax.Delta_equational
-            | ":=" ->
-                r FStar_Syntax_Const.write_lid
-                  FStar_Syntax_Syntax.Delta_equational
-            | "<" ->
-                r FStar_Syntax_Const.op_LT
-                  FStar_Syntax_Syntax.Delta_equational
-            | "<=" ->
-                r FStar_Syntax_Const.op_LTE
-                  FStar_Syntax_Syntax.Delta_equational
-            | ">" ->
-                r FStar_Syntax_Const.op_GT
-                  FStar_Syntax_Syntax.Delta_equational
-            | ">=" ->
-                r FStar_Syntax_Const.op_GTE
-                  FStar_Syntax_Syntax.Delta_equational
-            | "&&" ->
-                r FStar_Syntax_Const.op_And
-                  FStar_Syntax_Syntax.Delta_equational
-            | "||" ->
-                r FStar_Syntax_Const.op_Or
-                  FStar_Syntax_Syntax.Delta_equational
-            | "+" ->
-                r FStar_Syntax_Const.op_Addition
-                  FStar_Syntax_Syntax.Delta_equational
-            | "-" when arity = (Prims.parse_int "1") ->
-                r FStar_Syntax_Const.op_Minus
-                  FStar_Syntax_Syntax.Delta_equational
-            | "-" ->
-                r FStar_Syntax_Const.op_Subtraction
-                  FStar_Syntax_Syntax.Delta_equational
-            | "/" ->
-                r FStar_Syntax_Const.op_Division
-                  FStar_Syntax_Syntax.Delta_equational
-            | "%" ->
-                r FStar_Syntax_Const.op_Modulus
-                  FStar_Syntax_Syntax.Delta_equational
-            | "!" ->
-                r FStar_Syntax_Const.read_lid
-                  FStar_Syntax_Syntax.Delta_equational
-            | "@" ->
-                let uu____165 = FStar_Options.ml_ish () in
-                if uu____165
-                then
-                  r FStar_Syntax_Const.list_append_lid
-                    FStar_Syntax_Syntax.Delta_equational
-                else
-                  r FStar_Syntax_Const.list_tot_append_lid
-                    FStar_Syntax_Syntax.Delta_equational
-            | "^" ->
-                r FStar_Syntax_Const.strcat_lid
-                  FStar_Syntax_Syntax.Delta_equational
-            | "|>" ->
-                r FStar_Syntax_Const.pipe_right_lid
-                  FStar_Syntax_Syntax.Delta_equational
-            | "<|" ->
-                r FStar_Syntax_Const.pipe_left_lid
-                  FStar_Syntax_Syntax.Delta_equational
-            | "<>" ->
-                r FStar_Syntax_Const.op_notEq
-                  FStar_Syntax_Syntax.Delta_equational
-            | "~" ->
-                r FStar_Syntax_Const.not_lid
-                  (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "2"))
-            | "==" ->
-                r FStar_Syntax_Const.eq2_lid
-                  FStar_Syntax_Syntax.Delta_constant
-            | "<<" ->
-                r FStar_Syntax_Const.precedes_lid
-                  FStar_Syntax_Syntax.Delta_constant
-            | "/\\" ->
-                r FStar_Syntax_Const.and_lid
-                  (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "1"))
-            | "\\/" ->
-                r FStar_Syntax_Const.or_lid
-                  (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "1"))
-            | "==>" ->
-                r FStar_Syntax_Const.imp_lid
-                  (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "1"))
-            | "<==>" ->
-                r FStar_Syntax_Const.iff_lid
-                  (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "2"))
-            | uu____168 -> None in
-          let uu____169 =
-            let uu____173 = compile_op_lid arity s rng in
-            FStar_ToSyntax_Env.try_lookup_lid env uu____173 in
-          match uu____169 with
-          | Some t -> Some (Prims.fst t)
-          | uu____180 -> fallback ()
-let sort_ftv: FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list =
-  fun ftv  ->
-    let uu____190 =
-      FStar_Util.remove_dups
-        (fun x  -> fun y  -> x.FStar_Ident.idText = y.FStar_Ident.idText) ftv in
-    FStar_All.pipe_left
-      (FStar_Util.sort_with
-         (fun x  ->
-            fun y  ->
-              FStar_String.compare x.FStar_Ident.idText y.FStar_Ident.idText))
-      uu____190
-let rec free_type_vars_b:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.binder ->
-      (FStar_ToSyntax_Env.env* FStar_Ident.ident Prims.list)
-  =
-  fun env  ->
-    fun binder  ->
-      match binder.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Variable uu____215 -> (env, [])
-      | FStar_Parser_AST.TVariable x ->
-          let uu____218 = FStar_ToSyntax_Env.push_bv env x in
-          (match uu____218 with | (env1,uu____225) -> (env1, [x]))
-      | FStar_Parser_AST.Annotated (uu____227,term) ->
-          let uu____229 = free_type_vars env term in (env, uu____229)
-      | FStar_Parser_AST.TAnnotated (id,uu____233) ->
-          let uu____234 = FStar_ToSyntax_Env.push_bv env id in
-          (match uu____234 with | (env1,uu____241) -> (env1, []))
-      | FStar_Parser_AST.NoName t ->
-          let uu____244 = free_type_vars env t in (env, uu____244)
-and free_type_vars:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.term -> FStar_Ident.ident Prims.list
-  =
-  fun env  ->
-    fun t  ->
-      let uu____249 =
-        let uu____250 = unparen t in uu____250.FStar_Parser_AST.tm in
-      match uu____249 with
-      | FStar_Parser_AST.Labeled uu____252 ->
-          failwith "Impossible --- labeled source term"
-      | FStar_Parser_AST.Tvar a ->
-          let uu____258 = FStar_ToSyntax_Env.try_lookup_id env a in
-          (match uu____258 with | None  -> [a] | uu____265 -> [])
-      | FStar_Parser_AST.Wild 
-        |FStar_Parser_AST.Const _
-         |FStar_Parser_AST.Uvar _
-          |FStar_Parser_AST.Var _
-           |FStar_Parser_AST.Projector _
-            |FStar_Parser_AST.Discrim _|FStar_Parser_AST.Name _
-          -> []
-      | FStar_Parser_AST.Assign (_,t1)
-        |FStar_Parser_AST.Requires (t1,_)
-         |FStar_Parser_AST.Ensures (t1,_)
-          |FStar_Parser_AST.NamedTyp (_,t1)|FStar_Parser_AST.Paren t1 ->
-          free_type_vars env t1
-      | FStar_Parser_AST.Ascribed (t1,t',tacopt) ->
-          let ts = t1 :: t' ::
-            (match tacopt with | None  -> [] | Some t2 -> [t2]) in
-          FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.Construct (uu____291,ts) ->
-          FStar_List.collect
-            (fun uu____301  ->
-               match uu____301 with | (t1,uu____306) -> free_type_vars env t1)
-            ts
-      | FStar_Parser_AST.Op (uu____307,ts) ->
-          FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.App (t1,t2,uu____313) ->
-          let uu____314 = free_type_vars env t1 in
-          let uu____316 = free_type_vars env t2 in
-          FStar_List.append uu____314 uu____316
-      | FStar_Parser_AST.Refine (b,t1) ->
-          let uu____320 = free_type_vars_b env b in
-          (match uu____320 with
-           | (env1,f) ->
-               let uu____329 = free_type_vars env1 t1 in
-               FStar_List.append f uu____329)
-      | FStar_Parser_AST.Product (binders,body)|FStar_Parser_AST.Sum
-        (binders,body) ->
-          let uu____337 =
-            FStar_List.fold_left
-              (fun uu____344  ->
-                 fun binder  ->
-                   match uu____344 with
-                   | (env1,free) ->
-                       let uu____356 = free_type_vars_b env1 binder in
-                       (match uu____356 with
-                        | (env2,f) -> (env2, (FStar_List.append f free))))
-              (env, []) binders in
-          (match uu____337 with
-           | (env1,free) ->
-               let uu____374 = free_type_vars env1 body in
-               FStar_List.append free uu____374)
-      | FStar_Parser_AST.Project (t1,uu____377) -> free_type_vars env t1
-      | FStar_Parser_AST.Attributes cattributes ->
-          FStar_List.collect (free_type_vars env) cattributes
-      | FStar_Parser_AST.Abs _
-        |FStar_Parser_AST.Let _
-         |FStar_Parser_AST.LetOpen _
-          |FStar_Parser_AST.If _
-           |FStar_Parser_AST.QForall _
-            |FStar_Parser_AST.QExists _
-             |FStar_Parser_AST.Record _
-              |FStar_Parser_AST.Match _
-               |FStar_Parser_AST.TryWith _|FStar_Parser_AST.Seq _
-          -> []
-let head_and_args:
-  FStar_Parser_AST.term ->
-    (FStar_Parser_AST.term* (FStar_Parser_AST.term* FStar_Parser_AST.imp)
-      Prims.list)
-  =
-  fun t  ->
-    let rec aux args t1 =
-      let uu____416 =
-        let uu____417 = unparen t1 in uu____417.FStar_Parser_AST.tm in
-      match uu____416 with
-      | FStar_Parser_AST.App (t2,arg,imp) -> aux ((arg, imp) :: args) t2
-      | FStar_Parser_AST.Construct (l,args') ->
-          ({
-             FStar_Parser_AST.tm = (FStar_Parser_AST.Name l);
-             FStar_Parser_AST.range = (t1.FStar_Parser_AST.range);
-             FStar_Parser_AST.level = (t1.FStar_Parser_AST.level)
-           }, (FStar_List.append args' args))
-      | uu____441 -> (t1, args) in
-    aux [] t
-let close:
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term =
-  fun env  ->
-    fun t  ->
-      let ftv =
-        let uu____455 = free_type_vars env t in
-        FStar_All.pipe_left sort_ftv uu____455 in
-      if (FStar_List.length ftv) = (Prims.parse_int "0")
-      then t
-      else
-        (let binders =
-           FStar_All.pipe_right ftv
-             (FStar_List.map
-                (fun x  ->
-                   let uu____467 =
-                     let uu____468 =
-                       let uu____471 = tm_type x.FStar_Ident.idRange in
-                       (x, uu____471) in
-                     FStar_Parser_AST.TAnnotated uu____468 in
-                   FStar_Parser_AST.mk_binder uu____467 x.FStar_Ident.idRange
-                     FStar_Parser_AST.Type_level
-                     (Some FStar_Parser_AST.Implicit))) in
-         let result =
-           FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (binders, t))
-             t.FStar_Parser_AST.range t.FStar_Parser_AST.level in
-         result)
-let close_fun:
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term =
-  fun env  ->
-    fun t  ->
-      let ftv =
-        let uu____482 = free_type_vars env t in
-        FStar_All.pipe_left sort_ftv uu____482 in
-      if (FStar_List.length ftv) = (Prims.parse_int "0")
-      then t
-      else
-        (let binders =
-           FStar_All.pipe_right ftv
-             (FStar_List.map
-                (fun x  ->
-                   let uu____494 =
-                     let uu____495 =
-                       let uu____498 = tm_type x.FStar_Ident.idRange in
-                       (x, uu____498) in
-                     FStar_Parser_AST.TAnnotated uu____495 in
-                   FStar_Parser_AST.mk_binder uu____494 x.FStar_Ident.idRange
-                     FStar_Parser_AST.Type_level
-                     (Some FStar_Parser_AST.Implicit))) in
-         let t1 =
-           let uu____500 =
-             let uu____501 = unparen t in uu____501.FStar_Parser_AST.tm in
-           match uu____500 with
-           | FStar_Parser_AST.Product uu____502 -> t
-           | uu____506 ->
-               FStar_Parser_AST.mk_term
-                 (FStar_Parser_AST.App
-                    ((FStar_Parser_AST.mk_term
-                        (FStar_Parser_AST.Name
-                           FStar_Syntax_Const.effect_Tot_lid)
-                        t.FStar_Parser_AST.range t.FStar_Parser_AST.level),
-                      t, FStar_Parser_AST.Nothing)) t.FStar_Parser_AST.range
-                 t.FStar_Parser_AST.level in
-         let result =
-           FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (binders, t1))
-             t1.FStar_Parser_AST.range t1.FStar_Parser_AST.level in
-         result)
-let rec uncurry:
-  FStar_Parser_AST.binder Prims.list ->
-    FStar_Parser_AST.term ->
-      (FStar_Parser_AST.binder Prims.list* FStar_Parser_AST.term)
-  =
-  fun bs  ->
-    fun t  ->
-      match t.FStar_Parser_AST.tm with
-      | FStar_Parser_AST.Product (binders,t1) ->
-          uncurry (FStar_List.append bs binders) t1
-      | uu____527 -> (bs, t)
-let rec is_var_pattern: FStar_Parser_AST.pattern -> Prims.bool =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatWild 
-      |FStar_Parser_AST.PatTvar (_,_)|FStar_Parser_AST.PatVar (_,_) -> true
-    | FStar_Parser_AST.PatAscribed (p1,uu____539) -> is_var_pattern p1
-    | uu____540 -> false
-let rec is_app_pattern: FStar_Parser_AST.pattern -> Prims.bool =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatAscribed (p1,uu____545) -> is_app_pattern p1
-    | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu____546;
-           FStar_Parser_AST.prange = uu____547;_},uu____548)
-        -> true
-    | uu____554 -> false
-let replace_unit_pattern:
-  FStar_Parser_AST.pattern -> FStar_Parser_AST.pattern =
-  fun p  ->
-    match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatConst (FStar_Const.Const_unit ) ->
-        FStar_Parser_AST.mk_pattern
-          (FStar_Parser_AST.PatAscribed
-             ((FStar_Parser_AST.mk_pattern FStar_Parser_AST.PatWild
-                 p.FStar_Parser_AST.prange), unit_ty))
-          p.FStar_Parser_AST.prange
-    | uu____558 -> p
-let rec destruct_app_pattern:
-  FStar_ToSyntax_Env.env ->
-    Prims.bool ->
-      FStar_Parser_AST.pattern ->
-        ((FStar_Ident.ident,FStar_Ident.lident) FStar_Util.either*
-          FStar_Parser_AST.pattern Prims.list* FStar_Parser_AST.term
-          Prims.option)
-  =
-  fun env  ->
-    fun is_top_level1  ->
-      fun p  ->
-        match p.FStar_Parser_AST.pat with
-        | FStar_Parser_AST.PatAscribed (p1,t) ->
-            let uu____584 = destruct_app_pattern env is_top_level1 p1 in
-            (match uu____584 with
-             | (name,args,uu____601) -> (name, args, (Some t)))
-        | FStar_Parser_AST.PatApp
-            ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____615);
-               FStar_Parser_AST.prange = uu____616;_},args)
-            when is_top_level1 ->
-            let uu____622 =
-              let uu____625 = FStar_ToSyntax_Env.qualify env id in
-              FStar_Util.Inr uu____625 in
-            (uu____622, args, None)
-        | FStar_Parser_AST.PatApp
-            ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____631);
-               FStar_Parser_AST.prange = uu____632;_},args)
-            -> ((FStar_Util.Inl id), args, None)
-        | uu____642 -> failwith "Not an app pattern"
-let rec gather_pattern_bound_vars_maybe_top:
-  FStar_Ident.ident FStar_Util.set ->
-    FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set
-  =
-  fun acc  ->
-    fun p  ->
-      let gather_pattern_bound_vars_from_list =
-        FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc in
-      match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatWild 
-        |FStar_Parser_AST.PatConst _
-         |FStar_Parser_AST.PatVar (_,Some (FStar_Parser_AST.Implicit ))
-          |FStar_Parser_AST.PatName _
-           |FStar_Parser_AST.PatTvar _|FStar_Parser_AST.PatOp _
-          -> acc
-      | FStar_Parser_AST.PatApp (phead,pats) ->
-          gather_pattern_bound_vars_from_list (phead :: pats)
-      | FStar_Parser_AST.PatVar (x,uu____677) -> FStar_Util.set_add x acc
-      | FStar_Parser_AST.PatList pats
-        |FStar_Parser_AST.PatTuple (pats,_)|FStar_Parser_AST.PatOr pats ->
-          gather_pattern_bound_vars_from_list pats
-      | FStar_Parser_AST.PatRecord guarded_pats ->
-          let uu____690 = FStar_List.map Prims.snd guarded_pats in
-          gather_pattern_bound_vars_from_list uu____690
-      | FStar_Parser_AST.PatAscribed (pat,uu____695) ->
-          gather_pattern_bound_vars_maybe_top acc pat
-let gather_pattern_bound_vars:
-  FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set =
-  let acc =
-    FStar_Util.new_set
-      (fun id1  ->
-         fun id2  ->
-           if id1.FStar_Ident.idText = id2.FStar_Ident.idText
-           then Prims.parse_int "0"
-           else Prims.parse_int "1") (fun uu____704  -> Prims.parse_int "0") in
-  fun p  -> gather_pattern_bound_vars_maybe_top acc p
+
+let trans_aqual : FStar_Parser_AST.arg_qualifier Prims.option  ->  FStar_Syntax_Syntax.arg_qualifier Prims.option = (fun uu___181_5 -> (match (uu___181_5) with
+| Some (FStar_Parser_AST.Implicit) -> begin
+Some (FStar_Syntax_Syntax.imp_tag)
+end
+| Some (FStar_Parser_AST.Equality) -> begin
+Some (FStar_Syntax_Syntax.Equality)
+end
+| uu____8 -> begin
+None
+end))
+
+
+let trans_qual : FStar_Range.range  ->  FStar_Ident.lident Prims.option  ->  FStar_Parser_AST.qualifier  ->  FStar_Syntax_Syntax.qualifier = (fun r maybe_effect_id uu___182_19 -> (match (uu___182_19) with
+| FStar_Parser_AST.Private -> begin
+FStar_Syntax_Syntax.Private
+end
+| FStar_Parser_AST.Assumption -> begin
+FStar_Syntax_Syntax.Assumption
+end
+| FStar_Parser_AST.Unfold_for_unification_and_vcgen -> begin
+FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
+end
+| FStar_Parser_AST.Inline_for_extraction -> begin
+FStar_Syntax_Syntax.Inline_for_extraction
+end
+| FStar_Parser_AST.NoExtract -> begin
+FStar_Syntax_Syntax.NoExtract
+end
+| FStar_Parser_AST.Irreducible -> begin
+FStar_Syntax_Syntax.Irreducible
+end
+| FStar_Parser_AST.Logic -> begin
+FStar_Syntax_Syntax.Logic
+end
+| FStar_Parser_AST.TotalEffect -> begin
+FStar_Syntax_Syntax.TotalEffect
+end
+| FStar_Parser_AST.Effect_qual -> begin
+FStar_Syntax_Syntax.Effect
+end
+| FStar_Parser_AST.New -> begin
+FStar_Syntax_Syntax.New
+end
+| FStar_Parser_AST.Abstract -> begin
+FStar_Syntax_Syntax.Abstract
+end
+| FStar_Parser_AST.Opaque -> begin
+((FStar_Errors.warn r "The \'opaque\' qualifier is deprecated since its use was strangely schizophrenic. There were two overloaded uses: (1) Given \'opaque val f : t\', the behavior was to exclude the definition of \'f\' to the SMT solver. This corresponds roughly to the new \'irreducible\' qualifier. (2) Given \'opaque type t = t\'\', the behavior was to provide the definition of \'t\' to the SMT solver, but not to inline it, unless absolutely required for unification. This corresponds roughly to the behavior of \'unfoldable\' (which is currently the default).");
+FStar_Syntax_Syntax.Visible_default;
+)
+end
+| FStar_Parser_AST.Reflectable -> begin
+(match (maybe_effect_id) with
+| None -> begin
+(Prims.raise (FStar_Errors.Error ((("Qualifier reflect only supported on effects"), (r)))))
+end
+| Some (effect_id) -> begin
+FStar_Syntax_Syntax.Reflectable (effect_id)
+end)
+end
+| FStar_Parser_AST.Reifiable -> begin
+FStar_Syntax_Syntax.Reifiable
+end
+| FStar_Parser_AST.Noeq -> begin
+FStar_Syntax_Syntax.Noeq
+end
+| FStar_Parser_AST.Unopteq -> begin
+FStar_Syntax_Syntax.Unopteq
+end
+| FStar_Parser_AST.DefaultEffect -> begin
+(Prims.raise (FStar_Errors.Error ((("The \'default\' qualifier on effects is no longer supported"), (r)))))
+end
+| (FStar_Parser_AST.Inline) | (FStar_Parser_AST.Visible) -> begin
+(Prims.raise (FStar_Errors.Error ((("Unsupported qualifier"), (r)))))
+end))
+
+
+let trans_pragma : FStar_Parser_AST.pragma  ->  FStar_Syntax_Syntax.pragma = (fun uu___183_25 -> (match (uu___183_25) with
+| FStar_Parser_AST.SetOptions (s) -> begin
+FStar_Syntax_Syntax.SetOptions (s)
+end
+| FStar_Parser_AST.ResetOptions (sopt) -> begin
+FStar_Syntax_Syntax.ResetOptions (sopt)
+end
+| FStar_Parser_AST.LightOff -> begin
+FStar_Syntax_Syntax.LightOff
+end))
+
+
+let as_imp : FStar_Parser_AST.imp  ->  FStar_Syntax_Syntax.arg_qualifier Prims.option = (fun uu___184_32 -> (match (uu___184_32) with
+| FStar_Parser_AST.Hash -> begin
+Some (FStar_Syntax_Syntax.imp_tag)
+end
+| uu____34 -> begin
+None
+end))
+
+
+let arg_withimp_e = (fun imp t -> ((t), ((as_imp imp))))
+
+
+let arg_withimp_t = (fun imp t -> (match (imp) with
+| FStar_Parser_AST.Hash -> begin
+((t), (Some (FStar_Syntax_Syntax.imp_tag)))
+end
+| uu____67 -> begin
+((t), (None))
+end))
+
+
+let contains_binder : FStar_Parser_AST.binder Prims.list  ->  Prims.bool = (fun binders -> (FStar_All.pipe_right binders (FStar_Util.for_some (fun b -> (match (b.FStar_Parser_AST.b) with
+| FStar_Parser_AST.Annotated (uu____76) -> begin
+true
+end
+| uu____79 -> begin
+false
+end)))))
+
+
+let rec unparen : FStar_Parser_AST.term  ->  FStar_Parser_AST.term = (fun t -> (match (t.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Paren (t1) -> begin
+(unparen t1)
+end
+| uu____84 -> begin
+t
+end))
+
+
+let tm_type_z : FStar_Range.range  ->  FStar_Parser_AST.term = (fun r -> (
+
+let uu____88 = (
+
+let uu____89 = (FStar_Ident.lid_of_path (("Type0")::[]) r)
+in FStar_Parser_AST.Name (uu____89))
+in (FStar_Parser_AST.mk_term uu____88 r FStar_Parser_AST.Kind)))
+
+
+let tm_type : FStar_Range.range  ->  FStar_Parser_AST.term = (fun r -> (
+
+let uu____93 = (
+
+let uu____94 = (FStar_Ident.lid_of_path (("Type")::[]) r)
+in FStar_Parser_AST.Name (uu____94))
+in (FStar_Parser_AST.mk_term uu____93 r FStar_Parser_AST.Kind)))
+
+
+let rec is_comp_type : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  Prims.bool = (fun env t -> (match (t.FStar_Parser_AST.tm) with
+| (FStar_Parser_AST.Name (l)) | (FStar_Parser_AST.Construct (l, _)) -> begin
+(
+
+let uu____106 = (FStar_ToSyntax_Env.try_lookup_effect_name env l)
+in (FStar_All.pipe_right uu____106 FStar_Option.isSome))
+end
+| FStar_Parser_AST.App (head1, uu____110, uu____111) -> begin
+(is_comp_type env head1)
+end
+| (FStar_Parser_AST.Paren (t1)) | (FStar_Parser_AST.Ascribed (t1, _, _)) | (FStar_Parser_AST.LetOpen (_, t1)) -> begin
+(is_comp_type env t1)
+end
+| uu____117 -> begin
+false
+end))
+
+
+let unit_ty : FStar_Parser_AST.term = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.unit_lid)) FStar_Range.dummyRange FStar_Parser_AST.Type_level)
+
+
+let compile_op_lid : Prims.int  ->  Prims.string  ->  FStar_Range.range  ->  FStar_Ident.lident = (fun n1 s r -> (
+
+let uu____127 = (
+
+let uu____129 = (
+
+let uu____130 = (
+
+let uu____133 = (FStar_Parser_AST.compile_op n1 s)
+in ((uu____133), (r)))
+in (FStar_Ident.mk_ident uu____130))
+in (uu____129)::[])
+in (FStar_All.pipe_right uu____127 FStar_Ident.lid_of_ids)))
+
+
+let op_as_term : FStar_ToSyntax_Env.env  ->  Prims.int  ->  FStar_Range.range  ->  Prims.string  ->  FStar_Syntax_Syntax.term Prims.option = (fun env arity rng s -> (
+
+let r = (fun l dd -> (
+
+let uu____157 = (
+
+let uu____158 = (FStar_Syntax_Syntax.lid_as_fv (FStar_Ident.set_lid_range l rng) dd None)
+in (FStar_All.pipe_right uu____158 FStar_Syntax_Syntax.fv_to_tm))
+in Some (uu____157)))
+in (
+
+let fallback = (fun uu____163 -> (match (s) with
+| "=" -> begin
+(r FStar_Syntax_Const.op_Eq FStar_Syntax_Syntax.Delta_equational)
+end
+| ":=" -> begin
+(r FStar_Syntax_Const.write_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| "<" -> begin
+(r FStar_Syntax_Const.op_LT FStar_Syntax_Syntax.Delta_equational)
+end
+| "<=" -> begin
+(r FStar_Syntax_Const.op_LTE FStar_Syntax_Syntax.Delta_equational)
+end
+| ">" -> begin
+(r FStar_Syntax_Const.op_GT FStar_Syntax_Syntax.Delta_equational)
+end
+| ">=" -> begin
+(r FStar_Syntax_Const.op_GTE FStar_Syntax_Syntax.Delta_equational)
+end
+| "&&" -> begin
+(r FStar_Syntax_Const.op_And FStar_Syntax_Syntax.Delta_equational)
+end
+| "||" -> begin
+(r FStar_Syntax_Const.op_Or FStar_Syntax_Syntax.Delta_equational)
+end
+| "+" -> begin
+(r FStar_Syntax_Const.op_Addition FStar_Syntax_Syntax.Delta_equational)
+end
+| "-" when (arity = (Prims.parse_int "1")) -> begin
+(r FStar_Syntax_Const.op_Minus FStar_Syntax_Syntax.Delta_equational)
+end
+| "-" -> begin
+(r FStar_Syntax_Const.op_Subtraction FStar_Syntax_Syntax.Delta_equational)
+end
+| "/" -> begin
+(r FStar_Syntax_Const.op_Division FStar_Syntax_Syntax.Delta_equational)
+end
+| "%" -> begin
+(r FStar_Syntax_Const.op_Modulus FStar_Syntax_Syntax.Delta_equational)
+end
+| "!" -> begin
+(r FStar_Syntax_Const.read_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| "@" -> begin
+(
+
+let uu____165 = (FStar_Options.ml_ish ())
+in (match (uu____165) with
+| true -> begin
+(r FStar_Syntax_Const.list_append_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____167 -> begin
+(r FStar_Syntax_Const.list_tot_append_lid FStar_Syntax_Syntax.Delta_equational)
+end))
+end
+| "^" -> begin
+(r FStar_Syntax_Const.strcat_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| "|>" -> begin
+(r FStar_Syntax_Const.pipe_right_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| "<|" -> begin
+(r FStar_Syntax_Const.pipe_left_lid FStar_Syntax_Syntax.Delta_equational)
+end
+| "<>" -> begin
+(r FStar_Syntax_Const.op_notEq FStar_Syntax_Syntax.Delta_equational)
+end
+| "~" -> begin
+(r FStar_Syntax_Const.not_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "2"))))
+end
+| "==" -> begin
+(r FStar_Syntax_Const.eq2_lid FStar_Syntax_Syntax.Delta_constant)
+end
+| "<<" -> begin
+(r FStar_Syntax_Const.precedes_lid FStar_Syntax_Syntax.Delta_constant)
+end
+| "/\\" -> begin
+(r FStar_Syntax_Const.and_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))))
+end
+| "\\/" -> begin
+(r FStar_Syntax_Const.or_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))))
+end
+| "==>" -> begin
+(r FStar_Syntax_Const.imp_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))))
+end
+| "<==>" -> begin
+(r FStar_Syntax_Const.iff_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "2"))))
+end
+| uu____168 -> begin
+None
+end))
+in (
+
+let uu____169 = (
+
+let uu____173 = (compile_op_lid arity s rng)
+in (FStar_ToSyntax_Env.try_lookup_lid env uu____173))
+in (match (uu____169) with
+| Some (t) -> begin
+Some ((Prims.fst t))
+end
+| uu____180 -> begin
+(fallback ())
+end)))))
+
+
+let sort_ftv : FStar_Ident.ident Prims.list  ->  FStar_Ident.ident Prims.list = (fun ftv -> (
+
+let uu____190 = (FStar_Util.remove_dups (fun x y -> (x.FStar_Ident.idText = y.FStar_Ident.idText)) ftv)
+in (FStar_All.pipe_left (FStar_Util.sort_with (fun x y -> (FStar_String.compare x.FStar_Ident.idText y.FStar_Ident.idText))) uu____190)))
+
+
+let rec free_type_vars_b : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.binder  ->  (FStar_ToSyntax_Env.env * FStar_Ident.ident Prims.list) = (fun env binder -> (match (binder.FStar_Parser_AST.b) with
+| FStar_Parser_AST.Variable (uu____215) -> begin
+((env), ([]))
+end
+| FStar_Parser_AST.TVariable (x) -> begin
+(
+
+let uu____218 = (FStar_ToSyntax_Env.push_bv env x)
+in (match (uu____218) with
+| (env1, uu____225) -> begin
+((env1), ((x)::[]))
+end))
+end
+| FStar_Parser_AST.Annotated (uu____227, term) -> begin
+(
+
+let uu____229 = (free_type_vars env term)
+in ((env), (uu____229)))
+end
+| FStar_Parser_AST.TAnnotated (id, uu____233) -> begin
+(
+
+let uu____234 = (FStar_ToSyntax_Env.push_bv env id)
+in (match (uu____234) with
+| (env1, uu____241) -> begin
+((env1), ([]))
+end))
+end
+| FStar_Parser_AST.NoName (t) -> begin
+(
+
+let uu____244 = (free_type_vars env t)
+in ((env), (uu____244)))
+end))
+and free_type_vars : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  FStar_Ident.ident Prims.list = (fun env t -> (
+
+let uu____249 = (
+
+let uu____250 = (unparen t)
+in uu____250.FStar_Parser_AST.tm)
+in (match (uu____249) with
+| FStar_Parser_AST.Labeled (uu____252) -> begin
+(failwith "Impossible --- labeled source term")
+end
+| FStar_Parser_AST.Tvar (a) -> begin
+(
+
+let uu____258 = (FStar_ToSyntax_Env.try_lookup_id env a)
+in (match (uu____258) with
+| None -> begin
+(a)::[]
+end
+| uu____265 -> begin
+[]
+end))
+end
+| (FStar_Parser_AST.Wild) | (FStar_Parser_AST.Const (_)) | (FStar_Parser_AST.Uvar (_)) | (FStar_Parser_AST.Var (_)) | (FStar_Parser_AST.Projector (_)) | (FStar_Parser_AST.Discrim (_)) | (FStar_Parser_AST.Name (_)) -> begin
+[]
+end
+| (FStar_Parser_AST.Assign (_, t1)) | (FStar_Parser_AST.Requires (t1, _)) | (FStar_Parser_AST.Ensures (t1, _)) | (FStar_Parser_AST.NamedTyp (_, t1)) | (FStar_Parser_AST.Paren (t1)) -> begin
+(free_type_vars env t1)
+end
+| FStar_Parser_AST.Ascribed (t1, t', tacopt) -> begin
+(
+
+let ts = (t1)::(t')::(match (tacopt) with
+| None -> begin
+[]
+end
+| Some (t2) -> begin
+(t2)::[]
+end)
+in (FStar_List.collect (free_type_vars env) ts))
+end
+| FStar_Parser_AST.Construct (uu____291, ts) -> begin
+(FStar_List.collect (fun uu____301 -> (match (uu____301) with
+| (t1, uu____306) -> begin
+(free_type_vars env t1)
+end)) ts)
+end
+| FStar_Parser_AST.Op (uu____307, ts) -> begin
+(FStar_List.collect (free_type_vars env) ts)
+end
+| FStar_Parser_AST.App (t1, t2, uu____313) -> begin
+(
+
+let uu____314 = (free_type_vars env t1)
+in (
+
+let uu____316 = (free_type_vars env t2)
+in (FStar_List.append uu____314 uu____316)))
+end
+| FStar_Parser_AST.Refine (b, t1) -> begin
+(
+
+let uu____320 = (free_type_vars_b env b)
+in (match (uu____320) with
+| (env1, f) -> begin
+(
+
+let uu____329 = (free_type_vars env1 t1)
+in (FStar_List.append f uu____329))
+end))
+end
+| (FStar_Parser_AST.Product (binders, body)) | (FStar_Parser_AST.Sum (binders, body)) -> begin
+(
+
+let uu____337 = (FStar_List.fold_left (fun uu____344 binder -> (match (uu____344) with
+| (env1, free) -> begin
+(
+
+let uu____356 = (free_type_vars_b env1 binder)
+in (match (uu____356) with
+| (env2, f) -> begin
+((env2), ((FStar_List.append f free)))
+end))
+end)) ((env), ([])) binders)
+in (match (uu____337) with
+| (env1, free) -> begin
+(
+
+let uu____374 = (free_type_vars env1 body)
+in (FStar_List.append free uu____374))
+end))
+end
+| FStar_Parser_AST.Project (t1, uu____377) -> begin
+(free_type_vars env t1)
+end
+| FStar_Parser_AST.Attributes (cattributes) -> begin
+(FStar_List.collect (free_type_vars env) cattributes)
+end
+| (FStar_Parser_AST.Abs (_)) | (FStar_Parser_AST.Let (_)) | (FStar_Parser_AST.LetOpen (_)) | (FStar_Parser_AST.If (_)) | (FStar_Parser_AST.QForall (_)) | (FStar_Parser_AST.QExists (_)) | (FStar_Parser_AST.Record (_)) | (FStar_Parser_AST.Match (_)) | (FStar_Parser_AST.TryWith (_)) | (FStar_Parser_AST.Seq (_)) -> begin
+[]
+end)))
+
+
+let head_and_args : FStar_Parser_AST.term  ->  (FStar_Parser_AST.term * (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list) = (fun t -> (
+
+let rec aux = (fun args t1 -> (
+
+let uu____416 = (
+
+let uu____417 = (unparen t1)
+in uu____417.FStar_Parser_AST.tm)
+in (match (uu____416) with
+| FStar_Parser_AST.App (t2, arg, imp) -> begin
+(aux ((((arg), (imp)))::args) t2)
+end
+| FStar_Parser_AST.Construct (l, args') -> begin
+(({FStar_Parser_AST.tm = FStar_Parser_AST.Name (l); FStar_Parser_AST.range = t1.FStar_Parser_AST.range; FStar_Parser_AST.level = t1.FStar_Parser_AST.level}), ((FStar_List.append args' args)))
+end
+| uu____441 -> begin
+((t1), (args))
+end)))
+in (aux [] t)))
+
+
+let close : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  FStar_Parser_AST.term = (fun env t -> (
+
+let ftv = (
+
+let uu____455 = (free_type_vars env t)
+in (FStar_All.pipe_left sort_ftv uu____455))
+in (match (((FStar_List.length ftv) = (Prims.parse_int "0"))) with
+| true -> begin
+t
+end
+| uu____461 -> begin
+(
+
+let binders = (FStar_All.pipe_right ftv (FStar_List.map (fun x -> (
+
+let uu____467 = (
+
+let uu____468 = (
+
+let uu____471 = (tm_type x.FStar_Ident.idRange)
+in ((x), (uu____471)))
+in FStar_Parser_AST.TAnnotated (uu____468))
+in (FStar_Parser_AST.mk_binder uu____467 x.FStar_Ident.idRange FStar_Parser_AST.Type_level (Some (FStar_Parser_AST.Implicit)))))))
+in (
+
+let result = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (((binders), (t)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)
+in result))
+end)))
+
+
+let close_fun : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  FStar_Parser_AST.term = (fun env t -> (
+
+let ftv = (
+
+let uu____482 = (free_type_vars env t)
+in (FStar_All.pipe_left sort_ftv uu____482))
+in (match (((FStar_List.length ftv) = (Prims.parse_int "0"))) with
+| true -> begin
+t
+end
+| uu____488 -> begin
+(
+
+let binders = (FStar_All.pipe_right ftv (FStar_List.map (fun x -> (
+
+let uu____494 = (
+
+let uu____495 = (
+
+let uu____498 = (tm_type x.FStar_Ident.idRange)
+in ((x), (uu____498)))
+in FStar_Parser_AST.TAnnotated (uu____495))
+in (FStar_Parser_AST.mk_binder uu____494 x.FStar_Ident.idRange FStar_Parser_AST.Type_level (Some (FStar_Parser_AST.Implicit)))))))
+in (
+
+let t1 = (
+
+let uu____500 = (
+
+let uu____501 = (unparen t)
+in uu____501.FStar_Parser_AST.tm)
+in (match (uu____500) with
+| FStar_Parser_AST.Product (uu____502) -> begin
+t
+end
+| uu____506 -> begin
+(FStar_Parser_AST.mk_term (FStar_Parser_AST.App ((((FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.effect_Tot_lid)) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)), (t), (FStar_Parser_AST.Nothing)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)
+end))
+in (
+
+let result = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (((binders), (t1)))) t1.FStar_Parser_AST.range t1.FStar_Parser_AST.level)
+in result)))
+end)))
+
+
+let rec uncurry : FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.term  ->  (FStar_Parser_AST.binder Prims.list * FStar_Parser_AST.term) = (fun bs t -> (match (t.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Product (binders, t1) -> begin
+(uncurry (FStar_List.append bs binders) t1)
+end
+| uu____527 -> begin
+((bs), (t))
+end))
+
+
+let rec is_var_pattern : FStar_Parser_AST.pattern  ->  Prims.bool = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| (FStar_Parser_AST.PatWild) | (FStar_Parser_AST.PatTvar (_, _)) | (FStar_Parser_AST.PatVar (_, _)) -> begin
+true
+end
+| FStar_Parser_AST.PatAscribed (p1, uu____539) -> begin
+(is_var_pattern p1)
+end
+| uu____540 -> begin
+false
+end))
+
+
+let rec is_app_pattern : FStar_Parser_AST.pattern  ->  Prims.bool = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (p1, uu____545) -> begin
+(is_app_pattern p1)
+end
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (uu____546); FStar_Parser_AST.prange = uu____547}, uu____548) -> begin
+true
+end
+| uu____554 -> begin
+false
+end))
+
+
+let replace_unit_pattern : FStar_Parser_AST.pattern  ->  FStar_Parser_AST.pattern = (fun p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatConst (FStar_Const.Const_unit) -> begin
+(FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatAscribed ((((FStar_Parser_AST.mk_pattern FStar_Parser_AST.PatWild p.FStar_Parser_AST.prange)), (unit_ty)))) p.FStar_Parser_AST.prange)
+end
+| uu____558 -> begin
+p
+end))
+
+
+let rec destruct_app_pattern : FStar_ToSyntax_Env.env  ->  Prims.bool  ->  FStar_Parser_AST.pattern  ->  ((FStar_Ident.ident, FStar_Ident.lident) FStar_Util.either * FStar_Parser_AST.pattern Prims.list * FStar_Parser_AST.term Prims.option) = (fun env is_top_level1 p -> (match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (p1, t) -> begin
+(
+
+let uu____584 = (destruct_app_pattern env is_top_level1 p1)
+in (match (uu____584) with
+| (name, args, uu____601) -> begin
+((name), (args), (Some (t)))
+end))
+end
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id, uu____615); FStar_Parser_AST.prange = uu____616}, args) when is_top_level1 -> begin
+(
+
+let uu____622 = (
+
+let uu____625 = (FStar_ToSyntax_Env.qualify env id)
+in FStar_Util.Inr (uu____625))
+in ((uu____622), (args), (None)))
+end
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id, uu____631); FStar_Parser_AST.prange = uu____632}, args) -> begin
+((FStar_Util.Inl (id)), (args), (None))
+end
+| uu____642 -> begin
+(failwith "Not an app pattern")
+end))
+
+
+let rec gather_pattern_bound_vars_maybe_top : FStar_Ident.ident FStar_Util.set  ->  FStar_Parser_AST.pattern  ->  FStar_Ident.ident FStar_Util.set = (fun acc p -> (
+
+let gather_pattern_bound_vars_from_list = (FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc)
+in (match (p.FStar_Parser_AST.pat) with
+| (FStar_Parser_AST.PatWild) | (FStar_Parser_AST.PatConst (_)) | (FStar_Parser_AST.PatVar (_, Some (FStar_Parser_AST.Implicit))) | (FStar_Parser_AST.PatName (_)) | (FStar_Parser_AST.PatTvar (_)) | (FStar_Parser_AST.PatOp (_)) -> begin
+acc
+end
+| FStar_Parser_AST.PatApp (phead, pats) -> begin
+(gather_pattern_bound_vars_from_list ((phead)::pats))
+end
+| FStar_Parser_AST.PatVar (x, uu____677) -> begin
+(FStar_Util.set_add x acc)
+end
+| (FStar_Parser_AST.PatList (pats)) | (FStar_Parser_AST.PatTuple (pats, _)) | (FStar_Parser_AST.PatOr (pats)) -> begin
+(gather_pattern_bound_vars_from_list pats)
+end
+| FStar_Parser_AST.PatRecord (guarded_pats) -> begin
+(
+
+let uu____690 = (FStar_List.map Prims.snd guarded_pats)
+in (gather_pattern_bound_vars_from_list uu____690))
+end
+| FStar_Parser_AST.PatAscribed (pat, uu____695) -> begin
+(gather_pattern_bound_vars_maybe_top acc pat)
+end)))
+
+
+let gather_pattern_bound_vars : FStar_Parser_AST.pattern  ->  FStar_Ident.ident FStar_Util.set = (
+
+let acc = (FStar_Util.new_set (fun id1 id2 -> (match ((id1.FStar_Ident.idText = id2.FStar_Ident.idText)) with
+| true -> begin
+(Prims.parse_int "0")
+end
+| uu____703 -> begin
+(Prims.parse_int "1")
+end)) (fun uu____704 -> (Prims.parse_int "0")))
+in (fun p -> (gather_pattern_bound_vars_maybe_top acc p)))
+
 type bnd =
-  | LocalBinder of (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual)
-  | LetBinder of (FStar_Ident.lident* FStar_Syntax_Syntax.term)
-let uu___is_LocalBinder: bnd -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LocalBinder _0 -> true | uu____722 -> false
-let __proj__LocalBinder__item___0:
-  bnd -> (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) =
-  fun projectee  -> match projectee with | LocalBinder _0 -> _0
-let uu___is_LetBinder: bnd -> Prims.bool =
-  fun projectee  ->
-    match projectee with | LetBinder _0 -> true | uu____742 -> false
-let __proj__LetBinder__item___0:
-  bnd -> (FStar_Ident.lident* FStar_Syntax_Syntax.term) =
-  fun projectee  -> match projectee with | LetBinder _0 -> _0
-let binder_of_bnd: bnd -> (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual)
-  =
-  fun uu___191_760  ->
-    match uu___191_760 with
-    | LocalBinder (a,aq) -> (a, aq)
-    | uu____765 -> failwith "Impossible"
-let as_binder:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.arg_qualifier Prims.option ->
-      (FStar_Ident.ident Prims.option* FStar_Syntax_Syntax.term) ->
-        (FStar_Syntax_Syntax.binder* FStar_ToSyntax_Env.env)
-  =
-  fun env  ->
-    fun imp  ->
-      fun uu___192_782  ->
-        match uu___192_782 with
-        | (None ,k) ->
-            let uu____791 = FStar_Syntax_Syntax.null_binder k in
-            (uu____791, env)
-        | (Some a,k) ->
-            let uu____795 = FStar_ToSyntax_Env.push_bv env a in
-            (match uu____795 with
-             | (env1,a1) ->
-                 (((let uu___214_806 = a1 in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___214_806.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index =
-                        (uu___214_806.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = k
-                    }), (trans_aqual imp)), env1))
-type env_t = FStar_ToSyntax_Env.env
-type lenv_t = FStar_Syntax_Syntax.bv Prims.list
-let mk_lb:
-  ((FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either*
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax*
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax) -> FStar_Syntax_Syntax.letbinding
-  =
-  fun uu____819  ->
-    match uu____819 with
-    | (n1,t,e) ->
-        {
-          FStar_Syntax_Syntax.lbname = n1;
-          FStar_Syntax_Syntax.lbunivs = [];
-          FStar_Syntax_Syntax.lbtyp = t;
-          FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_ALL_lid;
-          FStar_Syntax_Syntax.lbdef = e
-        }
-let no_annot_abs:
-  (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  = fun bs  -> fun t  -> FStar_Syntax_Util.abs bs t None
-let mk_ref_read tm =
-  let tm' =
-    let uu____875 =
-      let uu____885 =
-        let uu____886 =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.sread_lid
-            FStar_Syntax_Syntax.Delta_constant None in
-        FStar_Syntax_Syntax.fv_to_tm uu____886 in
-      let uu____887 =
-        let uu____893 =
-          let uu____898 = FStar_Syntax_Syntax.as_implicit false in
-          (tm, uu____898) in
-        [uu____893] in
-      (uu____885, uu____887) in
-    FStar_Syntax_Syntax.Tm_app uu____875 in
-  FStar_Syntax_Syntax.mk tm' None tm.FStar_Syntax_Syntax.pos
-let mk_ref_alloc tm =
-  let tm' =
-    let uu____932 =
-      let uu____942 =
-        let uu____943 =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.salloc_lid
-            FStar_Syntax_Syntax.Delta_constant None in
-        FStar_Syntax_Syntax.fv_to_tm uu____943 in
-      let uu____944 =
-        let uu____950 =
-          let uu____955 = FStar_Syntax_Syntax.as_implicit false in
-          (tm, uu____955) in
-        [uu____950] in
-      (uu____942, uu____944) in
-    FStar_Syntax_Syntax.Tm_app uu____932 in
-  FStar_Syntax_Syntax.mk tm' None tm.FStar_Syntax_Syntax.pos
-let mk_ref_assign t1 t2 pos =
-  let tm =
-    let uu____1003 =
-      let uu____1013 =
-        let uu____1014 =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.swrite_lid
-            FStar_Syntax_Syntax.Delta_constant None in
-        FStar_Syntax_Syntax.fv_to_tm uu____1014 in
-      let uu____1015 =
-        let uu____1021 =
-          let uu____1026 = FStar_Syntax_Syntax.as_implicit false in
-          (t1, uu____1026) in
-        let uu____1029 =
-          let uu____1035 =
-            let uu____1040 = FStar_Syntax_Syntax.as_implicit false in
-            (t2, uu____1040) in
-          [uu____1035] in
-        uu____1021 :: uu____1029 in
-      (uu____1013, uu____1015) in
-    FStar_Syntax_Syntax.Tm_app uu____1003 in
-  FStar_Syntax_Syntax.mk tm None pos
-let is_special_effect_combinator: Prims.string -> Prims.bool =
-  fun uu___193_1066  ->
-    match uu___193_1066 with
-    | "repr"|"post"|"pre"|"wp" -> true
-    | uu____1067 -> false
-let rec sum_to_universe:
-  FStar_Syntax_Syntax.universe -> Prims.int -> FStar_Syntax_Syntax.universe =
-  fun u  ->
-    fun n1  ->
-      if n1 = (Prims.parse_int "0")
-      then u
-      else
-        (let uu____1075 = sum_to_universe u (n1 - (Prims.parse_int "1")) in
-         FStar_Syntax_Syntax.U_succ uu____1075)
-let int_to_universe: Prims.int -> FStar_Syntax_Syntax.universe =
-  fun n1  -> sum_to_universe FStar_Syntax_Syntax.U_zero n1
-let rec desugar_maybe_non_constant_universe:
-  FStar_Parser_AST.term ->
-    (Prims.int,FStar_Syntax_Syntax.universe) FStar_Util.either
-  =
-  fun t  ->
-    let uu____1086 =
-      let uu____1087 = unparen t in uu____1087.FStar_Parser_AST.tm in
-    match uu____1086 with
-    | FStar_Parser_AST.Wild  ->
-        let uu____1090 =
-          let uu____1091 = FStar_Unionfind.fresh None in
-          FStar_Syntax_Syntax.U_unif uu____1091 in
-        FStar_Util.Inr uu____1090
-    | FStar_Parser_AST.Uvar u ->
-        FStar_Util.Inr (FStar_Syntax_Syntax.U_name u)
-    | FStar_Parser_AST.Const (FStar_Const.Const_int (repr,uu____1097)) ->
-        let n1 = FStar_Util.int_of_string repr in
-        (if n1 < (Prims.parse_int "0")
-         then
-           Prims.raise
-             (FStar_Errors.Error
-                ((Prims.strcat
-                    "Negative universe constant  are not supported : " repr),
-                  (t.FStar_Parser_AST.range)))
-         else ();
-         FStar_Util.Inl n1)
-    | FStar_Parser_AST.Op (op_plus,t1::t2::[]) ->
-        let u1 = desugar_maybe_non_constant_universe t1 in
-        let u2 = desugar_maybe_non_constant_universe t2 in
-        (match (u1, u2) with
-         | (FStar_Util.Inl n1,FStar_Util.Inl n2) -> FStar_Util.Inl (n1 + n2)
-         | (FStar_Util.Inl n1,FStar_Util.Inr u)
-           |(FStar_Util.Inr u,FStar_Util.Inl n1) ->
-             let uu____1140 = sum_to_universe u n1 in
-             FStar_Util.Inr uu____1140
-         | (FStar_Util.Inr u11,FStar_Util.Inr u21) ->
-             let uu____1147 =
-               let uu____1148 =
-                 let uu____1151 =
-                   let uu____1152 = FStar_Parser_AST.term_to_string t in
-                   Prims.strcat
-                     "This universe might contain a sum of two universe variables "
-                     uu____1152 in
-                 (uu____1151, (t.FStar_Parser_AST.range)) in
-               FStar_Errors.Error uu____1148 in
-             Prims.raise uu____1147)
-    | FStar_Parser_AST.App uu____1155 ->
-        let rec aux t1 univargs =
-          let uu____1174 =
-            let uu____1175 = unparen t1 in uu____1175.FStar_Parser_AST.tm in
-          match uu____1174 with
-          | FStar_Parser_AST.App (t2,targ,uu____1180) ->
-              let uarg = desugar_maybe_non_constant_universe targ in
-              aux t2 (uarg :: univargs)
-          | FStar_Parser_AST.Var max_lid1 ->
-              if
-                FStar_List.existsb
-                  (fun uu___194_1192  ->
-                     match uu___194_1192 with
-                     | FStar_Util.Inr uu____1195 -> true
-                     | uu____1196 -> false) univargs
-              then
-                let uu____1199 =
-                  let uu____1200 =
-                    FStar_List.map
-                      (fun uu___195_1204  ->
-                         match uu___195_1204 with
-                         | FStar_Util.Inl n1 -> int_to_universe n1
-                         | FStar_Util.Inr u -> u) univargs in
-                  FStar_Syntax_Syntax.U_max uu____1200 in
-                FStar_Util.Inr uu____1199
-              else
-                (let nargs =
-                   FStar_List.map
-                     (fun uu___196_1214  ->
-                        match uu___196_1214 with
-                        | FStar_Util.Inl n1 -> n1
-                        | FStar_Util.Inr uu____1218 -> failwith "impossible")
-                     univargs in
-                 let uu____1219 =
-                   FStar_List.fold_left
-                     (fun m  -> fun n1  -> if m > n1 then m else n1)
-                     (Prims.parse_int "0") nargs in
-                 FStar_Util.Inl uu____1219)
-          | uu____1223 ->
-              let uu____1224 =
-                let uu____1225 =
-                  let uu____1228 =
-                    let uu____1229 =
-                      let uu____1230 = FStar_Parser_AST.term_to_string t1 in
-                      Prims.strcat uu____1230 " in universe context" in
-                    Prims.strcat "Unexpected term " uu____1229 in
-                  (uu____1228, (t1.FStar_Parser_AST.range)) in
-                FStar_Errors.Error uu____1225 in
-              Prims.raise uu____1224 in
-        aux t []
-    | uu____1235 ->
-        let uu____1236 =
-          let uu____1237 =
-            let uu____1240 =
-              let uu____1241 =
-                let uu____1242 = FStar_Parser_AST.term_to_string t in
-                Prims.strcat uu____1242 " in universe context" in
-              Prims.strcat "Unexpected term " uu____1241 in
-            (uu____1240, (t.FStar_Parser_AST.range)) in
-          FStar_Errors.Error uu____1237 in
-        Prims.raise uu____1236
-let rec desugar_universe:
-  FStar_Parser_AST.term -> FStar_Syntax_Syntax.universe =
-  fun t  ->
-    let u = desugar_maybe_non_constant_universe t in
-    match u with
-    | FStar_Util.Inl n1 -> int_to_universe n1
-    | FStar_Util.Inr u1 -> u1
-let check_fields env fields rg =
-  let uu____1276 = FStar_List.hd fields in
-  match uu____1276 with
-  | (f,uu____1282) ->
-      let record =
-        FStar_ToSyntax_Env.fail_or env
-          (FStar_ToSyntax_Env.try_lookup_record_by_field_name env) f in
-      let check_field uu____1289 =
-        match uu____1289 with
-        | (f',uu____1293) ->
-            let uu____1294 =
-              FStar_ToSyntax_Env.belongs_to_record env f' record in
-            if uu____1294
-            then ()
-            else
-              (let msg =
-                 FStar_Util.format3
-                   "Field %s belongs to record type %s, whereas field %s does not"
-                   f.FStar_Ident.str
-                   (record.FStar_ToSyntax_Env.typename).FStar_Ident.str
-                   f'.FStar_Ident.str in
-               Prims.raise (FStar_Errors.Error (msg, rg))) in
-      ((let uu____1298 = FStar_List.tl fields in
-        FStar_List.iter check_field uu____1298);
-       (match () with | () -> record))
-let rec desugar_data_pat:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.pattern ->
-      Prims.bool -> (env_t* bnd* FStar_Syntax_Syntax.pat)
-  =
-  fun env  ->
-    fun p  ->
-      fun is_mut  ->
-        let check_linear_pattern_variables p1 =
-          let rec pat_vars p2 =
-            match p2.FStar_Syntax_Syntax.v with
-            | FStar_Syntax_Syntax.Pat_dot_term _
-              |FStar_Syntax_Syntax.Pat_wild _
-               |FStar_Syntax_Syntax.Pat_constant _ ->
-                FStar_Syntax_Syntax.no_names
-            | FStar_Syntax_Syntax.Pat_var x ->
-                FStar_Util.set_add x FStar_Syntax_Syntax.no_names
-            | FStar_Syntax_Syntax.Pat_cons (uu____1458,pats) ->
-                FStar_All.pipe_right pats
-                  (FStar_List.fold_left
-                     (fun out  ->
-                        fun uu____1480  ->
-                          match uu____1480 with
-                          | (p3,uu____1486) ->
-                              let uu____1487 = pat_vars p3 in
-                              FStar_Util.set_union out uu____1487)
-                     FStar_Syntax_Syntax.no_names)
-            | FStar_Syntax_Syntax.Pat_disj [] -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Pat_disj (hd1::tl1) ->
-                let xs = pat_vars hd1 in
-                let uu____1501 =
-                  let uu____1502 =
-                    FStar_Util.for_all
-                      (fun p3  ->
-                         let ys = pat_vars p3 in
-                         (FStar_Util.set_is_subset_of xs ys) &&
-                           (FStar_Util.set_is_subset_of ys xs)) tl1 in
-                  Prims.op_Negation uu____1502 in
-                if uu____1501
-                then
-                  Prims.raise
-                    (FStar_Errors.Error
-                       ("Disjunctive pattern binds different variables in each case",
-                         (p2.FStar_Syntax_Syntax.p)))
-                else xs in
-          pat_vars p1 in
-        (match (is_mut, (p.FStar_Parser_AST.pat)) with
-         | (false ,_)|(true ,FStar_Parser_AST.PatVar _) -> ()
-         | (true ,uu____1509) ->
-             Prims.raise
-               (FStar_Errors.Error
-                  ("let-mutable is for variables only",
-                    (p.FStar_Parser_AST.prange))));
-        (let push_bv_maybe_mut =
-           if is_mut
-           then FStar_ToSyntax_Env.push_bv_mutable
-           else FStar_ToSyntax_Env.push_bv in
-         let resolvex l e x =
-           let uu____1537 =
-             FStar_All.pipe_right l
-               (FStar_Util.find_opt
-                  (fun y  ->
-                     (y.FStar_Syntax_Syntax.ppname).FStar_Ident.idText =
-                       x.FStar_Ident.idText)) in
-           match uu____1537 with
-           | Some y -> (l, e, y)
-           | uu____1545 ->
-               let uu____1547 = push_bv_maybe_mut e x in
-               (match uu____1547 with | (e1,x1) -> ((x1 :: l), e1, x1)) in
-         let rec aux loc env1 p1 =
-           let pos q =
-             FStar_Syntax_Syntax.withinfo q
-               FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-               p1.FStar_Parser_AST.prange in
-           let pos_r r q =
-             FStar_Syntax_Syntax.withinfo q
-               FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r in
-           match p1.FStar_Parser_AST.pat with
-           | FStar_Parser_AST.PatOp op ->
-               let uu____1596 =
-                 let uu____1597 =
-                   let uu____1598 =
-                     let uu____1602 =
-                       let uu____1603 =
-                         FStar_Parser_AST.compile_op (Prims.parse_int "0") op in
-                       FStar_Ident.id_of_text uu____1603 in
-                     (uu____1602, None) in
-                   FStar_Parser_AST.PatVar uu____1598 in
-                 {
-                   FStar_Parser_AST.pat = uu____1597;
-                   FStar_Parser_AST.prange = (p1.FStar_Parser_AST.prange)
-                 } in
-               aux loc env1 uu____1596
-           | FStar_Parser_AST.PatOr [] -> failwith "impossible"
-           | FStar_Parser_AST.PatOr (p2::ps) ->
-               let uu____1615 = aux loc env1 p2 in
-               (match uu____1615 with
-                | (loc1,env2,var,p3,uu____1634) ->
-                    let uu____1639 =
-                      FStar_List.fold_left
-                        (fun uu____1652  ->
-                           fun p4  ->
-                             match uu____1652 with
-                             | (loc2,env3,ps1) ->
-                                 let uu____1675 = aux loc2 env3 p4 in
-                                 (match uu____1675 with
-                                  | (loc3,env4,uu____1691,p5,uu____1693) ->
-                                      (loc3, env4, (p5 :: ps1))))
-                        (loc1, env2, []) ps in
-                    (match uu____1639 with
-                     | (loc2,env3,ps1) ->
-                         let pat =
-                           FStar_All.pipe_left pos
-                             (FStar_Syntax_Syntax.Pat_disj (p3 ::
-                                (FStar_List.rev ps1))) in
-                         (loc2, env3, var, pat, false)))
-           | FStar_Parser_AST.PatAscribed (p2,t) ->
-               let uu____1737 = aux loc env1 p2 in
-               (match uu____1737 with
-                | (loc1,env',binder,p3,imp) ->
-                    let binder1 =
-                      match binder with
-                      | LetBinder uu____1762 -> failwith "impossible"
-                      | LocalBinder (x,aq) ->
-                          let t1 =
-                            let uu____1768 = close_fun env1 t in
-                            desugar_term env1 uu____1768 in
-                          (if
-                             (match (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.n
-                              with
-                              | FStar_Syntax_Syntax.Tm_unknown  -> false
-                              | uu____1770 -> true)
-                           then
-                             (let uu____1771 =
-                                FStar_Syntax_Print.bv_to_string x in
-                              let uu____1772 =
-                                FStar_Syntax_Print.term_to_string
-                                  x.FStar_Syntax_Syntax.sort in
-                              let uu____1773 =
-                                FStar_Syntax_Print.term_to_string t1 in
-                              FStar_Util.print3_warning
-                                "Multiple ascriptions for %s in pattern, type %s was shadowed by %s"
-                                uu____1771 uu____1772 uu____1773)
-                           else ();
-                           LocalBinder
-                             (((let uu___215_1775 = x in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___215_1775.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index =
-                                    (uu___215_1775.FStar_Syntax_Syntax.index);
-                                  FStar_Syntax_Syntax.sort = t1
-                                })), aq)) in
-                    (loc1, env', binder1, p3, imp))
-           | FStar_Parser_AST.PatWild  ->
-               let x =
-                 FStar_Syntax_Syntax.new_bv
-                   (Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun in
-               let uu____1779 =
-                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild x) in
-               (loc, env1, (LocalBinder (x, None)), uu____1779, false)
-           | FStar_Parser_AST.PatConst c ->
-               let x =
-                 FStar_Syntax_Syntax.new_bv
-                   (Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun in
-               let uu____1789 =
-                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant c) in
-               (loc, env1, (LocalBinder (x, None)), uu____1789, false)
-           | FStar_Parser_AST.PatTvar (x,aq)|FStar_Parser_AST.PatVar (x,aq)
-               ->
-               let imp = aq = (Some FStar_Parser_AST.Implicit) in
-               let aq1 = trans_aqual aq in
-               let uu____1807 = resolvex loc env1 x in
-               (match uu____1807 with
-                | (loc1,env2,xbv) ->
-                    let uu____1821 =
-                      FStar_All.pipe_left pos
-                        (FStar_Syntax_Syntax.Pat_var xbv) in
-                    (loc1, env2, (LocalBinder (xbv, aq1)), uu____1821, imp))
-           | FStar_Parser_AST.PatName l ->
-               let l1 =
-                 FStar_ToSyntax_Env.fail_or env1
-                   (FStar_ToSyntax_Env.try_lookup_datacon env1) l in
-               let x =
-                 FStar_Syntax_Syntax.new_bv
-                   (Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun in
-               let uu____1832 =
-                 FStar_All.pipe_left pos
-                   (FStar_Syntax_Syntax.Pat_cons (l1, [])) in
-               (loc, env1, (LocalBinder (x, None)), uu____1832, false)
-           | FStar_Parser_AST.PatApp
-               ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName l;
-                  FStar_Parser_AST.prange = uu____1850;_},args)
-               ->
-               let uu____1854 =
-                 FStar_List.fold_right
-                   (fun arg  ->
-                      fun uu____1872  ->
-                        match uu____1872 with
-                        | (loc1,env2,args1) ->
-                            let uu____1902 = aux loc1 env2 arg in
-                            (match uu____1902 with
-                             | (loc2,env3,uu____1920,arg1,imp) ->
-                                 (loc2, env3, ((arg1, imp) :: args1)))) args
-                   (loc, env1, []) in
-               (match uu____1854 with
-                | (loc1,env2,args1) ->
-                    let l1 =
-                      FStar_ToSyntax_Env.fail_or env2
-                        (FStar_ToSyntax_Env.try_lookup_datacon env2) l in
-                    let x =
-                      FStar_Syntax_Syntax.new_bv
-                        (Some (p1.FStar_Parser_AST.prange))
-                        FStar_Syntax_Syntax.tun in
-                    let uu____1969 =
-                      FStar_All.pipe_left pos
-                        (FStar_Syntax_Syntax.Pat_cons (l1, args1)) in
-                    (loc1, env2, (LocalBinder (x, None)), uu____1969, false))
-           | FStar_Parser_AST.PatApp uu____1982 ->
-               Prims.raise
-                 (FStar_Errors.Error
-                    ("Unexpected pattern", (p1.FStar_Parser_AST.prange)))
-           | FStar_Parser_AST.PatList pats ->
-               let uu____1995 =
-                 FStar_List.fold_right
-                   (fun pat  ->
-                      fun uu____2009  ->
-                        match uu____2009 with
-                        | (loc1,env2,pats1) ->
-                            let uu____2031 = aux loc1 env2 pat in
-                            (match uu____2031 with
-                             | (loc2,env3,uu____2047,pat1,uu____2049) ->
-                                 (loc2, env3, (pat1 :: pats1)))) pats
-                   (loc, env1, []) in
-               (match uu____1995 with
-                | (loc1,env2,pats1) ->
-                    let pat =
-                      let uu____2083 =
-                        let uu____2086 =
-                          let uu____2091 =
-                            FStar_Range.end_range p1.FStar_Parser_AST.prange in
-                          pos_r uu____2091 in
-                        let uu____2092 =
-                          let uu____2093 =
-                            let uu____2101 =
-                              FStar_Syntax_Syntax.lid_as_fv
-                                FStar_Syntax_Const.nil_lid
-                                FStar_Syntax_Syntax.Delta_constant
-                                (Some FStar_Syntax_Syntax.Data_ctor) in
-                            (uu____2101, []) in
-                          FStar_Syntax_Syntax.Pat_cons uu____2093 in
-                        FStar_All.pipe_left uu____2086 uu____2092 in
-                      FStar_List.fold_right
-                        (fun hd1  ->
-                           fun tl1  ->
-                             let r =
-                               FStar_Range.union_ranges
-                                 hd1.FStar_Syntax_Syntax.p
-                                 tl1.FStar_Syntax_Syntax.p in
-                             let uu____2124 =
-                               let uu____2125 =
-                                 let uu____2133 =
-                                   FStar_Syntax_Syntax.lid_as_fv
-                                     FStar_Syntax_Const.cons_lid
-                                     FStar_Syntax_Syntax.Delta_constant
-                                     (Some FStar_Syntax_Syntax.Data_ctor) in
-                                 (uu____2133, [(hd1, false); (tl1, false)]) in
-                               FStar_Syntax_Syntax.Pat_cons uu____2125 in
-                             FStar_All.pipe_left (pos_r r) uu____2124) pats1
-                        uu____2083 in
-                    let x =
-                      FStar_Syntax_Syntax.new_bv
-                        (Some (p1.FStar_Parser_AST.prange))
-                        FStar_Syntax_Syntax.tun in
-                    (loc1, env2, (LocalBinder (x, None)), pat, false))
-           | FStar_Parser_AST.PatTuple (args,dep1) ->
-               let uu____2165 =
-                 FStar_List.fold_left
-                   (fun uu____2182  ->
-                      fun p2  ->
-                        match uu____2182 with
-                        | (loc1,env2,pats) ->
-                            let uu____2213 = aux loc1 env2 p2 in
-                            (match uu____2213 with
-                             | (loc2,env3,uu____2231,pat,uu____2233) ->
-                                 (loc2, env3, ((pat, false) :: pats))))
-                   (loc, env1, []) args in
-               (match uu____2165 with
-                | (loc1,env2,args1) ->
-                    let args2 = FStar_List.rev args1 in
-                    let l =
-                      if dep1
-                      then
-                        FStar_Syntax_Util.mk_dtuple_data_lid
-                          (FStar_List.length args2)
-                          p1.FStar_Parser_AST.prange
-                      else
-                        FStar_Syntax_Util.mk_tuple_data_lid
-                          (FStar_List.length args2)
-                          p1.FStar_Parser_AST.prange in
-                    let uu____2304 =
-                      FStar_ToSyntax_Env.fail_or env2
-                        (FStar_ToSyntax_Env.try_lookup_lid env2) l in
-                    (match uu____2304 with
-                     | (constr,uu____2317) ->
-                         let l1 =
-                           match constr.FStar_Syntax_Syntax.n with
-                           | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                           | uu____2320 -> failwith "impossible" in
-                         let x =
-                           FStar_Syntax_Syntax.new_bv
-                             (Some (p1.FStar_Parser_AST.prange))
-                             FStar_Syntax_Syntax.tun in
-                         let uu____2322 =
-                           FStar_All.pipe_left pos
-                             (FStar_Syntax_Syntax.Pat_cons (l1, args2)) in
-                         (loc1, env2, (LocalBinder (x, None)), uu____2322,
-                           false)))
-           | FStar_Parser_AST.PatRecord [] ->
-               Prims.raise
-                 (FStar_Errors.Error
-                    ("Unexpected pattern", (p1.FStar_Parser_AST.prange)))
-           | FStar_Parser_AST.PatRecord fields ->
-               let record =
-                 check_fields env1 fields p1.FStar_Parser_AST.prange in
-               let fields1 =
-                 FStar_All.pipe_right fields
-                   (FStar_List.map
-                      (fun uu____2363  ->
-                         match uu____2363 with
-                         | (f,p2) -> ((f.FStar_Ident.ident), p2))) in
-               let args =
-                 FStar_All.pipe_right record.FStar_ToSyntax_Env.fields
-                   (FStar_List.map
-                      (fun uu____2378  ->
-                         match uu____2378 with
-                         | (f,uu____2382) ->
-                             let uu____2383 =
-                               FStar_All.pipe_right fields1
-                                 (FStar_List.tryFind
-                                    (fun uu____2395  ->
-                                       match uu____2395 with
-                                       | (g,uu____2399) ->
-                                           f.FStar_Ident.idText =
-                                             g.FStar_Ident.idText)) in
-                             (match uu____2383 with
-                              | None  ->
-                                  FStar_Parser_AST.mk_pattern
-                                    FStar_Parser_AST.PatWild
-                                    p1.FStar_Parser_AST.prange
-                              | Some (uu____2402,p2) -> p2))) in
-               let app =
-                 let uu____2407 =
-                   let uu____2408 =
-                     let uu____2412 =
-                       let uu____2413 =
-                         let uu____2414 =
-                           FStar_Ident.lid_of_ids
-                             (FStar_List.append
-                                (record.FStar_ToSyntax_Env.typename).FStar_Ident.ns
-                                [record.FStar_ToSyntax_Env.constrname]) in
-                         FStar_Parser_AST.PatName uu____2414 in
-                       FStar_Parser_AST.mk_pattern uu____2413
-                         p1.FStar_Parser_AST.prange in
-                     (uu____2412, args) in
-                   FStar_Parser_AST.PatApp uu____2408 in
-                 FStar_Parser_AST.mk_pattern uu____2407
-                   p1.FStar_Parser_AST.prange in
-               let uu____2416 = aux loc env1 app in
-               (match uu____2416 with
-                | (env2,e,b,p2,uu____2435) ->
-                    let p3 =
-                      match p2.FStar_Syntax_Syntax.v with
-                      | FStar_Syntax_Syntax.Pat_cons (fv,args1) ->
-                          let uu____2457 =
-                            let uu____2458 =
-                              let uu____2466 =
-                                let uu___216_2467 = fv in
-                                let uu____2468 =
-                                  let uu____2470 =
-                                    let uu____2471 =
-                                      let uu____2475 =
-                                        FStar_All.pipe_right
-                                          record.FStar_ToSyntax_Env.fields
-                                          (FStar_List.map Prims.fst) in
-                                      ((record.FStar_ToSyntax_Env.typename),
-                                        uu____2475) in
-                                    FStar_Syntax_Syntax.Record_ctor
-                                      uu____2471 in
-                                  Some uu____2470 in
-                                {
-                                  FStar_Syntax_Syntax.fv_name =
-                                    (uu___216_2467.FStar_Syntax_Syntax.fv_name);
-                                  FStar_Syntax_Syntax.fv_delta =
-                                    (uu___216_2467.FStar_Syntax_Syntax.fv_delta);
-                                  FStar_Syntax_Syntax.fv_qual = uu____2468
-                                } in
-                              (uu____2466, args1) in
-                            FStar_Syntax_Syntax.Pat_cons uu____2458 in
-                          FStar_All.pipe_left pos uu____2457
-                      | uu____2494 -> p2 in
-                    (env2, e, b, p3, false)) in
-         let uu____2497 = aux [] env p in
-         match uu____2497 with
-         | (uu____2508,env1,b,p1,uu____2512) ->
-             ((let uu____2518 = check_linear_pattern_variables p1 in
-               FStar_All.pipe_left Prims.ignore uu____2518);
-              (env1, b, p1)))
-and desugar_binding_pat_maybe_top:
-  Prims.bool ->
-    FStar_ToSyntax_Env.env ->
-      FStar_Parser_AST.pattern ->
-        Prims.bool -> (env_t* bnd* FStar_Syntax_Syntax.pat Prims.option)
-  =
-  fun top  ->
-    fun env  ->
-      fun p  ->
-        fun is_mut  ->
-          let mklet x =
-            let uu____2537 =
-              let uu____2538 =
-                let uu____2541 = FStar_ToSyntax_Env.qualify env x in
-                (uu____2541, FStar_Syntax_Syntax.tun) in
-              LetBinder uu____2538 in
-            (env, uu____2537, None) in
-          if top
-          then
-            match p.FStar_Parser_AST.pat with
-            | FStar_Parser_AST.PatOp x ->
-                let uu____2552 =
-                  let uu____2553 =
-                    FStar_Parser_AST.compile_op (Prims.parse_int "0") x in
-                  FStar_Ident.id_of_text uu____2553 in
-                mklet uu____2552
-            | FStar_Parser_AST.PatVar (x,uu____2555) -> mklet x
-            | FStar_Parser_AST.PatAscribed
-                ({
-                   FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                     (x,uu____2559);
-                   FStar_Parser_AST.prange = uu____2560;_},t)
-                ->
-                let uu____2564 =
-                  let uu____2565 =
-                    let uu____2568 = FStar_ToSyntax_Env.qualify env x in
-                    let uu____2569 = desugar_term env t in
-                    (uu____2568, uu____2569) in
-                  LetBinder uu____2565 in
-                (env, uu____2564, None)
-            | uu____2571 ->
-                Prims.raise
-                  (FStar_Errors.Error
-                     ("Unexpected pattern at the top-level",
-                       (p.FStar_Parser_AST.prange)))
-          else
-            (let uu____2577 = desugar_data_pat env p is_mut in
-             match uu____2577 with
-             | (env1,binder,p1) ->
-                 let p2 =
-                   match p1.FStar_Syntax_Syntax.v with
-                   | FStar_Syntax_Syntax.Pat_var _
-                     |FStar_Syntax_Syntax.Pat_wild _ -> None
-                   | uu____2593 -> Some p1 in
-                 (env1, binder, p2))
-and desugar_binding_pat:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.pattern ->
-      (env_t* bnd* FStar_Syntax_Syntax.pat Prims.option)
-  = fun env  -> fun p  -> desugar_binding_pat_maybe_top false env p false
-and desugar_match_pat_maybe_top:
-  Prims.bool ->
-    FStar_ToSyntax_Env.env ->
-      FStar_Parser_AST.pattern -> (env_t* FStar_Syntax_Syntax.pat)
-  =
-  fun uu____2597  ->
-    fun env  ->
-      fun pat  ->
-        let uu____2600 = desugar_data_pat env pat false in
-        match uu____2600 with | (env1,uu____2607,pat1) -> (env1, pat1)
-and desugar_match_pat:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.pattern -> (env_t* FStar_Syntax_Syntax.pat)
-  = fun env  -> fun p  -> desugar_match_pat_maybe_top false env p
-and desugar_term:
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun e  ->
-      let env1 =
-        let uu___217_2614 = env in
-        {
-          FStar_ToSyntax_Env.curmodule =
-            (uu___217_2614.FStar_ToSyntax_Env.curmodule);
-          FStar_ToSyntax_Env.curmonad =
-            (uu___217_2614.FStar_ToSyntax_Env.curmonad);
-          FStar_ToSyntax_Env.modules =
-            (uu___217_2614.FStar_ToSyntax_Env.modules);
-          FStar_ToSyntax_Env.scope_mods =
-            (uu___217_2614.FStar_ToSyntax_Env.scope_mods);
-          FStar_ToSyntax_Env.exported_ids =
-            (uu___217_2614.FStar_ToSyntax_Env.exported_ids);
-          FStar_ToSyntax_Env.trans_exported_ids =
-            (uu___217_2614.FStar_ToSyntax_Env.trans_exported_ids);
-          FStar_ToSyntax_Env.includes =
-            (uu___217_2614.FStar_ToSyntax_Env.includes);
-          FStar_ToSyntax_Env.sigaccum =
-            (uu___217_2614.FStar_ToSyntax_Env.sigaccum);
-          FStar_ToSyntax_Env.sigmap =
-            (uu___217_2614.FStar_ToSyntax_Env.sigmap);
-          FStar_ToSyntax_Env.iface = (uu___217_2614.FStar_ToSyntax_Env.iface);
-          FStar_ToSyntax_Env.admitted_iface =
-            (uu___217_2614.FStar_ToSyntax_Env.admitted_iface);
-          FStar_ToSyntax_Env.expect_typ = false
-        } in
-      desugar_term_maybe_top false env1 e
-and desugar_typ:
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun e  ->
-      let env1 =
-        let uu___218_2618 = env in
-        {
-          FStar_ToSyntax_Env.curmodule =
-            (uu___218_2618.FStar_ToSyntax_Env.curmodule);
-          FStar_ToSyntax_Env.curmonad =
-            (uu___218_2618.FStar_ToSyntax_Env.curmonad);
-          FStar_ToSyntax_Env.modules =
-            (uu___218_2618.FStar_ToSyntax_Env.modules);
-          FStar_ToSyntax_Env.scope_mods =
-            (uu___218_2618.FStar_ToSyntax_Env.scope_mods);
-          FStar_ToSyntax_Env.exported_ids =
-            (uu___218_2618.FStar_ToSyntax_Env.exported_ids);
-          FStar_ToSyntax_Env.trans_exported_ids =
-            (uu___218_2618.FStar_ToSyntax_Env.trans_exported_ids);
-          FStar_ToSyntax_Env.includes =
-            (uu___218_2618.FStar_ToSyntax_Env.includes);
-          FStar_ToSyntax_Env.sigaccum =
-            (uu___218_2618.FStar_ToSyntax_Env.sigaccum);
-          FStar_ToSyntax_Env.sigmap =
-            (uu___218_2618.FStar_ToSyntax_Env.sigmap);
-          FStar_ToSyntax_Env.iface = (uu___218_2618.FStar_ToSyntax_Env.iface);
-          FStar_ToSyntax_Env.admitted_iface =
-            (uu___218_2618.FStar_ToSyntax_Env.admitted_iface);
-          FStar_ToSyntax_Env.expect_typ = true
-        } in
-      desugar_term_maybe_top false env1 e
-and desugar_machine_integer:
-  FStar_ToSyntax_Env.env ->
-    Prims.string ->
-      (FStar_Const.signedness* FStar_Const.width) ->
-        FStar_Range.range ->
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    fun repr  ->
-      fun uu____2621  ->
-        fun range  ->
-          match uu____2621 with
-          | (signedness,width) ->
-              let lid =
-                Prims.strcat "FStar."
-                  (Prims.strcat
-                     (match signedness with
-                      | FStar_Const.Unsigned  -> "U"
-                      | FStar_Const.Signed  -> "")
-                     (Prims.strcat "Int"
-                        (Prims.strcat
-                           (match width with
-                            | FStar_Const.Int8  -> "8"
-                            | FStar_Const.Int16  -> "16"
-                            | FStar_Const.Int32  -> "32"
-                            | FStar_Const.Int64  -> "64")
-                           (Prims.strcat "."
-                              (Prims.strcat
-                                 (match signedness with
-                                  | FStar_Const.Unsigned  -> "u"
-                                  | FStar_Const.Signed  -> "") "int_to_t"))))) in
-              let lid1 =
-                FStar_Ident.lid_of_path (FStar_Ident.path_of_text lid) range in
-              let lid2 =
-                let uu____2632 = FStar_ToSyntax_Env.try_lookup_lid env lid1 in
-                match uu____2632 with
-                | Some lid2 -> Prims.fst lid2
-                | None  ->
-                    let uu____2643 =
-                      FStar_Util.format1 "%s not in scope\n"
-                        (FStar_Ident.text_of_lid lid1) in
-                    failwith uu____2643 in
-              let repr1 =
-                (FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_constant
-                      (FStar_Const.Const_int (repr, None)))) None range in
-              let uu____2660 =
-                let uu____2663 =
-                  let uu____2664 =
-                    let uu____2674 =
-                      let uu____2680 =
-                        let uu____2685 =
-                          FStar_Syntax_Syntax.as_implicit false in
-                        (repr1, uu____2685) in
-                      [uu____2680] in
-                    (lid2, uu____2674) in
-                  FStar_Syntax_Syntax.Tm_app uu____2664 in
-                FStar_Syntax_Syntax.mk uu____2663 in
-              uu____2660 None range
-and desugar_name:
-  (FStar_Syntax_Syntax.term' -> FStar_Syntax_Syntax.term) ->
-    (FStar_Syntax_Syntax.term ->
-       (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-         FStar_Syntax_Syntax.syntax)
-      -> env_t -> Prims.bool -> FStar_Ident.lid -> FStar_Syntax_Syntax.term
-  =
-  fun mk1  ->
-    fun setpos  ->
-      fun env  ->
-        fun resolve  ->
-          fun l  ->
-            let uu____2720 =
-              FStar_ToSyntax_Env.fail_or env
-                ((if resolve
-                  then FStar_ToSyntax_Env.try_lookup_lid
-                  else FStar_ToSyntax_Env.try_lookup_lid_no_resolve) env) l in
-            match uu____2720 with
-            | (tm,mut) ->
-                let tm1 = setpos tm in
-                if mut
-                then
-                  let uu____2738 =
-                    let uu____2739 =
-                      let uu____2744 = mk_ref_read tm1 in
-                      (uu____2744,
-                        (FStar_Syntax_Syntax.Meta_desugared
-                           FStar_Syntax_Syntax.Mutable_rval)) in
-                    FStar_Syntax_Syntax.Tm_meta uu____2739 in
-                  FStar_All.pipe_left mk1 uu____2738
-                else tm1
-and desugar_attributes:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.term Prims.list -> FStar_Syntax_Syntax.cflags Prims.list
-  =
-  fun env  ->
-    fun cattributes  ->
-      let desugar_attribute t =
-        let uu____2758 =
-          let uu____2759 = unparen t in uu____2759.FStar_Parser_AST.tm in
-        match uu____2758 with
-        | FStar_Parser_AST.Var
-            { FStar_Ident.ns = uu____2760; FStar_Ident.ident = uu____2761;
-              FStar_Ident.nsstr = uu____2762; FStar_Ident.str = "cps";_}
-            -> FStar_Syntax_Syntax.CPS
-        | uu____2764 ->
-            let uu____2765 =
-              let uu____2766 =
-                let uu____2769 =
-                  let uu____2770 = FStar_Parser_AST.term_to_string t in
-                  Prims.strcat "Unknown attribute " uu____2770 in
-                (uu____2769, (t.FStar_Parser_AST.range)) in
-              FStar_Errors.Error uu____2766 in
-            Prims.raise uu____2765 in
-      FStar_List.map desugar_attribute cattributes
-and desugar_term_maybe_top:
-  Prims.bool -> env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term =
-  fun top_level  ->
-    fun env  ->
-      fun top  ->
-        let mk1 e =
-          (FStar_Syntax_Syntax.mk e) None top.FStar_Parser_AST.range in
-        let setpos e =
-          let uu___219_2798 = e in
-          {
-            FStar_Syntax_Syntax.n = (uu___219_2798.FStar_Syntax_Syntax.n);
-            FStar_Syntax_Syntax.tk = (uu___219_2798.FStar_Syntax_Syntax.tk);
-            FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
-            FStar_Syntax_Syntax.vars =
-              (uu___219_2798.FStar_Syntax_Syntax.vars)
-          } in
-        let uu____2805 =
-          let uu____2806 = unparen top in uu____2806.FStar_Parser_AST.tm in
-        match uu____2805 with
-        | FStar_Parser_AST.Wild  -> setpos FStar_Syntax_Syntax.tun
-        | FStar_Parser_AST.Labeled uu____2807 -> desugar_formula env top
-        | FStar_Parser_AST.Requires (t,lopt) -> desugar_formula env t
-        | FStar_Parser_AST.Ensures (t,lopt) -> desugar_formula env t
-        | FStar_Parser_AST.Attributes ts ->
-            failwith
-              "Attributes should not be desugared by desugar_term_maybe_top"
-        | FStar_Parser_AST.Const (FStar_Const.Const_int (i,Some size)) ->
-            desugar_machine_integer env i size top.FStar_Parser_AST.range
-        | FStar_Parser_AST.Const c -> mk1 (FStar_Syntax_Syntax.Tm_constant c)
-        | FStar_Parser_AST.Op ("=!=",args) ->
-            desugar_term env
-              (FStar_Parser_AST.mk_term
-                 (FStar_Parser_AST.Op
-                    ("~",
-                      [FStar_Parser_AST.mk_term
-                         (FStar_Parser_AST.Op ("==", args))
-                         top.FStar_Parser_AST.range
-                         top.FStar_Parser_AST.level]))
-                 top.FStar_Parser_AST.range top.FStar_Parser_AST.level)
-        | FStar_Parser_AST.Op ("*",uu____2836::uu____2837::[]) when
-            let uu____2839 =
-              op_as_term env (Prims.parse_int "2") top.FStar_Parser_AST.range
-                "*" in
-            FStar_All.pipe_right uu____2839 FStar_Option.isNone ->
-            let rec flatten1 t =
-              match t.FStar_Parser_AST.tm with
-              | FStar_Parser_AST.Op ("*",t1::t2::[]) ->
-                  let uu____2851 = flatten1 t1 in
-                  FStar_List.append uu____2851 [t2]
-              | uu____2853 -> [t] in
-            let targs =
-              let uu____2856 =
-                let uu____2858 = unparen top in flatten1 uu____2858 in
-              FStar_All.pipe_right uu____2856
-                (FStar_List.map
-                   (fun t  ->
-                      let uu____2862 = desugar_typ env t in
-                      FStar_Syntax_Syntax.as_arg uu____2862)) in
-            let uu____2863 =
-              let uu____2866 =
-                FStar_Syntax_Util.mk_tuple_lid (FStar_List.length targs)
-                  top.FStar_Parser_AST.range in
-              FStar_ToSyntax_Env.fail_or env
-                (FStar_ToSyntax_Env.try_lookup_lid env) uu____2866 in
-            (match uu____2863 with
-             | (tup,uu____2873) ->
-                 mk1 (FStar_Syntax_Syntax.Tm_app (tup, targs)))
-        | FStar_Parser_AST.Tvar a ->
-            let uu____2876 =
-              let uu____2879 =
-                FStar_ToSyntax_Env.fail_or2
-                  (FStar_ToSyntax_Env.try_lookup_id env) a in
-              Prims.fst uu____2879 in
-            FStar_All.pipe_left setpos uu____2876
-        | FStar_Parser_AST.Uvar u ->
-            Prims.raise
-              (FStar_Errors.Error
-                 ((Prims.strcat "Unexpected universe variable "
-                     (Prims.strcat (FStar_Ident.text_of_id u)
-                        " in non-universe context")),
-                   (top.FStar_Parser_AST.range)))
-        | FStar_Parser_AST.Op (s,args) ->
-            let uu____2893 =
-              op_as_term env (FStar_List.length args)
-                top.FStar_Parser_AST.range s in
-            (match uu____2893 with
-             | None  ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ((Prims.strcat "Unexpected or unbound operator: " s),
-                        (top.FStar_Parser_AST.range)))
-             | Some op ->
-                 if (FStar_List.length args) > (Prims.parse_int "0")
-                 then
-                   let args1 =
-                     FStar_All.pipe_right args
-                       (FStar_List.map
-                          (fun t  ->
-                             let uu____2915 = desugar_term env t in
-                             (uu____2915, None))) in
-                   mk1 (FStar_Syntax_Syntax.Tm_app (op, args1))
-                 else op)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____2922; FStar_Ident.ident = uu____2923;
-              FStar_Ident.nsstr = uu____2924; FStar_Ident.str = "Type0";_}
-            -> mk1 (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____2926; FStar_Ident.ident = uu____2927;
-              FStar_Ident.nsstr = uu____2928; FStar_Ident.str = "Type";_}
-            ->
-            mk1 (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-        | FStar_Parser_AST.Construct
-            ({ FStar_Ident.ns = uu____2930; FStar_Ident.ident = uu____2931;
-               FStar_Ident.nsstr = uu____2932; FStar_Ident.str = "Type";_},
-             (t,FStar_Parser_AST.UnivApp )::[])
-            ->
-            let uu____2942 =
-              let uu____2943 = desugar_universe t in
-              FStar_Syntax_Syntax.Tm_type uu____2943 in
-            mk1 uu____2942
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____2944; FStar_Ident.ident = uu____2945;
-              FStar_Ident.nsstr = uu____2946; FStar_Ident.str = "Effect";_}
-            -> mk1 (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_effect)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____2948; FStar_Ident.ident = uu____2949;
-              FStar_Ident.nsstr = uu____2950; FStar_Ident.str = "True";_}
-            ->
-            FStar_Syntax_Syntax.fvar
-              (FStar_Ident.set_lid_range FStar_Syntax_Const.true_lid
-                 top.FStar_Parser_AST.range)
-              FStar_Syntax_Syntax.Delta_constant None
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____2952; FStar_Ident.ident = uu____2953;
-              FStar_Ident.nsstr = uu____2954; FStar_Ident.str = "False";_}
-            ->
-            FStar_Syntax_Syntax.fvar
-              (FStar_Ident.set_lid_range FStar_Syntax_Const.false_lid
-                 top.FStar_Parser_AST.range)
-              FStar_Syntax_Syntax.Delta_constant None
-        | FStar_Parser_AST.Projector
-            (eff_name,{ FStar_Ident.idText = txt;
-                        FStar_Ident.idRange = uu____2958;_})
-            when
-            (is_special_effect_combinator txt) &&
-              (FStar_ToSyntax_Env.is_effect_name env eff_name)
-            ->
-            let uu____2959 =
-              FStar_ToSyntax_Env.try_lookup_effect_defn env eff_name in
-            (match uu____2959 with
-             | Some ed ->
-                 let uu____2962 =
-                   FStar_Ident.lid_of_path
-                     (FStar_Ident.path_of_text
-                        (Prims.strcat
-                           (FStar_Ident.text_of_lid
-                              ed.FStar_Syntax_Syntax.mname)
-                           (Prims.strcat "_" txt))) FStar_Range.dummyRange in
-                 FStar_Syntax_Syntax.fvar uu____2962
-                   (FStar_Syntax_Syntax.Delta_defined_at_level
-                      (Prims.parse_int "1")) None
-             | None  ->
-                 let uu____2963 =
-                   FStar_Util.format2
-                     "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
-                     (FStar_Ident.text_of_lid eff_name) txt in
-                 failwith uu____2963)
-        | FStar_Parser_AST.Assign (ident,t2) ->
-            let t21 = desugar_term env t2 in
-            let uu____2967 =
-              FStar_ToSyntax_Env.fail_or2
-                (FStar_ToSyntax_Env.try_lookup_id env) ident in
-            (match uu____2967 with
-             | (t1,mut) ->
-                 (if Prims.op_Negation mut
-                  then
-                    Prims.raise
-                      (FStar_Errors.Error
-                         ("Can only assign to mutable values",
-                           (top.FStar_Parser_AST.range)))
-                  else ();
-                  mk_ref_assign t1 t21 top.FStar_Parser_AST.range))
-        | FStar_Parser_AST.Var l|FStar_Parser_AST.Name l ->
-            desugar_name mk1 setpos env true l
-        | FStar_Parser_AST.Projector (l,i) ->
-            let name =
-              let uu____2983 = FStar_ToSyntax_Env.try_lookup_datacon env l in
-              match uu____2983 with
-              | Some uu____2988 -> Some (true, l)
-              | None  ->
-                  let uu____2991 =
-                    FStar_ToSyntax_Env.try_lookup_root_effect_name env l in
-                  (match uu____2991 with
-                   | Some new_name -> Some (false, new_name)
-                   | uu____2999 -> None) in
-            (match name with
-             | Some (resolve,new_name) ->
-                 let uu____3007 =
-                   FStar_Syntax_Util.mk_field_projector_name_from_ident
-                     new_name i in
-                 desugar_name mk1 setpos env resolve uu____3007
-             | uu____3008 ->
-                 let uu____3012 =
-                   let uu____3013 =
-                     let uu____3016 =
-                       FStar_Util.format1
-                         "Data constructor or effect %s not found"
-                         l.FStar_Ident.str in
-                     (uu____3016, (top.FStar_Parser_AST.range)) in
-                   FStar_Errors.Error uu____3013 in
-                 Prims.raise uu____3012)
-        | FStar_Parser_AST.Discrim lid ->
-            let uu____3018 = FStar_ToSyntax_Env.try_lookup_datacon env lid in
-            (match uu____3018 with
-             | None  ->
-                 let uu____3020 =
-                   let uu____3021 =
-                     let uu____3024 =
-                       FStar_Util.format1 "Data constructor %s not found"
-                         lid.FStar_Ident.str in
-                     (uu____3024, (top.FStar_Parser_AST.range)) in
-                   FStar_Errors.Error uu____3021 in
-                 Prims.raise uu____3020
-             | uu____3025 ->
-                 let lid' = FStar_Syntax_Util.mk_discriminator lid in
-                 desugar_name mk1 setpos env true lid')
-        | FStar_Parser_AST.Construct (l,args) ->
-            let uu____3036 = FStar_ToSyntax_Env.try_lookup_datacon env l in
-            (match uu____3036 with
-             | Some head1 ->
-                 let uu____3039 =
-                   let uu____3044 = mk1 (FStar_Syntax_Syntax.Tm_fvar head1) in
-                   (uu____3044, true) in
-                 (match uu____3039 with
-                  | (head2,is_data) ->
-                      (match args with
-                       | [] -> head2
-                       | uu____3057 ->
-                           let uu____3061 =
-                             FStar_Util.take
-                               (fun uu____3072  ->
-                                  match uu____3072 with
-                                  | (uu____3075,imp) ->
-                                      imp = FStar_Parser_AST.UnivApp) args in
-                           (match uu____3061 with
-                            | (universes,args1) ->
-                                let universes1 =
-                                  FStar_List.map
-                                    (fun x  -> desugar_universe (Prims.fst x))
-                                    universes in
-                                let args2 =
-                                  FStar_List.map
-                                    (fun uu____3108  ->
-                                       match uu____3108 with
-                                       | (t,imp) ->
-                                           let te = desugar_term env t in
-                                           arg_withimp_e imp te) args1 in
-                                let head3 =
-                                  if universes1 = []
-                                  then head2
-                                  else
-                                    mk1
-                                      (FStar_Syntax_Syntax.Tm_uinst
-                                         (head2, universes1)) in
-                                let app =
-                                  mk1
-                                    (FStar_Syntax_Syntax.Tm_app
-                                       (head3, args2)) in
-                                if is_data
-                                then
-                                  mk1
-                                    (FStar_Syntax_Syntax.Tm_meta
-                                       (app,
-                                         (FStar_Syntax_Syntax.Meta_desugared
-                                            FStar_Syntax_Syntax.Data_app)))
-                                else app)))
-             | None  ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ((Prims.strcat "Constructor "
-                          (Prims.strcat l.FStar_Ident.str " not found")),
-                        (top.FStar_Parser_AST.range))))
-        | FStar_Parser_AST.Sum (binders,t) ->
-            let uu____3143 =
-              FStar_List.fold_left
-                (fun uu____3160  ->
-                   fun b  ->
-                     match uu____3160 with
-                     | (env1,tparams,typs) ->
-                         let uu____3191 = desugar_binder env1 b in
-                         (match uu____3191 with
-                          | (xopt,t1) ->
-                              let uu____3207 =
-                                match xopt with
-                                | None  ->
-                                    let uu____3212 =
-                                      FStar_Syntax_Syntax.new_bv
-                                        (Some (top.FStar_Parser_AST.range))
-                                        FStar_Syntax_Syntax.tun in
-                                    (env1, uu____3212)
-                                | Some x -> FStar_ToSyntax_Env.push_bv env1 x in
-                              (match uu____3207 with
-                               | (env2,x) ->
-                                   let uu____3224 =
-                                     let uu____3226 =
-                                       let uu____3228 =
-                                         let uu____3229 =
-                                           no_annot_abs tparams t1 in
-                                         FStar_All.pipe_left
-                                           FStar_Syntax_Syntax.as_arg
-                                           uu____3229 in
-                                       [uu____3228] in
-                                     FStar_List.append typs uu____3226 in
-                                   (env2,
-                                     (FStar_List.append tparams
-                                        [(((let uu___220_3242 = x in
-                                            {
-                                              FStar_Syntax_Syntax.ppname =
-                                                (uu___220_3242.FStar_Syntax_Syntax.ppname);
-                                              FStar_Syntax_Syntax.index =
-                                                (uu___220_3242.FStar_Syntax_Syntax.index);
-                                              FStar_Syntax_Syntax.sort = t1
-                                            })), None)]), uu____3224))))
-                (env, [], [])
-                (FStar_List.append binders
-                   [FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
-                      t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
-                      None]) in
-            (match uu____3143 with
-             | (env1,uu____3255,targs) ->
-                 let uu____3267 =
-                   let uu____3270 =
-                     FStar_Syntax_Util.mk_dtuple_lid
-                       (FStar_List.length targs) top.FStar_Parser_AST.range in
-                   FStar_ToSyntax_Env.fail_or env1
-                     (FStar_ToSyntax_Env.try_lookup_lid env1) uu____3270 in
-                 (match uu____3267 with
-                  | (tup,uu____3277) ->
-                      FStar_All.pipe_left mk1
-                        (FStar_Syntax_Syntax.Tm_app (tup, targs))))
-        | FStar_Parser_AST.Product (binders,t) ->
-            let uu____3285 = uncurry binders t in
-            (match uu____3285 with
-             | (bs,t1) ->
-                 let rec aux env1 bs1 uu___197_3308 =
-                   match uu___197_3308 with
-                   | [] ->
-                       let cod =
-                         desugar_comp top.FStar_Parser_AST.range env1 t1 in
-                       let uu____3318 =
-                         FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod in
-                       FStar_All.pipe_left setpos uu____3318
-                   | hd1::tl1 ->
-                       let bb = desugar_binder env1 hd1 in
-                       let uu____3334 =
-                         as_binder env1 hd1.FStar_Parser_AST.aqual bb in
-                       (match uu____3334 with
-                        | (b,env2) -> aux env2 (b :: bs1) tl1) in
-                 aux env [] bs)
-        | FStar_Parser_AST.Refine (b,f) ->
-            let uu____3345 = desugar_binder env b in
-            (match uu____3345 with
-             | (None ,uu____3349) -> failwith "Missing binder in refinement"
-             | b1 ->
-                 let uu____3355 = as_binder env None b1 in
-                 (match uu____3355 with
-                  | ((x,uu____3359),env1) ->
-                      let f1 = desugar_formula env1 f in
-                      let uu____3364 = FStar_Syntax_Util.refine x f1 in
-                      FStar_All.pipe_left setpos uu____3364))
-        | FStar_Parser_AST.Abs (binders,body) ->
-            let binders1 =
-              FStar_All.pipe_right binders
-                (FStar_List.map replace_unit_pattern) in
-            let uu____3379 =
-              FStar_List.fold_left
-                (fun uu____3386  ->
-                   fun pat  ->
-                     match uu____3386 with
-                     | (env1,ftvs) ->
-                         (match pat.FStar_Parser_AST.pat with
-                          | FStar_Parser_AST.PatAscribed (uu____3401,t) ->
-                              let uu____3403 =
-                                let uu____3405 = free_type_vars env1 t in
-                                FStar_List.append uu____3405 ftvs in
-                              (env1, uu____3403)
-                          | uu____3408 -> (env1, ftvs))) (env, []) binders1 in
-            (match uu____3379 with
-             | (uu____3411,ftv) ->
-                 let ftv1 = sort_ftv ftv in
-                 let binders2 =
-                   let uu____3419 =
-                     FStar_All.pipe_right ftv1
-                       (FStar_List.map
-                          (fun a  ->
-                             FStar_Parser_AST.mk_pattern
-                               (FStar_Parser_AST.PatTvar
-                                  (a, (Some FStar_Parser_AST.Implicit)))
-                               top.FStar_Parser_AST.range)) in
-                   FStar_List.append uu____3419 binders1 in
-                 let rec aux env1 bs sc_pat_opt uu___198_3448 =
-                   match uu___198_3448 with
-                   | [] ->
-                       let body1 = desugar_term env1 body in
-                       let body2 =
-                         match sc_pat_opt with
-                         | Some (sc,pat) ->
-                             let body2 =
-                               let uu____3477 =
-                                 let uu____3478 =
-                                   FStar_Syntax_Syntax.pat_bvs pat in
-                                 FStar_All.pipe_right uu____3478
-                                   (FStar_List.map
-                                      FStar_Syntax_Syntax.mk_binder) in
-                               FStar_Syntax_Subst.close uu____3477 body1 in
-                             (FStar_Syntax_Syntax.mk
-                                (FStar_Syntax_Syntax.Tm_match
-                                   (sc, [(pat, None, body2)]))) None
-                               body2.FStar_Syntax_Syntax.pos
-                         | None  -> body1 in
-                       let uu____3520 =
-                         no_annot_abs (FStar_List.rev bs) body2 in
-                       setpos uu____3520
-                   | p::rest ->
-                       let uu____3528 = desugar_binding_pat env1 p in
-                       (match uu____3528 with
-                        | (env2,b,pat) ->
-                            let uu____3540 =
-                              match b with
-                              | LetBinder uu____3559 -> failwith "Impossible"
-                              | LocalBinder (x,aq) ->
-                                  let sc_pat_opt1 =
-                                    match (pat, sc_pat_opt) with
-                                    | (None ,uu____3590) -> sc_pat_opt
-                                    | (Some p1,None ) ->
-                                        let uu____3613 =
-                                          let uu____3616 =
-                                            FStar_Syntax_Syntax.bv_to_name x in
-                                          (uu____3616, p1) in
-                                        Some uu____3613
-                                    | (Some p1,Some (sc,p')) ->
-                                        (match ((sc.FStar_Syntax_Syntax.n),
-                                                 (p'.FStar_Syntax_Syntax.v))
-                                         with
-                                         | (FStar_Syntax_Syntax.Tm_name
-                                            uu____3641,uu____3642) ->
-                                             let tup2 =
-                                               let uu____3644 =
-                                                 FStar_Syntax_Util.mk_tuple_data_lid
-                                                   (Prims.parse_int "2")
-                                                   top.FStar_Parser_AST.range in
-                                               FStar_Syntax_Syntax.lid_as_fv
-                                                 uu____3644
-                                                 FStar_Syntax_Syntax.Delta_constant
-                                                 (Some
-                                                    FStar_Syntax_Syntax.Data_ctor) in
-                                             let sc1 =
-                                               let uu____3648 =
-                                                 let uu____3651 =
-                                                   let uu____3652 =
-                                                     let uu____3662 =
-                                                       mk1
-                                                         (FStar_Syntax_Syntax.Tm_fvar
-                                                            tup2) in
-                                                     let uu____3665 =
-                                                       let uu____3667 =
-                                                         FStar_Syntax_Syntax.as_arg
-                                                           sc in
-                                                       let uu____3668 =
-                                                         let uu____3670 =
-                                                           let uu____3671 =
-                                                             FStar_Syntax_Syntax.bv_to_name
-                                                               x in
-                                                           FStar_All.pipe_left
-                                                             FStar_Syntax_Syntax.as_arg
-                                                             uu____3671 in
-                                                         [uu____3670] in
-                                                       uu____3667 ::
-                                                         uu____3668 in
-                                                     (uu____3662, uu____3665) in
-                                                   FStar_Syntax_Syntax.Tm_app
-                                                     uu____3652 in
-                                                 FStar_Syntax_Syntax.mk
-                                                   uu____3651 in
-                                               uu____3648 None
-                                                 top.FStar_Parser_AST.range in
-                                             let p2 =
-                                               let uu____3686 =
-                                                 FStar_Range.union_ranges
-                                                   p'.FStar_Syntax_Syntax.p
-                                                   p1.FStar_Syntax_Syntax.p in
-                                               FStar_Syntax_Syntax.withinfo
-                                                 (FStar_Syntax_Syntax.Pat_cons
-                                                    (tup2,
-                                                      [(p', false);
-                                                      (p1, false)]))
-                                                 FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-                                                 uu____3686 in
-                                             Some (sc1, p2)
-                                         | (FStar_Syntax_Syntax.Tm_app
-                                            (uu____3706,args),FStar_Syntax_Syntax.Pat_cons
-                                            (uu____3708,pats)) ->
-                                             let tupn =
-                                               let uu____3735 =
-                                                 FStar_Syntax_Util.mk_tuple_data_lid
-                                                   ((Prims.parse_int "1") +
-                                                      (FStar_List.length args))
-                                                   top.FStar_Parser_AST.range in
-                                               FStar_Syntax_Syntax.lid_as_fv
-                                                 uu____3735
-                                                 FStar_Syntax_Syntax.Delta_constant
-                                                 (Some
-                                                    FStar_Syntax_Syntax.Data_ctor) in
-                                             let sc1 =
-                                               let uu____3745 =
-                                                 let uu____3746 =
-                                                   let uu____3756 =
-                                                     mk1
-                                                       (FStar_Syntax_Syntax.Tm_fvar
-                                                          tupn) in
-                                                   let uu____3759 =
-                                                     let uu____3765 =
-                                                       let uu____3771 =
-                                                         let uu____3772 =
-                                                           FStar_Syntax_Syntax.bv_to_name
-                                                             x in
-                                                         FStar_All.pipe_left
-                                                           FStar_Syntax_Syntax.as_arg
-                                                           uu____3772 in
-                                                       [uu____3771] in
-                                                     FStar_List.append args
-                                                       uu____3765 in
-                                                   (uu____3756, uu____3759) in
-                                                 FStar_Syntax_Syntax.Tm_app
-                                                   uu____3746 in
-                                               mk1 uu____3745 in
-                                             let p2 =
-                                               let uu____3787 =
-                                                 FStar_Range.union_ranges
-                                                   p'.FStar_Syntax_Syntax.p
-                                                   p1.FStar_Syntax_Syntax.p in
-                                               FStar_Syntax_Syntax.withinfo
-                                                 (FStar_Syntax_Syntax.Pat_cons
-                                                    (tupn,
-                                                      (FStar_List.append pats
-                                                         [(p1, false)])))
-                                                 FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-                                                 uu____3787 in
-                                             Some (sc1, p2)
-                                         | uu____3811 ->
-                                             failwith "Impossible") in
-                                  ((x, aq), sc_pat_opt1) in
-                            (match uu____3540 with
-                             | (b1,sc_pat_opt1) ->
-                                 aux env2 (b1 :: bs) sc_pat_opt1 rest)) in
-                 aux env [] None binders2)
-        | FStar_Parser_AST.App
-            (uu____3852,uu____3853,FStar_Parser_AST.UnivApp ) ->
-            let rec aux universes e =
-              let uu____3865 =
-                let uu____3866 = unparen e in uu____3866.FStar_Parser_AST.tm in
-              match uu____3865 with
-              | FStar_Parser_AST.App (e1,t,FStar_Parser_AST.UnivApp ) ->
-                  let univ_arg = desugar_universe t in
-                  aux (univ_arg :: universes) e1
-              | uu____3872 ->
-                  let head1 = desugar_term env e in
-                  mk1 (FStar_Syntax_Syntax.Tm_uinst (head1, universes)) in
-            aux [] top
-        | FStar_Parser_AST.App uu____3875 ->
-            let rec aux args e =
-              let uu____3896 =
-                let uu____3897 = unparen e in uu____3897.FStar_Parser_AST.tm in
-              match uu____3896 with
-              | FStar_Parser_AST.App (e1,t,imp) when
-                  imp <> FStar_Parser_AST.UnivApp ->
-                  let arg =
-                    let uu____3907 = desugar_term env t in
-                    FStar_All.pipe_left (arg_withimp_e imp) uu____3907 in
-                  aux (arg :: args) e1
-              | uu____3914 ->
-                  let head1 = desugar_term env e in
-                  mk1 (FStar_Syntax_Syntax.Tm_app (head1, args)) in
-            aux [] top
-        | FStar_Parser_AST.Seq (t1,t2) ->
-            let uu____3925 =
-              let uu____3926 =
-                let uu____3931 =
-                  desugar_term env
-                    (FStar_Parser_AST.mk_term
-                       (FStar_Parser_AST.Let
-                          (FStar_Parser_AST.NoLetQualifier,
-                            [((FStar_Parser_AST.mk_pattern
-                                 FStar_Parser_AST.PatWild
-                                 t1.FStar_Parser_AST.range), t1)], t2))
-                       top.FStar_Parser_AST.range FStar_Parser_AST.Expr) in
-                (uu____3931,
-                  (FStar_Syntax_Syntax.Meta_desugared
-                     FStar_Syntax_Syntax.Sequence)) in
-              FStar_Syntax_Syntax.Tm_meta uu____3926 in
-            mk1 uu____3925
-        | FStar_Parser_AST.LetOpen (lid,e) ->
-            let env1 = FStar_ToSyntax_Env.push_namespace env lid in
-            desugar_term_maybe_top top_level env1 e
-        | FStar_Parser_AST.Let (qual1,(pat,_snd)::_tl,body) ->
-            let is_rec = qual1 = FStar_Parser_AST.Rec in
-            let ds_let_rec_or_app uu____3961 =
-              let bindings = (pat, _snd) :: _tl in
-              let funs =
-                FStar_All.pipe_right bindings
-                  (FStar_List.map
-                     (fun uu____4003  ->
-                        match uu____4003 with
-                        | (p,def) ->
-                            let uu____4017 = is_app_pattern p in
-                            if uu____4017
-                            then
-                              let uu____4027 =
-                                destruct_app_pattern env top_level p in
-                              (uu____4027, def)
-                            else
-                              (match FStar_Parser_AST.un_function p def with
-                               | Some (p1,def1) ->
-                                   let uu____4056 =
-                                     destruct_app_pattern env top_level p1 in
-                                   (uu____4056, def1)
-                               | uu____4071 ->
-                                   (match p.FStar_Parser_AST.pat with
-                                    | FStar_Parser_AST.PatAscribed
-                                        ({
-                                           FStar_Parser_AST.pat =
-                                             FStar_Parser_AST.PatVar
-                                             (id,uu____4085);
-                                           FStar_Parser_AST.prange =
-                                             uu____4086;_},t)
-                                        ->
-                                        if top_level
-                                        then
-                                          let uu____4099 =
-                                            let uu____4107 =
-                                              let uu____4110 =
-                                                FStar_ToSyntax_Env.qualify
-                                                  env id in
-                                              FStar_Util.Inr uu____4110 in
-                                            (uu____4107, [], (Some t)) in
-                                          (uu____4099, def)
-                                        else
-                                          (((FStar_Util.Inl id), [],
-                                             (Some t)), def)
-                                    | FStar_Parser_AST.PatVar (id,uu____4135)
-                                        ->
-                                        if top_level
-                                        then
-                                          let uu____4147 =
-                                            let uu____4155 =
-                                              let uu____4158 =
-                                                FStar_ToSyntax_Env.qualify
-                                                  env id in
-                                              FStar_Util.Inr uu____4158 in
-                                            (uu____4155, [], None) in
-                                          (uu____4147, def)
-                                        else
-                                          (((FStar_Util.Inl id), [], None),
-                                            def)
-                                    | uu____4182 ->
-                                        Prims.raise
-                                          (FStar_Errors.Error
-                                             ("Unexpected let binding",
-                                               (p.FStar_Parser_AST.prange))))))) in
-              let uu____4192 =
-                FStar_List.fold_left
-                  (fun uu____4216  ->
-                     fun uu____4217  ->
-                       match (uu____4216, uu____4217) with
-                       | ((env1,fnames,rec_bindings),((f,uu____4261,uu____4262),uu____4263))
-                           ->
-                           let uu____4303 =
-                             match f with
-                             | FStar_Util.Inl x ->
-                                 let uu____4317 =
-                                   FStar_ToSyntax_Env.push_bv env1 x in
-                                 (match uu____4317 with
-                                  | (env2,xx) ->
-                                      let uu____4328 =
-                                        let uu____4330 =
-                                          FStar_Syntax_Syntax.mk_binder xx in
-                                        uu____4330 :: rec_bindings in
-                                      (env2, (FStar_Util.Inl xx), uu____4328))
-                             | FStar_Util.Inr l ->
-                                 let uu____4335 =
-                                   FStar_ToSyntax_Env.push_top_level_rec_binding
-                                     env1 l.FStar_Ident.ident
-                                     FStar_Syntax_Syntax.Delta_equational in
-                                 (uu____4335, (FStar_Util.Inr l),
-                                   rec_bindings) in
-                           (match uu____4303 with
-                            | (env2,lbname,rec_bindings1) ->
-                                (env2, (lbname :: fnames), rec_bindings1)))
-                  (env, [], []) funs in
-              match uu____4192 with
-              | (env',fnames,rec_bindings) ->
-                  let fnames1 = FStar_List.rev fnames in
-                  let rec_bindings1 = FStar_List.rev rec_bindings in
-                  let desugar_one_def env1 lbname uu____4408 =
-                    match uu____4408 with
-                    | ((uu____4420,args,result_t),def) ->
-                        let args1 =
-                          FStar_All.pipe_right args
-                            (FStar_List.map replace_unit_pattern) in
-                        let def1 =
-                          match result_t with
-                          | None  -> def
-                          | Some t ->
-                              let t1 =
-                                let uu____4446 = is_comp_type env1 t in
-                                if uu____4446
-                                then
-                                  ((let uu____4448 =
-                                      FStar_All.pipe_right args1
-                                        (FStar_List.tryFind
-                                           (fun x  ->
-                                              let uu____4453 =
-                                                is_var_pattern x in
-                                              Prims.op_Negation uu____4453)) in
-                                    match uu____4448 with
-                                    | None  -> ()
-                                    | Some p ->
-                                        Prims.raise
-                                          (FStar_Errors.Error
-                                             ("Computation type annotations are only permitted on let-bindings without inlined patterns; replace this pattern with a variable",
-                                               (p.FStar_Parser_AST.prange))));
-                                   t)
-                                else
-                                  (let uu____4456 =
-                                     ((FStar_Options.ml_ish ()) &&
-                                        (let uu____4457 =
-                                           FStar_ToSyntax_Env.try_lookup_effect_name
-                                             env1
-                                             FStar_Syntax_Const.effect_ML_lid in
-                                         FStar_Option.isSome uu____4457))
-                                       &&
-                                       ((Prims.op_Negation is_rec) ||
-                                          ((FStar_List.length args1) <>
-                                             (Prims.parse_int "0"))) in
-                                   if uu____4456
-                                   then FStar_Parser_AST.ml_comp t
-                                   else FStar_Parser_AST.tot_comp t) in
-                              let uu____4462 =
-                                FStar_Range.union_ranges
-                                  t1.FStar_Parser_AST.range
-                                  def.FStar_Parser_AST.range in
-                              FStar_Parser_AST.mk_term
-                                (FStar_Parser_AST.Ascribed (def, t1, None))
-                                uu____4462 FStar_Parser_AST.Expr in
-                        let def2 =
-                          match args1 with
-                          | [] -> def1
-                          | uu____4465 ->
-                              FStar_Parser_AST.mk_term
-                                (FStar_Parser_AST.un_curry_abs args1 def1)
-                                top.FStar_Parser_AST.range
-                                top.FStar_Parser_AST.level in
-                        let body1 = desugar_term env1 def2 in
-                        let lbname1 =
-                          match lbname with
-                          | FStar_Util.Inl x -> FStar_Util.Inl x
-                          | FStar_Util.Inr l ->
-                              let uu____4475 =
-                                let uu____4476 =
-                                  FStar_Syntax_Util.incr_delta_qualifier
-                                    body1 in
-                                FStar_Syntax_Syntax.lid_as_fv l uu____4476
-                                  None in
-                              FStar_Util.Inr uu____4475 in
-                        let body2 =
-                          if is_rec
-                          then FStar_Syntax_Subst.close rec_bindings1 body1
-                          else body1 in
-                        mk_lb (lbname1, FStar_Syntax_Syntax.tun, body2) in
-                  let lbs =
-                    FStar_List.map2
-                      (desugar_one_def (if is_rec then env' else env))
-                      fnames1 funs in
-                  let body1 = desugar_term env' body in
-                  let uu____4496 =
-                    let uu____4497 =
-                      let uu____4505 =
-                        FStar_Syntax_Subst.close rec_bindings1 body1 in
-                      ((is_rec, lbs), uu____4505) in
-                    FStar_Syntax_Syntax.Tm_let uu____4497 in
-                  FStar_All.pipe_left mk1 uu____4496 in
-            let ds_non_rec pat1 t1 t2 =
-              let t11 = desugar_term env t1 in
-              let is_mutable = qual1 = FStar_Parser_AST.Mutable in
-              let t12 = if is_mutable then mk_ref_alloc t11 else t11 in
-              let uu____4532 =
-                desugar_binding_pat_maybe_top top_level env pat1 is_mutable in
-              match uu____4532 with
-              | (env1,binder,pat2) ->
-                  let tm =
-                    match binder with
-                    | LetBinder (l,t) ->
-                        let body1 = desugar_term env1 t2 in
-                        let fv =
-                          let uu____4553 =
-                            FStar_Syntax_Util.incr_delta_qualifier t12 in
-                          FStar_Syntax_Syntax.lid_as_fv l uu____4553 None in
-                        FStar_All.pipe_left mk1
-                          (FStar_Syntax_Syntax.Tm_let
-                             ((false,
-                                [{
-                                   FStar_Syntax_Syntax.lbname =
-                                     (FStar_Util.Inr fv);
-                                   FStar_Syntax_Syntax.lbunivs = [];
-                                   FStar_Syntax_Syntax.lbtyp = t;
-                                   FStar_Syntax_Syntax.lbeff =
-                                     FStar_Syntax_Const.effect_ALL_lid;
-                                   FStar_Syntax_Syntax.lbdef = t12
-                                 }]), body1))
-                    | LocalBinder (x,uu____4561) ->
-                        let body1 = desugar_term env1 t2 in
-                        let body2 =
-                          match pat2 with
-                          | None |Some
-                            {
-                              FStar_Syntax_Syntax.v =
-                                FStar_Syntax_Syntax.Pat_wild _;
-                              FStar_Syntax_Syntax.ty = _;
-                              FStar_Syntax_Syntax.p = _;_} -> body1
-                          | Some pat3 ->
-                              let uu____4570 =
-                                let uu____4573 =
-                                  let uu____4574 =
-                                    let uu____4590 =
-                                      FStar_Syntax_Syntax.bv_to_name x in
-                                    let uu____4591 =
-                                      let uu____4593 =
-                                        FStar_Syntax_Util.branch
-                                          (pat3, None, body1) in
-                                      [uu____4593] in
-                                    (uu____4590, uu____4591) in
-                                  FStar_Syntax_Syntax.Tm_match uu____4574 in
-                                FStar_Syntax_Syntax.mk uu____4573 in
-                              uu____4570 None body1.FStar_Syntax_Syntax.pos in
-                        let uu____4608 =
-                          let uu____4609 =
-                            let uu____4617 =
-                              let uu____4618 =
-                                let uu____4619 =
-                                  FStar_Syntax_Syntax.mk_binder x in
-                                [uu____4619] in
-                              FStar_Syntax_Subst.close uu____4618 body2 in
-                            ((false,
-                               [mk_lb
-                                  ((FStar_Util.Inl x),
-                                    (x.FStar_Syntax_Syntax.sort), t12)]),
-                              uu____4617) in
-                          FStar_Syntax_Syntax.Tm_let uu____4609 in
-                        FStar_All.pipe_left mk1 uu____4608 in
-                  if is_mutable
-                  then
-                    FStar_All.pipe_left mk1
-                      (FStar_Syntax_Syntax.Tm_meta
-                         (tm,
-                           (FStar_Syntax_Syntax.Meta_desugared
-                              FStar_Syntax_Syntax.Mutable_alloc)))
-                  else tm in
-            let uu____4639 = is_rec || (is_app_pattern pat) in
-            if uu____4639
-            then ds_let_rec_or_app ()
-            else ds_non_rec pat _snd body
-        | FStar_Parser_AST.If (t1,t2,t3) ->
-            let x =
-              FStar_Syntax_Syntax.new_bv (Some (t3.FStar_Parser_AST.range))
-                FStar_Syntax_Syntax.tun in
-            let uu____4645 =
-              let uu____4646 =
-                let uu____4662 = desugar_term env t1 in
-                let uu____4663 =
-                  let uu____4673 =
-                    let uu____4682 =
-                      FStar_Syntax_Syntax.withinfo
-                        (FStar_Syntax_Syntax.Pat_constant
-                           (FStar_Const.Const_bool true))
-                        FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-                        t2.FStar_Parser_AST.range in
-                    let uu____4685 = desugar_term env t2 in
-                    (uu____4682, None, uu____4685) in
-                  let uu____4693 =
-                    let uu____4703 =
-                      let uu____4712 =
-                        FStar_Syntax_Syntax.withinfo
-                          (FStar_Syntax_Syntax.Pat_wild x)
-                          FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-                          t3.FStar_Parser_AST.range in
-                      let uu____4715 = desugar_term env t3 in
-                      (uu____4712, None, uu____4715) in
-                    [uu____4703] in
-                  uu____4673 :: uu____4693 in
-                (uu____4662, uu____4663) in
-              FStar_Syntax_Syntax.Tm_match uu____4646 in
-            mk1 uu____4645
-        | FStar_Parser_AST.TryWith (e,branches) ->
-            let r = top.FStar_Parser_AST.range in
-            let handler = FStar_Parser_AST.mk_function branches r r in
-            let body =
-              FStar_Parser_AST.mk_function
-                [((FStar_Parser_AST.mk_pattern
-                     (FStar_Parser_AST.PatConst FStar_Const.Const_unit) r),
-                   None, e)] r r in
-            let a1 =
-              FStar_Parser_AST.mk_term
-                (FStar_Parser_AST.App
-                   ((FStar_Parser_AST.mk_term
-                       (FStar_Parser_AST.Var FStar_Syntax_Const.try_with_lid)
-                       r top.FStar_Parser_AST.level), body,
-                     FStar_Parser_AST.Nothing)) r top.FStar_Parser_AST.level in
-            let a2 =
-              FStar_Parser_AST.mk_term
-                (FStar_Parser_AST.App (a1, handler, FStar_Parser_AST.Nothing))
-                r top.FStar_Parser_AST.level in
-            desugar_term env a2
-        | FStar_Parser_AST.Match (e,branches) ->
-            let desugar_branch uu____4801 =
-              match uu____4801 with
-              | (pat,wopt,b) ->
-                  let uu____4811 = desugar_match_pat env pat in
-                  (match uu____4811 with
-                   | (env1,pat1) ->
-                       let wopt1 =
-                         match wopt with
-                         | None  -> None
-                         | Some e1 ->
-                             let uu____4820 = desugar_term env1 e1 in
-                             Some uu____4820 in
-                       let b1 = desugar_term env1 b in
-                       FStar_Syntax_Util.branch (pat1, wopt1, b1)) in
-            let uu____4823 =
-              let uu____4824 =
-                let uu____4840 = desugar_term env e in
-                let uu____4841 = FStar_List.map desugar_branch branches in
-                (uu____4840, uu____4841) in
-              FStar_Syntax_Syntax.Tm_match uu____4824 in
-            FStar_All.pipe_left mk1 uu____4823
-        | FStar_Parser_AST.Ascribed (e,t,tac_opt) ->
-            let annot =
-              let uu____4860 = is_comp_type env t in
-              if uu____4860
-              then
-                let uu____4865 = desugar_comp t.FStar_Parser_AST.range env t in
-                FStar_Util.Inr uu____4865
-              else
-                (let uu____4871 = desugar_term env t in
-                 FStar_Util.Inl uu____4871) in
-            let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env) in
-            let uu____4876 =
-              let uu____4877 =
-                let uu____4895 = desugar_term env e in
-                (uu____4895, (annot, tac_opt1), None) in
-              FStar_Syntax_Syntax.Tm_ascribed uu____4877 in
-            FStar_All.pipe_left mk1 uu____4876
-        | FStar_Parser_AST.Record (uu____4911,[]) ->
-            Prims.raise
-              (FStar_Errors.Error
-                 ("Unexpected empty record", (top.FStar_Parser_AST.range)))
-        | FStar_Parser_AST.Record (eopt,fields) ->
-            let record = check_fields env fields top.FStar_Parser_AST.range in
-            let user_ns =
-              let uu____4932 = FStar_List.hd fields in
-              match uu____4932 with | (f,uu____4939) -> f.FStar_Ident.ns in
-            let get_field xopt f =
-              let found =
-                FStar_All.pipe_right fields
-                  (FStar_Util.find_opt
-                     (fun uu____4963  ->
-                        match uu____4963 with
-                        | (g,uu____4967) ->
-                            f.FStar_Ident.idText =
-                              (g.FStar_Ident.ident).FStar_Ident.idText)) in
-              let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f]) in
-              match found with
-              | Some (uu____4971,e) -> (fn, e)
-              | None  ->
-                  (match xopt with
-                   | None  ->
-                       let uu____4979 =
-                         let uu____4980 =
-                           let uu____4983 =
-                             FStar_Util.format2
-                               "Field %s of record type %s is missing"
-                               f.FStar_Ident.idText
-                               (record.FStar_ToSyntax_Env.typename).FStar_Ident.str in
-                           (uu____4983, (top.FStar_Parser_AST.range)) in
-                         FStar_Errors.Error uu____4980 in
-                       Prims.raise uu____4979
-                   | Some x ->
-                       (fn,
-                         (FStar_Parser_AST.mk_term
-                            (FStar_Parser_AST.Project (x, fn))
-                            x.FStar_Parser_AST.range x.FStar_Parser_AST.level))) in
-            let user_constrname =
-              FStar_Ident.lid_of_ids
-                (FStar_List.append user_ns
-                   [record.FStar_ToSyntax_Env.constrname]) in
-            let recterm =
-              match eopt with
-              | None  ->
-                  let uu____4989 =
-                    let uu____4995 =
-                      FStar_All.pipe_right record.FStar_ToSyntax_Env.fields
-                        (FStar_List.map
-                           (fun uu____5009  ->
-                              match uu____5009 with
-                              | (f,uu____5015) ->
-                                  let uu____5016 =
-                                    let uu____5017 = get_field None f in
-                                    FStar_All.pipe_left Prims.snd uu____5017 in
-                                  (uu____5016, FStar_Parser_AST.Nothing))) in
-                    (user_constrname, uu____4995) in
-                  FStar_Parser_AST.Construct uu____4989
-              | Some e ->
-                  let x = FStar_Ident.gen e.FStar_Parser_AST.range in
-                  let xterm =
-                    let uu____5028 =
-                      let uu____5029 = FStar_Ident.lid_of_ids [x] in
-                      FStar_Parser_AST.Var uu____5029 in
-                    FStar_Parser_AST.mk_term uu____5028 x.FStar_Ident.idRange
-                      FStar_Parser_AST.Expr in
-                  let record1 =
-                    let uu____5031 =
-                      let uu____5038 =
-                        FStar_All.pipe_right record.FStar_ToSyntax_Env.fields
-                          (FStar_List.map
-                             (fun uu____5052  ->
-                                match uu____5052 with
-                                | (f,uu____5058) -> get_field (Some xterm) f)) in
-                      (None, uu____5038) in
-                    FStar_Parser_AST.Record uu____5031 in
-                  FStar_Parser_AST.Let
-                    (FStar_Parser_AST.NoLetQualifier,
-                      [((FStar_Parser_AST.mk_pattern
-                           (FStar_Parser_AST.PatVar (x, None))
-                           x.FStar_Ident.idRange), e)],
-                      (FStar_Parser_AST.mk_term record1
-                         top.FStar_Parser_AST.range
-                         top.FStar_Parser_AST.level)) in
-            let recterm1 =
-              FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
-                top.FStar_Parser_AST.level in
-            let e = desugar_term env recterm1 in
-            (match e.FStar_Syntax_Syntax.n with
-             | FStar_Syntax_Syntax.Tm_meta
-                 ({
-                    FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app
-                      ({
-                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                           fv;
-                         FStar_Syntax_Syntax.tk = uu____5074;
-                         FStar_Syntax_Syntax.pos = uu____5075;
-                         FStar_Syntax_Syntax.vars = uu____5076;_},args);
-                    FStar_Syntax_Syntax.tk = uu____5078;
-                    FStar_Syntax_Syntax.pos = uu____5079;
-                    FStar_Syntax_Syntax.vars = uu____5080;_},FStar_Syntax_Syntax.Meta_desugared
-                  (FStar_Syntax_Syntax.Data_app ))
-                 ->
-                 let e1 =
-                   let uu____5102 =
-                     let uu____5103 =
-                       let uu____5113 =
-                         let uu____5114 =
-                           let uu____5116 =
-                             let uu____5117 =
-                               let uu____5121 =
-                                 FStar_All.pipe_right
-                                   record.FStar_ToSyntax_Env.fields
-                                   (FStar_List.map Prims.fst) in
-                               ((record.FStar_ToSyntax_Env.typename),
-                                 uu____5121) in
-                             FStar_Syntax_Syntax.Record_ctor uu____5117 in
-                           Some uu____5116 in
-                         FStar_Syntax_Syntax.fvar
-                           (FStar_Ident.set_lid_range
-                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                              e.FStar_Syntax_Syntax.pos)
-                           FStar_Syntax_Syntax.Delta_constant uu____5114 in
-                       (uu____5113, args) in
-                     FStar_Syntax_Syntax.Tm_app uu____5103 in
-                   FStar_All.pipe_left mk1 uu____5102 in
-                 FStar_All.pipe_left mk1
-                   (FStar_Syntax_Syntax.Tm_meta
-                      (e1,
-                        (FStar_Syntax_Syntax.Meta_desugared
-                           FStar_Syntax_Syntax.Data_app)))
-             | uu____5145 -> e)
-        | FStar_Parser_AST.Project (e,f) ->
-            let uu____5148 =
-              FStar_ToSyntax_Env.fail_or env
-                (FStar_ToSyntax_Env.try_lookup_dc_by_field_name env) f in
-            (match uu____5148 with
-             | (constrname,is_rec) ->
-                 let e1 = desugar_term env e in
-                 let projname =
-                   FStar_Syntax_Util.mk_field_projector_name_from_ident
-                     constrname f.FStar_Ident.ident in
-                 let qual1 =
-                   if is_rec
-                   then
-                     Some
-                       (FStar_Syntax_Syntax.Record_projector
-                          (constrname, (f.FStar_Ident.ident)))
-                   else None in
-                 let uu____5161 =
-                   let uu____5162 =
-                     let uu____5172 =
-                       FStar_Syntax_Syntax.fvar
-                         (FStar_Ident.set_lid_range projname
-                            (FStar_Ident.range_of_lid f))
-                         FStar_Syntax_Syntax.Delta_equational qual1 in
-                     let uu____5173 =
-                       let uu____5175 = FStar_Syntax_Syntax.as_arg e1 in
-                       [uu____5175] in
-                     (uu____5172, uu____5173) in
-                   FStar_Syntax_Syntax.Tm_app uu____5162 in
-                 FStar_All.pipe_left mk1 uu____5161)
-        | FStar_Parser_AST.NamedTyp (_,e)|FStar_Parser_AST.Paren e ->
-            desugar_term env e
-        | uu____5181 when
-            top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            desugar_formula env top
-        | uu____5182 ->
-            FStar_Parser_AST.error "Unexpected term" top
-              top.FStar_Parser_AST.range
-        | FStar_Parser_AST.Let (uu____5183,uu____5184,uu____5185) ->
-            failwith "Not implemented yet"
-        | FStar_Parser_AST.QForall (uu____5192,uu____5193,uu____5194) ->
-            failwith "Not implemented yet"
-        | FStar_Parser_AST.QExists (uu____5201,uu____5202,uu____5203) ->
-            failwith "Not implemented yet"
-and desugar_args:
-  FStar_ToSyntax_Env.env ->
-    (FStar_Parser_AST.term* FStar_Parser_AST.imp) Prims.list ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.arg_qualifier
-        Prims.option) Prims.list
-  =
-  fun env  ->
-    fun args  ->
-      FStar_All.pipe_right args
-        (FStar_List.map
-           (fun uu____5227  ->
-              match uu____5227 with
-              | (a,imp) ->
-                  let uu____5235 = desugar_term env a in
-                  arg_withimp_e imp uu____5235))
-and desugar_comp:
-  FStar_Range.range ->
-    FStar_ToSyntax_Env.env ->
-      FStar_Parser_AST.term ->
-        (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun r  ->
-    fun env  ->
-      fun t  ->
-        let fail msg = Prims.raise (FStar_Errors.Error (msg, r)) in
-        let is_requires uu____5252 =
-          match uu____5252 with
-          | (t1,uu____5256) ->
-              let uu____5257 =
-                let uu____5258 = unparen t1 in uu____5258.FStar_Parser_AST.tm in
-              (match uu____5257 with
-               | FStar_Parser_AST.Requires uu____5259 -> true
-               | uu____5263 -> false) in
-        let is_ensures uu____5269 =
-          match uu____5269 with
-          | (t1,uu____5273) ->
-              let uu____5274 =
-                let uu____5275 = unparen t1 in uu____5275.FStar_Parser_AST.tm in
-              (match uu____5274 with
-               | FStar_Parser_AST.Ensures uu____5276 -> true
-               | uu____5280 -> false) in
-        let is_app head1 uu____5289 =
-          match uu____5289 with
-          | (t1,uu____5293) ->
-              let uu____5294 =
-                let uu____5295 = unparen t1 in uu____5295.FStar_Parser_AST.tm in
-              (match uu____5294 with
-               | FStar_Parser_AST.App
-                   ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                      FStar_Parser_AST.range = uu____5297;
-                      FStar_Parser_AST.level = uu____5298;_},uu____5299,uu____5300)
-                   -> (d.FStar_Ident.ident).FStar_Ident.idText = head1
-               | uu____5301 -> false) in
-        let is_decreases = is_app "decreases" in
-        let pre_process_comp_typ t1 =
-          let uu____5319 = head_and_args t1 in
-          match uu____5319 with
-          | (head1,args) ->
-              (match head1.FStar_Parser_AST.tm with
-               | FStar_Parser_AST.Name lemma when
-                   (lemma.FStar_Ident.ident).FStar_Ident.idText = "Lemma" ->
-                   let unit_tm =
-                     ((FStar_Parser_AST.mk_term
-                         (FStar_Parser_AST.Name FStar_Syntax_Const.unit_lid)
-                         t1.FStar_Parser_AST.range
-                         FStar_Parser_AST.Type_level),
-                       FStar_Parser_AST.Nothing) in
-                   let nil_pat =
-                     ((FStar_Parser_AST.mk_term
-                         (FStar_Parser_AST.Name FStar_Syntax_Const.nil_lid)
-                         t1.FStar_Parser_AST.range FStar_Parser_AST.Expr),
-                       FStar_Parser_AST.Nothing) in
-                   let req_true =
-                     ((FStar_Parser_AST.mk_term
-                         (FStar_Parser_AST.Requires
-                            ((FStar_Parser_AST.mk_term
-                                (FStar_Parser_AST.Name
-                                   FStar_Syntax_Const.true_lid)
-                                t1.FStar_Parser_AST.range
-                                FStar_Parser_AST.Formula), None))
-                         t1.FStar_Parser_AST.range
-                         FStar_Parser_AST.Type_level),
-                       FStar_Parser_AST.Nothing) in
-                   let args1 =
-                     match args with
-                     | [] ->
-                         Prims.raise
-                           (FStar_Errors.Error
-                              ("Not enough arguments to 'Lemma'",
-                                (t1.FStar_Parser_AST.range)))
-                     | ens::[] -> [unit_tm; req_true; ens; nil_pat]
-                     | req::ens::[] when
-                         (is_requires req) && (is_ensures ens) ->
-                         [unit_tm; req; ens; nil_pat]
-                     | ens::dec::[] when
-                         (is_ensures ens) && (is_decreases dec) ->
-                         [unit_tm; req_true; ens; nil_pat; dec]
-                     | req::ens::dec::[] when
-                         ((is_requires req) && (is_ensures ens)) &&
-                           (is_app "decreases" dec)
-                         -> [unit_tm; req; ens; nil_pat; dec]
-                     | more -> unit_tm :: more in
-                   let head_and_attributes =
-                     FStar_ToSyntax_Env.fail_or env
-                       (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes
-                          env) lemma in
-                   (head_and_attributes, args1)
-               | FStar_Parser_AST.Name l when
-                   FStar_ToSyntax_Env.is_effect_name env l ->
-                   let uu____5484 =
-                     FStar_ToSyntax_Env.fail_or env
-                       (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes
-                          env) l in
-                   (uu____5484, args)
-               | FStar_Parser_AST.Name l when
-                   (let uu____5498 = FStar_ToSyntax_Env.current_module env in
-                    FStar_Ident.lid_equals uu____5498
-                      FStar_Syntax_Const.prims_lid)
-                     && ((l.FStar_Ident.ident).FStar_Ident.idText = "Tot")
-                   ->
-                   (((FStar_Ident.set_lid_range
-                        FStar_Syntax_Const.effect_Tot_lid
-                        head1.FStar_Parser_AST.range), []), args)
-               | FStar_Parser_AST.Name l when
-                   (let uu____5507 = FStar_ToSyntax_Env.current_module env in
-                    FStar_Ident.lid_equals uu____5507
-                      FStar_Syntax_Const.prims_lid)
-                     && ((l.FStar_Ident.ident).FStar_Ident.idText = "GTot")
-                   ->
-                   (((FStar_Ident.set_lid_range
-                        FStar_Syntax_Const.effect_GTot_lid
-                        head1.FStar_Parser_AST.range), []), args)
-               | FStar_Parser_AST.Name l when
-                   (((l.FStar_Ident.ident).FStar_Ident.idText = "Type") ||
-                      ((l.FStar_Ident.ident).FStar_Ident.idText = "Type0"))
-                     || ((l.FStar_Ident.ident).FStar_Ident.idText = "Effect")
-                   ->
-                   (((FStar_Ident.set_lid_range
-                        FStar_Syntax_Const.effect_Tot_lid
-                        head1.FStar_Parser_AST.range), []),
-                     [(t1, FStar_Parser_AST.Nothing)])
-               | uu____5527 ->
-                   let default_effect =
-                     let uu____5529 = FStar_Options.ml_ish () in
-                     if uu____5529
-                     then FStar_Syntax_Const.effect_ML_lid
-                     else
-                       ((let uu____5532 =
-                           FStar_Options.warn_default_effects () in
-                         if uu____5532
-                         then
-                           FStar_Errors.warn head1.FStar_Parser_AST.range
-                             "Using default effect Tot"
-                         else ());
-                        FStar_Syntax_Const.effect_Tot_lid) in
-                   (((FStar_Ident.set_lid_range default_effect
-                        head1.FStar_Parser_AST.range), []),
-                     [(t1, FStar_Parser_AST.Nothing)])) in
-        let uu____5545 = pre_process_comp_typ t in
-        match uu____5545 with
-        | ((eff,cattributes),args) ->
-            (if (FStar_List.length args) = (Prims.parse_int "0")
-             then
-               (let uu____5575 =
-                  let uu____5576 = FStar_Syntax_Print.lid_to_string eff in
-                  FStar_Util.format1 "Not enough args to effect %s"
-                    uu____5576 in
-                fail uu____5575)
-             else ();
-             (let is_universe uu____5583 =
-                match uu____5583 with
-                | (uu____5586,imp) -> imp = FStar_Parser_AST.UnivApp in
-              let uu____5588 = FStar_Util.take is_universe args in
-              match uu____5588 with
-              | (universes,args1) ->
-                  let universes1 =
-                    FStar_List.map
-                      (fun uu____5619  ->
-                         match uu____5619 with
-                         | (u,imp) -> desugar_universe u) universes in
-                  let uu____5624 =
-                    let uu____5632 = FStar_List.hd args1 in
-                    let uu____5637 = FStar_List.tl args1 in
-                    (uu____5632, uu____5637) in
-                  (match uu____5624 with
-                   | (result_arg,rest) ->
-                       let result_typ =
-                         desugar_typ env (Prims.fst result_arg) in
-                       let rest1 = desugar_args env rest in
-                       let uu____5668 =
-                         FStar_All.pipe_right rest1
-                           (FStar_List.partition
-                              (fun uu____5706  ->
-                                 match uu____5706 with
-                                 | (t1,uu____5713) ->
-                                     (match t1.FStar_Syntax_Syntax.n with
-                                      | FStar_Syntax_Syntax.Tm_app
-                                          ({
-                                             FStar_Syntax_Syntax.n =
-                                               FStar_Syntax_Syntax.Tm_fvar fv;
-                                             FStar_Syntax_Syntax.tk =
-                                               uu____5721;
-                                             FStar_Syntax_Syntax.pos =
-                                               uu____5722;
-                                             FStar_Syntax_Syntax.vars =
-                                               uu____5723;_},uu____5724::[])
-                                          ->
-                                          FStar_Syntax_Syntax.fv_eq_lid fv
-                                            FStar_Syntax_Const.decreases_lid
-                                      | uu____5746 -> false))) in
-                       (match uu____5668 with
-                        | (dec,rest2) ->
-                            let decreases_clause =
-                              FStar_All.pipe_right dec
-                                (FStar_List.map
-                                   (fun uu____5789  ->
-                                      match uu____5789 with
-                                      | (t1,uu____5796) ->
-                                          (match t1.FStar_Syntax_Syntax.n
-                                           with
-                                           | FStar_Syntax_Syntax.Tm_app
-                                               (uu____5803,(arg,uu____5805)::[])
-                                               ->
-                                               FStar_Syntax_Syntax.DECREASES
-                                                 arg
-                                           | uu____5827 -> failwith "impos"))) in
-                            let no_additional_args =
-                              let is_empty l =
-                                match l with
-                                | [] -> true
-                                | uu____5839 -> false in
-                              (((is_empty decreases_clause) &&
-                                  (is_empty rest2))
-                                 && (is_empty cattributes))
-                                && (is_empty universes1) in
-                            if
-                              no_additional_args &&
-                                (FStar_Ident.lid_equals eff
-                                   FStar_Syntax_Const.effect_Tot_lid)
-                            then FStar_Syntax_Syntax.mk_Total result_typ
-                            else
-                              if
-                                no_additional_args &&
-                                  (FStar_Ident.lid_equals eff
-                                     FStar_Syntax_Const.effect_GTot_lid)
-                              then FStar_Syntax_Syntax.mk_GTotal result_typ
-                              else
-                                (let flags =
-                                   if
-                                     FStar_Ident.lid_equals eff
-                                       FStar_Syntax_Const.effect_Lemma_lid
-                                   then [FStar_Syntax_Syntax.LEMMA]
-                                   else
-                                     if
-                                       FStar_Ident.lid_equals eff
-                                         FStar_Syntax_Const.effect_Tot_lid
-                                     then [FStar_Syntax_Syntax.TOTAL]
-                                     else
-                                       if
-                                         FStar_Ident.lid_equals eff
-                                           FStar_Syntax_Const.effect_ML_lid
-                                       then [FStar_Syntax_Syntax.MLEFFECT]
-                                       else
-                                         if
-                                           FStar_Ident.lid_equals eff
-                                             FStar_Syntax_Const.effect_GTot_lid
-                                         then
-                                           [FStar_Syntax_Syntax.SOMETRIVIAL]
-                                         else [] in
-                                 let flags1 =
-                                   FStar_List.append flags cattributes in
-                                 let rest3 =
-                                   if
-                                     FStar_Ident.lid_equals eff
-                                       FStar_Syntax_Const.effect_Lemma_lid
-                                   then
-                                     match rest2 with
-                                     | req::ens::(pat,aq)::[] ->
-                                         let pat1 =
-                                           match pat.FStar_Syntax_Syntax.n
-                                           with
-                                           | FStar_Syntax_Syntax.Tm_fvar fv
-                                               when
-                                               FStar_Syntax_Syntax.fv_eq_lid
-                                                 fv
-                                                 FStar_Syntax_Const.nil_lid
-                                               ->
-                                               let nil =
-                                                 FStar_Syntax_Syntax.mk_Tm_uinst
-                                                   pat
-                                                   [FStar_Syntax_Syntax.U_succ
-                                                      FStar_Syntax_Syntax.U_zero] in
-                                               let pattern =
-                                                 let uu____5931 =
-                                                   FStar_Syntax_Syntax.fvar
-                                                     (FStar_Ident.set_lid_range
-                                                        FStar_Syntax_Const.pattern_lid
-                                                        pat.FStar_Syntax_Syntax.pos)
-                                                     FStar_Syntax_Syntax.Delta_constant
-                                                     None in
-                                                 FStar_Syntax_Syntax.mk_Tm_uinst
-                                                   uu____5931
-                                                   [FStar_Syntax_Syntax.U_zero] in
-                                               (FStar_Syntax_Syntax.mk_Tm_app
-                                                  nil
-                                                  [(pattern,
-                                                     (Some
-                                                        FStar_Syntax_Syntax.imp_tag))])
-                                                 None
-                                                 pat.FStar_Syntax_Syntax.pos
-                                           | uu____5943 -> pat in
-                                         let uu____5944 =
-                                           let uu____5951 =
-                                             let uu____5958 =
-                                               let uu____5964 =
-                                                 (FStar_Syntax_Syntax.mk
-                                                    (FStar_Syntax_Syntax.Tm_meta
-                                                       (pat1,
-                                                         (FStar_Syntax_Syntax.Meta_desugared
-                                                            FStar_Syntax_Syntax.Meta_smt_pat))))
-                                                   None
-                                                   pat1.FStar_Syntax_Syntax.pos in
-                                               (uu____5964, aq) in
-                                             [uu____5958] in
-                                           ens :: uu____5951 in
-                                         req :: uu____5944
-                                     | uu____6000 -> rest2
-                                   else rest2 in
-                                 FStar_Syntax_Syntax.mk_Comp
-                                   {
-                                     FStar_Syntax_Syntax.comp_univs =
-                                       universes1;
-                                     FStar_Syntax_Syntax.effect_name = eff;
-                                     FStar_Syntax_Syntax.result_typ =
-                                       result_typ;
-                                     FStar_Syntax_Syntax.effect_args = rest3;
-                                     FStar_Syntax_Syntax.flags =
-                                       (FStar_List.append flags1
-                                          decreases_clause)
-                                   })))))
-and desugar_formula:
-  env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term =
-  fun env  ->
-    fun f  ->
-      let connective s =
-        match s with
-        | "/\\" -> Some FStar_Syntax_Const.and_lid
-        | "\\/" -> Some FStar_Syntax_Const.or_lid
-        | "==>" -> Some FStar_Syntax_Const.imp_lid
-        | "<==>" -> Some FStar_Syntax_Const.iff_lid
-        | "~" -> Some FStar_Syntax_Const.not_lid
-        | uu____6016 -> None in
-      let mk1 t = (FStar_Syntax_Syntax.mk t) None f.FStar_Parser_AST.range in
-      let pos t = t None f.FStar_Parser_AST.range in
-      let setpos t =
-        let uu___221_6057 = t in
-        {
-          FStar_Syntax_Syntax.n = (uu___221_6057.FStar_Syntax_Syntax.n);
-          FStar_Syntax_Syntax.tk = (uu___221_6057.FStar_Syntax_Syntax.tk);
-          FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
-          FStar_Syntax_Syntax.vars = (uu___221_6057.FStar_Syntax_Syntax.vars)
-        } in
-      let desugar_quant q b pats body =
-        let tk =
-          desugar_binder env
-            (let uu___222_6087 = b in
-             {
-               FStar_Parser_AST.b = (uu___222_6087.FStar_Parser_AST.b);
-               FStar_Parser_AST.brange =
-                 (uu___222_6087.FStar_Parser_AST.brange);
-               FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
-               FStar_Parser_AST.aqual =
-                 (uu___222_6087.FStar_Parser_AST.aqual)
-             }) in
-        let desugar_pats env1 pats1 =
-          FStar_List.map
-            (fun es  ->
-               FStar_All.pipe_right es
-                 (FStar_List.map
-                    (fun e  ->
-                       let uu____6120 = desugar_term env1 e in
-                       FStar_All.pipe_left
-                         (arg_withimp_t FStar_Parser_AST.Nothing) uu____6120)))
-            pats1 in
-        match tk with
-        | (Some a,k) ->
-            let uu____6129 = FStar_ToSyntax_Env.push_bv env a in
-            (match uu____6129 with
-             | (env1,a1) ->
-                 let a2 =
-                   let uu___223_6137 = a1 in
-                   {
-                     FStar_Syntax_Syntax.ppname =
-                       (uu___223_6137.FStar_Syntax_Syntax.ppname);
-                     FStar_Syntax_Syntax.index =
-                       (uu___223_6137.FStar_Syntax_Syntax.index);
-                     FStar_Syntax_Syntax.sort = k
-                   } in
-                 let pats1 = desugar_pats env1 pats in
-                 let body1 = desugar_formula env1 body in
-                 let body2 =
-                   match pats1 with
-                   | [] -> body1
-                   | uu____6150 ->
-                       mk1
-                         (FStar_Syntax_Syntax.Tm_meta
-                            (body1, (FStar_Syntax_Syntax.Meta_pattern pats1))) in
-                 let body3 =
-                   let uu____6159 =
-                     let uu____6162 =
-                       let uu____6166 = FStar_Syntax_Syntax.mk_binder a2 in
-                       [uu____6166] in
-                     no_annot_abs uu____6162 body2 in
-                   FStar_All.pipe_left setpos uu____6159 in
-                 let uu____6171 =
-                   let uu____6172 =
-                     let uu____6182 =
-                       FStar_Syntax_Syntax.fvar
-                         (FStar_Ident.set_lid_range q
-                            b.FStar_Parser_AST.brange)
-                         (FStar_Syntax_Syntax.Delta_defined_at_level
-                            (Prims.parse_int "1")) None in
-                     let uu____6183 =
-                       let uu____6185 = FStar_Syntax_Syntax.as_arg body3 in
-                       [uu____6185] in
-                     (uu____6182, uu____6183) in
-                   FStar_Syntax_Syntax.Tm_app uu____6172 in
-                 FStar_All.pipe_left mk1 uu____6171)
-        | uu____6189 -> failwith "impossible" in
-      let push_quant q binders pats body =
-        match binders with
-        | b::b'::_rest ->
-            let rest = b' :: _rest in
-            let body1 =
-              let uu____6238 = q (rest, pats, body) in
-              let uu____6242 =
-                FStar_Range.union_ranges b'.FStar_Parser_AST.brange
-                  body.FStar_Parser_AST.range in
-              FStar_Parser_AST.mk_term uu____6238 uu____6242
-                FStar_Parser_AST.Formula in
-            let uu____6243 = q ([b], [], body1) in
-            FStar_Parser_AST.mk_term uu____6243 f.FStar_Parser_AST.range
-              FStar_Parser_AST.Formula
-        | uu____6248 -> failwith "impossible" in
-      let uu____6250 =
-        let uu____6251 = unparen f in uu____6251.FStar_Parser_AST.tm in
-      match uu____6250 with
-      | FStar_Parser_AST.Labeled (f1,l,p) ->
-          let f2 = desugar_formula env f1 in
-          FStar_All.pipe_left mk1
-            (FStar_Syntax_Syntax.Tm_meta
-               (f2,
-                 (FStar_Syntax_Syntax.Meta_labeled
-                    (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([],_,_)|FStar_Parser_AST.QExists ([],_,_)
-          -> failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QForall (_1::_2::_3,pats,body) ->
-          let binders = _1 :: _2 :: _3 in
-          let uu____6281 =
-            push_quant (fun x  -> FStar_Parser_AST.QForall x) binders pats
-              body in
-          desugar_formula env uu____6281
-      | FStar_Parser_AST.QExists (_1::_2::_3,pats,body) ->
-          let binders = _1 :: _2 :: _3 in
-          let uu____6302 =
-            push_quant (fun x  -> FStar_Parser_AST.QExists x) binders pats
-              body in
-          desugar_formula env uu____6302
-      | FStar_Parser_AST.QForall (b::[],pats,body) ->
-          desugar_quant FStar_Syntax_Const.forall_lid b pats body
-      | FStar_Parser_AST.QExists (b::[],pats,body) ->
-          desugar_quant FStar_Syntax_Const.exists_lid b pats body
-      | FStar_Parser_AST.Paren f1 -> desugar_formula env f1
-      | uu____6327 -> desugar_term env f
-and typars_of_binders:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.binder Prims.list ->
-      (FStar_ToSyntax_Env.env* (FStar_Syntax_Syntax.bv*
-        FStar_Syntax_Syntax.arg_qualifier Prims.option) Prims.list)
-  =
-  fun env  ->
-    fun bs  ->
-      let uu____6331 =
-        FStar_List.fold_left
-          (fun uu____6344  ->
-             fun b  ->
-               match uu____6344 with
-               | (env1,out) ->
-                   let tk =
-                     desugar_binder env1
-                       (let uu___224_6372 = b in
-                        {
-                          FStar_Parser_AST.b =
-                            (uu___224_6372.FStar_Parser_AST.b);
-                          FStar_Parser_AST.brange =
-                            (uu___224_6372.FStar_Parser_AST.brange);
-                          FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
-                          FStar_Parser_AST.aqual =
-                            (uu___224_6372.FStar_Parser_AST.aqual)
-                        }) in
-                   (match tk with
-                    | (Some a,k) ->
-                        let uu____6382 = FStar_ToSyntax_Env.push_bv env1 a in
-                        (match uu____6382 with
-                         | (env2,a1) ->
-                             let a2 =
-                               let uu___225_6394 = a1 in
-                               {
-                                 FStar_Syntax_Syntax.ppname =
-                                   (uu___225_6394.FStar_Syntax_Syntax.ppname);
-                                 FStar_Syntax_Syntax.index =
-                                   (uu___225_6394.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = k
-                               } in
-                             (env2,
-                               ((a2, (trans_aqual b.FStar_Parser_AST.aqual))
-                               :: out)))
-                    | uu____6403 ->
-                        Prims.raise
-                          (FStar_Errors.Error
-                             ("Unexpected binder",
-                               (b.FStar_Parser_AST.brange))))) (env, []) bs in
-      match uu____6331 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
-and desugar_binder:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.binder ->
-      (FStar_Ident.ident Prims.option* FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun b  ->
-      match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.TAnnotated (x,t)|FStar_Parser_AST.Annotated (x,t) ->
-          let uu____6453 = desugar_typ env t in ((Some x), uu____6453)
-      | FStar_Parser_AST.TVariable x ->
-          let uu____6456 =
-            (FStar_Syntax_Syntax.mk
-               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown))
-              None x.FStar_Ident.idRange in
-          ((Some x), uu____6456)
-      | FStar_Parser_AST.NoName t ->
-          let uu____6471 = desugar_typ env t in (None, uu____6471)
-      | FStar_Parser_AST.Variable x -> ((Some x), FStar_Syntax_Syntax.tun)
-let mk_data_discriminators quals env t tps k datas =
-  let quals1 =
-    FStar_All.pipe_right quals
-      (FStar_List.filter
-         (fun uu___199_6520  ->
-            match uu___199_6520 with
-            | FStar_Syntax_Syntax.Abstract |FStar_Syntax_Syntax.Private  ->
-                true
-            | uu____6521 -> false)) in
-  let quals2 q =
-    let uu____6529 =
-      (FStar_All.pipe_left Prims.op_Negation env.FStar_ToSyntax_Env.iface) ||
-        env.FStar_ToSyntax_Env.admitted_iface in
-    if uu____6529
-    then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
-    else FStar_List.append q quals1 in
-  FStar_All.pipe_right datas
-    (FStar_List.map
-       (fun d  ->
-          let disc_name = FStar_Syntax_Util.mk_discriminator d in
-          let uu____6536 =
-            let uu____6543 =
-              quals2
-                [FStar_Syntax_Syntax.OnlyName;
-                FStar_Syntax_Syntax.Discriminator d] in
-            (disc_name, [], FStar_Syntax_Syntax.tun, uu____6543,
-              (FStar_Ident.range_of_lid disc_name)) in
-          FStar_Syntax_Syntax.Sig_declare_typ uu____6536))
-let mk_indexed_projector_names:
-  FStar_Syntax_Syntax.qualifier Prims.list ->
-    FStar_Syntax_Syntax.fv_qual ->
-      FStar_ToSyntax_Env.env ->
-        FStar_Ident.lid ->
-          FStar_Syntax_Syntax.binder Prims.list ->
-            FStar_Syntax_Syntax.sigelt Prims.list
-  =
-  fun iquals  ->
-    fun fvq  ->
-      fun env  ->
-        fun lid  ->
-          fun fields  ->
-            let p = FStar_Ident.range_of_lid lid in
-            let uu____6568 =
-              FStar_All.pipe_right fields
-                (FStar_List.mapi
-                   (fun i  ->
-                      fun uu____6578  ->
-                        match uu____6578 with
-                        | (x,uu____6583) ->
-                            let uu____6584 =
-                              FStar_Syntax_Util.mk_field_projector_name lid x
-                                i in
-                            (match uu____6584 with
-                             | (field_name,uu____6589) ->
-                                 let only_decl =
-                                   ((let uu____6591 =
-                                       FStar_ToSyntax_Env.current_module env in
-                                     FStar_Ident.lid_equals
-                                       FStar_Syntax_Const.prims_lid
-                                       uu____6591)
-                                      ||
-                                      (fvq <> FStar_Syntax_Syntax.Data_ctor))
-                                     ||
-                                     (let uu____6592 =
-                                        let uu____6593 =
-                                          FStar_ToSyntax_Env.current_module
-                                            env in
-                                        uu____6593.FStar_Ident.str in
-                                      FStar_Options.dont_gen_projectors
-                                        uu____6592) in
-                                 let no_decl =
-                                   FStar_Syntax_Syntax.is_type
-                                     x.FStar_Syntax_Syntax.sort in
-                                 let quals q =
-                                   if only_decl
-                                   then
-                                     let uu____6603 =
-                                       FStar_List.filter
-                                         (fun uu___200_6605  ->
-                                            match uu___200_6605 with
-                                            | FStar_Syntax_Syntax.Abstract 
-                                                -> false
-                                            | uu____6606 -> true) q in
-                                     FStar_Syntax_Syntax.Assumption ::
-                                       uu____6603
-                                   else q in
-                                 let quals1 =
-                                   let iquals1 =
-                                     FStar_All.pipe_right iquals
-                                       (FStar_List.filter
-                                          (fun uu___201_6614  ->
-                                             match uu___201_6614 with
-                                             | FStar_Syntax_Syntax.Abstract 
-                                               |FStar_Syntax_Syntax.Private 
-                                                 -> true
-                                             | uu____6615 -> false)) in
-                                   quals (FStar_Syntax_Syntax.OnlyName ::
-                                     (FStar_Syntax_Syntax.Projector
-                                        (lid, (x.FStar_Syntax_Syntax.ppname)))
-                                     :: iquals1) in
-                                 let decl =
-                                   FStar_Syntax_Syntax.Sig_declare_typ
-                                     (field_name, [],
-                                       FStar_Syntax_Syntax.tun, quals1,
-                                       (FStar_Ident.range_of_lid field_name)) in
-                                 if only_decl
-                                 then [decl]
-                                 else
-                                   (let dd =
-                                      let uu____6622 =
-                                        FStar_All.pipe_right quals1
-                                          (FStar_List.contains
-                                             FStar_Syntax_Syntax.Abstract) in
-                                      if uu____6622
-                                      then
-                                        FStar_Syntax_Syntax.Delta_abstract
-                                          FStar_Syntax_Syntax.Delta_equational
-                                      else
-                                        FStar_Syntax_Syntax.Delta_equational in
-                                    let lb =
-                                      let uu____6626 =
-                                        let uu____6629 =
-                                          FStar_Syntax_Syntax.lid_as_fv
-                                            field_name dd None in
-                                        FStar_Util.Inr uu____6629 in
-                                      {
-                                        FStar_Syntax_Syntax.lbname =
-                                          uu____6626;
-                                        FStar_Syntax_Syntax.lbunivs = [];
-                                        FStar_Syntax_Syntax.lbtyp =
-                                          FStar_Syntax_Syntax.tun;
-                                        FStar_Syntax_Syntax.lbeff =
-                                          FStar_Syntax_Const.effect_Tot_lid;
-                                        FStar_Syntax_Syntax.lbdef =
-                                          FStar_Syntax_Syntax.tun
-                                      } in
-                                    let impl =
-                                      let uu____6631 =
-                                        let uu____6640 =
-                                          let uu____6642 =
-                                            let uu____6643 =
-                                              FStar_All.pipe_right
-                                                lb.FStar_Syntax_Syntax.lbname
-                                                FStar_Util.right in
-                                            FStar_All.pipe_right uu____6643
-                                              (fun fv  ->
-                                                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                          [uu____6642] in
-                                        ((false, [lb]), p, uu____6640,
-                                          quals1, []) in
-                                      FStar_Syntax_Syntax.Sig_let uu____6631 in
-                                    if no_decl then [impl] else [decl; impl])))) in
-            FStar_All.pipe_right uu____6568 FStar_List.flatten
-let mk_data_projector_names iquals env uu____6683 =
-  match uu____6683 with
-  | (inductive_tps,se) ->
-      (match se with
-       | FStar_Syntax_Syntax.Sig_datacon
-           (lid,uu____6691,t,uu____6693,n1,quals,uu____6696,uu____6697) when
-           Prims.op_Negation
-             (FStar_Ident.lid_equals lid FStar_Syntax_Const.lexcons_lid)
-           ->
-           let uu____6702 = FStar_Syntax_Util.arrow_formals t in
-           (match uu____6702 with
-            | (formals,uu____6712) ->
-                (match formals with
-                 | [] -> []
-                 | uu____6726 ->
-                     let filter_records uu___202_6734 =
-                       match uu___202_6734 with
-                       | FStar_Syntax_Syntax.RecordConstructor
-                           (uu____6736,fns) ->
-                           Some (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                       | uu____6743 -> None in
-                     let fv_qual =
-                       let uu____6745 =
-                         FStar_Util.find_map quals filter_records in
-                       match uu____6745 with
-                       | None  -> FStar_Syntax_Syntax.Data_ctor
-                       | Some q -> q in
-                     let iquals1 =
-                       if
-                         FStar_List.contains FStar_Syntax_Syntax.Abstract
-                           iquals
-                       then FStar_Syntax_Syntax.Private :: iquals
-                       else iquals in
-                     let uu____6752 = FStar_Util.first_N n1 formals in
-                     (match uu____6752 with
-                      | (uu____6764,rest) ->
-                          mk_indexed_projector_names iquals1 fv_qual env lid
-                            rest)))
-       | uu____6778 -> [])
-let mk_typ_abbrev:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.univ_name Prims.list ->
-      (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-        FStar_Syntax_Syntax.typ ->
-          FStar_Syntax_Syntax.term ->
-            FStar_Ident.lident Prims.list ->
-              FStar_Syntax_Syntax.qualifier Prims.list ->
-                FStar_Range.range -> FStar_Syntax_Syntax.sigelt
-  =
-  fun lid  ->
-    fun uvs  ->
-      fun typars  ->
-        fun k  ->
-          fun t  ->
-            fun lids  ->
-              fun quals  ->
-                fun rng  ->
-                  let dd =
-                    let uu____6816 =
-                      FStar_All.pipe_right quals
-                        (FStar_List.contains FStar_Syntax_Syntax.Abstract) in
-                    if uu____6816
-                    then
-                      let uu____6818 =
-                        FStar_Syntax_Util.incr_delta_qualifier t in
-                      FStar_Syntax_Syntax.Delta_abstract uu____6818
-                    else FStar_Syntax_Util.incr_delta_qualifier t in
-                  let lb =
-                    let uu____6821 =
-                      let uu____6824 =
-                        FStar_Syntax_Syntax.lid_as_fv lid dd None in
-                      FStar_Util.Inr uu____6824 in
-                    let uu____6825 =
-                      let uu____6828 = FStar_Syntax_Syntax.mk_Total k in
-                      FStar_Syntax_Util.arrow typars uu____6828 in
-                    let uu____6831 = no_annot_abs typars t in
-                    {
-                      FStar_Syntax_Syntax.lbname = uu____6821;
-                      FStar_Syntax_Syntax.lbunivs = uvs;
-                      FStar_Syntax_Syntax.lbtyp = uu____6825;
-                      FStar_Syntax_Syntax.lbeff =
-                        FStar_Syntax_Const.effect_Tot_lid;
-                      FStar_Syntax_Syntax.lbdef = uu____6831
-                    } in
-                  FStar_Syntax_Syntax.Sig_let
-                    ((false, [lb]), rng, lids, quals, [])
-let rec desugar_tycon:
-  FStar_ToSyntax_Env.env ->
-    FStar_Range.range ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Parser_AST.tycon Prims.list ->
-          (env_t* FStar_Syntax_Syntax.sigelts)
-  =
-  fun env  ->
-    fun rng  ->
-      fun quals  ->
-        fun tcs  ->
-          let tycon_id uu___203_6864 =
-            match uu___203_6864 with
-            | FStar_Parser_AST.TyconAbstract (id,_,_)
-              |FStar_Parser_AST.TyconAbbrev (id,_,_,_)
-               |FStar_Parser_AST.TyconRecord (id,_,_,_)
-                |FStar_Parser_AST.TyconVariant (id,_,_,_) -> id in
-          let binder_to_term b =
-            match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x,_)|FStar_Parser_AST.Variable x ->
-                let uu____6903 =
-                  let uu____6904 = FStar_Ident.lid_of_ids [x] in
-                  FStar_Parser_AST.Var uu____6904 in
-                FStar_Parser_AST.mk_term uu____6903 x.FStar_Ident.idRange
-                  FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a,_)|FStar_Parser_AST.TVariable a
-                ->
-                FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  a.FStar_Ident.idRange FStar_Parser_AST.Type_level
-            | FStar_Parser_AST.NoName t -> t in
-          let tot =
-            FStar_Parser_AST.mk_term
-              (FStar_Parser_AST.Name FStar_Syntax_Const.effect_Tot_lid) rng
-              FStar_Parser_AST.Expr in
-          let with_constructor_effect t =
-            FStar_Parser_AST.mk_term
-              (FStar_Parser_AST.App (tot, t, FStar_Parser_AST.Nothing))
-              t.FStar_Parser_AST.range t.FStar_Parser_AST.level in
-          let apply_binders t binders =
-            let imp_of_aqual b =
-              match b.FStar_Parser_AST.aqual with
-              | Some (FStar_Parser_AST.Implicit ) -> FStar_Parser_AST.Hash
-              | uu____6926 -> FStar_Parser_AST.Nothing in
-            FStar_List.fold_left
-              (fun out  ->
-                 fun b  ->
-                   let uu____6929 =
-                     let uu____6930 =
-                       let uu____6934 = binder_to_term b in
-                       (out, uu____6934, (imp_of_aqual b)) in
-                     FStar_Parser_AST.App uu____6930 in
-                   FStar_Parser_AST.mk_term uu____6929
-                     out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
-              binders in
-          let tycon_record_as_variant uu___204_6941 =
-            match uu___204_6941 with
-            | FStar_Parser_AST.TyconRecord (id,parms,kopt,fields) ->
-                let constrName =
-                  FStar_Ident.mk_ident
-                    ((Prims.strcat "Mk" id.FStar_Ident.idText),
-                      (id.FStar_Ident.idRange)) in
-                let mfields =
-                  FStar_List.map
-                    (fun uu____6970  ->
-                       match uu____6970 with
-                       | (x,t,uu____6977) ->
-                           FStar_Parser_AST.mk_binder
-                             (FStar_Parser_AST.Annotated
-                                ((FStar_Syntax_Util.mangle_field_name x), t))
-                             x.FStar_Ident.idRange FStar_Parser_AST.Expr None)
-                    fields in
-                let result =
-                  let uu____6981 =
-                    let uu____6982 =
-                      let uu____6983 = FStar_Ident.lid_of_ids [id] in
-                      FStar_Parser_AST.Var uu____6983 in
-                    FStar_Parser_AST.mk_term uu____6982
-                      id.FStar_Ident.idRange FStar_Parser_AST.Type_level in
-                  apply_binders uu____6981 parms in
-                let constrTyp =
-                  FStar_Parser_AST.mk_term
-                    (FStar_Parser_AST.Product
-                       (mfields, (with_constructor_effect result)))
-                    id.FStar_Ident.idRange FStar_Parser_AST.Type_level in
-                let uu____6986 =
-                  FStar_All.pipe_right fields
-                    (FStar_List.map
-                       (fun uu____6998  ->
-                          match uu____6998 with
-                          | (x,uu____7004,uu____7005) ->
-                              FStar_Syntax_Util.unmangle_field_name x)) in
-                ((FStar_Parser_AST.TyconVariant
-                    (id, parms, kopt,
-                      [(constrName, (Some constrTyp), None, false)])),
-                  uu____6986)
-            | uu____7032 -> failwith "impossible" in
-          let desugar_abstract_tc quals1 _env mutuals uu___205_7054 =
-            match uu___205_7054 with
-            | FStar_Parser_AST.TyconAbstract (id,binders,kopt) ->
-                let uu____7068 = typars_of_binders _env binders in
-                (match uu____7068 with
-                 | (_env',typars) ->
-                     let k =
-                       match kopt with
-                       | None  -> FStar_Syntax_Util.ktype
-                       | Some k -> desugar_term _env' k in
-                     let tconstr =
-                       let uu____7096 =
-                         let uu____7097 =
-                           let uu____7098 = FStar_Ident.lid_of_ids [id] in
-                           FStar_Parser_AST.Var uu____7098 in
-                         FStar_Parser_AST.mk_term uu____7097
-                           id.FStar_Ident.idRange FStar_Parser_AST.Type_level in
-                       apply_binders uu____7096 binders in
-                     let qlid = FStar_ToSyntax_Env.qualify _env id in
-                     let typars1 = FStar_Syntax_Subst.close_binders typars in
-                     let k1 = FStar_Syntax_Subst.close typars1 k in
-                     let se =
-                       FStar_Syntax_Syntax.Sig_inductive_typ
-                         (qlid, [], typars1, k1, mutuals, [], quals1, rng) in
-                     let _env1 =
-                       FStar_ToSyntax_Env.push_top_level_rec_binding _env id
-                         FStar_Syntax_Syntax.Delta_constant in
-                     let _env2 =
-                       FStar_ToSyntax_Env.push_top_level_rec_binding _env' id
-                         FStar_Syntax_Syntax.Delta_constant in
-                     (_env1, _env2, se, tconstr))
-            | uu____7109 -> failwith "Unexpected tycon" in
-          let push_tparams env1 bs =
-            let uu____7135 =
-              FStar_List.fold_left
-                (fun uu____7151  ->
-                   fun uu____7152  ->
-                     match (uu____7151, uu____7152) with
-                     | ((env2,tps),(x,imp)) ->
-                         let uu____7200 =
-                           FStar_ToSyntax_Env.push_bv env2
-                             x.FStar_Syntax_Syntax.ppname in
-                         (match uu____7200 with
-                          | (env3,y) -> (env3, ((y, imp) :: tps))))
-                (env1, []) bs in
-            match uu____7135 with
-            | (env2,bs1) -> (env2, (FStar_List.rev bs1)) in
-          match tcs with
-          | (FStar_Parser_AST.TyconAbstract (id,bs,kopt))::[] ->
-              let kopt1 =
-                match kopt with
-                | None  ->
-                    let uu____7261 = tm_type_z id.FStar_Ident.idRange in
-                    Some uu____7261
-                | uu____7262 -> kopt in
-              let tc = FStar_Parser_AST.TyconAbstract (id, bs, kopt1) in
-              let uu____7267 = desugar_abstract_tc quals env [] tc in
-              (match uu____7267 with
-               | (uu____7274,uu____7275,se,uu____7277) ->
-                   let se1 =
-                     match se with
-                     | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,uu____7280,typars,k,[],[],quals1,rng1) ->
-                         let quals2 =
-                           let uu____7291 =
-                             FStar_All.pipe_right quals1
-                               (FStar_List.contains
-                                  FStar_Syntax_Syntax.Assumption) in
-                           if uu____7291
-                           then quals1
-                           else
-                             ((let uu____7296 =
-                                 FStar_Range.string_of_range rng1 in
-                               let uu____7297 =
-                                 FStar_Syntax_Print.lid_to_string l in
-                               FStar_Util.print2
-                                 "%s (Warning): Adding an implicit 'assume new' qualifier on %s\n"
-                                 uu____7296 uu____7297);
-                              FStar_Syntax_Syntax.Assumption
-                              ::
-                              FStar_Syntax_Syntax.New
-                              ::
-                              quals1) in
-                         let t =
-                           match typars with
-                           | [] -> k
-                           | uu____7301 ->
-                               let uu____7302 =
-                                 let uu____7305 =
-                                   let uu____7306 =
-                                     let uu____7314 =
-                                       FStar_Syntax_Syntax.mk_Total k in
-                                     (typars, uu____7314) in
-                                   FStar_Syntax_Syntax.Tm_arrow uu____7306 in
-                                 FStar_Syntax_Syntax.mk uu____7305 in
-                               uu____7302 None rng1 in
-                         FStar_Syntax_Syntax.Sig_declare_typ
-                           (l, [], t, quals2, rng1)
-                     | uu____7325 -> se in
-                   let env1 = FStar_ToSyntax_Env.push_sigelt env se1 in
-                   (env1, [se1]))
-          | (FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t))::[] ->
-              let uu____7336 = typars_of_binders env binders in
-              (match uu____7336 with
-               | (env',typars) ->
-                   let k =
-                     match kopt with
-                     | None  ->
-                         let uu____7356 =
-                           FStar_Util.for_some
-                             (fun uu___206_7357  ->
-                                match uu___206_7357 with
-                                | FStar_Syntax_Syntax.Effect  -> true
-                                | uu____7358 -> false) quals in
-                         if uu____7356
-                         then FStar_Syntax_Syntax.teff
-                         else FStar_Syntax_Syntax.tun
-                     | Some k -> desugar_term env' k in
-                   let t0 = t in
-                   let quals1 =
-                     let uu____7364 =
-                       FStar_All.pipe_right quals
-                         (FStar_Util.for_some
-                            (fun uu___207_7366  ->
-                               match uu___207_7366 with
-                               | FStar_Syntax_Syntax.Logic  -> true
-                               | uu____7367 -> false)) in
-                     if uu____7364
-                     then quals
-                     else
-                       if
-                         t0.FStar_Parser_AST.level = FStar_Parser_AST.Formula
-                       then FStar_Syntax_Syntax.Logic :: quals
-                       else quals in
-                   let se =
-                     let uu____7373 =
-                       FStar_All.pipe_right quals1
-                         (FStar_List.contains FStar_Syntax_Syntax.Effect) in
-                     if uu____7373
-                     then
-                       let uu____7375 =
-                         let uu____7379 =
-                           let uu____7380 = unparen t in
-                           uu____7380.FStar_Parser_AST.tm in
-                         match uu____7379 with
-                         | FStar_Parser_AST.Construct (head1,args) ->
-                             let uu____7392 =
-                               match FStar_List.rev args with
-                               | (last_arg,uu____7408)::args_rev ->
-                                   let uu____7415 =
-                                     let uu____7416 = unparen last_arg in
-                                     uu____7416.FStar_Parser_AST.tm in
-                                   (match uu____7415 with
-                                    | FStar_Parser_AST.Attributes ts ->
-                                        (ts, (FStar_List.rev args_rev))
-                                    | uu____7431 -> ([], args))
-                               | uu____7436 -> ([], args) in
-                             (match uu____7392 with
-                              | (cattributes,args1) ->
-                                  let uu____7457 =
-                                    desugar_attributes env cattributes in
-                                  ((FStar_Parser_AST.mk_term
-                                      (FStar_Parser_AST.Construct
-                                         (head1, args1))
-                                      t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____7457))
-                         | uu____7463 -> (t, []) in
-                       match uu____7375 with
-                       | (t1,cattributes) ->
-                           let c =
-                             desugar_comp t1.FStar_Parser_AST.range env' t1 in
-                           let typars1 =
-                             FStar_Syntax_Subst.close_binders typars in
-                           let c1 = FStar_Syntax_Subst.close_comp typars1 c in
-                           let uu____7474 =
-                             let uu____7484 =
-                               FStar_ToSyntax_Env.qualify env id in
-                             let uu____7485 =
-                               FStar_All.pipe_right quals1
-                                 (FStar_List.filter
-                                    (fun uu___208_7489  ->
-                                       match uu___208_7489 with
-                                       | FStar_Syntax_Syntax.Effect  -> false
-                                       | uu____7490 -> true)) in
-                             (uu____7484, [], typars1, c1, uu____7485,
-                               (FStar_List.append cattributes
-                                  (FStar_Syntax_Util.comp_flags c1)), rng) in
-                           FStar_Syntax_Syntax.Sig_effect_abbrev uu____7474
-                     else
-                       (let t1 = desugar_typ env' t in
-                        let nm = FStar_ToSyntax_Env.qualify env id in
-                        mk_typ_abbrev nm [] typars k t1 [nm] quals1 rng) in
-                   let env1 = FStar_ToSyntax_Env.push_sigelt env se in
-                   (env1, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____7499)::[] ->
-              let trec = FStar_List.hd tcs in
-              let uu____7512 = tycon_record_as_variant trec in
-              (match uu____7512 with
-               | (t,fs) ->
-                   let uu____7522 =
-                     let uu____7524 =
-                       let uu____7525 =
-                         let uu____7530 =
-                           let uu____7532 =
-                             FStar_ToSyntax_Env.current_module env in
-                           FStar_Ident.ids_of_lid uu____7532 in
-                         (uu____7530, fs) in
-                       FStar_Syntax_Syntax.RecordType uu____7525 in
-                     uu____7524 :: quals in
-                   desugar_tycon env rng uu____7522 [t])
-          | uu____7535::uu____7536 ->
-              let env0 = env in
-              let mutuals =
-                FStar_List.map
-                  (fun x  ->
-                     FStar_All.pipe_left (FStar_ToSyntax_Env.qualify env)
-                       (tycon_id x)) tcs in
-              let rec collect_tcs quals1 et tc =
-                let uu____7623 = et in
-                match uu____7623 with
-                | (env1,tcs1) ->
-                    (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____7737 ->
-                         let trec = tc in
-                         let uu____7750 = tycon_record_as_variant trec in
-                         (match uu____7750 with
-                          | (t,fs) ->
-                              let uu____7781 =
-                                let uu____7783 =
-                                  let uu____7784 =
-                                    let uu____7789 =
-                                      let uu____7791 =
-                                        FStar_ToSyntax_Env.current_module
-                                          env1 in
-                                      FStar_Ident.ids_of_lid uu____7791 in
-                                    (uu____7789, fs) in
-                                  FStar_Syntax_Syntax.RecordType uu____7784 in
-                                uu____7783 :: quals1 in
-                              collect_tcs uu____7781 (env1, tcs1) t)
-                     | FStar_Parser_AST.TyconVariant
-                         (id,binders,kopt,constructors) ->
-                         let uu____7837 =
-                           desugar_abstract_tc quals1 env1 mutuals
-                             (FStar_Parser_AST.TyconAbstract
-                                (id, binders, kopt)) in
-                         (match uu____7837 with
-                          | (env2,uu____7868,se,tconstr) ->
-                              (env2,
-                                ((FStar_Util.Inl
-                                    (se, constructors, tconstr, quals1)) ::
-                                tcs1)))
-                     | FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t) ->
-                         let uu____7946 =
-                           desugar_abstract_tc quals1 env1 mutuals
-                             (FStar_Parser_AST.TyconAbstract
-                                (id, binders, kopt)) in
-                         (match uu____7946 with
-                          | (env2,uu____7977,se,tconstr) ->
-                              (env2,
-                                ((FStar_Util.Inr (se, binders, t, quals1)) ::
-                                tcs1)))
-                     | uu____8041 ->
-                         failwith "Unrecognized mutual type definition") in
-              let uu____8065 =
-                FStar_List.fold_left (collect_tcs quals) (env, []) tcs in
-              (match uu____8065 with
-               | (env1,tcs1) ->
-                   let tcs2 = FStar_List.rev tcs1 in
-                   let tps_sigelts =
-                     FStar_All.pipe_right tcs2
-                       (FStar_List.collect
-                          (fun uu___210_8303  ->
-                             match uu___210_8303 with
-                             | FStar_Util.Inr
-                                 (FStar_Syntax_Syntax.Sig_inductive_typ
-                                  (id,uvs,tpars,k,uu____8335,uu____8336,uu____8337,uu____8338),binders,t,quals1)
-                                 ->
-                                 let t1 =
-                                   let uu____8371 =
-                                     typars_of_binders env1 binders in
-                                   match uu____8371 with
-                                   | (env2,tpars1) ->
-                                       let uu____8388 =
-                                         push_tparams env2 tpars1 in
-                                       (match uu____8388 with
-                                        | (env_tps,tpars2) ->
-                                            let t1 = desugar_typ env_tps t in
-                                            let tpars3 =
-                                              FStar_Syntax_Subst.close_binders
-                                                tpars2 in
-                                            FStar_Syntax_Subst.close tpars3
-                                              t1) in
-                                 let uu____8407 =
-                                   let uu____8414 =
-                                     mk_typ_abbrev id uvs tpars k t1 
-                                       [id] quals1 rng in
-                                   ([], uu____8414) in
-                                 [uu____8407]
-                             | FStar_Util.Inl
-                                 (FStar_Syntax_Syntax.Sig_inductive_typ
-                                  (tname,univs,tpars,k,mutuals1,uu____8439,tags,uu____8441),constrs,tconstr,quals1)
-                                 ->
-                                 let mk_tot t =
-                                   let tot1 =
-                                     FStar_Parser_AST.mk_term
-                                       (FStar_Parser_AST.Name
-                                          FStar_Syntax_Const.effect_Tot_lid)
-                                       t.FStar_Parser_AST.range
-                                       t.FStar_Parser_AST.level in
-                                   FStar_Parser_AST.mk_term
-                                     (FStar_Parser_AST.App
-                                        (tot1, t, FStar_Parser_AST.Nothing))
-                                     t.FStar_Parser_AST.range
-                                     t.FStar_Parser_AST.level in
-                                 let tycon = (tname, tpars, k) in
-                                 let uu____8494 = push_tparams env1 tpars in
-                                 (match uu____8494 with
-                                  | (env_tps,tps) ->
-                                      let data_tpars =
-                                        FStar_List.map
-                                          (fun uu____8529  ->
-                                             match uu____8529 with
-                                             | (x,uu____8537) ->
-                                                 (x,
-                                                   (Some
-                                                      (FStar_Syntax_Syntax.Implicit
-                                                         true)))) tps in
-                                      let tot_tconstr = mk_tot tconstr in
-                                      let uu____8542 =
-                                        let uu____8553 =
-                                          FStar_All.pipe_right constrs
-                                            (FStar_List.map
-                                               (fun uu____8593  ->
-                                                  match uu____8593 with
-                                                  | (id,topt,uu____8610,of_notation)
-                                                      ->
-                                                      let t =
-                                                        if of_notation
-                                                        then
-                                                          match topt with
-                                                          | Some t ->
-                                                              FStar_Parser_AST.mk_term
-                                                                (FStar_Parser_AST.Product
-                                                                   ([
-                                                                    FStar_Parser_AST.mk_binder
-                                                                    (FStar_Parser_AST.NoName
-                                                                    t)
-                                                                    t.FStar_Parser_AST.range
-                                                                    t.FStar_Parser_AST.level
-                                                                    None],
-                                                                    tot_tconstr))
-                                                                t.FStar_Parser_AST.range
-                                                                t.FStar_Parser_AST.level
-                                                          | None  -> tconstr
-                                                        else
-                                                          (match topt with
-                                                           | None  ->
-                                                               failwith
-                                                                 "Impossible"
-                                                           | Some t -> t) in
-                                                      let t1 =
-                                                        let uu____8622 =
-                                                          close env_tps t in
-                                                        desugar_term env_tps
-                                                          uu____8622 in
-                                                      let name =
-                                                        FStar_ToSyntax_Env.qualify
-                                                          env1 id in
-                                                      let quals2 =
-                                                        FStar_All.pipe_right
-                                                          tags
-                                                          (FStar_List.collect
-                                                             (fun
-                                                                uu___209_8628
-                                                                 ->
-                                                                match uu___209_8628
-                                                                with
-                                                                | FStar_Syntax_Syntax.RecordType
-                                                                    fns ->
-                                                                    [
-                                                                    FStar_Syntax_Syntax.RecordConstructor
-                                                                    fns]
-                                                                | uu____8635
-                                                                    -> [])) in
-                                                      let ntps =
-                                                        FStar_List.length
-                                                          data_tpars in
-                                                      let uu____8641 =
-                                                        let uu____8648 =
-                                                          let uu____8649 =
-                                                            let uu____8660 =
-                                                              let uu____8663
-                                                                =
-                                                                let uu____8666
-                                                                  =
-                                                                  FStar_All.pipe_right
-                                                                    t1
-                                                                    FStar_Syntax_Util.name_function_binders in
-                                                                FStar_Syntax_Syntax.mk_Total
-                                                                  uu____8666 in
-                                                              FStar_Syntax_Util.arrow
-                                                                data_tpars
-                                                                uu____8663 in
-                                                            (name, univs,
-                                                              uu____8660,
-                                                              tname, ntps,
-                                                              quals2,
-                                                              mutuals1, rng) in
-                                                          FStar_Syntax_Syntax.Sig_datacon
-                                                            uu____8649 in
-                                                        (tps, uu____8648) in
-                                                      (name, uu____8641))) in
-                                        FStar_All.pipe_left FStar_List.split
-                                          uu____8553 in
-                                      (match uu____8542 with
-                                       | (constrNames,constrs1) ->
-                                           ([],
-                                             (FStar_Syntax_Syntax.Sig_inductive_typ
-                                                (tname, univs, tpars, k,
-                                                  mutuals1, constrNames,
-                                                  tags, rng)))
-                                           :: constrs1))
-                             | uu____8751 -> failwith "impossible")) in
-                   let sigelts =
-                     FStar_All.pipe_right tps_sigelts
-                       (FStar_List.map Prims.snd) in
-                   let uu____8799 =
-                     let uu____8803 =
-                       FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
-                         sigelts in
-                     FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____8803 rng in
-                   (match uu____8799 with
-                    | (bundle,abbrevs) ->
-                        let env2 = FStar_ToSyntax_Env.push_sigelt env0 bundle in
-                        let env3 =
-                          FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt
-                            env2 abbrevs in
-                        let data_ops =
-                          FStar_All.pipe_right tps_sigelts
-                            (FStar_List.collect
-                               (mk_data_projector_names quals env3)) in
-                        let discs =
-                          FStar_All.pipe_right sigelts
-                            (FStar_List.collect
-                               (fun uu___211_8837  ->
-                                  match uu___211_8837 with
-                                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,uu____8840,tps,k,uu____8843,constrs,quals1,uu____8846)
-                                      when
-                                      (FStar_List.length constrs) >
-                                        (Prims.parse_int "1")
-                                      ->
-                                      let quals2 =
-                                        if
-                                          FStar_List.contains
-                                            FStar_Syntax_Syntax.Abstract
-                                            quals1
-                                        then FStar_Syntax_Syntax.Private ::
-                                          quals1
-                                        else quals1 in
-                                      mk_data_discriminators quals2 env3
-                                        tname tps k constrs
-                                  | uu____8860 -> [])) in
-                        let ops = FStar_List.append discs data_ops in
-                        let env4 =
-                          FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt
-                            env3 ops in
-                        (env4,
-                          (FStar_List.append [bundle]
-                             (FStar_List.append abbrevs ops)))))
-          | [] -> failwith "impossible"
-let desugar_binders:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.binder Prims.list ->
-      (FStar_ToSyntax_Env.env* FStar_Syntax_Syntax.binder Prims.list)
-  =
-  fun env  ->
-    fun binders  ->
-      let uu____8878 =
-        FStar_List.fold_left
-          (fun uu____8885  ->
-             fun b  ->
-               match uu____8885 with
-               | (env1,binders1) ->
-                   let uu____8897 = desugar_binder env1 b in
-                   (match uu____8897 with
-                    | (Some a,k) ->
-                        let uu____8907 = FStar_ToSyntax_Env.push_bv env1 a in
-                        (match uu____8907 with
-                         | (env2,a1) ->
-                             let uu____8915 =
-                               let uu____8917 =
-                                 FStar_Syntax_Syntax.mk_binder
-                                   (let uu___226_8918 = a1 in
-                                    {
-                                      FStar_Syntax_Syntax.ppname =
-                                        (uu___226_8918.FStar_Syntax_Syntax.ppname);
-                                      FStar_Syntax_Syntax.index =
-                                        (uu___226_8918.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = k
-                                    }) in
-                               uu____8917 :: binders1 in
-                             (env2, uu____8915))
-                    | uu____8920 ->
-                        Prims.raise
-                          (FStar_Errors.Error
-                             ("Missing name in binder",
-                               (b.FStar_Parser_AST.brange))))) (env, [])
-          binders in
-      match uu____8878 with
-      | (env1,binders1) -> (env1, (FStar_List.rev binders1))
-let rec desugar_effect:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.decl ->
-      FStar_Parser_AST.qualifiers ->
-        FStar_Ident.ident ->
-          FStar_Parser_AST.binder Prims.list ->
-            FStar_Parser_AST.term ->
-              FStar_Parser_AST.decl Prims.list ->
-                (FStar_ToSyntax_Env.env* FStar_Syntax_Syntax.sigelt
-                  Prims.list)
-  =
-  fun env  ->
-    fun d  ->
-      fun quals  ->
-        fun eff_name  ->
-          fun eff_binders  ->
-            fun eff_typ  ->
-              fun eff_decls  ->
-                let env0 = env in
-                let monad_env =
-                  FStar_ToSyntax_Env.enter_monad_scope env eff_name in
-                let uu____8998 = desugar_binders monad_env eff_binders in
-                match uu____8998 with
-                | (env1,binders) ->
-                    let eff_t = desugar_term env1 eff_typ in
-                    let for_free =
-                      let uu____9011 =
-                        let uu____9012 =
-                          let uu____9016 =
-                            FStar_Syntax_Util.arrow_formals eff_t in
-                          Prims.fst uu____9016 in
-                        FStar_List.length uu____9012 in
-                      uu____9011 = (Prims.parse_int "1") in
-                    let mandatory_members =
-                      let rr_members = ["repr"; "return"; "bind"] in
-                      if for_free
-                      then rr_members
-                      else
-                        FStar_List.append rr_members
-                          ["return_wp";
-                          "bind_wp";
-                          "if_then_else";
-                          "ite_wp";
-                          "stronger";
-                          "close_wp";
-                          "assert_p";
-                          "assume_p";
-                          "null_wp";
-                          "trivial"] in
-                    let name_of_eff_decl decl =
-                      match decl.FStar_Parser_AST.d with
-                      | FStar_Parser_AST.Tycon
-                          (uu____9044,(FStar_Parser_AST.TyconAbbrev
-                                       (name,uu____9046,uu____9047,uu____9048),uu____9049)::[])
-                          -> FStar_Ident.text_of_id name
-                      | uu____9066 ->
-                          failwith "Malformed effect member declaration." in
-                    let uu____9067 =
-                      FStar_List.partition
-                        (fun decl  ->
-                           let uu____9073 = name_of_eff_decl decl in
-                           FStar_List.mem uu____9073 mandatory_members)
-                        eff_decls in
-                    (match uu____9067 with
-                     | (mandatory_members_decls,actions) ->
-                         let uu____9083 =
-                           FStar_All.pipe_right mandatory_members_decls
-                             (FStar_List.fold_left
-                                (fun uu____9094  ->
-                                   fun decl  ->
-                                     match uu____9094 with
-                                     | (env2,out) ->
-                                         let uu____9106 =
-                                           desugar_decl env2 decl in
-                                         (match uu____9106 with
-                                          | (env3,ses) ->
-                                              let uu____9114 =
-                                                let uu____9116 =
-                                                  FStar_List.hd ses in
-                                                uu____9116 :: out in
-                                              (env3, uu____9114))) (env1, [])) in
-                         (match uu____9083 with
-                          | (env2,decls) ->
-                              let binders1 =
-                                FStar_Syntax_Subst.close_binders binders in
-                              let actions1 =
-                                FStar_All.pipe_right actions
-                                  (FStar_List.map
-                                     (fun d1  ->
-                                        match d1.FStar_Parser_AST.d with
-                                        | FStar_Parser_AST.Tycon
-                                            (uu____9132,(FStar_Parser_AST.TyconAbbrev
-                                                         (name,uu____9134,uu____9135,
-                                                          {
-                                                            FStar_Parser_AST.tm
-                                                              =
-                                                              FStar_Parser_AST.Construct
-                                                              (uu____9136,
-                                                               (def,uu____9138)::
-                                                               (cps_type,uu____9140)::[]);
-                                                            FStar_Parser_AST.range
-                                                              = uu____9141;
-                                                            FStar_Parser_AST.level
-                                                              = uu____9142;_}),uu____9143)::[])
-                                            when Prims.op_Negation for_free
-                                            ->
-                                            let uu____9169 =
-                                              FStar_ToSyntax_Env.qualify env2
-                                                name in
-                                            let uu____9170 =
-                                              let uu____9171 =
-                                                desugar_term env2 def in
-                                              FStar_Syntax_Subst.close
-                                                binders1 uu____9171 in
-                                            let uu____9172 =
-                                              let uu____9173 =
-                                                desugar_typ env2 cps_type in
-                                              FStar_Syntax_Subst.close
-                                                binders1 uu____9173 in
-                                            {
-                                              FStar_Syntax_Syntax.action_name
-                                                = uu____9169;
-                                              FStar_Syntax_Syntax.action_unqualified_name
-                                                = name;
-                                              FStar_Syntax_Syntax.action_univs
-                                                = [];
-                                              FStar_Syntax_Syntax.action_defn
-                                                = uu____9170;
-                                              FStar_Syntax_Syntax.action_typ
-                                                = uu____9172
-                                            }
-                                        | FStar_Parser_AST.Tycon
-                                            (uu____9174,(FStar_Parser_AST.TyconAbbrev
-                                                         (name,uu____9176,uu____9177,defn),uu____9179)::[])
-                                            when for_free ->
-                                            let uu____9196 =
-                                              FStar_ToSyntax_Env.qualify env2
-                                                name in
-                                            let uu____9197 =
-                                              let uu____9198 =
-                                                desugar_term env2 defn in
-                                              FStar_Syntax_Subst.close
-                                                binders1 uu____9198 in
-                                            {
-                                              FStar_Syntax_Syntax.action_name
-                                                = uu____9196;
-                                              FStar_Syntax_Syntax.action_unqualified_name
-                                                = name;
-                                              FStar_Syntax_Syntax.action_univs
-                                                = [];
-                                              FStar_Syntax_Syntax.action_defn
-                                                = uu____9197;
-                                              FStar_Syntax_Syntax.action_typ
-                                                = FStar_Syntax_Syntax.tun
-                                            }
-                                        | uu____9199 ->
-                                            Prims.raise
-                                              (FStar_Errors.Error
-                                                 ("Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).",
-                                                   (d1.FStar_Parser_AST.drange))))) in
-                              let eff_t1 =
-                                FStar_Syntax_Subst.close binders1 eff_t in
-                              let lookup s =
-                                let l =
-                                  FStar_ToSyntax_Env.qualify env2
-                                    (FStar_Ident.mk_ident
-                                       (s, (d.FStar_Parser_AST.drange))) in
-                                let uu____9209 =
-                                  let uu____9210 =
-                                    FStar_ToSyntax_Env.fail_or env2
-                                      (FStar_ToSyntax_Env.try_lookup_definition
-                                         env2) l in
-                                  FStar_All.pipe_left
-                                    (FStar_Syntax_Subst.close binders1)
-                                    uu____9210 in
-                                ([], uu____9209) in
-                              let mname =
-                                FStar_ToSyntax_Env.qualify env0 eff_name in
-                              let qualifiers =
-                                FStar_List.map
-                                  (trans_qual d.FStar_Parser_AST.drange
-                                     (Some mname)) quals in
-                              let se =
-                                if for_free
-                                then
-                                  let dummy_tscheme =
-                                    let uu____9222 =
-                                      FStar_Syntax_Syntax.mk
-                                        FStar_Syntax_Syntax.Tm_unknown None
-                                        FStar_Range.dummyRange in
-                                    ([], uu____9222) in
-                                  let uu____9232 =
-                                    let uu____9235 =
-                                      let uu____9236 =
-                                        let uu____9237 = lookup "repr" in
-                                        Prims.snd uu____9237 in
-                                      let uu____9242 = lookup "return" in
-                                      let uu____9243 = lookup "bind" in
-                                      {
-                                        FStar_Syntax_Syntax.qualifiers =
-                                          qualifiers;
-                                        FStar_Syntax_Syntax.cattributes = [];
-                                        FStar_Syntax_Syntax.mname = mname;
-                                        FStar_Syntax_Syntax.univs = [];
-                                        FStar_Syntax_Syntax.binders =
-                                          binders1;
-                                        FStar_Syntax_Syntax.signature =
-                                          eff_t1;
-                                        FStar_Syntax_Syntax.ret_wp =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.bind_wp =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.if_then_else =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.ite_wp =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.stronger =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.close_wp =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.assert_p =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.assume_p =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.null_wp =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.trivial =
-                                          dummy_tscheme;
-                                        FStar_Syntax_Syntax.repr = uu____9236;
-                                        FStar_Syntax_Syntax.return_repr =
-                                          uu____9242;
-                                        FStar_Syntax_Syntax.bind_repr =
-                                          uu____9243;
-                                        FStar_Syntax_Syntax.actions =
-                                          actions1
-                                      } in
-                                    (uu____9235, (d.FStar_Parser_AST.drange)) in
-                                  FStar_Syntax_Syntax.Sig_new_effect_for_free
-                                    uu____9232
-                                else
-                                  (let rr =
-                                     FStar_Util.for_some
-                                       (fun uu___212_9246  ->
-                                          match uu___212_9246 with
-                                          | FStar_Syntax_Syntax.Reifiable 
-                                            |FStar_Syntax_Syntax.Reflectable
-                                            _ -> true
-                                          | uu____9248 -> false) qualifiers in
-                                   let un_ts = ([], FStar_Syntax_Syntax.tun) in
-                                   let uu____9254 =
-                                     let uu____9257 =
-                                       let uu____9258 = lookup "return_wp" in
-                                       let uu____9259 = lookup "bind_wp" in
-                                       let uu____9260 = lookup "if_then_else" in
-                                       let uu____9261 = lookup "ite_wp" in
-                                       let uu____9262 = lookup "stronger" in
-                                       let uu____9263 = lookup "close_wp" in
-                                       let uu____9264 = lookup "assert_p" in
-                                       let uu____9265 = lookup "assume_p" in
-                                       let uu____9266 = lookup "null_wp" in
-                                       let uu____9267 = lookup "trivial" in
-                                       let uu____9268 =
-                                         if rr
-                                         then
-                                           let uu____9269 = lookup "repr" in
-                                           FStar_All.pipe_left Prims.snd
-                                             uu____9269
-                                         else FStar_Syntax_Syntax.tun in
-                                       let uu____9278 =
-                                         if rr
-                                         then lookup "return"
-                                         else un_ts in
-                                       let uu____9280 =
-                                         if rr then lookup "bind" else un_ts in
-                                       {
-                                         FStar_Syntax_Syntax.qualifiers =
-                                           qualifiers;
-                                         FStar_Syntax_Syntax.cattributes = [];
-                                         FStar_Syntax_Syntax.mname = mname;
-                                         FStar_Syntax_Syntax.univs = [];
-                                         FStar_Syntax_Syntax.binders =
-                                           binders1;
-                                         FStar_Syntax_Syntax.signature =
-                                           eff_t1;
-                                         FStar_Syntax_Syntax.ret_wp =
-                                           uu____9258;
-                                         FStar_Syntax_Syntax.bind_wp =
-                                           uu____9259;
-                                         FStar_Syntax_Syntax.if_then_else =
-                                           uu____9260;
-                                         FStar_Syntax_Syntax.ite_wp =
-                                           uu____9261;
-                                         FStar_Syntax_Syntax.stronger =
-                                           uu____9262;
-                                         FStar_Syntax_Syntax.close_wp =
-                                           uu____9263;
-                                         FStar_Syntax_Syntax.assert_p =
-                                           uu____9264;
-                                         FStar_Syntax_Syntax.assume_p =
-                                           uu____9265;
-                                         FStar_Syntax_Syntax.null_wp =
-                                           uu____9266;
-                                         FStar_Syntax_Syntax.trivial =
-                                           uu____9267;
-                                         FStar_Syntax_Syntax.repr =
-                                           uu____9268;
-                                         FStar_Syntax_Syntax.return_repr =
-                                           uu____9278;
-                                         FStar_Syntax_Syntax.bind_repr =
-                                           uu____9280;
-                                         FStar_Syntax_Syntax.actions =
-                                           actions1
-                                       } in
-                                     (uu____9257,
-                                       (d.FStar_Parser_AST.drange)) in
-                                   FStar_Syntax_Syntax.Sig_new_effect
-                                     uu____9254) in
-                              let env3 =
-                                FStar_ToSyntax_Env.push_sigelt env0 se in
-                              let env4 =
-                                FStar_All.pipe_right actions1
-                                  (FStar_List.fold_left
-                                     (fun env4  ->
-                                        fun a  ->
-                                          let uu____9287 =
-                                            FStar_Syntax_Util.action_as_lb
-                                              mname a in
-                                          FStar_ToSyntax_Env.push_sigelt env4
-                                            uu____9287) env3) in
-                              let env5 =
-                                let uu____9289 =
-                                  FStar_All.pipe_right quals
-                                    (FStar_List.contains
-                                       FStar_Parser_AST.Reflectable) in
-                                if uu____9289
-                                then
-                                  let reflect_lid =
-                                    FStar_All.pipe_right
-                                      (FStar_Ident.id_of_text "reflect")
-                                      (FStar_ToSyntax_Env.qualify monad_env) in
-                                  let refl_decl =
-                                    FStar_Syntax_Syntax.Sig_declare_typ
-                                      (reflect_lid, [],
-                                        FStar_Syntax_Syntax.tun,
-                                        [FStar_Syntax_Syntax.Assumption;
-                                        FStar_Syntax_Syntax.Reflectable mname],
-                                        (d.FStar_Parser_AST.drange)) in
-                                  FStar_ToSyntax_Env.push_sigelt env4
-                                    refl_decl
-                                else env4 in
-                              (env5, [se])))
-and desugar_redefine_effect:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.decl ->
-      (FStar_Ident.lident Prims.option ->
-         FStar_Parser_AST.qualifier -> FStar_Syntax_Syntax.qualifier)
-        ->
-        FStar_Parser_AST.qualifier Prims.list ->
-          FStar_Ident.ident ->
-            FStar_Parser_AST.binder Prims.list ->
-              FStar_Parser_AST.term ->
-                (FStar_ToSyntax_Env.env* FStar_Syntax_Syntax.sigelt
-                  Prims.list)
-  =
-  fun env  ->
-    fun d  ->
-      fun trans_qual1  ->
-        fun quals  ->
-          fun eff_name  ->
-            fun eff_binders  ->
-              fun defn  ->
-                let env0 = env in
-                let env1 = FStar_ToSyntax_Env.enter_monad_scope env eff_name in
-                let uu____9312 = desugar_binders env1 eff_binders in
-                match uu____9312 with
-                | (env2,binders) ->
-                    let uu____9323 =
-                      let uu____9332 = head_and_args defn in
-                      match uu____9332 with
-                      | (head1,args) ->
-                          let ed =
-                            match head1.FStar_Parser_AST.tm with
-                            | FStar_Parser_AST.Name l ->
-                                FStar_ToSyntax_Env.fail_or env2
-                                  (FStar_ToSyntax_Env.try_lookup_effect_defn
-                                     env2) l
-                            | uu____9356 ->
-                                let uu____9357 =
-                                  let uu____9358 =
-                                    let uu____9361 =
-                                      let uu____9362 =
-                                        let uu____9363 =
-                                          FStar_Parser_AST.term_to_string
-                                            head1 in
-                                        Prims.strcat uu____9363 " not found" in
-                                      Prims.strcat "Effect " uu____9362 in
-                                    (uu____9361, (d.FStar_Parser_AST.drange)) in
-                                  FStar_Errors.Error uu____9358 in
-                                Prims.raise uu____9357 in
-                          let uu____9364 =
-                            match FStar_List.rev args with
-                            | (last_arg,uu____9380)::args_rev ->
-                                let uu____9387 =
-                                  let uu____9388 = unparen last_arg in
-                                  uu____9388.FStar_Parser_AST.tm in
-                                (match uu____9387 with
-                                 | FStar_Parser_AST.Attributes ts ->
-                                     (ts, (FStar_List.rev args_rev))
-                                 | uu____9403 -> ([], args))
-                            | uu____9408 -> ([], args) in
-                          (match uu____9364 with
-                           | (cattributes,args1) ->
-                               let uu____9434 = desugar_args env2 args1 in
-                               let uu____9439 =
-                                 desugar_attributes env2 cattributes in
-                               (ed, uu____9434, uu____9439)) in
-                    (match uu____9323 with
-                     | (ed,args,cattributes) ->
-                         let binders1 =
-                           FStar_Syntax_Subst.close_binders binders in
-                         let sub1 uu____9472 =
-                           match uu____9472 with
-                           | (uu____9479,x) ->
-                               let uu____9483 =
-                                 FStar_Syntax_Subst.open_term
-                                   ed.FStar_Syntax_Syntax.binders x in
-                               (match uu____9483 with
-                                | (edb,x1) ->
-                                    (if
-                                       (FStar_List.length args) <>
-                                         (FStar_List.length edb)
-                                     then
-                                       Prims.raise
-                                         (FStar_Errors.Error
-                                            ("Unexpected number of arguments to effect constructor",
-                                              (defn.FStar_Parser_AST.range)))
-                                     else ();
-                                     (let s =
-                                        FStar_Syntax_Util.subst_of_list edb
-                                          args in
-                                      let uu____9503 =
-                                        let uu____9504 =
-                                          FStar_Syntax_Subst.subst s x1 in
-                                        FStar_Syntax_Subst.close binders1
-                                          uu____9504 in
-                                      ([], uu____9503)))) in
-                         let mname = FStar_ToSyntax_Env.qualify env0 eff_name in
-                         let ed1 =
-                           let uu____9508 =
-                             let uu____9510 = trans_qual1 (Some mname) in
-                             FStar_List.map uu____9510 quals in
-                           let uu____9513 =
-                             let uu____9514 =
-                               sub1 ([], (ed.FStar_Syntax_Syntax.signature)) in
-                             Prims.snd uu____9514 in
-                           let uu____9520 =
-                             sub1 ed.FStar_Syntax_Syntax.ret_wp in
-                           let uu____9521 =
-                             sub1 ed.FStar_Syntax_Syntax.bind_wp in
-                           let uu____9522 =
-                             sub1 ed.FStar_Syntax_Syntax.if_then_else in
-                           let uu____9523 =
-                             sub1 ed.FStar_Syntax_Syntax.ite_wp in
-                           let uu____9524 =
-                             sub1 ed.FStar_Syntax_Syntax.stronger in
-                           let uu____9525 =
-                             sub1 ed.FStar_Syntax_Syntax.close_wp in
-                           let uu____9526 =
-                             sub1 ed.FStar_Syntax_Syntax.assert_p in
-                           let uu____9527 =
-                             sub1 ed.FStar_Syntax_Syntax.assume_p in
-                           let uu____9528 =
-                             sub1 ed.FStar_Syntax_Syntax.null_wp in
-                           let uu____9529 =
-                             sub1 ed.FStar_Syntax_Syntax.trivial in
-                           let uu____9530 =
-                             let uu____9531 =
-                               sub1 ([], (ed.FStar_Syntax_Syntax.repr)) in
-                             Prims.snd uu____9531 in
-                           let uu____9537 =
-                             sub1 ed.FStar_Syntax_Syntax.return_repr in
-                           let uu____9538 =
-                             sub1 ed.FStar_Syntax_Syntax.bind_repr in
-                           let uu____9539 =
-                             FStar_List.map
-                               (fun action  ->
-                                  let uu____9542 =
-                                    FStar_ToSyntax_Env.qualify env2
-                                      action.FStar_Syntax_Syntax.action_unqualified_name in
-                                  let uu____9543 =
-                                    let uu____9544 =
-                                      sub1
-                                        ([],
-                                          (action.FStar_Syntax_Syntax.action_defn)) in
-                                    Prims.snd uu____9544 in
-                                  let uu____9550 =
-                                    let uu____9551 =
-                                      sub1
-                                        ([],
-                                          (action.FStar_Syntax_Syntax.action_typ)) in
-                                    Prims.snd uu____9551 in
-                                  {
-                                    FStar_Syntax_Syntax.action_name =
-                                      uu____9542;
-                                    FStar_Syntax_Syntax.action_unqualified_name
-                                      =
-                                      (action.FStar_Syntax_Syntax.action_unqualified_name);
-                                    FStar_Syntax_Syntax.action_univs =
-                                      (action.FStar_Syntax_Syntax.action_univs);
-                                    FStar_Syntax_Syntax.action_defn =
-                                      uu____9543;
-                                    FStar_Syntax_Syntax.action_typ =
-                                      uu____9550
-                                  }) ed.FStar_Syntax_Syntax.actions in
-                           {
-                             FStar_Syntax_Syntax.qualifiers = uu____9508;
-                             FStar_Syntax_Syntax.cattributes = cattributes;
-                             FStar_Syntax_Syntax.mname = mname;
-                             FStar_Syntax_Syntax.univs = [];
-                             FStar_Syntax_Syntax.binders = binders1;
-                             FStar_Syntax_Syntax.signature = uu____9513;
-                             FStar_Syntax_Syntax.ret_wp = uu____9520;
-                             FStar_Syntax_Syntax.bind_wp = uu____9521;
-                             FStar_Syntax_Syntax.if_then_else = uu____9522;
-                             FStar_Syntax_Syntax.ite_wp = uu____9523;
-                             FStar_Syntax_Syntax.stronger = uu____9524;
-                             FStar_Syntax_Syntax.close_wp = uu____9525;
-                             FStar_Syntax_Syntax.assert_p = uu____9526;
-                             FStar_Syntax_Syntax.assume_p = uu____9527;
-                             FStar_Syntax_Syntax.null_wp = uu____9528;
-                             FStar_Syntax_Syntax.trivial = uu____9529;
-                             FStar_Syntax_Syntax.repr = uu____9530;
-                             FStar_Syntax_Syntax.return_repr = uu____9537;
-                             FStar_Syntax_Syntax.bind_repr = uu____9538;
-                             FStar_Syntax_Syntax.actions = uu____9539
-                           } in
-                         let se =
-                           let for_free =
-                             let uu____9559 =
-                               let uu____9560 =
-                                 let uu____9564 =
-                                   FStar_Syntax_Util.arrow_formals
-                                     ed1.FStar_Syntax_Syntax.signature in
-                                 Prims.fst uu____9564 in
-                               FStar_List.length uu____9560 in
-                             uu____9559 = (Prims.parse_int "1") in
-                           if for_free
-                           then
-                             FStar_Syntax_Syntax.Sig_new_effect_for_free
-                               (ed1, (d.FStar_Parser_AST.drange))
-                           else
-                             FStar_Syntax_Syntax.Sig_new_effect
-                               (ed1, (d.FStar_Parser_AST.drange)) in
-                         let monad_env = env2 in
-                         let env3 = FStar_ToSyntax_Env.push_sigelt env0 se in
-                         let env4 =
-                           FStar_All.pipe_right
-                             ed1.FStar_Syntax_Syntax.actions
-                             (FStar_List.fold_left
-                                (fun env4  ->
-                                   fun a  ->
-                                     let uu____9589 =
-                                       FStar_Syntax_Util.action_as_lb mname a in
-                                     FStar_ToSyntax_Env.push_sigelt env4
-                                       uu____9589) env3) in
-                         let env5 =
-                           let uu____9591 =
-                             FStar_All.pipe_right quals
-                               (FStar_List.contains
-                                  FStar_Parser_AST.Reflectable) in
-                           if uu____9591
-                           then
-                             let reflect_lid =
-                               FStar_All.pipe_right
-                                 (FStar_Ident.id_of_text "reflect")
-                                 (FStar_ToSyntax_Env.qualify monad_env) in
-                             let refl_decl =
-                               FStar_Syntax_Syntax.Sig_declare_typ
-                                 (reflect_lid, [], FStar_Syntax_Syntax.tun,
-                                   [FStar_Syntax_Syntax.Assumption;
-                                   FStar_Syntax_Syntax.Reflectable mname],
-                                   (d.FStar_Parser_AST.drange)) in
-                             FStar_ToSyntax_Env.push_sigelt env4 refl_decl
-                           else env4 in
-                         (env5, [se]))
-and desugar_decl:
-  env_t -> FStar_Parser_AST.decl -> (env_t* FStar_Syntax_Syntax.sigelts) =
-  fun env  ->
-    fun d  ->
-      let trans_qual1 = trans_qual d.FStar_Parser_AST.drange in
-      match d.FStar_Parser_AST.d with
-      | FStar_Parser_AST.Pragma p ->
-          let se =
-            FStar_Syntax_Syntax.Sig_pragma
-              ((trans_pragma p), (d.FStar_Parser_AST.drange)) in
-          (if p = FStar_Parser_AST.LightOff
-           then FStar_Options.set_ml_ish ()
-           else ();
-           (env, [se]))
-      | FStar_Parser_AST.Fsdoc uu____9616 -> (env, [])
-      | FStar_Parser_AST.TopLevelModule id -> (env, [])
-      | FStar_Parser_AST.Open lid ->
-          let env1 = FStar_ToSyntax_Env.push_namespace env lid in (env1, [])
-      | FStar_Parser_AST.Include lid ->
-          let env1 = FStar_ToSyntax_Env.push_include env lid in (env1, [])
-      | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____9628 = FStar_ToSyntax_Env.push_module_abbrev env x l in
-          (uu____9628, [])
-      | FStar_Parser_AST.Tycon (is_effect,tcs) ->
-          let quals =
-            if is_effect
-            then FStar_Parser_AST.Effect_qual :: (d.FStar_Parser_AST.quals)
-            else d.FStar_Parser_AST.quals in
-          let tcs1 =
-            FStar_List.map
-              (fun uu____9649  -> match uu____9649 with | (x,uu____9654) -> x)
-              tcs in
-          let uu____9657 = FStar_List.map (trans_qual1 None) quals in
-          desugar_tycon env d.FStar_Parser_AST.drange uu____9657 tcs1
-      | FStar_Parser_AST.TopLevelLet (isrec,lets) ->
-          let quals = d.FStar_Parser_AST.quals in
-          let attrs = d.FStar_Parser_AST.attrs in
-          let attrs1 = FStar_List.map (desugar_term env) attrs in
-          let expand_toplevel_pattern =
-            (isrec = FStar_Parser_AST.NoLetQualifier) &&
-              (match lets with
-               | ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatOp _;
-                    FStar_Parser_AST.prange = _;_},_)::[]
-                 |({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar _;
-                     FStar_Parser_AST.prange = _;_},_)::[]
-                  |({
-                      FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
-                        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar _;
-                           FStar_Parser_AST.prange = _;_},_);
-                      FStar_Parser_AST.prange = _;_},_)::[]
-                   -> false
-               | (p,uu____9696)::[] ->
-                   let uu____9701 = is_app_pattern p in
-                   Prims.op_Negation uu____9701
-               | uu____9702 -> false) in
-          if Prims.op_Negation expand_toplevel_pattern
-          then
-            let as_inner_let =
-              FStar_Parser_AST.mk_term
-                (FStar_Parser_AST.Let
-                   (isrec, lets,
-                     (FStar_Parser_AST.mk_term
-                        (FStar_Parser_AST.Const FStar_Const.Const_unit)
-                        d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
-                d.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
-            let ds_lets = desugar_term_maybe_top true env as_inner_let in
-            let uu____9713 =
-              let uu____9714 =
-                FStar_All.pipe_left FStar_Syntax_Subst.compress ds_lets in
-              uu____9714.FStar_Syntax_Syntax.n in
-            (match uu____9713 with
-             | FStar_Syntax_Syntax.Tm_let (lbs,uu____9720) ->
-                 let fvs =
-                   FStar_All.pipe_right (Prims.snd lbs)
-                     (FStar_List.map
-                        (fun lb  ->
-                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname)) in
-                 let quals1 =
-                   match quals with
-                   | uu____9740::uu____9741 ->
-                       FStar_List.map (trans_qual1 None) quals
-                   | uu____9743 ->
-                       FStar_All.pipe_right (Prims.snd lbs)
-                         (FStar_List.collect
-                            (fun uu___213_9747  ->
-                               match uu___213_9747 with
-                               | {
-                                   FStar_Syntax_Syntax.lbname =
-                                     FStar_Util.Inl uu____9749;
-                                   FStar_Syntax_Syntax.lbunivs = uu____9750;
-                                   FStar_Syntax_Syntax.lbtyp = uu____9751;
-                                   FStar_Syntax_Syntax.lbeff = uu____9752;
-                                   FStar_Syntax_Syntax.lbdef = uu____9753;_}
-                                   -> []
-                               | {
-                                   FStar_Syntax_Syntax.lbname =
-                                     FStar_Util.Inr fv;
-                                   FStar_Syntax_Syntax.lbunivs = uu____9760;
-                                   FStar_Syntax_Syntax.lbtyp = uu____9761;
-                                   FStar_Syntax_Syntax.lbeff = uu____9762;
-                                   FStar_Syntax_Syntax.lbdef = uu____9763;_}
-                                   ->
-                                   FStar_ToSyntax_Env.lookup_letbinding_quals
-                                     env
-                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
-                 let quals2 =
-                   let uu____9775 =
-                     FStar_All.pipe_right lets
-                       (FStar_Util.for_some
-                          (fun uu____9781  ->
-                             match uu____9781 with
-                             | (uu____9784,t) ->
-                                 t.FStar_Parser_AST.level =
-                                   FStar_Parser_AST.Formula)) in
-                   if uu____9775
-                   then FStar_Syntax_Syntax.Logic :: quals1
-                   else quals1 in
-                 let lbs1 =
-                   let uu____9792 =
-                     FStar_All.pipe_right quals2
-                       (FStar_List.contains FStar_Syntax_Syntax.Abstract) in
-                   if uu____9792
-                   then
-                     let uu____9797 =
-                       FStar_All.pipe_right (Prims.snd lbs)
-                         (FStar_List.map
-                            (fun lb  ->
-                               let fv =
-                                 FStar_Util.right
-                                   lb.FStar_Syntax_Syntax.lbname in
-                               let uu___227_9804 = lb in
-                               {
-                                 FStar_Syntax_Syntax.lbname =
-                                   (FStar_Util.Inr
-                                      (let uu___228_9805 = fv in
-                                       {
-                                         FStar_Syntax_Syntax.fv_name =
-                                           (uu___228_9805.FStar_Syntax_Syntax.fv_name);
-                                         FStar_Syntax_Syntax.fv_delta =
-                                           (FStar_Syntax_Syntax.Delta_abstract
-                                              (fv.FStar_Syntax_Syntax.fv_delta));
-                                         FStar_Syntax_Syntax.fv_qual =
-                                           (uu___228_9805.FStar_Syntax_Syntax.fv_qual)
-                                       }));
-                                 FStar_Syntax_Syntax.lbunivs =
-                                   (uu___227_9804.FStar_Syntax_Syntax.lbunivs);
-                                 FStar_Syntax_Syntax.lbtyp =
-                                   (uu___227_9804.FStar_Syntax_Syntax.lbtyp);
-                                 FStar_Syntax_Syntax.lbeff =
-                                   (uu___227_9804.FStar_Syntax_Syntax.lbeff);
-                                 FStar_Syntax_Syntax.lbdef =
-                                   (uu___227_9804.FStar_Syntax_Syntax.lbdef)
-                               })) in
-                     ((Prims.fst lbs), uu____9797)
-                   else lbs in
-                 let s =
-                   let uu____9813 =
-                     let uu____9822 =
-                       FStar_All.pipe_right fvs
-                         (FStar_List.map
-                            (fun fv  ->
-                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
-                     (lbs1, (d.FStar_Parser_AST.drange), uu____9822, quals2,
-                       attrs1) in
-                   FStar_Syntax_Syntax.Sig_let uu____9813 in
-                 let env1 = FStar_ToSyntax_Env.push_sigelt env s in
-                 (env1, [s])
-             | uu____9839 ->
-                 failwith "Desugaring a let did not produce a let")
-          else
-            (let uu____9843 =
-               match lets with
-               | (pat,body)::[] -> (pat, body)
-               | uu____9854 ->
-                   failwith
-                     "expand_toplevel_pattern should only allow single definition lets" in
-             match uu____9843 with
-             | (pat,body) ->
-                 let fresh_toplevel_name =
-                   FStar_Ident.gen FStar_Range.dummyRange in
-                 let fresh_pat =
-                   let var_pat =
-                     FStar_Parser_AST.mk_pattern
-                       (FStar_Parser_AST.PatVar (fresh_toplevel_name, None))
-                       FStar_Range.dummyRange in
-                   match pat.FStar_Parser_AST.pat with
-                   | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___229_9870 = pat1 in
-                       {
-                         FStar_Parser_AST.pat =
-                           (FStar_Parser_AST.PatAscribed (var_pat, ty));
-                         FStar_Parser_AST.prange =
-                           (uu___229_9870.FStar_Parser_AST.prange)
-                       }
-                   | uu____9871 -> var_pat in
-                 let main_let =
-                   desugar_decl env
-                     (let uu___230_9875 = d in
-                      {
-                        FStar_Parser_AST.d =
-                          (FStar_Parser_AST.TopLevelLet
-                             (isrec, [(fresh_pat, body)]));
-                        FStar_Parser_AST.drange =
-                          (uu___230_9875.FStar_Parser_AST.drange);
-                        FStar_Parser_AST.doc =
-                          (uu___230_9875.FStar_Parser_AST.doc);
-                        FStar_Parser_AST.quals = (FStar_Parser_AST.Private ::
-                          (d.FStar_Parser_AST.quals));
-                        FStar_Parser_AST.attrs =
-                          (uu___230_9875.FStar_Parser_AST.attrs)
-                      }) in
-                 let build_projection uu____9894 id =
-                   match uu____9894 with
-                   | (env1,ses) ->
-                       let main =
-                         let uu____9907 =
-                           let uu____9908 =
-                             FStar_Ident.lid_of_ids [fresh_toplevel_name] in
-                           FStar_Parser_AST.Var uu____9908 in
-                         FStar_Parser_AST.mk_term uu____9907
-                           FStar_Range.dummyRange FStar_Parser_AST.Expr in
-                       let lid = FStar_Ident.lid_of_ids [id] in
-                       let projectee =
-                         FStar_Parser_AST.mk_term (FStar_Parser_AST.Var lid)
-                           FStar_Range.dummyRange FStar_Parser_AST.Expr in
-                       let body1 =
-                         FStar_Parser_AST.mk_term
-                           (FStar_Parser_AST.Match
-                              (main, [(pat, None, projectee)]))
-                           FStar_Range.dummyRange FStar_Parser_AST.Expr in
-                       let bv_pat =
-                         FStar_Parser_AST.mk_pattern
-                           (FStar_Parser_AST.PatVar (id, None))
-                           FStar_Range.dummyRange in
-                       let id_decl =
-                         FStar_Parser_AST.mk_decl
-                           (FStar_Parser_AST.TopLevelLet
-                              (FStar_Parser_AST.NoLetQualifier,
-                                [(bv_pat, body1)])) FStar_Range.dummyRange [] in
-                       let uu____9936 = desugar_decl env1 id_decl in
-                       (match uu____9936 with
-                        | (env2,ses') -> (env2, (FStar_List.append ses ses'))) in
-                 let bvs =
-                   let uu____9947 = gather_pattern_bound_vars pat in
-                   FStar_All.pipe_right uu____9947 FStar_Util.set_elements in
-                 FStar_List.fold_left build_projection main_let bvs)
-      | FStar_Parser_AST.Main t ->
-          let e = desugar_term env t in
-          let se =
-            FStar_Syntax_Syntax.Sig_main (e, (d.FStar_Parser_AST.drange)) in
-          (env, [se])
-      | FStar_Parser_AST.Assume (id,t) ->
-          let f = desugar_formula env t in
-          let uu____9961 =
-            let uu____9963 =
-              let uu____9964 =
-                let uu____9970 = FStar_ToSyntax_Env.qualify env id in
-                (uu____9970, f, [FStar_Syntax_Syntax.Assumption],
-                  (d.FStar_Parser_AST.drange)) in
-              FStar_Syntax_Syntax.Sig_assume uu____9964 in
-            [uu____9963] in
-          (env, uu____9961)
-      | FStar_Parser_AST.Val (id,t) ->
-          let quals = d.FStar_Parser_AST.quals in
-          let t1 =
-            let uu____9977 = close_fun env t in desugar_term env uu____9977 in
-          let quals1 =
-            if
-              env.FStar_ToSyntax_Env.iface &&
-                env.FStar_ToSyntax_Env.admitted_iface
-            then FStar_Parser_AST.Assumption :: quals
-            else quals in
-          let se =
-            let uu____9983 =
-              let uu____9990 = FStar_ToSyntax_Env.qualify env id in
-              let uu____9991 = FStar_List.map (trans_qual1 None) quals1 in
-              (uu____9990, [], t1, uu____9991, (d.FStar_Parser_AST.drange)) in
-            FStar_Syntax_Syntax.Sig_declare_typ uu____9983 in
-          let env1 = FStar_ToSyntax_Env.push_sigelt env se in (env1, [se])
-      | FStar_Parser_AST.Exception (id,None ) ->
-          let uu____9999 =
-            FStar_ToSyntax_Env.fail_or env
-              (FStar_ToSyntax_Env.try_lookup_lid env)
-              FStar_Syntax_Const.exn_lid in
-          (match uu____9999 with
-           | (t,uu____10007) ->
-               let l = FStar_ToSyntax_Env.qualify env id in
-               let se =
-                 FStar_Syntax_Syntax.Sig_datacon
-                   (l, [], t, FStar_Syntax_Const.exn_lid,
-                     (Prims.parse_int "0"),
-                     [FStar_Syntax_Syntax.ExceptionConstructor],
-                     [FStar_Syntax_Const.exn_lid],
-                     (d.FStar_Parser_AST.drange)) in
-               let se' =
-                 FStar_Syntax_Syntax.Sig_bundle
-                   ([se], [FStar_Syntax_Syntax.ExceptionConstructor], 
-                     [l], (d.FStar_Parser_AST.drange)) in
-               let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
-               let data_ops = mk_data_projector_names [] env1 ([], se) in
-               let discs =
-                 mk_data_discriminators [] env1 FStar_Syntax_Const.exn_lid []
-                   FStar_Syntax_Syntax.tun [l] in
-               let env2 =
-                 FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env1
-                   (FStar_List.append discs data_ops) in
-               (env2, (FStar_List.append (se' :: discs) data_ops)))
-      | FStar_Parser_AST.Exception (id,Some term) ->
-          let t = desugar_term env term in
-          let t1 =
-            let uu____10034 =
-              let uu____10038 = FStar_Syntax_Syntax.null_binder t in
-              [uu____10038] in
-            let uu____10039 =
-              let uu____10042 =
-                let uu____10043 =
-                  FStar_ToSyntax_Env.fail_or env
-                    (FStar_ToSyntax_Env.try_lookup_lid env)
-                    FStar_Syntax_Const.exn_lid in
-                Prims.fst uu____10043 in
-              FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu____10042 in
-            FStar_Syntax_Util.arrow uu____10034 uu____10039 in
-          let l = FStar_ToSyntax_Env.qualify env id in
-          let se =
-            FStar_Syntax_Syntax.Sig_datacon
-              (l, [], t1, FStar_Syntax_Const.exn_lid, (Prims.parse_int "0"),
-                [FStar_Syntax_Syntax.ExceptionConstructor],
-                [FStar_Syntax_Const.exn_lid], (d.FStar_Parser_AST.drange)) in
-          let se' =
-            FStar_Syntax_Syntax.Sig_bundle
-              ([se], [FStar_Syntax_Syntax.ExceptionConstructor], [l],
-                (d.FStar_Parser_AST.drange)) in
-          let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
-          let data_ops = mk_data_projector_names [] env1 ([], se) in
-          let discs =
-            mk_data_discriminators [] env1 FStar_Syntax_Const.exn_lid []
-              FStar_Syntax_Syntax.tun [l] in
-          let env2 =
-            FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env1
-              (FStar_List.append discs data_ops) in
-          (env2, (FStar_List.append (se' :: discs) data_ops))
-      | FStar_Parser_AST.NewEffect (FStar_Parser_AST.RedefineEffect
-          (eff_name,eff_binders,defn)) ->
-          let quals = d.FStar_Parser_AST.quals in
-          desugar_redefine_effect env d trans_qual1 quals eff_name
-            eff_binders defn
-      | FStar_Parser_AST.NewEffect (FStar_Parser_AST.DefineEffect
-          (eff_name,eff_binders,eff_typ,eff_decls)) ->
-          let quals = d.FStar_Parser_AST.quals in
-          desugar_effect env d quals eff_name eff_binders eff_typ eff_decls
-      | FStar_Parser_AST.SubEffect l ->
-          let lookup l1 =
-            let uu____10089 =
-              FStar_ToSyntax_Env.try_lookup_effect_name env l1 in
-            match uu____10089 with
-            | None  ->
-                let uu____10091 =
-                  let uu____10092 =
-                    let uu____10095 =
-                      let uu____10096 =
-                        let uu____10097 = FStar_Syntax_Print.lid_to_string l1 in
-                        Prims.strcat uu____10097 " not found" in
-                      Prims.strcat "Effect name " uu____10096 in
-                    (uu____10095, (d.FStar_Parser_AST.drange)) in
-                  FStar_Errors.Error uu____10092 in
-                Prims.raise uu____10091
-            | Some l2 -> l2 in
-          let src = lookup l.FStar_Parser_AST.msource in
-          let dst = lookup l.FStar_Parser_AST.mdest in
-          let uu____10101 =
-            match l.FStar_Parser_AST.lift_op with
-            | FStar_Parser_AST.NonReifiableLift t ->
-                let uu____10123 =
-                  let uu____10128 =
-                    let uu____10132 = desugar_term env t in ([], uu____10132) in
-                  Some uu____10128 in
-                (uu____10123, None)
-            | FStar_Parser_AST.ReifiableLift (wp,t) ->
-                let uu____10150 =
-                  let uu____10155 =
-                    let uu____10159 = desugar_term env wp in
-                    ([], uu____10159) in
-                  Some uu____10155 in
-                let uu____10164 =
-                  let uu____10169 =
-                    let uu____10173 = desugar_term env t in ([], uu____10173) in
-                  Some uu____10169 in
-                (uu____10150, uu____10164)
-            | FStar_Parser_AST.LiftForFree t ->
-                let uu____10187 =
-                  let uu____10192 =
-                    let uu____10196 = desugar_term env t in ([], uu____10196) in
-                  Some uu____10192 in
-                (None, uu____10187) in
-          (match uu____10101 with
-           | (lift_wp,lift) ->
-               let se =
-                 FStar_Syntax_Syntax.Sig_sub_effect
-                   ({
-                      FStar_Syntax_Syntax.source = src;
-                      FStar_Syntax_Syntax.target = dst;
-                      FStar_Syntax_Syntax.lift_wp = lift_wp;
-                      FStar_Syntax_Syntax.lift = lift
-                    }, (d.FStar_Parser_AST.drange)) in
-               (env, [se]))
-let desugar_decls:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.decl Prims.list ->
-      (env_t* FStar_Syntax_Syntax.sigelt Prims.list)
-  =
-  fun env  ->
-    fun decls  ->
-      FStar_List.fold_left
-        (fun uu____10247  ->
-           fun d  ->
-             match uu____10247 with
-             | (env1,sigelts) ->
-                 let uu____10259 = desugar_decl env1 d in
-                 (match uu____10259 with
-                  | (env2,se) -> (env2, (FStar_List.append sigelts se))))
-        (env, []) decls
-let open_prims_all:
-  (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
-    Prims.list
-  =
-  [FStar_Parser_AST.mk_decl
-     (FStar_Parser_AST.Open FStar_Syntax_Const.prims_lid)
-     FStar_Range.dummyRange;
-  FStar_Parser_AST.mk_decl (FStar_Parser_AST.Open FStar_Syntax_Const.all_lid)
-    FStar_Range.dummyRange]
-let desugar_modul_common:
-  FStar_Syntax_Syntax.modul Prims.option ->
-    FStar_ToSyntax_Env.env ->
-      FStar_Parser_AST.modul ->
-        (env_t* FStar_Syntax_Syntax.modul* Prims.bool)
-  =
-  fun curmod  ->
-    fun env  ->
-      fun m  ->
-        let env1 =
-          match (curmod, m) with
-          | (None ,uu____10301) -> env
-          | (Some
-             { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____10304;
-               FStar_Syntax_Syntax.exports = uu____10305;
-               FStar_Syntax_Syntax.is_interface = uu____10306;_},FStar_Parser_AST.Module
-             (current_lid,uu____10308)) when
-              (FStar_Ident.lid_equals prev_lid current_lid) &&
-                (FStar_Options.interactive ())
-              -> env
-          | (Some prev_mod,uu____10313) ->
-              FStar_ToSyntax_Env.finish_module_or_interface env prev_mod in
-        let uu____10315 =
-          match m with
-          | FStar_Parser_AST.Interface (mname,decls,admitted) ->
-              let uu____10335 =
-                FStar_ToSyntax_Env.prepare_module_or_interface true admitted
-                  env1 mname in
-              (uu____10335, mname, decls, true)
-          | FStar_Parser_AST.Module (mname,decls) ->
-              let uu____10345 =
-                FStar_ToSyntax_Env.prepare_module_or_interface false false
-                  env1 mname in
-              (uu____10345, mname, decls, false) in
-        match uu____10315 with
-        | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____10363 = desugar_decls env2 decls in
-            (match uu____10363 with
-             | (env3,sigelts) ->
-                 let modul =
-                   {
-                     FStar_Syntax_Syntax.name = mname;
-                     FStar_Syntax_Syntax.declarations = sigelts;
-                     FStar_Syntax_Syntax.exports = [];
-                     FStar_Syntax_Syntax.is_interface = intf
-                   } in
-                 (env3, modul, pop_when_done))
-let desugar_partial_modul:
-  FStar_Syntax_Syntax.modul Prims.option ->
-    env_t -> FStar_Parser_AST.modul -> (env_t* FStar_Syntax_Syntax.modul)
-  =
-  fun curmod  ->
-    fun env  ->
-      fun m  ->
-        let m1 =
-          let uu____10388 =
-            (FStar_Options.interactive ()) &&
-              (let uu____10389 =
-                 let uu____10390 =
-                   let uu____10391 = FStar_Options.file_list () in
-                   FStar_List.hd uu____10391 in
-                 FStar_Util.get_file_extension uu____10390 in
-               uu____10389 = "fsti") in
-          if uu____10388
-          then
-            match m with
-            | FStar_Parser_AST.Module (mname,decls) ->
-                FStar_Parser_AST.Interface (mname, decls, true)
-            | FStar_Parser_AST.Interface (mname,uu____10399,uu____10400) ->
-                failwith
-                  (Prims.strcat "Impossible: "
-                     (mname.FStar_Ident.ident).FStar_Ident.idText)
-          else m in
-        let uu____10404 = desugar_modul_common curmod env m1 in
-        match uu____10404 with
-        | (x,y,pop_when_done) ->
-            (if pop_when_done
-             then (let uu____10414 = FStar_ToSyntax_Env.pop () in ())
-             else ();
-             (x, y))
-let desugar_modul:
-  FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.modul -> (env_t* FStar_Syntax_Syntax.modul)
-  =
-  fun env  ->
-    fun m  ->
-      let uu____10426 = desugar_modul_common None env m in
-      match uu____10426 with
-      | (env1,modul,pop_when_done) ->
-          let env2 = FStar_ToSyntax_Env.finish_module_or_interface env1 modul in
-          ((let uu____10437 =
-              FStar_Options.dump_module
-                (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
-            if uu____10437
-            then
-              let uu____10438 = FStar_Syntax_Print.modul_to_string modul in
-              FStar_Util.print1 "%s\n" uu____10438
-            else ());
-           (let uu____10440 =
-              if pop_when_done
-              then
-                FStar_ToSyntax_Env.export_interface
-                  modul.FStar_Syntax_Syntax.name env2
-              else env2 in
-            (uu____10440, modul)))
-let desugar_file:
-  env_t ->
-    FStar_Parser_AST.file ->
-      (FStar_ToSyntax_Env.env* FStar_Syntax_Syntax.modul Prims.list)
-  =
-  fun env  ->
-    fun f  ->
-      let uu____10451 =
-        FStar_List.fold_left
-          (fun uu____10458  ->
-             fun m  ->
-               match uu____10458 with
-               | (env1,mods) ->
-                   let uu____10470 = desugar_modul env1 m in
-                   (match uu____10470 with
-                    | (env2,m1) -> (env2, (m1 :: mods)))) (env, []) f in
-      match uu____10451 with | (env1,mods) -> (env1, (FStar_List.rev mods))
-let add_modul_to_env:
-  FStar_Syntax_Syntax.modul ->
-    FStar_ToSyntax_Env.env -> FStar_ToSyntax_Env.env
-  =
-  fun m  ->
-    fun en  ->
-      let uu____10494 =
-        FStar_ToSyntax_Env.prepare_module_or_interface false false en
-          m.FStar_Syntax_Syntax.name in
-      match uu____10494 with
-      | (en1,pop_when_done) ->
-          let en2 =
-            FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt
-              (let uu___231_10500 = en1 in
-               {
-                 FStar_ToSyntax_Env.curmodule =
-                   (Some (m.FStar_Syntax_Syntax.name));
-                 FStar_ToSyntax_Env.curmonad =
-                   (uu___231_10500.FStar_ToSyntax_Env.curmonad);
-                 FStar_ToSyntax_Env.modules =
-                   (uu___231_10500.FStar_ToSyntax_Env.modules);
-                 FStar_ToSyntax_Env.scope_mods =
-                   (uu___231_10500.FStar_ToSyntax_Env.scope_mods);
-                 FStar_ToSyntax_Env.exported_ids =
-                   (uu___231_10500.FStar_ToSyntax_Env.exported_ids);
-                 FStar_ToSyntax_Env.trans_exported_ids =
-                   (uu___231_10500.FStar_ToSyntax_Env.trans_exported_ids);
-                 FStar_ToSyntax_Env.includes =
-                   (uu___231_10500.FStar_ToSyntax_Env.includes);
-                 FStar_ToSyntax_Env.sigaccum =
-                   (uu___231_10500.FStar_ToSyntax_Env.sigaccum);
-                 FStar_ToSyntax_Env.sigmap =
-                   (uu___231_10500.FStar_ToSyntax_Env.sigmap);
-                 FStar_ToSyntax_Env.iface =
-                   (uu___231_10500.FStar_ToSyntax_Env.iface);
-                 FStar_ToSyntax_Env.admitted_iface =
-                   (uu___231_10500.FStar_ToSyntax_Env.admitted_iface);
-                 FStar_ToSyntax_Env.expect_typ =
-                   (uu___231_10500.FStar_ToSyntax_Env.expect_typ)
-               }) m.FStar_Syntax_Syntax.exports in
-          let env = FStar_ToSyntax_Env.finish_module_or_interface en2 m in
-          if pop_when_done
-          then
-            FStar_ToSyntax_Env.export_interface m.FStar_Syntax_Syntax.name
-              env
-          else env
+| LocalBinder of (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)
+| LetBinder of (FStar_Ident.lident * FStar_Syntax_Syntax.term)
+
+
+let uu___is_LocalBinder : bnd  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LocalBinder (_0) -> begin
+true
+end
+| uu____722 -> begin
+false
+end))
+
+
+let __proj__LocalBinder__item___0 : bnd  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) = (fun projectee -> (match (projectee) with
+| LocalBinder (_0) -> begin
+_0
+end))
+
+
+let uu___is_LetBinder : bnd  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| LetBinder (_0) -> begin
+true
+end
+| uu____742 -> begin
+false
+end))
+
+
+let __proj__LetBinder__item___0 : bnd  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.term) = (fun projectee -> (match (projectee) with
+| LetBinder (_0) -> begin
+_0
+end))
+
+
+let binder_of_bnd : bnd  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) = (fun uu___185_760 -> (match (uu___185_760) with
+| LocalBinder (a, aq) -> begin
+((a), (aq))
+end
+| uu____765 -> begin
+(failwith "Impossible")
+end))
+
+
+let as_binder : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.arg_qualifier Prims.option  ->  (FStar_Ident.ident Prims.option * FStar_Syntax_Syntax.term)  ->  (FStar_Syntax_Syntax.binder * FStar_ToSyntax_Env.env) = (fun env imp uu___186_782 -> (match (uu___186_782) with
+| (None, k) -> begin
+(
+
+let uu____791 = (FStar_Syntax_Syntax.null_binder k)
+in ((uu____791), (env)))
+end
+| (Some (a), k) -> begin
+(
+
+let uu____795 = (FStar_ToSyntax_Env.push_bv env a)
+in (match (uu____795) with
+| (env1, a1) -> begin
+(((((
+
+let uu___207_806 = a1
+in {FStar_Syntax_Syntax.ppname = uu___207_806.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___207_806.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = k})), ((trans_aqual imp)))), (env1))
+end))
+end))
+
+
+type env_t =
+FStar_ToSyntax_Env.env
+
+
+type lenv_t =
+FStar_Syntax_Syntax.bv Prims.list
+
+
+let mk_lb : ((FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  FStar_Syntax_Syntax.letbinding = (fun uu____819 -> (match (uu____819) with
+| (n1, t, e) -> begin
+{FStar_Syntax_Syntax.lbname = n1; FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_ALL_lid; FStar_Syntax_Syntax.lbdef = e}
+end))
+
+
+let no_annot_abs : (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun bs t -> (FStar_Syntax_Util.abs bs t None))
+
+
+let mk_ref_read = (fun tm -> (
+
+let tm' = (
+
+let uu____875 = (
+
+let uu____885 = (
+
+let uu____886 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.sread_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____886))
+in (
+
+let uu____887 = (
+
+let uu____893 = (
+
+let uu____898 = (FStar_Syntax_Syntax.as_implicit false)
+in ((tm), (uu____898)))
+in (uu____893)::[])
+in ((uu____885), (uu____887))))
+in FStar_Syntax_Syntax.Tm_app (uu____875))
+in (FStar_Syntax_Syntax.mk tm' None tm.FStar_Syntax_Syntax.pos)))
+
+
+let mk_ref_alloc = (fun tm -> (
+
+let tm' = (
+
+let uu____932 = (
+
+let uu____942 = (
+
+let uu____943 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.salloc_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____943))
+in (
+
+let uu____944 = (
+
+let uu____950 = (
+
+let uu____955 = (FStar_Syntax_Syntax.as_implicit false)
+in ((tm), (uu____955)))
+in (uu____950)::[])
+in ((uu____942), (uu____944))))
+in FStar_Syntax_Syntax.Tm_app (uu____932))
+in (FStar_Syntax_Syntax.mk tm' None tm.FStar_Syntax_Syntax.pos)))
+
+
+let mk_ref_assign = (fun t1 t2 pos -> (
+
+let tm = (
+
+let uu____1003 = (
+
+let uu____1013 = (
+
+let uu____1014 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.swrite_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____1014))
+in (
+
+let uu____1015 = (
+
+let uu____1021 = (
+
+let uu____1026 = (FStar_Syntax_Syntax.as_implicit false)
+in ((t1), (uu____1026)))
+in (
+
+let uu____1029 = (
+
+let uu____1035 = (
+
+let uu____1040 = (FStar_Syntax_Syntax.as_implicit false)
+in ((t2), (uu____1040)))
+in (uu____1035)::[])
+in (uu____1021)::uu____1029))
+in ((uu____1013), (uu____1015))))
+in FStar_Syntax_Syntax.Tm_app (uu____1003))
+in (FStar_Syntax_Syntax.mk tm None pos)))
+
+
+let is_special_effect_combinator : Prims.string  ->  Prims.bool = (fun uu___187_1066 -> (match (uu___187_1066) with
+| ("repr") | ("post") | ("pre") | ("wp") -> begin
+true
+end
+| uu____1067 -> begin
+false
+end))
+
+
+let rec sum_to_universe : FStar_Syntax_Syntax.universe  ->  Prims.int  ->  FStar_Syntax_Syntax.universe = (fun u n1 -> (match ((n1 = (Prims.parse_int "0"))) with
+| true -> begin
+u
+end
+| uu____1074 -> begin
+(
+
+let uu____1075 = (sum_to_universe u (n1 - (Prims.parse_int "1")))
+in FStar_Syntax_Syntax.U_succ (uu____1075))
+end))
+
+
+let int_to_universe : Prims.int  ->  FStar_Syntax_Syntax.universe = (fun n1 -> (sum_to_universe FStar_Syntax_Syntax.U_zero n1))
+
+
+let rec desugar_maybe_non_constant_universe : FStar_Parser_AST.term  ->  (Prims.int, FStar_Syntax_Syntax.universe) FStar_Util.either = (fun t -> (
+
+let uu____1086 = (
+
+let uu____1087 = (unparen t)
+in uu____1087.FStar_Parser_AST.tm)
+in (match (uu____1086) with
+| FStar_Parser_AST.Wild -> begin
+(
+
+let uu____1090 = (
+
+let uu____1091 = (FStar_Unionfind.fresh None)
+in FStar_Syntax_Syntax.U_unif (uu____1091))
+in FStar_Util.Inr (uu____1090))
+end
+| FStar_Parser_AST.Uvar (u) -> begin
+FStar_Util.Inr (FStar_Syntax_Syntax.U_name (u))
+end
+| FStar_Parser_AST.Const (FStar_Const.Const_int (repr, uu____1097)) -> begin
+(
+
+let n1 = (FStar_Util.int_of_string repr)
+in ((match ((n1 < (Prims.parse_int "0"))) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Negative universe constant  are not supported : " repr)), (t.FStar_Parser_AST.range)))))
+end
+| uu____1106 -> begin
+()
+end);
+FStar_Util.Inl (n1);
+))
+end
+| FStar_Parser_AST.Op (op_plus, (t1)::(t2)::[]) -> begin
+(
+
+let u1 = (desugar_maybe_non_constant_universe t1)
+in (
+
+let u2 = (desugar_maybe_non_constant_universe t2)
+in (match (((u1), (u2))) with
+| (FStar_Util.Inl (n1), FStar_Util.Inl (n2)) -> begin
+FStar_Util.Inl ((n1 + n2))
+end
+| ((FStar_Util.Inl (n1), FStar_Util.Inr (u))) | ((FStar_Util.Inr (u), FStar_Util.Inl (n1))) -> begin
+(
+
+let uu____1140 = (sum_to_universe u n1)
+in FStar_Util.Inr (uu____1140))
+end
+| (FStar_Util.Inr (u11), FStar_Util.Inr (u21)) -> begin
+(
+
+let uu____1147 = (
+
+let uu____1148 = (
+
+let uu____1151 = (
+
+let uu____1152 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat "This universe might contain a sum of two universe variables " uu____1152))
+in ((uu____1151), (t.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____1148))
+in (Prims.raise uu____1147))
+end)))
+end
+| FStar_Parser_AST.App (uu____1155) -> begin
+(
+
+let rec aux = (fun t1 univargs -> (
+
+let uu____1174 = (
+
+let uu____1175 = (unparen t1)
+in uu____1175.FStar_Parser_AST.tm)
+in (match (uu____1174) with
+| FStar_Parser_AST.App (t2, targ, uu____1180) -> begin
+(
+
+let uarg = (desugar_maybe_non_constant_universe targ)
+in (aux t2 ((uarg)::univargs)))
+end
+| FStar_Parser_AST.Var (max_lid1) -> begin
+(match ((FStar_List.existsb (fun uu___188_1192 -> (match (uu___188_1192) with
+| FStar_Util.Inr (uu____1195) -> begin
+true
+end
+| uu____1196 -> begin
+false
+end)) univargs)) with
+| true -> begin
+(
+
+let uu____1199 = (
+
+let uu____1200 = (FStar_List.map (fun uu___189_1204 -> (match (uu___189_1204) with
+| FStar_Util.Inl (n1) -> begin
+(int_to_universe n1)
+end
+| FStar_Util.Inr (u) -> begin
+u
+end)) univargs)
+in FStar_Syntax_Syntax.U_max (uu____1200))
+in FStar_Util.Inr (uu____1199))
+end
+| uu____1209 -> begin
+(
+
+let nargs = (FStar_List.map (fun uu___190_1214 -> (match (uu___190_1214) with
+| FStar_Util.Inl (n1) -> begin
+n1
+end
+| FStar_Util.Inr (uu____1218) -> begin
+(failwith "impossible")
+end)) univargs)
+in (
+
+let uu____1219 = (FStar_List.fold_left (fun m n1 -> (match ((m > n1)) with
+| true -> begin
+m
+end
+| uu____1222 -> begin
+n1
+end)) (Prims.parse_int "0") nargs)
+in FStar_Util.Inl (uu____1219)))
+end)
+end
+| uu____1223 -> begin
+(
+
+let uu____1224 = (
+
+let uu____1225 = (
+
+let uu____1228 = (
+
+let uu____1229 = (
+
+let uu____1230 = (FStar_Parser_AST.term_to_string t1)
+in (Prims.strcat uu____1230 " in universe context"))
+in (Prims.strcat "Unexpected term " uu____1229))
+in ((uu____1228), (t1.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____1225))
+in (Prims.raise uu____1224))
+end)))
+in (aux t []))
+end
+| uu____1235 -> begin
+(
+
+let uu____1236 = (
+
+let uu____1237 = (
+
+let uu____1240 = (
+
+let uu____1241 = (
+
+let uu____1242 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat uu____1242 " in universe context"))
+in (Prims.strcat "Unexpected term " uu____1241))
+in ((uu____1240), (t.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____1237))
+in (Prims.raise uu____1236))
+end)))
+
+
+let rec desugar_universe : FStar_Parser_AST.term  ->  FStar_Syntax_Syntax.universe = (fun t -> (
+
+let u = (desugar_maybe_non_constant_universe t)
+in (match (u) with
+| FStar_Util.Inl (n1) -> begin
+(int_to_universe n1)
+end
+| FStar_Util.Inr (u1) -> begin
+u1
+end)))
+
+
+let check_fields = (fun env fields rg -> (
+
+let uu____1276 = (FStar_List.hd fields)
+in (match (uu____1276) with
+| (f, uu____1282) -> begin
+(
+
+let record = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_record_by_field_name env) f)
+in (
+
+let check_field = (fun uu____1289 -> (match (uu____1289) with
+| (f', uu____1293) -> begin
+(
+
+let uu____1294 = (FStar_ToSyntax_Env.belongs_to_record env f' record)
+in (match (uu____1294) with
+| true -> begin
+()
+end
+| uu____1295 -> begin
+(
+
+let msg = (FStar_Util.format3 "Field %s belongs to record type %s, whereas field %s does not" f.FStar_Ident.str record.FStar_ToSyntax_Env.typename.FStar_Ident.str f'.FStar_Ident.str)
+in (Prims.raise (FStar_Errors.Error (((msg), (rg))))))
+end))
+end))
+in ((
+
+let uu____1298 = (FStar_List.tl fields)
+in (FStar_List.iter check_field uu____1298));
+(match (()) with
+| () -> begin
+record
+end);
+)))
+end)))
+
+
+let rec desugar_data_pat : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.pattern  ->  Prims.bool  ->  (env_t * bnd * FStar_Syntax_Syntax.pat) = (fun env p is_mut -> (
+
+let check_linear_pattern_variables = (fun p1 -> (
+
+let rec pat_vars = (fun p2 -> (match (p2.FStar_Syntax_Syntax.v) with
+| (FStar_Syntax_Syntax.Pat_dot_term (_)) | (FStar_Syntax_Syntax.Pat_wild (_)) | (FStar_Syntax_Syntax.Pat_constant (_)) -> begin
+FStar_Syntax_Syntax.no_names
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(FStar_Util.set_add x FStar_Syntax_Syntax.no_names)
+end
+| FStar_Syntax_Syntax.Pat_cons (uu____1458, pats) -> begin
+(FStar_All.pipe_right pats (FStar_List.fold_left (fun out uu____1480 -> (match (uu____1480) with
+| (p3, uu____1486) -> begin
+(
+
+let uu____1487 = (pat_vars p3)
+in (FStar_Util.set_union out uu____1487))
+end)) FStar_Syntax_Syntax.no_names))
+end
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Pat_disj ((hd1)::tl1) -> begin
+(
+
+let xs = (pat_vars hd1)
+in (
+
+let uu____1501 = (
+
+let uu____1502 = (FStar_Util.for_all (fun p3 -> (
+
+let ys = (pat_vars p3)
+in ((FStar_Util.set_is_subset_of xs ys) && (FStar_Util.set_is_subset_of ys xs)))) tl1)
+in (not (uu____1502)))
+in (match (uu____1501) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Disjunctive pattern binds different variables in each case"), (p2.FStar_Syntax_Syntax.p)))))
+end
+| uu____1505 -> begin
+xs
+end)))
+end))
+in (pat_vars p1)))
+in ((match (((is_mut), (p.FStar_Parser_AST.pat))) with
+| ((false, _)) | ((true, FStar_Parser_AST.PatVar (_))) -> begin
+()
+end
+| (true, uu____1509) -> begin
+(Prims.raise (FStar_Errors.Error ((("let-mutable is for variables only"), (p.FStar_Parser_AST.prange)))))
+end);
+(
+
+let push_bv_maybe_mut = (match (is_mut) with
+| true -> begin
+FStar_ToSyntax_Env.push_bv_mutable
+end
+| uu____1523 -> begin
+FStar_ToSyntax_Env.push_bv
+end)
+in (
+
+let resolvex = (fun l e x -> (
+
+let uu____1537 = (FStar_All.pipe_right l (FStar_Util.find_opt (fun y -> (y.FStar_Syntax_Syntax.ppname.FStar_Ident.idText = x.FStar_Ident.idText))))
+in (match (uu____1537) with
+| Some (y) -> begin
+((l), (e), (y))
+end
+| uu____1545 -> begin
+(
+
+let uu____1547 = (push_bv_maybe_mut e x)
+in (match (uu____1547) with
+| (e1, x1) -> begin
+(((x1)::l), (e1), (x1))
+end))
+end)))
+in (
+
+let rec aux = (fun loc env1 p1 -> (
+
+let pos = (fun q -> (FStar_Syntax_Syntax.withinfo q FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n p1.FStar_Parser_AST.prange))
+in (
+
+let pos_r = (fun r q -> (FStar_Syntax_Syntax.withinfo q FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r))
+in (match (p1.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatOp (op) -> begin
+(
+
+let uu____1596 = (
+
+let uu____1597 = (
+
+let uu____1598 = (
+
+let uu____1602 = (
+
+let uu____1603 = (FStar_Parser_AST.compile_op (Prims.parse_int "0") op)
+in (FStar_Ident.id_of_text uu____1603))
+in ((uu____1602), (None)))
+in FStar_Parser_AST.PatVar (uu____1598))
+in {FStar_Parser_AST.pat = uu____1597; FStar_Parser_AST.prange = p1.FStar_Parser_AST.prange})
+in (aux loc env1 uu____1596))
+end
+| FStar_Parser_AST.PatOr ([]) -> begin
+(failwith "impossible")
+end
+| FStar_Parser_AST.PatOr ((p2)::ps) -> begin
+(
+
+let uu____1615 = (aux loc env1 p2)
+in (match (uu____1615) with
+| (loc1, env2, var, p3, uu____1634) -> begin
+(
+
+let uu____1639 = (FStar_List.fold_left (fun uu____1652 p4 -> (match (uu____1652) with
+| (loc2, env3, ps1) -> begin
+(
+
+let uu____1675 = (aux loc2 env3 p4)
+in (match (uu____1675) with
+| (loc3, env4, uu____1691, p5, uu____1693) -> begin
+((loc3), (env4), ((p5)::ps1))
+end))
+end)) ((loc1), (env2), ([])) ps)
+in (match (uu____1639) with
+| (loc2, env3, ps1) -> begin
+(
+
+let pat = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_disj ((p3)::(FStar_List.rev ps1))))
+in ((loc2), (env3), (var), (pat), (false)))
+end))
+end))
+end
+| FStar_Parser_AST.PatAscribed (p2, t) -> begin
+(
+
+let uu____1737 = (aux loc env1 p2)
+in (match (uu____1737) with
+| (loc1, env', binder, p3, imp) -> begin
+(
+
+let binder1 = (match (binder) with
+| LetBinder (uu____1762) -> begin
+(failwith "impossible")
+end
+| LocalBinder (x, aq) -> begin
+(
+
+let t1 = (
+
+let uu____1768 = (close_fun env1 t)
+in (desugar_term env1 uu____1768))
+in ((match ((match (x.FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+false
+end
+| uu____1770 -> begin
+true
+end)) with
+| true -> begin
+(
+
+let uu____1771 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____1772 = (FStar_Syntax_Print.term_to_string x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____1773 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print3_warning "Multiple ascriptions for %s in pattern, type %s was shadowed by %s" uu____1771 uu____1772 uu____1773))))
+end
+| uu____1774 -> begin
+()
+end);
+LocalBinder ((((
+
+let uu___208_1775 = x
+in {FStar_Syntax_Syntax.ppname = uu___208_1775.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___208_1775.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1})), (aq)));
+))
+end)
+in ((loc1), (env'), (binder1), (p3), (imp)))
+end))
+end
+| FStar_Parser_AST.PatWild -> begin
+(
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____1779 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild (x)))
+in ((loc), (env1), (LocalBinder (((x), (None)))), (uu____1779), (false))))
+end
+| FStar_Parser_AST.PatConst (c) -> begin
+(
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____1789 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant (c)))
+in ((loc), (env1), (LocalBinder (((x), (None)))), (uu____1789), (false))))
+end
+| (FStar_Parser_AST.PatTvar (x, aq)) | (FStar_Parser_AST.PatVar (x, aq)) -> begin
+(
+
+let imp = (aq = Some (FStar_Parser_AST.Implicit))
+in (
+
+let aq1 = (trans_aqual aq)
+in (
+
+let uu____1807 = (resolvex loc env1 x)
+in (match (uu____1807) with
+| (loc1, env2, xbv) -> begin
+(
+
+let uu____1821 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_var (xbv)))
+in ((loc1), (env2), (LocalBinder (((xbv), (aq1)))), (uu____1821), (imp)))
+end))))
+end
+| FStar_Parser_AST.PatName (l) -> begin
+(
+
+let l1 = (FStar_ToSyntax_Env.fail_or env1 (FStar_ToSyntax_Env.try_lookup_datacon env1) l)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____1832 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_cons (((l1), ([])))))
+in ((loc), (env1), (LocalBinder (((x), (None)))), (uu____1832), (false)))))
+end
+| FStar_Parser_AST.PatApp ({FStar_Parser_AST.pat = FStar_Parser_AST.PatName (l); FStar_Parser_AST.prange = uu____1850}, args) -> begin
+(
+
+let uu____1854 = (FStar_List.fold_right (fun arg uu____1872 -> (match (uu____1872) with
+| (loc1, env2, args1) -> begin
+(
+
+let uu____1902 = (aux loc1 env2 arg)
+in (match (uu____1902) with
+| (loc2, env3, uu____1920, arg1, imp) -> begin
+((loc2), (env3), ((((arg1), (imp)))::args1))
+end))
+end)) args ((loc), (env1), ([])))
+in (match (uu____1854) with
+| (loc1, env2, args1) -> begin
+(
+
+let l1 = (FStar_ToSyntax_Env.fail_or env2 (FStar_ToSyntax_Env.try_lookup_datacon env2) l)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____1969 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_cons (((l1), (args1)))))
+in ((loc1), (env2), (LocalBinder (((x), (None)))), (uu____1969), (false)))))
+end))
+end
+| FStar_Parser_AST.PatApp (uu____1982) -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected pattern"), (p1.FStar_Parser_AST.prange)))))
+end
+| FStar_Parser_AST.PatList (pats) -> begin
+(
+
+let uu____1995 = (FStar_List.fold_right (fun pat uu____2009 -> (match (uu____2009) with
+| (loc1, env2, pats1) -> begin
+(
+
+let uu____2031 = (aux loc1 env2 pat)
+in (match (uu____2031) with
+| (loc2, env3, uu____2047, pat1, uu____2049) -> begin
+((loc2), (env3), ((pat1)::pats1))
+end))
+end)) pats ((loc), (env1), ([])))
+in (match (uu____1995) with
+| (loc1, env2, pats1) -> begin
+(
+
+let pat = (
+
+let uu____2083 = (
+
+let uu____2086 = (
+
+let uu____2091 = (FStar_Range.end_range p1.FStar_Parser_AST.prange)
+in (pos_r uu____2091))
+in (
+
+let uu____2092 = (
+
+let uu____2093 = (
+
+let uu____2101 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.nil_lid FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in ((uu____2101), ([])))
+in FStar_Syntax_Syntax.Pat_cons (uu____2093))
+in (FStar_All.pipe_left uu____2086 uu____2092)))
+in (FStar_List.fold_right (fun hd1 tl1 -> (
+
+let r = (FStar_Range.union_ranges hd1.FStar_Syntax_Syntax.p tl1.FStar_Syntax_Syntax.p)
+in (
+
+let uu____2124 = (
+
+let uu____2125 = (
+
+let uu____2133 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.cons_lid FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in ((uu____2133), ((((hd1), (false)))::(((tl1), (false)))::[])))
+in FStar_Syntax_Syntax.Pat_cons (uu____2125))
+in (FStar_All.pipe_left (pos_r r) uu____2124)))) pats1 uu____2083))
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in ((loc1), (env2), (LocalBinder (((x), (None)))), (pat), (false))))
+end))
+end
+| FStar_Parser_AST.PatTuple (args, dep1) -> begin
+(
+
+let uu____2165 = (FStar_List.fold_left (fun uu____2182 p2 -> (match (uu____2182) with
+| (loc1, env2, pats) -> begin
+(
+
+let uu____2213 = (aux loc1 env2 p2)
+in (match (uu____2213) with
+| (loc2, env3, uu____2231, pat, uu____2233) -> begin
+((loc2), (env3), ((((pat), (false)))::pats))
+end))
+end)) ((loc), (env1), ([])) args)
+in (match (uu____2165) with
+| (loc1, env2, args1) -> begin
+(
+
+let args2 = (FStar_List.rev args1)
+in (
+
+let l = (match (dep1) with
+| true -> begin
+(FStar_Syntax_Util.mk_dtuple_data_lid (FStar_List.length args2) p1.FStar_Parser_AST.prange)
+end
+| uu____2296 -> begin
+(FStar_Syntax_Util.mk_tuple_data_lid (FStar_List.length args2) p1.FStar_Parser_AST.prange)
+end)
+in (
+
+let uu____2304 = (FStar_ToSyntax_Env.fail_or env2 (FStar_ToSyntax_Env.try_lookup_lid env2) l)
+in (match (uu____2304) with
+| (constr, uu____2317) -> begin
+(
+
+let l1 = (match (constr.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+fv
+end
+| uu____2320 -> begin
+(failwith "impossible")
+end)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Parser_AST.prange)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____2322 = (FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_cons (((l1), (args2)))))
+in ((loc1), (env2), (LocalBinder (((x), (None)))), (uu____2322), (false)))))
+end))))
+end))
+end
+| FStar_Parser_AST.PatRecord ([]) -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected pattern"), (p1.FStar_Parser_AST.prange)))))
+end
+| FStar_Parser_AST.PatRecord (fields) -> begin
+(
+
+let record = (check_fields env1 fields p1.FStar_Parser_AST.prange)
+in (
+
+let fields1 = (FStar_All.pipe_right fields (FStar_List.map (fun uu____2363 -> (match (uu____2363) with
+| (f, p2) -> begin
+((f.FStar_Ident.ident), (p2))
+end))))
+in (
+
+let args = (FStar_All.pipe_right record.FStar_ToSyntax_Env.fields (FStar_List.map (fun uu____2378 -> (match (uu____2378) with
+| (f, uu____2382) -> begin
+(
+
+let uu____2383 = (FStar_All.pipe_right fields1 (FStar_List.tryFind (fun uu____2395 -> (match (uu____2395) with
+| (g, uu____2399) -> begin
+(f.FStar_Ident.idText = g.FStar_Ident.idText)
+end))))
+in (match (uu____2383) with
+| None -> begin
+(FStar_Parser_AST.mk_pattern FStar_Parser_AST.PatWild p1.FStar_Parser_AST.prange)
+end
+| Some (uu____2402, p2) -> begin
+p2
+end))
+end))))
+in (
+
+let app = (
+
+let uu____2407 = (
+
+let uu____2408 = (
+
+let uu____2412 = (
+
+let uu____2413 = (
+
+let uu____2414 = (FStar_Ident.lid_of_ids (FStar_List.append record.FStar_ToSyntax_Env.typename.FStar_Ident.ns ((record.FStar_ToSyntax_Env.constrname)::[])))
+in FStar_Parser_AST.PatName (uu____2414))
+in (FStar_Parser_AST.mk_pattern uu____2413 p1.FStar_Parser_AST.prange))
+in ((uu____2412), (args)))
+in FStar_Parser_AST.PatApp (uu____2408))
+in (FStar_Parser_AST.mk_pattern uu____2407 p1.FStar_Parser_AST.prange))
+in (
+
+let uu____2416 = (aux loc env1 app)
+in (match (uu____2416) with
+| (env2, e, b, p2, uu____2435) -> begin
+(
+
+let p3 = (match (p2.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_cons (fv, args1) -> begin
+(
+
+let uu____2457 = (
+
+let uu____2458 = (
+
+let uu____2466 = (
+
+let uu___209_2467 = fv
+in (
+
+let uu____2468 = (
+
+let uu____2470 = (
+
+let uu____2471 = (
+
+let uu____2475 = (FStar_All.pipe_right record.FStar_ToSyntax_Env.fields (FStar_List.map Prims.fst))
+in ((record.FStar_ToSyntax_Env.typename), (uu____2475)))
+in FStar_Syntax_Syntax.Record_ctor (uu____2471))
+in Some (uu____2470))
+in {FStar_Syntax_Syntax.fv_name = uu___209_2467.FStar_Syntax_Syntax.fv_name; FStar_Syntax_Syntax.fv_delta = uu___209_2467.FStar_Syntax_Syntax.fv_delta; FStar_Syntax_Syntax.fv_qual = uu____2468}))
+in ((uu____2466), (args1)))
+in FStar_Syntax_Syntax.Pat_cons (uu____2458))
+in (FStar_All.pipe_left pos uu____2457))
+end
+| uu____2494 -> begin
+p2
+end)
+in ((env2), (e), (b), (p3), (false)))
+end))))))
+end))))
+in (
+
+let uu____2497 = (aux [] env p)
+in (match (uu____2497) with
+| (uu____2508, env1, b, p1, uu____2512) -> begin
+((
+
+let uu____2518 = (check_linear_pattern_variables p1)
+in (FStar_All.pipe_left Prims.ignore uu____2518));
+((env1), (b), (p1));
+)
+end)))));
+)))
+and desugar_binding_pat_maybe_top : Prims.bool  ->  FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.pattern  ->  Prims.bool  ->  (env_t * bnd * FStar_Syntax_Syntax.pat Prims.option) = (fun top env p is_mut -> (
+
+let mklet = (fun x -> (
+
+let uu____2537 = (
+
+let uu____2538 = (
+
+let uu____2541 = (FStar_ToSyntax_Env.qualify env x)
+in ((uu____2541), (FStar_Syntax_Syntax.tun)))
+in LetBinder (uu____2538))
+in ((env), (uu____2537), (None))))
+in (match (top) with
+| true -> begin
+(match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatOp (x) -> begin
+(
+
+let uu____2552 = (
+
+let uu____2553 = (FStar_Parser_AST.compile_op (Prims.parse_int "0") x)
+in (FStar_Ident.id_of_text uu____2553))
+in (mklet uu____2552))
+end
+| FStar_Parser_AST.PatVar (x, uu____2555) -> begin
+(mklet x)
+end
+| FStar_Parser_AST.PatAscribed ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, uu____2559); FStar_Parser_AST.prange = uu____2560}, t) -> begin
+(
+
+let uu____2564 = (
+
+let uu____2565 = (
+
+let uu____2568 = (FStar_ToSyntax_Env.qualify env x)
+in (
+
+let uu____2569 = (desugar_term env t)
+in ((uu____2568), (uu____2569))))
+in LetBinder (uu____2565))
+in ((env), (uu____2564), (None)))
+end
+| uu____2571 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected pattern at the top-level"), (p.FStar_Parser_AST.prange)))))
+end)
+end
+| uu____2576 -> begin
+(
+
+let uu____2577 = (desugar_data_pat env p is_mut)
+in (match (uu____2577) with
+| (env1, binder, p1) -> begin
+(
+
+let p2 = (match (p1.FStar_Syntax_Syntax.v) with
+| (FStar_Syntax_Syntax.Pat_var (_)) | (FStar_Syntax_Syntax.Pat_wild (_)) -> begin
+None
+end
+| uu____2593 -> begin
+Some (p1)
+end)
+in ((env1), (binder), (p2)))
+end))
+end)))
+and desugar_binding_pat : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.pattern  ->  (env_t * bnd * FStar_Syntax_Syntax.pat Prims.option) = (fun env p -> (desugar_binding_pat_maybe_top false env p false))
+and desugar_match_pat_maybe_top : Prims.bool  ->  FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.pattern  ->  (env_t * FStar_Syntax_Syntax.pat) = (fun uu____2597 env pat -> (
+
+let uu____2600 = (desugar_data_pat env pat false)
+in (match (uu____2600) with
+| (env1, uu____2607, pat1) -> begin
+((env1), (pat1))
+end)))
+and desugar_match_pat : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.pattern  ->  (env_t * FStar_Syntax_Syntax.pat) = (fun env p -> (desugar_match_pat_maybe_top false env p))
+and desugar_term : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  FStar_Syntax_Syntax.term = (fun env e -> (
+
+let env1 = (
+
+let uu___210_2614 = env
+in {FStar_ToSyntax_Env.curmodule = uu___210_2614.FStar_ToSyntax_Env.curmodule; FStar_ToSyntax_Env.curmonad = uu___210_2614.FStar_ToSyntax_Env.curmonad; FStar_ToSyntax_Env.modules = uu___210_2614.FStar_ToSyntax_Env.modules; FStar_ToSyntax_Env.scope_mods = uu___210_2614.FStar_ToSyntax_Env.scope_mods; FStar_ToSyntax_Env.exported_ids = uu___210_2614.FStar_ToSyntax_Env.exported_ids; FStar_ToSyntax_Env.trans_exported_ids = uu___210_2614.FStar_ToSyntax_Env.trans_exported_ids; FStar_ToSyntax_Env.includes = uu___210_2614.FStar_ToSyntax_Env.includes; FStar_ToSyntax_Env.sigaccum = uu___210_2614.FStar_ToSyntax_Env.sigaccum; FStar_ToSyntax_Env.sigmap = uu___210_2614.FStar_ToSyntax_Env.sigmap; FStar_ToSyntax_Env.iface = uu___210_2614.FStar_ToSyntax_Env.iface; FStar_ToSyntax_Env.admitted_iface = uu___210_2614.FStar_ToSyntax_Env.admitted_iface; FStar_ToSyntax_Env.expect_typ = false})
+in (desugar_term_maybe_top false env1 e)))
+and desugar_typ : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  FStar_Syntax_Syntax.term = (fun env e -> (
+
+let env1 = (
+
+let uu___211_2618 = env
+in {FStar_ToSyntax_Env.curmodule = uu___211_2618.FStar_ToSyntax_Env.curmodule; FStar_ToSyntax_Env.curmonad = uu___211_2618.FStar_ToSyntax_Env.curmonad; FStar_ToSyntax_Env.modules = uu___211_2618.FStar_ToSyntax_Env.modules; FStar_ToSyntax_Env.scope_mods = uu___211_2618.FStar_ToSyntax_Env.scope_mods; FStar_ToSyntax_Env.exported_ids = uu___211_2618.FStar_ToSyntax_Env.exported_ids; FStar_ToSyntax_Env.trans_exported_ids = uu___211_2618.FStar_ToSyntax_Env.trans_exported_ids; FStar_ToSyntax_Env.includes = uu___211_2618.FStar_ToSyntax_Env.includes; FStar_ToSyntax_Env.sigaccum = uu___211_2618.FStar_ToSyntax_Env.sigaccum; FStar_ToSyntax_Env.sigmap = uu___211_2618.FStar_ToSyntax_Env.sigmap; FStar_ToSyntax_Env.iface = uu___211_2618.FStar_ToSyntax_Env.iface; FStar_ToSyntax_Env.admitted_iface = uu___211_2618.FStar_ToSyntax_Env.admitted_iface; FStar_ToSyntax_Env.expect_typ = true})
+in (desugar_term_maybe_top false env1 e)))
+and desugar_machine_integer : FStar_ToSyntax_Env.env  ->  Prims.string  ->  (FStar_Const.signedness * FStar_Const.width)  ->  FStar_Range.range  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun env repr uu____2621 range -> (match (uu____2621) with
+| (signedness, width) -> begin
+(
+
+let lid = (Prims.strcat "FStar." (Prims.strcat (match (signedness) with
+| FStar_Const.Unsigned -> begin
+"U"
+end
+| FStar_Const.Signed -> begin
+""
+end) (Prims.strcat "Int" (Prims.strcat (match (width) with
+| FStar_Const.Int8 -> begin
+"8"
+end
+| FStar_Const.Int16 -> begin
+"16"
+end
+| FStar_Const.Int32 -> begin
+"32"
+end
+| FStar_Const.Int64 -> begin
+"64"
+end) (Prims.strcat "." (Prims.strcat (match (signedness) with
+| FStar_Const.Unsigned -> begin
+"u"
+end
+| FStar_Const.Signed -> begin
+""
+end) "int_to_t"))))))
+in (
+
+let lid1 = (FStar_Ident.lid_of_path (FStar_Ident.path_of_text lid) range)
+in (
+
+let lid2 = (
+
+let uu____2632 = (FStar_ToSyntax_Env.try_lookup_lid env lid1)
+in (match (uu____2632) with
+| Some (lid2) -> begin
+(Prims.fst lid2)
+end
+| None -> begin
+(
+
+let uu____2643 = (FStar_Util.format1 "%s not in scope\n" (FStar_Ident.text_of_lid lid1))
+in (failwith uu____2643))
+end))
+in (
+
+let repr1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (((repr), (None)))))) None range)
+in (
+
+let uu____2660 = (
+
+let uu____2663 = (
+
+let uu____2664 = (
+
+let uu____2674 = (
+
+let uu____2680 = (
+
+let uu____2685 = (FStar_Syntax_Syntax.as_implicit false)
+in ((repr1), (uu____2685)))
+in (uu____2680)::[])
+in ((lid2), (uu____2674)))
+in FStar_Syntax_Syntax.Tm_app (uu____2664))
+in (FStar_Syntax_Syntax.mk uu____2663))
+in (uu____2660 None range))))))
+end))
+and desugar_name : (FStar_Syntax_Syntax.term'  ->  FStar_Syntax_Syntax.term)  ->  (FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  env_t  ->  Prims.bool  ->  FStar_Ident.lid  ->  FStar_Syntax_Syntax.term = (fun mk1 setpos env resolve l -> (
+
+let uu____2720 = (FStar_ToSyntax_Env.fail_or env ((match (resolve) with
+| true -> begin
+FStar_ToSyntax_Env.try_lookup_lid
+end
+| uu____2732 -> begin
+FStar_ToSyntax_Env.try_lookup_lid_no_resolve
+end) env) l)
+in (match (uu____2720) with
+| (tm, mut) -> begin
+(
+
+let tm1 = (setpos tm)
+in (match (mut) with
+| true -> begin
+(
+
+let uu____2738 = (
+
+let uu____2739 = (
+
+let uu____2744 = (mk_ref_read tm1)
+in ((uu____2744), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Mutable_rval))))
+in FStar_Syntax_Syntax.Tm_meta (uu____2739))
+in (FStar_All.pipe_left mk1 uu____2738))
+end
+| uu____2749 -> begin
+tm1
+end))
+end)))
+and desugar_attributes : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term Prims.list  ->  FStar_Syntax_Syntax.cflags Prims.list = (fun env cattributes -> (
+
+let desugar_attribute = (fun t -> (
+
+let uu____2758 = (
+
+let uu____2759 = (unparen t)
+in uu____2759.FStar_Parser_AST.tm)
+in (match (uu____2758) with
+| FStar_Parser_AST.Var ({FStar_Ident.ns = uu____2760; FStar_Ident.ident = uu____2761; FStar_Ident.nsstr = uu____2762; FStar_Ident.str = "cps"}) -> begin
+FStar_Syntax_Syntax.CPS
+end
+| uu____2764 -> begin
+(
+
+let uu____2765 = (
+
+let uu____2766 = (
+
+let uu____2769 = (
+
+let uu____2770 = (FStar_Parser_AST.term_to_string t)
+in (Prims.strcat "Unknown attribute " uu____2770))
+in ((uu____2769), (t.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____2766))
+in (Prims.raise uu____2765))
+end)))
+in (FStar_List.map desugar_attribute cattributes)))
+and desugar_term_maybe_top : Prims.bool  ->  env_t  ->  FStar_Parser_AST.term  ->  FStar_Syntax_Syntax.term = (fun top_level env top -> (
+
+let mk1 = (fun e -> ((FStar_Syntax_Syntax.mk e) None top.FStar_Parser_AST.range))
+in (
+
+let setpos = (fun e -> (
+
+let uu___212_2798 = e
+in {FStar_Syntax_Syntax.n = uu___212_2798.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___212_2798.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = top.FStar_Parser_AST.range; FStar_Syntax_Syntax.vars = uu___212_2798.FStar_Syntax_Syntax.vars}))
+in (
+
+let uu____2805 = (
+
+let uu____2806 = (unparen top)
+in uu____2806.FStar_Parser_AST.tm)
+in (match (uu____2805) with
+| FStar_Parser_AST.Wild -> begin
+(setpos FStar_Syntax_Syntax.tun)
+end
+| FStar_Parser_AST.Labeled (uu____2807) -> begin
+(desugar_formula env top)
+end
+| FStar_Parser_AST.Requires (t, lopt) -> begin
+(desugar_formula env t)
+end
+| FStar_Parser_AST.Ensures (t, lopt) -> begin
+(desugar_formula env t)
+end
+| FStar_Parser_AST.Attributes (ts) -> begin
+(failwith "Attributes should not be desugared by desugar_term_maybe_top")
+end
+| FStar_Parser_AST.Const (FStar_Const.Const_int (i, Some (size))) -> begin
+(desugar_machine_integer env i size top.FStar_Parser_AST.range)
+end
+| FStar_Parser_AST.Const (c) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_constant (c)))
+end
+| FStar_Parser_AST.Op ("=!=", args) -> begin
+(desugar_term env (FStar_Parser_AST.mk_term (FStar_Parser_AST.Op ((("~"), (((FStar_Parser_AST.mk_term (FStar_Parser_AST.Op ((("=="), (args)))) top.FStar_Parser_AST.range top.FStar_Parser_AST.level))::[])))) top.FStar_Parser_AST.range top.FStar_Parser_AST.level))
+end
+| FStar_Parser_AST.Op ("*", (uu____2836)::(uu____2837)::[]) when (
+
+let uu____2839 = (op_as_term env (Prims.parse_int "2") top.FStar_Parser_AST.range "*")
+in (FStar_All.pipe_right uu____2839 FStar_Option.isNone)) -> begin
+(
+
+let rec flatten1 = (fun t -> (match (t.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Op ("*", (t1)::(t2)::[]) -> begin
+(
+
+let uu____2851 = (flatten1 t1)
+in (FStar_List.append uu____2851 ((t2)::[])))
+end
+| uu____2853 -> begin
+(t)::[]
+end))
+in (
+
+let targs = (
+
+let uu____2856 = (
+
+let uu____2858 = (unparen top)
+in (flatten1 uu____2858))
+in (FStar_All.pipe_right uu____2856 (FStar_List.map (fun t -> (
+
+let uu____2862 = (desugar_typ env t)
+in (FStar_Syntax_Syntax.as_arg uu____2862))))))
+in (
+
+let uu____2863 = (
+
+let uu____2866 = (FStar_Syntax_Util.mk_tuple_lid (FStar_List.length targs) top.FStar_Parser_AST.range)
+in (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_lid env) uu____2866))
+in (match (uu____2863) with
+| (tup, uu____2873) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_app (((tup), (targs)))))
+end))))
+end
+| FStar_Parser_AST.Tvar (a) -> begin
+(
+
+let uu____2876 = (
+
+let uu____2879 = (FStar_ToSyntax_Env.fail_or2 (FStar_ToSyntax_Env.try_lookup_id env) a)
+in (Prims.fst uu____2879))
+in (FStar_All.pipe_left setpos uu____2876))
+end
+| FStar_Parser_AST.Uvar (u) -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Unexpected universe variable " (Prims.strcat (FStar_Ident.text_of_id u) " in non-universe context"))), (top.FStar_Parser_AST.range)))))
+end
+| FStar_Parser_AST.Op (s, args) -> begin
+(
+
+let uu____2893 = (op_as_term env (FStar_List.length args) top.FStar_Parser_AST.range s)
+in (match (uu____2893) with
+| None -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Unexpected or unbound operator: " s)), (top.FStar_Parser_AST.range)))))
+end
+| Some (op) -> begin
+(match (((FStar_List.length args) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let args1 = (FStar_All.pipe_right args (FStar_List.map (fun t -> (
+
+let uu____2915 = (desugar_term env t)
+in ((uu____2915), (None))))))
+in (mk1 (FStar_Syntax_Syntax.Tm_app (((op), (args1))))))
+end
+| uu____2921 -> begin
+op
+end)
+end))
+end
+| FStar_Parser_AST.Name ({FStar_Ident.ns = uu____2922; FStar_Ident.ident = uu____2923; FStar_Ident.nsstr = uu____2924; FStar_Ident.str = "Type0"}) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_zero)))
+end
+| FStar_Parser_AST.Name ({FStar_Ident.ns = uu____2926; FStar_Ident.ident = uu____2927; FStar_Ident.nsstr = uu____2928; FStar_Ident.str = "Type"}) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_unknown)))
+end
+| FStar_Parser_AST.Construct ({FStar_Ident.ns = uu____2930; FStar_Ident.ident = uu____2931; FStar_Ident.nsstr = uu____2932; FStar_Ident.str = "Type"}, ((t, FStar_Parser_AST.UnivApp))::[]) -> begin
+(
+
+let uu____2942 = (
+
+let uu____2943 = (desugar_universe t)
+in FStar_Syntax_Syntax.Tm_type (uu____2943))
+in (mk1 uu____2942))
+end
+| FStar_Parser_AST.Name ({FStar_Ident.ns = uu____2944; FStar_Ident.ident = uu____2945; FStar_Ident.nsstr = uu____2946; FStar_Ident.str = "Effect"}) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_effect)))
+end
+| FStar_Parser_AST.Name ({FStar_Ident.ns = uu____2948; FStar_Ident.ident = uu____2949; FStar_Ident.nsstr = uu____2950; FStar_Ident.str = "True"}) -> begin
+(FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.true_lid top.FStar_Parser_AST.range) FStar_Syntax_Syntax.Delta_constant None)
+end
+| FStar_Parser_AST.Name ({FStar_Ident.ns = uu____2952; FStar_Ident.ident = uu____2953; FStar_Ident.nsstr = uu____2954; FStar_Ident.str = "False"}) -> begin
+(FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.false_lid top.FStar_Parser_AST.range) FStar_Syntax_Syntax.Delta_constant None)
+end
+| FStar_Parser_AST.Projector (eff_name, {FStar_Ident.idText = txt; FStar_Ident.idRange = uu____2958}) when ((is_special_effect_combinator txt) && (FStar_ToSyntax_Env.is_effect_name env eff_name)) -> begin
+(
+
+let uu____2959 = (FStar_ToSyntax_Env.try_lookup_effect_defn env eff_name)
+in (match (uu____2959) with
+| Some (ed) -> begin
+(
+
+let uu____2962 = (FStar_Ident.lid_of_path (FStar_Ident.path_of_text (Prims.strcat (FStar_Ident.text_of_lid ed.FStar_Syntax_Syntax.mname) (Prims.strcat "_" txt))) FStar_Range.dummyRange)
+in (FStar_Syntax_Syntax.fvar uu____2962 (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None))
+end
+| None -> begin
+(
+
+let uu____2963 = (FStar_Util.format2 "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)" (FStar_Ident.text_of_lid eff_name) txt)
+in (failwith uu____2963))
+end))
+end
+| FStar_Parser_AST.Assign (ident, t2) -> begin
+(
+
+let t21 = (desugar_term env t2)
+in (
+
+let uu____2967 = (FStar_ToSyntax_Env.fail_or2 (FStar_ToSyntax_Env.try_lookup_id env) ident)
+in (match (uu____2967) with
+| (t1, mut) -> begin
+((match ((not (mut))) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Can only assign to mutable values"), (top.FStar_Parser_AST.range)))))
+end
+| uu____2975 -> begin
+()
+end);
+(mk_ref_assign t1 t21 top.FStar_Parser_AST.range);
+)
+end)))
+end
+| (FStar_Parser_AST.Var (l)) | (FStar_Parser_AST.Name (l)) -> begin
+(desugar_name mk1 setpos env true l)
+end
+| FStar_Parser_AST.Projector (l, i) -> begin
+(
+
+let name = (
+
+let uu____2983 = (FStar_ToSyntax_Env.try_lookup_datacon env l)
+in (match (uu____2983) with
+| Some (uu____2988) -> begin
+Some (((true), (l)))
+end
+| None -> begin
+(
+
+let uu____2991 = (FStar_ToSyntax_Env.try_lookup_root_effect_name env l)
+in (match (uu____2991) with
+| Some (new_name) -> begin
+Some (((false), (new_name)))
+end
+| uu____2999 -> begin
+None
+end))
+end))
+in (match (name) with
+| Some (resolve, new_name) -> begin
+(
+
+let uu____3007 = (FStar_Syntax_Util.mk_field_projector_name_from_ident new_name i)
+in (desugar_name mk1 setpos env resolve uu____3007))
+end
+| uu____3008 -> begin
+(
+
+let uu____3012 = (
+
+let uu____3013 = (
+
+let uu____3016 = (FStar_Util.format1 "Data constructor or effect %s not found" l.FStar_Ident.str)
+in ((uu____3016), (top.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____3013))
+in (Prims.raise uu____3012))
+end))
+end
+| FStar_Parser_AST.Discrim (lid) -> begin
+(
+
+let uu____3018 = (FStar_ToSyntax_Env.try_lookup_datacon env lid)
+in (match (uu____3018) with
+| None -> begin
+(
+
+let uu____3020 = (
+
+let uu____3021 = (
+
+let uu____3024 = (FStar_Util.format1 "Data constructor %s not found" lid.FStar_Ident.str)
+in ((uu____3024), (top.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____3021))
+in (Prims.raise uu____3020))
+end
+| uu____3025 -> begin
+(
+
+let lid' = (FStar_Syntax_Util.mk_discriminator lid)
+in (desugar_name mk1 setpos env true lid'))
+end))
+end
+| FStar_Parser_AST.Construct (l, args) -> begin
+(
+
+let uu____3036 = (FStar_ToSyntax_Env.try_lookup_datacon env l)
+in (match (uu____3036) with
+| Some (head1) -> begin
+(
+
+let uu____3039 = (
+
+let uu____3044 = (mk1 (FStar_Syntax_Syntax.Tm_fvar (head1)))
+in ((uu____3044), (true)))
+in (match (uu____3039) with
+| (head2, is_data) -> begin
+(match (args) with
+| [] -> begin
+head2
+end
+| uu____3057 -> begin
+(
+
+let uu____3061 = (FStar_Util.take (fun uu____3072 -> (match (uu____3072) with
+| (uu____3075, imp) -> begin
+(imp = FStar_Parser_AST.UnivApp)
+end)) args)
+in (match (uu____3061) with
+| (universes, args1) -> begin
+(
+
+let universes1 = (FStar_List.map (fun x -> (desugar_universe (Prims.fst x))) universes)
+in (
+
+let args2 = (FStar_List.map (fun uu____3108 -> (match (uu____3108) with
+| (t, imp) -> begin
+(
+
+let te = (desugar_term env t)
+in (arg_withimp_e imp te))
+end)) args1)
+in (
+
+let head3 = (match ((universes1 = [])) with
+| true -> begin
+head2
+end
+| uu____3123 -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_uinst (((head2), (universes1)))))
+end)
+in (
+
+let app = (mk1 (FStar_Syntax_Syntax.Tm_app (((head3), (args2)))))
+in (match (is_data) with
+| true -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_meta (((app), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app))))))
+end
+| uu____3138 -> begin
+app
+end)))))
+end))
+end)
+end))
+end
+| None -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Constructor " (Prims.strcat l.FStar_Ident.str " not found"))), (top.FStar_Parser_AST.range)))))
+end))
+end
+| FStar_Parser_AST.Sum (binders, t) -> begin
+(
+
+let uu____3143 = (FStar_List.fold_left (fun uu____3160 b -> (match (uu____3160) with
+| (env1, tparams, typs) -> begin
+(
+
+let uu____3191 = (desugar_binder env1 b)
+in (match (uu____3191) with
+| (xopt, t1) -> begin
+(
+
+let uu____3207 = (match (xopt) with
+| None -> begin
+(
+
+let uu____3212 = (FStar_Syntax_Syntax.new_bv (Some (top.FStar_Parser_AST.range)) FStar_Syntax_Syntax.tun)
+in ((env1), (uu____3212)))
+end
+| Some (x) -> begin
+(FStar_ToSyntax_Env.push_bv env1 x)
+end)
+in (match (uu____3207) with
+| (env2, x) -> begin
+(
+
+let uu____3224 = (
+
+let uu____3226 = (
+
+let uu____3228 = (
+
+let uu____3229 = (no_annot_abs tparams t1)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3229))
+in (uu____3228)::[])
+in (FStar_List.append typs uu____3226))
+in ((env2), ((FStar_List.append tparams (((((
+
+let uu___213_3242 = x
+in {FStar_Syntax_Syntax.ppname = uu___213_3242.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___213_3242.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1})), (None)))::[]))), (uu____3224)))
+end))
+end))
+end)) ((env), ([]), ([])) (FStar_List.append binders (((FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName (t)) t.FStar_Parser_AST.range FStar_Parser_AST.Type_level None))::[])))
+in (match (uu____3143) with
+| (env1, uu____3255, targs) -> begin
+(
+
+let uu____3267 = (
+
+let uu____3270 = (FStar_Syntax_Util.mk_dtuple_lid (FStar_List.length targs) top.FStar_Parser_AST.range)
+in (FStar_ToSyntax_Env.fail_or env1 (FStar_ToSyntax_Env.try_lookup_lid env1) uu____3270))
+in (match (uu____3267) with
+| (tup, uu____3277) -> begin
+(FStar_All.pipe_left mk1 (FStar_Syntax_Syntax.Tm_app (((tup), (targs)))))
+end))
+end))
+end
+| FStar_Parser_AST.Product (binders, t) -> begin
+(
+
+let uu____3285 = (uncurry binders t)
+in (match (uu____3285) with
+| (bs, t1) -> begin
+(
+
+let rec aux = (fun env1 bs1 uu___191_3308 -> (match (uu___191_3308) with
+| [] -> begin
+(
+
+let cod = (desugar_comp top.FStar_Parser_AST.range env1 t1)
+in (
+
+let uu____3318 = (FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod)
+in (FStar_All.pipe_left setpos uu____3318)))
+end
+| (hd1)::tl1 -> begin
+(
+
+let bb = (desugar_binder env1 hd1)
+in (
+
+let uu____3334 = (as_binder env1 hd1.FStar_Parser_AST.aqual bb)
+in (match (uu____3334) with
+| (b, env2) -> begin
+(aux env2 ((b)::bs1) tl1)
+end)))
+end))
+in (aux env [] bs))
+end))
+end
+| FStar_Parser_AST.Refine (b, f) -> begin
+(
+
+let uu____3345 = (desugar_binder env b)
+in (match (uu____3345) with
+| (None, uu____3349) -> begin
+(failwith "Missing binder in refinement")
+end
+| b1 -> begin
+(
+
+let uu____3355 = (as_binder env None b1)
+in (match (uu____3355) with
+| ((x, uu____3359), env1) -> begin
+(
+
+let f1 = (desugar_formula env1 f)
+in (
+
+let uu____3364 = (FStar_Syntax_Util.refine x f1)
+in (FStar_All.pipe_left setpos uu____3364)))
+end))
+end))
+end
+| FStar_Parser_AST.Abs (binders, body) -> begin
+(
+
+let binders1 = (FStar_All.pipe_right binders (FStar_List.map replace_unit_pattern))
+in (
+
+let uu____3379 = (FStar_List.fold_left (fun uu____3386 pat -> (match (uu____3386) with
+| (env1, ftvs) -> begin
+(match (pat.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (uu____3401, t) -> begin
+(
+
+let uu____3403 = (
+
+let uu____3405 = (free_type_vars env1 t)
+in (FStar_List.append uu____3405 ftvs))
+in ((env1), (uu____3403)))
+end
+| uu____3408 -> begin
+((env1), (ftvs))
+end)
+end)) ((env), ([])) binders1)
+in (match (uu____3379) with
+| (uu____3411, ftv) -> begin
+(
+
+let ftv1 = (sort_ftv ftv)
+in (
+
+let binders2 = (
+
+let uu____3419 = (FStar_All.pipe_right ftv1 (FStar_List.map (fun a -> (FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatTvar (((a), (Some (FStar_Parser_AST.Implicit))))) top.FStar_Parser_AST.range))))
+in (FStar_List.append uu____3419 binders1))
+in (
+
+let rec aux = (fun env1 bs sc_pat_opt uu___192_3448 -> (match (uu___192_3448) with
+| [] -> begin
+(
+
+let body1 = (desugar_term env1 body)
+in (
+
+let body2 = (match (sc_pat_opt) with
+| Some (sc, pat) -> begin
+(
+
+let body2 = (
+
+let uu____3477 = (
+
+let uu____3478 = (FStar_Syntax_Syntax.pat_bvs pat)
+in (FStar_All.pipe_right uu____3478 (FStar_List.map FStar_Syntax_Syntax.mk_binder)))
+in (FStar_Syntax_Subst.close uu____3477 body1))
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (((sc), ((((pat), (None), (body2)))::[]))))) None body2.FStar_Syntax_Syntax.pos))
+end
+| None -> begin
+body1
+end)
+in (
+
+let uu____3520 = (no_annot_abs (FStar_List.rev bs) body2)
+in (setpos uu____3520))))
+end
+| (p)::rest -> begin
+(
+
+let uu____3528 = (desugar_binding_pat env1 p)
+in (match (uu____3528) with
+| (env2, b, pat) -> begin
+(
+
+let uu____3540 = (match (b) with
+| LetBinder (uu____3559) -> begin
+(failwith "Impossible")
+end
+| LocalBinder (x, aq) -> begin
+(
+
+let sc_pat_opt1 = (match (((pat), (sc_pat_opt))) with
+| (None, uu____3590) -> begin
+sc_pat_opt
+end
+| (Some (p1), None) -> begin
+(
+
+let uu____3613 = (
+
+let uu____3616 = (FStar_Syntax_Syntax.bv_to_name x)
+in ((uu____3616), (p1)))
+in Some (uu____3613))
+end
+| (Some (p1), Some (sc, p')) -> begin
+(match (((sc.FStar_Syntax_Syntax.n), (p'.FStar_Syntax_Syntax.v))) with
+| (FStar_Syntax_Syntax.Tm_name (uu____3641), uu____3642) -> begin
+(
+
+let tup2 = (
+
+let uu____3644 = (FStar_Syntax_Util.mk_tuple_data_lid (Prims.parse_int "2") top.FStar_Parser_AST.range)
+in (FStar_Syntax_Syntax.lid_as_fv uu____3644 FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor))))
+in (
+
+let sc1 = (
+
+let uu____3648 = (
+
+let uu____3651 = (
+
+let uu____3652 = (
+
+let uu____3662 = (mk1 (FStar_Syntax_Syntax.Tm_fvar (tup2)))
+in (
+
+let uu____3665 = (
+
+let uu____3667 = (FStar_Syntax_Syntax.as_arg sc)
+in (
+
+let uu____3668 = (
+
+let uu____3670 = (
+
+let uu____3671 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3671))
+in (uu____3670)::[])
+in (uu____3667)::uu____3668))
+in ((uu____3662), (uu____3665))))
+in FStar_Syntax_Syntax.Tm_app (uu____3652))
+in (FStar_Syntax_Syntax.mk uu____3651))
+in (uu____3648 None top.FStar_Parser_AST.range))
+in (
+
+let p2 = (
+
+let uu____3686 = (FStar_Range.union_ranges p'.FStar_Syntax_Syntax.p p1.FStar_Syntax_Syntax.p)
+in (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_cons (((tup2), ((((p'), (false)))::(((p1), (false)))::[])))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n uu____3686))
+in Some (((sc1), (p2))))))
+end
+| (FStar_Syntax_Syntax.Tm_app (uu____3706, args), FStar_Syntax_Syntax.Pat_cons (uu____3708, pats)) -> begin
+(
+
+let tupn = (
+
+let uu____3735 = (FStar_Syntax_Util.mk_tuple_data_lid ((Prims.parse_int "1") + (FStar_List.length args)) top.FStar_Parser_AST.range)
+in (FStar_Syntax_Syntax.lid_as_fv uu____3735 FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor))))
+in (
+
+let sc1 = (
+
+let uu____3745 = (
+
+let uu____3746 = (
+
+let uu____3756 = (mk1 (FStar_Syntax_Syntax.Tm_fvar (tupn)))
+in (
+
+let uu____3759 = (
+
+let uu____3765 = (
+
+let uu____3771 = (
+
+let uu____3772 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3772))
+in (uu____3771)::[])
+in (FStar_List.append args uu____3765))
+in ((uu____3756), (uu____3759))))
+in FStar_Syntax_Syntax.Tm_app (uu____3746))
+in (mk1 uu____3745))
+in (
+
+let p2 = (
+
+let uu____3787 = (FStar_Range.union_ranges p'.FStar_Syntax_Syntax.p p1.FStar_Syntax_Syntax.p)
+in (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_cons (((tupn), ((FStar_List.append pats ((((p1), (false)))::[])))))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n uu____3787))
+in Some (((sc1), (p2))))))
+end
+| uu____3811 -> begin
+(failwith "Impossible")
+end)
+end)
+in ((((x), (aq))), (sc_pat_opt1)))
+end)
+in (match (uu____3540) with
+| (b1, sc_pat_opt1) -> begin
+(aux env2 ((b1)::bs) sc_pat_opt1 rest)
+end))
+end))
+end))
+in (aux env [] None binders2))))
+end)))
+end
+| FStar_Parser_AST.App (uu____3852, uu____3853, FStar_Parser_AST.UnivApp) -> begin
+(
+
+let rec aux = (fun universes e -> (
+
+let uu____3865 = (
+
+let uu____3866 = (unparen e)
+in uu____3866.FStar_Parser_AST.tm)
+in (match (uu____3865) with
+| FStar_Parser_AST.App (e1, t, FStar_Parser_AST.UnivApp) -> begin
+(
+
+let univ_arg = (desugar_universe t)
+in (aux ((univ_arg)::universes) e1))
+end
+| uu____3872 -> begin
+(
+
+let head1 = (desugar_term env e)
+in (mk1 (FStar_Syntax_Syntax.Tm_uinst (((head1), (universes))))))
+end)))
+in (aux [] top))
+end
+| FStar_Parser_AST.App (uu____3875) -> begin
+(
+
+let rec aux = (fun args e -> (
+
+let uu____3896 = (
+
+let uu____3897 = (unparen e)
+in uu____3897.FStar_Parser_AST.tm)
+in (match (uu____3896) with
+| FStar_Parser_AST.App (e1, t, imp) when (imp <> FStar_Parser_AST.UnivApp) -> begin
+(
+
+let arg = (
+
+let uu____3907 = (desugar_term env t)
+in (FStar_All.pipe_left (arg_withimp_e imp) uu____3907))
+in (aux ((arg)::args) e1))
+end
+| uu____3914 -> begin
+(
+
+let head1 = (desugar_term env e)
+in (mk1 (FStar_Syntax_Syntax.Tm_app (((head1), (args))))))
+end)))
+in (aux [] top))
+end
+| FStar_Parser_AST.Seq (t1, t2) -> begin
+(
+
+let uu____3925 = (
+
+let uu____3926 = (
+
+let uu____3931 = (desugar_term env (FStar_Parser_AST.mk_term (FStar_Parser_AST.Let (((FStar_Parser_AST.NoLetQualifier), (((((FStar_Parser_AST.mk_pattern FStar_Parser_AST.PatWild t1.FStar_Parser_AST.range)), (t1)))::[]), (t2)))) top.FStar_Parser_AST.range FStar_Parser_AST.Expr))
+in ((uu____3931), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Sequence))))
+in FStar_Syntax_Syntax.Tm_meta (uu____3926))
+in (mk1 uu____3925))
+end
+| FStar_Parser_AST.LetOpen (lid, e) -> begin
+(
+
+let env1 = (FStar_ToSyntax_Env.push_namespace env lid)
+in (desugar_term_maybe_top top_level env1 e))
+end
+| FStar_Parser_AST.Let (qual1, ((pat, _snd))::_tl, body) -> begin
+(
+
+let is_rec = (qual1 = FStar_Parser_AST.Rec)
+in (
+
+let ds_let_rec_or_app = (fun uu____3961 -> (
+
+let bindings = (((pat), (_snd)))::_tl
+in (
+
+let funs = (FStar_All.pipe_right bindings (FStar_List.map (fun uu____4003 -> (match (uu____4003) with
+| (p, def) -> begin
+(
+
+let uu____4017 = (is_app_pattern p)
+in (match (uu____4017) with
+| true -> begin
+(
+
+let uu____4027 = (destruct_app_pattern env top_level p)
+in ((uu____4027), (def)))
+end
+| uu____4042 -> begin
+(match ((FStar_Parser_AST.un_function p def)) with
+| Some (p1, def1) -> begin
+(
+
+let uu____4056 = (destruct_app_pattern env top_level p1)
+in ((uu____4056), (def1)))
+end
+| uu____4071 -> begin
+(match (p.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id, uu____4085); FStar_Parser_AST.prange = uu____4086}, t) -> begin
+(match (top_level) with
+| true -> begin
+(
+
+let uu____4099 = (
+
+let uu____4107 = (
+
+let uu____4110 = (FStar_ToSyntax_Env.qualify env id)
+in FStar_Util.Inr (uu____4110))
+in ((uu____4107), ([]), (Some (t))))
+in ((uu____4099), (def)))
+end
+| uu____4122 -> begin
+((((FStar_Util.Inl (id)), ([]), (Some (t)))), (def))
+end)
+end
+| FStar_Parser_AST.PatVar (id, uu____4135) -> begin
+(match (top_level) with
+| true -> begin
+(
+
+let uu____4147 = (
+
+let uu____4155 = (
+
+let uu____4158 = (FStar_ToSyntax_Env.qualify env id)
+in FStar_Util.Inr (uu____4158))
+in ((uu____4155), ([]), (None)))
+in ((uu____4147), (def)))
+end
+| uu____4170 -> begin
+((((FStar_Util.Inl (id)), ([]), (None))), (def))
+end)
+end
+| uu____4182 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected let binding"), (p.FStar_Parser_AST.prange)))))
+end)
+end)
+end))
+end))))
+in (
+
+let uu____4192 = (FStar_List.fold_left (fun uu____4216 uu____4217 -> (match (((uu____4216), (uu____4217))) with
+| ((env1, fnames, rec_bindings), ((f, uu____4261, uu____4262), uu____4263)) -> begin
+(
+
+let uu____4303 = (match (f) with
+| FStar_Util.Inl (x) -> begin
+(
+
+let uu____4317 = (FStar_ToSyntax_Env.push_bv env1 x)
+in (match (uu____4317) with
+| (env2, xx) -> begin
+(
+
+let uu____4328 = (
+
+let uu____4330 = (FStar_Syntax_Syntax.mk_binder xx)
+in (uu____4330)::rec_bindings)
+in ((env2), (FStar_Util.Inl (xx)), (uu____4328)))
+end))
+end
+| FStar_Util.Inr (l) -> begin
+(
+
+let uu____4335 = (FStar_ToSyntax_Env.push_top_level_rec_binding env1 l.FStar_Ident.ident FStar_Syntax_Syntax.Delta_equational)
+in ((uu____4335), (FStar_Util.Inr (l)), (rec_bindings)))
+end)
+in (match (uu____4303) with
+| (env2, lbname, rec_bindings1) -> begin
+((env2), ((lbname)::fnames), (rec_bindings1))
+end))
+end)) ((env), ([]), ([])) funs)
+in (match (uu____4192) with
+| (env', fnames, rec_bindings) -> begin
+(
+
+let fnames1 = (FStar_List.rev fnames)
+in (
+
+let rec_bindings1 = (FStar_List.rev rec_bindings)
+in (
+
+let desugar_one_def = (fun env1 lbname uu____4408 -> (match (uu____4408) with
+| ((uu____4420, args, result_t), def) -> begin
+(
+
+let args1 = (FStar_All.pipe_right args (FStar_List.map replace_unit_pattern))
+in (
+
+let def1 = (match (result_t) with
+| None -> begin
+def
+end
+| Some (t) -> begin
+(
+
+let t1 = (
+
+let uu____4446 = (is_comp_type env1 t)
+in (match (uu____4446) with
+| true -> begin
+((
+
+let uu____4448 = (FStar_All.pipe_right args1 (FStar_List.tryFind (fun x -> (
+
+let uu____4453 = (is_var_pattern x)
+in (not (uu____4453))))))
+in (match (uu____4448) with
+| None -> begin
+()
+end
+| Some (p) -> begin
+(Prims.raise (FStar_Errors.Error ((("Computation type annotations are only permitted on let-bindings without inlined patterns; replace this pattern with a variable"), (p.FStar_Parser_AST.prange)))))
+end));
+t;
+)
+end
+| uu____4455 -> begin
+(
+
+let uu____4456 = (((FStar_Options.ml_ish ()) && (
+
+let uu____4457 = (FStar_ToSyntax_Env.try_lookup_effect_name env1 FStar_Syntax_Const.effect_ML_lid)
+in (FStar_Option.isSome uu____4457))) && ((not (is_rec)) || ((FStar_List.length args1) <> (Prims.parse_int "0"))))
+in (match (uu____4456) with
+| true -> begin
+(FStar_Parser_AST.ml_comp t)
+end
+| uu____4461 -> begin
+(FStar_Parser_AST.tot_comp t)
+end))
+end))
+in (
+
+let uu____4462 = (FStar_Range.union_ranges t1.FStar_Parser_AST.range def.FStar_Parser_AST.range)
+in (FStar_Parser_AST.mk_term (FStar_Parser_AST.Ascribed (((def), (t1), (None)))) uu____4462 FStar_Parser_AST.Expr)))
+end)
+in (
+
+let def2 = (match (args1) with
+| [] -> begin
+def1
+end
+| uu____4465 -> begin
+(FStar_Parser_AST.mk_term (FStar_Parser_AST.un_curry_abs args1 def1) top.FStar_Parser_AST.range top.FStar_Parser_AST.level)
+end)
+in (
+
+let body1 = (desugar_term env1 def2)
+in (
+
+let lbname1 = (match (lbname) with
+| FStar_Util.Inl (x) -> begin
+FStar_Util.Inl (x)
+end
+| FStar_Util.Inr (l) -> begin
+(
+
+let uu____4475 = (
+
+let uu____4476 = (FStar_Syntax_Util.incr_delta_qualifier body1)
+in (FStar_Syntax_Syntax.lid_as_fv l uu____4476 None))
+in FStar_Util.Inr (uu____4475))
+end)
+in (
+
+let body2 = (match (is_rec) with
+| true -> begin
+(FStar_Syntax_Subst.close rec_bindings1 body1)
+end
+| uu____4478 -> begin
+body1
+end)
+in (mk_lb ((lbname1), (FStar_Syntax_Syntax.tun), (body2)))))))))
+end))
+in (
+
+let lbs = (FStar_List.map2 (desugar_one_def (match (is_rec) with
+| true -> begin
+env'
+end
+| uu____4494 -> begin
+env
+end)) fnames1 funs)
+in (
+
+let body1 = (desugar_term env' body)
+in (
+
+let uu____4496 = (
+
+let uu____4497 = (
+
+let uu____4505 = (FStar_Syntax_Subst.close rec_bindings1 body1)
+in ((((is_rec), (lbs))), (uu____4505)))
+in FStar_Syntax_Syntax.Tm_let (uu____4497))
+in (FStar_All.pipe_left mk1 uu____4496)))))))
+end)))))
+in (
+
+let ds_non_rec = (fun pat1 t1 t2 -> (
+
+let t11 = (desugar_term env t1)
+in (
+
+let is_mutable = (qual1 = FStar_Parser_AST.Mutable)
+in (
+
+let t12 = (match (is_mutable) with
+| true -> begin
+(mk_ref_alloc t11)
+end
+| uu____4531 -> begin
+t11
+end)
+in (
+
+let uu____4532 = (desugar_binding_pat_maybe_top top_level env pat1 is_mutable)
+in (match (uu____4532) with
+| (env1, binder, pat2) -> begin
+(
+
+let tm = (match (binder) with
+| LetBinder (l, t) -> begin
+(
+
+let body1 = (desugar_term env1 t2)
+in (
+
+let fv = (
+
+let uu____4553 = (FStar_Syntax_Util.incr_delta_qualifier t12)
+in (FStar_Syntax_Syntax.lid_as_fv l uu____4553 None))
+in (FStar_All.pipe_left mk1 (FStar_Syntax_Syntax.Tm_let (((((false), (({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv); FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_ALL_lid; FStar_Syntax_Syntax.lbdef = t12})::[]))), (body1)))))))
+end
+| LocalBinder (x, uu____4561) -> begin
+(
+
+let body1 = (desugar_term env1 t2)
+in (
+
+let body2 = (match (pat2) with
+| (None) | (Some ({FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (_); FStar_Syntax_Syntax.ty = _; FStar_Syntax_Syntax.p = _})) -> begin
+body1
+end
+| Some (pat3) -> begin
+(
+
+let uu____4570 = (
+
+let uu____4573 = (
+
+let uu____4574 = (
+
+let uu____4590 = (FStar_Syntax_Syntax.bv_to_name x)
+in (
+
+let uu____4591 = (
+
+let uu____4593 = (FStar_Syntax_Util.branch ((pat3), (None), (body1)))
+in (uu____4593)::[])
+in ((uu____4590), (uu____4591))))
+in FStar_Syntax_Syntax.Tm_match (uu____4574))
+in (FStar_Syntax_Syntax.mk uu____4573))
+in (uu____4570 None body1.FStar_Syntax_Syntax.pos))
+end)
+in (
+
+let uu____4608 = (
+
+let uu____4609 = (
+
+let uu____4617 = (
+
+let uu____4618 = (
+
+let uu____4619 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____4619)::[])
+in (FStar_Syntax_Subst.close uu____4618 body2))
+in ((((false), (((mk_lb ((FStar_Util.Inl (x)), (x.FStar_Syntax_Syntax.sort), (t12))))::[]))), (uu____4617)))
+in FStar_Syntax_Syntax.Tm_let (uu____4609))
+in (FStar_All.pipe_left mk1 uu____4608))))
+end)
+in (match (is_mutable) with
+| true -> begin
+(FStar_All.pipe_left mk1 (FStar_Syntax_Syntax.Tm_meta (((tm), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Mutable_alloc))))))
+end
+| uu____4638 -> begin
+tm
+end))
+end))))))
+in (
+
+let uu____4639 = (is_rec || (is_app_pattern pat))
+in (match (uu____4639) with
+| true -> begin
+(ds_let_rec_or_app ())
+end
+| uu____4640 -> begin
+(ds_non_rec pat _snd body)
+end)))))
+end
+| FStar_Parser_AST.If (t1, t2, t3) -> begin
+(
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (t3.FStar_Parser_AST.range)) FStar_Syntax_Syntax.tun)
+in (
+
+let uu____4645 = (
+
+let uu____4646 = (
+
+let uu____4662 = (desugar_term env t1)
+in (
+
+let uu____4663 = (
+
+let uu____4673 = (
+
+let uu____4682 = (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n t2.FStar_Parser_AST.range)
+in (
+
+let uu____4685 = (desugar_term env t2)
+in ((uu____4682), (None), (uu____4685))))
+in (
+
+let uu____4693 = (
+
+let uu____4703 = (
+
+let uu____4712 = (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_wild (x)) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n t3.FStar_Parser_AST.range)
+in (
+
+let uu____4715 = (desugar_term env t3)
+in ((uu____4712), (None), (uu____4715))))
+in (uu____4703)::[])
+in (uu____4673)::uu____4693))
+in ((uu____4662), (uu____4663))))
+in FStar_Syntax_Syntax.Tm_match (uu____4646))
+in (mk1 uu____4645)))
+end
+| FStar_Parser_AST.TryWith (e, branches) -> begin
+(
+
+let r = top.FStar_Parser_AST.range
+in (
+
+let handler = (FStar_Parser_AST.mk_function branches r r)
+in (
+
+let body = (FStar_Parser_AST.mk_function (((((FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatConst (FStar_Const.Const_unit)) r)), (None), (e)))::[]) r r)
+in (
+
+let a1 = (FStar_Parser_AST.mk_term (FStar_Parser_AST.App ((((FStar_Parser_AST.mk_term (FStar_Parser_AST.Var (FStar_Syntax_Const.try_with_lid)) r top.FStar_Parser_AST.level)), (body), (FStar_Parser_AST.Nothing)))) r top.FStar_Parser_AST.level)
+in (
+
+let a2 = (FStar_Parser_AST.mk_term (FStar_Parser_AST.App (((a1), (handler), (FStar_Parser_AST.Nothing)))) r top.FStar_Parser_AST.level)
+in (desugar_term env a2))))))
+end
+| FStar_Parser_AST.Match (e, branches) -> begin
+(
+
+let desugar_branch = (fun uu____4801 -> (match (uu____4801) with
+| (pat, wopt, b) -> begin
+(
+
+let uu____4811 = (desugar_match_pat env pat)
+in (match (uu____4811) with
+| (env1, pat1) -> begin
+(
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (e1) -> begin
+(
+
+let uu____4820 = (desugar_term env1 e1)
+in Some (uu____4820))
+end)
+in (
+
+let b1 = (desugar_term env1 b)
+in (FStar_Syntax_Util.branch ((pat1), (wopt1), (b1)))))
+end))
+end))
+in (
+
+let uu____4823 = (
+
+let uu____4824 = (
+
+let uu____4840 = (desugar_term env e)
+in (
+
+let uu____4841 = (FStar_List.map desugar_branch branches)
+in ((uu____4840), (uu____4841))))
+in FStar_Syntax_Syntax.Tm_match (uu____4824))
+in (FStar_All.pipe_left mk1 uu____4823)))
+end
+| FStar_Parser_AST.Ascribed (e, t, tac_opt) -> begin
+(
+
+let annot = (
+
+let uu____4860 = (is_comp_type env t)
+in (match (uu____4860) with
+| true -> begin
+(
+
+let uu____4865 = (desugar_comp t.FStar_Parser_AST.range env t)
+in FStar_Util.Inr (uu____4865))
+end
+| uu____4870 -> begin
+(
+
+let uu____4871 = (desugar_term env t)
+in FStar_Util.Inl (uu____4871))
+end))
+in (
+
+let tac_opt1 = (FStar_Util.map_opt tac_opt (desugar_term env))
+in (
+
+let uu____4876 = (
+
+let uu____4877 = (
+
+let uu____4895 = (desugar_term env e)
+in ((uu____4895), (((annot), (tac_opt1))), (None)))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____4877))
+in (FStar_All.pipe_left mk1 uu____4876))))
+end
+| FStar_Parser_AST.Record (uu____4911, []) -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected empty record"), (top.FStar_Parser_AST.range)))))
+end
+| FStar_Parser_AST.Record (eopt, fields) -> begin
+(
+
+let record = (check_fields env fields top.FStar_Parser_AST.range)
+in (
+
+let user_ns = (
+
+let uu____4932 = (FStar_List.hd fields)
+in (match (uu____4932) with
+| (f, uu____4939) -> begin
+f.FStar_Ident.ns
+end))
+in (
+
+let get_field = (fun xopt f -> (
+
+let found = (FStar_All.pipe_right fields (FStar_Util.find_opt (fun uu____4963 -> (match (uu____4963) with
+| (g, uu____4967) -> begin
+(f.FStar_Ident.idText = g.FStar_Ident.ident.FStar_Ident.idText)
+end))))
+in (
+
+let fn = (FStar_Ident.lid_of_ids (FStar_List.append user_ns ((f)::[])))
+in (match (found) with
+| Some (uu____4971, e) -> begin
+((fn), (e))
+end
+| None -> begin
+(match (xopt) with
+| None -> begin
+(
+
+let uu____4979 = (
+
+let uu____4980 = (
+
+let uu____4983 = (FStar_Util.format2 "Field %s of record type %s is missing" f.FStar_Ident.idText record.FStar_ToSyntax_Env.typename.FStar_Ident.str)
+in ((uu____4983), (top.FStar_Parser_AST.range)))
+in FStar_Errors.Error (uu____4980))
+in (Prims.raise uu____4979))
+end
+| Some (x) -> begin
+((fn), ((FStar_Parser_AST.mk_term (FStar_Parser_AST.Project (((x), (fn)))) x.FStar_Parser_AST.range x.FStar_Parser_AST.level)))
+end)
+end))))
+in (
+
+let user_constrname = (FStar_Ident.lid_of_ids (FStar_List.append user_ns ((record.FStar_ToSyntax_Env.constrname)::[])))
+in (
+
+let recterm = (match (eopt) with
+| None -> begin
+(
+
+let uu____4989 = (
+
+let uu____4995 = (FStar_All.pipe_right record.FStar_ToSyntax_Env.fields (FStar_List.map (fun uu____5009 -> (match (uu____5009) with
+| (f, uu____5015) -> begin
+(
+
+let uu____5016 = (
+
+let uu____5017 = (get_field None f)
+in (FStar_All.pipe_left Prims.snd uu____5017))
+in ((uu____5016), (FStar_Parser_AST.Nothing)))
+end))))
+in ((user_constrname), (uu____4995)))
+in FStar_Parser_AST.Construct (uu____4989))
+end
+| Some (e) -> begin
+(
+
+let x = (FStar_Ident.gen e.FStar_Parser_AST.range)
+in (
+
+let xterm = (
+
+let uu____5028 = (
+
+let uu____5029 = (FStar_Ident.lid_of_ids ((x)::[]))
+in FStar_Parser_AST.Var (uu____5029))
+in (FStar_Parser_AST.mk_term uu____5028 x.FStar_Ident.idRange FStar_Parser_AST.Expr))
+in (
+
+let record1 = (
+
+let uu____5031 = (
+
+let uu____5038 = (FStar_All.pipe_right record.FStar_ToSyntax_Env.fields (FStar_List.map (fun uu____5052 -> (match (uu____5052) with
+| (f, uu____5058) -> begin
+(get_field (Some (xterm)) f)
+end))))
+in ((None), (uu____5038)))
+in FStar_Parser_AST.Record (uu____5031))
+in FStar_Parser_AST.Let (((FStar_Parser_AST.NoLetQualifier), (((((FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatVar (((x), (None)))) x.FStar_Ident.idRange)), (e)))::[]), ((FStar_Parser_AST.mk_term record1 top.FStar_Parser_AST.range top.FStar_Parser_AST.level)))))))
+end)
+in (
+
+let recterm1 = (FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range top.FStar_Parser_AST.level)
+in (
+
+let e = (desugar_term env recterm1)
+in (match (e.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_meta ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____5074; FStar_Syntax_Syntax.pos = uu____5075; FStar_Syntax_Syntax.vars = uu____5076}, args); FStar_Syntax_Syntax.tk = uu____5078; FStar_Syntax_Syntax.pos = uu____5079; FStar_Syntax_Syntax.vars = uu____5080}, FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app)) -> begin
+(
+
+let e1 = (
+
+let uu____5102 = (
+
+let uu____5103 = (
+
+let uu____5113 = (
+
+let uu____5114 = (
+
+let uu____5116 = (
+
+let uu____5117 = (
+
+let uu____5121 = (FStar_All.pipe_right record.FStar_ToSyntax_Env.fields (FStar_List.map Prims.fst))
+in ((record.FStar_ToSyntax_Env.typename), (uu____5121)))
+in FStar_Syntax_Syntax.Record_ctor (uu____5117))
+in Some (uu____5116))
+in (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v e.FStar_Syntax_Syntax.pos) FStar_Syntax_Syntax.Delta_constant uu____5114))
+in ((uu____5113), (args)))
+in FStar_Syntax_Syntax.Tm_app (uu____5103))
+in (FStar_All.pipe_left mk1 uu____5102))
+in (FStar_All.pipe_left mk1 (FStar_Syntax_Syntax.Tm_meta (((e1), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app)))))))
+end
+| uu____5145 -> begin
+e
+end))))))))
+end
+| FStar_Parser_AST.Project (e, f) -> begin
+(
+
+let uu____5148 = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_dc_by_field_name env) f)
+in (match (uu____5148) with
+| (constrname, is_rec) -> begin
+(
+
+let e1 = (desugar_term env e)
+in (
+
+let projname = (FStar_Syntax_Util.mk_field_projector_name_from_ident constrname f.FStar_Ident.ident)
+in (
+
+let qual1 = (match (is_rec) with
+| true -> begin
+Some (FStar_Syntax_Syntax.Record_projector (((constrname), (f.FStar_Ident.ident))))
+end
+| uu____5160 -> begin
+None
+end)
+in (
+
+let uu____5161 = (
+
+let uu____5162 = (
+
+let uu____5172 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range projname (FStar_Ident.range_of_lid f)) FStar_Syntax_Syntax.Delta_equational qual1)
+in (
+
+let uu____5173 = (
+
+let uu____5175 = (FStar_Syntax_Syntax.as_arg e1)
+in (uu____5175)::[])
+in ((uu____5172), (uu____5173))))
+in FStar_Syntax_Syntax.Tm_app (uu____5162))
+in (FStar_All.pipe_left mk1 uu____5161)))))
+end))
+end
+| (FStar_Parser_AST.NamedTyp (_, e)) | (FStar_Parser_AST.Paren (e)) -> begin
+(desugar_term env e)
+end
+| uu____5181 when (top.FStar_Parser_AST.level = FStar_Parser_AST.Formula) -> begin
+(desugar_formula env top)
+end
+| uu____5182 -> begin
+(FStar_Parser_AST.error "Unexpected term" top top.FStar_Parser_AST.range)
+end
+| FStar_Parser_AST.Let (uu____5183, uu____5184, uu____5185) -> begin
+(failwith "Not implemented yet")
+end
+| FStar_Parser_AST.QForall (uu____5192, uu____5193, uu____5194) -> begin
+(failwith "Not implemented yet")
+end
+| FStar_Parser_AST.QExists (uu____5201, uu____5202, uu____5203) -> begin
+(failwith "Not implemented yet")
+end)))))
+and desugar_args : FStar_ToSyntax_Env.env  ->  (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier Prims.option) Prims.list = (fun env args -> (FStar_All.pipe_right args (FStar_List.map (fun uu____5227 -> (match (uu____5227) with
+| (a, imp) -> begin
+(
+
+let uu____5235 = (desugar_term env a)
+in (arg_withimp_e imp uu____5235))
+end)))))
+and desugar_comp : FStar_Range.range  ->  FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.term  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun r env t -> (
+
+let fail = (fun msg -> (Prims.raise (FStar_Errors.Error (((msg), (r))))))
+in (
+
+let is_requires = (fun uu____5252 -> (match (uu____5252) with
+| (t1, uu____5256) -> begin
+(
+
+let uu____5257 = (
+
+let uu____5258 = (unparen t1)
+in uu____5258.FStar_Parser_AST.tm)
+in (match (uu____5257) with
+| FStar_Parser_AST.Requires (uu____5259) -> begin
+true
+end
+| uu____5263 -> begin
+false
+end))
+end))
+in (
+
+let is_ensures = (fun uu____5269 -> (match (uu____5269) with
+| (t1, uu____5273) -> begin
+(
+
+let uu____5274 = (
+
+let uu____5275 = (unparen t1)
+in uu____5275.FStar_Parser_AST.tm)
+in (match (uu____5274) with
+| FStar_Parser_AST.Ensures (uu____5276) -> begin
+true
+end
+| uu____5280 -> begin
+false
+end))
+end))
+in (
+
+let is_app = (fun head1 uu____5289 -> (match (uu____5289) with
+| (t1, uu____5293) -> begin
+(
+
+let uu____5294 = (
+
+let uu____5295 = (unparen t1)
+in uu____5295.FStar_Parser_AST.tm)
+in (match (uu____5294) with
+| FStar_Parser_AST.App ({FStar_Parser_AST.tm = FStar_Parser_AST.Var (d); FStar_Parser_AST.range = uu____5297; FStar_Parser_AST.level = uu____5298}, uu____5299, uu____5300) -> begin
+(d.FStar_Ident.ident.FStar_Ident.idText = head1)
+end
+| uu____5301 -> begin
+false
+end))
+end))
+in (
+
+let is_decreases = (is_app "decreases")
+in (
+
+let pre_process_comp_typ = (fun t1 -> (
+
+let uu____5319 = (head_and_args t1)
+in (match (uu____5319) with
+| (head1, args) -> begin
+(match (head1.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Name (lemma) when (lemma.FStar_Ident.ident.FStar_Ident.idText = "Lemma") -> begin
+(
+
+let unit_tm = (((FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.unit_lid)) t1.FStar_Parser_AST.range FStar_Parser_AST.Type_level)), (FStar_Parser_AST.Nothing))
+in (
+
+let nil_pat = (((FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.nil_lid)) t1.FStar_Parser_AST.range FStar_Parser_AST.Expr)), (FStar_Parser_AST.Nothing))
+in (
+
+let req_true = (((FStar_Parser_AST.mk_term (FStar_Parser_AST.Requires ((((FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.true_lid)) t1.FStar_Parser_AST.range FStar_Parser_AST.Formula)), (None)))) t1.FStar_Parser_AST.range FStar_Parser_AST.Type_level)), (FStar_Parser_AST.Nothing))
+in (
+
+let args1 = (match (args) with
+| [] -> begin
+(Prims.raise (FStar_Errors.Error ((("Not enough arguments to \'Lemma\'"), (t1.FStar_Parser_AST.range)))))
+end
+| (ens)::[] -> begin
+(unit_tm)::(req_true)::(ens)::(nil_pat)::[]
+end
+| (req)::(ens)::[] when ((is_requires req) && (is_ensures ens)) -> begin
+(unit_tm)::(req)::(ens)::(nil_pat)::[]
+end
+| (ens)::(dec)::[] when ((is_ensures ens) && (is_decreases dec)) -> begin
+(unit_tm)::(req_true)::(ens)::(nil_pat)::(dec)::[]
+end
+| (req)::(ens)::(dec)::[] when (((is_requires req) && (is_ensures ens)) && (is_app "decreases" dec)) -> begin
+(unit_tm)::(req)::(ens)::(nil_pat)::(dec)::[]
+end
+| more -> begin
+(unit_tm)::more
+end)
+in (
+
+let head_and_attributes = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes env) lemma)
+in ((head_and_attributes), (args1)))))))
+end
+| FStar_Parser_AST.Name (l) when (FStar_ToSyntax_Env.is_effect_name env l) -> begin
+(
+
+let uu____5484 = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes env) l)
+in ((uu____5484), (args)))
+end
+| FStar_Parser_AST.Name (l) when ((
+
+let uu____5498 = (FStar_ToSyntax_Env.current_module env)
+in (FStar_Ident.lid_equals uu____5498 FStar_Syntax_Const.prims_lid)) && (l.FStar_Ident.ident.FStar_Ident.idText = "Tot")) -> begin
+(((((FStar_Ident.set_lid_range FStar_Syntax_Const.effect_Tot_lid head1.FStar_Parser_AST.range)), ([]))), (args))
+end
+| FStar_Parser_AST.Name (l) when ((
+
+let uu____5507 = (FStar_ToSyntax_Env.current_module env)
+in (FStar_Ident.lid_equals uu____5507 FStar_Syntax_Const.prims_lid)) && (l.FStar_Ident.ident.FStar_Ident.idText = "GTot")) -> begin
+(((((FStar_Ident.set_lid_range FStar_Syntax_Const.effect_GTot_lid head1.FStar_Parser_AST.range)), ([]))), (args))
+end
+| FStar_Parser_AST.Name (l) when (((l.FStar_Ident.ident.FStar_Ident.idText = "Type") || (l.FStar_Ident.ident.FStar_Ident.idText = "Type0")) || (l.FStar_Ident.ident.FStar_Ident.idText = "Effect")) -> begin
+(((((FStar_Ident.set_lid_range FStar_Syntax_Const.effect_Tot_lid head1.FStar_Parser_AST.range)), ([]))), ((((t1), (FStar_Parser_AST.Nothing)))::[]))
+end
+| uu____5527 -> begin
+(
+
+let default_effect = (
+
+let uu____5529 = (FStar_Options.ml_ish ())
+in (match (uu____5529) with
+| true -> begin
+FStar_Syntax_Const.effect_ML_lid
+end
+| uu____5530 -> begin
+((
+
+let uu____5532 = (FStar_Options.warn_default_effects ())
+in (match (uu____5532) with
+| true -> begin
+(FStar_Errors.warn head1.FStar_Parser_AST.range "Using default effect Tot")
+end
+| uu____5533 -> begin
+()
+end));
+FStar_Syntax_Const.effect_Tot_lid;
+)
+end))
+in (((((FStar_Ident.set_lid_range default_effect head1.FStar_Parser_AST.range)), ([]))), ((((t1), (FStar_Parser_AST.Nothing)))::[])))
+end)
+end)))
+in (
+
+let uu____5545 = (pre_process_comp_typ t)
+in (match (uu____5545) with
+| ((eff, cattributes), args) -> begin
+((match (((FStar_List.length args) = (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____5575 = (
+
+let uu____5576 = (FStar_Syntax_Print.lid_to_string eff)
+in (FStar_Util.format1 "Not enough args to effect %s" uu____5576))
+in (fail uu____5575))
+end
+| uu____5577 -> begin
+()
+end);
+(
+
+let is_universe = (fun uu____5583 -> (match (uu____5583) with
+| (uu____5586, imp) -> begin
+(imp = FStar_Parser_AST.UnivApp)
+end))
+in (
+
+let uu____5588 = (FStar_Util.take is_universe args)
+in (match (uu____5588) with
+| (universes, args1) -> begin
+(
+
+let universes1 = (FStar_List.map (fun uu____5619 -> (match (uu____5619) with
+| (u, imp) -> begin
+(desugar_universe u)
+end)) universes)
+in (
+
+let uu____5624 = (
+
+let uu____5632 = (FStar_List.hd args1)
+in (
+
+let uu____5637 = (FStar_List.tl args1)
+in ((uu____5632), (uu____5637))))
+in (match (uu____5624) with
+| (result_arg, rest) -> begin
+(
+
+let result_typ = (desugar_typ env (Prims.fst result_arg))
+in (
+
+let rest1 = (desugar_args env rest)
+in (
+
+let uu____5668 = (FStar_All.pipe_right rest1 (FStar_List.partition (fun uu____5706 -> (match (uu____5706) with
+| (t1, uu____5713) -> begin
+(match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____5721; FStar_Syntax_Syntax.pos = uu____5722; FStar_Syntax_Syntax.vars = uu____5723}, (uu____5724)::[]) -> begin
+(FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.decreases_lid)
+end
+| uu____5746 -> begin
+false
+end)
+end))))
+in (match (uu____5668) with
+| (dec, rest2) -> begin
+(
+
+let decreases_clause = (FStar_All.pipe_right dec (FStar_List.map (fun uu____5789 -> (match (uu____5789) with
+| (t1, uu____5796) -> begin
+(match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app (uu____5803, ((arg, uu____5805))::[]) -> begin
+FStar_Syntax_Syntax.DECREASES (arg)
+end
+| uu____5827 -> begin
+(failwith "impos")
+end)
+end))))
+in (
+
+let no_additional_args = (
+
+let is_empty = (fun l -> (match (l) with
+| [] -> begin
+true
+end
+| uu____5839 -> begin
+false
+end))
+in ((((is_empty decreases_clause) && (is_empty rest2)) && (is_empty cattributes)) && (is_empty universes1)))
+in (match ((no_additional_args && (FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_Tot_lid))) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total result_typ)
+end
+| uu____5848 -> begin
+(match ((no_additional_args && (FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_GTot_lid))) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_GTotal result_typ)
+end
+| uu____5851 -> begin
+(
+
+let flags = (match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_Lemma_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.LEMMA)::[]
+end
+| uu____5855 -> begin
+(match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_Tot_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.TOTAL)::[]
+end
+| uu____5857 -> begin
+(match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_ML_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.MLEFFECT)::[]
+end
+| uu____5859 -> begin
+(match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_GTot_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.SOMETRIVIAL)::[]
+end
+| uu____5861 -> begin
+[]
+end)
+end)
+end)
+end)
+in (
+
+let flags1 = (FStar_List.append flags cattributes)
+in (
+
+let rest3 = (match ((FStar_Ident.lid_equals eff FStar_Syntax_Const.effect_Lemma_lid)) with
+| true -> begin
+(match (rest2) with
+| (req)::(ens)::((pat, aq))::[] -> begin
+(
+
+let pat1 = (match (pat.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.nil_lid) -> begin
+(
+
+let nil = (FStar_Syntax_Syntax.mk_Tm_uinst pat ((FStar_Syntax_Syntax.U_succ (FStar_Syntax_Syntax.U_zero))::[]))
+in (
+
+let pattern = (
+
+let uu____5931 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.pattern_lid pat.FStar_Syntax_Syntax.pos) FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____5931 ((FStar_Syntax_Syntax.U_zero)::[])))
+in ((FStar_Syntax_Syntax.mk_Tm_app nil ((((pattern), (Some (FStar_Syntax_Syntax.imp_tag))))::[])) None pat.FStar_Syntax_Syntax.pos)))
+end
+| uu____5943 -> begin
+pat
+end)
+in (
+
+let uu____5944 = (
+
+let uu____5951 = (
+
+let uu____5958 = (
+
+let uu____5964 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((pat1), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Meta_smt_pat)))))) None pat1.FStar_Syntax_Syntax.pos)
+in ((uu____5964), (aq)))
+in (uu____5958)::[])
+in (ens)::uu____5951)
+in (req)::uu____5944))
+end
+| uu____6000 -> begin
+rest2
+end)
+end
+| uu____6007 -> begin
+rest2
+end)
+in (FStar_Syntax_Syntax.mk_Comp {FStar_Syntax_Syntax.comp_univs = universes1; FStar_Syntax_Syntax.effect_name = eff; FStar_Syntax_Syntax.result_typ = result_typ; FStar_Syntax_Syntax.effect_args = rest3; FStar_Syntax_Syntax.flags = (FStar_List.append flags1 decreases_clause)}))))
+end)
+end)))
+end))))
+end)))
+end)));
+)
+end)))))))))
+and desugar_formula : env_t  ->  FStar_Parser_AST.term  ->  FStar_Syntax_Syntax.term = (fun env f -> (
+
+let connective = (fun s -> (match (s) with
+| "/\\" -> begin
+Some (FStar_Syntax_Const.and_lid)
+end
+| "\\/" -> begin
+Some (FStar_Syntax_Const.or_lid)
+end
+| "==>" -> begin
+Some (FStar_Syntax_Const.imp_lid)
+end
+| "<==>" -> begin
+Some (FStar_Syntax_Const.iff_lid)
+end
+| "~" -> begin
+Some (FStar_Syntax_Const.not_lid)
+end
+| uu____6016 -> begin
+None
+end))
+in (
+
+let mk1 = (fun t -> ((FStar_Syntax_Syntax.mk t) None f.FStar_Parser_AST.range))
+in (
+
+let pos = (fun t -> (t None f.FStar_Parser_AST.range))
+in (
+
+let setpos = (fun t -> (
+
+let uu___214_6057 = t
+in {FStar_Syntax_Syntax.n = uu___214_6057.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___214_6057.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = f.FStar_Parser_AST.range; FStar_Syntax_Syntax.vars = uu___214_6057.FStar_Syntax_Syntax.vars}))
+in (
+
+let desugar_quant = (fun q b pats body -> (
+
+let tk = (desugar_binder env (
+
+let uu___215_6087 = b
+in {FStar_Parser_AST.b = uu___215_6087.FStar_Parser_AST.b; FStar_Parser_AST.brange = uu___215_6087.FStar_Parser_AST.brange; FStar_Parser_AST.blevel = FStar_Parser_AST.Formula; FStar_Parser_AST.aqual = uu___215_6087.FStar_Parser_AST.aqual}))
+in (
+
+let desugar_pats = (fun env1 pats1 -> (FStar_List.map (fun es -> (FStar_All.pipe_right es (FStar_List.map (fun e -> (
+
+let uu____6120 = (desugar_term env1 e)
+in (FStar_All.pipe_left (arg_withimp_t FStar_Parser_AST.Nothing) uu____6120)))))) pats1))
+in (match (tk) with
+| (Some (a), k) -> begin
+(
+
+let uu____6129 = (FStar_ToSyntax_Env.push_bv env a)
+in (match (uu____6129) with
+| (env1, a1) -> begin
+(
+
+let a2 = (
+
+let uu___216_6137 = a1
+in {FStar_Syntax_Syntax.ppname = uu___216_6137.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___216_6137.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = k})
+in (
+
+let pats1 = (desugar_pats env1 pats)
+in (
+
+let body1 = (desugar_formula env1 body)
+in (
+
+let body2 = (match (pats1) with
+| [] -> begin
+body1
+end
+| uu____6150 -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_meta (((body1), (FStar_Syntax_Syntax.Meta_pattern (pats1))))))
+end)
+in (
+
+let body3 = (
+
+let uu____6159 = (
+
+let uu____6162 = (
+
+let uu____6166 = (FStar_Syntax_Syntax.mk_binder a2)
+in (uu____6166)::[])
+in (no_annot_abs uu____6162 body2))
+in (FStar_All.pipe_left setpos uu____6159))
+in (
+
+let uu____6171 = (
+
+let uu____6172 = (
+
+let uu____6182 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range q b.FStar_Parser_AST.brange) (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in (
+
+let uu____6183 = (
+
+let uu____6185 = (FStar_Syntax_Syntax.as_arg body3)
+in (uu____6185)::[])
+in ((uu____6182), (uu____6183))))
+in FStar_Syntax_Syntax.Tm_app (uu____6172))
+in (FStar_All.pipe_left mk1 uu____6171)))))))
+end))
+end
+| uu____6189 -> begin
+(failwith "impossible")
+end))))
+in (
+
+let push_quant = (fun q binders pats body -> (match (binders) with
+| (b)::(b')::_rest -> begin
+(
+
+let rest = (b')::_rest
+in (
+
+let body1 = (
+
+let uu____6238 = (q ((rest), (pats), (body)))
+in (
+
+let uu____6242 = (FStar_Range.union_ranges b'.FStar_Parser_AST.brange body.FStar_Parser_AST.range)
+in (FStar_Parser_AST.mk_term uu____6238 uu____6242 FStar_Parser_AST.Formula)))
+in (
+
+let uu____6243 = (q (((b)::[]), ([]), (body1)))
+in (FStar_Parser_AST.mk_term uu____6243 f.FStar_Parser_AST.range FStar_Parser_AST.Formula))))
+end
+| uu____6248 -> begin
+(failwith "impossible")
+end))
+in (
+
+let uu____6250 = (
+
+let uu____6251 = (unparen f)
+in uu____6251.FStar_Parser_AST.tm)
+in (match (uu____6250) with
+| FStar_Parser_AST.Labeled (f1, l, p) -> begin
+(
+
+let f2 = (desugar_formula env f1)
+in (FStar_All.pipe_left mk1 (FStar_Syntax_Syntax.Tm_meta (((f2), (FStar_Syntax_Syntax.Meta_labeled (((l), (f2.FStar_Syntax_Syntax.pos), (p)))))))))
+end
+| (FStar_Parser_AST.QForall ([], _, _)) | (FStar_Parser_AST.QExists ([], _, _)) -> begin
+(failwith "Impossible: Quantifier without binders")
+end
+| FStar_Parser_AST.QForall ((_1)::(_2)::_3, pats, body) -> begin
+(
+
+let binders = (_1)::(_2)::_3
+in (
+
+let uu____6281 = (push_quant (fun x -> FStar_Parser_AST.QForall (x)) binders pats body)
+in (desugar_formula env uu____6281)))
+end
+| FStar_Parser_AST.QExists ((_1)::(_2)::_3, pats, body) -> begin
+(
+
+let binders = (_1)::(_2)::_3
+in (
+
+let uu____6302 = (push_quant (fun x -> FStar_Parser_AST.QExists (x)) binders pats body)
+in (desugar_formula env uu____6302)))
+end
+| FStar_Parser_AST.QForall ((b)::[], pats, body) -> begin
+(desugar_quant FStar_Syntax_Const.forall_lid b pats body)
+end
+| FStar_Parser_AST.QExists ((b)::[], pats, body) -> begin
+(desugar_quant FStar_Syntax_Const.exists_lid b pats body)
+end
+| FStar_Parser_AST.Paren (f1) -> begin
+(desugar_formula env f1)
+end
+| uu____6327 -> begin
+(desugar_term env f)
+end)))))))))
+and typars_of_binders : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.binder Prims.list  ->  (FStar_ToSyntax_Env.env * (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier Prims.option) Prims.list) = (fun env bs -> (
+
+let uu____6331 = (FStar_List.fold_left (fun uu____6344 b -> (match (uu____6344) with
+| (env1, out) -> begin
+(
+
+let tk = (desugar_binder env1 (
+
+let uu___217_6372 = b
+in {FStar_Parser_AST.b = uu___217_6372.FStar_Parser_AST.b; FStar_Parser_AST.brange = uu___217_6372.FStar_Parser_AST.brange; FStar_Parser_AST.blevel = FStar_Parser_AST.Formula; FStar_Parser_AST.aqual = uu___217_6372.FStar_Parser_AST.aqual}))
+in (match (tk) with
+| (Some (a), k) -> begin
+(
+
+let uu____6382 = (FStar_ToSyntax_Env.push_bv env1 a)
+in (match (uu____6382) with
+| (env2, a1) -> begin
+(
+
+let a2 = (
+
+let uu___218_6394 = a1
+in {FStar_Syntax_Syntax.ppname = uu___218_6394.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___218_6394.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = k})
+in ((env2), ((((a2), ((trans_aqual b.FStar_Parser_AST.aqual))))::out)))
+end))
+end
+| uu____6403 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected binder"), (b.FStar_Parser_AST.brange)))))
+end))
+end)) ((env), ([])) bs)
+in (match (uu____6331) with
+| (env1, tpars) -> begin
+((env1), ((FStar_List.rev tpars)))
+end)))
+and desugar_binder : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.binder  ->  (FStar_Ident.ident Prims.option * FStar_Syntax_Syntax.term) = (fun env b -> (match (b.FStar_Parser_AST.b) with
+| (FStar_Parser_AST.TAnnotated (x, t)) | (FStar_Parser_AST.Annotated (x, t)) -> begin
+(
+
+let uu____6453 = (desugar_typ env t)
+in ((Some (x)), (uu____6453)))
+end
+| FStar_Parser_AST.TVariable (x) -> begin
+(
+
+let uu____6456 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_unknown))) None x.FStar_Ident.idRange)
+in ((Some (x)), (uu____6456)))
+end
+| FStar_Parser_AST.NoName (t) -> begin
+(
+
+let uu____6471 = (desugar_typ env t)
+in ((None), (uu____6471)))
+end
+| FStar_Parser_AST.Variable (x) -> begin
+((Some (x)), (FStar_Syntax_Syntax.tun))
+end))
+
+
+let mk_data_discriminators = (fun quals env t tps k datas -> (
+
+let quals1 = (FStar_All.pipe_right quals (FStar_List.filter (fun uu___193_6520 -> (match (uu___193_6520) with
+| (FStar_Syntax_Syntax.Abstract) | (FStar_Syntax_Syntax.Private) -> begin
+true
+end
+| uu____6521 -> begin
+false
+end))))
+in (
+
+let quals2 = (fun q -> (
+
+let uu____6529 = ((FStar_All.pipe_left Prims.op_Negation env.FStar_ToSyntax_Env.iface) || env.FStar_ToSyntax_Env.admitted_iface)
+in (match (uu____6529) with
+| true -> begin
+(FStar_List.append ((FStar_Syntax_Syntax.Assumption)::q) quals1)
+end
+| uu____6531 -> begin
+(FStar_List.append q quals1)
+end)))
+in (FStar_All.pipe_right datas (FStar_List.map (fun d -> (
+
+let disc_name = (FStar_Syntax_Util.mk_discriminator d)
+in (
+
+let uu____6536 = (
+
+let uu____6537 = (
+
+let uu____6543 = (quals2 ((FStar_Syntax_Syntax.OnlyName)::(FStar_Syntax_Syntax.Discriminator (d))::[]))
+in ((disc_name), ([]), (FStar_Syntax_Syntax.tun), (uu____6543)))
+in FStar_Syntax_Syntax.Sig_declare_typ (uu____6537))
+in {FStar_Syntax_Syntax.sigel = uu____6536; FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid disc_name)}))))))))
+
+
+let mk_indexed_projector_names : FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Syntax_Syntax.fv_qual  ->  FStar_ToSyntax_Env.env  ->  FStar_Ident.lid  ->  FStar_Syntax_Syntax.binder Prims.list  ->  FStar_Syntax_Syntax.sigelt Prims.list = (fun iquals fvq env lid fields -> (
+
+let p = (FStar_Ident.range_of_lid lid)
+in (
+
+let uu____6568 = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____6578 -> (match (uu____6578) with
+| (x, uu____6583) -> begin
+(
+
+let uu____6584 = (FStar_Syntax_Util.mk_field_projector_name lid x i)
+in (match (uu____6584) with
+| (field_name, uu____6589) -> begin
+(
+
+let only_decl = (((
+
+let uu____6591 = (FStar_ToSyntax_Env.current_module env)
+in (FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____6591)) || (fvq <> FStar_Syntax_Syntax.Data_ctor)) || (
+
+let uu____6592 = (
+
+let uu____6593 = (FStar_ToSyntax_Env.current_module env)
+in uu____6593.FStar_Ident.str)
+in (FStar_Options.dont_gen_projectors uu____6592)))
+in (
+
+let no_decl = (FStar_Syntax_Syntax.is_type x.FStar_Syntax_Syntax.sort)
+in (
+
+let quals = (fun q -> (match (only_decl) with
+| true -> begin
+(
+
+let uu____6603 = (FStar_List.filter (fun uu___194_6605 -> (match (uu___194_6605) with
+| FStar_Syntax_Syntax.Abstract -> begin
+false
+end
+| uu____6606 -> begin
+true
+end)) q)
+in (FStar_Syntax_Syntax.Assumption)::uu____6603)
+end
+| uu____6607 -> begin
+q
+end))
+in (
+
+let quals1 = (
+
+let iquals1 = (FStar_All.pipe_right iquals (FStar_List.filter (fun uu___195_6614 -> (match (uu___195_6614) with
+| (FStar_Syntax_Syntax.Abstract) | (FStar_Syntax_Syntax.Private) -> begin
+true
+end
+| uu____6615 -> begin
+false
+end))))
+in (quals ((FStar_Syntax_Syntax.OnlyName)::(FStar_Syntax_Syntax.Projector (((lid), (x.FStar_Syntax_Syntax.ppname))))::iquals1)))
+in (
+
+let decl = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((field_name), ([]), (FStar_Syntax_Syntax.tun), (quals1))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid field_name)}
+in (match (only_decl) with
+| true -> begin
+(decl)::[]
+end
+| uu____6620 -> begin
+(
+
+let dd = (
+
+let uu____6622 = (FStar_All.pipe_right quals1 (FStar_List.contains FStar_Syntax_Syntax.Abstract))
+in (match (uu____6622) with
+| true -> begin
+FStar_Syntax_Syntax.Delta_abstract (FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____6624 -> begin
+FStar_Syntax_Syntax.Delta_equational
+end))
+in (
+
+let lb = (
+
+let uu____6626 = (
+
+let uu____6629 = (FStar_Syntax_Syntax.lid_as_fv field_name dd None)
+in FStar_Util.Inr (uu____6629))
+in {FStar_Syntax_Syntax.lbname = uu____6626; FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = FStar_Syntax_Syntax.tun; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid; FStar_Syntax_Syntax.lbdef = FStar_Syntax_Syntax.tun})
+in (
+
+let impl = (
+
+let uu____6631 = (
+
+let uu____6632 = (
+
+let uu____6640 = (
+
+let uu____6642 = (
+
+let uu____6643 = (FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbname FStar_Util.right)
+in (FStar_All.pipe_right uu____6643 (fun fv -> fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))
+in (uu____6642)::[])
+in ((((false), ((lb)::[]))), (uu____6640), (quals1), ([])))
+in FStar_Syntax_Syntax.Sig_let (uu____6632))
+in {FStar_Syntax_Syntax.sigel = uu____6631; FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = p})
+in (match (no_decl) with
+| true -> begin
+(impl)::[]
+end
+| uu____6659 -> begin
+(decl)::(impl)::[]
+end))))
+end))))))
+end))
+end))))
+in (FStar_All.pipe_right uu____6568 FStar_List.flatten))))
+
+
+let mk_data_projector_names = (fun iquals env uu____6683 -> (match (uu____6683) with
+| (inductive_tps, se) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (lid, uu____6691, t, uu____6693, n1, quals, uu____6696) when (not ((FStar_Ident.lid_equals lid FStar_Syntax_Const.lexcons_lid))) -> begin
+(
+
+let uu____6701 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____6701) with
+| (formals, uu____6711) -> begin
+(match (formals) with
+| [] -> begin
+[]
+end
+| uu____6725 -> begin
+(
+
+let filter_records = (fun uu___196_6733 -> (match (uu___196_6733) with
+| FStar_Syntax_Syntax.RecordConstructor (uu____6735, fns) -> begin
+Some (FStar_Syntax_Syntax.Record_ctor (((lid), (fns))))
+end
+| uu____6742 -> begin
+None
+end))
+in (
+
+let fv_qual = (
+
+let uu____6744 = (FStar_Util.find_map quals filter_records)
+in (match (uu____6744) with
+| None -> begin
+FStar_Syntax_Syntax.Data_ctor
+end
+| Some (q) -> begin
+q
+end))
+in (
+
+let iquals1 = (match ((FStar_List.contains FStar_Syntax_Syntax.Abstract iquals)) with
+| true -> begin
+(FStar_Syntax_Syntax.Private)::iquals
+end
+| uu____6750 -> begin
+iquals
+end)
+in (
+
+let uu____6751 = (FStar_Util.first_N n1 formals)
+in (match (uu____6751) with
+| (uu____6763, rest) -> begin
+(mk_indexed_projector_names iquals1 fv_qual env lid rest)
+end)))))
+end)
+end))
+end
+| uu____6777 -> begin
+[]
+end)
+end))
+
+
+let mk_typ_abbrev : FStar_Ident.lident  ->  FStar_Syntax_Syntax.univ_name Prims.list  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Ident.lident Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.fsdoc Prims.option  ->  FStar_Syntax_Syntax.sigelt = (fun lid uvs typars k t lids quals rng doc1 -> (
+
+let dd = (
+
+let uu____6820 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Abstract))
+in (match (uu____6820) with
+| true -> begin
+(
+
+let uu____6822 = (FStar_Syntax_Util.incr_delta_qualifier t)
+in FStar_Syntax_Syntax.Delta_abstract (uu____6822))
+end
+| uu____6823 -> begin
+(FStar_Syntax_Util.incr_delta_qualifier t)
+end))
+in (
+
+let lb = (
+
+let uu____6825 = (
+
+let uu____6828 = (FStar_Syntax_Syntax.lid_as_fv lid dd None)
+in FStar_Util.Inr (uu____6828))
+in (
+
+let uu____6829 = (
+
+let uu____6832 = (FStar_Syntax_Syntax.mk_Total k)
+in (FStar_Syntax_Util.arrow typars uu____6832))
+in (
+
+let uu____6835 = (no_annot_abs typars t)
+in {FStar_Syntax_Syntax.lbname = uu____6825; FStar_Syntax_Syntax.lbunivs = uvs; FStar_Syntax_Syntax.lbtyp = uu____6829; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid; FStar_Syntax_Syntax.lbdef = uu____6835})))
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let (((((false), ((lb)::[]))), (lids), (quals), ([]))); FStar_Syntax_Syntax.sigdoc = doc1; FStar_Syntax_Syntax.sigrng = rng})))
+
+
+let rec desugar_tycon : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.decl  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Parser_AST.tycon Prims.list  ->  (env_t * FStar_Syntax_Syntax.sigelts) = (fun env d quals tcs -> (
+
+let rng = d.FStar_Parser_AST.drange
+in (
+
+let tycon_id = (fun uu___197_6869 -> (match (uu___197_6869) with
+| (FStar_Parser_AST.TyconAbstract (id, _, _)) | (FStar_Parser_AST.TyconAbbrev (id, _, _, _)) | (FStar_Parser_AST.TyconRecord (id, _, _, _)) | (FStar_Parser_AST.TyconVariant (id, _, _, _)) -> begin
+id
+end))
+in (
+
+let binder_to_term = (fun b -> (match (b.FStar_Parser_AST.b) with
+| (FStar_Parser_AST.Annotated (x, _)) | (FStar_Parser_AST.Variable (x)) -> begin
+(
+
+let uu____6908 = (
+
+let uu____6909 = (FStar_Ident.lid_of_ids ((x)::[]))
+in FStar_Parser_AST.Var (uu____6909))
+in (FStar_Parser_AST.mk_term uu____6908 x.FStar_Ident.idRange FStar_Parser_AST.Expr))
+end
+| (FStar_Parser_AST.TAnnotated (a, _)) | (FStar_Parser_AST.TVariable (a)) -> begin
+(FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar (a)) a.FStar_Ident.idRange FStar_Parser_AST.Type_level)
+end
+| FStar_Parser_AST.NoName (t) -> begin
+t
+end))
+in (
+
+let tot = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.effect_Tot_lid)) rng FStar_Parser_AST.Expr)
+in (
+
+let with_constructor_effect = (fun t -> (FStar_Parser_AST.mk_term (FStar_Parser_AST.App (((tot), (t), (FStar_Parser_AST.Nothing)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level))
+in (
+
+let apply_binders = (fun t binders -> (
+
+let imp_of_aqual = (fun b -> (match (b.FStar_Parser_AST.aqual) with
+| Some (FStar_Parser_AST.Implicit) -> begin
+FStar_Parser_AST.Hash
+end
+| uu____6931 -> begin
+FStar_Parser_AST.Nothing
+end))
+in (FStar_List.fold_left (fun out b -> (
+
+let uu____6934 = (
+
+let uu____6935 = (
+
+let uu____6939 = (binder_to_term b)
+in ((out), (uu____6939), ((imp_of_aqual b))))
+in FStar_Parser_AST.App (uu____6935))
+in (FStar_Parser_AST.mk_term uu____6934 out.FStar_Parser_AST.range out.FStar_Parser_AST.level))) t binders)))
+in (
+
+let tycon_record_as_variant = (fun uu___198_6946 -> (match (uu___198_6946) with
+| FStar_Parser_AST.TyconRecord (id, parms, kopt, fields) -> begin
+(
+
+let constrName = (FStar_Ident.mk_ident (((Prims.strcat "Mk" id.FStar_Ident.idText)), (id.FStar_Ident.idRange)))
+in (
+
+let mfields = (FStar_List.map (fun uu____6975 -> (match (uu____6975) with
+| (x, t, uu____6982) -> begin
+(FStar_Parser_AST.mk_binder (FStar_Parser_AST.Annotated ((((FStar_Syntax_Util.mangle_field_name x)), (t)))) x.FStar_Ident.idRange FStar_Parser_AST.Expr None)
+end)) fields)
+in (
+
+let result = (
+
+let uu____6986 = (
+
+let uu____6987 = (
+
+let uu____6988 = (FStar_Ident.lid_of_ids ((id)::[]))
+in FStar_Parser_AST.Var (uu____6988))
+in (FStar_Parser_AST.mk_term uu____6987 id.FStar_Ident.idRange FStar_Parser_AST.Type_level))
+in (apply_binders uu____6986 parms))
+in (
+
+let constrTyp = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (((mfields), ((with_constructor_effect result))))) id.FStar_Ident.idRange FStar_Parser_AST.Type_level)
+in (
+
+let uu____6991 = (FStar_All.pipe_right fields (FStar_List.map (fun uu____7003 -> (match (uu____7003) with
+| (x, uu____7009, uu____7010) -> begin
+(FStar_Syntax_Util.unmangle_field_name x)
+end))))
+in ((FStar_Parser_AST.TyconVariant (((id), (parms), (kopt), ((((constrName), (Some (constrTyp)), (None), (false)))::[])))), (uu____6991)))))))
+end
+| uu____7037 -> begin
+(failwith "impossible")
+end))
+in (
+
+let desugar_abstract_tc = (fun quals1 _env mutuals uu___199_7059 -> (match (uu___199_7059) with
+| FStar_Parser_AST.TyconAbstract (id, binders, kopt) -> begin
+(
+
+let uu____7073 = (typars_of_binders _env binders)
+in (match (uu____7073) with
+| (_env', typars) -> begin
+(
+
+let k = (match (kopt) with
+| None -> begin
+FStar_Syntax_Util.ktype
+end
+| Some (k) -> begin
+(desugar_term _env' k)
+end)
+in (
+
+let tconstr = (
+
+let uu____7101 = (
+
+let uu____7102 = (
+
+let uu____7103 = (FStar_Ident.lid_of_ids ((id)::[]))
+in FStar_Parser_AST.Var (uu____7103))
+in (FStar_Parser_AST.mk_term uu____7102 id.FStar_Ident.idRange FStar_Parser_AST.Type_level))
+in (apply_binders uu____7101 binders))
+in (
+
+let qlid = (FStar_ToSyntax_Env.qualify _env id)
+in (
+
+let typars1 = (FStar_Syntax_Subst.close_binders typars)
+in (
+
+let k1 = (FStar_Syntax_Subst.close typars1 k)
+in (
+
+let se = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((qlid), ([]), (typars1), (k1), (mutuals), ([]), (quals1))); FStar_Syntax_Syntax.sigdoc = d.FStar_Parser_AST.doc; FStar_Syntax_Syntax.sigrng = rng}
+in (
+
+let _env1 = (FStar_ToSyntax_Env.push_top_level_rec_binding _env id FStar_Syntax_Syntax.Delta_constant)
+in (
+
+let _env2 = (FStar_ToSyntax_Env.push_top_level_rec_binding _env' id FStar_Syntax_Syntax.Delta_constant)
+in ((_env1), (_env2), (se), (tconstr))))))))))
+end))
+end
+| uu____7114 -> begin
+(failwith "Unexpected tycon")
+end))
+in (
+
+let push_tparams = (fun env1 bs -> (
+
+let uu____7140 = (FStar_List.fold_left (fun uu____7156 uu____7157 -> (match (((uu____7156), (uu____7157))) with
+| ((env2, tps), (x, imp)) -> begin
+(
+
+let uu____7205 = (FStar_ToSyntax_Env.push_bv env2 x.FStar_Syntax_Syntax.ppname)
+in (match (uu____7205) with
+| (env3, y) -> begin
+((env3), ((((y), (imp)))::tps))
+end))
+end)) ((env1), ([])) bs)
+in (match (uu____7140) with
+| (env2, bs1) -> begin
+((env2), ((FStar_List.rev bs1)))
+end)))
+in (match (tcs) with
+| (FStar_Parser_AST.TyconAbstract (id, bs, kopt))::[] -> begin
+(
+
+let kopt1 = (match (kopt) with
+| None -> begin
+(
+
+let uu____7266 = (tm_type_z id.FStar_Ident.idRange)
+in Some (uu____7266))
+end
+| uu____7267 -> begin
+kopt
+end)
+in (
+
+let tc = FStar_Parser_AST.TyconAbstract (((id), (bs), (kopt1)))
+in (
+
+let uu____7272 = (desugar_abstract_tc quals env [] tc)
+in (match (uu____7272) with
+| (uu____7279, uu____7280, se, uu____7282) -> begin
+(
+
+let se1 = (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (l, uu____7285, typars, k, [], [], quals1) -> begin
+(
+
+let quals2 = (
+
+let uu____7295 = (FStar_All.pipe_right quals1 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
+in (match (uu____7295) with
+| true -> begin
+quals1
+end
+| uu____7298 -> begin
+((
+
+let uu____7300 = (FStar_Range.string_of_range se.FStar_Syntax_Syntax.sigrng)
+in (
+
+let uu____7301 = (FStar_Syntax_Print.lid_to_string l)
+in (FStar_Util.print2 "%s (Warning): Adding an implicit \'assume new\' qualifier on %s\n" uu____7300 uu____7301)));
+(FStar_Syntax_Syntax.Assumption)::(FStar_Syntax_Syntax.New)::quals1;
+)
+end))
+in (
+
+let t = (match (typars) with
+| [] -> begin
+k
+end
+| uu____7305 -> begin
+(
+
+let uu____7306 = (
+
+let uu____7309 = (
+
+let uu____7310 = (
+
+let uu____7318 = (FStar_Syntax_Syntax.mk_Total k)
+in ((typars), (uu____7318)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____7310))
+in (FStar_Syntax_Syntax.mk uu____7309))
+in (uu____7306 None se.FStar_Syntax_Syntax.sigrng))
+end)
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), ([]), (t), (quals2))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = se.FStar_Syntax_Syntax.sigrng}))
+end
+| uu____7329 -> begin
+se
+end)
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env se1)
+in ((env1), ((se1)::[]))))
+end))))
+end
+| (FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t))::[] -> begin
+(
+
+let uu____7340 = (typars_of_binders env binders)
+in (match (uu____7340) with
+| (env', typars) -> begin
+(
+
+let k = (match (kopt) with
+| None -> begin
+(
+
+let uu____7360 = (FStar_Util.for_some (fun uu___200_7361 -> (match (uu___200_7361) with
+| FStar_Syntax_Syntax.Effect -> begin
+true
+end
+| uu____7362 -> begin
+false
+end)) quals)
+in (match (uu____7360) with
+| true -> begin
+FStar_Syntax_Syntax.teff
+end
+| uu____7363 -> begin
+FStar_Syntax_Syntax.tun
+end))
+end
+| Some (k) -> begin
+(desugar_term env' k)
+end)
+in (
+
+let t0 = t
+in (
+
+let quals1 = (
+
+let uu____7368 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___201_7370 -> (match (uu___201_7370) with
+| FStar_Syntax_Syntax.Logic -> begin
+true
+end
+| uu____7371 -> begin
+false
+end))))
+in (match (uu____7368) with
+| true -> begin
+quals
+end
+| uu____7373 -> begin
+(match ((t0.FStar_Parser_AST.level = FStar_Parser_AST.Formula)) with
+| true -> begin
+(FStar_Syntax_Syntax.Logic)::quals
+end
+| uu____7375 -> begin
+quals
+end)
+end))
+in (
+
+let se = (
+
+let uu____7377 = (FStar_All.pipe_right quals1 (FStar_List.contains FStar_Syntax_Syntax.Effect))
+in (match (uu____7377) with
+| true -> begin
+(
+
+let uu____7379 = (
+
+let uu____7383 = (
+
+let uu____7384 = (unparen t)
+in uu____7384.FStar_Parser_AST.tm)
+in (match (uu____7383) with
+| FStar_Parser_AST.Construct (head1, args) -> begin
+(
+
+let uu____7396 = (match ((FStar_List.rev args)) with
+| ((last_arg, uu____7412))::args_rev -> begin
+(
+
+let uu____7419 = (
+
+let uu____7420 = (unparen last_arg)
+in uu____7420.FStar_Parser_AST.tm)
+in (match (uu____7419) with
+| FStar_Parser_AST.Attributes (ts) -> begin
+((ts), ((FStar_List.rev args_rev)))
+end
+| uu____7435 -> begin
+(([]), (args))
+end))
+end
+| uu____7440 -> begin
+(([]), (args))
+end)
+in (match (uu____7396) with
+| (cattributes, args1) -> begin
+(
+
+let uu____7461 = (desugar_attributes env cattributes)
+in (((FStar_Parser_AST.mk_term (FStar_Parser_AST.Construct (((head1), (args1)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)), (uu____7461)))
+end))
+end
+| uu____7467 -> begin
+((t), ([]))
+end))
+in (match (uu____7379) with
+| (t1, cattributes) -> begin
+(
+
+let c = (desugar_comp t1.FStar_Parser_AST.range env' t1)
+in (
+
+let typars1 = (FStar_Syntax_Subst.close_binders typars)
+in (
+
+let c1 = (FStar_Syntax_Subst.close_comp typars1 c)
+in (
+
+let uu____7478 = (
+
+let uu____7479 = (
+
+let uu____7488 = (FStar_ToSyntax_Env.qualify env id)
+in (
+
+let uu____7489 = (FStar_All.pipe_right quals1 (FStar_List.filter (fun uu___202_7493 -> (match (uu___202_7493) with
+| FStar_Syntax_Syntax.Effect -> begin
+false
+end
+| uu____7494 -> begin
+true
+end))))
+in ((uu____7488), ([]), (typars1), (c1), (uu____7489), ((FStar_List.append cattributes (FStar_Syntax_Util.comp_flags c1))))))
+in FStar_Syntax_Syntax.Sig_effect_abbrev (uu____7479))
+in {FStar_Syntax_Syntax.sigel = uu____7478; FStar_Syntax_Syntax.sigdoc = d.FStar_Parser_AST.doc; FStar_Syntax_Syntax.sigrng = rng}))))
+end))
+end
+| uu____7498 -> begin
+(
+
+let t1 = (desugar_typ env' t)
+in (
+
+let nm = (FStar_ToSyntax_Env.qualify env id)
+in (mk_typ_abbrev nm [] typars k t1 ((nm)::[]) quals1 rng d.FStar_Parser_AST.doc)))
+end))
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env se)
+in ((env1), ((se)::[])))))))
+end))
+end
+| (FStar_Parser_AST.TyconRecord (uu____7503))::[] -> begin
+(
+
+let trec = (FStar_List.hd tcs)
+in (
+
+let uu____7516 = (tycon_record_as_variant trec)
+in (match (uu____7516) with
+| (t, fs) -> begin
+(
+
+let uu____7526 = (
+
+let uu____7528 = (
+
+let uu____7529 = (
+
+let uu____7534 = (
+
+let uu____7536 = (FStar_ToSyntax_Env.current_module env)
+in (FStar_Ident.ids_of_lid uu____7536))
+in ((uu____7534), (fs)))
+in FStar_Syntax_Syntax.RecordType (uu____7529))
+in (uu____7528)::quals)
+in (desugar_tycon env d uu____7526 ((t)::[])))
+end)))
+end
+| (uu____7539)::uu____7540 -> begin
+(
+
+let env0 = env
+in (
+
+let mutuals = (FStar_List.map (fun x -> (FStar_All.pipe_left (FStar_ToSyntax_Env.qualify env) (tycon_id x))) tcs)
+in (
+
+let rec collect_tcs = (fun quals1 et tc -> (
+
+let uu____7627 = et
+in (match (uu____7627) with
+| (env1, tcs1) -> begin
+(match (tc) with
+| FStar_Parser_AST.TyconRecord (uu____7741) -> begin
+(
+
+let trec = tc
+in (
+
+let uu____7754 = (tycon_record_as_variant trec)
+in (match (uu____7754) with
+| (t, fs) -> begin
+(
+
+let uu____7785 = (
+
+let uu____7787 = (
+
+let uu____7788 = (
+
+let uu____7793 = (
+
+let uu____7795 = (FStar_ToSyntax_Env.current_module env1)
+in (FStar_Ident.ids_of_lid uu____7795))
+in ((uu____7793), (fs)))
+in FStar_Syntax_Syntax.RecordType (uu____7788))
+in (uu____7787)::quals1)
+in (collect_tcs uu____7785 ((env1), (tcs1)) t))
+end)))
+end
+| FStar_Parser_AST.TyconVariant (id, binders, kopt, constructors) -> begin
+(
+
+let uu____7841 = (desugar_abstract_tc quals1 env1 mutuals (FStar_Parser_AST.TyconAbstract (((id), (binders), (kopt)))))
+in (match (uu____7841) with
+| (env2, uu____7872, se, tconstr) -> begin
+((env2), ((FStar_Util.Inl (((se), (constructors), (tconstr), (quals1))))::tcs1))
+end))
+end
+| FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t) -> begin
+(
+
+let uu____7950 = (desugar_abstract_tc quals1 env1 mutuals (FStar_Parser_AST.TyconAbstract (((id), (binders), (kopt)))))
+in (match (uu____7950) with
+| (env2, uu____7981, se, tconstr) -> begin
+((env2), ((FStar_Util.Inr (((se), (binders), (t), (quals1))))::tcs1))
+end))
+end
+| uu____8045 -> begin
+(failwith "Unrecognized mutual type definition")
+end)
+end)))
+in (
+
+let uu____8069 = (FStar_List.fold_left (collect_tcs quals) ((env), ([])) tcs)
+in (match (uu____8069) with
+| (env1, tcs1) -> begin
+(
+
+let tcs2 = (FStar_List.rev tcs1)
+in (
+
+let tps_sigelts = (FStar_All.pipe_right tcs2 (FStar_List.collect (fun uu___204_8307 -> (match (uu___204_8307) with
+| FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (id, uvs, tpars, k, uu____8339, uu____8340, uu____8341); FStar_Syntax_Syntax.sigdoc = uu____8342; FStar_Syntax_Syntax.sigrng = uu____8343}, binders, t, quals1) -> begin
+(
+
+let t1 = (
+
+let uu____8377 = (typars_of_binders env1 binders)
+in (match (uu____8377) with
+| (env2, tpars1) -> begin
+(
+
+let uu____8394 = (push_tparams env2 tpars1)
+in (match (uu____8394) with
+| (env_tps, tpars2) -> begin
+(
+
+let t1 = (desugar_typ env_tps t)
+in (
+
+let tpars3 = (FStar_Syntax_Subst.close_binders tpars2)
+in (FStar_Syntax_Subst.close tpars3 t1)))
+end))
+end))
+in (
+
+let uu____8413 = (
+
+let uu____8420 = (mk_typ_abbrev id uvs tpars k t1 ((id)::[]) quals1 rng d.FStar_Parser_AST.doc)
+in (([]), (uu____8420)))
+in (uu____8413)::[]))
+end
+| FStar_Util.Inl ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (tname, univs, tpars, k, mutuals1, uu____8445, tags); FStar_Syntax_Syntax.sigdoc = uu____8447; FStar_Syntax_Syntax.sigrng = uu____8448}, constrs, tconstr, quals1) -> begin
+(
+
+let mk_tot = (fun t -> (
+
+let tot1 = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Name (FStar_Syntax_Const.effect_Tot_lid)) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)
+in (FStar_Parser_AST.mk_term (FStar_Parser_AST.App (((tot1), (t), (FStar_Parser_AST.Nothing)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)))
+in (
+
+let tycon = ((tname), (tpars), (k))
+in (
+
+let uu____8502 = (push_tparams env1 tpars)
+in (match (uu____8502) with
+| (env_tps, tps) -> begin
+(
+
+let data_tpars = (FStar_List.map (fun uu____8537 -> (match (uu____8537) with
+| (x, uu____8545) -> begin
+((x), (Some (FStar_Syntax_Syntax.Implicit (true))))
+end)) tps)
+in (
+
+let tot_tconstr = (mk_tot tconstr)
+in (
+
+let uu____8550 = (
+
+let uu____8561 = (FStar_All.pipe_right constrs (FStar_List.map (fun uu____8601 -> (match (uu____8601) with
+| (id, topt, uu____8618, of_notation) -> begin
+(
+
+let t = (match (of_notation) with
+| true -> begin
+(match (topt) with
+| Some (t) -> begin
+(FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (((((FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName (t)) t.FStar_Parser_AST.range t.FStar_Parser_AST.level None))::[]), (tot_tconstr)))) t.FStar_Parser_AST.range t.FStar_Parser_AST.level)
+end
+| None -> begin
+tconstr
+end)
+end
+| uu____8627 -> begin
+(match (topt) with
+| None -> begin
+(failwith "Impossible")
+end
+| Some (t) -> begin
+t
+end)
+end)
+in (
+
+let t1 = (
+
+let uu____8630 = (close env_tps t)
+in (desugar_term env_tps uu____8630))
+in (
+
+let name = (FStar_ToSyntax_Env.qualify env1 id)
+in (
+
+let quals2 = (FStar_All.pipe_right tags (FStar_List.collect (fun uu___203_8636 -> (match (uu___203_8636) with
+| FStar_Syntax_Syntax.RecordType (fns) -> begin
+(FStar_Syntax_Syntax.RecordConstructor (fns))::[]
+end
+| uu____8643 -> begin
+[]
+end))))
+in (
+
+let ntps = (FStar_List.length data_tpars)
+in (
+
+let uu____8649 = (
+
+let uu____8656 = (
+
+let uu____8657 = (
+
+let uu____8658 = (
+
+let uu____8668 = (
+
+let uu____8671 = (
+
+let uu____8674 = (FStar_All.pipe_right t1 FStar_Syntax_Util.name_function_binders)
+in (FStar_Syntax_Syntax.mk_Total uu____8674))
+in (FStar_Syntax_Util.arrow data_tpars uu____8671))
+in ((name), (univs), (uu____8668), (tname), (ntps), (quals2), (mutuals1)))
+in FStar_Syntax_Syntax.Sig_datacon (uu____8658))
+in {FStar_Syntax_Syntax.sigel = uu____8657; FStar_Syntax_Syntax.sigdoc = d.FStar_Parser_AST.doc; FStar_Syntax_Syntax.sigrng = rng})
+in ((tps), (uu____8656)))
+in ((name), (uu____8649))))))))
+end))))
+in (FStar_All.pipe_left FStar_List.split uu____8561))
+in (match (uu____8550) with
+| (constrNames, constrs1) -> begin
+((([]), ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((tname), (univs), (tpars), (k), (mutuals1), (constrNames), (tags))); FStar_Syntax_Syntax.sigdoc = d.FStar_Parser_AST.doc; FStar_Syntax_Syntax.sigrng = rng})))::constrs1
+end))))
+end))))
+end
+| uu____8759 -> begin
+(failwith "impossible")
+end))))
+in (
+
+let sigelts = (FStar_All.pipe_right tps_sigelts (FStar_List.map Prims.snd))
+in (
+
+let uu____8807 = (
+
+let uu____8811 = (FStar_List.collect FStar_Syntax_Util.lids_of_sigelt sigelts)
+in (FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle sigelts quals uu____8811 rng d.FStar_Parser_AST.doc))
+in (match (uu____8807) with
+| (bundle, abbrevs) -> begin
+(
+
+let env2 = (FStar_ToSyntax_Env.push_sigelt env0 bundle)
+in (
+
+let env3 = (FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env2 abbrevs)
+in (
+
+let data_ops = (FStar_All.pipe_right tps_sigelts (FStar_List.collect (mk_data_projector_names quals env3)))
+in (
+
+let discs = (FStar_All.pipe_right sigelts (FStar_List.collect (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (tname, uu____8848, tps, k, uu____8851, constrs, quals1) when ((FStar_List.length constrs) > (Prims.parse_int "1")) -> begin
+(
+
+let quals2 = (match ((FStar_List.contains FStar_Syntax_Syntax.Abstract quals1)) with
+| true -> begin
+(FStar_Syntax_Syntax.Private)::quals1
+end
+| uu____8866 -> begin
+quals1
+end)
+in (mk_data_discriminators quals2 env3 tname tps k constrs))
+end
+| uu____8867 -> begin
+[]
+end))))
+in (
+
+let ops = (FStar_List.append discs data_ops)
+in (
+
+let env4 = (FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env3 ops)
+in ((env4), ((FStar_List.append ((bundle)::[]) (FStar_List.append abbrevs ops))))))))))
+end)))))
+end)))))
+end
+| [] -> begin
+(failwith "impossible")
+end)))))))))))
+
+
+let desugar_binders : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.binder Prims.list  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.binder Prims.list) = (fun env binders -> (
+
+let uu____8885 = (FStar_List.fold_left (fun uu____8892 b -> (match (uu____8892) with
+| (env1, binders1) -> begin
+(
+
+let uu____8904 = (desugar_binder env1 b)
+in (match (uu____8904) with
+| (Some (a), k) -> begin
+(
+
+let uu____8914 = (FStar_ToSyntax_Env.push_bv env1 a)
+in (match (uu____8914) with
+| (env2, a1) -> begin
+(
+
+let uu____8922 = (
+
+let uu____8924 = (FStar_Syntax_Syntax.mk_binder (
+
+let uu___219_8925 = a1
+in {FStar_Syntax_Syntax.ppname = uu___219_8925.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___219_8925.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = k}))
+in (uu____8924)::binders1)
+in ((env2), (uu____8922)))
+end))
+end
+| uu____8927 -> begin
+(Prims.raise (FStar_Errors.Error ((("Missing name in binder"), (b.FStar_Parser_AST.brange)))))
+end))
+end)) ((env), ([])) binders)
+in (match (uu____8885) with
+| (env1, binders1) -> begin
+((env1), ((FStar_List.rev binders1)))
+end)))
+
+
+let rec desugar_effect : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.decl  ->  FStar_Parser_AST.qualifiers  ->  FStar_Ident.ident  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.term  ->  FStar_Parser_AST.decl Prims.list  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env d quals eff_name eff_binders eff_typ eff_decls -> (
+
+let env0 = env
+in (
+
+let monad_env = (FStar_ToSyntax_Env.enter_monad_scope env eff_name)
+in (
+
+let uu____9005 = (desugar_binders monad_env eff_binders)
+in (match (uu____9005) with
+| (env1, binders) -> begin
+(
+
+let eff_t = (desugar_term env1 eff_typ)
+in (
+
+let for_free = (
+
+let uu____9018 = (
+
+let uu____9019 = (
+
+let uu____9023 = (FStar_Syntax_Util.arrow_formals eff_t)
+in (Prims.fst uu____9023))
+in (FStar_List.length uu____9019))
+in (uu____9018 = (Prims.parse_int "1")))
+in (
+
+let mandatory_members = (
+
+let rr_members = ("repr")::("return")::("bind")::[]
+in (match (for_free) with
+| true -> begin
+rr_members
+end
+| uu____9046 -> begin
+(FStar_List.append rr_members (("return_wp")::("bind_wp")::("if_then_else")::("ite_wp")::("stronger")::("close_wp")::("assert_p")::("assume_p")::("null_wp")::("trivial")::[]))
+end))
+in (
+
+let name_of_eff_decl = (fun decl -> (match (decl.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Tycon (uu____9051, ((FStar_Parser_AST.TyconAbbrev (name, uu____9053, uu____9054, uu____9055), uu____9056))::[]) -> begin
+(FStar_Ident.text_of_id name)
+end
+| uu____9073 -> begin
+(failwith "Malformed effect member declaration.")
+end))
+in (
+
+let uu____9074 = (FStar_List.partition (fun decl -> (
+
+let uu____9080 = (name_of_eff_decl decl)
+in (FStar_List.mem uu____9080 mandatory_members))) eff_decls)
+in (match (uu____9074) with
+| (mandatory_members_decls, actions) -> begin
+(
+
+let uu____9090 = (FStar_All.pipe_right mandatory_members_decls (FStar_List.fold_left (fun uu____9101 decl -> (match (uu____9101) with
+| (env2, out) -> begin
+(
+
+let uu____9113 = (desugar_decl env2 decl)
+in (match (uu____9113) with
+| (env3, ses) -> begin
+(
+
+let uu____9121 = (
+
+let uu____9123 = (FStar_List.hd ses)
+in (uu____9123)::out)
+in ((env3), (uu____9121)))
+end))
+end)) ((env1), ([]))))
+in (match (uu____9090) with
+| (env2, decls) -> begin
+(
+
+let binders1 = (FStar_Syntax_Subst.close_binders binders)
+in (
+
+let actions1 = (FStar_All.pipe_right actions (FStar_List.map (fun d1 -> (match (d1.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Tycon (uu____9139, ((FStar_Parser_AST.TyconAbbrev (name, uu____9141, uu____9142, {FStar_Parser_AST.tm = FStar_Parser_AST.Construct (uu____9143, ((def, uu____9145))::((cps_type, uu____9147))::[]); FStar_Parser_AST.range = uu____9148; FStar_Parser_AST.level = uu____9149}), uu____9150))::[]) when (not (for_free)) -> begin
+(
+
+let uu____9176 = (FStar_ToSyntax_Env.qualify env2 name)
+in (
+
+let uu____9177 = (
+
+let uu____9178 = (desugar_term env2 def)
+in (FStar_Syntax_Subst.close binders1 uu____9178))
+in (
+
+let uu____9179 = (
+
+let uu____9180 = (desugar_typ env2 cps_type)
+in (FStar_Syntax_Subst.close binders1 uu____9180))
+in {FStar_Syntax_Syntax.action_name = uu____9176; FStar_Syntax_Syntax.action_unqualified_name = name; FStar_Syntax_Syntax.action_univs = []; FStar_Syntax_Syntax.action_defn = uu____9177; FStar_Syntax_Syntax.action_typ = uu____9179})))
+end
+| FStar_Parser_AST.Tycon (uu____9181, ((FStar_Parser_AST.TyconAbbrev (name, uu____9183, uu____9184, defn), uu____9186))::[]) when for_free -> begin
+(
+
+let uu____9203 = (FStar_ToSyntax_Env.qualify env2 name)
+in (
+
+let uu____9204 = (
+
+let uu____9205 = (desugar_term env2 defn)
+in (FStar_Syntax_Subst.close binders1 uu____9205))
+in {FStar_Syntax_Syntax.action_name = uu____9203; FStar_Syntax_Syntax.action_unqualified_name = name; FStar_Syntax_Syntax.action_univs = []; FStar_Syntax_Syntax.action_defn = uu____9204; FStar_Syntax_Syntax.action_typ = FStar_Syntax_Syntax.tun}))
+end
+| uu____9206 -> begin
+(Prims.raise (FStar_Errors.Error ((("Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples)."), (d1.FStar_Parser_AST.drange)))))
+end))))
+in (
+
+let eff_t1 = (FStar_Syntax_Subst.close binders1 eff_t)
+in (
+
+let lookup = (fun s -> (
+
+let l = (FStar_ToSyntax_Env.qualify env2 (FStar_Ident.mk_ident ((s), (d.FStar_Parser_AST.drange))))
+in (
+
+let uu____9216 = (
+
+let uu____9217 = (FStar_ToSyntax_Env.fail_or env2 (FStar_ToSyntax_Env.try_lookup_definition env2) l)
+in (FStar_All.pipe_left (FStar_Syntax_Subst.close binders1) uu____9217))
+in (([]), (uu____9216)))))
+in (
+
+let mname = (FStar_ToSyntax_Env.qualify env0 eff_name)
+in (
+
+let qualifiers = (FStar_List.map (trans_qual d.FStar_Parser_AST.drange (Some (mname))) quals)
+in (
+
+let se = (match (for_free) with
+| true -> begin
+(
+
+let dummy_tscheme = (
+
+let uu____9229 = (FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown None FStar_Range.dummyRange)
+in (([]), (uu____9229)))
+in (
+
+let uu____9239 = (
+
+let uu____9240 = (
+
+let uu____9241 = (
+
+let uu____9242 = (lookup "repr")
+in (Prims.snd uu____9242))
+in (
+
+let uu____9247 = (lookup "return")
+in (
+
+let uu____9248 = (lookup "bind")
+in {FStar_Syntax_Syntax.qualifiers = qualifiers; FStar_Syntax_Syntax.cattributes = []; FStar_Syntax_Syntax.mname = mname; FStar_Syntax_Syntax.univs = []; FStar_Syntax_Syntax.binders = binders1; FStar_Syntax_Syntax.signature = eff_t1; FStar_Syntax_Syntax.ret_wp = dummy_tscheme; FStar_Syntax_Syntax.bind_wp = dummy_tscheme; FStar_Syntax_Syntax.if_then_else = dummy_tscheme; FStar_Syntax_Syntax.ite_wp = dummy_tscheme; FStar_Syntax_Syntax.stronger = dummy_tscheme; FStar_Syntax_Syntax.close_wp = dummy_tscheme; FStar_Syntax_Syntax.assert_p = dummy_tscheme; FStar_Syntax_Syntax.assume_p = dummy_tscheme; FStar_Syntax_Syntax.null_wp = dummy_tscheme; FStar_Syntax_Syntax.trivial = dummy_tscheme; FStar_Syntax_Syntax.repr = uu____9241; FStar_Syntax_Syntax.return_repr = uu____9247; FStar_Syntax_Syntax.bind_repr = uu____9248; FStar_Syntax_Syntax.actions = actions1})))
+in FStar_Syntax_Syntax.Sig_new_effect_for_free (uu____9240))
+in (FStar_Parser_AST.sigelt_of_decl d uu____9239)))
+end
+| uu____9249 -> begin
+(
+
+let rr = (FStar_Util.for_some (fun uu___205_9251 -> (match (uu___205_9251) with
+| (FStar_Syntax_Syntax.Reifiable) | (FStar_Syntax_Syntax.Reflectable (_)) -> begin
+true
+end
+| uu____9253 -> begin
+false
+end)) qualifiers)
+in (
+
+let un_ts = (([]), (FStar_Syntax_Syntax.tun))
+in (
+
+let uu____9259 = (
+
+let uu____9260 = (
+
+let uu____9261 = (lookup "return_wp")
+in (
+
+let uu____9262 = (lookup "bind_wp")
+in (
+
+let uu____9263 = (lookup "if_then_else")
+in (
+
+let uu____9264 = (lookup "ite_wp")
+in (
+
+let uu____9265 = (lookup "stronger")
+in (
+
+let uu____9266 = (lookup "close_wp")
+in (
+
+let uu____9267 = (lookup "assert_p")
+in (
+
+let uu____9268 = (lookup "assume_p")
+in (
+
+let uu____9269 = (lookup "null_wp")
+in (
+
+let uu____9270 = (lookup "trivial")
+in (
+
+let uu____9271 = (match (rr) with
+| true -> begin
+(
+
+let uu____9272 = (lookup "repr")
+in (FStar_All.pipe_left Prims.snd uu____9272))
+end
+| uu____9280 -> begin
+FStar_Syntax_Syntax.tun
+end)
+in (
+
+let uu____9281 = (match (rr) with
+| true -> begin
+(lookup "return")
+end
+| uu____9282 -> begin
+un_ts
+end)
+in (
+
+let uu____9283 = (match (rr) with
+| true -> begin
+(lookup "bind")
+end
+| uu____9284 -> begin
+un_ts
+end)
+in {FStar_Syntax_Syntax.qualifiers = qualifiers; FStar_Syntax_Syntax.cattributes = []; FStar_Syntax_Syntax.mname = mname; FStar_Syntax_Syntax.univs = []; FStar_Syntax_Syntax.binders = binders1; FStar_Syntax_Syntax.signature = eff_t1; FStar_Syntax_Syntax.ret_wp = uu____9261; FStar_Syntax_Syntax.bind_wp = uu____9262; FStar_Syntax_Syntax.if_then_else = uu____9263; FStar_Syntax_Syntax.ite_wp = uu____9264; FStar_Syntax_Syntax.stronger = uu____9265; FStar_Syntax_Syntax.close_wp = uu____9266; FStar_Syntax_Syntax.assert_p = uu____9267; FStar_Syntax_Syntax.assume_p = uu____9268; FStar_Syntax_Syntax.null_wp = uu____9269; FStar_Syntax_Syntax.trivial = uu____9270; FStar_Syntax_Syntax.repr = uu____9271; FStar_Syntax_Syntax.return_repr = uu____9281; FStar_Syntax_Syntax.bind_repr = uu____9283; FStar_Syntax_Syntax.actions = actions1})))))))))))))
+in FStar_Syntax_Syntax.Sig_new_effect (uu____9260))
+in (FStar_Parser_AST.sigelt_of_decl d uu____9259))))
+end)
+in (
+
+let env3 = (FStar_ToSyntax_Env.push_sigelt env0 se)
+in (
+
+let env4 = (FStar_All.pipe_right actions1 (FStar_List.fold_left (fun env4 a -> (
+
+let uu____9290 = (FStar_Syntax_Util.action_as_lb mname a)
+in (FStar_ToSyntax_Env.push_sigelt env4 uu____9290))) env3))
+in (
+
+let env5 = (
+
+let uu____9292 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Parser_AST.Reflectable))
+in (match (uu____9292) with
+| true -> begin
+(
+
+let reflect_lid = (FStar_All.pipe_right (FStar_Ident.id_of_text "reflect") (FStar_ToSyntax_Env.qualify monad_env))
+in (
+
+let refl_decl = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_declare_typ (((reflect_lid), ([]), (FStar_Syntax_Syntax.tun), ((FStar_Syntax_Syntax.Assumption)::(FStar_Syntax_Syntax.Reflectable (mname))::[])))))
+in (FStar_ToSyntax_Env.push_sigelt env4 refl_decl)))
+end
+| uu____9297 -> begin
+env4
+end))
+in ((env5), ((se)::[]))))))))))))
+end))
+end))))))
+end)))))
+and desugar_redefine_effect : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.decl  ->  (FStar_Ident.lident Prims.option  ->  FStar_Parser_AST.qualifier  ->  FStar_Syntax_Syntax.qualifier)  ->  FStar_Parser_AST.qualifier Prims.list  ->  FStar_Ident.ident  ->  FStar_Parser_AST.binder Prims.list  ->  FStar_Parser_AST.term  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env d trans_qual1 quals eff_name eff_binders defn -> (
+
+let env0 = env
+in (
+
+let env1 = (FStar_ToSyntax_Env.enter_monad_scope env eff_name)
+in (
+
+let uu____9315 = (desugar_binders env1 eff_binders)
+in (match (uu____9315) with
+| (env2, binders) -> begin
+(
+
+let uu____9326 = (
+
+let uu____9335 = (head_and_args defn)
+in (match (uu____9335) with
+| (head1, args) -> begin
+(
+
+let ed = (match (head1.FStar_Parser_AST.tm) with
+| FStar_Parser_AST.Name (l) -> begin
+(FStar_ToSyntax_Env.fail_or env2 (FStar_ToSyntax_Env.try_lookup_effect_defn env2) l)
+end
+| uu____9359 -> begin
+(
+
+let uu____9360 = (
+
+let uu____9361 = (
+
+let uu____9364 = (
+
+let uu____9365 = (
+
+let uu____9366 = (FStar_Parser_AST.term_to_string head1)
+in (Prims.strcat uu____9366 " not found"))
+in (Prims.strcat "Effect " uu____9365))
+in ((uu____9364), (d.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____9361))
+in (Prims.raise uu____9360))
+end)
+in (
+
+let uu____9367 = (match ((FStar_List.rev args)) with
+| ((last_arg, uu____9383))::args_rev -> begin
+(
+
+let uu____9390 = (
+
+let uu____9391 = (unparen last_arg)
+in uu____9391.FStar_Parser_AST.tm)
+in (match (uu____9390) with
+| FStar_Parser_AST.Attributes (ts) -> begin
+((ts), ((FStar_List.rev args_rev)))
+end
+| uu____9406 -> begin
+(([]), (args))
+end))
+end
+| uu____9411 -> begin
+(([]), (args))
+end)
+in (match (uu____9367) with
+| (cattributes, args1) -> begin
+(
+
+let uu____9437 = (desugar_args env2 args1)
+in (
+
+let uu____9442 = (desugar_attributes env2 cattributes)
+in ((ed), (uu____9437), (uu____9442))))
+end)))
+end))
+in (match (uu____9326) with
+| (ed, args, cattributes) -> begin
+(
+
+let binders1 = (FStar_Syntax_Subst.close_binders binders)
+in (
+
+let sub1 = (fun uu____9475 -> (match (uu____9475) with
+| (uu____9482, x) -> begin
+(
+
+let uu____9486 = (FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders x)
+in (match (uu____9486) with
+| (edb, x1) -> begin
+((match (((FStar_List.length args) <> (FStar_List.length edb))) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected number of arguments to effect constructor"), (defn.FStar_Parser_AST.range)))))
+end
+| uu____9504 -> begin
+()
+end);
+(
+
+let s = (FStar_Syntax_Util.subst_of_list edb args)
+in (
+
+let uu____9506 = (
+
+let uu____9507 = (FStar_Syntax_Subst.subst s x1)
+in (FStar_Syntax_Subst.close binders1 uu____9507))
+in (([]), (uu____9506))));
+)
+end))
+end))
+in (
+
+let mname = (FStar_ToSyntax_Env.qualify env0 eff_name)
+in (
+
+let ed1 = (
+
+let uu____9511 = (
+
+let uu____9513 = (trans_qual1 (Some (mname)))
+in (FStar_List.map uu____9513 quals))
+in (
+
+let uu____9516 = (
+
+let uu____9517 = (sub1 (([]), (ed.FStar_Syntax_Syntax.signature)))
+in (Prims.snd uu____9517))
+in (
+
+let uu____9523 = (sub1 ed.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____9524 = (sub1 ed.FStar_Syntax_Syntax.bind_wp)
+in (
+
+let uu____9525 = (sub1 ed.FStar_Syntax_Syntax.if_then_else)
+in (
+
+let uu____9526 = (sub1 ed.FStar_Syntax_Syntax.ite_wp)
+in (
+
+let uu____9527 = (sub1 ed.FStar_Syntax_Syntax.stronger)
+in (
+
+let uu____9528 = (sub1 ed.FStar_Syntax_Syntax.close_wp)
+in (
+
+let uu____9529 = (sub1 ed.FStar_Syntax_Syntax.assert_p)
+in (
+
+let uu____9530 = (sub1 ed.FStar_Syntax_Syntax.assume_p)
+in (
+
+let uu____9531 = (sub1 ed.FStar_Syntax_Syntax.null_wp)
+in (
+
+let uu____9532 = (sub1 ed.FStar_Syntax_Syntax.trivial)
+in (
+
+let uu____9533 = (
+
+let uu____9534 = (sub1 (([]), (ed.FStar_Syntax_Syntax.repr)))
+in (Prims.snd uu____9534))
+in (
+
+let uu____9540 = (sub1 ed.FStar_Syntax_Syntax.return_repr)
+in (
+
+let uu____9541 = (sub1 ed.FStar_Syntax_Syntax.bind_repr)
+in (
+
+let uu____9542 = (FStar_List.map (fun action -> (
+
+let uu____9545 = (FStar_ToSyntax_Env.qualify env2 action.FStar_Syntax_Syntax.action_unqualified_name)
+in (
+
+let uu____9546 = (
+
+let uu____9547 = (sub1 (([]), (action.FStar_Syntax_Syntax.action_defn)))
+in (Prims.snd uu____9547))
+in (
+
+let uu____9553 = (
+
+let uu____9554 = (sub1 (([]), (action.FStar_Syntax_Syntax.action_typ)))
+in (Prims.snd uu____9554))
+in {FStar_Syntax_Syntax.action_name = uu____9545; FStar_Syntax_Syntax.action_unqualified_name = action.FStar_Syntax_Syntax.action_unqualified_name; FStar_Syntax_Syntax.action_univs = action.FStar_Syntax_Syntax.action_univs; FStar_Syntax_Syntax.action_defn = uu____9546; FStar_Syntax_Syntax.action_typ = uu____9553})))) ed.FStar_Syntax_Syntax.actions)
+in {FStar_Syntax_Syntax.qualifiers = uu____9511; FStar_Syntax_Syntax.cattributes = cattributes; FStar_Syntax_Syntax.mname = mname; FStar_Syntax_Syntax.univs = []; FStar_Syntax_Syntax.binders = binders1; FStar_Syntax_Syntax.signature = uu____9516; FStar_Syntax_Syntax.ret_wp = uu____9523; FStar_Syntax_Syntax.bind_wp = uu____9524; FStar_Syntax_Syntax.if_then_else = uu____9525; FStar_Syntax_Syntax.ite_wp = uu____9526; FStar_Syntax_Syntax.stronger = uu____9527; FStar_Syntax_Syntax.close_wp = uu____9528; FStar_Syntax_Syntax.assert_p = uu____9529; FStar_Syntax_Syntax.assume_p = uu____9530; FStar_Syntax_Syntax.null_wp = uu____9531; FStar_Syntax_Syntax.trivial = uu____9532; FStar_Syntax_Syntax.repr = uu____9533; FStar_Syntax_Syntax.return_repr = uu____9540; FStar_Syntax_Syntax.bind_repr = uu____9541; FStar_Syntax_Syntax.actions = uu____9542}))))))))))))))))
+in (
+
+let se = (
+
+let for_free = (
+
+let uu____9562 = (
+
+let uu____9563 = (
+
+let uu____9567 = (FStar_Syntax_Util.arrow_formals ed1.FStar_Syntax_Syntax.signature)
+in (Prims.fst uu____9567))
+in (FStar_List.length uu____9563))
+in (uu____9562 = (Prims.parse_int "1")))
+in (FStar_Parser_AST.sigelt_of_decl d (match (for_free) with
+| true -> begin
+FStar_Syntax_Syntax.Sig_new_effect_for_free (ed1)
+end
+| uu____9585 -> begin
+FStar_Syntax_Syntax.Sig_new_effect (ed1)
+end)))
+in (
+
+let monad_env = env2
+in (
+
+let env3 = (FStar_ToSyntax_Env.push_sigelt env0 se)
+in (
+
+let env4 = (FStar_All.pipe_right ed1.FStar_Syntax_Syntax.actions (FStar_List.fold_left (fun env4 a -> (
+
+let uu____9592 = (FStar_Syntax_Util.action_as_lb mname a)
+in (FStar_ToSyntax_Env.push_sigelt env4 uu____9592))) env3))
+in (
+
+let env5 = (
+
+let uu____9594 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Parser_AST.Reflectable))
+in (match (uu____9594) with
+| true -> begin
+(
+
+let reflect_lid = (FStar_All.pipe_right (FStar_Ident.id_of_text "reflect") (FStar_ToSyntax_Env.qualify monad_env))
+in (
+
+let refl_decl = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_declare_typ (((reflect_lid), ([]), (FStar_Syntax_Syntax.tun), ((FStar_Syntax_Syntax.Assumption)::(FStar_Syntax_Syntax.Reflectable (mname))::[])))))
+in (FStar_ToSyntax_Env.push_sigelt env4 refl_decl)))
+end
+| uu____9600 -> begin
+env4
+end))
+in ((env5), ((se)::[])))))))))))
+end))
+end)))))
+and desugar_decl : env_t  ->  FStar_Parser_AST.decl  ->  (env_t * FStar_Syntax_Syntax.sigelts) = (fun env d -> (
+
+let trans_qual1 = (trans_qual d.FStar_Parser_AST.drange)
+in (match (d.FStar_Parser_AST.d) with
+| FStar_Parser_AST.Pragma (p) -> begin
+(
+
+let se = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_pragma ((trans_pragma p))))
+in ((match ((p = FStar_Parser_AST.LightOff)) with
+| true -> begin
+(FStar_Options.set_ml_ish ())
+end
+| uu____9617 -> begin
+()
+end);
+((env), ((se)::[]));
+))
+end
+| FStar_Parser_AST.Fsdoc (uu____9619) -> begin
+((env), ([]))
+end
+| FStar_Parser_AST.TopLevelModule (id) -> begin
+((env), ([]))
+end
+| FStar_Parser_AST.Open (lid) -> begin
+(
+
+let env1 = (FStar_ToSyntax_Env.push_namespace env lid)
+in ((env1), ([])))
+end
+| FStar_Parser_AST.Include (lid) -> begin
+(
+
+let env1 = (FStar_ToSyntax_Env.push_include env lid)
+in ((env1), ([])))
+end
+| FStar_Parser_AST.ModuleAbbrev (x, l) -> begin
+(
+
+let uu____9631 = (FStar_ToSyntax_Env.push_module_abbrev env x l)
+in ((uu____9631), ([])))
+end
+| FStar_Parser_AST.Tycon (is_effect, tcs) -> begin
+(
+
+let quals = (match (is_effect) with
+| true -> begin
+(FStar_Parser_AST.Effect_qual)::d.FStar_Parser_AST.quals
+end
+| uu____9646 -> begin
+d.FStar_Parser_AST.quals
+end)
+in (
+
+let tcs1 = (FStar_List.map (fun uu____9652 -> (match (uu____9652) with
+| (x, uu____9657) -> begin
+x
+end)) tcs)
+in (
+
+let uu____9660 = (FStar_List.map (trans_qual1 None) quals)
+in (desugar_tycon env d uu____9660 tcs1))))
+end
+| FStar_Parser_AST.TopLevelLet (isrec, lets) -> begin
+(
+
+let quals = d.FStar_Parser_AST.quals
+in (
+
+let attrs = d.FStar_Parser_AST.attrs
+in (
+
+let attrs1 = (FStar_List.map (desugar_term env) attrs)
+in (
+
+let expand_toplevel_pattern = ((isrec = FStar_Parser_AST.NoLetQualifier) && (match (lets) with
+| ((({FStar_Parser_AST.pat = FStar_Parser_AST.PatOp (_); FStar_Parser_AST.prange = _}, _))::[]) | ((({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (_); FStar_Parser_AST.prange = _}, _))::[]) | ((({FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed ({FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (_); FStar_Parser_AST.prange = _}, _); FStar_Parser_AST.prange = _}, _))::[]) -> begin
+false
+end
+| ((p, uu____9699))::[] -> begin
+(
+
+let uu____9704 = (is_app_pattern p)
+in (not (uu____9704)))
+end
+| uu____9705 -> begin
+false
+end))
+in (match ((not (expand_toplevel_pattern))) with
+| true -> begin
+(
+
+let as_inner_let = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Let (((isrec), (lets), ((FStar_Parser_AST.mk_term (FStar_Parser_AST.Const (FStar_Const.Const_unit)) d.FStar_Parser_AST.drange FStar_Parser_AST.Expr))))) d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)
+in (
+
+let ds_lets = (desugar_term_maybe_top true env as_inner_let)
+in (
+
+let uu____9716 = (
+
+let uu____9717 = (FStar_All.pipe_left FStar_Syntax_Subst.compress ds_lets)
+in uu____9717.FStar_Syntax_Syntax.n)
+in (match (uu____9716) with
+| FStar_Syntax_Syntax.Tm_let (lbs, uu____9723) -> begin
+(
+
+let fvs = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.map (fun lb -> (FStar_Util.right lb.FStar_Syntax_Syntax.lbname))))
+in (
+
+let quals1 = (match (quals) with
+| (uu____9743)::uu____9744 -> begin
+(FStar_List.map (trans_qual1 None) quals)
+end
+| uu____9746 -> begin
+(FStar_All.pipe_right (Prims.snd lbs) (FStar_List.collect (fun uu___206_9750 -> (match (uu___206_9750) with
+| {FStar_Syntax_Syntax.lbname = FStar_Util.Inl (uu____9752); FStar_Syntax_Syntax.lbunivs = uu____9753; FStar_Syntax_Syntax.lbtyp = uu____9754; FStar_Syntax_Syntax.lbeff = uu____9755; FStar_Syntax_Syntax.lbdef = uu____9756} -> begin
+[]
+end
+| {FStar_Syntax_Syntax.lbname = FStar_Util.Inr (fv); FStar_Syntax_Syntax.lbunivs = uu____9763; FStar_Syntax_Syntax.lbtyp = uu____9764; FStar_Syntax_Syntax.lbeff = uu____9765; FStar_Syntax_Syntax.lbdef = uu____9766} -> begin
+(FStar_ToSyntax_Env.lookup_letbinding_quals env fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+end))))
+end)
+in (
+
+let quals2 = (
+
+let uu____9778 = (FStar_All.pipe_right lets (FStar_Util.for_some (fun uu____9784 -> (match (uu____9784) with
+| (uu____9787, t) -> begin
+(t.FStar_Parser_AST.level = FStar_Parser_AST.Formula)
+end))))
+in (match (uu____9778) with
+| true -> begin
+(FStar_Syntax_Syntax.Logic)::quals1
+end
+| uu____9790 -> begin
+quals1
+end))
+in (
+
+let lbs1 = (
+
+let uu____9795 = (FStar_All.pipe_right quals2 (FStar_List.contains FStar_Syntax_Syntax.Abstract))
+in (match (uu____9795) with
+| true -> begin
+(
+
+let uu____9800 = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.map (fun lb -> (
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu___220_9807 = lb
+in {FStar_Syntax_Syntax.lbname = FStar_Util.Inr ((
+
+let uu___221_9808 = fv
+in {FStar_Syntax_Syntax.fv_name = uu___221_9808.FStar_Syntax_Syntax.fv_name; FStar_Syntax_Syntax.fv_delta = FStar_Syntax_Syntax.Delta_abstract (fv.FStar_Syntax_Syntax.fv_delta); FStar_Syntax_Syntax.fv_qual = uu___221_9808.FStar_Syntax_Syntax.fv_qual})); FStar_Syntax_Syntax.lbunivs = uu___220_9807.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___220_9807.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___220_9807.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___220_9807.FStar_Syntax_Syntax.lbdef})))))
+in (((Prims.fst lbs)), (uu____9800)))
+end
+| uu____9814 -> begin
+lbs
+end))
+in (
+
+let s = (
+
+let uu____9816 = (
+
+let uu____9817 = (
+
+let uu____9825 = (FStar_All.pipe_right fvs (FStar_List.map (fun fv -> fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))
+in ((lbs1), (uu____9825), (quals2), (attrs1)))
+in FStar_Syntax_Syntax.Sig_let (uu____9817))
+in (FStar_Parser_AST.sigelt_of_decl d uu____9816))
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env s)
+in ((env1), ((s)::[]))))))))
+end
+| uu____9842 -> begin
+(failwith "Desugaring a let did not produce a let")
+end))))
+end
+| uu____9845 -> begin
+(
+
+let uu____9846 = (match (lets) with
+| ((pat, body))::[] -> begin
+((pat), (body))
+end
+| uu____9857 -> begin
+(failwith "expand_toplevel_pattern should only allow single definition lets")
+end)
+in (match (uu____9846) with
+| (pat, body) -> begin
+(
+
+let fresh_toplevel_name = (FStar_Ident.gen FStar_Range.dummyRange)
+in (
+
+let fresh_pat = (
+
+let var_pat = (FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatVar (((fresh_toplevel_name), (None)))) FStar_Range.dummyRange)
+in (match (pat.FStar_Parser_AST.pat) with
+| FStar_Parser_AST.PatAscribed (pat1, ty) -> begin
+(
+
+let uu___222_9873 = pat1
+in {FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed (((var_pat), (ty))); FStar_Parser_AST.prange = uu___222_9873.FStar_Parser_AST.prange})
+end
+| uu____9874 -> begin
+var_pat
+end))
+in (
+
+let main_let = (desugar_decl env (
+
+let uu___223_9878 = d
+in {FStar_Parser_AST.d = FStar_Parser_AST.TopLevelLet (((isrec), ((((fresh_pat), (body)))::[]))); FStar_Parser_AST.drange = uu___223_9878.FStar_Parser_AST.drange; FStar_Parser_AST.doc = uu___223_9878.FStar_Parser_AST.doc; FStar_Parser_AST.quals = (FStar_Parser_AST.Private)::d.FStar_Parser_AST.quals; FStar_Parser_AST.attrs = uu___223_9878.FStar_Parser_AST.attrs}))
+in (
+
+let build_projection = (fun uu____9897 id -> (match (uu____9897) with
+| (env1, ses) -> begin
+(
+
+let main = (
+
+let uu____9910 = (
+
+let uu____9911 = (FStar_Ident.lid_of_ids ((fresh_toplevel_name)::[]))
+in FStar_Parser_AST.Var (uu____9911))
+in (FStar_Parser_AST.mk_term uu____9910 FStar_Range.dummyRange FStar_Parser_AST.Expr))
+in (
+
+let lid = (FStar_Ident.lid_of_ids ((id)::[]))
+in (
+
+let projectee = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Var (lid)) FStar_Range.dummyRange FStar_Parser_AST.Expr)
+in (
+
+let body1 = (FStar_Parser_AST.mk_term (FStar_Parser_AST.Match (((main), ((((pat), (None), (projectee)))::[])))) FStar_Range.dummyRange FStar_Parser_AST.Expr)
+in (
+
+let bv_pat = (FStar_Parser_AST.mk_pattern (FStar_Parser_AST.PatVar (((id), (None)))) FStar_Range.dummyRange)
+in (
+
+let id_decl = (FStar_Parser_AST.mk_decl (FStar_Parser_AST.TopLevelLet (((FStar_Parser_AST.NoLetQualifier), ((((bv_pat), (body1)))::[])))) FStar_Range.dummyRange [])
+in (
+
+let uu____9939 = (desugar_decl env1 id_decl)
+in (match (uu____9939) with
+| (env2, ses') -> begin
+((env2), ((FStar_List.append ses ses')))
+end))))))))
+end))
+in (
+
+let bvs = (
+
+let uu____9950 = (gather_pattern_bound_vars pat)
+in (FStar_All.pipe_right uu____9950 FStar_Util.set_elements))
+in (FStar_List.fold_left build_projection main_let bvs))))))
+end))
+end)))))
+end
+| FStar_Parser_AST.Main (t) -> begin
+(
+
+let e = (desugar_term env t)
+in (
+
+let se = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_main (e)))
+in ((env), ((se)::[]))))
+end
+| FStar_Parser_AST.Assume (id, t) -> begin
+(
+
+let f = (desugar_formula env t)
+in (
+
+let uu____9964 = (
+
+let uu____9966 = (
+
+let uu____9967 = (
+
+let uu____9968 = (
+
+let uu____9973 = (FStar_ToSyntax_Env.qualify env id)
+in ((uu____9973), (f), ((FStar_Syntax_Syntax.Assumption)::[])))
+in FStar_Syntax_Syntax.Sig_assume (uu____9968))
+in (FStar_Parser_AST.sigelt_of_decl d uu____9967))
+in (uu____9966)::[])
+in ((env), (uu____9964))))
+end
+| FStar_Parser_AST.Val (id, t) -> begin
+(
+
+let quals = d.FStar_Parser_AST.quals
+in (
+
+let t1 = (
+
+let uu____9980 = (close_fun env t)
+in (desugar_term env uu____9980))
+in (
+
+let quals1 = (match ((env.FStar_ToSyntax_Env.iface && env.FStar_ToSyntax_Env.admitted_iface)) with
+| true -> begin
+(FStar_Parser_AST.Assumption)::quals
+end
+| uu____9984 -> begin
+quals
+end)
+in (
+
+let se = (
+
+let uu____9986 = (
+
+let uu____9987 = (
+
+let uu____9993 = (FStar_ToSyntax_Env.qualify env id)
+in (
+
+let uu____9994 = (FStar_List.map (trans_qual1 None) quals1)
+in ((uu____9993), ([]), (t1), (uu____9994))))
+in FStar_Syntax_Syntax.Sig_declare_typ (uu____9987))
+in (FStar_Parser_AST.sigelt_of_decl d uu____9986))
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env se)
+in ((env1), ((se)::[])))))))
+end
+| FStar_Parser_AST.Exception (id, None) -> begin
+(
+
+let uu____10002 = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_lid env) FStar_Syntax_Const.exn_lid)
+in (match (uu____10002) with
+| (t, uu____10010) -> begin
+(
+
+let l = (FStar_ToSyntax_Env.qualify env id)
+in (
+
+let se = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_datacon (((l), ([]), (t), (FStar_Syntax_Const.exn_lid), ((Prims.parse_int "0")), ((FStar_Syntax_Syntax.ExceptionConstructor)::[]), ((FStar_Syntax_Const.exn_lid)::[])))))
+in (
+
+let se' = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_bundle ((((se)::[]), ((FStar_Syntax_Syntax.ExceptionConstructor)::[]), ((l)::[])))))
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env se')
+in (
+
+let data_ops = (mk_data_projector_names [] env1 (([]), (se)))
+in (
+
+let discs = (mk_data_discriminators [] env1 FStar_Syntax_Const.exn_lid [] FStar_Syntax_Syntax.tun ((l)::[]))
+in (
+
+let env2 = (FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env1 (FStar_List.append discs data_ops))
+in ((env2), ((FStar_List.append ((se')::discs) data_ops))))))))))
+end))
+end
+| FStar_Parser_AST.Exception (id, Some (term)) -> begin
+(
+
+let t = (desugar_term env term)
+in (
+
+let t1 = (
+
+let uu____10037 = (
+
+let uu____10041 = (FStar_Syntax_Syntax.null_binder t)
+in (uu____10041)::[])
+in (
+
+let uu____10042 = (
+
+let uu____10045 = (
+
+let uu____10046 = (FStar_ToSyntax_Env.fail_or env (FStar_ToSyntax_Env.try_lookup_lid env) FStar_Syntax_Const.exn_lid)
+in (Prims.fst uu____10046))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu____10045))
+in (FStar_Syntax_Util.arrow uu____10037 uu____10042)))
+in (
+
+let l = (FStar_ToSyntax_Env.qualify env id)
+in (
+
+let se = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_datacon (((l), ([]), (t1), (FStar_Syntax_Const.exn_lid), ((Prims.parse_int "0")), ((FStar_Syntax_Syntax.ExceptionConstructor)::[]), ((FStar_Syntax_Const.exn_lid)::[])))))
+in (
+
+let se' = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_bundle ((((se)::[]), ((FStar_Syntax_Syntax.ExceptionConstructor)::[]), ((l)::[])))))
+in (
+
+let env1 = (FStar_ToSyntax_Env.push_sigelt env se')
+in (
+
+let data_ops = (mk_data_projector_names [] env1 (([]), (se)))
+in (
+
+let discs = (mk_data_discriminators [] env1 FStar_Syntax_Const.exn_lid [] FStar_Syntax_Syntax.tun ((l)::[]))
+in (
+
+let env2 = (FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env1 (FStar_List.append discs data_ops))
+in ((env2), ((FStar_List.append ((se')::discs) data_ops))))))))))))
+end
+| FStar_Parser_AST.NewEffect (FStar_Parser_AST.RedefineEffect (eff_name, eff_binders, defn)) -> begin
+(
+
+let quals = d.FStar_Parser_AST.quals
+in (desugar_redefine_effect env d trans_qual1 quals eff_name eff_binders defn))
+end
+| FStar_Parser_AST.NewEffect (FStar_Parser_AST.DefineEffect (eff_name, eff_binders, eff_typ, eff_decls)) -> begin
+(
+
+let quals = d.FStar_Parser_AST.quals
+in (desugar_effect env d quals eff_name eff_binders eff_typ eff_decls))
+end
+| FStar_Parser_AST.SubEffect (l) -> begin
+(
+
+let lookup = (fun l1 -> (
+
+let uu____10092 = (FStar_ToSyntax_Env.try_lookup_effect_name env l1)
+in (match (uu____10092) with
+| None -> begin
+(
+
+let uu____10094 = (
+
+let uu____10095 = (
+
+let uu____10098 = (
+
+let uu____10099 = (
+
+let uu____10100 = (FStar_Syntax_Print.lid_to_string l1)
+in (Prims.strcat uu____10100 " not found"))
+in (Prims.strcat "Effect name " uu____10099))
+in ((uu____10098), (d.FStar_Parser_AST.drange)))
+in FStar_Errors.Error (uu____10095))
+in (Prims.raise uu____10094))
+end
+| Some (l2) -> begin
+l2
+end)))
+in (
+
+let src = (lookup l.FStar_Parser_AST.msource)
+in (
+
+let dst = (lookup l.FStar_Parser_AST.mdest)
+in (
+
+let uu____10104 = (match (l.FStar_Parser_AST.lift_op) with
+| FStar_Parser_AST.NonReifiableLift (t) -> begin
+(
+
+let uu____10126 = (
+
+let uu____10131 = (
+
+let uu____10135 = (desugar_term env t)
+in (([]), (uu____10135)))
+in Some (uu____10131))
+in ((uu____10126), (None)))
+end
+| FStar_Parser_AST.ReifiableLift (wp, t) -> begin
+(
+
+let uu____10153 = (
+
+let uu____10158 = (
+
+let uu____10162 = (desugar_term env wp)
+in (([]), (uu____10162)))
+in Some (uu____10158))
+in (
+
+let uu____10167 = (
+
+let uu____10172 = (
+
+let uu____10176 = (desugar_term env t)
+in (([]), (uu____10176)))
+in Some (uu____10172))
+in ((uu____10153), (uu____10167))))
+end
+| FStar_Parser_AST.LiftForFree (t) -> begin
+(
+
+let uu____10190 = (
+
+let uu____10195 = (
+
+let uu____10199 = (desugar_term env t)
+in (([]), (uu____10199)))
+in Some (uu____10195))
+in ((None), (uu____10190)))
+end)
+in (match (uu____10104) with
+| (lift_wp, lift) -> begin
+(
+
+let se = (FStar_Parser_AST.sigelt_of_decl d (FStar_Syntax_Syntax.Sig_sub_effect ({FStar_Syntax_Syntax.source = src; FStar_Syntax_Syntax.target = dst; FStar_Syntax_Syntax.lift_wp = lift_wp; FStar_Syntax_Syntax.lift = lift})))
+in ((env), ((se)::[])))
+end)))))
+end)))
+
+
+let desugar_decls : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.decl Prims.list  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.sigelts) = (fun env decls -> (FStar_List.fold_left (fun uu____10250 d -> (match (uu____10250) with
+| (env1, sigelts) -> begin
+(
+
+let uu____10262 = (desugar_decl env1 d)
+in (match (uu____10262) with
+| (env2, se) -> begin
+((env2), ((FStar_List.append sigelts se)))
+end))
+end)) ((env), ([])) decls))
+
+
+let open_prims_all : (FStar_Parser_AST.decoration Prims.list  ->  FStar_Parser_AST.decl) Prims.list = ((FStar_Parser_AST.mk_decl (FStar_Parser_AST.Open (FStar_Syntax_Const.prims_lid)) FStar_Range.dummyRange))::((FStar_Parser_AST.mk_decl (FStar_Parser_AST.Open (FStar_Syntax_Const.all_lid)) FStar_Range.dummyRange))::[]
+
+
+let desugar_modul_common : FStar_Syntax_Syntax.modul Prims.option  ->  FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.modul  ->  (env_t * FStar_Syntax_Syntax.modul * Prims.bool) = (fun curmod env m -> (
+
+let env1 = (match (((curmod), (m))) with
+| (None, uu____10304) -> begin
+env
+end
+| (Some ({FStar_Syntax_Syntax.name = prev_lid; FStar_Syntax_Syntax.declarations = uu____10307; FStar_Syntax_Syntax.exports = uu____10308; FStar_Syntax_Syntax.is_interface = uu____10309}), FStar_Parser_AST.Module (current_lid, uu____10311)) when ((FStar_Ident.lid_equals prev_lid current_lid) && (FStar_Options.interactive ())) -> begin
+env
+end
+| (Some (prev_mod), uu____10316) -> begin
+(FStar_ToSyntax_Env.finish_module_or_interface env prev_mod)
+end)
+in (
+
+let uu____10318 = (match (m) with
+| FStar_Parser_AST.Interface (mname, decls, admitted) -> begin
+(
+
+let uu____10338 = (FStar_ToSyntax_Env.prepare_module_or_interface true admitted env1 mname)
+in ((uu____10338), (mname), (decls), (true)))
+end
+| FStar_Parser_AST.Module (mname, decls) -> begin
+(
+
+let uu____10348 = (FStar_ToSyntax_Env.prepare_module_or_interface false false env1 mname)
+in ((uu____10348), (mname), (decls), (false)))
+end)
+in (match (uu____10318) with
+| ((env2, pop_when_done), mname, decls, intf) -> begin
+(
+
+let uu____10366 = (desugar_decls env2 decls)
+in (match (uu____10366) with
+| (env3, sigelts) -> begin
+(
+
+let modul = {FStar_Syntax_Syntax.name = mname; FStar_Syntax_Syntax.declarations = sigelts; FStar_Syntax_Syntax.exports = []; FStar_Syntax_Syntax.is_interface = intf}
+in ((env3), (modul), (pop_when_done)))
+end))
+end))))
+
+
+let desugar_partial_modul : FStar_Syntax_Syntax.modul Prims.option  ->  FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.modul  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.modul) = (fun curmod env m -> (
+
+let m1 = (
+
+let uu____10391 = ((FStar_Options.interactive ()) && (
+
+let uu____10392 = (
+
+let uu____10393 = (
+
+let uu____10394 = (FStar_Options.file_list ())
+in (FStar_List.hd uu____10394))
+in (FStar_Util.get_file_extension uu____10393))
+in (uu____10392 = "fsti")))
+in (match (uu____10391) with
+| true -> begin
+(match (m) with
+| FStar_Parser_AST.Module (mname, decls) -> begin
+FStar_Parser_AST.Interface (((mname), (decls), (true)))
+end
+| FStar_Parser_AST.Interface (mname, uu____10402, uu____10403) -> begin
+(failwith (Prims.strcat "Impossible: " mname.FStar_Ident.ident.FStar_Ident.idText))
+end)
+end
+| uu____10406 -> begin
+m
+end))
+in (
+
+let uu____10407 = (desugar_modul_common curmod env m1)
+in (match (uu____10407) with
+| (x, y, pop_when_done) -> begin
+((match (pop_when_done) with
+| true -> begin
+(
+
+let uu____10417 = (FStar_ToSyntax_Env.pop ())
+in ())
+end
+| uu____10418 -> begin
+()
+end);
+((x), (y));
+)
+end))))
+
+
+let desugar_modul : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.modul  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.modul) = (fun env m -> (
+
+let uu____10429 = (desugar_modul_common None env m)
+in (match (uu____10429) with
+| (env1, modul, pop_when_done) -> begin
+(
+
+let env2 = (FStar_ToSyntax_Env.finish_module_or_interface env1 modul)
+in ((
+
+let uu____10440 = (FStar_Options.dump_module modul.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in (match (uu____10440) with
+| true -> begin
+(
+
+let uu____10441 = (FStar_Syntax_Print.modul_to_string modul)
+in (FStar_Util.print1 "%s\n" uu____10441))
+end
+| uu____10442 -> begin
+()
+end));
+(
+
+let uu____10443 = (match (pop_when_done) with
+| true -> begin
+(FStar_ToSyntax_Env.export_interface modul.FStar_Syntax_Syntax.name env2)
+end
+| uu____10444 -> begin
+env2
+end)
+in ((uu____10443), (modul)));
+))
+end)))
+
+
+let desugar_file : FStar_ToSyntax_Env.env  ->  FStar_Parser_AST.file  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.modul Prims.list) = (fun env f -> (
+
+let uu____10454 = (FStar_List.fold_left (fun uu____10461 m -> (match (uu____10461) with
+| (env1, mods) -> begin
+(
+
+let uu____10473 = (desugar_modul env1 m)
+in (match (uu____10473) with
+| (env2, m1) -> begin
+((env2), ((m1)::mods))
+end))
+end)) ((env), ([])) f)
+in (match (uu____10454) with
+| (env1, mods) -> begin
+((env1), ((FStar_List.rev mods)))
+end)))
+
+
+let add_modul_to_env : FStar_Syntax_Syntax.modul  ->  FStar_ToSyntax_Env.env  ->  FStar_ToSyntax_Env.env = (fun m en -> (
+
+let uu____10497 = (FStar_ToSyntax_Env.prepare_module_or_interface false false en m.FStar_Syntax_Syntax.name)
+in (match (uu____10497) with
+| (en1, pop_when_done) -> begin
+(
+
+let en2 = (FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt (
+
+let uu___224_10503 = en1
+in {FStar_ToSyntax_Env.curmodule = Some (m.FStar_Syntax_Syntax.name); FStar_ToSyntax_Env.curmonad = uu___224_10503.FStar_ToSyntax_Env.curmonad; FStar_ToSyntax_Env.modules = uu___224_10503.FStar_ToSyntax_Env.modules; FStar_ToSyntax_Env.scope_mods = uu___224_10503.FStar_ToSyntax_Env.scope_mods; FStar_ToSyntax_Env.exported_ids = uu___224_10503.FStar_ToSyntax_Env.exported_ids; FStar_ToSyntax_Env.trans_exported_ids = uu___224_10503.FStar_ToSyntax_Env.trans_exported_ids; FStar_ToSyntax_Env.includes = uu___224_10503.FStar_ToSyntax_Env.includes; FStar_ToSyntax_Env.sigaccum = uu___224_10503.FStar_ToSyntax_Env.sigaccum; FStar_ToSyntax_Env.sigmap = uu___224_10503.FStar_ToSyntax_Env.sigmap; FStar_ToSyntax_Env.iface = uu___224_10503.FStar_ToSyntax_Env.iface; FStar_ToSyntax_Env.admitted_iface = uu___224_10503.FStar_ToSyntax_Env.admitted_iface; FStar_ToSyntax_Env.expect_typ = uu___224_10503.FStar_ToSyntax_Env.expect_typ}) m.FStar_Syntax_Syntax.exports)
+in (
+
+let env = (FStar_ToSyntax_Env.finish_module_or_interface en2 m)
+in (match (pop_when_done) with
+| true -> begin
+(FStar_ToSyntax_Env.export_interface m.FStar_Syntax_Syntax.name env)
+end
+| uu____10505 -> begin
+env
+end)))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -1,296 +1,431 @@
+
 open Prims
 type rel =
-  | EQ
-  | SUB
-  | SUBINV
-let uu___is_EQ: rel -> Prims.bool =
-  fun projectee  -> match projectee with | EQ  -> true | uu____4 -> false
-let uu___is_SUB: rel -> Prims.bool =
-  fun projectee  -> match projectee with | SUB  -> true | uu____8 -> false
-let uu___is_SUBINV: rel -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SUBINV  -> true | uu____12 -> false
-type ('a,'b) problem =
-  {
-  pid: Prims.int;
-  lhs: 'a;
-  relation: rel;
-  rhs: 'a;
-  element: 'b Prims.option;
-  logical_guard: (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term);
-  scope: FStar_Syntax_Syntax.binders;
-  reason: Prims.string Prims.list;
-  loc: FStar_Range.range;
-  rank: Prims.int Prims.option;}
+| EQ
+| SUB
+| SUBINV
+
+
+let uu___is_EQ : rel  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EQ -> begin
+true
+end
+| uu____4 -> begin
+false
+end))
+
+
+let uu___is_SUB : rel  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SUB -> begin
+true
+end
+| uu____8 -> begin
+false
+end))
+
+
+let uu___is_SUBINV : rel  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| SUBINV -> begin
+true
+end
+| uu____12 -> begin
+false
+end))
+
+type ('a, 'b) problem =
+{pid : Prims.int; lhs : 'a; relation : rel; rhs : 'a; element : 'b Prims.option; logical_guard : (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term); scope : FStar_Syntax_Syntax.binders; reason : Prims.string Prims.list; loc : FStar_Range.range; rank : Prims.int Prims.option}
+
 type prob =
-  | TProb of (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem
-  | CProb of (FStar_Syntax_Syntax.comp,Prims.unit) problem
-let uu___is_TProb: prob -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TProb _0 -> true | uu____240 -> false
-let __proj__TProb__item___0:
-  prob -> (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem =
-  fun projectee  -> match projectee with | TProb _0 -> _0
-let uu___is_CProb: prob -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CProb _0 -> true | uu____260 -> false
-let __proj__CProb__item___0:
-  prob -> (FStar_Syntax_Syntax.comp,Prims.unit) problem =
-  fun projectee  -> match projectee with | CProb _0 -> _0
-type probs = prob Prims.list
+| TProb of (FStar_Syntax_Syntax.typ, FStar_Syntax_Syntax.term) problem
+| CProb of (FStar_Syntax_Syntax.comp, Prims.unit) problem
+
+
+let uu___is_TProb : prob  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TProb (_0) -> begin
+true
+end
+| uu____240 -> begin
+false
+end))
+
+
+let __proj__TProb__item___0 : prob  ->  (FStar_Syntax_Syntax.typ, FStar_Syntax_Syntax.term) problem = (fun projectee -> (match (projectee) with
+| TProb (_0) -> begin
+_0
+end))
+
+
+let uu___is_CProb : prob  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CProb (_0) -> begin
+true
+end
+| uu____260 -> begin
+false
+end))
+
+
+let __proj__CProb__item___0 : prob  ->  (FStar_Syntax_Syntax.comp, Prims.unit) problem = (fun projectee -> (match (projectee) with
+| CProb (_0) -> begin
+_0
+end))
+
+
+type probs =
+prob Prims.list
+
 type guard_formula =
-  | Trivial
-  | NonTrivial of FStar_Syntax_Syntax.formula
-let uu___is_Trivial: guard_formula -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Trivial  -> true | uu____281 -> false
-let uu___is_NonTrivial: guard_formula -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NonTrivial _0 -> true | uu____286 -> false
-let __proj__NonTrivial__item___0:
-  guard_formula -> FStar_Syntax_Syntax.formula =
-  fun projectee  -> match projectee with | NonTrivial _0 -> _0
-type deferred = (Prims.string* prob) Prims.list
-type univ_ineq = (FStar_Syntax_Syntax.universe* FStar_Syntax_Syntax.universe)
-let tconst:
-  FStar_Ident.lident ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun l  ->
-    let uu____304 =
-      let uu____307 =
-        let uu____308 =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-            None in
-        FStar_Syntax_Syntax.Tm_fvar uu____308 in
-      FStar_Syntax_Syntax.mk uu____307 in
-    uu____304 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-      FStar_Range.dummyRange
-let tabbrev:
-  FStar_Ident.lident ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun l  ->
-    let uu____322 =
-      let uu____325 =
-        let uu____326 =
-          FStar_Syntax_Syntax.lid_as_fv l
-            (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1"))
-            None in
-        FStar_Syntax_Syntax.Tm_fvar uu____326 in
-      FStar_Syntax_Syntax.mk uu____325 in
-    uu____322 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-      FStar_Range.dummyRange
-let t_unit:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.unit_lid
-let t_bool:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.bool_lid
-let t_int:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.int_lid
-let t_string:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.string_lid
-let t_float:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.float_lid
-let t_char:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tabbrev FStar_Syntax_Const.char_lid
-let t_range:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  = tconst FStar_Syntax_Const.range_lid
-let t_tactic_unit:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  =
-  let uu____351 =
-    let uu____352 =
-      let uu____353 = tabbrev FStar_Syntax_Const.tactic_lid in
-      FStar_Syntax_Syntax.mk_Tm_uinst uu____353 [FStar_Syntax_Syntax.U_zero] in
-    let uu____354 =
-      let uu____355 = FStar_Syntax_Syntax.as_arg t_unit in [uu____355] in
-    FStar_Syntax_Syntax.mk_Tm_app uu____352 uu____354 in
-  uu____351 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-    FStar_Range.dummyRange
-let unit_const:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax
-  =
-  (FStar_Syntax_Syntax.mk
-     (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_unit))
-    (Some (t_unit.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange
-let mk_by_tactic:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun tac  ->
-    fun f  ->
-      let t_by_tactic =
-        let uu____379 = tabbrev FStar_Syntax_Const.by_tactic_lid in
-        FStar_Syntax_Syntax.mk_Tm_uinst uu____379
-          [FStar_Syntax_Syntax.U_zero] in
-      let tac1 =
-        let uu____383 =
-          let uu____384 = tabbrev FStar_Syntax_Const.reify_tactic_lid in
-          let uu____385 =
-            let uu____386 = FStar_Syntax_Syntax.as_arg tac in [uu____386] in
-          FStar_Syntax_Syntax.mk_Tm_app uu____384 uu____385 in
-        uu____383 None FStar_Range.dummyRange in
-      let uu____391 =
-        let uu____392 =
-          let uu____393 = FStar_Syntax_Syntax.as_arg tac1 in
-          let uu____394 =
-            let uu____396 = FStar_Syntax_Syntax.as_arg f in [uu____396] in
-          uu____393 :: uu____394 in
-        FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____392 in
-      uu____391 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-        FStar_Range.dummyRange
-let rec delta_depth_greater_than:
-  FStar_Syntax_Syntax.delta_depth ->
-    FStar_Syntax_Syntax.delta_depth -> Prims.bool
-  =
-  fun l  ->
-    fun m  ->
-      match (l, m) with
-      | (FStar_Syntax_Syntax.Delta_constant ,uu____407) -> false
-      | (FStar_Syntax_Syntax.Delta_equational ,uu____408) -> true
-      | (uu____409,FStar_Syntax_Syntax.Delta_equational ) -> false
-      | (FStar_Syntax_Syntax.Delta_defined_at_level
-         i,FStar_Syntax_Syntax.Delta_defined_at_level j) -> i > j
-      | (FStar_Syntax_Syntax.Delta_defined_at_level
-         uu____412,FStar_Syntax_Syntax.Delta_constant ) -> true
-      | (FStar_Syntax_Syntax.Delta_abstract d,uu____414) ->
-          delta_depth_greater_than d m
-      | (uu____415,FStar_Syntax_Syntax.Delta_abstract d) ->
-          delta_depth_greater_than l d
-let rec decr_delta_depth:
-  FStar_Syntax_Syntax.delta_depth ->
-    FStar_Syntax_Syntax.delta_depth Prims.option
-  =
-  fun uu___93_420  ->
-    match uu___93_420 with
-    | FStar_Syntax_Syntax.Delta_constant 
-      |FStar_Syntax_Syntax.Delta_equational  -> None
-    | FStar_Syntax_Syntax.Delta_defined_at_level _0_27 when
-        _0_27 = (Prims.parse_int "1") ->
-        Some FStar_Syntax_Syntax.Delta_constant
-    | FStar_Syntax_Syntax.Delta_defined_at_level i ->
-        Some
-          (FStar_Syntax_Syntax.Delta_defined_at_level
-             (i - (Prims.parse_int "1")))
-    | FStar_Syntax_Syntax.Delta_abstract d -> decr_delta_depth d
+| Trivial
+| NonTrivial of FStar_Syntax_Syntax.formula
+
+
+let uu___is_Trivial : guard_formula  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Trivial -> begin
+true
+end
+| uu____281 -> begin
+false
+end))
+
+
+let uu___is_NonTrivial : guard_formula  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NonTrivial (_0) -> begin
+true
+end
+| uu____286 -> begin
+false
+end))
+
+
+let __proj__NonTrivial__item___0 : guard_formula  ->  FStar_Syntax_Syntax.formula = (fun projectee -> (match (projectee) with
+| NonTrivial (_0) -> begin
+_0
+end))
+
+
+type deferred =
+(Prims.string * prob) Prims.list
+
+
+type univ_ineq =
+(FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.universe)
+
+
+let tconst : FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun l -> (
+
+let uu____304 = (
+
+let uu____307 = (
+
+let uu____308 = (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None)
+in FStar_Syntax_Syntax.Tm_fvar (uu____308))
+in (FStar_Syntax_Syntax.mk uu____307))
+in (uu____304 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange)))
+
+
+let tabbrev : FStar_Ident.lident  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun l -> (
+
+let uu____322 = (
+
+let uu____325 = (
+
+let uu____326 = (FStar_Syntax_Syntax.lid_as_fv l (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in FStar_Syntax_Syntax.Tm_fvar (uu____326))
+in (FStar_Syntax_Syntax.mk uu____325))
+in (uu____322 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange)))
+
+
+let t_unit : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.unit_lid)
+
+
+let t_bool : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.bool_lid)
+
+
+let t_int : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.int_lid)
+
+
+let t_string : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.string_lid)
+
+
+let t_float : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.float_lid)
+
+
+let t_char : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tabbrev FStar_Syntax_Const.char_lid)
+
+
+let t_range : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (tconst FStar_Syntax_Const.range_lid)
+
+
+let t_tactic_unit : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (
+
+let uu____351 = (
+
+let uu____352 = (
+
+let uu____353 = (tabbrev FStar_Syntax_Const.tactic_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____353 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____354 = (
+
+let uu____355 = (FStar_Syntax_Syntax.as_arg t_unit)
+in (uu____355)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____352 uu____354)))
+in (uu____351 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange))
+
+
+let unit_const : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit))) (Some (t_unit.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange)
+
+
+let mk_by_tactic : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun tac f -> (
+
+let t_by_tactic = (
+
+let uu____379 = (tabbrev FStar_Syntax_Const.by_tactic_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____379 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let tac1 = (
+
+let uu____383 = (
+
+let uu____384 = (tabbrev FStar_Syntax_Const.reify_tactic_lid)
+in (
+
+let uu____385 = (
+
+let uu____386 = (FStar_Syntax_Syntax.as_arg tac)
+in (uu____386)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____384 uu____385)))
+in (uu____383 None FStar_Range.dummyRange))
+in (
+
+let uu____391 = (
+
+let uu____392 = (
+
+let uu____393 = (FStar_Syntax_Syntax.as_arg tac1)
+in (
+
+let uu____394 = (
+
+let uu____396 = (FStar_Syntax_Syntax.as_arg f)
+in (uu____396)::[])
+in (uu____393)::uu____394))
+in (FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____392))
+in (uu____391 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) FStar_Range.dummyRange)))))
+
+
+let rec delta_depth_greater_than : FStar_Syntax_Syntax.delta_depth  ->  FStar_Syntax_Syntax.delta_depth  ->  Prims.bool = (fun l m -> (match (((l), (m))) with
+| (FStar_Syntax_Syntax.Delta_constant, uu____407) -> begin
+false
+end
+| (FStar_Syntax_Syntax.Delta_equational, uu____408) -> begin
+true
+end
+| (uu____409, FStar_Syntax_Syntax.Delta_equational) -> begin
+false
+end
+| (FStar_Syntax_Syntax.Delta_defined_at_level (i), FStar_Syntax_Syntax.Delta_defined_at_level (j)) -> begin
+(i > j)
+end
+| (FStar_Syntax_Syntax.Delta_defined_at_level (uu____412), FStar_Syntax_Syntax.Delta_constant) -> begin
+true
+end
+| (FStar_Syntax_Syntax.Delta_abstract (d), uu____414) -> begin
+(delta_depth_greater_than d m)
+end
+| (uu____415, FStar_Syntax_Syntax.Delta_abstract (d)) -> begin
+(delta_depth_greater_than l d)
+end))
+
+
+let rec decr_delta_depth : FStar_Syntax_Syntax.delta_depth  ->  FStar_Syntax_Syntax.delta_depth Prims.option = (fun uu___93_420 -> (match (uu___93_420) with
+| (FStar_Syntax_Syntax.Delta_constant) | (FStar_Syntax_Syntax.Delta_equational) -> begin
+None
+end
+| FStar_Syntax_Syntax.Delta_defined_at_level (_0_27) when (_0_27 = (Prims.parse_int "1")) -> begin
+Some (FStar_Syntax_Syntax.Delta_constant)
+end
+| FStar_Syntax_Syntax.Delta_defined_at_level (i) -> begin
+Some (FStar_Syntax_Syntax.Delta_defined_at_level ((i - (Prims.parse_int "1"))))
+end
+| FStar_Syntax_Syntax.Delta_abstract (d) -> begin
+(decr_delta_depth d)
+end))
+
 type identifier_info =
-  {
-  identifier:
-    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either;
-  identifier_ty: FStar_Syntax_Syntax.typ;}
-let rec insert_col_info col info col_infos =
-  match col_infos with
-  | [] -> [(col, info)]
-  | (c,i)::rest ->
-      if col < c
-      then (col, info) :: col_infos
-      else
-        (let uu____490 = insert_col_info col info rest in (c, i) :: uu____490)
-let find_nearest_preceding_col_info col col_infos =
-  let rec aux out uu___94_526 =
-    match uu___94_526 with
-    | [] -> out
-    | (c,i)::rest -> if c > col then out else aux (Some i) rest in
-  aux None col_infos
-type col_info = (Prims.int* identifier_info) Prims.list
-type row_info = col_info FStar_ST.ref FStar_Util.imap
-type file_info = row_info FStar_Util.smap
-let mk_info:
-  (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-    FStar_Syntax_Syntax.typ -> identifier_info
-  = fun id  -> fun ty  -> { identifier = id; identifier_ty = ty }
-let file_info_table: row_info FStar_Util.smap =
-  FStar_Util.smap_create (Prims.parse_int "50")
-let insert_identifier_info:
-  (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-    FStar_Syntax_Syntax.typ -> FStar_Range.range -> Prims.unit
-  =
-  fun id  ->
-    fun ty  ->
-      fun range  ->
-        let info = mk_info id ty in
-        let use_range =
-          let uu___95_576 = range in
-          {
-            FStar_Range.def_range = (range.FStar_Range.use_range);
-            FStar_Range.use_range = (uu___95_576.FStar_Range.use_range)
-          } in
-        let fn = FStar_Range.file_of_range use_range in
-        let start = FStar_Range.start_of_range use_range in
-        let uu____579 =
-          let uu____582 = FStar_Range.line_of_pos start in
-          let uu____583 = FStar_Range.col_of_pos start in
-          (uu____582, uu____583) in
-        match uu____579 with
-        | (row,col) ->
-            let uu____586 = FStar_Util.smap_try_find file_info_table fn in
-            (match uu____586 with
-             | None  ->
-                 let col_info =
-                   let uu____593 = insert_col_info col info [] in
-                   FStar_Util.mk_ref uu____593 in
-                 let rows = FStar_Util.imap_create (Prims.parse_int "1000") in
-                 (FStar_Util.imap_add rows row col_info;
-                  FStar_Util.smap_add file_info_table fn rows)
-             | Some file_rows ->
-                 let uu____621 = FStar_Util.imap_try_find file_rows row in
-                 (match uu____621 with
-                  | None  ->
-                      let col_info =
-                        let uu____631 = insert_col_info col info [] in
-                        FStar_Util.mk_ref uu____631 in
-                      FStar_Util.imap_add file_rows row col_info
-                  | Some col_infos ->
-                      let uu____647 =
-                        let uu____648 = FStar_ST.read col_infos in
-                        insert_col_info col info uu____648 in
-                      FStar_ST.write col_infos uu____647))
-let info_at_pos:
-  Prims.string -> Prims.int -> Prims.int -> identifier_info Prims.option =
-  fun fn  ->
-    fun row  ->
-      fun col  ->
-        let uu____667 = FStar_Util.smap_try_find file_info_table fn in
-        match uu____667 with
-        | None  -> None
-        | Some rows ->
-            let uu____671 = FStar_Util.imap_try_find rows row in
-            (match uu____671 with
-             | None  -> None
-             | Some cols ->
-                 let uu____680 =
-                   let uu____682 = FStar_ST.read cols in
-                   find_nearest_preceding_col_info col uu____682 in
-                 (match uu____680 with | None  -> None | Some ci -> Some ci))
-let insert_bv:
-  FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> Prims.unit =
-  fun bv  ->
-    fun ty  ->
-      let uu____696 = FStar_Syntax_Syntax.range_of_bv bv in
-      insert_identifier_info (FStar_Util.Inl bv) ty uu____696
-let insert_fv:
-  FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> Prims.unit =
-  fun fv  ->
-    fun ty  ->
-      let uu____703 = FStar_Syntax_Syntax.range_of_fv fv in
-      insert_identifier_info (FStar_Util.Inr fv) ty uu____703
+{identifier : (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either; identifier_ty : FStar_Syntax_Syntax.typ}
+
+
+let rec insert_col_info = (fun col info col_infos -> (match (col_infos) with
+| [] -> begin
+(((col), (info)))::[]
+end
+| ((c, i))::rest -> begin
+(match ((col < c)) with
+| true -> begin
+(((col), (info)))::col_infos
+end
+| uu____489 -> begin
+(
+
+let uu____490 = (insert_col_info col info rest)
+in (((c), (i)))::uu____490)
+end)
+end))
+
+
+let find_nearest_preceding_col_info = (fun col col_infos -> (
+
+let rec aux = (fun out uu___94_526 -> (match (uu___94_526) with
+| [] -> begin
+out
+end
+| ((c, i))::rest -> begin
+(match ((c > col)) with
+| true -> begin
+out
+end
+| uu____543 -> begin
+(aux (Some (i)) rest)
+end)
+end))
+in (aux None col_infos)))
+
+
+type col_info =
+(Prims.int * identifier_info) Prims.list
+
+
+type row_info =
+col_info FStar_ST.ref FStar_Util.imap
+
+
+type file_info =
+row_info FStar_Util.smap
+
+
+let mk_info : (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either  ->  FStar_Syntax_Syntax.typ  ->  identifier_info = (fun id ty -> {identifier = id; identifier_ty = ty})
+
+
+let file_info_table : row_info FStar_Util.smap = (FStar_Util.smap_create (Prims.parse_int "50"))
+
+
+let insert_identifier_info : (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either  ->  FStar_Syntax_Syntax.typ  ->  FStar_Range.range  ->  Prims.unit = (fun id ty range -> (
+
+let info = (mk_info id ty)
+in (
+
+let use_range = (
+
+let uu___95_576 = range
+in {FStar_Range.def_range = range.FStar_Range.use_range; FStar_Range.use_range = uu___95_576.FStar_Range.use_range})
+in (
+
+let fn = (FStar_Range.file_of_range use_range)
+in (
+
+let start = (FStar_Range.start_of_range use_range)
+in (
+
+let uu____579 = (
+
+let uu____582 = (FStar_Range.line_of_pos start)
+in (
+
+let uu____583 = (FStar_Range.col_of_pos start)
+in ((uu____582), (uu____583))))
+in (match (uu____579) with
+| (row, col) -> begin
+(
+
+let uu____586 = (FStar_Util.smap_try_find file_info_table fn)
+in (match (uu____586) with
+| None -> begin
+(
+
+let col_info = (
+
+let uu____593 = (insert_col_info col info [])
+in (FStar_Util.mk_ref uu____593))
+in (
+
+let rows = (FStar_Util.imap_create (Prims.parse_int "1000"))
+in ((FStar_Util.imap_add rows row col_info);
+(FStar_Util.smap_add file_info_table fn rows);
+)))
+end
+| Some (file_rows) -> begin
+(
+
+let uu____621 = (FStar_Util.imap_try_find file_rows row)
+in (match (uu____621) with
+| None -> begin
+(
+
+let col_info = (
+
+let uu____631 = (insert_col_info col info [])
+in (FStar_Util.mk_ref uu____631))
+in (FStar_Util.imap_add file_rows row col_info))
+end
+| Some (col_infos) -> begin
+(
+
+let uu____647 = (
+
+let uu____648 = (FStar_ST.read col_infos)
+in (insert_col_info col info uu____648))
+in (FStar_ST.write col_infos uu____647))
+end))
+end))
+end)))))))
+
+
+let info_at_pos : Prims.string  ->  Prims.int  ->  Prims.int  ->  identifier_info Prims.option = (fun fn row col -> (
+
+let uu____667 = (FStar_Util.smap_try_find file_info_table fn)
+in (match (uu____667) with
+| None -> begin
+None
+end
+| Some (rows) -> begin
+(
+
+let uu____671 = (FStar_Util.imap_try_find rows row)
+in (match (uu____671) with
+| None -> begin
+None
+end
+| Some (cols) -> begin
+(
+
+let uu____680 = (
+
+let uu____682 = (FStar_ST.read cols)
+in (find_nearest_preceding_col_info col uu____682))
+in (match (uu____680) with
+| None -> begin
+None
+end
+| Some (ci) -> begin
+Some (ci)
+end))
+end))
+end)))
+
+
+let insert_bv : FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit = (fun bv ty -> (
+
+let uu____696 = (FStar_Syntax_Syntax.range_of_bv bv)
+in (insert_identifier_info (FStar_Util.Inl (bv)) ty uu____696)))
+
+
+let insert_fv : FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit = (fun fv ty -> (
+
+let uu____703 = (FStar_Syntax_Syntax.range_of_fv fv)
+in (insert_identifier_info (FStar_Util.Inr (fv)) ty uu____703)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_DMFF.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DMFF.ml
@@ -1,3035 +1,4052 @@
+
 open Prims
 type env =
-  {
-  env: FStar_TypeChecker_Env.env;
-  subst: FStar_Syntax_Syntax.subst_elt Prims.list;
-  tc_const: FStar_Const.sconst -> FStar_Syntax_Syntax.typ;}
-let empty:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Const.sconst -> FStar_Syntax_Syntax.typ) -> env
-  = fun env  -> fun tc_const  -> { env; subst = []; tc_const }
-let gen_wps_for_free:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.bv ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.eff_decl ->
-            (FStar_Syntax_Syntax.sigelts* FStar_Syntax_Syntax.eff_decl)
-  =
-  fun env  ->
-    fun binders  ->
-      fun a  ->
-        fun wp_a  ->
-          fun ed  ->
-            let wp_a1 =
-              FStar_TypeChecker_Normalize.normalize
-                [FStar_TypeChecker_Normalize.Beta;
-                FStar_TypeChecker_Normalize.EraseUniverses] env wp_a in
-            let a1 =
-              let uu___97_64 = a in
-              let uu____65 =
-                FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Normalize.EraseUniverses] env
-                  a.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname =
-                  (uu___97_64.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___97_64.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____65
-              } in
-            let d s = FStar_Util.print1 "\\x1b[01;36m%s\\x1b[00m\n" s in
-            (let uu____73 =
-               FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-             if uu____73
-             then
-               (d "Elaborating extra WP combinators";
-                (let uu____75 = FStar_Syntax_Print.term_to_string wp_a1 in
-                 FStar_Util.print1 "wp_a is: %s\n" uu____75))
-             else ());
-            (let rec collect_binders t =
-               let uu____84 =
-                 let uu____85 =
-                   let uu____88 = FStar_Syntax_Subst.compress t in
-                   FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____88 in
-                 uu____85.FStar_Syntax_Syntax.n in
-               match uu____84 with
-               | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
-                   let rest =
-                     match comp.FStar_Syntax_Syntax.n with
-                     | FStar_Syntax_Syntax.Total (t1,uu____110) -> t1
-                     | uu____117 -> failwith "wp_a contains non-Tot arrow" in
-                   let uu____120 = collect_binders rest in
-                   FStar_List.append bs uu____120
-               | FStar_Syntax_Syntax.Tm_type uu____126 -> []
-               | uu____129 -> failwith "wp_a doesn't end in Type0" in
-             let mk_lid name =
-               FStar_Ident.lid_of_path
-                 (FStar_Ident.path_of_text
-                    (Prims.strcat
-                       (FStar_Ident.text_of_lid ed.FStar_Syntax_Syntax.mname)
-                       (Prims.strcat "_" name))) FStar_Range.dummyRange in
-             let gamma =
-               let uu____141 = collect_binders wp_a1 in
-               FStar_All.pipe_right uu____141 FStar_Syntax_Util.name_binders in
-             (let uu____152 =
-                FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-              if uu____152
-              then
-                let uu____153 =
-                  let uu____154 =
-                    FStar_Syntax_Print.binders_to_string ", " gamma in
-                  FStar_Util.format1 "Gamma is %s\n" uu____154 in
-                d uu____153
-              else ());
-             (let unknown = FStar_Syntax_Syntax.tun in
-              let mk1 x =
-                (FStar_Syntax_Syntax.mk x) None FStar_Range.dummyRange in
-              let sigelts = FStar_Util.mk_ref [] in
-              let register env1 lident def =
-                let uu____186 =
-                  FStar_TypeChecker_Util.mk_toplevel_definition env1 lident
-                    def in
-                match uu____186 with
-                | (sigelt,fv) ->
-                    ((let uu____192 =
-                        let uu____194 = FStar_ST.read sigelts in sigelt ::
-                          uu____194 in
-                      FStar_ST.write sigelts uu____192);
-                     fv) in
-              let binders_of_list1 =
-                FStar_List.map
-                  (fun uu____215  ->
-                     match uu____215 with
-                     | (t,b) ->
-                         let uu____222 = FStar_Syntax_Syntax.as_implicit b in
-                         (t, uu____222)) in
-              let mk_all_implicit =
-                FStar_List.map
-                  (fun t  ->
-                     let uu____239 = FStar_Syntax_Syntax.as_implicit true in
-                     ((Prims.fst t), uu____239)) in
-              let args_of_binders1 =
-                FStar_List.map
-                  (fun bv  ->
-                     let uu____252 =
-                       FStar_Syntax_Syntax.bv_to_name (Prims.fst bv) in
-                     FStar_Syntax_Syntax.as_arg uu____252) in
-              let uu____253 =
-                let uu____265 =
-                  let mk2 f =
-                    let t =
-                      FStar_Syntax_Syntax.gen_bv "t" None
-                        FStar_Syntax_Util.ktype in
-                    let body =
-                      let uu____285 = f (FStar_Syntax_Syntax.bv_to_name t) in
-                      FStar_Syntax_Util.arrow gamma uu____285 in
-                    let uu____288 =
-                      let uu____292 =
-                        let uu____296 = FStar_Syntax_Syntax.mk_binder a1 in
-                        let uu____297 =
-                          let uu____299 = FStar_Syntax_Syntax.mk_binder t in
-                          [uu____299] in
-                        uu____296 :: uu____297 in
-                      FStar_List.append binders uu____292 in
-                    FStar_Syntax_Util.abs uu____288 body None in
-                  let uu____307 = mk2 FStar_Syntax_Syntax.mk_Total in
-                  let uu____308 = mk2 FStar_Syntax_Syntax.mk_GTotal in
-                  (uu____307, uu____308) in
-                match uu____265 with
-                | (ctx_def,gctx_def) ->
-                    let ctx_lid = mk_lid "ctx" in
-                    let ctx_fv = register env ctx_lid ctx_def in
-                    let gctx_lid = mk_lid "gctx" in
-                    let gctx_fv = register env gctx_lid gctx_def in
-                    let mk_app1 fv t =
-                      let uu____339 =
-                        let uu____340 =
-                          let uu____350 =
-                            let uu____354 =
-                              FStar_List.map
-                                (fun uu____362  ->
-                                   match uu____362 with
-                                   | (bv,uu____368) ->
-                                       let uu____369 =
-                                         FStar_Syntax_Syntax.bv_to_name bv in
-                                       let uu____370 =
-                                         FStar_Syntax_Syntax.as_implicit
-                                           false in
-                                       (uu____369, uu____370)) binders in
-                            let uu____371 =
-                              let uu____375 =
-                                let uu____378 =
-                                  FStar_Syntax_Syntax.bv_to_name a1 in
-                                let uu____379 =
-                                  FStar_Syntax_Syntax.as_implicit false in
-                                (uu____378, uu____379) in
-                              let uu____380 =
-                                let uu____384 =
-                                  let uu____387 =
-                                    FStar_Syntax_Syntax.as_implicit false in
-                                  (t, uu____387) in
-                                [uu____384] in
-                              uu____375 :: uu____380 in
-                            FStar_List.append uu____354 uu____371 in
-                          (fv, uu____350) in
-                        FStar_Syntax_Syntax.Tm_app uu____340 in
-                      mk1 uu____339 in
-                    (env, (mk_app1 ctx_fv), (mk_app1 gctx_fv)) in
-              match uu____253 with
-              | (env1,mk_ctx,mk_gctx) ->
-                  let c_pure =
-                    let t =
-                      FStar_Syntax_Syntax.gen_bv "t" None
-                        FStar_Syntax_Util.ktype in
-                    let x =
-                      let uu____433 = FStar_Syntax_Syntax.bv_to_name t in
-                      FStar_Syntax_Syntax.gen_bv "x" None uu____433 in
-                    let ret1 =
-                      let uu____441 =
-                        let uu____447 =
-                          let uu____448 =
-                            let uu____451 =
-                              let uu____452 =
-                                FStar_Syntax_Syntax.bv_to_name t in
-                              mk_ctx uu____452 in
-                            FStar_Syntax_Syntax.mk_Total uu____451 in
-                          FStar_Syntax_Util.lcomp_of_comp uu____448 in
-                        FStar_Util.Inl uu____447 in
-                      Some uu____441 in
-                    let body =
-                      let uu____462 = FStar_Syntax_Syntax.bv_to_name x in
-                      FStar_Syntax_Util.abs gamma uu____462 ret1 in
-                    let uu____463 =
-                      let uu____467 = mk_all_implicit binders in
-                      let uu____471 =
-                        binders_of_list1 [(a1, true); (t, true); (x, false)] in
-                      FStar_List.append uu____467 uu____471 in
-                    FStar_Syntax_Util.abs uu____463 body ret1 in
-                  let c_pure1 =
-                    let uu____486 = mk_lid "pure" in
-                    register env1 uu____486 c_pure in
-                  let c_app =
-                    let t1 =
-                      FStar_Syntax_Syntax.gen_bv "t1" None
-                        FStar_Syntax_Util.ktype in
-                    let t2 =
-                      FStar_Syntax_Syntax.gen_bv "t2" None
-                        FStar_Syntax_Util.ktype in
-                    let l =
-                      let uu____491 =
-                        let uu____492 =
-                          let uu____493 =
-                            let uu____497 =
-                              let uu____498 =
-                                let uu____499 =
-                                  FStar_Syntax_Syntax.bv_to_name t1 in
-                                FStar_Syntax_Syntax.new_bv None uu____499 in
-                              FStar_Syntax_Syntax.mk_binder uu____498 in
-                            [uu____497] in
-                          let uu____500 =
-                            let uu____503 = FStar_Syntax_Syntax.bv_to_name t2 in
-                            FStar_Syntax_Syntax.mk_GTotal uu____503 in
-                          FStar_Syntax_Util.arrow uu____493 uu____500 in
-                        mk_gctx uu____492 in
-                      FStar_Syntax_Syntax.gen_bv "l" None uu____491 in
-                    let r =
-                      let uu____505 =
-                        let uu____506 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____506 in
-                      FStar_Syntax_Syntax.gen_bv "r" None uu____505 in
-                    let ret1 =
-                      let uu____514 =
-                        let uu____520 =
-                          let uu____521 =
-                            let uu____524 =
-                              let uu____525 =
-                                FStar_Syntax_Syntax.bv_to_name t2 in
-                              mk_gctx uu____525 in
-                            FStar_Syntax_Syntax.mk_Total uu____524 in
-                          FStar_Syntax_Util.lcomp_of_comp uu____521 in
-                        FStar_Util.Inl uu____520 in
-                      Some uu____514 in
-                    let outer_body =
-                      let gamma_as_args = args_of_binders1 gamma in
-                      let inner_body =
-                        let uu____540 = FStar_Syntax_Syntax.bv_to_name l in
-                        let uu____543 =
-                          let uu____549 =
-                            let uu____551 =
-                              let uu____552 =
-                                let uu____553 =
-                                  FStar_Syntax_Syntax.bv_to_name r in
-                                FStar_Syntax_Util.mk_app uu____553
-                                  gamma_as_args in
-                              FStar_Syntax_Syntax.as_arg uu____552 in
-                            [uu____551] in
-                          FStar_List.append gamma_as_args uu____549 in
-                        FStar_Syntax_Util.mk_app uu____540 uu____543 in
-                      FStar_Syntax_Util.abs gamma inner_body ret1 in
-                    let uu____556 =
-                      let uu____560 = mk_all_implicit binders in
-                      let uu____564 =
-                        binders_of_list1
-                          [(a1, true);
-                          (t1, true);
-                          (t2, true);
-                          (l, false);
-                          (r, false)] in
-                      FStar_List.append uu____560 uu____564 in
-                    FStar_Syntax_Util.abs uu____556 outer_body ret1 in
-                  let c_app1 =
-                    let uu____583 = mk_lid "app" in
-                    register env1 uu____583 c_app in
-                  let c_lift1 =
-                    let t1 =
-                      FStar_Syntax_Syntax.gen_bv "t1" None
-                        FStar_Syntax_Util.ktype in
-                    let t2 =
-                      FStar_Syntax_Syntax.gen_bv "t2" None
-                        FStar_Syntax_Util.ktype in
-                    let t_f =
-                      let uu____590 =
-                        let uu____594 =
-                          let uu____595 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____595 in
-                        [uu____594] in
-                      let uu____596 =
-                        let uu____599 = FStar_Syntax_Syntax.bv_to_name t2 in
-                        FStar_Syntax_Syntax.mk_GTotal uu____599 in
-                      FStar_Syntax_Util.arrow uu____590 uu____596 in
-                    let f = FStar_Syntax_Syntax.gen_bv "f" None t_f in
-                    let a11 =
-                      let uu____602 =
-                        let uu____603 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____603 in
-                      FStar_Syntax_Syntax.gen_bv "a1" None uu____602 in
-                    let ret1 =
-                      let uu____611 =
-                        let uu____617 =
-                          let uu____618 =
-                            let uu____621 =
-                              let uu____622 =
-                                FStar_Syntax_Syntax.bv_to_name t2 in
-                              mk_gctx uu____622 in
-                            FStar_Syntax_Syntax.mk_Total uu____621 in
-                          FStar_Syntax_Util.lcomp_of_comp uu____618 in
-                        FStar_Util.Inl uu____617 in
-                      Some uu____611 in
-                    let uu____631 =
-                      let uu____635 = mk_all_implicit binders in
-                      let uu____639 =
-                        binders_of_list1
-                          [(a1, true);
-                          (t1, true);
-                          (t2, true);
-                          (f, false);
-                          (a11, false)] in
-                      FStar_List.append uu____635 uu____639 in
-                    let uu____657 =
-                      let uu____658 =
-                        let uu____664 =
-                          let uu____666 =
-                            let uu____669 =
-                              let uu____675 =
-                                let uu____677 =
-                                  FStar_Syntax_Syntax.bv_to_name f in
-                                [uu____677] in
-                              FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____675 in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____669 in
-                          let uu____678 =
-                            let uu____682 =
-                              FStar_Syntax_Syntax.bv_to_name a11 in
-                            [uu____682] in
-                          uu____666 :: uu____678 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____664 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____658 in
-                    FStar_Syntax_Util.abs uu____631 uu____657 ret1 in
-                  let c_lift11 =
-                    let uu____686 = mk_lid "lift1" in
-                    register env1 uu____686 c_lift1 in
-                  let c_lift2 =
-                    let t1 =
-                      FStar_Syntax_Syntax.gen_bv "t1" None
-                        FStar_Syntax_Util.ktype in
-                    let t2 =
-                      FStar_Syntax_Syntax.gen_bv "t2" None
-                        FStar_Syntax_Util.ktype in
-                    let t3 =
-                      FStar_Syntax_Syntax.gen_bv "t3" None
-                        FStar_Syntax_Util.ktype in
-                    let t_f =
-                      let uu____694 =
-                        let uu____698 =
-                          let uu____699 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____699 in
-                        let uu____700 =
-                          let uu____702 =
-                            let uu____703 = FStar_Syntax_Syntax.bv_to_name t2 in
-                            FStar_Syntax_Syntax.null_binder uu____703 in
-                          [uu____702] in
-                        uu____698 :: uu____700 in
-                      let uu____704 =
-                        let uu____707 = FStar_Syntax_Syntax.bv_to_name t3 in
-                        FStar_Syntax_Syntax.mk_GTotal uu____707 in
-                      FStar_Syntax_Util.arrow uu____694 uu____704 in
-                    let f = FStar_Syntax_Syntax.gen_bv "f" None t_f in
-                    let a11 =
-                      let uu____710 =
-                        let uu____711 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____711 in
-                      FStar_Syntax_Syntax.gen_bv "a1" None uu____710 in
-                    let a2 =
-                      let uu____713 =
-                        let uu____714 = FStar_Syntax_Syntax.bv_to_name t2 in
-                        mk_gctx uu____714 in
-                      FStar_Syntax_Syntax.gen_bv "a2" None uu____713 in
-                    let ret1 =
-                      let uu____722 =
-                        let uu____728 =
-                          let uu____729 =
-                            let uu____732 =
-                              let uu____733 =
-                                FStar_Syntax_Syntax.bv_to_name t3 in
-                              mk_gctx uu____733 in
-                            FStar_Syntax_Syntax.mk_Total uu____732 in
-                          FStar_Syntax_Util.lcomp_of_comp uu____729 in
-                        FStar_Util.Inl uu____728 in
-                      Some uu____722 in
-                    let uu____742 =
-                      let uu____746 = mk_all_implicit binders in
-                      let uu____750 =
-                        binders_of_list1
-                          [(a1, true);
-                          (t1, true);
-                          (t2, true);
-                          (t3, true);
-                          (f, false);
-                          (a11, false);
-                          (a2, false)] in
-                      FStar_List.append uu____746 uu____750 in
-                    let uu____772 =
-                      let uu____773 =
-                        let uu____779 =
-                          let uu____781 =
-                            let uu____784 =
-                              let uu____790 =
-                                let uu____792 =
-                                  let uu____795 =
-                                    let uu____801 =
-                                      let uu____803 =
-                                        FStar_Syntax_Syntax.bv_to_name f in
-                                      [uu____803] in
-                                    FStar_List.map FStar_Syntax_Syntax.as_arg
-                                      uu____801 in
-                                  FStar_Syntax_Util.mk_app c_pure1 uu____795 in
-                                let uu____804 =
-                                  let uu____808 =
-                                    FStar_Syntax_Syntax.bv_to_name a11 in
-                                  [uu____808] in
-                                uu____792 :: uu____804 in
-                              FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____790 in
-                            FStar_Syntax_Util.mk_app c_app1 uu____784 in
-                          let uu____811 =
-                            let uu____815 = FStar_Syntax_Syntax.bv_to_name a2 in
-                            [uu____815] in
-                          uu____781 :: uu____811 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____779 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____773 in
-                    FStar_Syntax_Util.abs uu____742 uu____772 ret1 in
-                  let c_lift21 =
-                    let uu____819 = mk_lid "lift2" in
-                    register env1 uu____819 c_lift2 in
-                  let c_push =
-                    let t1 =
-                      FStar_Syntax_Syntax.gen_bv "t1" None
-                        FStar_Syntax_Util.ktype in
-                    let t2 =
-                      FStar_Syntax_Syntax.gen_bv "t2" None
-                        FStar_Syntax_Util.ktype in
-                    let t_f =
-                      let uu____826 =
-                        let uu____830 =
-                          let uu____831 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____831 in
-                        [uu____830] in
-                      let uu____832 =
-                        let uu____835 =
-                          let uu____836 = FStar_Syntax_Syntax.bv_to_name t2 in
-                          mk_gctx uu____836 in
-                        FStar_Syntax_Syntax.mk_Total uu____835 in
-                      FStar_Syntax_Util.arrow uu____826 uu____832 in
-                    let f = FStar_Syntax_Syntax.gen_bv "f" None t_f in
-                    let ret1 =
-                      let uu____845 =
-                        let uu____851 =
-                          let uu____852 =
-                            let uu____855 =
-                              let uu____856 =
-                                let uu____857 =
-                                  let uu____861 =
-                                    let uu____862 =
-                                      FStar_Syntax_Syntax.bv_to_name t1 in
-                                    FStar_Syntax_Syntax.null_binder uu____862 in
-                                  [uu____861] in
-                                let uu____863 =
-                                  let uu____866 =
-                                    FStar_Syntax_Syntax.bv_to_name t2 in
-                                  FStar_Syntax_Syntax.mk_GTotal uu____866 in
-                                FStar_Syntax_Util.arrow uu____857 uu____863 in
-                              mk_ctx uu____856 in
-                            FStar_Syntax_Syntax.mk_Total uu____855 in
-                          FStar_Syntax_Util.lcomp_of_comp uu____852 in
-                        FStar_Util.Inl uu____851 in
-                      Some uu____845 in
-                    let e1 =
-                      let uu____876 = FStar_Syntax_Syntax.bv_to_name t1 in
-                      FStar_Syntax_Syntax.gen_bv "e1" None uu____876 in
-                    let body =
-                      let uu____878 =
-                        let uu____882 =
-                          let uu____886 = FStar_Syntax_Syntax.mk_binder e1 in
-                          [uu____886] in
-                        FStar_List.append gamma uu____882 in
-                      let uu____889 =
-                        let uu____890 = FStar_Syntax_Syntax.bv_to_name f in
-                        let uu____893 =
-                          let uu____899 =
-                            let uu____900 = FStar_Syntax_Syntax.bv_to_name e1 in
-                            FStar_Syntax_Syntax.as_arg uu____900 in
-                          let uu____901 = args_of_binders1 gamma in uu____899
-                            :: uu____901 in
-                        FStar_Syntax_Util.mk_app uu____890 uu____893 in
-                      FStar_Syntax_Util.abs uu____878 uu____889 ret1 in
-                    let uu____903 =
-                      let uu____907 = mk_all_implicit binders in
-                      let uu____911 =
-                        binders_of_list1
-                          [(a1, true); (t1, true); (t2, true); (f, false)] in
-                      FStar_List.append uu____907 uu____911 in
-                    FStar_Syntax_Util.abs uu____903 body ret1 in
-                  let c_push1 =
-                    let uu____928 = mk_lid "push" in
-                    register env1 uu____928 c_push in
-                  let ret_tot_wp_a =
-                    let uu____936 =
-                      let uu____942 =
-                        let uu____943 = FStar_Syntax_Syntax.mk_Total wp_a1 in
-                        FStar_Syntax_Util.lcomp_of_comp uu____943 in
-                      FStar_Util.Inl uu____942 in
-                    Some uu____936 in
-                  let mk_generic_app c =
-                    if (FStar_List.length binders) > (Prims.parse_int "0")
-                    then
-                      let uu____971 =
-                        let uu____972 =
-                          let uu____982 = args_of_binders1 binders in
-                          (c, uu____982) in
-                        FStar_Syntax_Syntax.Tm_app uu____972 in
-                      mk1 uu____971
-                    else c in
-                  let wp_if_then_else =
-                    let result_comp =
-                      let uu____990 =
-                        let uu____991 =
-                          let uu____995 =
-                            FStar_Syntax_Syntax.null_binder wp_a1 in
-                          let uu____996 =
-                            let uu____998 =
-                              FStar_Syntax_Syntax.null_binder wp_a1 in
-                            [uu____998] in
-                          uu____995 :: uu____996 in
-                        let uu____999 = FStar_Syntax_Syntax.mk_Total wp_a1 in
-                        FStar_Syntax_Util.arrow uu____991 uu____999 in
-                      FStar_Syntax_Syntax.mk_Total uu____990 in
-                    let c =
-                      FStar_Syntax_Syntax.gen_bv "c" None
-                        FStar_Syntax_Util.ktype in
-                    let uu____1003 =
-                      let uu____1007 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; c] in
-                      FStar_List.append binders uu____1007 in
-                    let uu____1013 =
-                      let l_ite =
-                        FStar_Syntax_Syntax.fvar FStar_Syntax_Const.ite_lid
-                          (FStar_Syntax_Syntax.Delta_defined_at_level
-                             (Prims.parse_int "2")) None in
-                      let uu____1015 =
-                        let uu____1018 =
-                          let uu____1024 =
-                            let uu____1026 =
-                              let uu____1029 =
-                                let uu____1035 =
-                                  let uu____1036 =
-                                    FStar_Syntax_Syntax.bv_to_name c in
-                                  FStar_Syntax_Syntax.as_arg uu____1036 in
-                                [uu____1035] in
-                              FStar_Syntax_Util.mk_app l_ite uu____1029 in
-                            [uu____1026] in
-                          FStar_List.map FStar_Syntax_Syntax.as_arg
-                            uu____1024 in
-                        FStar_Syntax_Util.mk_app c_lift21 uu____1018 in
-                      FStar_Syntax_Util.ascribe uu____1015
-                        ((FStar_Util.Inr result_comp), None) in
-                    FStar_Syntax_Util.abs uu____1003 uu____1013
-                      (Some
-                         (FStar_Util.Inl
-                            (FStar_Syntax_Util.lcomp_of_comp result_comp))) in
-                  let wp_if_then_else1 =
-                    let uu____1061 = mk_lid "wp_if_then_else" in
-                    register env1 uu____1061 wp_if_then_else in
-                  let wp_if_then_else2 = mk_generic_app wp_if_then_else1 in
-                  let wp_assert =
-                    let q =
-                      FStar_Syntax_Syntax.gen_bv "q" None
-                        FStar_Syntax_Util.ktype in
-                    let wp = FStar_Syntax_Syntax.gen_bv "wp" None wp_a1 in
-                    let l_and =
-                      FStar_Syntax_Syntax.fvar FStar_Syntax_Const.and_lid
-                        (FStar_Syntax_Syntax.Delta_defined_at_level
-                           (Prims.parse_int "1")) None in
-                    let body =
-                      let uu____1072 =
-                        let uu____1078 =
-                          let uu____1080 =
-                            let uu____1083 =
-                              let uu____1089 =
-                                let uu____1091 =
-                                  let uu____1094 =
-                                    let uu____1100 =
-                                      let uu____1101 =
-                                        FStar_Syntax_Syntax.bv_to_name q in
-                                      FStar_Syntax_Syntax.as_arg uu____1101 in
-                                    [uu____1100] in
-                                  FStar_Syntax_Util.mk_app l_and uu____1094 in
-                                [uu____1091] in
-                              FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1089 in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1083 in
-                          let uu____1106 =
-                            let uu____1110 =
-                              FStar_Syntax_Syntax.bv_to_name wp in
-                            [uu____1110] in
-                          uu____1080 :: uu____1106 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1078 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1072 in
-                    let uu____1113 =
-                      let uu____1117 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp] in
-                      FStar_List.append binders uu____1117 in
-                    FStar_Syntax_Util.abs uu____1113 body ret_tot_wp_a in
-                  let wp_assert1 =
-                    let uu____1124 = mk_lid "wp_assert" in
-                    register env1 uu____1124 wp_assert in
-                  let wp_assert2 = mk_generic_app wp_assert1 in
-                  let wp_assume =
-                    let q =
-                      FStar_Syntax_Syntax.gen_bv "q" None
-                        FStar_Syntax_Util.ktype in
-                    let wp = FStar_Syntax_Syntax.gen_bv "wp" None wp_a1 in
-                    let l_imp =
-                      FStar_Syntax_Syntax.fvar FStar_Syntax_Const.imp_lid
-                        (FStar_Syntax_Syntax.Delta_defined_at_level
-                           (Prims.parse_int "1")) None in
-                    let body =
-                      let uu____1135 =
-                        let uu____1141 =
-                          let uu____1143 =
-                            let uu____1146 =
-                              let uu____1152 =
-                                let uu____1154 =
-                                  let uu____1157 =
-                                    let uu____1163 =
-                                      let uu____1164 =
-                                        FStar_Syntax_Syntax.bv_to_name q in
-                                      FStar_Syntax_Syntax.as_arg uu____1164 in
-                                    [uu____1163] in
-                                  FStar_Syntax_Util.mk_app l_imp uu____1157 in
-                                [uu____1154] in
-                              FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1152 in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1146 in
-                          let uu____1169 =
-                            let uu____1173 =
-                              FStar_Syntax_Syntax.bv_to_name wp in
-                            [uu____1173] in
-                          uu____1143 :: uu____1169 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1141 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1135 in
-                    let uu____1176 =
-                      let uu____1180 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp] in
-                      FStar_List.append binders uu____1180 in
-                    FStar_Syntax_Util.abs uu____1176 body ret_tot_wp_a in
-                  let wp_assume1 =
-                    let uu____1187 = mk_lid "wp_assume" in
-                    register env1 uu____1187 wp_assume in
-                  let wp_assume2 = mk_generic_app wp_assume1 in
-                  let wp_close =
-                    let b =
-                      FStar_Syntax_Syntax.gen_bv "b" None
-                        FStar_Syntax_Util.ktype in
-                    let t_f =
-                      let uu____1196 =
-                        let uu____1200 =
-                          let uu____1201 = FStar_Syntax_Syntax.bv_to_name b in
-                          FStar_Syntax_Syntax.null_binder uu____1201 in
-                        [uu____1200] in
-                      let uu____1202 = FStar_Syntax_Syntax.mk_Total wp_a1 in
-                      FStar_Syntax_Util.arrow uu____1196 uu____1202 in
-                    let f = FStar_Syntax_Syntax.gen_bv "f" None t_f in
-                    let body =
-                      let uu____1209 =
-                        let uu____1215 =
-                          let uu____1217 =
-                            let uu____1220 =
-                              FStar_List.map FStar_Syntax_Syntax.as_arg
-                                [FStar_Syntax_Util.tforall] in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1220 in
-                          let uu____1226 =
-                            let uu____1230 =
-                              let uu____1233 =
-                                let uu____1239 =
-                                  let uu____1241 =
-                                    FStar_Syntax_Syntax.bv_to_name f in
-                                  [uu____1241] in
-                                FStar_List.map FStar_Syntax_Syntax.as_arg
-                                  uu____1239 in
-                              FStar_Syntax_Util.mk_app c_push1 uu____1233 in
-                            [uu____1230] in
-                          uu____1217 :: uu____1226 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1215 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1209 in
-                    let uu____1248 =
-                      let uu____1252 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; b; f] in
-                      FStar_List.append binders uu____1252 in
-                    FStar_Syntax_Util.abs uu____1248 body ret_tot_wp_a in
-                  let wp_close1 =
-                    let uu____1259 = mk_lid "wp_close" in
-                    register env1 uu____1259 wp_close in
-                  let wp_close2 = mk_generic_app wp_close1 in
-                  let ret_tot_type =
-                    let uu____1270 =
-                      let uu____1276 =
-                        let uu____1277 =
-                          FStar_Syntax_Syntax.mk_Total
-                            FStar_Syntax_Util.ktype in
-                        FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                          uu____1277 in
-                      FStar_Util.Inl uu____1276 in
-                    Some uu____1270 in
-                  let ret_gtot_type =
-                    let uu____1297 =
-                      let uu____1303 =
-                        let uu____1304 =
-                          FStar_Syntax_Syntax.mk_GTotal
-                            FStar_Syntax_Util.ktype in
-                        FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                          uu____1304 in
-                      FStar_Util.Inl uu____1303 in
-                    Some uu____1297 in
-                  let mk_forall1 x body =
-                    let uu____1324 =
-                      let uu____1327 =
-                        let uu____1328 =
-                          let uu____1338 =
-                            let uu____1340 =
-                              let uu____1341 =
-                                let uu____1342 =
-                                  let uu____1346 =
-                                    FStar_Syntax_Syntax.mk_binder x in
-                                  [uu____1346] in
-                                FStar_Syntax_Util.abs uu____1342 body
-                                  ret_tot_type in
-                              FStar_Syntax_Syntax.as_arg uu____1341 in
-                            [uu____1340] in
-                          (FStar_Syntax_Util.tforall, uu____1338) in
-                        FStar_Syntax_Syntax.Tm_app uu____1328 in
-                      FStar_Syntax_Syntax.mk uu____1327 in
-                    uu____1324 None FStar_Range.dummyRange in
-                  let rec is_discrete t =
-                    let uu____1360 =
-                      let uu____1361 = FStar_Syntax_Subst.compress t in
-                      uu____1361.FStar_Syntax_Syntax.n in
-                    match uu____1360 with
-                    | FStar_Syntax_Syntax.Tm_type uu____1364 -> false
-                    | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                        (FStar_List.for_all
-                           (fun uu____1379  ->
-                              match uu____1379 with
-                              | (b,uu____1383) ->
-                                  is_discrete b.FStar_Syntax_Syntax.sort) bs)
-                          && (is_discrete (FStar_Syntax_Util.comp_result c))
-                    | uu____1384 -> true in
-                  let rec is_monotonic t =
-                    let uu____1389 =
-                      let uu____1390 = FStar_Syntax_Subst.compress t in
-                      uu____1390.FStar_Syntax_Syntax.n in
-                    match uu____1389 with
-                    | FStar_Syntax_Syntax.Tm_type uu____1393 -> true
-                    | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                        (FStar_List.for_all
-                           (fun uu____1408  ->
-                              match uu____1408 with
-                              | (b,uu____1412) ->
-                                  is_discrete b.FStar_Syntax_Syntax.sort) bs)
-                          && (is_monotonic (FStar_Syntax_Util.comp_result c))
-                    | uu____1413 -> is_discrete t in
-                  let rec mk_rel rel t x y =
-                    let mk_rel1 = mk_rel rel in
-                    let t1 =
-                      FStar_TypeChecker_Normalize.normalize
-                        [FStar_TypeChecker_Normalize.Beta;
-                        FStar_TypeChecker_Normalize.Eager_unfolding;
-                        FStar_TypeChecker_Normalize.UnfoldUntil
-                          FStar_Syntax_Syntax.Delta_constant] env1 t in
-                    let uu____1465 =
-                      let uu____1466 = FStar_Syntax_Subst.compress t1 in
-                      uu____1466.FStar_Syntax_Syntax.n in
-                    match uu____1465 with
-                    | FStar_Syntax_Syntax.Tm_type uu____1469 -> rel x y
-                    | FStar_Syntax_Syntax.Tm_arrow
-                      (binder::[],{
-                                    FStar_Syntax_Syntax.n =
-                                      FStar_Syntax_Syntax.GTotal (b,_);
-                                    FStar_Syntax_Syntax.tk = _;
-                                    FStar_Syntax_Syntax.pos = _;
-                                    FStar_Syntax_Syntax.vars = _;_})
-                      |FStar_Syntax_Syntax.Tm_arrow
-                      (binder::[],{
-                                    FStar_Syntax_Syntax.n =
-                                      FStar_Syntax_Syntax.Total (b,_);
-                                    FStar_Syntax_Syntax.tk = _;
-                                    FStar_Syntax_Syntax.pos = _;
-                                    FStar_Syntax_Syntax.vars = _;_})
-                        ->
-                        let a2 = (Prims.fst binder).FStar_Syntax_Syntax.sort in
-                        let uu____1515 =
-                          (is_monotonic a2) || (is_monotonic b) in
-                        if uu____1515
-                        then
-                          let a11 = FStar_Syntax_Syntax.gen_bv "a1" None a2 in
-                          let body =
-                            let uu____1518 =
-                              let uu____1521 =
-                                let uu____1527 =
-                                  let uu____1528 =
-                                    FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____1528 in
-                                [uu____1527] in
-                              FStar_Syntax_Util.mk_app x uu____1521 in
-                            let uu____1529 =
-                              let uu____1532 =
-                                let uu____1538 =
-                                  let uu____1539 =
-                                    FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____1539 in
-                                [uu____1538] in
-                              FStar_Syntax_Util.mk_app y uu____1532 in
-                            mk_rel1 b uu____1518 uu____1529 in
-                          mk_forall1 a11 body
-                        else
-                          (let a11 = FStar_Syntax_Syntax.gen_bv "a1" None a2 in
-                           let a21 = FStar_Syntax_Syntax.gen_bv "a2" None a2 in
-                           let body =
-                             let uu____1544 =
-                               let uu____1545 =
-                                 FStar_Syntax_Syntax.bv_to_name a11 in
-                               let uu____1548 =
-                                 FStar_Syntax_Syntax.bv_to_name a21 in
-                               mk_rel1 a2 uu____1545 uu____1548 in
-                             let uu____1551 =
-                               let uu____1552 =
-                                 let uu____1555 =
-                                   let uu____1561 =
-                                     let uu____1562 =
-                                       FStar_Syntax_Syntax.bv_to_name a11 in
-                                     FStar_Syntax_Syntax.as_arg uu____1562 in
-                                   [uu____1561] in
-                                 FStar_Syntax_Util.mk_app x uu____1555 in
-                               let uu____1563 =
-                                 let uu____1566 =
-                                   let uu____1572 =
-                                     let uu____1573 =
-                                       FStar_Syntax_Syntax.bv_to_name a21 in
-                                     FStar_Syntax_Syntax.as_arg uu____1573 in
-                                   [uu____1572] in
-                                 FStar_Syntax_Util.mk_app y uu____1566 in
-                               mk_rel1 b uu____1552 uu____1563 in
-                             FStar_Syntax_Util.mk_imp uu____1544 uu____1551 in
-                           let uu____1574 = mk_forall1 a21 body in
-                           mk_forall1 a11 uu____1574)
-                    | FStar_Syntax_Syntax.Tm_arrow (binder::binders1,comp) ->
-                        let t2 =
-                          let uu___98_1595 = t1 in
-                          let uu____1596 =
-                            let uu____1597 =
-                              let uu____1605 =
-                                let uu____1606 =
-                                  FStar_Syntax_Util.arrow binders1 comp in
-                                FStar_Syntax_Syntax.mk_Total uu____1606 in
-                              ([binder], uu____1605) in
-                            FStar_Syntax_Syntax.Tm_arrow uu____1597 in
-                          {
-                            FStar_Syntax_Syntax.n = uu____1596;
-                            FStar_Syntax_Syntax.tk =
-                              (uu___98_1595.FStar_Syntax_Syntax.tk);
-                            FStar_Syntax_Syntax.pos =
-                              (uu___98_1595.FStar_Syntax_Syntax.pos);
-                            FStar_Syntax_Syntax.vars =
-                              (uu___98_1595.FStar_Syntax_Syntax.vars)
-                          } in
-                        mk_rel1 t2 x y
-                    | FStar_Syntax_Syntax.Tm_arrow uu____1618 ->
-                        failwith "unhandled arrow"
-                    | uu____1626 -> FStar_Syntax_Util.mk_untyped_eq2 x y in
-                  let stronger =
-                    let wp1 = FStar_Syntax_Syntax.gen_bv "wp1" None wp_a1 in
-                    let wp2 = FStar_Syntax_Syntax.gen_bv "wp2" None wp_a1 in
-                    let rec mk_stronger t x y =
-                      let t1 =
-                        FStar_TypeChecker_Normalize.normalize
-                          [FStar_TypeChecker_Normalize.Beta;
-                          FStar_TypeChecker_Normalize.Eager_unfolding;
-                          FStar_TypeChecker_Normalize.UnfoldUntil
-                            FStar_Syntax_Syntax.Delta_constant] env1 t in
-                      let uu____1641 =
-                        let uu____1642 = FStar_Syntax_Subst.compress t1 in
-                        uu____1642.FStar_Syntax_Syntax.n in
-                      match uu____1641 with
-                      | FStar_Syntax_Syntax.Tm_type uu____1645 ->
-                          FStar_Syntax_Util.mk_imp x y
-                      | FStar_Syntax_Syntax.Tm_app (head1,args) when
-                          let uu____1662 = FStar_Syntax_Subst.compress head1 in
-                          FStar_Syntax_Util.is_tuple_constructor uu____1662
-                          ->
-                          let project i tuple =
-                            let projector =
-                              let uu____1677 =
-                                let uu____1678 =
-                                  FStar_Syntax_Util.mk_tuple_data_lid
-                                    (FStar_List.length args)
-                                    FStar_Range.dummyRange in
-                                FStar_TypeChecker_Env.lookup_projector env1
-                                  uu____1678 i in
-                              FStar_Syntax_Syntax.fvar uu____1677
-                                (FStar_Syntax_Syntax.Delta_defined_at_level
-                                   (Prims.parse_int "1")) None in
-                            FStar_Syntax_Util.mk_app projector
-                              [(tuple, None)] in
-                          let uu____1699 =
-                            let uu____1703 =
-                              FStar_List.mapi
-                                (fun i  ->
-                                   fun uu____1708  ->
-                                     match uu____1708 with
-                                     | (t2,q) ->
-                                         let uu____1713 = project i x in
-                                         let uu____1714 = project i y in
-                                         mk_stronger t2 uu____1713 uu____1714)
-                                args in
-                            match uu____1703 with
-                            | [] ->
-                                failwith
-                                  "Impossible : Empty application when creating stronger relation in DM4F"
-                            | rel0::rels -> (rel0, rels) in
-                          (match uu____1699 with
-                           | (rel0,rels) ->
-                               FStar_List.fold_left FStar_Syntax_Util.mk_conj
-                                 rel0 rels)
-                      | FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,{
-                                    FStar_Syntax_Syntax.n =
-                                      FStar_Syntax_Syntax.GTotal (b,_);
-                                    FStar_Syntax_Syntax.tk = _;
-                                    FStar_Syntax_Syntax.pos = _;
-                                    FStar_Syntax_Syntax.vars = _;_})
-                        |FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,{
-                                    FStar_Syntax_Syntax.n =
-                                      FStar_Syntax_Syntax.Total (b,_);
-                                    FStar_Syntax_Syntax.tk = _;
-                                    FStar_Syntax_Syntax.pos = _;
-                                    FStar_Syntax_Syntax.vars = _;_})
-                          ->
-                          let bvs =
-                            FStar_List.mapi
-                              (fun i  ->
-                                 fun uu____1770  ->
-                                   match uu____1770 with
-                                   | (bv,q) ->
-                                       let uu____1775 =
-                                         let uu____1776 =
-                                           FStar_Util.string_of_int i in
-                                         Prims.strcat "a" uu____1776 in
-                                       FStar_Syntax_Syntax.gen_bv uu____1775
-                                         None bv.FStar_Syntax_Syntax.sort)
-                              binders1 in
-                          let args =
-                            FStar_List.map
-                              (fun ai  ->
-                                 let uu____1780 =
-                                   FStar_Syntax_Syntax.bv_to_name ai in
-                                 FStar_Syntax_Syntax.as_arg uu____1780) bvs in
-                          let body =
-                            let uu____1782 = FStar_Syntax_Util.mk_app x args in
-                            let uu____1783 = FStar_Syntax_Util.mk_app y args in
-                            mk_stronger b uu____1782 uu____1783 in
-                          FStar_List.fold_right
-                            (fun bv  -> fun body1  -> mk_forall1 bv body1)
-                            bvs body
-                      | uu____1786 -> failwith "Not a DM elaborated type" in
-                    let body =
-                      let uu____1788 = FStar_Syntax_Util.unascribe wp_a1 in
-                      let uu____1789 = FStar_Syntax_Syntax.bv_to_name wp1 in
-                      let uu____1790 = FStar_Syntax_Syntax.bv_to_name wp2 in
-                      mk_stronger uu____1788 uu____1789 uu____1790 in
-                    let uu____1791 =
-                      let uu____1795 =
-                        binders_of_list1
-                          [(a1, false); (wp1, false); (wp2, false)] in
-                      FStar_List.append binders uu____1795 in
-                    FStar_Syntax_Util.abs uu____1791 body ret_tot_type in
-                  let stronger1 =
-                    let uu____1810 = mk_lid "stronger" in
-                    register env1 uu____1810 stronger in
-                  let stronger2 = mk_generic_app stronger1 in
-                  let wp_ite =
-                    let wp = FStar_Syntax_Syntax.gen_bv "wp" None wp_a1 in
-                    let uu____1816 = FStar_Util.prefix gamma in
-                    match uu____1816 with
-                    | (wp_args,post) ->
-                        let k =
-                          FStar_Syntax_Syntax.gen_bv "k" None
-                            (Prims.fst post).FStar_Syntax_Syntax.sort in
-                        let equiv =
-                          let k_tm = FStar_Syntax_Syntax.bv_to_name k in
-                          let eq1 =
-                            let uu____1842 =
-                              FStar_Syntax_Syntax.bv_to_name (Prims.fst post) in
-                            mk_rel FStar_Syntax_Util.mk_iff
-                              k.FStar_Syntax_Syntax.sort k_tm uu____1842 in
-                          let uu____1845 =
-                            FStar_Syntax_Util.destruct_typ_as_formula eq1 in
-                          match uu____1845 with
-                          | Some (FStar_Syntax_Util.QAll (binders1,[],body))
-                              ->
-                              let k_app =
-                                let uu____1853 = args_of_binders1 binders1 in
-                                FStar_Syntax_Util.mk_app k_tm uu____1853 in
-                              let guard_free1 =
-                                let uu____1860 =
-                                  FStar_Syntax_Syntax.lid_as_fv
-                                    FStar_Syntax_Const.guard_free
-                                    FStar_Syntax_Syntax.Delta_constant None in
-                                FStar_Syntax_Syntax.fv_to_tm uu____1860 in
-                              let pat =
-                                let uu____1864 =
-                                  let uu____1870 =
-                                    FStar_Syntax_Syntax.as_arg k_app in
-                                  [uu____1870] in
-                                FStar_Syntax_Util.mk_app guard_free1
-                                  uu____1864 in
-                              let pattern_guarded_body =
-                                let uu____1874 =
-                                  let uu____1875 =
-                                    let uu____1880 =
-                                      let uu____1881 =
-                                        let uu____1888 =
-                                          let uu____1890 =
-                                            FStar_Syntax_Syntax.as_arg pat in
-                                          [uu____1890] in
-                                        [uu____1888] in
-                                      FStar_Syntax_Syntax.Meta_pattern
-                                        uu____1881 in
-                                    (body, uu____1880) in
-                                  FStar_Syntax_Syntax.Tm_meta uu____1875 in
-                                mk1 uu____1874 in
-                              FStar_Syntax_Util.close_forall_no_univs
-                                binders1 pattern_guarded_body
-                          | uu____1893 ->
-                              failwith
-                                "Impossible: Expected the equivalence to be a quantified formula" in
-                        let body =
-                          let uu____1896 =
-                            let uu____1897 =
-                              let uu____1898 =
-                                let uu____1899 =
-                                  FStar_Syntax_Syntax.bv_to_name wp in
-                                let uu____1902 =
-                                  let uu____1908 = args_of_binders1 wp_args in
-                                  let uu____1910 =
-                                    let uu____1912 =
-                                      let uu____1913 =
-                                        FStar_Syntax_Syntax.bv_to_name k in
-                                      FStar_Syntax_Syntax.as_arg uu____1913 in
-                                    [uu____1912] in
-                                  FStar_List.append uu____1908 uu____1910 in
-                                FStar_Syntax_Util.mk_app uu____1899
-                                  uu____1902 in
-                              FStar_Syntax_Util.mk_imp equiv uu____1898 in
-                            FStar_Syntax_Util.mk_forall_no_univ k uu____1897 in
-                          FStar_Syntax_Util.abs gamma uu____1896
-                            ret_gtot_type in
-                        let uu____1914 =
-                          let uu____1918 =
-                            FStar_Syntax_Syntax.binders_of_list [a1; wp] in
-                          FStar_List.append binders uu____1918 in
-                        FStar_Syntax_Util.abs uu____1914 body ret_gtot_type in
-                  let wp_ite1 =
-                    let uu____1925 = mk_lid "wp_ite" in
-                    register env1 uu____1925 wp_ite in
-                  let wp_ite2 = mk_generic_app wp_ite1 in
-                  let null_wp =
-                    let wp = FStar_Syntax_Syntax.gen_bv "wp" None wp_a1 in
-                    let uu____1931 = FStar_Util.prefix gamma in
-                    match uu____1931 with
-                    | (wp_args,post) ->
-                        let x =
-                          FStar_Syntax_Syntax.gen_bv "x" None
-                            FStar_Syntax_Syntax.tun in
-                        let body =
-                          let uu____1955 =
-                            let uu____1956 =
-                              FStar_All.pipe_left
-                                FStar_Syntax_Syntax.bv_to_name
-                                (Prims.fst post) in
-                            let uu____1959 =
-                              let uu____1965 =
-                                let uu____1966 =
-                                  FStar_Syntax_Syntax.bv_to_name x in
-                                FStar_Syntax_Syntax.as_arg uu____1966 in
-                              [uu____1965] in
-                            FStar_Syntax_Util.mk_app uu____1956 uu____1959 in
-                          FStar_Syntax_Util.mk_forall_no_univ x uu____1955 in
-                        let uu____1967 =
-                          let uu____1971 =
-                            let uu____1975 =
-                              FStar_Syntax_Syntax.binders_of_list [a1] in
-                            FStar_List.append uu____1975 gamma in
-                          FStar_List.append binders uu____1971 in
-                        FStar_Syntax_Util.abs uu____1967 body ret_gtot_type in
-                  let null_wp1 =
-                    let uu____1984 = mk_lid "null_wp" in
-                    register env1 uu____1984 null_wp in
-                  let null_wp2 = mk_generic_app null_wp1 in
-                  let wp_trivial =
-                    let wp = FStar_Syntax_Syntax.gen_bv "wp" None wp_a1 in
-                    let body =
-                      let uu____1993 =
-                        let uu____1999 =
-                          let uu____2001 = FStar_Syntax_Syntax.bv_to_name a1 in
-                          let uu____2002 =
-                            let uu____2004 =
-                              let uu____2007 =
-                                let uu____2013 =
-                                  let uu____2014 =
-                                    FStar_Syntax_Syntax.bv_to_name a1 in
-                                  FStar_Syntax_Syntax.as_arg uu____2014 in
-                                [uu____2013] in
-                              FStar_Syntax_Util.mk_app null_wp2 uu____2007 in
-                            let uu____2015 =
-                              let uu____2019 =
-                                FStar_Syntax_Syntax.bv_to_name wp in
-                              [uu____2019] in
-                            uu____2004 :: uu____2015 in
-                          uu____2001 :: uu____2002 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1999 in
-                      FStar_Syntax_Util.mk_app stronger2 uu____1993 in
-                    let uu____2022 =
-                      let uu____2026 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; wp] in
-                      FStar_List.append binders uu____2026 in
-                    FStar_Syntax_Util.abs uu____2022 body ret_tot_type in
-                  let wp_trivial1 =
-                    let uu____2033 = mk_lid "wp_trivial" in
-                    register env1 uu____2033 wp_trivial in
-                  let wp_trivial2 = mk_generic_app wp_trivial1 in
-                  ((let uu____2038 =
-                      FStar_TypeChecker_Env.debug env1
-                        (FStar_Options.Other "ED") in
-                    if uu____2038
-                    then d "End Dijkstra monads for free"
-                    else ());
-                   (let c = FStar_Syntax_Subst.close binders in
-                    let uu____2043 =
-                      let uu____2045 = FStar_ST.read sigelts in
-                      FStar_List.rev uu____2045 in
-                    let uu____2050 =
-                      let uu___99_2051 = ed in
-                      let uu____2052 =
-                        let uu____2053 = c wp_if_then_else2 in
-                        ([], uu____2053) in
-                      let uu____2055 =
-                        let uu____2056 = c wp_ite2 in ([], uu____2056) in
-                      let uu____2058 =
-                        let uu____2059 = c stronger2 in ([], uu____2059) in
-                      let uu____2061 =
-                        let uu____2062 = c wp_close2 in ([], uu____2062) in
-                      let uu____2064 =
-                        let uu____2065 = c wp_assert2 in ([], uu____2065) in
-                      let uu____2067 =
-                        let uu____2068 = c wp_assume2 in ([], uu____2068) in
-                      let uu____2070 =
-                        let uu____2071 = c null_wp2 in ([], uu____2071) in
-                      let uu____2073 =
-                        let uu____2074 = c wp_trivial2 in ([], uu____2074) in
-                      {
-                        FStar_Syntax_Syntax.qualifiers =
-                          (uu___99_2051.FStar_Syntax_Syntax.qualifiers);
-                        FStar_Syntax_Syntax.cattributes =
-                          (uu___99_2051.FStar_Syntax_Syntax.cattributes);
-                        FStar_Syntax_Syntax.mname =
-                          (uu___99_2051.FStar_Syntax_Syntax.mname);
-                        FStar_Syntax_Syntax.univs =
-                          (uu___99_2051.FStar_Syntax_Syntax.univs);
-                        FStar_Syntax_Syntax.binders =
-                          (uu___99_2051.FStar_Syntax_Syntax.binders);
-                        FStar_Syntax_Syntax.signature =
-                          (uu___99_2051.FStar_Syntax_Syntax.signature);
-                        FStar_Syntax_Syntax.ret_wp =
-                          (uu___99_2051.FStar_Syntax_Syntax.ret_wp);
-                        FStar_Syntax_Syntax.bind_wp =
-                          (uu___99_2051.FStar_Syntax_Syntax.bind_wp);
-                        FStar_Syntax_Syntax.if_then_else = uu____2052;
-                        FStar_Syntax_Syntax.ite_wp = uu____2055;
-                        FStar_Syntax_Syntax.stronger = uu____2058;
-                        FStar_Syntax_Syntax.close_wp = uu____2061;
-                        FStar_Syntax_Syntax.assert_p = uu____2064;
-                        FStar_Syntax_Syntax.assume_p = uu____2067;
-                        FStar_Syntax_Syntax.null_wp = uu____2070;
-                        FStar_Syntax_Syntax.trivial = uu____2073;
-                        FStar_Syntax_Syntax.repr =
-                          (uu___99_2051.FStar_Syntax_Syntax.repr);
-                        FStar_Syntax_Syntax.return_repr =
-                          (uu___99_2051.FStar_Syntax_Syntax.return_repr);
-                        FStar_Syntax_Syntax.bind_repr =
-                          (uu___99_2051.FStar_Syntax_Syntax.bind_repr);
-                        FStar_Syntax_Syntax.actions =
-                          (uu___99_2051.FStar_Syntax_Syntax.actions)
-                      } in
-                    (uu____2043, uu____2050)))))
-type env_ = env
-let get_env: env -> FStar_TypeChecker_Env.env = fun env  -> env.env
+{env : FStar_TypeChecker_Env.env; subst : FStar_Syntax_Syntax.subst_elt Prims.list; tc_const : FStar_Const.sconst  ->  FStar_Syntax_Syntax.typ}
+
+
+let empty : FStar_TypeChecker_Env.env  ->  (FStar_Const.sconst  ->  FStar_Syntax_Syntax.typ)  ->  env = (fun env tc_const -> {env = env; subst = []; tc_const = tc_const})
+
+
+let gen_wps_for_free : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.bv  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.eff_decl  ->  (FStar_Syntax_Syntax.sigelts * FStar_Syntax_Syntax.eff_decl) = (fun env binders a wp_a ed -> (
+
+let wp_a1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env wp_a)
+in (
+
+let a1 = (
+
+let uu___97_64 = a
+in (
+
+let uu____65 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.EraseUniverses)::[]) env a.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___97_64.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___97_64.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____65}))
+in (
+
+let d = (fun s -> (FStar_Util.print1 "[01;36m%s[00m\n" s))
+in ((
+
+let uu____73 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("ED")))
+in (match (uu____73) with
+| true -> begin
+((d "Elaborating extra WP combinators");
+(
+
+let uu____75 = (FStar_Syntax_Print.term_to_string wp_a1)
+in (FStar_Util.print1 "wp_a is: %s\n" uu____75));
+)
+end
+| uu____76 -> begin
+()
+end));
+(
+
+let rec collect_binders = (fun t -> (
+
+let uu____84 = (
+
+let uu____85 = (
+
+let uu____88 = (FStar_Syntax_Subst.compress t)
+in (FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____88))
+in uu____85.FStar_Syntax_Syntax.n)
+in (match (uu____84) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, comp) -> begin
+(
+
+let rest = (match (comp.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t1, uu____110) -> begin
+t1
+end
+| uu____117 -> begin
+(failwith "wp_a contains non-Tot arrow")
+end)
+in (
+
+let uu____120 = (collect_binders rest)
+in (FStar_List.append bs uu____120)))
+end
+| FStar_Syntax_Syntax.Tm_type (uu____126) -> begin
+[]
+end
+| uu____129 -> begin
+(failwith "wp_a doesn\'t end in Type0")
+end)))
+in (
+
+let mk_lid = (fun name -> (FStar_Ident.lid_of_path (FStar_Ident.path_of_text (Prims.strcat (FStar_Ident.text_of_lid ed.FStar_Syntax_Syntax.mname) (Prims.strcat "_" name))) FStar_Range.dummyRange))
+in (
+
+let gamma = (
+
+let uu____141 = (collect_binders wp_a1)
+in (FStar_All.pipe_right uu____141 FStar_Syntax_Util.name_binders))
+in ((
+
+let uu____152 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("ED")))
+in (match (uu____152) with
+| true -> begin
+(
+
+let uu____153 = (
+
+let uu____154 = (FStar_Syntax_Print.binders_to_string ", " gamma)
+in (FStar_Util.format1 "Gamma is %s\n" uu____154))
+in (d uu____153))
+end
+| uu____155 -> begin
+()
+end));
+(
+
+let unknown = FStar_Syntax_Syntax.tun
+in (
+
+let mk1 = (fun x -> ((FStar_Syntax_Syntax.mk x) None FStar_Range.dummyRange))
+in (
+
+let sigelts = (FStar_Util.mk_ref [])
+in (
+
+let register = (fun env1 lident def -> (
+
+let uu____186 = (FStar_TypeChecker_Util.mk_toplevel_definition env1 lident def)
+in (match (uu____186) with
+| (sigelt, fv) -> begin
+((
+
+let uu____192 = (
+
+let uu____194 = (FStar_ST.read sigelts)
+in (sigelt)::uu____194)
+in (FStar_ST.write sigelts uu____192));
+fv;
+)
+end)))
+in (
+
+let binders_of_list1 = (FStar_List.map (fun uu____215 -> (match (uu____215) with
+| (t, b) -> begin
+(
+
+let uu____222 = (FStar_Syntax_Syntax.as_implicit b)
+in ((t), (uu____222)))
+end)))
+in (
+
+let mk_all_implicit = (FStar_List.map (fun t -> (
+
+let uu____239 = (FStar_Syntax_Syntax.as_implicit true)
+in (((Prims.fst t)), (uu____239)))))
+in (
+
+let args_of_binders1 = (FStar_List.map (fun bv -> (
+
+let uu____252 = (FStar_Syntax_Syntax.bv_to_name (Prims.fst bv))
+in (FStar_Syntax_Syntax.as_arg uu____252))))
+in (
+
+let uu____253 = (
+
+let uu____265 = (
+
+let mk2 = (fun f -> (
+
+let t = (FStar_Syntax_Syntax.gen_bv "t" None FStar_Syntax_Util.ktype)
+in (
+
+let body = (
+
+let uu____285 = (f (FStar_Syntax_Syntax.bv_to_name t))
+in (FStar_Syntax_Util.arrow gamma uu____285))
+in (
+
+let uu____288 = (
+
+let uu____292 = (
+
+let uu____296 = (FStar_Syntax_Syntax.mk_binder a1)
+in (
+
+let uu____297 = (
+
+let uu____299 = (FStar_Syntax_Syntax.mk_binder t)
+in (uu____299)::[])
+in (uu____296)::uu____297))
+in (FStar_List.append binders uu____292))
+in (FStar_Syntax_Util.abs uu____288 body None)))))
+in (
+
+let uu____307 = (mk2 FStar_Syntax_Syntax.mk_Total)
+in (
+
+let uu____308 = (mk2 FStar_Syntax_Syntax.mk_GTotal)
+in ((uu____307), (uu____308)))))
+in (match (uu____265) with
+| (ctx_def, gctx_def) -> begin
+(
+
+let ctx_lid = (mk_lid "ctx")
+in (
+
+let ctx_fv = (register env ctx_lid ctx_def)
+in (
+
+let gctx_lid = (mk_lid "gctx")
+in (
+
+let gctx_fv = (register env gctx_lid gctx_def)
+in (
+
+let mk_app1 = (fun fv t -> (
+
+let uu____339 = (
+
+let uu____340 = (
+
+let uu____350 = (
+
+let uu____354 = (FStar_List.map (fun uu____362 -> (match (uu____362) with
+| (bv, uu____368) -> begin
+(
+
+let uu____369 = (FStar_Syntax_Syntax.bv_to_name bv)
+in (
+
+let uu____370 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____369), (uu____370))))
+end)) binders)
+in (
+
+let uu____371 = (
+
+let uu____375 = (
+
+let uu____378 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (
+
+let uu____379 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____378), (uu____379))))
+in (
+
+let uu____380 = (
+
+let uu____384 = (
+
+let uu____387 = (FStar_Syntax_Syntax.as_implicit false)
+in ((t), (uu____387)))
+in (uu____384)::[])
+in (uu____375)::uu____380))
+in (FStar_List.append uu____354 uu____371)))
+in ((fv), (uu____350)))
+in FStar_Syntax_Syntax.Tm_app (uu____340))
+in (mk1 uu____339)))
+in ((env), ((mk_app1 ctx_fv)), ((mk_app1 gctx_fv))))))))
+end))
+in (match (uu____253) with
+| (env1, mk_ctx, mk_gctx) -> begin
+(
+
+let c_pure = (
+
+let t = (FStar_Syntax_Syntax.gen_bv "t" None FStar_Syntax_Util.ktype)
+in (
+
+let x = (
+
+let uu____433 = (FStar_Syntax_Syntax.bv_to_name t)
+in (FStar_Syntax_Syntax.gen_bv "x" None uu____433))
+in (
+
+let ret1 = (
+
+let uu____441 = (
+
+let uu____447 = (
+
+let uu____448 = (
+
+let uu____451 = (
+
+let uu____452 = (FStar_Syntax_Syntax.bv_to_name t)
+in (mk_ctx uu____452))
+in (FStar_Syntax_Syntax.mk_Total uu____451))
+in (FStar_Syntax_Util.lcomp_of_comp uu____448))
+in FStar_Util.Inl (uu____447))
+in Some (uu____441))
+in (
+
+let body = (
+
+let uu____462 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_Syntax_Util.abs gamma uu____462 ret1))
+in (
+
+let uu____463 = (
+
+let uu____467 = (mk_all_implicit binders)
+in (
+
+let uu____471 = (binders_of_list1 ((((a1), (true)))::(((t), (true)))::(((x), (false)))::[]))
+in (FStar_List.append uu____467 uu____471)))
+in (FStar_Syntax_Util.abs uu____463 body ret1))))))
+in (
+
+let c_pure1 = (
+
+let uu____486 = (mk_lid "pure")
+in (register env1 uu____486 c_pure))
+in (
+
+let c_app = (
+
+let t1 = (FStar_Syntax_Syntax.gen_bv "t1" None FStar_Syntax_Util.ktype)
+in (
+
+let t2 = (FStar_Syntax_Syntax.gen_bv "t2" None FStar_Syntax_Util.ktype)
+in (
+
+let l = (
+
+let uu____491 = (
+
+let uu____492 = (
+
+let uu____493 = (
+
+let uu____497 = (
+
+let uu____498 = (
+
+let uu____499 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.new_bv None uu____499))
+in (FStar_Syntax_Syntax.mk_binder uu____498))
+in (uu____497)::[])
+in (
+
+let uu____500 = (
+
+let uu____503 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (FStar_Syntax_Syntax.mk_GTotal uu____503))
+in (FStar_Syntax_Util.arrow uu____493 uu____500)))
+in (mk_gctx uu____492))
+in (FStar_Syntax_Syntax.gen_bv "l" None uu____491))
+in (
+
+let r = (
+
+let uu____505 = (
+
+let uu____506 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (mk_gctx uu____506))
+in (FStar_Syntax_Syntax.gen_bv "r" None uu____505))
+in (
+
+let ret1 = (
+
+let uu____514 = (
+
+let uu____520 = (
+
+let uu____521 = (
+
+let uu____524 = (
+
+let uu____525 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (mk_gctx uu____525))
+in (FStar_Syntax_Syntax.mk_Total uu____524))
+in (FStar_Syntax_Util.lcomp_of_comp uu____521))
+in FStar_Util.Inl (uu____520))
+in Some (uu____514))
+in (
+
+let outer_body = (
+
+let gamma_as_args = (args_of_binders1 gamma)
+in (
+
+let inner_body = (
+
+let uu____540 = (FStar_Syntax_Syntax.bv_to_name l)
+in (
+
+let uu____543 = (
+
+let uu____549 = (
+
+let uu____551 = (
+
+let uu____552 = (
+
+let uu____553 = (FStar_Syntax_Syntax.bv_to_name r)
+in (FStar_Syntax_Util.mk_app uu____553 gamma_as_args))
+in (FStar_Syntax_Syntax.as_arg uu____552))
+in (uu____551)::[])
+in (FStar_List.append gamma_as_args uu____549))
+in (FStar_Syntax_Util.mk_app uu____540 uu____543)))
+in (FStar_Syntax_Util.abs gamma inner_body ret1)))
+in (
+
+let uu____556 = (
+
+let uu____560 = (mk_all_implicit binders)
+in (
+
+let uu____564 = (binders_of_list1 ((((a1), (true)))::(((t1), (true)))::(((t2), (true)))::(((l), (false)))::(((r), (false)))::[]))
+in (FStar_List.append uu____560 uu____564)))
+in (FStar_Syntax_Util.abs uu____556 outer_body ret1))))))))
+in (
+
+let c_app1 = (
+
+let uu____583 = (mk_lid "app")
+in (register env1 uu____583 c_app))
+in (
+
+let c_lift1 = (
+
+let t1 = (FStar_Syntax_Syntax.gen_bv "t1" None FStar_Syntax_Util.ktype)
+in (
+
+let t2 = (FStar_Syntax_Syntax.gen_bv "t2" None FStar_Syntax_Util.ktype)
+in (
+
+let t_f = (
+
+let uu____590 = (
+
+let uu____594 = (
+
+let uu____595 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.null_binder uu____595))
+in (uu____594)::[])
+in (
+
+let uu____596 = (
+
+let uu____599 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (FStar_Syntax_Syntax.mk_GTotal uu____599))
+in (FStar_Syntax_Util.arrow uu____590 uu____596)))
+in (
+
+let f = (FStar_Syntax_Syntax.gen_bv "f" None t_f)
+in (
+
+let a11 = (
+
+let uu____602 = (
+
+let uu____603 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (mk_gctx uu____603))
+in (FStar_Syntax_Syntax.gen_bv "a1" None uu____602))
+in (
+
+let ret1 = (
+
+let uu____611 = (
+
+let uu____617 = (
+
+let uu____618 = (
+
+let uu____621 = (
+
+let uu____622 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (mk_gctx uu____622))
+in (FStar_Syntax_Syntax.mk_Total uu____621))
+in (FStar_Syntax_Util.lcomp_of_comp uu____618))
+in FStar_Util.Inl (uu____617))
+in Some (uu____611))
+in (
+
+let uu____631 = (
+
+let uu____635 = (mk_all_implicit binders)
+in (
+
+let uu____639 = (binders_of_list1 ((((a1), (true)))::(((t1), (true)))::(((t2), (true)))::(((f), (false)))::(((a11), (false)))::[]))
+in (FStar_List.append uu____635 uu____639)))
+in (
+
+let uu____657 = (
+
+let uu____658 = (
+
+let uu____664 = (
+
+let uu____666 = (
+
+let uu____669 = (
+
+let uu____675 = (
+
+let uu____677 = (FStar_Syntax_Syntax.bv_to_name f)
+in (uu____677)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____675))
+in (FStar_Syntax_Util.mk_app c_pure1 uu____669))
+in (
+
+let uu____678 = (
+
+let uu____682 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (uu____682)::[])
+in (uu____666)::uu____678))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____664))
+in (FStar_Syntax_Util.mk_app c_app1 uu____658))
+in (FStar_Syntax_Util.abs uu____631 uu____657 ret1)))))))))
+in (
+
+let c_lift11 = (
+
+let uu____686 = (mk_lid "lift1")
+in (register env1 uu____686 c_lift1))
+in (
+
+let c_lift2 = (
+
+let t1 = (FStar_Syntax_Syntax.gen_bv "t1" None FStar_Syntax_Util.ktype)
+in (
+
+let t2 = (FStar_Syntax_Syntax.gen_bv "t2" None FStar_Syntax_Util.ktype)
+in (
+
+let t3 = (FStar_Syntax_Syntax.gen_bv "t3" None FStar_Syntax_Util.ktype)
+in (
+
+let t_f = (
+
+let uu____694 = (
+
+let uu____698 = (
+
+let uu____699 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.null_binder uu____699))
+in (
+
+let uu____700 = (
+
+let uu____702 = (
+
+let uu____703 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (FStar_Syntax_Syntax.null_binder uu____703))
+in (uu____702)::[])
+in (uu____698)::uu____700))
+in (
+
+let uu____704 = (
+
+let uu____707 = (FStar_Syntax_Syntax.bv_to_name t3)
+in (FStar_Syntax_Syntax.mk_GTotal uu____707))
+in (FStar_Syntax_Util.arrow uu____694 uu____704)))
+in (
+
+let f = (FStar_Syntax_Syntax.gen_bv "f" None t_f)
+in (
+
+let a11 = (
+
+let uu____710 = (
+
+let uu____711 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (mk_gctx uu____711))
+in (FStar_Syntax_Syntax.gen_bv "a1" None uu____710))
+in (
+
+let a2 = (
+
+let uu____713 = (
+
+let uu____714 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (mk_gctx uu____714))
+in (FStar_Syntax_Syntax.gen_bv "a2" None uu____713))
+in (
+
+let ret1 = (
+
+let uu____722 = (
+
+let uu____728 = (
+
+let uu____729 = (
+
+let uu____732 = (
+
+let uu____733 = (FStar_Syntax_Syntax.bv_to_name t3)
+in (mk_gctx uu____733))
+in (FStar_Syntax_Syntax.mk_Total uu____732))
+in (FStar_Syntax_Util.lcomp_of_comp uu____729))
+in FStar_Util.Inl (uu____728))
+in Some (uu____722))
+in (
+
+let uu____742 = (
+
+let uu____746 = (mk_all_implicit binders)
+in (
+
+let uu____750 = (binders_of_list1 ((((a1), (true)))::(((t1), (true)))::(((t2), (true)))::(((t3), (true)))::(((f), (false)))::(((a11), (false)))::(((a2), (false)))::[]))
+in (FStar_List.append uu____746 uu____750)))
+in (
+
+let uu____772 = (
+
+let uu____773 = (
+
+let uu____779 = (
+
+let uu____781 = (
+
+let uu____784 = (
+
+let uu____790 = (
+
+let uu____792 = (
+
+let uu____795 = (
+
+let uu____801 = (
+
+let uu____803 = (FStar_Syntax_Syntax.bv_to_name f)
+in (uu____803)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____801))
+in (FStar_Syntax_Util.mk_app c_pure1 uu____795))
+in (
+
+let uu____804 = (
+
+let uu____808 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (uu____808)::[])
+in (uu____792)::uu____804))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____790))
+in (FStar_Syntax_Util.mk_app c_app1 uu____784))
+in (
+
+let uu____811 = (
+
+let uu____815 = (FStar_Syntax_Syntax.bv_to_name a2)
+in (uu____815)::[])
+in (uu____781)::uu____811))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____779))
+in (FStar_Syntax_Util.mk_app c_app1 uu____773))
+in (FStar_Syntax_Util.abs uu____742 uu____772 ret1)))))))))))
+in (
+
+let c_lift21 = (
+
+let uu____819 = (mk_lid "lift2")
+in (register env1 uu____819 c_lift2))
+in (
+
+let c_push = (
+
+let t1 = (FStar_Syntax_Syntax.gen_bv "t1" None FStar_Syntax_Util.ktype)
+in (
+
+let t2 = (FStar_Syntax_Syntax.gen_bv "t2" None FStar_Syntax_Util.ktype)
+in (
+
+let t_f = (
+
+let uu____826 = (
+
+let uu____830 = (
+
+let uu____831 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.null_binder uu____831))
+in (uu____830)::[])
+in (
+
+let uu____832 = (
+
+let uu____835 = (
+
+let uu____836 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (mk_gctx uu____836))
+in (FStar_Syntax_Syntax.mk_Total uu____835))
+in (FStar_Syntax_Util.arrow uu____826 uu____832)))
+in (
+
+let f = (FStar_Syntax_Syntax.gen_bv "f" None t_f)
+in (
+
+let ret1 = (
+
+let uu____845 = (
+
+let uu____851 = (
+
+let uu____852 = (
+
+let uu____855 = (
+
+let uu____856 = (
+
+let uu____857 = (
+
+let uu____861 = (
+
+let uu____862 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.null_binder uu____862))
+in (uu____861)::[])
+in (
+
+let uu____863 = (
+
+let uu____866 = (FStar_Syntax_Syntax.bv_to_name t2)
+in (FStar_Syntax_Syntax.mk_GTotal uu____866))
+in (FStar_Syntax_Util.arrow uu____857 uu____863)))
+in (mk_ctx uu____856))
+in (FStar_Syntax_Syntax.mk_Total uu____855))
+in (FStar_Syntax_Util.lcomp_of_comp uu____852))
+in FStar_Util.Inl (uu____851))
+in Some (uu____845))
+in (
+
+let e1 = (
+
+let uu____876 = (FStar_Syntax_Syntax.bv_to_name t1)
+in (FStar_Syntax_Syntax.gen_bv "e1" None uu____876))
+in (
+
+let body = (
+
+let uu____878 = (
+
+let uu____882 = (
+
+let uu____886 = (FStar_Syntax_Syntax.mk_binder e1)
+in (uu____886)::[])
+in (FStar_List.append gamma uu____882))
+in (
+
+let uu____889 = (
+
+let uu____890 = (FStar_Syntax_Syntax.bv_to_name f)
+in (
+
+let uu____893 = (
+
+let uu____899 = (
+
+let uu____900 = (FStar_Syntax_Syntax.bv_to_name e1)
+in (FStar_Syntax_Syntax.as_arg uu____900))
+in (
+
+let uu____901 = (args_of_binders1 gamma)
+in (uu____899)::uu____901))
+in (FStar_Syntax_Util.mk_app uu____890 uu____893)))
+in (FStar_Syntax_Util.abs uu____878 uu____889 ret1)))
+in (
+
+let uu____903 = (
+
+let uu____907 = (mk_all_implicit binders)
+in (
+
+let uu____911 = (binders_of_list1 ((((a1), (true)))::(((t1), (true)))::(((t2), (true)))::(((f), (false)))::[]))
+in (FStar_List.append uu____907 uu____911)))
+in (FStar_Syntax_Util.abs uu____903 body ret1)))))))))
+in (
+
+let c_push1 = (
+
+let uu____928 = (mk_lid "push")
+in (register env1 uu____928 c_push))
+in (
+
+let ret_tot_wp_a = (
+
+let uu____936 = (
+
+let uu____942 = (
+
+let uu____943 = (FStar_Syntax_Syntax.mk_Total wp_a1)
+in (FStar_Syntax_Util.lcomp_of_comp uu____943))
+in FStar_Util.Inl (uu____942))
+in Some (uu____936))
+in (
+
+let mk_generic_app = (fun c -> (match (((FStar_List.length binders) > (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let uu____971 = (
+
+let uu____972 = (
+
+let uu____982 = (args_of_binders1 binders)
+in ((c), (uu____982)))
+in FStar_Syntax_Syntax.Tm_app (uu____972))
+in (mk1 uu____971))
+end
+| uu____987 -> begin
+c
+end))
+in (
+
+let wp_if_then_else = (
+
+let result_comp = (
+
+let uu____990 = (
+
+let uu____991 = (
+
+let uu____995 = (FStar_Syntax_Syntax.null_binder wp_a1)
+in (
+
+let uu____996 = (
+
+let uu____998 = (FStar_Syntax_Syntax.null_binder wp_a1)
+in (uu____998)::[])
+in (uu____995)::uu____996))
+in (
+
+let uu____999 = (FStar_Syntax_Syntax.mk_Total wp_a1)
+in (FStar_Syntax_Util.arrow uu____991 uu____999)))
+in (FStar_Syntax_Syntax.mk_Total uu____990))
+in (
+
+let c = (FStar_Syntax_Syntax.gen_bv "c" None FStar_Syntax_Util.ktype)
+in (
+
+let uu____1003 = (
+
+let uu____1007 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(c)::[]))
+in (FStar_List.append binders uu____1007))
+in (
+
+let uu____1013 = (
+
+let l_ite = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.ite_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "2"))) None)
+in (
+
+let uu____1015 = (
+
+let uu____1018 = (
+
+let uu____1024 = (
+
+let uu____1026 = (
+
+let uu____1029 = (
+
+let uu____1035 = (
+
+let uu____1036 = (FStar_Syntax_Syntax.bv_to_name c)
+in (FStar_Syntax_Syntax.as_arg uu____1036))
+in (uu____1035)::[])
+in (FStar_Syntax_Util.mk_app l_ite uu____1029))
+in (uu____1026)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1024))
+in (FStar_Syntax_Util.mk_app c_lift21 uu____1018))
+in (FStar_Syntax_Util.ascribe uu____1015 ((FStar_Util.Inr (result_comp)), (None)))))
+in (FStar_Syntax_Util.abs uu____1003 uu____1013 (Some (FStar_Util.Inl ((FStar_Syntax_Util.lcomp_of_comp result_comp)))))))))
+in (
+
+let wp_if_then_else1 = (
+
+let uu____1061 = (mk_lid "wp_if_then_else")
+in (register env1 uu____1061 wp_if_then_else))
+in (
+
+let wp_if_then_else2 = (mk_generic_app wp_if_then_else1)
+in (
+
+let wp_assert = (
+
+let q = (FStar_Syntax_Syntax.gen_bv "q" None FStar_Syntax_Util.ktype)
+in (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp" None wp_a1)
+in (
+
+let l_and = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.and_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in (
+
+let body = (
+
+let uu____1072 = (
+
+let uu____1078 = (
+
+let uu____1080 = (
+
+let uu____1083 = (
+
+let uu____1089 = (
+
+let uu____1091 = (
+
+let uu____1094 = (
+
+let uu____1100 = (
+
+let uu____1101 = (FStar_Syntax_Syntax.bv_to_name q)
+in (FStar_Syntax_Syntax.as_arg uu____1101))
+in (uu____1100)::[])
+in (FStar_Syntax_Util.mk_app l_and uu____1094))
+in (uu____1091)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1089))
+in (FStar_Syntax_Util.mk_app c_pure1 uu____1083))
+in (
+
+let uu____1106 = (
+
+let uu____1110 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (uu____1110)::[])
+in (uu____1080)::uu____1106))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1078))
+in (FStar_Syntax_Util.mk_app c_app1 uu____1072))
+in (
+
+let uu____1113 = (
+
+let uu____1117 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(q)::(wp)::[]))
+in (FStar_List.append binders uu____1117))
+in (FStar_Syntax_Util.abs uu____1113 body ret_tot_wp_a))))))
+in (
+
+let wp_assert1 = (
+
+let uu____1124 = (mk_lid "wp_assert")
+in (register env1 uu____1124 wp_assert))
+in (
+
+let wp_assert2 = (mk_generic_app wp_assert1)
+in (
+
+let wp_assume = (
+
+let q = (FStar_Syntax_Syntax.gen_bv "q" None FStar_Syntax_Util.ktype)
+in (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp" None wp_a1)
+in (
+
+let l_imp = (FStar_Syntax_Syntax.fvar FStar_Syntax_Const.imp_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in (
+
+let body = (
+
+let uu____1135 = (
+
+let uu____1141 = (
+
+let uu____1143 = (
+
+let uu____1146 = (
+
+let uu____1152 = (
+
+let uu____1154 = (
+
+let uu____1157 = (
+
+let uu____1163 = (
+
+let uu____1164 = (FStar_Syntax_Syntax.bv_to_name q)
+in (FStar_Syntax_Syntax.as_arg uu____1164))
+in (uu____1163)::[])
+in (FStar_Syntax_Util.mk_app l_imp uu____1157))
+in (uu____1154)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1152))
+in (FStar_Syntax_Util.mk_app c_pure1 uu____1146))
+in (
+
+let uu____1169 = (
+
+let uu____1173 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (uu____1173)::[])
+in (uu____1143)::uu____1169))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1141))
+in (FStar_Syntax_Util.mk_app c_app1 uu____1135))
+in (
+
+let uu____1176 = (
+
+let uu____1180 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(q)::(wp)::[]))
+in (FStar_List.append binders uu____1180))
+in (FStar_Syntax_Util.abs uu____1176 body ret_tot_wp_a))))))
+in (
+
+let wp_assume1 = (
+
+let uu____1187 = (mk_lid "wp_assume")
+in (register env1 uu____1187 wp_assume))
+in (
+
+let wp_assume2 = (mk_generic_app wp_assume1)
+in (
+
+let wp_close = (
+
+let b = (FStar_Syntax_Syntax.gen_bv "b" None FStar_Syntax_Util.ktype)
+in (
+
+let t_f = (
+
+let uu____1196 = (
+
+let uu____1200 = (
+
+let uu____1201 = (FStar_Syntax_Syntax.bv_to_name b)
+in (FStar_Syntax_Syntax.null_binder uu____1201))
+in (uu____1200)::[])
+in (
+
+let uu____1202 = (FStar_Syntax_Syntax.mk_Total wp_a1)
+in (FStar_Syntax_Util.arrow uu____1196 uu____1202)))
+in (
+
+let f = (FStar_Syntax_Syntax.gen_bv "f" None t_f)
+in (
+
+let body = (
+
+let uu____1209 = (
+
+let uu____1215 = (
+
+let uu____1217 = (
+
+let uu____1220 = (FStar_List.map FStar_Syntax_Syntax.as_arg ((FStar_Syntax_Util.tforall)::[]))
+in (FStar_Syntax_Util.mk_app c_pure1 uu____1220))
+in (
+
+let uu____1226 = (
+
+let uu____1230 = (
+
+let uu____1233 = (
+
+let uu____1239 = (
+
+let uu____1241 = (FStar_Syntax_Syntax.bv_to_name f)
+in (uu____1241)::[])
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1239))
+in (FStar_Syntax_Util.mk_app c_push1 uu____1233))
+in (uu____1230)::[])
+in (uu____1217)::uu____1226))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1215))
+in (FStar_Syntax_Util.mk_app c_app1 uu____1209))
+in (
+
+let uu____1248 = (
+
+let uu____1252 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(b)::(f)::[]))
+in (FStar_List.append binders uu____1252))
+in (FStar_Syntax_Util.abs uu____1248 body ret_tot_wp_a))))))
+in (
+
+let wp_close1 = (
+
+let uu____1259 = (mk_lid "wp_close")
+in (register env1 uu____1259 wp_close))
+in (
+
+let wp_close2 = (mk_generic_app wp_close1)
+in (
+
+let ret_tot_type = (
+
+let uu____1270 = (
+
+let uu____1276 = (
+
+let uu____1277 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____1277))
+in FStar_Util.Inl (uu____1276))
+in Some (uu____1270))
+in (
+
+let ret_gtot_type = (
+
+let uu____1297 = (
+
+let uu____1303 = (
+
+let uu____1304 = (FStar_Syntax_Syntax.mk_GTotal FStar_Syntax_Util.ktype)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____1304))
+in FStar_Util.Inl (uu____1303))
+in Some (uu____1297))
+in (
+
+let mk_forall1 = (fun x body -> (
+
+let uu____1324 = (
+
+let uu____1327 = (
+
+let uu____1328 = (
+
+let uu____1338 = (
+
+let uu____1340 = (
+
+let uu____1341 = (
+
+let uu____1342 = (
+
+let uu____1346 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____1346)::[])
+in (FStar_Syntax_Util.abs uu____1342 body ret_tot_type))
+in (FStar_Syntax_Syntax.as_arg uu____1341))
+in (uu____1340)::[])
+in ((FStar_Syntax_Util.tforall), (uu____1338)))
+in FStar_Syntax_Syntax.Tm_app (uu____1328))
+in (FStar_Syntax_Syntax.mk uu____1327))
+in (uu____1324 None FStar_Range.dummyRange)))
+in (
+
+let rec is_discrete = (fun t -> (
+
+let uu____1360 = (
+
+let uu____1361 = (FStar_Syntax_Subst.compress t)
+in uu____1361.FStar_Syntax_Syntax.n)
+in (match (uu____1360) with
+| FStar_Syntax_Syntax.Tm_type (uu____1364) -> begin
+false
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+((FStar_List.for_all (fun uu____1379 -> (match (uu____1379) with
+| (b, uu____1383) -> begin
+(is_discrete b.FStar_Syntax_Syntax.sort)
+end)) bs) && (is_discrete (FStar_Syntax_Util.comp_result c)))
+end
+| uu____1384 -> begin
+true
+end)))
+in (
+
+let rec is_monotonic = (fun t -> (
+
+let uu____1389 = (
+
+let uu____1390 = (FStar_Syntax_Subst.compress t)
+in uu____1390.FStar_Syntax_Syntax.n)
+in (match (uu____1389) with
+| FStar_Syntax_Syntax.Tm_type (uu____1393) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+((FStar_List.for_all (fun uu____1408 -> (match (uu____1408) with
+| (b, uu____1412) -> begin
+(is_discrete b.FStar_Syntax_Syntax.sort)
+end)) bs) && (is_monotonic (FStar_Syntax_Util.comp_result c)))
+end
+| uu____1413 -> begin
+(is_discrete t)
+end)))
+in (
+
+let rec mk_rel = (fun rel t x y -> (
+
+let mk_rel1 = (mk_rel rel)
+in (
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env1 t)
+in (
+
+let uu____1465 = (
+
+let uu____1466 = (FStar_Syntax_Subst.compress t1)
+in uu____1466.FStar_Syntax_Syntax.n)
+in (match (uu____1465) with
+| FStar_Syntax_Syntax.Tm_type (uu____1469) -> begin
+(rel x y)
+end
+| (FStar_Syntax_Syntax.Tm_arrow ((binder)::[], {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal (b, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) | (FStar_Syntax_Syntax.Tm_arrow ((binder)::[], {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total (b, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) -> begin
+(
+
+let a2 = (Prims.fst binder).FStar_Syntax_Syntax.sort
+in (
+
+let uu____1515 = ((is_monotonic a2) || (is_monotonic b))
+in (match (uu____1515) with
+| true -> begin
+(
+
+let a11 = (FStar_Syntax_Syntax.gen_bv "a1" None a2)
+in (
+
+let body = (
+
+let uu____1518 = (
+
+let uu____1521 = (
+
+let uu____1527 = (
+
+let uu____1528 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (FStar_Syntax_Syntax.as_arg uu____1528))
+in (uu____1527)::[])
+in (FStar_Syntax_Util.mk_app x uu____1521))
+in (
+
+let uu____1529 = (
+
+let uu____1532 = (
+
+let uu____1538 = (
+
+let uu____1539 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (FStar_Syntax_Syntax.as_arg uu____1539))
+in (uu____1538)::[])
+in (FStar_Syntax_Util.mk_app y uu____1532))
+in (mk_rel1 b uu____1518 uu____1529)))
+in (mk_forall1 a11 body)))
+end
+| uu____1540 -> begin
+(
+
+let a11 = (FStar_Syntax_Syntax.gen_bv "a1" None a2)
+in (
+
+let a21 = (FStar_Syntax_Syntax.gen_bv "a2" None a2)
+in (
+
+let body = (
+
+let uu____1544 = (
+
+let uu____1545 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (
+
+let uu____1548 = (FStar_Syntax_Syntax.bv_to_name a21)
+in (mk_rel1 a2 uu____1545 uu____1548)))
+in (
+
+let uu____1551 = (
+
+let uu____1552 = (
+
+let uu____1555 = (
+
+let uu____1561 = (
+
+let uu____1562 = (FStar_Syntax_Syntax.bv_to_name a11)
+in (FStar_Syntax_Syntax.as_arg uu____1562))
+in (uu____1561)::[])
+in (FStar_Syntax_Util.mk_app x uu____1555))
+in (
+
+let uu____1563 = (
+
+let uu____1566 = (
+
+let uu____1572 = (
+
+let uu____1573 = (FStar_Syntax_Syntax.bv_to_name a21)
+in (FStar_Syntax_Syntax.as_arg uu____1573))
+in (uu____1572)::[])
+in (FStar_Syntax_Util.mk_app y uu____1566))
+in (mk_rel1 b uu____1552 uu____1563)))
+in (FStar_Syntax_Util.mk_imp uu____1544 uu____1551)))
+in (
+
+let uu____1574 = (mk_forall1 a21 body)
+in (mk_forall1 a11 uu____1574)))))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_arrow ((binder)::binders1, comp) -> begin
+(
+
+let t2 = (
+
+let uu___98_1595 = t1
+in (
+
+let uu____1596 = (
+
+let uu____1597 = (
+
+let uu____1605 = (
+
+let uu____1606 = (FStar_Syntax_Util.arrow binders1 comp)
+in (FStar_Syntax_Syntax.mk_Total uu____1606))
+in (((binder)::[]), (uu____1605)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____1597))
+in {FStar_Syntax_Syntax.n = uu____1596; FStar_Syntax_Syntax.tk = uu___98_1595.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___98_1595.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___98_1595.FStar_Syntax_Syntax.vars}))
+in (mk_rel1 t2 x y))
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____1618) -> begin
+(failwith "unhandled arrow")
+end
+| uu____1626 -> begin
+(FStar_Syntax_Util.mk_untyped_eq2 x y)
+end)))))
+in (
+
+let stronger = (
+
+let wp1 = (FStar_Syntax_Syntax.gen_bv "wp1" None wp_a1)
+in (
+
+let wp2 = (FStar_Syntax_Syntax.gen_bv "wp2" None wp_a1)
+in (
+
+let rec mk_stronger = (fun t x y -> (
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env1 t)
+in (
+
+let uu____1641 = (
+
+let uu____1642 = (FStar_Syntax_Subst.compress t1)
+in uu____1642.FStar_Syntax_Syntax.n)
+in (match (uu____1641) with
+| FStar_Syntax_Syntax.Tm_type (uu____1645) -> begin
+(FStar_Syntax_Util.mk_imp x y)
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) when (
+
+let uu____1662 = (FStar_Syntax_Subst.compress head1)
+in (FStar_Syntax_Util.is_tuple_constructor uu____1662)) -> begin
+(
+
+let project = (fun i tuple -> (
+
+let projector = (
+
+let uu____1677 = (
+
+let uu____1678 = (FStar_Syntax_Util.mk_tuple_data_lid (FStar_List.length args) FStar_Range.dummyRange)
+in (FStar_TypeChecker_Env.lookup_projector env1 uu____1678 i))
+in (FStar_Syntax_Syntax.fvar uu____1677 (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None))
+in (FStar_Syntax_Util.mk_app projector ((((tuple), (None)))::[]))))
+in (
+
+let uu____1699 = (
+
+let uu____1703 = (FStar_List.mapi (fun i uu____1708 -> (match (uu____1708) with
+| (t2, q) -> begin
+(
+
+let uu____1713 = (project i x)
+in (
+
+let uu____1714 = (project i y)
+in (mk_stronger t2 uu____1713 uu____1714)))
+end)) args)
+in (match (uu____1703) with
+| [] -> begin
+(failwith "Impossible : Empty application when creating stronger relation in DM4F")
+end
+| (rel0)::rels -> begin
+((rel0), (rels))
+end))
+in (match (uu____1699) with
+| (rel0, rels) -> begin
+(FStar_List.fold_left FStar_Syntax_Util.mk_conj rel0 rels)
+end)))
+end
+| (FStar_Syntax_Syntax.Tm_arrow (binders1, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal (b, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) | (FStar_Syntax_Syntax.Tm_arrow (binders1, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total (b, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) -> begin
+(
+
+let bvs = (FStar_List.mapi (fun i uu____1770 -> (match (uu____1770) with
+| (bv, q) -> begin
+(
+
+let uu____1775 = (
+
+let uu____1776 = (FStar_Util.string_of_int i)
+in (Prims.strcat "a" uu____1776))
+in (FStar_Syntax_Syntax.gen_bv uu____1775 None bv.FStar_Syntax_Syntax.sort))
+end)) binders1)
+in (
+
+let args = (FStar_List.map (fun ai -> (
+
+let uu____1780 = (FStar_Syntax_Syntax.bv_to_name ai)
+in (FStar_Syntax_Syntax.as_arg uu____1780))) bvs)
+in (
+
+let body = (
+
+let uu____1782 = (FStar_Syntax_Util.mk_app x args)
+in (
+
+let uu____1783 = (FStar_Syntax_Util.mk_app y args)
+in (mk_stronger b uu____1782 uu____1783)))
+in (FStar_List.fold_right (fun bv body1 -> (mk_forall1 bv body1)) bvs body))))
+end
+| uu____1786 -> begin
+(failwith "Not a DM elaborated type")
+end))))
+in (
+
+let body = (
+
+let uu____1788 = (FStar_Syntax_Util.unascribe wp_a1)
+in (
+
+let uu____1789 = (FStar_Syntax_Syntax.bv_to_name wp1)
+in (
+
+let uu____1790 = (FStar_Syntax_Syntax.bv_to_name wp2)
+in (mk_stronger uu____1788 uu____1789 uu____1790))))
+in (
+
+let uu____1791 = (
+
+let uu____1795 = (binders_of_list1 ((((a1), (false)))::(((wp1), (false)))::(((wp2), (false)))::[]))
+in (FStar_List.append binders uu____1795))
+in (FStar_Syntax_Util.abs uu____1791 body ret_tot_type))))))
+in (
+
+let stronger1 = (
+
+let uu____1810 = (mk_lid "stronger")
+in (register env1 uu____1810 stronger))
+in (
+
+let stronger2 = (mk_generic_app stronger1)
+in (
+
+let wp_ite = (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp" None wp_a1)
+in (
+
+let uu____1816 = (FStar_Util.prefix gamma)
+in (match (uu____1816) with
+| (wp_args, post) -> begin
+(
+
+let k = (FStar_Syntax_Syntax.gen_bv "k" None (Prims.fst post).FStar_Syntax_Syntax.sort)
+in (
+
+let equiv = (
+
+let k_tm = (FStar_Syntax_Syntax.bv_to_name k)
+in (
+
+let eq1 = (
+
+let uu____1842 = (FStar_Syntax_Syntax.bv_to_name (Prims.fst post))
+in (mk_rel FStar_Syntax_Util.mk_iff k.FStar_Syntax_Syntax.sort k_tm uu____1842))
+in (
+
+let uu____1845 = (FStar_Syntax_Util.destruct_typ_as_formula eq1)
+in (match (uu____1845) with
+| Some (FStar_Syntax_Util.QAll (binders1, [], body)) -> begin
+(
+
+let k_app = (
+
+let uu____1853 = (args_of_binders1 binders1)
+in (FStar_Syntax_Util.mk_app k_tm uu____1853))
+in (
+
+let guard_free1 = (
+
+let uu____1860 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.guard_free FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____1860))
+in (
+
+let pat = (
+
+let uu____1864 = (
+
+let uu____1870 = (FStar_Syntax_Syntax.as_arg k_app)
+in (uu____1870)::[])
+in (FStar_Syntax_Util.mk_app guard_free1 uu____1864))
+in (
+
+let pattern_guarded_body = (
+
+let uu____1874 = (
+
+let uu____1875 = (
+
+let uu____1880 = (
+
+let uu____1881 = (
+
+let uu____1888 = (
+
+let uu____1890 = (FStar_Syntax_Syntax.as_arg pat)
+in (uu____1890)::[])
+in (uu____1888)::[])
+in FStar_Syntax_Syntax.Meta_pattern (uu____1881))
+in ((body), (uu____1880)))
+in FStar_Syntax_Syntax.Tm_meta (uu____1875))
+in (mk1 uu____1874))
+in (FStar_Syntax_Util.close_forall_no_univs binders1 pattern_guarded_body)))))
+end
+| uu____1893 -> begin
+(failwith "Impossible: Expected the equivalence to be a quantified formula")
+end))))
+in (
+
+let body = (
+
+let uu____1896 = (
+
+let uu____1897 = (
+
+let uu____1898 = (
+
+let uu____1899 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (
+
+let uu____1902 = (
+
+let uu____1908 = (args_of_binders1 wp_args)
+in (
+
+let uu____1910 = (
+
+let uu____1912 = (
+
+let uu____1913 = (FStar_Syntax_Syntax.bv_to_name k)
+in (FStar_Syntax_Syntax.as_arg uu____1913))
+in (uu____1912)::[])
+in (FStar_List.append uu____1908 uu____1910)))
+in (FStar_Syntax_Util.mk_app uu____1899 uu____1902)))
+in (FStar_Syntax_Util.mk_imp equiv uu____1898))
+in (FStar_Syntax_Util.mk_forall_no_univ k uu____1897))
+in (FStar_Syntax_Util.abs gamma uu____1896 ret_gtot_type))
+in (
+
+let uu____1914 = (
+
+let uu____1918 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(wp)::[]))
+in (FStar_List.append binders uu____1918))
+in (FStar_Syntax_Util.abs uu____1914 body ret_gtot_type)))))
+end)))
+in (
+
+let wp_ite1 = (
+
+let uu____1925 = (mk_lid "wp_ite")
+in (register env1 uu____1925 wp_ite))
+in (
+
+let wp_ite2 = (mk_generic_app wp_ite1)
+in (
+
+let null_wp = (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp" None wp_a1)
+in (
+
+let uu____1931 = (FStar_Util.prefix gamma)
+in (match (uu____1931) with
+| (wp_args, post) -> begin
+(
+
+let x = (FStar_Syntax_Syntax.gen_bv "x" None FStar_Syntax_Syntax.tun)
+in (
+
+let body = (
+
+let uu____1955 = (
+
+let uu____1956 = (FStar_All.pipe_left FStar_Syntax_Syntax.bv_to_name (Prims.fst post))
+in (
+
+let uu____1959 = (
+
+let uu____1965 = (
+
+let uu____1966 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_Syntax_Syntax.as_arg uu____1966))
+in (uu____1965)::[])
+in (FStar_Syntax_Util.mk_app uu____1956 uu____1959)))
+in (FStar_Syntax_Util.mk_forall_no_univ x uu____1955))
+in (
+
+let uu____1967 = (
+
+let uu____1971 = (
+
+let uu____1975 = (FStar_Syntax_Syntax.binders_of_list ((a1)::[]))
+in (FStar_List.append uu____1975 gamma))
+in (FStar_List.append binders uu____1971))
+in (FStar_Syntax_Util.abs uu____1967 body ret_gtot_type))))
+end)))
+in (
+
+let null_wp1 = (
+
+let uu____1984 = (mk_lid "null_wp")
+in (register env1 uu____1984 null_wp))
+in (
+
+let null_wp2 = (mk_generic_app null_wp1)
+in (
+
+let wp_trivial = (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp" None wp_a1)
+in (
+
+let body = (
+
+let uu____1993 = (
+
+let uu____1999 = (
+
+let uu____2001 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (
+
+let uu____2002 = (
+
+let uu____2004 = (
+
+let uu____2007 = (
+
+let uu____2013 = (
+
+let uu____2014 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (FStar_Syntax_Syntax.as_arg uu____2014))
+in (uu____2013)::[])
+in (FStar_Syntax_Util.mk_app null_wp2 uu____2007))
+in (
+
+let uu____2015 = (
+
+let uu____2019 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (uu____2019)::[])
+in (uu____2004)::uu____2015))
+in (uu____2001)::uu____2002))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____1999))
+in (FStar_Syntax_Util.mk_app stronger2 uu____1993))
+in (
+
+let uu____2022 = (
+
+let uu____2026 = (FStar_Syntax_Syntax.binders_of_list ((a1)::(wp)::[]))
+in (FStar_List.append binders uu____2026))
+in (FStar_Syntax_Util.abs uu____2022 body ret_tot_type))))
+in (
+
+let wp_trivial1 = (
+
+let uu____2033 = (mk_lid "wp_trivial")
+in (register env1 uu____2033 wp_trivial))
+in (
+
+let wp_trivial2 = (mk_generic_app wp_trivial1)
+in ((
+
+let uu____2038 = (FStar_TypeChecker_Env.debug env1 (FStar_Options.Other ("ED")))
+in (match (uu____2038) with
+| true -> begin
+(d "End Dijkstra monads for free")
+end
+| uu____2039 -> begin
+()
+end));
+(
+
+let c = (FStar_Syntax_Subst.close binders)
+in (
+
+let uu____2043 = (
+
+let uu____2045 = (FStar_ST.read sigelts)
+in (FStar_List.rev uu____2045))
+in (
+
+let uu____2050 = (
+
+let uu___99_2051 = ed
+in (
+
+let uu____2052 = (
+
+let uu____2053 = (c wp_if_then_else2)
+in (([]), (uu____2053)))
+in (
+
+let uu____2055 = (
+
+let uu____2056 = (c wp_ite2)
+in (([]), (uu____2056)))
+in (
+
+let uu____2058 = (
+
+let uu____2059 = (c stronger2)
+in (([]), (uu____2059)))
+in (
+
+let uu____2061 = (
+
+let uu____2062 = (c wp_close2)
+in (([]), (uu____2062)))
+in (
+
+let uu____2064 = (
+
+let uu____2065 = (c wp_assert2)
+in (([]), (uu____2065)))
+in (
+
+let uu____2067 = (
+
+let uu____2068 = (c wp_assume2)
+in (([]), (uu____2068)))
+in (
+
+let uu____2070 = (
+
+let uu____2071 = (c null_wp2)
+in (([]), (uu____2071)))
+in (
+
+let uu____2073 = (
+
+let uu____2074 = (c wp_trivial2)
+in (([]), (uu____2074)))
+in {FStar_Syntax_Syntax.qualifiers = uu___99_2051.FStar_Syntax_Syntax.qualifiers; FStar_Syntax_Syntax.cattributes = uu___99_2051.FStar_Syntax_Syntax.cattributes; FStar_Syntax_Syntax.mname = uu___99_2051.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.univs = uu___99_2051.FStar_Syntax_Syntax.univs; FStar_Syntax_Syntax.binders = uu___99_2051.FStar_Syntax_Syntax.binders; FStar_Syntax_Syntax.signature = uu___99_2051.FStar_Syntax_Syntax.signature; FStar_Syntax_Syntax.ret_wp = uu___99_2051.FStar_Syntax_Syntax.ret_wp; FStar_Syntax_Syntax.bind_wp = uu___99_2051.FStar_Syntax_Syntax.bind_wp; FStar_Syntax_Syntax.if_then_else = uu____2052; FStar_Syntax_Syntax.ite_wp = uu____2055; FStar_Syntax_Syntax.stronger = uu____2058; FStar_Syntax_Syntax.close_wp = uu____2061; FStar_Syntax_Syntax.assert_p = uu____2064; FStar_Syntax_Syntax.assume_p = uu____2067; FStar_Syntax_Syntax.null_wp = uu____2070; FStar_Syntax_Syntax.trivial = uu____2073; FStar_Syntax_Syntax.repr = uu___99_2051.FStar_Syntax_Syntax.repr; FStar_Syntax_Syntax.return_repr = uu___99_2051.FStar_Syntax_Syntax.return_repr; FStar_Syntax_Syntax.bind_repr = uu___99_2051.FStar_Syntax_Syntax.bind_repr; FStar_Syntax_Syntax.actions = uu___99_2051.FStar_Syntax_Syntax.actions})))))))))
+in ((uu____2043), (uu____2050)))));
+)))))))))))))))))))))))))))))))))))))))))))
+end)))))))));
+))));
+)))))
+
+
+type env_ =
+env
+
+
+let get_env : env  ->  FStar_TypeChecker_Env.env = (fun env -> env.env)
+
 type nm =
-  | N of FStar_Syntax_Syntax.typ
-  | M of FStar_Syntax_Syntax.typ
-let uu___is_N: nm -> Prims.bool =
-  fun projectee  -> match projectee with | N _0 -> true | uu____2090 -> false
-let __proj__N__item___0: nm -> FStar_Syntax_Syntax.typ =
-  fun projectee  -> match projectee with | N _0 -> _0
-let uu___is_M: nm -> Prims.bool =
-  fun projectee  -> match projectee with | M _0 -> true | uu____2102 -> false
-let __proj__M__item___0: nm -> FStar_Syntax_Syntax.typ =
-  fun projectee  -> match projectee with | M _0 -> _0
-type nm_ = nm
-let nm_of_comp: FStar_Syntax_Syntax.comp' -> nm =
-  fun uu___86_2112  ->
-    match uu___86_2112 with
-    | FStar_Syntax_Syntax.Total (t,uu____2114) -> N t
-    | FStar_Syntax_Syntax.Comp c when
-        FStar_All.pipe_right c.FStar_Syntax_Syntax.flags
-          (FStar_Util.for_some
-             (fun uu___85_2123  ->
-                match uu___85_2123 with
-                | FStar_Syntax_Syntax.CPS  -> true
-                | uu____2124 -> false))
-        -> M (c.FStar_Syntax_Syntax.result_typ)
-    | FStar_Syntax_Syntax.Comp c ->
-        let uu____2126 =
-          let uu____2127 =
-            let uu____2128 = FStar_Syntax_Syntax.mk_Comp c in
-            FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____2128 in
-          FStar_Util.format1 "[nm_of_comp]: impossible (%s)" uu____2127 in
-        failwith uu____2126
-    | FStar_Syntax_Syntax.GTotal uu____2129 ->
-        failwith "[nm_of_comp]: impossible (GTot)"
-let string_of_nm: nm -> Prims.string =
-  fun uu___87_2137  ->
-    match uu___87_2137 with
-    | N t ->
-        let uu____2139 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "N[%s]" uu____2139
-    | M t ->
-        let uu____2141 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "M[%s]" uu____2141
-let is_monadic_arrow: FStar_Syntax_Syntax.term' -> nm =
-  fun n1  ->
-    match n1 with
-    | FStar_Syntax_Syntax.Tm_arrow
-        (uu____2145,{ FStar_Syntax_Syntax.n = n2;
-                      FStar_Syntax_Syntax.tk = uu____2147;
-                      FStar_Syntax_Syntax.pos = uu____2148;
-                      FStar_Syntax_Syntax.vars = uu____2149;_})
-        -> nm_of_comp n2
-    | uu____2160 -> failwith "unexpected_argument: [is_monadic_arrow]"
-let is_monadic_comp c =
-  let uu____2172 = nm_of_comp c.FStar_Syntax_Syntax.n in
-  match uu____2172 with | M uu____2173 -> true | N uu____2174 -> false
+| N of FStar_Syntax_Syntax.typ
+| M of FStar_Syntax_Syntax.typ
+
+
+let uu___is_N : nm  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| N (_0) -> begin
+true
+end
+| uu____2090 -> begin
+false
+end))
+
+
+let __proj__N__item___0 : nm  ->  FStar_Syntax_Syntax.typ = (fun projectee -> (match (projectee) with
+| N (_0) -> begin
+_0
+end))
+
+
+let uu___is_M : nm  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| M (_0) -> begin
+true
+end
+| uu____2102 -> begin
+false
+end))
+
+
+let __proj__M__item___0 : nm  ->  FStar_Syntax_Syntax.typ = (fun projectee -> (match (projectee) with
+| M (_0) -> begin
+_0
+end))
+
+
+type nm_ =
+nm
+
+
+let nm_of_comp : FStar_Syntax_Syntax.comp'  ->  nm = (fun uu___86_2112 -> (match (uu___86_2112) with
+| FStar_Syntax_Syntax.Total (t, uu____2114) -> begin
+N (t)
+end
+| FStar_Syntax_Syntax.Comp (c) when (FStar_All.pipe_right c.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___85_2123 -> (match (uu___85_2123) with
+| FStar_Syntax_Syntax.CPS -> begin
+true
+end
+| uu____2124 -> begin
+false
+end)))) -> begin
+M (c.FStar_Syntax_Syntax.result_typ)
+end
+| FStar_Syntax_Syntax.Comp (c) -> begin
+(
+
+let uu____2126 = (
+
+let uu____2127 = (
+
+let uu____2128 = (FStar_Syntax_Syntax.mk_Comp c)
+in (FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____2128))
+in (FStar_Util.format1 "[nm_of_comp]: impossible (%s)" uu____2127))
+in (failwith uu____2126))
+end
+| FStar_Syntax_Syntax.GTotal (uu____2129) -> begin
+(failwith "[nm_of_comp]: impossible (GTot)")
+end))
+
+
+let string_of_nm : nm  ->  Prims.string = (fun uu___87_2137 -> (match (uu___87_2137) with
+| N (t) -> begin
+(
+
+let uu____2139 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format1 "N[%s]" uu____2139))
+end
+| M (t) -> begin
+(
+
+let uu____2141 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format1 "M[%s]" uu____2141))
+end))
+
+
+let is_monadic_arrow : FStar_Syntax_Syntax.term'  ->  nm = (fun n1 -> (match (n1) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____2145, {FStar_Syntax_Syntax.n = n2; FStar_Syntax_Syntax.tk = uu____2147; FStar_Syntax_Syntax.pos = uu____2148; FStar_Syntax_Syntax.vars = uu____2149}) -> begin
+(nm_of_comp n2)
+end
+| uu____2160 -> begin
+(failwith "unexpected_argument: [is_monadic_arrow]")
+end))
+
+
+let is_monadic_comp = (fun c -> (
+
+let uu____2172 = (nm_of_comp c.FStar_Syntax_Syntax.n)
+in (match (uu____2172) with
+| M (uu____2173) -> begin
+true
+end
+| N (uu____2174) -> begin
+false
+end)))
+
 exception Not_found
-let uu___is_Not_found: Prims.exn -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Not_found  -> true | uu____2178 -> false
-let double_star:
-  FStar_Syntax_Syntax.typ ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun typ  ->
-    let star_once typ1 =
-      let uu____2188 =
-        let uu____2192 =
-          let uu____2193 = FStar_Syntax_Syntax.new_bv None typ1 in
-          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____2193 in
-        [uu____2192] in
-      let uu____2194 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-      FStar_Syntax_Util.arrow uu____2188 uu____2194 in
-    let uu____2197 = FStar_All.pipe_right typ star_once in
-    FStar_All.pipe_left star_once uu____2197
-let rec mk_star_to_type:
-  (FStar_Syntax_Syntax.term' ->
-     (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-       FStar_Syntax_Syntax.syntax)
-    ->
-    env ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax ->
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax
-  =
-  fun mk1  ->
-    fun env  ->
-      fun a  ->
-        mk1
-          (let uu____2232 =
-             let uu____2240 =
-               let uu____2244 =
-                 let uu____2247 =
-                   let uu____2248 = star_type' env a in
-                   FStar_Syntax_Syntax.null_bv uu____2248 in
-                 let uu____2249 = FStar_Syntax_Syntax.as_implicit false in
-                 (uu____2247, uu____2249) in
-               [uu____2244] in
-             let uu____2254 =
-               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-             (uu____2240, uu____2254) in
-           FStar_Syntax_Syntax.Tm_arrow uu____2232)
-and star_type':
-  env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      let mk1 x = (FStar_Syntax_Syntax.mk x) None t.FStar_Syntax_Syntax.pos in
-      let mk_star_to_type1 = mk_star_to_type mk1 in
-      let t1 = FStar_Syntax_Subst.compress t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_arrow (binders,uu____2287) ->
-          let binders1 =
-            FStar_List.map
-              (fun uu____2306  ->
-                 match uu____2306 with
-                 | (bv,aqual) ->
-                     let uu____2313 =
-                       let uu___100_2314 = bv in
-                       let uu____2315 =
-                         star_type' env bv.FStar_Syntax_Syntax.sort in
-                       {
-                         FStar_Syntax_Syntax.ppname =
-                           (uu___100_2314.FStar_Syntax_Syntax.ppname);
-                         FStar_Syntax_Syntax.index =
-                           (uu___100_2314.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____2315
-                       } in
-                     (uu____2313, aqual)) binders in
-          (match t1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_arrow
-               (uu____2318,{
-                             FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.GTotal (hn,uu____2320);
-                             FStar_Syntax_Syntax.tk = uu____2321;
-                             FStar_Syntax_Syntax.pos = uu____2322;
-                             FStar_Syntax_Syntax.vars = uu____2323;_})
-               ->
-               let uu____2340 =
-                 let uu____2341 =
-                   let uu____2349 =
-                     let uu____2350 = star_type' env hn in
-                     FStar_Syntax_Syntax.mk_GTotal uu____2350 in
-                   (binders1, uu____2349) in
-                 FStar_Syntax_Syntax.Tm_arrow uu____2341 in
-               mk1 uu____2340
-           | uu____2354 ->
-               let uu____2355 = is_monadic_arrow t1.FStar_Syntax_Syntax.n in
-               (match uu____2355 with
-                | N hn ->
-                    let uu____2357 =
-                      let uu____2358 =
-                        let uu____2366 =
-                          let uu____2367 = star_type' env hn in
-                          FStar_Syntax_Syntax.mk_Total uu____2367 in
-                        (binders1, uu____2366) in
-                      FStar_Syntax_Syntax.Tm_arrow uu____2358 in
-                    mk1 uu____2357
-                | M a ->
-                    let uu____2372 =
-                      let uu____2373 =
-                        let uu____2381 =
-                          let uu____2385 =
-                            let uu____2389 =
-                              let uu____2392 =
-                                let uu____2393 = mk_star_to_type1 env a in
-                                FStar_Syntax_Syntax.null_bv uu____2393 in
-                              let uu____2394 =
-                                FStar_Syntax_Syntax.as_implicit false in
-                              (uu____2392, uu____2394) in
-                            [uu____2389] in
-                          FStar_List.append binders1 uu____2385 in
-                        let uu____2401 =
-                          FStar_Syntax_Syntax.mk_Total
-                            FStar_Syntax_Util.ktype0 in
-                        (uu____2381, uu____2401) in
-                      FStar_Syntax_Syntax.Tm_arrow uu____2373 in
-                    mk1 uu____2372))
-      | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let debug1 t2 s =
-            let string_of_set f s1 =
-              let elts = FStar_Util.set_elements s1 in
-              match elts with
-              | [] -> "{}"
-              | x::xs ->
-                  let strb = FStar_Util.new_string_builder () in
-                  (FStar_Util.string_builder_append strb "{";
-                   (let uu____2452 = f x in
-                    FStar_Util.string_builder_append strb uu____2452);
-                   FStar_List.iter
-                     (fun x1  ->
-                        FStar_Util.string_builder_append strb ", ";
-                        (let uu____2456 = f x1 in
-                         FStar_Util.string_builder_append strb uu____2456))
-                     xs;
-                   FStar_Util.string_builder_append strb "}";
-                   FStar_Util.string_of_string_builder strb) in
-            let uu____2458 = FStar_Syntax_Print.term_to_string t2 in
-            let uu____2459 = string_of_set FStar_Syntax_Print.bv_to_string s in
-            FStar_Util.print2_warning "Dependency found in term %s : %s"
-              uu____2458 uu____2459 in
-          let rec is_non_dependent_arrow ty n1 =
-            let uu____2467 =
-              let uu____2468 = FStar_Syntax_Subst.compress ty in
-              uu____2468.FStar_Syntax_Syntax.n in
-            match uu____2467 with
-            | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-                let uu____2483 =
-                  let uu____2484 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                  Prims.op_Negation uu____2484 in
-                if uu____2483
-                then false
-                else
-                  (try
-                     let non_dependent_or_raise s ty1 =
-                       let sinter =
-                         let uu____2498 = FStar_Syntax_Free.names ty1 in
-                         FStar_Util.set_intersect uu____2498 s in
-                       let uu____2500 =
-                         let uu____2501 = FStar_Util.set_is_empty sinter in
-                         Prims.op_Negation uu____2501 in
-                       if uu____2500
-                       then (debug1 ty1 sinter; Prims.raise Not_found)
-                       else () in
-                     let uu____2504 = FStar_Syntax_Subst.open_comp binders c in
-                     match uu____2504 with
-                     | (binders1,c1) ->
-                         let s =
-                           FStar_List.fold_left
-                             (fun s  ->
-                                fun uu____2515  ->
-                                  match uu____2515 with
-                                  | (bv,uu____2521) ->
-                                      (non_dependent_or_raise s
-                                         bv.FStar_Syntax_Syntax.sort;
-                                       FStar_Util.set_add bv s))
-                             FStar_Syntax_Syntax.no_names binders1 in
-                         let ct = FStar_Syntax_Util.comp_result c1 in
-                         (non_dependent_or_raise s ct;
-                          (let k = n1 - (FStar_List.length binders1) in
-                           if k > (Prims.parse_int "0")
-                           then is_non_dependent_arrow ct k
-                           else true))
-                   with | Not_found  -> false)
-            | uu____2534 ->
-                ((let uu____2536 = FStar_Syntax_Print.term_to_string ty in
-                  FStar_Util.print1_warning "Not a dependent arrow : %s"
-                    uu____2536);
-                 false) in
-          let rec is_valid_application head2 =
-            let uu____2541 =
-              let uu____2542 = FStar_Syntax_Subst.compress head2 in
-              uu____2542.FStar_Syntax_Syntax.n in
-            match uu____2541 with
-            | FStar_Syntax_Syntax.Tm_fvar fv when
-                (((FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Syntax_Const.option_lid)
-                    ||
-                    (FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Syntax_Const.either_lid))
-                   ||
-                   (FStar_Syntax_Syntax.fv_eq_lid fv
-                      FStar_Syntax_Const.eq2_lid))
-                  ||
-                  (let uu____2546 = FStar_Syntax_Subst.compress head2 in
-                   FStar_Syntax_Util.is_tuple_constructor uu____2546)
-                -> true
-            | FStar_Syntax_Syntax.Tm_fvar fv when
-                is_non_dependent_arrow
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.ty
-                  (FStar_List.length args)
-                ->
-                let res =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Inlining;
-                    FStar_TypeChecker_Normalize.UnfoldUntil
-                      FStar_Syntax_Syntax.Delta_constant] env.env t1 in
-                (match res.FStar_Syntax_Syntax.n with
-                 | FStar_Syntax_Syntax.Tm_app uu____2559 -> true
-                 | uu____2569 ->
-                     ((let uu____2571 =
-                         FStar_Syntax_Print.term_to_string head2 in
-                       FStar_Util.print1_warning
-                         "Got a term which might be a non-dependent user-defined data-type %s\n"
-                         uu____2571);
-                      false))
-            | FStar_Syntax_Syntax.Tm_bvar _|FStar_Syntax_Syntax.Tm_name _ ->
-                true
-            | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2575) ->
-                is_valid_application t2
-            | uu____2580 -> false in
-          let uu____2581 = is_valid_application head1 in
-          if uu____2581
-          then
-            let uu____2582 =
-              let uu____2583 =
-                let uu____2593 =
-                  FStar_List.map
-                    (fun uu____2603  ->
-                       match uu____2603 with
-                       | (t2,qual) ->
-                           let uu____2616 = star_type' env t2 in
-                           (uu____2616, qual)) args in
-                (head1, uu____2593) in
-              FStar_Syntax_Syntax.Tm_app uu____2583 in
-            mk1 uu____2582
-          else
-            (let uu____2623 =
-               let uu____2624 =
-                 let uu____2625 = FStar_Syntax_Print.term_to_string t1 in
-                 FStar_Util.format1
-                   "For now, only [either], [option] and [eq2] are supported in the definition language (got: %s)"
-                   uu____2625 in
-               FStar_Errors.Err uu____2624 in
-             Prims.raise uu____2623)
-      | FStar_Syntax_Syntax.Tm_bvar _
-        |FStar_Syntax_Syntax.Tm_name _
-         |FStar_Syntax_Syntax.Tm_type _|FStar_Syntax_Syntax.Tm_fvar _ -> t1
-      | FStar_Syntax_Syntax.Tm_abs (binders,repr,something) ->
-          let uu____2655 = FStar_Syntax_Subst.open_term binders repr in
-          (match uu____2655 with
-           | (binders1,repr1) ->
-               let env1 =
-                 let uu___103_2661 = env in
-                 let uu____2662 =
-                   FStar_TypeChecker_Env.push_binders env.env binders1 in
-                 {
-                   env = uu____2662;
-                   subst = (uu___103_2661.subst);
-                   tc_const = (uu___103_2661.tc_const)
-                 } in
-               let repr2 = star_type' env1 repr1 in
-               FStar_Syntax_Util.abs binders1 repr2 something)
-      | FStar_Syntax_Syntax.Tm_refine (x,t2) when false ->
-          let x1 = FStar_Syntax_Syntax.freshen_bv x in
-          let sort = star_type' env x1.FStar_Syntax_Syntax.sort in
-          let subst1 = [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x1)] in
-          let t3 = FStar_Syntax_Subst.subst subst1 t2 in
-          let t4 = star_type' env t3 in
-          let subst2 = [FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))] in
-          let t5 = FStar_Syntax_Subst.subst subst2 t4 in
-          mk1
-            (FStar_Syntax_Syntax.Tm_refine
-               ((let uu___104_2679 = x1 in
-                 {
-                   FStar_Syntax_Syntax.ppname =
-                     (uu___104_2679.FStar_Syntax_Syntax.ppname);
-                   FStar_Syntax_Syntax.index =
-                     (uu___104_2679.FStar_Syntax_Syntax.index);
-                   FStar_Syntax_Syntax.sort = sort
-                 }), t5))
-      | FStar_Syntax_Syntax.Tm_meta (t2,m) ->
-          let uu____2686 =
-            let uu____2687 =
-              let uu____2692 = star_type' env t2 in (uu____2692, m) in
-            FStar_Syntax_Syntax.Tm_meta uu____2687 in
-          mk1 uu____2686
-      | FStar_Syntax_Syntax.Tm_ascribed
-          (e,(FStar_Util.Inl t2,None ),something) ->
-          let uu____2730 =
-            let uu____2731 =
-              let uu____2749 = star_type' env e in
-              let uu____2750 =
-                let uu____2760 =
-                  let uu____2765 = star_type' env t2 in
-                  FStar_Util.Inl uu____2765 in
-                (uu____2760, None) in
-              (uu____2749, uu____2750, something) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____2731 in
-          mk1 uu____2730
-      | FStar_Syntax_Syntax.Tm_ascribed uu____2787 ->
-          let uu____2805 =
-            let uu____2806 =
-              let uu____2807 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_ascribed is outside of the definition language: %s"
-                uu____2807 in
-            FStar_Errors.Err uu____2806 in
-          Prims.raise uu____2805
-      | FStar_Syntax_Syntax.Tm_refine uu____2808 ->
-          let uu____2813 =
-            let uu____2814 =
-              let uu____2815 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_refine is outside of the definition language: %s"
-                uu____2815 in
-            FStar_Errors.Err uu____2814 in
-          Prims.raise uu____2813
-      | FStar_Syntax_Syntax.Tm_uinst uu____2816 ->
-          let uu____2821 =
-            let uu____2822 =
-              let uu____2823 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_uinst is outside of the definition language: %s"
-                uu____2823 in
-            FStar_Errors.Err uu____2822 in
-          Prims.raise uu____2821
-      | FStar_Syntax_Syntax.Tm_constant uu____2824 ->
-          let uu____2825 =
-            let uu____2826 =
-              let uu____2827 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_constant is outside of the definition language: %s"
-                uu____2827 in
-            FStar_Errors.Err uu____2826 in
-          Prims.raise uu____2825
-      | FStar_Syntax_Syntax.Tm_match uu____2828 ->
-          let uu____2844 =
-            let uu____2845 =
-              let uu____2846 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_match is outside of the definition language: %s"
-                uu____2846 in
-            FStar_Errors.Err uu____2845 in
-          Prims.raise uu____2844
-      | FStar_Syntax_Syntax.Tm_let uu____2847 ->
-          let uu____2855 =
-            let uu____2856 =
-              let uu____2857 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_let is outside of the definition language: %s" uu____2857 in
-            FStar_Errors.Err uu____2856 in
-          Prims.raise uu____2855
-      | FStar_Syntax_Syntax.Tm_uvar uu____2858 ->
-          let uu____2867 =
-            let uu____2868 =
-              let uu____2869 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_uvar is outside of the definition language: %s"
-                uu____2869 in
-            FStar_Errors.Err uu____2868 in
-          Prims.raise uu____2867
-      | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____2870 =
-            let uu____2871 =
-              let uu____2872 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1
-                "Tm_unknown is outside of the definition language: %s"
-                uu____2872 in
-            FStar_Errors.Err uu____2871 in
-          Prims.raise uu____2870
-      | FStar_Syntax_Syntax.Tm_delayed uu____2873 -> failwith "impossible"
-let is_monadic uu___89_2906 =
-  match uu___89_2906 with
-  | None  -> failwith "un-annotated lambda?!"
-  | Some (FStar_Util.Inl
-    { FStar_Syntax_Syntax.eff_name = _; FStar_Syntax_Syntax.res_typ = _;
-      FStar_Syntax_Syntax.cflags = flags; FStar_Syntax_Syntax.comp = _;_})
-    |Some (FStar_Util.Inr (_,flags)) ->
-      FStar_All.pipe_right flags
-        (FStar_Util.for_some
-           (fun uu___88_2943  ->
-              match uu___88_2943 with
-              | FStar_Syntax_Syntax.CPS  -> true
-              | uu____2944 -> false))
-let rec is_C: FStar_Syntax_Syntax.typ -> Prims.bool =
-  fun t  ->
-    let uu____2948 =
-      let uu____2949 = FStar_Syntax_Subst.compress t in
-      uu____2949.FStar_Syntax_Syntax.n in
-    match uu____2948 with
-    | FStar_Syntax_Syntax.Tm_app (head1,args) when
-        FStar_Syntax_Util.is_tuple_constructor head1 ->
-        let r =
-          let uu____2969 =
-            let uu____2970 = FStar_List.hd args in Prims.fst uu____2970 in
-          is_C uu____2969 in
-        if r
-        then
-          ((let uu____2982 =
-              let uu____2983 =
-                FStar_List.for_all
-                  (fun uu____2986  ->
-                     match uu____2986 with | (h,uu____2990) -> is_C h) args in
-              Prims.op_Negation uu____2983 in
-            if uu____2982 then failwith "not a C (A * C)" else ());
-           true)
-        else
-          ((let uu____2994 =
-              let uu____2995 =
-                FStar_List.for_all
-                  (fun uu____2998  ->
-                     match uu____2998 with
-                     | (h,uu____3002) ->
-                         let uu____3003 = is_C h in
-                         Prims.op_Negation uu____3003) args in
-              Prims.op_Negation uu____2995 in
-            if uu____2994 then failwith "not a C (C * A)" else ());
-           false)
-    | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-        let uu____3017 = nm_of_comp comp.FStar_Syntax_Syntax.n in
-        (match uu____3017 with
-         | M t1 ->
-             ((let uu____3020 = is_C t1 in
-               if uu____3020 then failwith "not a C (C -> C)" else ());
-              true)
-         | N t1 -> is_C t1)
-    | FStar_Syntax_Syntax.Tm_meta (t1,_)
-      |FStar_Syntax_Syntax.Tm_uinst (t1,_)|FStar_Syntax_Syntax.Tm_ascribed
-       (t1,_,_) -> is_C t1
-    | uu____3052 -> false
-let mk_return:
-  env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      fun e  ->
-        let mk1 x = (FStar_Syntax_Syntax.mk x) None e.FStar_Syntax_Syntax.pos in
-        let p_type = mk_star_to_type mk1 env t in
-        let p = FStar_Syntax_Syntax.gen_bv "p'" None p_type in
-        let body =
-          let uu____3083 =
-            let uu____3084 =
-              let uu____3094 = FStar_Syntax_Syntax.bv_to_name p in
-              let uu____3095 =
-                let uu____3099 =
-                  let uu____3102 = FStar_Syntax_Syntax.as_implicit false in
-                  (e, uu____3102) in
-                [uu____3099] in
-              (uu____3094, uu____3095) in
-            FStar_Syntax_Syntax.Tm_app uu____3084 in
-          mk1 uu____3083 in
-        let uu____3110 =
-          let uu____3114 = FStar_Syntax_Syntax.mk_binder p in [uu____3114] in
-        let uu____3115 =
-          let uu____3122 =
-            let uu____3128 =
-              let uu____3129 =
-                FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-              FStar_Syntax_Util.lcomp_of_comp uu____3129 in
-            FStar_Util.Inl uu____3128 in
-          Some uu____3122 in
-        FStar_Syntax_Util.abs uu____3110 body uu____3115
-let is_unknown: FStar_Syntax_Syntax.term' -> Prims.bool =
-  fun uu___90_3142  ->
-    match uu___90_3142 with
-    | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____3143 -> false
-let rec check:
-  env ->
-    FStar_Syntax_Syntax.term ->
-      nm -> (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun e  ->
-      fun context_nm  ->
-        let mk1 x = FStar_Syntax_Syntax.mk x None e.FStar_Syntax_Syntax.pos in
-        let return_if uu____3287 =
-          match uu____3287 with
-          | (rec_nm,s_e,u_e) ->
-              let check1 t1 t2 =
-                let uu____3308 =
-                  (Prims.op_Negation (is_unknown t2.FStar_Syntax_Syntax.n))
-                    &&
-                    (let uu____3309 =
-                       let uu____3310 =
-                         FStar_TypeChecker_Rel.teq env.env t1 t2 in
-                       FStar_TypeChecker_Rel.is_trivial uu____3310 in
-                     Prims.op_Negation uu____3309) in
-                if uu____3308
-                then
-                  let uu____3311 =
-                    let uu____3312 =
-                      let uu____3313 = FStar_Syntax_Print.term_to_string e in
-                      let uu____3314 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____3315 = FStar_Syntax_Print.term_to_string t2 in
-                      FStar_Util.format3
-                        "[check]: the expression [%s] has type [%s] but should have type [%s]"
-                        uu____3313 uu____3314 uu____3315 in
-                    FStar_Errors.Err uu____3312 in
-                  Prims.raise uu____3311
-                else () in
-              (match (rec_nm, context_nm) with
-               | (N t1,N t2)|(M t1,M t2) ->
-                   (check1 t1 t2; (rec_nm, s_e, u_e))
-               | (N t1,M t2) ->
-                   (check1 t1 t2;
-                    (let uu____3326 = mk_return env t1 s_e in
-                     ((M t1), uu____3326, u_e)))
-               | (M t1,N t2) ->
-                   let uu____3329 =
-                     let uu____3330 =
-                       let uu____3331 = FStar_Syntax_Print.term_to_string e in
-                       let uu____3332 = FStar_Syntax_Print.term_to_string t1 in
-                       let uu____3333 = FStar_Syntax_Print.term_to_string t2 in
-                       FStar_Util.format3
-                         "[check %s]: got an effectful computation [%s] in lieu of a pure computation [%s]"
-                         uu____3331 uu____3332 uu____3333 in
-                     FStar_Errors.Err uu____3330 in
-                   Prims.raise uu____3329) in
-        let ensure_m env1 e2 =
-          let strip_m uu___91_3359 =
-            match uu___91_3359 with
-            | (M t,s_e,u_e) -> (t, s_e, u_e)
-            | uu____3369 -> failwith "impossible" in
-          match context_nm with
-          | N t ->
-              let uu____3380 =
-                let uu____3381 =
-                  let uu____3384 =
-                    let uu____3385 = FStar_Syntax_Print.term_to_string t in
-                    Prims.strcat
-                      "let-bound monadic body has a non-monadic continuation or a branch of a match is monadic and the others aren't : "
-                      uu____3385 in
-                  (uu____3384, (e2.FStar_Syntax_Syntax.pos)) in
-                FStar_Errors.Error uu____3381 in
-              Prims.raise uu____3380
-          | M uu____3389 ->
-              let uu____3390 = check env1 e2 context_nm in strip_m uu____3390 in
-        let uu____3394 =
-          let uu____3395 = FStar_Syntax_Subst.compress e in
-          uu____3395.FStar_Syntax_Syntax.n in
-        match uu____3394 with
-        | FStar_Syntax_Syntax.Tm_bvar _
-          |FStar_Syntax_Syntax.Tm_name _
-           |FStar_Syntax_Syntax.Tm_fvar _
-            |FStar_Syntax_Syntax.Tm_abs _
-             |FStar_Syntax_Syntax.Tm_constant _|FStar_Syntax_Syntax.Tm_app _
-            -> let uu____3407 = infer env e in return_if uu____3407
-        | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
-            mk_let env binding e2
-              (fun env1  -> fun e21  -> check env1 e21 context_nm) ensure_m
-        | FStar_Syntax_Syntax.Tm_match (e0,branches) ->
-            mk_match env e0 branches
-              (fun env1  -> fun body  -> check env1 body context_nm)
-        | FStar_Syntax_Syntax.Tm_meta (e1,_)
-          |FStar_Syntax_Syntax.Tm_uinst (e1,_)
-           |FStar_Syntax_Syntax.Tm_ascribed (e1,_,_) ->
-            check env e1 context_nm
-        | FStar_Syntax_Syntax.Tm_let uu____3482 ->
-            let uu____3490 =
-              let uu____3491 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_let %s" uu____3491 in
-            failwith uu____3490
-        | FStar_Syntax_Syntax.Tm_type uu____3495 ->
-            failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_arrow uu____3499 ->
-            failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_refine uu____3510 ->
-            let uu____3515 =
-              let uu____3516 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_refine %s" uu____3516 in
-            failwith uu____3515
-        | FStar_Syntax_Syntax.Tm_uvar uu____3520 ->
-            let uu____3529 =
-              let uu____3530 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_uvar %s" uu____3530 in
-            failwith uu____3529
-        | FStar_Syntax_Syntax.Tm_delayed uu____3534 ->
-            failwith "impossible (compressed)"
-        | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____3558 =
-              let uu____3559 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_unknown %s" uu____3559 in
-            failwith uu____3558
-and infer:
-  env ->
-    FStar_Syntax_Syntax.term ->
-      (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun e  ->
-      let mk1 x = FStar_Syntax_Syntax.mk x None e.FStar_Syntax_Syntax.pos in
-      let normalize1 =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.UnfoldUntil
-            FStar_Syntax_Syntax.Delta_constant;
-          FStar_TypeChecker_Normalize.EraseUniverses] env.env in
-      let uu____3581 =
-        let uu____3582 = FStar_Syntax_Subst.compress e in
-        uu____3582.FStar_Syntax_Syntax.n in
-      match uu____3581 with
-      | FStar_Syntax_Syntax.Tm_bvar bv ->
-          failwith "I failed to open a binder... boo"
-      | FStar_Syntax_Syntax.Tm_name bv ->
-          ((N (bv.FStar_Syntax_Syntax.sort)), e, e)
-      | FStar_Syntax_Syntax.Tm_abs (binders,body,what) ->
-          let binders1 = FStar_Syntax_Subst.open_binders binders in
-          let subst1 = FStar_Syntax_Subst.opening_of_binders binders1 in
-          let body1 = FStar_Syntax_Subst.subst subst1 body in
-          let env1 =
-            let uu___105_3622 = env in
-            let uu____3623 =
-              FStar_TypeChecker_Env.push_binders env.env binders1 in
-            {
-              env = uu____3623;
-              subst = (uu___105_3622.subst);
-              tc_const = (uu___105_3622.tc_const)
-            } in
-          let s_binders =
-            FStar_List.map
-              (fun uu____3632  ->
-                 match uu____3632 with
-                 | (bv,qual) ->
-                     let sort = star_type' env1 bv.FStar_Syntax_Syntax.sort in
-                     ((let uu___106_3640 = bv in
-                       {
-                         FStar_Syntax_Syntax.ppname =
-                           (uu___106_3640.FStar_Syntax_Syntax.ppname);
-                         FStar_Syntax_Syntax.index =
-                           (uu___106_3640.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = sort
-                       }), qual)) binders1 in
-          let uu____3641 =
-            FStar_List.fold_left
-              (fun uu____3650  ->
-                 fun uu____3651  ->
-                   match (uu____3650, uu____3651) with
-                   | ((env2,acc),(bv,qual)) ->
-                       let c = bv.FStar_Syntax_Syntax.sort in
-                       let uu____3679 = is_C c in
-                       if uu____3679
-                       then
-                         let xw =
-                           let uu____3684 = star_type' env2 c in
-                           FStar_Syntax_Syntax.gen_bv
-                             (Prims.strcat
-                                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                "^w") None uu____3684 in
-                         let x =
-                           let uu___107_3686 = bv in
-                           let uu____3687 =
-                             let uu____3690 =
-                               FStar_Syntax_Syntax.bv_to_name xw in
-                             trans_F_ env2 c uu____3690 in
-                           {
-                             FStar_Syntax_Syntax.ppname =
-                               (uu___107_3686.FStar_Syntax_Syntax.ppname);
-                             FStar_Syntax_Syntax.index =
-                               (uu___107_3686.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____3687
-                           } in
-                         let env3 =
-                           let uu___108_3692 = env2 in
-                           let uu____3693 =
-                             let uu____3695 =
-                               let uu____3696 =
-                                 let uu____3701 =
-                                   FStar_Syntax_Syntax.bv_to_name xw in
-                                 (bv, uu____3701) in
-                               FStar_Syntax_Syntax.NT uu____3696 in
-                             uu____3695 :: (env2.subst) in
-                           {
-                             env = (uu___108_3692.env);
-                             subst = uu____3693;
-                             tc_const = (uu___108_3692.tc_const)
-                           } in
-                         let uu____3702 =
-                           let uu____3704 = FStar_Syntax_Syntax.mk_binder x in
-                           let uu____3705 =
-                             let uu____3707 =
-                               FStar_Syntax_Syntax.mk_binder xw in
-                             uu____3707 :: acc in
-                           uu____3704 :: uu____3705 in
-                         (env3, uu____3702)
-                       else
-                         (let x =
-                            let uu___109_3711 = bv in
-                            let uu____3712 =
-                              star_type' env2 bv.FStar_Syntax_Syntax.sort in
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (uu___109_3711.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (uu___109_3711.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = uu____3712
-                            } in
-                          let uu____3715 =
-                            let uu____3717 = FStar_Syntax_Syntax.mk_binder x in
-                            uu____3717 :: acc in
-                          (env2, uu____3715))) (env1, []) binders1 in
-          (match uu____3641 with
-           | (env2,u_binders) ->
-               let u_binders1 = FStar_List.rev u_binders in
-               let uu____3729 =
-                 let check_what =
-                   let uu____3741 = is_monadic what in
-                   if uu____3741 then check_m else check_n in
-                 let uu____3750 = check_what env2 body1 in
-                 match uu____3750 with
-                 | (t,s_body,u_body) ->
-                     let uu____3760 =
-                       let uu____3761 =
-                         let uu____3762 = is_monadic what in
-                         if uu____3762 then M t else N t in
-                       comp_of_nm uu____3761 in
-                     (uu____3760, s_body, u_body) in
-               (match uu____3729 with
-                | (comp,s_body,u_body) ->
-                    let t = FStar_Syntax_Util.arrow binders1 comp in
-                    let s_what =
-                      match what with
-                      | None  -> None
-                      | Some (FStar_Util.Inl lc) ->
-                          let uu____3805 =
-                            FStar_All.pipe_right
-                              lc.FStar_Syntax_Syntax.cflags
-                              (FStar_Util.for_some
-                                 (fun uu___92_3807  ->
-                                    match uu___92_3807 with
-                                    | FStar_Syntax_Syntax.CPS  -> true
-                                    | uu____3808 -> false)) in
-                          if uu____3805
-                          then
-                            let double_starred_comp =
-                              let uu____3816 =
-                                let uu____3817 =
-                                  let uu____3818 =
-                                    lc.FStar_Syntax_Syntax.comp () in
-                                  FStar_Syntax_Util.comp_result uu____3818 in
-                                FStar_All.pipe_left double_star uu____3817 in
-                              FStar_Syntax_Syntax.mk_Total uu____3816 in
-                            let flags =
-                              FStar_List.filter
-                                (fun uu___93_3823  ->
-                                   match uu___93_3823 with
-                                   | FStar_Syntax_Syntax.CPS  -> false
-                                   | uu____3824 -> true)
-                                lc.FStar_Syntax_Syntax.cflags in
-                            let uu____3825 =
-                              let uu____3831 =
-                                let uu____3832 =
-                                  FStar_Syntax_Util.comp_set_flags
-                                    double_starred_comp flags in
-                                FStar_Syntax_Util.lcomp_of_comp uu____3832 in
-                              FStar_Util.Inl uu____3831 in
-                            Some uu____3825
-                          else
-                            Some
-                              (FStar_Util.Inl
-                                 ((let uu___110_3852 = lc in
-                                   {
-                                     FStar_Syntax_Syntax.eff_name =
-                                       (uu___110_3852.FStar_Syntax_Syntax.eff_name);
-                                     FStar_Syntax_Syntax.res_typ =
-                                       (uu___110_3852.FStar_Syntax_Syntax.res_typ);
-                                     FStar_Syntax_Syntax.cflags =
-                                       (uu___110_3852.FStar_Syntax_Syntax.cflags);
-                                     FStar_Syntax_Syntax.comp =
-                                       (fun uu____3853  ->
-                                          let c =
-                                            lc.FStar_Syntax_Syntax.comp () in
-                                          let result_typ =
-                                            star_type' env2
-                                              (FStar_Syntax_Util.comp_result
-                                                 c) in
-                                          FStar_Syntax_Util.set_result_typ c
-                                            result_typ)
-                                   })))
-                      | Some (FStar_Util.Inr (lid,flags)) ->
-                          let uu____3870 =
-                            let uu____3876 =
-                              let uu____3880 =
-                                FStar_All.pipe_right flags
-                                  (FStar_Util.for_some
-                                     (fun uu___94_3882  ->
-                                        match uu___94_3882 with
-                                        | FStar_Syntax_Syntax.CPS  -> true
-                                        | uu____3883 -> false)) in
-                              if uu____3880
-                              then
-                                let uu____3887 =
-                                  FStar_List.filter
-                                    (fun uu___95_3889  ->
-                                       match uu___95_3889 with
-                                       | FStar_Syntax_Syntax.CPS  -> false
-                                       | uu____3890 -> true) flags in
-                                (FStar_Syntax_Const.effect_Tot_lid,
-                                  uu____3887)
-                              else (lid, flags) in
-                            FStar_Util.Inr uu____3876 in
-                          Some uu____3870 in
-                    let uu____3902 =
-                      let comp1 =
-                        let uu____3914 = is_monadic what in
-                        let uu____3915 =
-                          FStar_Syntax_Subst.subst env2.subst s_body in
-                        trans_G env2 (FStar_Syntax_Util.comp_result comp)
-                          uu____3914 uu____3915 in
-                      let uu____3916 =
-                        FStar_Syntax_Util.ascribe u_body
-                          ((FStar_Util.Inr comp1), None) in
-                      (uu____3916,
-                        (Some
-                           (FStar_Util.Inl
-                              (FStar_Syntax_Util.lcomp_of_comp comp1)))) in
-                    (match uu____3902 with
-                     | (u_body1,u_what) ->
-                         let s_body1 =
-                           FStar_Syntax_Subst.close s_binders s_body in
-                         let s_binders1 =
-                           FStar_Syntax_Subst.close_binders s_binders in
-                         let s_term =
-                           mk1
-                             (FStar_Syntax_Syntax.Tm_abs
-                                (s_binders1, s_body1, s_what)) in
-                         let u_body2 =
-                           FStar_Syntax_Subst.close u_binders1 u_body1 in
-                         let u_binders2 =
-                           FStar_Syntax_Subst.close_binders u_binders1 in
-                         let u_term =
-                           mk1
-                             (FStar_Syntax_Syntax.Tm_abs
-                                (u_binders2, u_body2, u_what)) in
-                         ((N t), s_term, u_term))))
-      | FStar_Syntax_Syntax.Tm_fvar
-          {
-            FStar_Syntax_Syntax.fv_name =
-              { FStar_Syntax_Syntax.v = lid;
-                FStar_Syntax_Syntax.ty = uu____3994;
-                FStar_Syntax_Syntax.p = uu____3995;_};
-            FStar_Syntax_Syntax.fv_delta = uu____3996;
-            FStar_Syntax_Syntax.fv_qual = uu____3997;_}
-          ->
-          let uu____4003 =
-            let uu____4006 = FStar_TypeChecker_Env.lookup_lid env.env lid in
-            FStar_All.pipe_left Prims.fst uu____4006 in
-          (match uu____4003 with
-           | (uu____4022,t) ->
-               let uu____4024 = let uu____4025 = normalize1 t in N uu____4025 in
-               (uu____4024, e, e))
-      | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let uu____4042 = check_n env head1 in
-          (match uu____4042 with
-           | (t_head,s_head,u_head) ->
-               let is_arrow t =
-                 let uu____4056 =
-                   let uu____4057 = FStar_Syntax_Subst.compress t in
-                   uu____4057.FStar_Syntax_Syntax.n in
-                 match uu____4056 with
-                 | FStar_Syntax_Syntax.Tm_arrow uu____4060 -> true
-                 | uu____4068 -> false in
-               let rec flatten1 t =
-                 let uu____4080 =
-                   let uu____4081 = FStar_Syntax_Subst.compress t in
-                   uu____4081.FStar_Syntax_Syntax.n in
-                 match uu____4080 with
-                 | FStar_Syntax_Syntax.Tm_arrow
-                     (binders,{
-                                FStar_Syntax_Syntax.n =
-                                  FStar_Syntax_Syntax.Total (t1,uu____4093);
-                                FStar_Syntax_Syntax.tk = uu____4094;
-                                FStar_Syntax_Syntax.pos = uu____4095;
-                                FStar_Syntax_Syntax.vars = uu____4096;_})
-                     when is_arrow t1 ->
-                     let uu____4113 = flatten1 t1 in
-                     (match uu____4113 with
-                      | (binders',comp) ->
-                          ((FStar_List.append binders binders'), comp))
-                 | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-                     (binders, comp)
-                 | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____4165,uu____4166)
-                     -> flatten1 e1
-                 | uu____4195 ->
-                     let uu____4196 =
-                       let uu____4197 =
-                         let uu____4198 =
-                           FStar_Syntax_Print.term_to_string t_head in
-                         FStar_Util.format1 "%s: not a function type"
-                           uu____4198 in
-                       FStar_Errors.Err uu____4197 in
-                     Prims.raise uu____4196 in
-               let uu____4206 = flatten1 t_head in
-               (match uu____4206 with
-                | (binders,comp) ->
-                    let n1 = FStar_List.length binders in
-                    let n' = FStar_List.length args in
-                    (if
-                       (FStar_List.length binders) < (FStar_List.length args)
-                     then
-                       (let uu____4251 =
-                          let uu____4252 =
-                            let uu____4253 = FStar_Util.string_of_int n1 in
-                            let uu____4257 =
-                              FStar_Util.string_of_int (n' - n1) in
-                            let uu____4263 = FStar_Util.string_of_int n1 in
-                            FStar_Util.format3
-                              "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments."
-                              uu____4253 uu____4257 uu____4263 in
-                          FStar_Errors.Err uu____4252 in
-                        Prims.raise uu____4251)
-                     else ();
-                     (let uu____4268 =
-                        FStar_Syntax_Subst.open_comp binders comp in
-                      match uu____4268 with
-                      | (binders1,comp1) ->
-                          let rec final_type subst1 uu____4295 args1 =
-                            match uu____4295 with
-                            | (binders2,comp2) ->
-                                (match (binders2, args1) with
-                                 | ([],[]) ->
-                                     let uu____4338 =
-                                       let uu____4339 =
-                                         FStar_Syntax_Subst.subst_comp subst1
-                                           comp2 in
-                                       uu____4339.FStar_Syntax_Syntax.n in
-                                     nm_of_comp uu____4338
-                                 | (binders3,[]) ->
-                                     let uu____4358 =
-                                       let uu____4359 =
-                                         let uu____4362 =
-                                           let uu____4363 =
-                                             mk1
-                                               (FStar_Syntax_Syntax.Tm_arrow
-                                                  (binders3, comp2)) in
-                                           FStar_Syntax_Subst.subst subst1
-                                             uu____4363 in
-                                         FStar_Syntax_Subst.compress
-                                           uu____4362 in
-                                       uu____4359.FStar_Syntax_Syntax.n in
-                                     (match uu____4358 with
-                                      | FStar_Syntax_Syntax.Tm_arrow
-                                          (binders4,comp3) ->
-                                          let uu____4379 =
-                                            let uu____4380 =
-                                              let uu____4381 =
-                                                let uu____4389 =
-                                                  FStar_Syntax_Subst.close_comp
-                                                    binders4 comp3 in
-                                                (binders4, uu____4389) in
-                                              FStar_Syntax_Syntax.Tm_arrow
-                                                uu____4381 in
-                                            mk1 uu____4380 in
-                                          N uu____4379
-                                      | uu____4393 -> failwith "wat?")
-                                 | ([],uu____4394::uu____4395) ->
-                                     failwith "just checked that?!"
-                                 | ((bv,uu____4420)::binders3,(arg,uu____4423)::args2)
-                                     ->
-                                     final_type
-                                       ((FStar_Syntax_Syntax.NT (bv, arg)) ::
-                                       subst1) (binders3, comp2) args2) in
-                          let final_type1 =
-                            final_type [] (binders1, comp1) args in
-                          let uu____4457 = FStar_List.splitAt n' binders1 in
-                          (match uu____4457 with
-                           | (binders2,uu____4474) ->
-                               let uu____4487 =
-                                 let uu____4497 =
-                                   FStar_List.map2
-                                     (fun uu____4517  ->
-                                        fun uu____4518  ->
-                                          match (uu____4517, uu____4518) with
-                                          | ((bv,uu____4535),(arg,q)) ->
-                                              let uu____4542 =
-                                                let uu____4543 =
-                                                  FStar_Syntax_Subst.compress
-                                                    bv.FStar_Syntax_Syntax.sort in
-                                                uu____4543.FStar_Syntax_Syntax.n in
-                                              (match uu____4542 with
-                                               | FStar_Syntax_Syntax.Tm_type
-                                                   uu____4553 ->
-                                                   let arg1 = (arg, q) in
-                                                   (arg1, [arg1])
-                                               | uu____4566 ->
-                                                   let uu____4567 =
-                                                     check_n env arg in
-                                                   (match uu____4567 with
-                                                    | (uu____4578,s_arg,u_arg)
-                                                        ->
-                                                        let uu____4581 =
-                                                          let uu____4585 =
-                                                            is_C
-                                                              bv.FStar_Syntax_Syntax.sort in
-                                                          if uu____4585
-                                                          then
-                                                            let uu____4589 =
-                                                              let uu____4592
-                                                                =
-                                                                FStar_Syntax_Subst.subst
-                                                                  env.subst
-                                                                  s_arg in
-                                                              (uu____4592, q) in
-                                                            [uu____4589;
-                                                            (u_arg, q)]
-                                                          else [(u_arg, q)] in
-                                                        ((s_arg, q),
-                                                          uu____4581))))
-                                     binders2 args in
-                                 FStar_List.split uu____4497 in
-                               (match uu____4487 with
-                                | (s_args,u_args) ->
-                                    let u_args1 = FStar_List.flatten u_args in
-                                    let uu____4639 =
-                                      mk1
-                                        (FStar_Syntax_Syntax.Tm_app
-                                           (s_head, s_args)) in
-                                    let uu____4645 =
-                                      mk1
-                                        (FStar_Syntax_Syntax.Tm_app
-                                           (u_head, u_args1)) in
-                                    (final_type1, uu____4639, uu____4645)))))))
-      | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
-          mk_let env binding e2 infer check_m
-      | FStar_Syntax_Syntax.Tm_match (e0,branches) ->
-          mk_match env e0 branches infer
-      | FStar_Syntax_Syntax.Tm_uinst (e1,_)
-        |FStar_Syntax_Syntax.Tm_meta (e1,_)|FStar_Syntax_Syntax.Tm_ascribed
-         (e1,_,_) -> infer env e1
-      | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____4723 = let uu____4724 = env.tc_const c in N uu____4724 in
-          (uu____4723, e, e)
-      | FStar_Syntax_Syntax.Tm_let uu____4725 ->
-          let uu____4733 =
-            let uu____4734 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_let %s" uu____4734 in
-          failwith uu____4733
-      | FStar_Syntax_Syntax.Tm_type uu____4738 ->
-          failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_arrow uu____4742 ->
-          failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_refine uu____4753 ->
-          let uu____4758 =
-            let uu____4759 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_refine %s" uu____4759 in
-          failwith uu____4758
-      | FStar_Syntax_Syntax.Tm_uvar uu____4763 ->
-          let uu____4772 =
-            let uu____4773 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____4773 in
-          failwith uu____4772
-      | FStar_Syntax_Syntax.Tm_delayed uu____4777 ->
-          failwith "impossible (compressed)"
-      | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____4801 =
-            let uu____4802 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____4802 in
-          failwith uu____4801
-and mk_match:
-  env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax ->
-      ((FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.withinfo_t*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax Prims.option*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax) Prims.list ->
-        (env ->
-           FStar_Syntax_Syntax.term ->
-             (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term))
-          -> (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun e0  ->
-      fun branches  ->
-        fun f  ->
-          let mk1 x =
-            FStar_Syntax_Syntax.mk x None e0.FStar_Syntax_Syntax.pos in
-          let uu____4840 = check_n env e0 in
-          match uu____4840 with
-          | (uu____4847,s_e0,u_e0) ->
-              let uu____4850 =
-                let uu____4868 =
-                  FStar_List.map
-                    (fun b  ->
-                       let uu____4901 = FStar_Syntax_Subst.open_branch b in
-                       match uu____4901 with
-                       | (pat,None ,body) ->
-                           let env1 =
-                             let uu___111_4933 = env in
-                             let uu____4934 =
-                               let uu____4935 =
-                                 FStar_Syntax_Syntax.pat_bvs pat in
-                               FStar_List.fold_left
-                                 FStar_TypeChecker_Env.push_bv env.env
-                                 uu____4935 in
-                             {
-                               env = uu____4934;
-                               subst = (uu___111_4933.subst);
-                               tc_const = (uu___111_4933.tc_const)
-                             } in
-                           let uu____4937 = f env1 body in
-                           (match uu____4937 with
-                            | (nm,s_body,u_body) ->
-                                (nm, (pat, None, (s_body, u_body, body))))
-                       | uu____4986 ->
-                           Prims.raise
-                             (FStar_Errors.Err
-                                "No when clauses in the definition language"))
-                    branches in
-                FStar_List.split uu____4868 in
-              (match uu____4850 with
-               | (nms,branches1) ->
-                   let t1 =
-                     let uu____5051 = FStar_List.hd nms in
-                     match uu____5051 with | M t1|N t1 -> t1 in
-                   let has_m =
-                     FStar_List.existsb
-                       (fun uu___96_5054  ->
-                          match uu___96_5054 with
-                          | M uu____5055 -> true
-                          | uu____5056 -> false) nms in
-                   let uu____5057 =
-                     let uu____5080 =
-                       FStar_List.map2
-                         (fun nm  ->
-                            fun uu____5132  ->
-                              match uu____5132 with
-                              | (pat,guard,(s_body,u_body,original_body)) ->
-                                  (match (nm, has_m) with
-                                   | (N t2,false )|(M t2,true ) ->
-                                       (nm, (pat, guard, s_body),
-                                         (pat, guard, u_body))
-                                   | (N t2,true ) ->
-                                       let uu____5228 =
-                                         check env original_body (M t2) in
-                                       (match uu____5228 with
-                                        | (uu____5251,s_body1,u_body1) ->
-                                            ((M t2), (pat, guard, s_body1),
-                                              (pat, guard, u_body1)))
-                                   | (M uu____5280,false ) ->
-                                       failwith "impossible")) nms branches1 in
-                     FStar_List.unzip3 uu____5080 in
-                   (match uu____5057 with
-                    | (nms1,s_branches,u_branches) ->
-                        if has_m
-                        then
-                          let p_type = mk_star_to_type mk1 env t1 in
-                          let p =
-                            FStar_Syntax_Syntax.gen_bv "p''" None p_type in
-                          let s_branches1 =
-                            FStar_List.map
-                              (fun uu____5399  ->
-                                 match uu____5399 with
-                                 | (pat,guard,s_body) ->
-                                     let s_body1 =
-                                       let uu____5440 =
-                                         let uu____5441 =
-                                           let uu____5451 =
-                                             let uu____5455 =
-                                               let uu____5458 =
-                                                 FStar_Syntax_Syntax.bv_to_name
-                                                   p in
-                                               let uu____5459 =
-                                                 FStar_Syntax_Syntax.as_implicit
-                                                   false in
-                                               (uu____5458, uu____5459) in
-                                             [uu____5455] in
-                                           (s_body, uu____5451) in
-                                         FStar_Syntax_Syntax.Tm_app
-                                           uu____5441 in
-                                       mk1 uu____5440 in
-                                     (pat, guard, s_body1)) s_branches in
-                          let s_branches2 =
-                            FStar_List.map FStar_Syntax_Subst.close_branch
-                              s_branches1 in
-                          let u_branches1 =
-                            FStar_List.map FStar_Syntax_Subst.close_branch
-                              u_branches in
-                          let s_e =
-                            let uu____5481 =
-                              let uu____5485 =
-                                FStar_Syntax_Syntax.mk_binder p in
-                              [uu____5485] in
-                            let uu____5486 =
-                              mk1
-                                (FStar_Syntax_Syntax.Tm_match
-                                   (s_e0, s_branches2)) in
-                            let uu____5488 =
-                              let uu____5495 =
-                                let uu____5501 =
-                                  let uu____5502 =
-                                    FStar_Syntax_Syntax.mk_Total
-                                      FStar_Syntax_Util.ktype0 in
-                                  FStar_Syntax_Util.lcomp_of_comp uu____5502 in
-                                FStar_Util.Inl uu____5501 in
-                              Some uu____5495 in
-                            FStar_Syntax_Util.abs uu____5481 uu____5486
-                              uu____5488 in
-                          let t1_star =
-                            let uu____5516 =
-                              let uu____5520 =
-                                let uu____5521 =
-                                  FStar_Syntax_Syntax.new_bv None p_type in
-                                FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.mk_binder uu____5521 in
-                              [uu____5520] in
-                            let uu____5522 =
-                              FStar_Syntax_Syntax.mk_Total
-                                FStar_Syntax_Util.ktype0 in
-                            FStar_Syntax_Util.arrow uu____5516 uu____5522 in
-                          let uu____5525 =
-                            mk1
-                              (FStar_Syntax_Syntax.Tm_ascribed
-                                 (s_e, ((FStar_Util.Inl t1_star), None),
-                                   None)) in
-                          let uu____5555 =
-                            mk1
-                              (FStar_Syntax_Syntax.Tm_match
-                                 (u_e0, u_branches1)) in
-                          ((M t1), uu____5525, uu____5555)
-                        else
-                          (let s_branches1 =
-                             FStar_List.map FStar_Syntax_Subst.close_branch
-                               s_branches in
-                           let u_branches1 =
-                             FStar_List.map FStar_Syntax_Subst.close_branch
-                               u_branches in
-                           let t1_star = t1 in
-                           let uu____5569 =
-                             let uu____5572 =
-                               let uu____5573 =
-                                 let uu____5591 =
-                                   mk1
-                                     (FStar_Syntax_Syntax.Tm_match
-                                        (s_e0, s_branches1)) in
-                                 (uu____5591,
-                                   ((FStar_Util.Inl t1_star), None), None) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____5573 in
-                             mk1 uu____5572 in
-                           let uu____5618 =
-                             mk1
-                               (FStar_Syntax_Syntax.Tm_match
-                                  (u_e0, u_branches1)) in
-                           ((N t1), uu____5569, uu____5618))))
-and mk_let:
-  env_ ->
-    FStar_Syntax_Syntax.letbinding ->
-      FStar_Syntax_Syntax.term ->
-        (env_ ->
-           FStar_Syntax_Syntax.term ->
-             (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term))
-          ->
-          (env_ ->
-             FStar_Syntax_Syntax.term ->
-               (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term*
-                 FStar_Syntax_Syntax.term))
-            -> (nm* FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun binding  ->
-      fun e2  ->
-        fun proceed  ->
-          fun ensure_m  ->
-            let mk1 x =
-              FStar_Syntax_Syntax.mk x None e2.FStar_Syntax_Syntax.pos in
-            let e1 = binding.FStar_Syntax_Syntax.lbdef in
-            let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname in
-            let x_binders =
-              let uu____5661 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____5661] in
-            let uu____5662 = FStar_Syntax_Subst.open_term x_binders e2 in
-            match uu____5662 with
-            | (x_binders1,e21) ->
-                let uu____5670 = infer env e1 in
-                (match uu____5670 with
-                 | (N t1,s_e1,u_e1) ->
-                     let u_binding =
-                       let uu____5681 = is_C t1 in
-                       if uu____5681
-                       then
-                         let uu___112_5682 = binding in
-                         let uu____5683 =
-                           let uu____5686 =
-                             FStar_Syntax_Subst.subst env.subst s_e1 in
-                           trans_F_ env t1 uu____5686 in
-                         {
-                           FStar_Syntax_Syntax.lbname =
-                             (uu___112_5682.FStar_Syntax_Syntax.lbname);
-                           FStar_Syntax_Syntax.lbunivs =
-                             (uu___112_5682.FStar_Syntax_Syntax.lbunivs);
-                           FStar_Syntax_Syntax.lbtyp = uu____5683;
-                           FStar_Syntax_Syntax.lbeff =
-                             (uu___112_5682.FStar_Syntax_Syntax.lbeff);
-                           FStar_Syntax_Syntax.lbdef =
-                             (uu___112_5682.FStar_Syntax_Syntax.lbdef)
-                         }
-                       else binding in
-                     let env1 =
-                       let uu___113_5689 = env in
-                       let uu____5690 =
-                         FStar_TypeChecker_Env.push_bv env.env
-                           (let uu___114_5691 = x in
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (uu___114_5691.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (uu___114_5691.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = t1
-                            }) in
-                       {
-                         env = uu____5690;
-                         subst = (uu___113_5689.subst);
-                         tc_const = (uu___113_5689.tc_const)
-                       } in
-                     let uu____5692 = proceed env1 e21 in
-                     (match uu____5692 with
-                      | (nm_rec,s_e2,u_e2) ->
-                          let s_binding =
-                            let uu___115_5703 = binding in
-                            let uu____5704 =
-                              star_type' env1
-                                binding.FStar_Syntax_Syntax.lbtyp in
-                            {
-                              FStar_Syntax_Syntax.lbname =
-                                (uu___115_5703.FStar_Syntax_Syntax.lbname);
-                              FStar_Syntax_Syntax.lbunivs =
-                                (uu___115_5703.FStar_Syntax_Syntax.lbunivs);
-                              FStar_Syntax_Syntax.lbtyp = uu____5704;
-                              FStar_Syntax_Syntax.lbeff =
-                                (uu___115_5703.FStar_Syntax_Syntax.lbeff);
-                              FStar_Syntax_Syntax.lbdef =
-                                (uu___115_5703.FStar_Syntax_Syntax.lbdef)
-                            } in
-                          let uu____5707 =
-                            let uu____5710 =
-                              let uu____5711 =
-                                let uu____5719 =
-                                  FStar_Syntax_Subst.close x_binders1 s_e2 in
-                                ((false,
-                                   [(let uu___116_5724 = s_binding in
-                                     {
-                                       FStar_Syntax_Syntax.lbname =
-                                         (uu___116_5724.FStar_Syntax_Syntax.lbname);
-                                       FStar_Syntax_Syntax.lbunivs =
-                                         (uu___116_5724.FStar_Syntax_Syntax.lbunivs);
-                                       FStar_Syntax_Syntax.lbtyp =
-                                         (uu___116_5724.FStar_Syntax_Syntax.lbtyp);
-                                       FStar_Syntax_Syntax.lbeff =
-                                         (uu___116_5724.FStar_Syntax_Syntax.lbeff);
-                                       FStar_Syntax_Syntax.lbdef = s_e1
-                                     })]), uu____5719) in
-                              FStar_Syntax_Syntax.Tm_let uu____5711 in
-                            mk1 uu____5710 in
-                          let uu____5725 =
-                            let uu____5728 =
-                              let uu____5729 =
-                                let uu____5737 =
-                                  FStar_Syntax_Subst.close x_binders1 u_e2 in
-                                ((false,
-                                   [(let uu___117_5742 = u_binding in
-                                     {
-                                       FStar_Syntax_Syntax.lbname =
-                                         (uu___117_5742.FStar_Syntax_Syntax.lbname);
-                                       FStar_Syntax_Syntax.lbunivs =
-                                         (uu___117_5742.FStar_Syntax_Syntax.lbunivs);
-                                       FStar_Syntax_Syntax.lbtyp =
-                                         (uu___117_5742.FStar_Syntax_Syntax.lbtyp);
-                                       FStar_Syntax_Syntax.lbeff =
-                                         (uu___117_5742.FStar_Syntax_Syntax.lbeff);
-                                       FStar_Syntax_Syntax.lbdef = u_e1
-                                     })]), uu____5737) in
-                              FStar_Syntax_Syntax.Tm_let uu____5729 in
-                            mk1 uu____5728 in
-                          (nm_rec, uu____5707, uu____5725))
-                 | (M t1,s_e1,u_e1) ->
-                     let u_binding =
-                       let uu___118_5751 = binding in
-                       {
-                         FStar_Syntax_Syntax.lbname =
-                           (uu___118_5751.FStar_Syntax_Syntax.lbname);
-                         FStar_Syntax_Syntax.lbunivs =
-                           (uu___118_5751.FStar_Syntax_Syntax.lbunivs);
-                         FStar_Syntax_Syntax.lbtyp = t1;
-                         FStar_Syntax_Syntax.lbeff =
-                           FStar_Syntax_Const.effect_PURE_lid;
-                         FStar_Syntax_Syntax.lbdef =
-                           (uu___118_5751.FStar_Syntax_Syntax.lbdef)
-                       } in
-                     let env1 =
-                       let uu___119_5753 = env in
-                       let uu____5754 =
-                         FStar_TypeChecker_Env.push_bv env.env
-                           (let uu___120_5755 = x in
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (uu___120_5755.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (uu___120_5755.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = t1
-                            }) in
-                       {
-                         env = uu____5754;
-                         subst = (uu___119_5753.subst);
-                         tc_const = (uu___119_5753.tc_const)
-                       } in
-                     let uu____5756 = ensure_m env1 e21 in
-                     (match uu____5756 with
-                      | (t2,s_e2,u_e2) ->
-                          let p_type = mk_star_to_type mk1 env1 t2 in
-                          let p =
-                            FStar_Syntax_Syntax.gen_bv "p''" None p_type in
-                          let s_e21 =
-                            let uu____5773 =
-                              let uu____5774 =
-                                let uu____5784 =
-                                  let uu____5788 =
-                                    let uu____5791 =
-                                      FStar_Syntax_Syntax.bv_to_name p in
-                                    let uu____5792 =
-                                      FStar_Syntax_Syntax.as_implicit false in
-                                    (uu____5791, uu____5792) in
-                                  [uu____5788] in
-                                (s_e2, uu____5784) in
-                              FStar_Syntax_Syntax.Tm_app uu____5774 in
-                            mk1 uu____5773 in
-                          let s_e22 =
-                            let uu____5801 =
-                              let uu____5808 =
-                                let uu____5814 =
-                                  let uu____5815 =
-                                    FStar_Syntax_Syntax.mk_Total
-                                      FStar_Syntax_Util.ktype0 in
-                                  FStar_Syntax_Util.lcomp_of_comp uu____5815 in
-                                FStar_Util.Inl uu____5814 in
-                              Some uu____5808 in
-                            FStar_Syntax_Util.abs x_binders1 s_e21 uu____5801 in
-                          let body =
-                            let uu____5829 =
-                              let uu____5830 =
-                                let uu____5840 =
-                                  let uu____5844 =
-                                    let uu____5847 =
-                                      FStar_Syntax_Syntax.as_implicit false in
-                                    (s_e22, uu____5847) in
-                                  [uu____5844] in
-                                (s_e1, uu____5840) in
-                              FStar_Syntax_Syntax.Tm_app uu____5830 in
-                            mk1 uu____5829 in
-                          let uu____5855 =
-                            let uu____5856 =
-                              let uu____5860 =
-                                FStar_Syntax_Syntax.mk_binder p in
-                              [uu____5860] in
-                            let uu____5861 =
-                              let uu____5868 =
-                                let uu____5874 =
-                                  let uu____5875 =
-                                    FStar_Syntax_Syntax.mk_Total
-                                      FStar_Syntax_Util.ktype0 in
-                                  FStar_Syntax_Util.lcomp_of_comp uu____5875 in
-                                FStar_Util.Inl uu____5874 in
-                              Some uu____5868 in
-                            FStar_Syntax_Util.abs uu____5856 body uu____5861 in
-                          let uu____5886 =
-                            let uu____5889 =
-                              let uu____5890 =
-                                let uu____5898 =
-                                  FStar_Syntax_Subst.close x_binders1 u_e2 in
-                                ((false,
-                                   [(let uu___121_5903 = u_binding in
-                                     {
-                                       FStar_Syntax_Syntax.lbname =
-                                         (uu___121_5903.FStar_Syntax_Syntax.lbname);
-                                       FStar_Syntax_Syntax.lbunivs =
-                                         (uu___121_5903.FStar_Syntax_Syntax.lbunivs);
-                                       FStar_Syntax_Syntax.lbtyp =
-                                         (uu___121_5903.FStar_Syntax_Syntax.lbtyp);
-                                       FStar_Syntax_Syntax.lbeff =
-                                         (uu___121_5903.FStar_Syntax_Syntax.lbeff);
-                                       FStar_Syntax_Syntax.lbdef = u_e1
-                                     })]), uu____5898) in
-                              FStar_Syntax_Syntax.Tm_let uu____5890 in
-                            mk1 uu____5889 in
-                          ((M t2), uu____5855, uu____5886)))
-and check_n:
-  env_ ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.term*
-        FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun e  ->
-      let mn =
-        let uu____5912 =
-          FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown None
-            e.FStar_Syntax_Syntax.pos in
-        N uu____5912 in
-      let uu____5917 = check env e mn in
-      match uu____5917 with
-      | (N t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____5927 -> failwith "[check_n]: impossible"
-and check_m:
-  env_ ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.term*
-        FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun e  ->
-      let mn =
-        let uu____5940 =
-          FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown None
-            e.FStar_Syntax_Syntax.pos in
-        M uu____5940 in
-      let uu____5945 = check env e mn in
-      match uu____5945 with
-      | (M t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____5955 -> failwith "[check_m]: impossible"
-and comp_of_nm: nm_ -> FStar_Syntax_Syntax.comp =
-  fun nm  ->
-    match nm with | N t -> FStar_Syntax_Syntax.mk_Total t | M t -> mk_M t
-and mk_M: FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp =
-  fun t  ->
-    FStar_Syntax_Syntax.mk_Comp
-      {
-        FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_unknown];
-        FStar_Syntax_Syntax.effect_name = FStar_Syntax_Const.monadic_lid;
-        FStar_Syntax_Syntax.result_typ = t;
-        FStar_Syntax_Syntax.effect_args = [];
-        FStar_Syntax_Syntax.flags =
-          [FStar_Syntax_Syntax.CPS; FStar_Syntax_Syntax.TOTAL]
-      }
-and type_of_comp:
-  (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  = fun t  -> FStar_Syntax_Util.comp_result t
-and trans_F_:
-  env_ ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun c  ->
-      fun wp  ->
-        (let uu____5977 =
-           let uu____5978 = is_C c in Prims.op_Negation uu____5978 in
-         if uu____5977 then failwith "not a C" else ());
-        (let mk1 x = FStar_Syntax_Syntax.mk x None c.FStar_Syntax_Syntax.pos in
-         let uu____5990 =
-           let uu____5991 = FStar_Syntax_Subst.compress c in
-           uu____5991.FStar_Syntax_Syntax.n in
-         match uu____5990 with
-         | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-             let uu____6010 = FStar_Syntax_Util.head_and_args wp in
-             (match uu____6010 with
-              | (wp_head,wp_args) ->
-                  ((let uu____6037 =
-                      (Prims.op_Negation
-                         ((FStar_List.length wp_args) =
-                            (FStar_List.length args)))
-                        ||
-                        (let uu____6050 =
-                           let uu____6051 =
-                             FStar_Syntax_Util.mk_tuple_data_lid
-                               (FStar_List.length wp_args)
-                               FStar_Range.dummyRange in
-                           FStar_Syntax_Util.is_constructor wp_head
-                             uu____6051 in
-                         Prims.op_Negation uu____6050) in
-                    if uu____6037 then failwith "mismatch" else ());
-                   (let uu____6060 =
-                      let uu____6061 =
-                        let uu____6071 =
-                          FStar_List.map2
-                            (fun uu____6081  ->
-                               fun uu____6082  ->
-                                 match (uu____6081, uu____6082) with
-                                 | ((arg,q),(wp_arg,q')) ->
-                                     let print_implicit q1 =
-                                       let uu____6105 =
-                                         FStar_Syntax_Syntax.is_implicit q1 in
-                                       if uu____6105
-                                       then "implicit"
-                                       else "explicit" in
-                                     (if q <> q'
-                                      then
-                                        (let uu____6108 = print_implicit q in
-                                         let uu____6109 = print_implicit q' in
-                                         FStar_Util.print2_warning
-                                           "Incoherent implicit qualifiers %b %b"
-                                           uu____6108 uu____6109)
-                                      else ();
-                                      (let uu____6111 =
-                                         trans_F_ env arg wp_arg in
-                                       (uu____6111, q)))) args wp_args in
-                        (head1, uu____6071) in
-                      FStar_Syntax_Syntax.Tm_app uu____6061 in
-                    mk1 uu____6060)))
-         | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-             let binders1 = FStar_Syntax_Util.name_binders binders in
-             let uu____6133 = FStar_Syntax_Subst.open_comp binders1 comp in
-             (match uu____6133 with
-              | (binders_orig,comp1) ->
-                  let uu____6138 =
-                    let uu____6146 =
-                      FStar_List.map
-                        (fun uu____6160  ->
-                           match uu____6160 with
-                           | (bv,q) ->
-                               let h = bv.FStar_Syntax_Syntax.sort in
-                               let uu____6173 = is_C h in
-                               if uu____6173
-                               then
-                                 let w' =
-                                   let uu____6180 = star_type' env h in
-                                   FStar_Syntax_Syntax.gen_bv
-                                     (Prims.strcat
-                                        (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                        "-w'") None uu____6180 in
-                                 let uu____6181 =
-                                   let uu____6185 =
-                                     let uu____6189 =
-                                       let uu____6192 =
-                                         let uu____6193 =
-                                           let uu____6194 =
-                                             FStar_Syntax_Syntax.bv_to_name
-                                               w' in
-                                           trans_F_ env h uu____6194 in
-                                         FStar_Syntax_Syntax.null_bv
-                                           uu____6193 in
-                                       (uu____6192, q) in
-                                     [uu____6189] in
-                                   (w', q) :: uu____6185 in
-                                 (w', uu____6181)
-                               else
-                                 (let x =
-                                    let uu____6206 = star_type' env h in
-                                    FStar_Syntax_Syntax.gen_bv
-                                      (Prims.strcat
-                                         (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                         "-x") None uu____6206 in
-                                  (x, [(x, q)]))) binders_orig in
-                    FStar_List.split uu____6146 in
-                  (match uu____6138 with
-                   | (bvs,binders2) ->
-                       let binders3 = FStar_List.flatten binders2 in
-                       let comp2 =
-                         let uu____6236 =
-                           let uu____6238 =
-                             FStar_Syntax_Syntax.binders_of_list bvs in
-                           FStar_Syntax_Util.rename_binders binders_orig
-                             uu____6238 in
-                         FStar_Syntax_Subst.subst_comp uu____6236 comp1 in
-                       let app =
-                         let uu____6242 =
-                           let uu____6243 =
-                             let uu____6253 =
-                               FStar_List.map
-                                 (fun bv  ->
-                                    let uu____6260 =
-                                      FStar_Syntax_Syntax.bv_to_name bv in
-                                    let uu____6261 =
-                                      FStar_Syntax_Syntax.as_implicit false in
-                                    (uu____6260, uu____6261)) bvs in
-                             (wp, uu____6253) in
-                           FStar_Syntax_Syntax.Tm_app uu____6243 in
-                         mk1 uu____6242 in
-                       let comp3 =
-                         let uu____6266 = type_of_comp comp2 in
-                         let uu____6267 = is_monadic_comp comp2 in
-                         trans_G env uu____6266 uu____6267 app in
-                       FStar_Syntax_Util.arrow binders3 comp3))
-         | FStar_Syntax_Syntax.Tm_ascribed (e,uu____6269,uu____6270) ->
-             trans_F_ env e wp
-         | uu____6299 -> failwith "impossible trans_F_")
-and trans_G:
-  env_ ->
-    FStar_Syntax_Syntax.typ ->
-      Prims.bool -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp
-  =
-  fun env  ->
-    fun h  ->
-      fun is_monadic1  ->
-        fun wp  ->
-          let mk1 x = FStar_Syntax_Syntax.mk x None h.FStar_Syntax_Syntax.pos in
-          if is_monadic1
-          then
-            let uu____6314 =
-              let uu____6315 = star_type' env h in
-              let uu____6318 =
-                let uu____6324 =
-                  let uu____6327 = FStar_Syntax_Syntax.as_implicit false in
-                  (wp, uu____6327) in
-                [uu____6324] in
-              {
-                FStar_Syntax_Syntax.comp_univs =
-                  [FStar_Syntax_Syntax.U_unknown];
-                FStar_Syntax_Syntax.effect_name =
-                  FStar_Syntax_Const.effect_PURE_lid;
-                FStar_Syntax_Syntax.result_typ = uu____6315;
-                FStar_Syntax_Syntax.effect_args = uu____6318;
-                FStar_Syntax_Syntax.flags = []
-              } in
-            FStar_Syntax_Syntax.mk_Comp uu____6314
-          else
-            (let uu____6333 = trans_F_ env h wp in
-             FStar_Syntax_Syntax.mk_Total uu____6333)
-let n:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  FStar_TypeChecker_Normalize.normalize
-    [FStar_TypeChecker_Normalize.Beta;
-    FStar_TypeChecker_Normalize.UnfoldUntil
-      FStar_Syntax_Syntax.Delta_constant;
-    FStar_TypeChecker_Normalize.NoDeltaSteps;
-    FStar_TypeChecker_Normalize.Eager_unfolding;
-    FStar_TypeChecker_Normalize.EraseUniverses]
-let star_type: env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term =
-  fun env  ->
-    fun t  -> let uu____6344 = n env.env t in star_type' env uu____6344
-let star_expr:
-  env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.term*
-        FStar_Syntax_Syntax.term)
-  =
-  fun env  ->
-    fun t  -> let uu____6356 = n env.env t in check_n env uu____6356
-let trans_F:
-  env_ ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun c  ->
-      fun wp  ->
-        let uu____6366 = n env.env c in
-        let uu____6367 = n env.env wp in trans_F_ env uu____6366 uu____6367
+
+
+let uu___is_Not_found : Prims.exn  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Not_found -> begin
+true
+end
+| uu____2178 -> begin
+false
+end))
+
+
+let double_star : FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun typ -> (
+
+let star_once = (fun typ1 -> (
+
+let uu____2188 = (
+
+let uu____2192 = (
+
+let uu____2193 = (FStar_Syntax_Syntax.new_bv None typ1)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____2193))
+in (uu____2192)::[])
+in (
+
+let uu____2194 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.arrow uu____2188 uu____2194))))
+in (
+
+let uu____2197 = (FStar_All.pipe_right typ star_once)
+in (FStar_All.pipe_left star_once uu____2197))))
+
+
+let rec mk_star_to_type : (FStar_Syntax_Syntax.term'  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun mk1 env a -> (mk1 (
+
+let uu____2232 = (
+
+let uu____2240 = (
+
+let uu____2244 = (
+
+let uu____2247 = (
+
+let uu____2248 = (star_type' env a)
+in (FStar_Syntax_Syntax.null_bv uu____2248))
+in (
+
+let uu____2249 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____2247), (uu____2249))))
+in (uu____2244)::[])
+in (
+
+let uu____2254 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in ((uu____2240), (uu____2254))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____2232))))
+and star_type' : env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let mk1 = (fun x -> ((FStar_Syntax_Syntax.mk x) None t.FStar_Syntax_Syntax.pos))
+in (
+
+let mk_star_to_type1 = (mk_star_to_type mk1)
+in (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, uu____2287) -> begin
+(
+
+let binders1 = (FStar_List.map (fun uu____2306 -> (match (uu____2306) with
+| (bv, aqual) -> begin
+(
+
+let uu____2313 = (
+
+let uu___100_2314 = bv
+in (
+
+let uu____2315 = (star_type' env bv.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___100_2314.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___100_2314.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2315}))
+in ((uu____2313), (aqual)))
+end)) binders)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____2318, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal (hn, uu____2320); FStar_Syntax_Syntax.tk = uu____2321; FStar_Syntax_Syntax.pos = uu____2322; FStar_Syntax_Syntax.vars = uu____2323}) -> begin
+(
+
+let uu____2340 = (
+
+let uu____2341 = (
+
+let uu____2349 = (
+
+let uu____2350 = (star_type' env hn)
+in (FStar_Syntax_Syntax.mk_GTotal uu____2350))
+in ((binders1), (uu____2349)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____2341))
+in (mk1 uu____2340))
+end
+| uu____2354 -> begin
+(
+
+let uu____2355 = (is_monadic_arrow t1.FStar_Syntax_Syntax.n)
+in (match (uu____2355) with
+| N (hn) -> begin
+(
+
+let uu____2357 = (
+
+let uu____2358 = (
+
+let uu____2366 = (
+
+let uu____2367 = (star_type' env hn)
+in (FStar_Syntax_Syntax.mk_Total uu____2367))
+in ((binders1), (uu____2366)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____2358))
+in (mk1 uu____2357))
+end
+| M (a) -> begin
+(
+
+let uu____2372 = (
+
+let uu____2373 = (
+
+let uu____2381 = (
+
+let uu____2385 = (
+
+let uu____2389 = (
+
+let uu____2392 = (
+
+let uu____2393 = (mk_star_to_type1 env a)
+in (FStar_Syntax_Syntax.null_bv uu____2393))
+in (
+
+let uu____2394 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____2392), (uu____2394))))
+in (uu____2389)::[])
+in (FStar_List.append binders1 uu____2385))
+in (
+
+let uu____2401 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in ((uu____2381), (uu____2401))))
+in FStar_Syntax_Syntax.Tm_arrow (uu____2373))
+in (mk1 uu____2372))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let debug1 = (fun t2 s -> (
+
+let string_of_set = (fun f s1 -> (
+
+let elts = (FStar_Util.set_elements s1)
+in (match (elts) with
+| [] -> begin
+"{}"
+end
+| (x)::xs -> begin
+(
+
+let strb = (FStar_Util.new_string_builder ())
+in ((FStar_Util.string_builder_append strb "{");
+(
+
+let uu____2452 = (f x)
+in (FStar_Util.string_builder_append strb uu____2452));
+(FStar_List.iter (fun x1 -> ((FStar_Util.string_builder_append strb ", ");
+(
+
+let uu____2456 = (f x1)
+in (FStar_Util.string_builder_append strb uu____2456));
+)) xs);
+(FStar_Util.string_builder_append strb "}");
+(FStar_Util.string_of_string_builder strb);
+))
+end)))
+in (
+
+let uu____2458 = (FStar_Syntax_Print.term_to_string t2)
+in (
+
+let uu____2459 = (string_of_set FStar_Syntax_Print.bv_to_string s)
+in (FStar_Util.print2_warning "Dependency found in term %s : %s" uu____2458 uu____2459)))))
+in (
+
+let rec is_non_dependent_arrow = (fun ty n1 -> (
+
+let uu____2467 = (
+
+let uu____2468 = (FStar_Syntax_Subst.compress ty)
+in uu____2468.FStar_Syntax_Syntax.n)
+in (match (uu____2467) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, c) -> begin
+(
+
+let uu____2483 = (
+
+let uu____2484 = (FStar_Syntax_Util.is_tot_or_gtot_comp c)
+in (not (uu____2484)))
+in (match (uu____2483) with
+| true -> begin
+false
+end
+| uu____2485 -> begin
+try
+(match (()) with
+| () -> begin
+(
+
+let non_dependent_or_raise = (fun s ty1 -> (
+
+let sinter = (
+
+let uu____2498 = (FStar_Syntax_Free.names ty1)
+in (FStar_Util.set_intersect uu____2498 s))
+in (
+
+let uu____2500 = (
+
+let uu____2501 = (FStar_Util.set_is_empty sinter)
+in (not (uu____2501)))
+in (match (uu____2500) with
+| true -> begin
+((debug1 ty1 sinter);
+(Prims.raise Not_found);
+)
+end
+| uu____2503 -> begin
+()
+end))))
+in (
+
+let uu____2504 = (FStar_Syntax_Subst.open_comp binders c)
+in (match (uu____2504) with
+| (binders1, c1) -> begin
+(
+
+let s = (FStar_List.fold_left (fun s uu____2515 -> (match (uu____2515) with
+| (bv, uu____2521) -> begin
+((non_dependent_or_raise s bv.FStar_Syntax_Syntax.sort);
+(FStar_Util.set_add bv s);
+)
+end)) FStar_Syntax_Syntax.no_names binders1)
+in (
+
+let ct = (FStar_Syntax_Util.comp_result c1)
+in ((non_dependent_or_raise s ct);
+(
+
+let k = (n1 - (FStar_List.length binders1))
+in (match ((k > (Prims.parse_int "0"))) with
+| true -> begin
+(is_non_dependent_arrow ct k)
+end
+| uu____2532 -> begin
+true
+end));
+)))
+end)))
+end)
+with
+| Not_found -> begin
+false
+end
+end))
+end
+| uu____2534 -> begin
+((
+
+let uu____2536 = (FStar_Syntax_Print.term_to_string ty)
+in (FStar_Util.print1_warning "Not a dependent arrow : %s" uu____2536));
+false;
+)
+end)))
+in (
+
+let rec is_valid_application = (fun head2 -> (
+
+let uu____2541 = (
+
+let uu____2542 = (FStar_Syntax_Subst.compress head2)
+in uu____2542.FStar_Syntax_Syntax.n)
+in (match (uu____2541) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when ((((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.option_lid) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.either_lid)) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.eq2_lid)) || (
+
+let uu____2546 = (FStar_Syntax_Subst.compress head2)
+in (FStar_Syntax_Util.is_tuple_constructor uu____2546))) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (is_non_dependent_arrow fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.ty (FStar_List.length args)) -> begin
+(
+
+let res = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Inlining)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env.env t1)
+in (match (res.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app (uu____2559) -> begin
+true
+end
+| uu____2569 -> begin
+((
+
+let uu____2571 = (FStar_Syntax_Print.term_to_string head2)
+in (FStar_Util.print1_warning "Got a term which might be a non-dependent user-defined data-type %s\n" uu____2571));
+false;
+)
+end))
+end
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_uinst (t2, uu____2575) -> begin
+(is_valid_application t2)
+end
+| uu____2580 -> begin
+false
+end)))
+in (
+
+let uu____2581 = (is_valid_application head1)
+in (match (uu____2581) with
+| true -> begin
+(
+
+let uu____2582 = (
+
+let uu____2583 = (
+
+let uu____2593 = (FStar_List.map (fun uu____2603 -> (match (uu____2603) with
+| (t2, qual) -> begin
+(
+
+let uu____2616 = (star_type' env t2)
+in ((uu____2616), (qual)))
+end)) args)
+in ((head1), (uu____2593)))
+in FStar_Syntax_Syntax.Tm_app (uu____2583))
+in (mk1 uu____2582))
+end
+| uu____2622 -> begin
+(
+
+let uu____2623 = (
+
+let uu____2624 = (
+
+let uu____2625 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "For now, only [either], [option] and [eq2] are supported in the definition language (got: %s)" uu____2625))
+in FStar_Errors.Err (uu____2624))
+in (Prims.raise uu____2623))
+end)))))
+end
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+t1
+end
+| FStar_Syntax_Syntax.Tm_abs (binders, repr, something) -> begin
+(
+
+let uu____2655 = (FStar_Syntax_Subst.open_term binders repr)
+in (match (uu____2655) with
+| (binders1, repr1) -> begin
+(
+
+let env1 = (
+
+let uu___103_2661 = env
+in (
+
+let uu____2662 = (FStar_TypeChecker_Env.push_binders env.env binders1)
+in {env = uu____2662; subst = uu___103_2661.subst; tc_const = uu___103_2661.tc_const}))
+in (
+
+let repr2 = (star_type' env1 repr1)
+in (FStar_Syntax_Util.abs binders1 repr2 something)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, t2) when false -> begin
+(
+
+let x1 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let sort = (star_type' env x1.FStar_Syntax_Syntax.sort)
+in (
+
+let subst1 = (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x1))))::[]
+in (
+
+let t3 = (FStar_Syntax_Subst.subst subst1 t2)
+in (
+
+let t4 = (star_type' env t3)
+in (
+
+let subst2 = (FStar_Syntax_Syntax.NM (((x1), ((Prims.parse_int "0")))))::[]
+in (
+
+let t5 = (FStar_Syntax_Subst.subst subst2 t4)
+in (mk1 (FStar_Syntax_Syntax.Tm_refine ((((
+
+let uu___104_2679 = x1
+in {FStar_Syntax_Syntax.ppname = uu___104_2679.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___104_2679.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = sort})), (t5))))))))))))
+end
+| FStar_Syntax_Syntax.Tm_meta (t2, m) -> begin
+(
+
+let uu____2686 = (
+
+let uu____2687 = (
+
+let uu____2692 = (star_type' env t2)
+in ((uu____2692), (m)))
+in FStar_Syntax_Syntax.Tm_meta (uu____2687))
+in (mk1 uu____2686))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e, (FStar_Util.Inl (t2), None), something) -> begin
+(
+
+let uu____2730 = (
+
+let uu____2731 = (
+
+let uu____2749 = (star_type' env e)
+in (
+
+let uu____2750 = (
+
+let uu____2760 = (
+
+let uu____2765 = (star_type' env t2)
+in FStar_Util.Inl (uu____2765))
+in ((uu____2760), (None)))
+in ((uu____2749), (uu____2750), (something))))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____2731))
+in (mk1 uu____2730))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____2787) -> begin
+(
+
+let uu____2805 = (
+
+let uu____2806 = (
+
+let uu____2807 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_ascribed is outside of the definition language: %s" uu____2807))
+in FStar_Errors.Err (uu____2806))
+in (Prims.raise uu____2805))
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____2808) -> begin
+(
+
+let uu____2813 = (
+
+let uu____2814 = (
+
+let uu____2815 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_refine is outside of the definition language: %s" uu____2815))
+in FStar_Errors.Err (uu____2814))
+in (Prims.raise uu____2813))
+end
+| FStar_Syntax_Syntax.Tm_uinst (uu____2816) -> begin
+(
+
+let uu____2821 = (
+
+let uu____2822 = (
+
+let uu____2823 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_uinst is outside of the definition language: %s" uu____2823))
+in FStar_Errors.Err (uu____2822))
+in (Prims.raise uu____2821))
+end
+| FStar_Syntax_Syntax.Tm_constant (uu____2824) -> begin
+(
+
+let uu____2825 = (
+
+let uu____2826 = (
+
+let uu____2827 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_constant is outside of the definition language: %s" uu____2827))
+in FStar_Errors.Err (uu____2826))
+in (Prims.raise uu____2825))
+end
+| FStar_Syntax_Syntax.Tm_match (uu____2828) -> begin
+(
+
+let uu____2844 = (
+
+let uu____2845 = (
+
+let uu____2846 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_match is outside of the definition language: %s" uu____2846))
+in FStar_Errors.Err (uu____2845))
+in (Prims.raise uu____2844))
+end
+| FStar_Syntax_Syntax.Tm_let (uu____2847) -> begin
+(
+
+let uu____2855 = (
+
+let uu____2856 = (
+
+let uu____2857 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_let is outside of the definition language: %s" uu____2857))
+in FStar_Errors.Err (uu____2856))
+in (Prims.raise uu____2855))
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____2858) -> begin
+(
+
+let uu____2867 = (
+
+let uu____2868 = (
+
+let uu____2869 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_uvar is outside of the definition language: %s" uu____2869))
+in FStar_Errors.Err (uu____2868))
+in (Prims.raise uu____2867))
+end
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+(
+
+let uu____2870 = (
+
+let uu____2871 = (
+
+let uu____2872 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format1 "Tm_unknown is outside of the definition language: %s" uu____2872))
+in FStar_Errors.Err (uu____2871))
+in (Prims.raise uu____2870))
+end
+| FStar_Syntax_Syntax.Tm_delayed (uu____2873) -> begin
+(failwith "impossible")
+end)))))
+
+
+let is_monadic = (fun uu___89_2906 -> (match (uu___89_2906) with
+| None -> begin
+(failwith "un-annotated lambda?!")
+end
+| (Some (FStar_Util.Inl ({FStar_Syntax_Syntax.eff_name = _; FStar_Syntax_Syntax.res_typ = _; FStar_Syntax_Syntax.cflags = flags; FStar_Syntax_Syntax.comp = _}))) | (Some (FStar_Util.Inr (_, flags))) -> begin
+(FStar_All.pipe_right flags (FStar_Util.for_some (fun uu___88_2943 -> (match (uu___88_2943) with
+| FStar_Syntax_Syntax.CPS -> begin
+true
+end
+| uu____2944 -> begin
+false
+end))))
+end))
+
+
+let rec is_C : FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun t -> (
+
+let uu____2948 = (
+
+let uu____2949 = (FStar_Syntax_Subst.compress t)
+in uu____2949.FStar_Syntax_Syntax.n)
+in (match (uu____2948) with
+| FStar_Syntax_Syntax.Tm_app (head1, args) when (FStar_Syntax_Util.is_tuple_constructor head1) -> begin
+(
+
+let r = (
+
+let uu____2969 = (
+
+let uu____2970 = (FStar_List.hd args)
+in (Prims.fst uu____2970))
+in (is_C uu____2969))
+in (match (r) with
+| true -> begin
+((
+
+let uu____2982 = (
+
+let uu____2983 = (FStar_List.for_all (fun uu____2986 -> (match (uu____2986) with
+| (h, uu____2990) -> begin
+(is_C h)
+end)) args)
+in (not (uu____2983)))
+in (match (uu____2982) with
+| true -> begin
+(failwith "not a C (A * C)")
+end
+| uu____2991 -> begin
+()
+end));
+true;
+)
+end
+| uu____2992 -> begin
+((
+
+let uu____2994 = (
+
+let uu____2995 = (FStar_List.for_all (fun uu____2998 -> (match (uu____2998) with
+| (h, uu____3002) -> begin
+(
+
+let uu____3003 = (is_C h)
+in (not (uu____3003)))
+end)) args)
+in (not (uu____2995)))
+in (match (uu____2994) with
+| true -> begin
+(failwith "not a C (C * A)")
+end
+| uu____3004 -> begin
+()
+end));
+false;
+)
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (binders, comp) -> begin
+(
+
+let uu____3017 = (nm_of_comp comp.FStar_Syntax_Syntax.n)
+in (match (uu____3017) with
+| M (t1) -> begin
+((
+
+let uu____3020 = (is_C t1)
+in (match (uu____3020) with
+| true -> begin
+(failwith "not a C (C -> C)")
+end
+| uu____3021 -> begin
+()
+end));
+true;
+)
+end
+| N (t1) -> begin
+(is_C t1)
+end))
+end
+| (FStar_Syntax_Syntax.Tm_meta (t1, _)) | (FStar_Syntax_Syntax.Tm_uinst (t1, _)) | (FStar_Syntax_Syntax.Tm_ascribed (t1, _, _)) -> begin
+(is_C t1)
+end
+| uu____3052 -> begin
+false
+end)))
+
+
+let mk_return : env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t e -> (
+
+let mk1 = (fun x -> ((FStar_Syntax_Syntax.mk x) None e.FStar_Syntax_Syntax.pos))
+in (
+
+let p_type = (mk_star_to_type mk1 env t)
+in (
+
+let p = (FStar_Syntax_Syntax.gen_bv "p\'" None p_type)
+in (
+
+let body = (
+
+let uu____3083 = (
+
+let uu____3084 = (
+
+let uu____3094 = (FStar_Syntax_Syntax.bv_to_name p)
+in (
+
+let uu____3095 = (
+
+let uu____3099 = (
+
+let uu____3102 = (FStar_Syntax_Syntax.as_implicit false)
+in ((e), (uu____3102)))
+in (uu____3099)::[])
+in ((uu____3094), (uu____3095))))
+in FStar_Syntax_Syntax.Tm_app (uu____3084))
+in (mk1 uu____3083))
+in (
+
+let uu____3110 = (
+
+let uu____3114 = (FStar_Syntax_Syntax.mk_binder p)
+in (uu____3114)::[])
+in (
+
+let uu____3115 = (
+
+let uu____3122 = (
+
+let uu____3128 = (
+
+let uu____3129 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.lcomp_of_comp uu____3129))
+in FStar_Util.Inl (uu____3128))
+in Some (uu____3122))
+in (FStar_Syntax_Util.abs uu____3110 body uu____3115))))))))
+
+
+let is_unknown : FStar_Syntax_Syntax.term'  ->  Prims.bool = (fun uu___90_3142 -> (match (uu___90_3142) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+true
+end
+| uu____3143 -> begin
+false
+end))
+
+
+let rec check : env  ->  FStar_Syntax_Syntax.term  ->  nm  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env e context_nm -> (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None e.FStar_Syntax_Syntax.pos))
+in (
+
+let return_if = (fun uu____3287 -> (match (uu____3287) with
+| (rec_nm, s_e, u_e) -> begin
+(
+
+let check1 = (fun t1 t2 -> (
+
+let uu____3308 = ((not ((is_unknown t2.FStar_Syntax_Syntax.n))) && (
+
+let uu____3309 = (
+
+let uu____3310 = (FStar_TypeChecker_Rel.teq env.env t1 t2)
+in (FStar_TypeChecker_Rel.is_trivial uu____3310))
+in (not (uu____3309))))
+in (match (uu____3308) with
+| true -> begin
+(
+
+let uu____3311 = (
+
+let uu____3312 = (
+
+let uu____3313 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____3314 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____3315 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.format3 "[check]: the expression [%s] has type [%s] but should have type [%s]" uu____3313 uu____3314 uu____3315))))
+in FStar_Errors.Err (uu____3312))
+in (Prims.raise uu____3311))
+end
+| uu____3316 -> begin
+()
+end)))
+in (match (((rec_nm), (context_nm))) with
+| ((N (t1), N (t2))) | ((M (t1), M (t2))) -> begin
+((check1 t1 t2);
+((rec_nm), (s_e), (u_e));
+)
+end
+| (N (t1), M (t2)) -> begin
+((check1 t1 t2);
+(
+
+let uu____3326 = (mk_return env t1 s_e)
+in ((M (t1)), (uu____3326), (u_e)));
+)
+end
+| (M (t1), N (t2)) -> begin
+(
+
+let uu____3329 = (
+
+let uu____3330 = (
+
+let uu____3331 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____3332 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____3333 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.format3 "[check %s]: got an effectful computation [%s] in lieu of a pure computation [%s]" uu____3331 uu____3332 uu____3333))))
+in FStar_Errors.Err (uu____3330))
+in (Prims.raise uu____3329))
+end))
+end))
+in (
+
+let ensure_m = (fun env1 e2 -> (
+
+let strip_m = (fun uu___91_3359 -> (match (uu___91_3359) with
+| (M (t), s_e, u_e) -> begin
+((t), (s_e), (u_e))
+end
+| uu____3369 -> begin
+(failwith "impossible")
+end))
+in (match (context_nm) with
+| N (t) -> begin
+(
+
+let uu____3380 = (
+
+let uu____3381 = (
+
+let uu____3384 = (
+
+let uu____3385 = (FStar_Syntax_Print.term_to_string t)
+in (Prims.strcat "let-bound monadic body has a non-monadic continuation or a branch of a match is monadic and the others aren\'t : " uu____3385))
+in ((uu____3384), (e2.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____3381))
+in (Prims.raise uu____3380))
+end
+| M (uu____3389) -> begin
+(
+
+let uu____3390 = (check env1 e2 context_nm)
+in (strip_m uu____3390))
+end)))
+in (
+
+let uu____3394 = (
+
+let uu____3395 = (FStar_Syntax_Subst.compress e)
+in uu____3395.FStar_Syntax_Syntax.n)
+in (match (uu____3394) with
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_app (_)) -> begin
+(
+
+let uu____3407 = (infer env e)
+in (return_if uu____3407))
+end
+| FStar_Syntax_Syntax.Tm_let ((false, (binding)::[]), e2) -> begin
+(mk_let env binding e2 (fun env1 e21 -> (check env1 e21 context_nm)) ensure_m)
+end
+| FStar_Syntax_Syntax.Tm_match (e0, branches) -> begin
+(mk_match env e0 branches (fun env1 body -> (check env1 body context_nm)))
+end
+| (FStar_Syntax_Syntax.Tm_meta (e1, _)) | (FStar_Syntax_Syntax.Tm_uinst (e1, _)) | (FStar_Syntax_Syntax.Tm_ascribed (e1, _, _)) -> begin
+(check env e1 context_nm)
+end
+| FStar_Syntax_Syntax.Tm_let (uu____3482) -> begin
+(
+
+let uu____3490 = (
+
+let uu____3491 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[check]: Tm_let %s" uu____3491))
+in (failwith uu____3490))
+end
+| FStar_Syntax_Syntax.Tm_type (uu____3495) -> begin
+(failwith "impossible (DM stratification)")
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____3499) -> begin
+(failwith "impossible (DM stratification)")
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____3510) -> begin
+(
+
+let uu____3515 = (
+
+let uu____3516 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[check]: Tm_refine %s" uu____3516))
+in (failwith uu____3515))
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____3520) -> begin
+(
+
+let uu____3529 = (
+
+let uu____3530 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[check]: Tm_uvar %s" uu____3530))
+in (failwith uu____3529))
+end
+| FStar_Syntax_Syntax.Tm_delayed (uu____3534) -> begin
+(failwith "impossible (compressed)")
+end
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+(
+
+let uu____3558 = (
+
+let uu____3559 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[check]: Tm_unknown %s" uu____3559))
+in (failwith uu____3558))
+end))))))
+and infer : env  ->  FStar_Syntax_Syntax.term  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env e -> (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None e.FStar_Syntax_Syntax.pos))
+in (
+
+let normalize1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env.env)
+in (
+
+let uu____3581 = (
+
+let uu____3582 = (FStar_Syntax_Subst.compress e)
+in uu____3582.FStar_Syntax_Syntax.n)
+in (match (uu____3581) with
+| FStar_Syntax_Syntax.Tm_bvar (bv) -> begin
+(failwith "I failed to open a binder... boo")
+end
+| FStar_Syntax_Syntax.Tm_name (bv) -> begin
+((N (bv.FStar_Syntax_Syntax.sort)), (e), (e))
+end
+| FStar_Syntax_Syntax.Tm_abs (binders, body, what) -> begin
+(
+
+let binders1 = (FStar_Syntax_Subst.open_binders binders)
+in (
+
+let subst1 = (FStar_Syntax_Subst.opening_of_binders binders1)
+in (
+
+let body1 = (FStar_Syntax_Subst.subst subst1 body)
+in (
+
+let env1 = (
+
+let uu___105_3622 = env
+in (
+
+let uu____3623 = (FStar_TypeChecker_Env.push_binders env.env binders1)
+in {env = uu____3623; subst = uu___105_3622.subst; tc_const = uu___105_3622.tc_const}))
+in (
+
+let s_binders = (FStar_List.map (fun uu____3632 -> (match (uu____3632) with
+| (bv, qual) -> begin
+(
+
+let sort = (star_type' env1 bv.FStar_Syntax_Syntax.sort)
+in (((
+
+let uu___106_3640 = bv
+in {FStar_Syntax_Syntax.ppname = uu___106_3640.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___106_3640.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = sort})), (qual)))
+end)) binders1)
+in (
+
+let uu____3641 = (FStar_List.fold_left (fun uu____3650 uu____3651 -> (match (((uu____3650), (uu____3651))) with
+| ((env2, acc), (bv, qual)) -> begin
+(
+
+let c = bv.FStar_Syntax_Syntax.sort
+in (
+
+let uu____3679 = (is_C c)
+in (match (uu____3679) with
+| true -> begin
+(
+
+let xw = (
+
+let uu____3684 = (star_type' env2 c)
+in (FStar_Syntax_Syntax.gen_bv (Prims.strcat bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText "^w") None uu____3684))
+in (
+
+let x = (
+
+let uu___107_3686 = bv
+in (
+
+let uu____3687 = (
+
+let uu____3690 = (FStar_Syntax_Syntax.bv_to_name xw)
+in (trans_F_ env2 c uu____3690))
+in {FStar_Syntax_Syntax.ppname = uu___107_3686.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___107_3686.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3687}))
+in (
+
+let env3 = (
+
+let uu___108_3692 = env2
+in (
+
+let uu____3693 = (
+
+let uu____3695 = (
+
+let uu____3696 = (
+
+let uu____3701 = (FStar_Syntax_Syntax.bv_to_name xw)
+in ((bv), (uu____3701)))
+in FStar_Syntax_Syntax.NT (uu____3696))
+in (uu____3695)::env2.subst)
+in {env = uu___108_3692.env; subst = uu____3693; tc_const = uu___108_3692.tc_const}))
+in (
+
+let uu____3702 = (
+
+let uu____3704 = (FStar_Syntax_Syntax.mk_binder x)
+in (
+
+let uu____3705 = (
+
+let uu____3707 = (FStar_Syntax_Syntax.mk_binder xw)
+in (uu____3707)::acc)
+in (uu____3704)::uu____3705))
+in ((env3), (uu____3702))))))
+end
+| uu____3709 -> begin
+(
+
+let x = (
+
+let uu___109_3711 = bv
+in (
+
+let uu____3712 = (star_type' env2 bv.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___109_3711.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___109_3711.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____3712}))
+in (
+
+let uu____3715 = (
+
+let uu____3717 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____3717)::acc)
+in ((env2), (uu____3715))))
+end)))
+end)) ((env1), ([])) binders1)
+in (match (uu____3641) with
+| (env2, u_binders) -> begin
+(
+
+let u_binders1 = (FStar_List.rev u_binders)
+in (
+
+let uu____3729 = (
+
+let check_what = (
+
+let uu____3741 = (is_monadic what)
+in (match (uu____3741) with
+| true -> begin
+check_m
+end
+| uu____3749 -> begin
+check_n
+end))
+in (
+
+let uu____3750 = (check_what env2 body1)
+in (match (uu____3750) with
+| (t, s_body, u_body) -> begin
+(
+
+let uu____3760 = (
+
+let uu____3761 = (
+
+let uu____3762 = (is_monadic what)
+in (match (uu____3762) with
+| true -> begin
+M (t)
+end
+| uu____3763 -> begin
+N (t)
+end))
+in (comp_of_nm uu____3761))
+in ((uu____3760), (s_body), (u_body)))
+end)))
+in (match (uu____3729) with
+| (comp, s_body, u_body) -> begin
+(
+
+let t = (FStar_Syntax_Util.arrow binders1 comp)
+in (
+
+let s_what = (match (what) with
+| None -> begin
+None
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let uu____3805 = (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags (FStar_Util.for_some (fun uu___92_3807 -> (match (uu___92_3807) with
+| FStar_Syntax_Syntax.CPS -> begin
+true
+end
+| uu____3808 -> begin
+false
+end))))
+in (match (uu____3805) with
+| true -> begin
+(
+
+let double_starred_comp = (
+
+let uu____3816 = (
+
+let uu____3817 = (
+
+let uu____3818 = (lc.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Util.comp_result uu____3818))
+in (FStar_All.pipe_left double_star uu____3817))
+in (FStar_Syntax_Syntax.mk_Total uu____3816))
+in (
+
+let flags = (FStar_List.filter (fun uu___93_3823 -> (match (uu___93_3823) with
+| FStar_Syntax_Syntax.CPS -> begin
+false
+end
+| uu____3824 -> begin
+true
+end)) lc.FStar_Syntax_Syntax.cflags)
+in (
+
+let uu____3825 = (
+
+let uu____3831 = (
+
+let uu____3832 = (FStar_Syntax_Util.comp_set_flags double_starred_comp flags)
+in (FStar_Syntax_Util.lcomp_of_comp uu____3832))
+in FStar_Util.Inl (uu____3831))
+in Some (uu____3825))))
+end
+| uu____3843 -> begin
+Some (FStar_Util.Inl ((
+
+let uu___110_3852 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___110_3852.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu___110_3852.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = uu___110_3852.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____3853 -> (
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (
+
+let result_typ = (star_type' env2 (FStar_Syntax_Util.comp_result c))
+in (FStar_Syntax_Util.set_result_typ c result_typ))))})))
+end))
+end
+| Some (FStar_Util.Inr (lid, flags)) -> begin
+(
+
+let uu____3870 = (
+
+let uu____3876 = (
+
+let uu____3880 = (FStar_All.pipe_right flags (FStar_Util.for_some (fun uu___94_3882 -> (match (uu___94_3882) with
+| FStar_Syntax_Syntax.CPS -> begin
+true
+end
+| uu____3883 -> begin
+false
+end))))
+in (match (uu____3880) with
+| true -> begin
+(
+
+let uu____3887 = (FStar_List.filter (fun uu___95_3889 -> (match (uu___95_3889) with
+| FStar_Syntax_Syntax.CPS -> begin
+false
+end
+| uu____3890 -> begin
+true
+end)) flags)
+in ((FStar_Syntax_Const.effect_Tot_lid), (uu____3887)))
+end
+| uu____3892 -> begin
+((lid), (flags))
+end))
+in FStar_Util.Inr (uu____3876))
+in Some (uu____3870))
+end)
+in (
+
+let uu____3902 = (
+
+let comp1 = (
+
+let uu____3914 = (is_monadic what)
+in (
+
+let uu____3915 = (FStar_Syntax_Subst.subst env2.subst s_body)
+in (trans_G env2 (FStar_Syntax_Util.comp_result comp) uu____3914 uu____3915)))
+in (
+
+let uu____3916 = (FStar_Syntax_Util.ascribe u_body ((FStar_Util.Inr (comp1)), (None)))
+in ((uu____3916), (Some (FStar_Util.Inl ((FStar_Syntax_Util.lcomp_of_comp comp1)))))))
+in (match (uu____3902) with
+| (u_body1, u_what) -> begin
+(
+
+let s_body1 = (FStar_Syntax_Subst.close s_binders s_body)
+in (
+
+let s_binders1 = (FStar_Syntax_Subst.close_binders s_binders)
+in (
+
+let s_term = (mk1 (FStar_Syntax_Syntax.Tm_abs (((s_binders1), (s_body1), (s_what)))))
+in (
+
+let u_body2 = (FStar_Syntax_Subst.close u_binders1 u_body1)
+in (
+
+let u_binders2 = (FStar_Syntax_Subst.close_binders u_binders1)
+in (
+
+let u_term = (mk1 (FStar_Syntax_Syntax.Tm_abs (((u_binders2), (u_body2), (u_what)))))
+in ((N (t)), (s_term), (u_term))))))))
+end))))
+end)))
+end)))))))
+end
+| FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = {FStar_Syntax_Syntax.v = lid; FStar_Syntax_Syntax.ty = uu____3994; FStar_Syntax_Syntax.p = uu____3995}; FStar_Syntax_Syntax.fv_delta = uu____3996; FStar_Syntax_Syntax.fv_qual = uu____3997}) -> begin
+(
+
+let uu____4003 = (
+
+let uu____4006 = (FStar_TypeChecker_Env.lookup_lid env.env lid)
+in (FStar_All.pipe_left Prims.fst uu____4006))
+in (match (uu____4003) with
+| (uu____4022, t) -> begin
+(
+
+let uu____4024 = (
+
+let uu____4025 = (normalize1 t)
+in N (uu____4025))
+in ((uu____4024), (e), (e)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let uu____4042 = (check_n env head1)
+in (match (uu____4042) with
+| (t_head, s_head, u_head) -> begin
+(
+
+let is_arrow = (fun t -> (
+
+let uu____4056 = (
+
+let uu____4057 = (FStar_Syntax_Subst.compress t)
+in uu____4057.FStar_Syntax_Syntax.n)
+in (match (uu____4056) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____4060) -> begin
+true
+end
+| uu____4068 -> begin
+false
+end)))
+in (
+
+let rec flatten1 = (fun t -> (
+
+let uu____4080 = (
+
+let uu____4081 = (FStar_Syntax_Subst.compress t)
+in uu____4081.FStar_Syntax_Syntax.n)
+in (match (uu____4080) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total (t1, uu____4093); FStar_Syntax_Syntax.tk = uu____4094; FStar_Syntax_Syntax.pos = uu____4095; FStar_Syntax_Syntax.vars = uu____4096}) when (is_arrow t1) -> begin
+(
+
+let uu____4113 = (flatten1 t1)
+in (match (uu____4113) with
+| (binders', comp) -> begin
+(((FStar_List.append binders binders')), (comp))
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (binders, comp) -> begin
+((binders), (comp))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e1, uu____4165, uu____4166) -> begin
+(flatten1 e1)
+end
+| uu____4195 -> begin
+(
+
+let uu____4196 = (
+
+let uu____4197 = (
+
+let uu____4198 = (FStar_Syntax_Print.term_to_string t_head)
+in (FStar_Util.format1 "%s: not a function type" uu____4198))
+in FStar_Errors.Err (uu____4197))
+in (Prims.raise uu____4196))
+end)))
+in (
+
+let uu____4206 = (flatten1 t_head)
+in (match (uu____4206) with
+| (binders, comp) -> begin
+(
+
+let n1 = (FStar_List.length binders)
+in (
+
+let n' = (FStar_List.length args)
+in ((match (((FStar_List.length binders) < (FStar_List.length args))) with
+| true -> begin
+(
+
+let uu____4251 = (
+
+let uu____4252 = (
+
+let uu____4253 = (FStar_Util.string_of_int n1)
+in (
+
+let uu____4257 = (FStar_Util.string_of_int (n' - n1))
+in (
+
+let uu____4263 = (FStar_Util.string_of_int n1)
+in (FStar_Util.format3 "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments." uu____4253 uu____4257 uu____4263))))
+in FStar_Errors.Err (uu____4252))
+in (Prims.raise uu____4251))
+end
+| uu____4267 -> begin
+()
+end);
+(
+
+let uu____4268 = (FStar_Syntax_Subst.open_comp binders comp)
+in (match (uu____4268) with
+| (binders1, comp1) -> begin
+(
+
+let rec final_type = (fun subst1 uu____4295 args1 -> (match (uu____4295) with
+| (binders2, comp2) -> begin
+(match (((binders2), (args1))) with
+| ([], []) -> begin
+(
+
+let uu____4338 = (
+
+let uu____4339 = (FStar_Syntax_Subst.subst_comp subst1 comp2)
+in uu____4339.FStar_Syntax_Syntax.n)
+in (nm_of_comp uu____4338))
+end
+| (binders3, []) -> begin
+(
+
+let uu____4358 = (
+
+let uu____4359 = (
+
+let uu____4362 = (
+
+let uu____4363 = (mk1 (FStar_Syntax_Syntax.Tm_arrow (((binders3), (comp2)))))
+in (FStar_Syntax_Subst.subst subst1 uu____4363))
+in (FStar_Syntax_Subst.compress uu____4362))
+in uu____4359.FStar_Syntax_Syntax.n)
+in (match (uu____4358) with
+| FStar_Syntax_Syntax.Tm_arrow (binders4, comp3) -> begin
+(
+
+let uu____4379 = (
+
+let uu____4380 = (
+
+let uu____4381 = (
+
+let uu____4389 = (FStar_Syntax_Subst.close_comp binders4 comp3)
+in ((binders4), (uu____4389)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____4381))
+in (mk1 uu____4380))
+in N (uu____4379))
+end
+| uu____4393 -> begin
+(failwith "wat?")
+end))
+end
+| ([], (uu____4394)::uu____4395) -> begin
+(failwith "just checked that?!")
+end
+| (((bv, uu____4420))::binders3, ((arg, uu____4423))::args2) -> begin
+(final_type ((FStar_Syntax_Syntax.NT (((bv), (arg))))::subst1) ((binders3), (comp2)) args2)
+end)
+end))
+in (
+
+let final_type1 = (final_type [] ((binders1), (comp1)) args)
+in (
+
+let uu____4457 = (FStar_List.splitAt n' binders1)
+in (match (uu____4457) with
+| (binders2, uu____4474) -> begin
+(
+
+let uu____4487 = (
+
+let uu____4497 = (FStar_List.map2 (fun uu____4517 uu____4518 -> (match (((uu____4517), (uu____4518))) with
+| ((bv, uu____4535), (arg, q)) -> begin
+(
+
+let uu____4542 = (
+
+let uu____4543 = (FStar_Syntax_Subst.compress bv.FStar_Syntax_Syntax.sort)
+in uu____4543.FStar_Syntax_Syntax.n)
+in (match (uu____4542) with
+| FStar_Syntax_Syntax.Tm_type (uu____4553) -> begin
+(
+
+let arg1 = ((arg), (q))
+in ((arg1), ((arg1)::[])))
+end
+| uu____4566 -> begin
+(
+
+let uu____4567 = (check_n env arg)
+in (match (uu____4567) with
+| (uu____4578, s_arg, u_arg) -> begin
+(
+
+let uu____4581 = (
+
+let uu____4585 = (is_C bv.FStar_Syntax_Syntax.sort)
+in (match (uu____4585) with
+| true -> begin
+(
+
+let uu____4589 = (
+
+let uu____4592 = (FStar_Syntax_Subst.subst env.subst s_arg)
+in ((uu____4592), (q)))
+in (uu____4589)::(((u_arg), (q)))::[])
+end
+| uu____4599 -> begin
+(((u_arg), (q)))::[]
+end))
+in ((((s_arg), (q))), (uu____4581)))
+end))
+end))
+end)) binders2 args)
+in (FStar_List.split uu____4497))
+in (match (uu____4487) with
+| (s_args, u_args) -> begin
+(
+
+let u_args1 = (FStar_List.flatten u_args)
+in (
+
+let uu____4639 = (mk1 (FStar_Syntax_Syntax.Tm_app (((s_head), (s_args)))))
+in (
+
+let uu____4645 = (mk1 (FStar_Syntax_Syntax.Tm_app (((u_head), (u_args1)))))
+in ((final_type1), (uu____4639), (uu____4645)))))
+end))
+end))))
+end));
+)))
+end))))
+end))
+end
+| FStar_Syntax_Syntax.Tm_let ((false, (binding)::[]), e2) -> begin
+(mk_let env binding e2 infer check_m)
+end
+| FStar_Syntax_Syntax.Tm_match (e0, branches) -> begin
+(mk_match env e0 branches infer)
+end
+| (FStar_Syntax_Syntax.Tm_uinst (e1, _)) | (FStar_Syntax_Syntax.Tm_meta (e1, _)) | (FStar_Syntax_Syntax.Tm_ascribed (e1, _, _)) -> begin
+(infer env e1)
+end
+| FStar_Syntax_Syntax.Tm_constant (c) -> begin
+(
+
+let uu____4723 = (
+
+let uu____4724 = (env.tc_const c)
+in N (uu____4724))
+in ((uu____4723), (e), (e)))
+end
+| FStar_Syntax_Syntax.Tm_let (uu____4725) -> begin
+(
+
+let uu____4733 = (
+
+let uu____4734 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[infer]: Tm_let %s" uu____4734))
+in (failwith uu____4733))
+end
+| FStar_Syntax_Syntax.Tm_type (uu____4738) -> begin
+(failwith "impossible (DM stratification)")
+end
+| FStar_Syntax_Syntax.Tm_arrow (uu____4742) -> begin
+(failwith "impossible (DM stratification)")
+end
+| FStar_Syntax_Syntax.Tm_refine (uu____4753) -> begin
+(
+
+let uu____4758 = (
+
+let uu____4759 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[infer]: Tm_refine %s" uu____4759))
+in (failwith uu____4758))
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____4763) -> begin
+(
+
+let uu____4772 = (
+
+let uu____4773 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[infer]: Tm_uvar %s" uu____4773))
+in (failwith uu____4772))
+end
+| FStar_Syntax_Syntax.Tm_delayed (uu____4777) -> begin
+(failwith "impossible (compressed)")
+end
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+(
+
+let uu____4801 = (
+
+let uu____4802 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "[infer]: Tm_unknown %s" uu____4802))
+in (failwith uu____4801))
+end)))))
+and mk_match : env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  ((FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.option * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) Prims.list  ->  (env  ->  FStar_Syntax_Syntax.term  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term))  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env e0 branches f -> (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None e0.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____4840 = (check_n env e0)
+in (match (uu____4840) with
+| (uu____4847, s_e0, u_e0) -> begin
+(
+
+let uu____4850 = (
+
+let uu____4868 = (FStar_List.map (fun b -> (
+
+let uu____4901 = (FStar_Syntax_Subst.open_branch b)
+in (match (uu____4901) with
+| (pat, None, body) -> begin
+(
+
+let env1 = (
+
+let uu___111_4933 = env
+in (
+
+let uu____4934 = (
+
+let uu____4935 = (FStar_Syntax_Syntax.pat_bvs pat)
+in (FStar_List.fold_left FStar_TypeChecker_Env.push_bv env.env uu____4935))
+in {env = uu____4934; subst = uu___111_4933.subst; tc_const = uu___111_4933.tc_const}))
+in (
+
+let uu____4937 = (f env1 body)
+in (match (uu____4937) with
+| (nm, s_body, u_body) -> begin
+((nm), (((pat), (None), (((s_body), (u_body), (body))))))
+end)))
+end
+| uu____4986 -> begin
+(Prims.raise (FStar_Errors.Err ("No when clauses in the definition language")))
+end))) branches)
+in (FStar_List.split uu____4868))
+in (match (uu____4850) with
+| (nms, branches1) -> begin
+(
+
+let t1 = (
+
+let uu____5051 = (FStar_List.hd nms)
+in (match (uu____5051) with
+| (M (t1)) | (N (t1)) -> begin
+t1
+end))
+in (
+
+let has_m = (FStar_List.existsb (fun uu___96_5054 -> (match (uu___96_5054) with
+| M (uu____5055) -> begin
+true
+end
+| uu____5056 -> begin
+false
+end)) nms)
+in (
+
+let uu____5057 = (
+
+let uu____5080 = (FStar_List.map2 (fun nm uu____5132 -> (match (uu____5132) with
+| (pat, guard, (s_body, u_body, original_body)) -> begin
+(match (((nm), (has_m))) with
+| ((N (t2), false)) | ((M (t2), true)) -> begin
+((nm), (((pat), (guard), (s_body))), (((pat), (guard), (u_body))))
+end
+| (N (t2), true) -> begin
+(
+
+let uu____5228 = (check env original_body (M (t2)))
+in (match (uu____5228) with
+| (uu____5251, s_body1, u_body1) -> begin
+((M (t2)), (((pat), (guard), (s_body1))), (((pat), (guard), (u_body1))))
+end))
+end
+| (M (uu____5280), false) -> begin
+(failwith "impossible")
+end)
+end)) nms branches1)
+in (FStar_List.unzip3 uu____5080))
+in (match (uu____5057) with
+| (nms1, s_branches, u_branches) -> begin
+(match (has_m) with
+| true -> begin
+(
+
+let p_type = (mk_star_to_type mk1 env t1)
+in (
+
+let p = (FStar_Syntax_Syntax.gen_bv "p\'\'" None p_type)
+in (
+
+let s_branches1 = (FStar_List.map (fun uu____5399 -> (match (uu____5399) with
+| (pat, guard, s_body) -> begin
+(
+
+let s_body1 = (
+
+let uu____5440 = (
+
+let uu____5441 = (
+
+let uu____5451 = (
+
+let uu____5455 = (
+
+let uu____5458 = (FStar_Syntax_Syntax.bv_to_name p)
+in (
+
+let uu____5459 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____5458), (uu____5459))))
+in (uu____5455)::[])
+in ((s_body), (uu____5451)))
+in FStar_Syntax_Syntax.Tm_app (uu____5441))
+in (mk1 uu____5440))
+in ((pat), (guard), (s_body1)))
+end)) s_branches)
+in (
+
+let s_branches2 = (FStar_List.map FStar_Syntax_Subst.close_branch s_branches1)
+in (
+
+let u_branches1 = (FStar_List.map FStar_Syntax_Subst.close_branch u_branches)
+in (
+
+let s_e = (
+
+let uu____5481 = (
+
+let uu____5485 = (FStar_Syntax_Syntax.mk_binder p)
+in (uu____5485)::[])
+in (
+
+let uu____5486 = (mk1 (FStar_Syntax_Syntax.Tm_match (((s_e0), (s_branches2)))))
+in (
+
+let uu____5488 = (
+
+let uu____5495 = (
+
+let uu____5501 = (
+
+let uu____5502 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.lcomp_of_comp uu____5502))
+in FStar_Util.Inl (uu____5501))
+in Some (uu____5495))
+in (FStar_Syntax_Util.abs uu____5481 uu____5486 uu____5488))))
+in (
+
+let t1_star = (
+
+let uu____5516 = (
+
+let uu____5520 = (
+
+let uu____5521 = (FStar_Syntax_Syntax.new_bv None p_type)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____5521))
+in (uu____5520)::[])
+in (
+
+let uu____5522 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.arrow uu____5516 uu____5522)))
+in (
+
+let uu____5525 = (mk1 (FStar_Syntax_Syntax.Tm_ascribed (((s_e), (((FStar_Util.Inl (t1_star)), (None))), (None)))))
+in (
+
+let uu____5555 = (mk1 (FStar_Syntax_Syntax.Tm_match (((u_e0), (u_branches1)))))
+in ((M (t1)), (uu____5525), (uu____5555)))))))))))
+end
+| uu____5563 -> begin
+(
+
+let s_branches1 = (FStar_List.map FStar_Syntax_Subst.close_branch s_branches)
+in (
+
+let u_branches1 = (FStar_List.map FStar_Syntax_Subst.close_branch u_branches)
+in (
+
+let t1_star = t1
+in (
+
+let uu____5569 = (
+
+let uu____5572 = (
+
+let uu____5573 = (
+
+let uu____5591 = (mk1 (FStar_Syntax_Syntax.Tm_match (((s_e0), (s_branches1)))))
+in ((uu____5591), (((FStar_Util.Inl (t1_star)), (None))), (None)))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____5573))
+in (mk1 uu____5572))
+in (
+
+let uu____5618 = (mk1 (FStar_Syntax_Syntax.Tm_match (((u_e0), (u_branches1)))))
+in ((N (t1)), (uu____5569), (uu____5618)))))))
+end)
+end))))
+end))
+end))))
+and mk_let : env_  ->  FStar_Syntax_Syntax.letbinding  ->  FStar_Syntax_Syntax.term  ->  (env_  ->  FStar_Syntax_Syntax.term  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term))  ->  (env_  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term))  ->  (nm * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env binding e2 proceed ensure_m -> (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None e2.FStar_Syntax_Syntax.pos))
+in (
+
+let e1 = binding.FStar_Syntax_Syntax.lbdef
+in (
+
+let x = (FStar_Util.left binding.FStar_Syntax_Syntax.lbname)
+in (
+
+let x_binders = (
+
+let uu____5661 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____5661)::[])
+in (
+
+let uu____5662 = (FStar_Syntax_Subst.open_term x_binders e2)
+in (match (uu____5662) with
+| (x_binders1, e21) -> begin
+(
+
+let uu____5670 = (infer env e1)
+in (match (uu____5670) with
+| (N (t1), s_e1, u_e1) -> begin
+(
+
+let u_binding = (
+
+let uu____5681 = (is_C t1)
+in (match (uu____5681) with
+| true -> begin
+(
+
+let uu___112_5682 = binding
+in (
+
+let uu____5683 = (
+
+let uu____5686 = (FStar_Syntax_Subst.subst env.subst s_e1)
+in (trans_F_ env t1 uu____5686))
+in {FStar_Syntax_Syntax.lbname = uu___112_5682.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___112_5682.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu____5683; FStar_Syntax_Syntax.lbeff = uu___112_5682.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___112_5682.FStar_Syntax_Syntax.lbdef}))
+end
+| uu____5687 -> begin
+binding
+end))
+in (
+
+let env1 = (
+
+let uu___113_5689 = env
+in (
+
+let uu____5690 = (FStar_TypeChecker_Env.push_bv env.env (
+
+let uu___114_5691 = x
+in {FStar_Syntax_Syntax.ppname = uu___114_5691.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___114_5691.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1}))
+in {env = uu____5690; subst = uu___113_5689.subst; tc_const = uu___113_5689.tc_const}))
+in (
+
+let uu____5692 = (proceed env1 e21)
+in (match (uu____5692) with
+| (nm_rec, s_e2, u_e2) -> begin
+(
+
+let s_binding = (
+
+let uu___115_5703 = binding
+in (
+
+let uu____5704 = (star_type' env1 binding.FStar_Syntax_Syntax.lbtyp)
+in {FStar_Syntax_Syntax.lbname = uu___115_5703.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___115_5703.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu____5704; FStar_Syntax_Syntax.lbeff = uu___115_5703.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___115_5703.FStar_Syntax_Syntax.lbdef}))
+in (
+
+let uu____5707 = (
+
+let uu____5710 = (
+
+let uu____5711 = (
+
+let uu____5719 = (FStar_Syntax_Subst.close x_binders1 s_e2)
+in ((((false), (((
+
+let uu___116_5724 = s_binding
+in {FStar_Syntax_Syntax.lbname = uu___116_5724.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___116_5724.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___116_5724.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___116_5724.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = s_e1}))::[]))), (uu____5719)))
+in FStar_Syntax_Syntax.Tm_let (uu____5711))
+in (mk1 uu____5710))
+in (
+
+let uu____5725 = (
+
+let uu____5728 = (
+
+let uu____5729 = (
+
+let uu____5737 = (FStar_Syntax_Subst.close x_binders1 u_e2)
+in ((((false), (((
+
+let uu___117_5742 = u_binding
+in {FStar_Syntax_Syntax.lbname = uu___117_5742.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___117_5742.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___117_5742.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___117_5742.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = u_e1}))::[]))), (uu____5737)))
+in FStar_Syntax_Syntax.Tm_let (uu____5729))
+in (mk1 uu____5728))
+in ((nm_rec), (uu____5707), (uu____5725)))))
+end))))
+end
+| (M (t1), s_e1, u_e1) -> begin
+(
+
+let u_binding = (
+
+let uu___118_5751 = binding
+in {FStar_Syntax_Syntax.lbname = uu___118_5751.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___118_5751.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = t1; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_PURE_lid; FStar_Syntax_Syntax.lbdef = uu___118_5751.FStar_Syntax_Syntax.lbdef})
+in (
+
+let env1 = (
+
+let uu___119_5753 = env
+in (
+
+let uu____5754 = (FStar_TypeChecker_Env.push_bv env.env (
+
+let uu___120_5755 = x
+in {FStar_Syntax_Syntax.ppname = uu___120_5755.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___120_5755.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1}))
+in {env = uu____5754; subst = uu___119_5753.subst; tc_const = uu___119_5753.tc_const}))
+in (
+
+let uu____5756 = (ensure_m env1 e21)
+in (match (uu____5756) with
+| (t2, s_e2, u_e2) -> begin
+(
+
+let p_type = (mk_star_to_type mk1 env1 t2)
+in (
+
+let p = (FStar_Syntax_Syntax.gen_bv "p\'\'" None p_type)
+in (
+
+let s_e21 = (
+
+let uu____5773 = (
+
+let uu____5774 = (
+
+let uu____5784 = (
+
+let uu____5788 = (
+
+let uu____5791 = (FStar_Syntax_Syntax.bv_to_name p)
+in (
+
+let uu____5792 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____5791), (uu____5792))))
+in (uu____5788)::[])
+in ((s_e2), (uu____5784)))
+in FStar_Syntax_Syntax.Tm_app (uu____5774))
+in (mk1 uu____5773))
+in (
+
+let s_e22 = (
+
+let uu____5801 = (
+
+let uu____5808 = (
+
+let uu____5814 = (
+
+let uu____5815 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.lcomp_of_comp uu____5815))
+in FStar_Util.Inl (uu____5814))
+in Some (uu____5808))
+in (FStar_Syntax_Util.abs x_binders1 s_e21 uu____5801))
+in (
+
+let body = (
+
+let uu____5829 = (
+
+let uu____5830 = (
+
+let uu____5840 = (
+
+let uu____5844 = (
+
+let uu____5847 = (FStar_Syntax_Syntax.as_implicit false)
+in ((s_e22), (uu____5847)))
+in (uu____5844)::[])
+in ((s_e1), (uu____5840)))
+in FStar_Syntax_Syntax.Tm_app (uu____5830))
+in (mk1 uu____5829))
+in (
+
+let uu____5855 = (
+
+let uu____5856 = (
+
+let uu____5860 = (FStar_Syntax_Syntax.mk_binder p)
+in (uu____5860)::[])
+in (
+
+let uu____5861 = (
+
+let uu____5868 = (
+
+let uu____5874 = (
+
+let uu____5875 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.lcomp_of_comp uu____5875))
+in FStar_Util.Inl (uu____5874))
+in Some (uu____5868))
+in (FStar_Syntax_Util.abs uu____5856 body uu____5861)))
+in (
+
+let uu____5886 = (
+
+let uu____5889 = (
+
+let uu____5890 = (
+
+let uu____5898 = (FStar_Syntax_Subst.close x_binders1 u_e2)
+in ((((false), (((
+
+let uu___121_5903 = u_binding
+in {FStar_Syntax_Syntax.lbname = uu___121_5903.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___121_5903.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___121_5903.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___121_5903.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = u_e1}))::[]))), (uu____5898)))
+in FStar_Syntax_Syntax.Tm_let (uu____5890))
+in (mk1 uu____5889))
+in ((M (t2)), (uu____5855), (uu____5886)))))))))
+end))))
+end))
+end)))))))
+and check_n : env_  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env e -> (
+
+let mn = (
+
+let uu____5912 = (FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown None e.FStar_Syntax_Syntax.pos)
+in N (uu____5912))
+in (
+
+let uu____5917 = (check env e mn)
+in (match (uu____5917) with
+| (N (t), s_e, u_e) -> begin
+((t), (s_e), (u_e))
+end
+| uu____5927 -> begin
+(failwith "[check_n]: impossible")
+end))))
+and check_m : env_  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env e -> (
+
+let mn = (
+
+let uu____5940 = (FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown None e.FStar_Syntax_Syntax.pos)
+in M (uu____5940))
+in (
+
+let uu____5945 = (check env e mn)
+in (match (uu____5945) with
+| (M (t), s_e, u_e) -> begin
+((t), (s_e), (u_e))
+end
+| uu____5955 -> begin
+(failwith "[check_m]: impossible")
+end))))
+and comp_of_nm : nm_  ->  FStar_Syntax_Syntax.comp = (fun nm -> (match (nm) with
+| N (t) -> begin
+(FStar_Syntax_Syntax.mk_Total t)
+end
+| M (t) -> begin
+(mk_M t)
+end))
+and mk_M : FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.comp = (fun t -> (FStar_Syntax_Syntax.mk_Comp {FStar_Syntax_Syntax.comp_univs = (FStar_Syntax_Syntax.U_unknown)::[]; FStar_Syntax_Syntax.effect_name = FStar_Syntax_Const.monadic_lid; FStar_Syntax_Syntax.result_typ = t; FStar_Syntax_Syntax.effect_args = []; FStar_Syntax_Syntax.flags = (FStar_Syntax_Syntax.CPS)::(FStar_Syntax_Syntax.TOTAL)::[]}))
+and type_of_comp : (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun t -> (FStar_Syntax_Util.comp_result t))
+and trans_F_ : env_  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env c wp -> ((
+
+let uu____5977 = (
+
+let uu____5978 = (is_C c)
+in (not (uu____5978)))
+in (match (uu____5977) with
+| true -> begin
+(failwith "not a C")
+end
+| uu____5979 -> begin
+()
+end));
+(
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None c.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____5990 = (
+
+let uu____5991 = (FStar_Syntax_Subst.compress c)
+in uu____5991.FStar_Syntax_Syntax.n)
+in (match (uu____5990) with
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let uu____6010 = (FStar_Syntax_Util.head_and_args wp)
+in (match (uu____6010) with
+| (wp_head, wp_args) -> begin
+((
+
+let uu____6037 = ((not (((FStar_List.length wp_args) = (FStar_List.length args)))) || (
+
+let uu____6050 = (
+
+let uu____6051 = (FStar_Syntax_Util.mk_tuple_data_lid (FStar_List.length wp_args) FStar_Range.dummyRange)
+in (FStar_Syntax_Util.is_constructor wp_head uu____6051))
+in (not (uu____6050))))
+in (match (uu____6037) with
+| true -> begin
+(failwith "mismatch")
+end
+| uu____6059 -> begin
+()
+end));
+(
+
+let uu____6060 = (
+
+let uu____6061 = (
+
+let uu____6071 = (FStar_List.map2 (fun uu____6081 uu____6082 -> (match (((uu____6081), (uu____6082))) with
+| ((arg, q), (wp_arg, q')) -> begin
+(
+
+let print_implicit = (fun q1 -> (
+
+let uu____6105 = (FStar_Syntax_Syntax.is_implicit q1)
+in (match (uu____6105) with
+| true -> begin
+"implicit"
+end
+| uu____6106 -> begin
+"explicit"
+end)))
+in ((match ((q <> q')) with
+| true -> begin
+(
+
+let uu____6108 = (print_implicit q)
+in (
+
+let uu____6109 = (print_implicit q')
+in (FStar_Util.print2_warning "Incoherent implicit qualifiers %b %b" uu____6108 uu____6109)))
+end
+| uu____6110 -> begin
+()
+end);
+(
+
+let uu____6111 = (trans_F_ env arg wp_arg)
+in ((uu____6111), (q)));
+))
+end)) args wp_args)
+in ((head1), (uu____6071)))
+in FStar_Syntax_Syntax.Tm_app (uu____6061))
+in (mk1 uu____6060));
+)
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (binders, comp) -> begin
+(
+
+let binders1 = (FStar_Syntax_Util.name_binders binders)
+in (
+
+let uu____6133 = (FStar_Syntax_Subst.open_comp binders1 comp)
+in (match (uu____6133) with
+| (binders_orig, comp1) -> begin
+(
+
+let uu____6138 = (
+
+let uu____6146 = (FStar_List.map (fun uu____6160 -> (match (uu____6160) with
+| (bv, q) -> begin
+(
+
+let h = bv.FStar_Syntax_Syntax.sort
+in (
+
+let uu____6173 = (is_C h)
+in (match (uu____6173) with
+| true -> begin
+(
+
+let w' = (
+
+let uu____6180 = (star_type' env h)
+in (FStar_Syntax_Syntax.gen_bv (Prims.strcat bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText "-w\'") None uu____6180))
+in (
+
+let uu____6181 = (
+
+let uu____6185 = (
+
+let uu____6189 = (
+
+let uu____6192 = (
+
+let uu____6193 = (
+
+let uu____6194 = (FStar_Syntax_Syntax.bv_to_name w')
+in (trans_F_ env h uu____6194))
+in (FStar_Syntax_Syntax.null_bv uu____6193))
+in ((uu____6192), (q)))
+in (uu____6189)::[])
+in (((w'), (q)))::uu____6185)
+in ((w'), (uu____6181))))
+end
+| uu____6204 -> begin
+(
+
+let x = (
+
+let uu____6206 = (star_type' env h)
+in (FStar_Syntax_Syntax.gen_bv (Prims.strcat bv.FStar_Syntax_Syntax.ppname.FStar_Ident.idText "-x") None uu____6206))
+in ((x), ((((x), (q)))::[])))
+end)))
+end)) binders_orig)
+in (FStar_List.split uu____6146))
+in (match (uu____6138) with
+| (bvs, binders2) -> begin
+(
+
+let binders3 = (FStar_List.flatten binders2)
+in (
+
+let comp2 = (
+
+let uu____6236 = (
+
+let uu____6238 = (FStar_Syntax_Syntax.binders_of_list bvs)
+in (FStar_Syntax_Util.rename_binders binders_orig uu____6238))
+in (FStar_Syntax_Subst.subst_comp uu____6236 comp1))
+in (
+
+let app = (
+
+let uu____6242 = (
+
+let uu____6243 = (
+
+let uu____6253 = (FStar_List.map (fun bv -> (
+
+let uu____6260 = (FStar_Syntax_Syntax.bv_to_name bv)
+in (
+
+let uu____6261 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____6260), (uu____6261))))) bvs)
+in ((wp), (uu____6253)))
+in FStar_Syntax_Syntax.Tm_app (uu____6243))
+in (mk1 uu____6242))
+in (
+
+let comp3 = (
+
+let uu____6266 = (type_of_comp comp2)
+in (
+
+let uu____6267 = (is_monadic_comp comp2)
+in (trans_G env uu____6266 uu____6267 app)))
+in (FStar_Syntax_Util.arrow binders3 comp3)))))
+end))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e, uu____6269, uu____6270) -> begin
+(trans_F_ env e wp)
+end
+| uu____6299 -> begin
+(failwith "impossible trans_F_")
+end)));
+))
+and trans_G : env_  ->  FStar_Syntax_Syntax.typ  ->  Prims.bool  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.comp = (fun env h is_monadic1 wp -> (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None h.FStar_Syntax_Syntax.pos))
+in (match (is_monadic1) with
+| true -> begin
+(
+
+let uu____6314 = (
+
+let uu____6315 = (star_type' env h)
+in (
+
+let uu____6318 = (
+
+let uu____6324 = (
+
+let uu____6327 = (FStar_Syntax_Syntax.as_implicit false)
+in ((wp), (uu____6327)))
+in (uu____6324)::[])
+in {FStar_Syntax_Syntax.comp_univs = (FStar_Syntax_Syntax.U_unknown)::[]; FStar_Syntax_Syntax.effect_name = FStar_Syntax_Const.effect_PURE_lid; FStar_Syntax_Syntax.result_typ = uu____6315; FStar_Syntax_Syntax.effect_args = uu____6318; FStar_Syntax_Syntax.flags = []}))
+in (FStar_Syntax_Syntax.mk_Comp uu____6314))
+end
+| uu____6332 -> begin
+(
+
+let uu____6333 = (trans_F_ env h wp)
+in (FStar_Syntax_Syntax.mk_Total uu____6333))
+end)))
+
+
+let n : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.NoDeltaSteps)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]))
+
+
+let star_type : env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun env t -> (
+
+let uu____6344 = (n env.env t)
+in (star_type' env uu____6344)))
+
+
+let star_expr : env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun env t -> (
+
+let uu____6356 = (n env.env t)
+in (check_n env uu____6356)))
+
+
+let trans_F : env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env c wp -> (
+
+let uu____6366 = (n env.env c)
+in (
+
+let uu____6367 = (n env.env wp)
+in (trans_F_ env uu____6366 uu____6367))))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -1,2579 +1,2706 @@
+
 open Prims
 type binding =
-  | Binding_var of FStar_Syntax_Syntax.bv
-  | Binding_lid of (FStar_Ident.lident* FStar_Syntax_Syntax.tscheme)
-  | Binding_sig of (FStar_Ident.lident Prims.list*
-  FStar_Syntax_Syntax.sigelt)
-  | Binding_univ of FStar_Syntax_Syntax.univ_name
-  | Binding_sig_inst of (FStar_Ident.lident Prims.list*
-  FStar_Syntax_Syntax.sigelt* FStar_Syntax_Syntax.universes)
-let uu___is_Binding_var: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_var _0 -> true | uu____29 -> false
-let __proj__Binding_var__item___0: binding -> FStar_Syntax_Syntax.bv =
-  fun projectee  -> match projectee with | Binding_var _0 -> _0
-let uu___is_Binding_lid: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_lid _0 -> true | uu____43 -> false
-let __proj__Binding_lid__item___0:
-  binding -> (FStar_Ident.lident* FStar_Syntax_Syntax.tscheme) =
-  fun projectee  -> match projectee with | Binding_lid _0 -> _0
-let uu___is_Binding_sig: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_sig _0 -> true | uu____64 -> false
-let __proj__Binding_sig__item___0:
-  binding -> (FStar_Ident.lident Prims.list* FStar_Syntax_Syntax.sigelt) =
-  fun projectee  -> match projectee with | Binding_sig _0 -> _0
-let uu___is_Binding_univ: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_univ _0 -> true | uu____85 -> false
-let __proj__Binding_univ__item___0: binding -> FStar_Syntax_Syntax.univ_name
-  = fun projectee  -> match projectee with | Binding_univ _0 -> _0
-let uu___is_Binding_sig_inst: binding -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Binding_sig_inst _0 -> true | uu____101 -> false
-let __proj__Binding_sig_inst__item___0:
-  binding ->
-    (FStar_Ident.lident Prims.list* FStar_Syntax_Syntax.sigelt*
-      FStar_Syntax_Syntax.universes)
-  = fun projectee  -> match projectee with | Binding_sig_inst _0 -> _0
+| Binding_var of FStar_Syntax_Syntax.bv
+| Binding_lid of (FStar_Ident.lident * FStar_Syntax_Syntax.tscheme)
+| Binding_sig of (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt)
+| Binding_univ of FStar_Syntax_Syntax.univ_name
+| Binding_sig_inst of (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes)
+
+
+let uu___is_Binding_var : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_var (_0) -> begin
+true
+end
+| uu____29 -> begin
+false
+end))
+
+
+let __proj__Binding_var__item___0 : binding  ->  FStar_Syntax_Syntax.bv = (fun projectee -> (match (projectee) with
+| Binding_var (_0) -> begin
+_0
+end))
+
+
+let uu___is_Binding_lid : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_lid (_0) -> begin
+true
+end
+| uu____43 -> begin
+false
+end))
+
+
+let __proj__Binding_lid__item___0 : binding  ->  (FStar_Ident.lident * FStar_Syntax_Syntax.tscheme) = (fun projectee -> (match (projectee) with
+| Binding_lid (_0) -> begin
+_0
+end))
+
+
+let uu___is_Binding_sig : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_sig (_0) -> begin
+true
+end
+| uu____64 -> begin
+false
+end))
+
+
+let __proj__Binding_sig__item___0 : binding  ->  (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt) = (fun projectee -> (match (projectee) with
+| Binding_sig (_0) -> begin
+_0
+end))
+
+
+let uu___is_Binding_univ : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_univ (_0) -> begin
+true
+end
+| uu____85 -> begin
+false
+end))
+
+
+let __proj__Binding_univ__item___0 : binding  ->  FStar_Syntax_Syntax.univ_name = (fun projectee -> (match (projectee) with
+| Binding_univ (_0) -> begin
+_0
+end))
+
+
+let uu___is_Binding_sig_inst : binding  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Binding_sig_inst (_0) -> begin
+true
+end
+| uu____101 -> begin
+false
+end))
+
+
+let __proj__Binding_sig_inst__item___0 : binding  ->  (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes) = (fun projectee -> (match (projectee) with
+| Binding_sig_inst (_0) -> begin
+_0
+end))
+
 type delta_level =
-  | NoDelta
-  | Inlining
-  | Eager_unfolding_only
-  | Unfold of FStar_Syntax_Syntax.delta_depth
-let uu___is_NoDelta: delta_level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoDelta  -> true | uu____127 -> false
-let uu___is_Inlining: delta_level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Inlining  -> true | uu____131 -> false
-let uu___is_Eager_unfolding_only: delta_level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eager_unfolding_only  -> true | uu____135 -> false
-let uu___is_Unfold: delta_level -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Unfold _0 -> true | uu____140 -> false
-let __proj__Unfold__item___0: delta_level -> FStar_Syntax_Syntax.delta_depth
-  = fun projectee  -> match projectee with | Unfold _0 -> _0
+| NoDelta
+| Inlining
+| Eager_unfolding_only
+| Unfold of FStar_Syntax_Syntax.delta_depth
+
+
+let uu___is_NoDelta : delta_level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoDelta -> begin
+true
+end
+| uu____127 -> begin
+false
+end))
+
+
+let uu___is_Inlining : delta_level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Inlining -> begin
+true
+end
+| uu____131 -> begin
+false
+end))
+
+
+let uu___is_Eager_unfolding_only : delta_level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eager_unfolding_only -> begin
+true
+end
+| uu____135 -> begin
+false
+end))
+
+
+let uu___is_Unfold : delta_level  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Unfold (_0) -> begin
+true
+end
+| uu____140 -> begin
+false
+end))
+
+
+let __proj__Unfold__item___0 : delta_level  ->  FStar_Syntax_Syntax.delta_depth = (fun projectee -> (match (projectee) with
+| Unfold (_0) -> begin
+_0
+end))
+
 type mlift =
-  {
-  mlift_wp:
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ;
-  mlift_term:
-    (FStar_Syntax_Syntax.typ ->
-       FStar_Syntax_Syntax.typ ->
-         FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-      Prims.option;}
+{mlift_wp : FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ; mlift_term : (FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term) Prims.option}
+
 type edge =
-  {
-  msource: FStar_Ident.lident;
-  mtarget: FStar_Ident.lident;
-  mlift: mlift;}
+{msource : FStar_Ident.lident; mtarget : FStar_Ident.lident; mlift : mlift}
+
 type effects =
-  {
-  decls: FStar_Syntax_Syntax.eff_decl Prims.list;
-  order: edge Prims.list;
-  joins:
-    (FStar_Ident.lident* FStar_Ident.lident* FStar_Ident.lident* mlift*
-      mlift) Prims.list;}
+{decls : FStar_Syntax_Syntax.eff_decl Prims.list; order : edge Prims.list; joins : (FStar_Ident.lident * FStar_Ident.lident * FStar_Ident.lident * mlift * mlift) Prims.list}
+
+
 type cached_elt =
-  (((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ),(FStar_Syntax_Syntax.sigelt*
-                                                               FStar_Syntax_Syntax.universes
-                                                               Prims.option))
-    FStar_Util.either* FStar_Range.range)
-type goal = FStar_Syntax_Syntax.term
+(((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ), (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes Prims.option)) FStar_Util.either * FStar_Range.range)
+
+
+type goal =
+FStar_Syntax_Syntax.term
+
 type env =
-  {
-  solver: solver_t;
-  range: FStar_Range.range;
-  curmodule: FStar_Ident.lident;
-  gamma: binding Prims.list;
-  gamma_cache: cached_elt FStar_Util.smap;
-  modules: FStar_Syntax_Syntax.modul Prims.list;
-  expected_typ: FStar_Syntax_Syntax.typ Prims.option;
-  sigtab: FStar_Syntax_Syntax.sigelt FStar_Util.smap;
-  is_pattern: Prims.bool;
-  instantiate_imp: Prims.bool;
-  effects: effects;
-  generalize: Prims.bool;
-  letrecs: (FStar_Syntax_Syntax.lbname* FStar_Syntax_Syntax.typ) Prims.list;
-  top_level: Prims.bool;
-  check_uvars: Prims.bool;
-  use_eq: Prims.bool;
-  is_iface: Prims.bool;
-  admit: Prims.bool;
-  lax: Prims.bool;
-  lax_universes: Prims.bool;
-  type_of:
-    env ->
-      FStar_Syntax_Syntax.term ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.typ* guard_t);
-  universe_of:
-    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe;
-  use_bv_sorts: Prims.bool;
-  qname_and_index: (FStar_Ident.lident* Prims.int) Prims.option;}
-and solver_t =
-  {
-  init: env -> Prims.unit;
-  push: Prims.string -> Prims.unit;
-  pop: Prims.string -> Prims.unit;
-  mark: Prims.string -> Prims.unit;
-  reset_mark: Prims.string -> Prims.unit;
-  commit_mark: Prims.string -> Prims.unit;
-  encode_modul: env -> FStar_Syntax_Syntax.modul -> Prims.unit;
-  encode_sig: env -> FStar_Syntax_Syntax.sigelt -> Prims.unit;
-  preprocess: env -> goal -> (env* goal) Prims.list;
-  solve:
-    (Prims.unit -> Prims.string) Prims.option ->
-      env -> FStar_Syntax_Syntax.typ -> Prims.unit;
-  is_trivial: env -> FStar_Syntax_Syntax.typ -> Prims.bool;
-  finish: Prims.unit -> Prims.unit;
-  refresh: Prims.unit -> Prims.unit;}
-and guard_t =
-  {
-  guard_f: FStar_TypeChecker_Common.guard_formula;
-  deferred: FStar_TypeChecker_Common.deferred;
-  univ_ineqs:
-    (FStar_Syntax_Syntax.universe Prims.list*
-      FStar_TypeChecker_Common.univ_ineq Prims.list);
-  implicits:
-    (Prims.string* env* FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.term*
-      FStar_Syntax_Syntax.typ* FStar_Range.range) Prims.list;}
+{solver : solver_t; range : FStar_Range.range; curmodule : FStar_Ident.lident; gamma : binding Prims.list; gamma_cache : cached_elt FStar_Util.smap; modules : FStar_Syntax_Syntax.modul Prims.list; expected_typ : FStar_Syntax_Syntax.typ Prims.option; sigtab : FStar_Syntax_Syntax.sigelt FStar_Util.smap; is_pattern : Prims.bool; instantiate_imp : Prims.bool; effects : effects; generalize : Prims.bool; letrecs : (FStar_Syntax_Syntax.lbname * FStar_Syntax_Syntax.typ) Prims.list; top_level : Prims.bool; check_uvars : Prims.bool; use_eq : Prims.bool; is_iface : Prims.bool; admit : Prims.bool; lax : Prims.bool; lax_universes : Prims.bool; type_of : env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * guard_t); universe_of : env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.universe; use_bv_sorts : Prims.bool; qname_and_index : (FStar_Ident.lident * Prims.int) Prims.option} 
+ and solver_t =
+{init : env  ->  Prims.unit; push : Prims.string  ->  Prims.unit; pop : Prims.string  ->  Prims.unit; mark : Prims.string  ->  Prims.unit; reset_mark : Prims.string  ->  Prims.unit; commit_mark : Prims.string  ->  Prims.unit; encode_modul : env  ->  FStar_Syntax_Syntax.modul  ->  Prims.unit; encode_sig : env  ->  FStar_Syntax_Syntax.sigelt  ->  Prims.unit; preprocess : env  ->  goal  ->  (env * goal) Prims.list; solve : (Prims.unit  ->  Prims.string) Prims.option  ->  env  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit; is_trivial : env  ->  FStar_Syntax_Syntax.typ  ->  Prims.bool; finish : Prims.unit  ->  Prims.unit; refresh : Prims.unit  ->  Prims.unit} 
+ and guard_t =
+{guard_f : FStar_TypeChecker_Common.guard_formula; deferred : FStar_TypeChecker_Common.deferred; univ_ineqs : (FStar_Syntax_Syntax.universe Prims.list * FStar_TypeChecker_Common.univ_ineq Prims.list); implicits : (Prims.string * env * FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * FStar_Range.range) Prims.list}
+
+
 type implicits =
-  (Prims.string* env* FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.term*
-    FStar_Syntax_Syntax.typ* FStar_Range.range) Prims.list
-type env_t = env
-type sigtable = FStar_Syntax_Syntax.sigelt FStar_Util.smap
-let should_verify: env -> Prims.bool =
-  fun env  ->
-    ((Prims.op_Negation env.lax) && (Prims.op_Negation env.admit)) &&
-      (FStar_Options.should_verify (env.curmodule).FStar_Ident.str)
-let visible_at: delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool =
-  fun d  ->
-    fun q  ->
-      match (d, q) with
-      | (NoDelta ,_)
-        |(Eager_unfolding_only
-          ,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
-         |(Unfold _,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
-          |(Unfold _,FStar_Syntax_Syntax.Visible_default ) -> true
-      | (Inlining ,FStar_Syntax_Syntax.Inline_for_extraction ) -> true
-      | uu____839 -> false
-let default_table_size: Prims.int = Prims.parse_int "200"
-let new_sigtab uu____849 = FStar_Util.smap_create default_table_size
-let new_gamma_cache uu____857 =
-  FStar_Util.smap_create (Prims.parse_int "100")
-let initial_env:
-  (env ->
-     FStar_Syntax_Syntax.term ->
-       (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.typ* guard_t))
-    ->
-    (env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe) ->
-      solver_t -> FStar_Ident.lident -> env
-  =
-  fun type_of  ->
-    fun universe_of  ->
-      fun solver  ->
-        fun module_lid  ->
-          let uu____896 = new_gamma_cache () in
-          let uu____898 = new_sigtab () in
-          {
-            solver;
-            range = FStar_Range.dummyRange;
-            curmodule = module_lid;
-            gamma = [];
-            gamma_cache = uu____896;
-            modules = [];
-            expected_typ = None;
-            sigtab = uu____898;
-            is_pattern = false;
-            instantiate_imp = true;
-            effects = { decls = []; order = []; joins = [] };
-            generalize = true;
-            letrecs = [];
-            top_level = false;
-            check_uvars = false;
-            use_eq = false;
-            is_iface = false;
-            admit = false;
-            lax = false;
-            lax_universes = false;
-            type_of;
-            universe_of;
-            use_bv_sorts = false;
-            qname_and_index = None
-          }
-let sigtab: env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap =
-  fun env  -> env.sigtab
-let gamma_cache: env -> cached_elt FStar_Util.smap =
-  fun env  -> env.gamma_cache
-let query_indices:
-  (FStar_Ident.lident* Prims.int) Prims.list Prims.list FStar_ST.ref =
-  FStar_Util.mk_ref [[]]
-let push_query_indices: Prims.unit -> Prims.unit =
-  fun uu____938  ->
-    let uu____939 = FStar_ST.read query_indices in
-    match uu____939 with
-    | [] -> failwith "Empty query indices!"
-    | uu____953 ->
-        let uu____958 =
-          let uu____963 =
-            let uu____967 = FStar_ST.read query_indices in
-            FStar_List.hd uu____967 in
-          let uu____981 = FStar_ST.read query_indices in uu____963 ::
-            uu____981 in
-        FStar_ST.write query_indices uu____958
-let pop_query_indices: Prims.unit -> Prims.unit =
-  fun uu____1003  ->
-    let uu____1004 = FStar_ST.read query_indices in
-    match uu____1004 with
-    | [] -> failwith "Empty query indices!"
-    | hd1::tl1 -> FStar_ST.write query_indices tl1
-let add_query_index: (FStar_Ident.lident* Prims.int) -> Prims.unit =
-  fun uu____1040  ->
-    match uu____1040 with
-    | (l,n1) ->
-        let uu____1045 = FStar_ST.read query_indices in
-        (match uu____1045 with
-         | hd1::tl1 -> FStar_ST.write query_indices (((l, n1) :: hd1) :: tl1)
-         | uu____1079 -> failwith "Empty query indices")
-let peek_query_indices:
-  Prims.unit -> (FStar_Ident.lident* Prims.int) Prims.list =
-  fun uu____1089  ->
-    let uu____1090 = FStar_ST.read query_indices in FStar_List.hd uu____1090
-let commit_query_index_mark: Prims.unit -> Prims.unit =
-  fun uu____1106  ->
-    let uu____1107 = FStar_ST.read query_indices in
-    match uu____1107 with
-    | hd1::uu____1119::tl1 -> FStar_ST.write query_indices (hd1 :: tl1)
-    | uu____1146 -> failwith "Unmarked query index stack"
-let stack: env Prims.list FStar_ST.ref = FStar_Util.mk_ref []
-let push_stack: env -> env =
-  fun env  ->
-    (let uu____1160 =
-       let uu____1162 = FStar_ST.read stack in env :: uu____1162 in
-     FStar_ST.write stack uu____1160);
-    (let uu___108_1170 = env in
-     let uu____1171 = FStar_Util.smap_copy (gamma_cache env) in
-     let uu____1173 = FStar_Util.smap_copy (sigtab env) in
-     {
-       solver = (uu___108_1170.solver);
-       range = (uu___108_1170.range);
-       curmodule = (uu___108_1170.curmodule);
-       gamma = (uu___108_1170.gamma);
-       gamma_cache = uu____1171;
-       modules = (uu___108_1170.modules);
-       expected_typ = (uu___108_1170.expected_typ);
-       sigtab = uu____1173;
-       is_pattern = (uu___108_1170.is_pattern);
-       instantiate_imp = (uu___108_1170.instantiate_imp);
-       effects = (uu___108_1170.effects);
-       generalize = (uu___108_1170.generalize);
-       letrecs = (uu___108_1170.letrecs);
-       top_level = (uu___108_1170.top_level);
-       check_uvars = (uu___108_1170.check_uvars);
-       use_eq = (uu___108_1170.use_eq);
-       is_iface = (uu___108_1170.is_iface);
-       admit = (uu___108_1170.admit);
-       lax = (uu___108_1170.lax);
-       lax_universes = (uu___108_1170.lax_universes);
-       type_of = (uu___108_1170.type_of);
-       universe_of = (uu___108_1170.universe_of);
-       use_bv_sorts = (uu___108_1170.use_bv_sorts);
-       qname_and_index = (uu___108_1170.qname_and_index)
-     })
-let pop_stack: Prims.unit -> env =
-  fun uu____1177  ->
-    let uu____1178 = FStar_ST.read stack in
-    match uu____1178 with
-    | env::tl1 -> (FStar_ST.write stack tl1; env)
-    | uu____1190 -> failwith "Impossible: Too many pops"
-let cleanup_interactive: env -> Prims.unit = fun env  -> (env.solver).pop ""
-let push: env -> Prims.string -> env =
-  fun env  ->
-    fun msg  -> push_query_indices (); (env.solver).push msg; push_stack env
-let pop: env -> Prims.string -> env =
-  fun env  ->
-    fun msg  -> (env.solver).pop msg; pop_query_indices (); pop_stack ()
-let mark: env -> env =
-  fun env  ->
-    (env.solver).mark "USER MARK"; push_query_indices (); push_stack env
-let commit_mark: env -> env =
-  fun env  ->
-    commit_query_index_mark ();
-    (env.solver).commit_mark "USER MARK";
-    (let uu____1222 = pop_stack () in ());
-    env
-let reset_mark: env -> env =
-  fun env  ->
-    (env.solver).reset_mark "USER MARK"; pop_query_indices (); pop_stack ()
-let incr_query_index: env -> env =
-  fun env  ->
-    let qix = peek_query_indices () in
-    match env.qname_and_index with
-    | None  -> env
-    | Some (l,n1) ->
-        let uu____1241 =
-          FStar_All.pipe_right qix
-            (FStar_List.tryFind
-               (fun uu____1253  ->
-                  match uu____1253 with
-                  | (m,uu____1257) -> FStar_Ident.lid_equals l m)) in
-        (match uu____1241 with
-         | None  ->
-             let next = n1 + (Prims.parse_int "1") in
-             (add_query_index (l, next);
-              (let uu___109_1262 = env in
-               {
-                 solver = (uu___109_1262.solver);
-                 range = (uu___109_1262.range);
-                 curmodule = (uu___109_1262.curmodule);
-                 gamma = (uu___109_1262.gamma);
-                 gamma_cache = (uu___109_1262.gamma_cache);
-                 modules = (uu___109_1262.modules);
-                 expected_typ = (uu___109_1262.expected_typ);
-                 sigtab = (uu___109_1262.sigtab);
-                 is_pattern = (uu___109_1262.is_pattern);
-                 instantiate_imp = (uu___109_1262.instantiate_imp);
-                 effects = (uu___109_1262.effects);
-                 generalize = (uu___109_1262.generalize);
-                 letrecs = (uu___109_1262.letrecs);
-                 top_level = (uu___109_1262.top_level);
-                 check_uvars = (uu___109_1262.check_uvars);
-                 use_eq = (uu___109_1262.use_eq);
-                 is_iface = (uu___109_1262.is_iface);
-                 admit = (uu___109_1262.admit);
-                 lax = (uu___109_1262.lax);
-                 lax_universes = (uu___109_1262.lax_universes);
-                 type_of = (uu___109_1262.type_of);
-                 universe_of = (uu___109_1262.universe_of);
-                 use_bv_sorts = (uu___109_1262.use_bv_sorts);
-                 qname_and_index = (Some (l, next))
-               }))
-         | Some (uu____1265,m) ->
-             let next = m + (Prims.parse_int "1") in
-             (add_query_index (l, next);
-              (let uu___110_1271 = env in
-               {
-                 solver = (uu___110_1271.solver);
-                 range = (uu___110_1271.range);
-                 curmodule = (uu___110_1271.curmodule);
-                 gamma = (uu___110_1271.gamma);
-                 gamma_cache = (uu___110_1271.gamma_cache);
-                 modules = (uu___110_1271.modules);
-                 expected_typ = (uu___110_1271.expected_typ);
-                 sigtab = (uu___110_1271.sigtab);
-                 is_pattern = (uu___110_1271.is_pattern);
-                 instantiate_imp = (uu___110_1271.instantiate_imp);
-                 effects = (uu___110_1271.effects);
-                 generalize = (uu___110_1271.generalize);
-                 letrecs = (uu___110_1271.letrecs);
-                 top_level = (uu___110_1271.top_level);
-                 check_uvars = (uu___110_1271.check_uvars);
-                 use_eq = (uu___110_1271.use_eq);
-                 is_iface = (uu___110_1271.is_iface);
-                 admit = (uu___110_1271.admit);
-                 lax = (uu___110_1271.lax);
-                 lax_universes = (uu___110_1271.lax_universes);
-                 type_of = (uu___110_1271.type_of);
-                 universe_of = (uu___110_1271.universe_of);
-                 use_bv_sorts = (uu___110_1271.use_bv_sorts);
-                 qname_and_index = (Some (l, next))
-               })))
-let debug: env -> FStar_Options.debug_level_t -> Prims.bool =
-  fun env  ->
-    fun l  -> FStar_Options.debug_at_level (env.curmodule).FStar_Ident.str l
-let set_range: env -> FStar_Range.range -> env =
-  fun e  ->
-    fun r  ->
-      if r = FStar_Range.dummyRange
-      then e
-      else
-        (let uu___111_1287 = e in
-         {
-           solver = (uu___111_1287.solver);
-           range = r;
-           curmodule = (uu___111_1287.curmodule);
-           gamma = (uu___111_1287.gamma);
-           gamma_cache = (uu___111_1287.gamma_cache);
-           modules = (uu___111_1287.modules);
-           expected_typ = (uu___111_1287.expected_typ);
-           sigtab = (uu___111_1287.sigtab);
-           is_pattern = (uu___111_1287.is_pattern);
-           instantiate_imp = (uu___111_1287.instantiate_imp);
-           effects = (uu___111_1287.effects);
-           generalize = (uu___111_1287.generalize);
-           letrecs = (uu___111_1287.letrecs);
-           top_level = (uu___111_1287.top_level);
-           check_uvars = (uu___111_1287.check_uvars);
-           use_eq = (uu___111_1287.use_eq);
-           is_iface = (uu___111_1287.is_iface);
-           admit = (uu___111_1287.admit);
-           lax = (uu___111_1287.lax);
-           lax_universes = (uu___111_1287.lax_universes);
-           type_of = (uu___111_1287.type_of);
-           universe_of = (uu___111_1287.universe_of);
-           use_bv_sorts = (uu___111_1287.use_bv_sorts);
-           qname_and_index = (uu___111_1287.qname_and_index)
-         })
-let get_range: env -> FStar_Range.range = fun e  -> e.range
-let modules: env -> FStar_Syntax_Syntax.modul Prims.list =
-  fun env  -> env.modules
-let current_module: env -> FStar_Ident.lident = fun env  -> env.curmodule
-let set_current_module: env -> FStar_Ident.lident -> env =
-  fun env  ->
-    fun lid  ->
-      let uu___112_1304 = env in
-      {
-        solver = (uu___112_1304.solver);
-        range = (uu___112_1304.range);
-        curmodule = lid;
-        gamma = (uu___112_1304.gamma);
-        gamma_cache = (uu___112_1304.gamma_cache);
-        modules = (uu___112_1304.modules);
-        expected_typ = (uu___112_1304.expected_typ);
-        sigtab = (uu___112_1304.sigtab);
-        is_pattern = (uu___112_1304.is_pattern);
-        instantiate_imp = (uu___112_1304.instantiate_imp);
-        effects = (uu___112_1304.effects);
-        generalize = (uu___112_1304.generalize);
-        letrecs = (uu___112_1304.letrecs);
-        top_level = (uu___112_1304.top_level);
-        check_uvars = (uu___112_1304.check_uvars);
-        use_eq = (uu___112_1304.use_eq);
-        is_iface = (uu___112_1304.is_iface);
-        admit = (uu___112_1304.admit);
-        lax = (uu___112_1304.lax);
-        lax_universes = (uu___112_1304.lax_universes);
-        type_of = (uu___112_1304.type_of);
-        universe_of = (uu___112_1304.universe_of);
-        use_bv_sorts = (uu___112_1304.use_bv_sorts);
-        qname_and_index = (uu___112_1304.qname_and_index)
-      }
-let has_interface: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun l  ->
-      FStar_All.pipe_right env.modules
-        (FStar_Util.for_some
-           (fun m  ->
-              m.FStar_Syntax_Syntax.is_interface &&
-                (FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name l)))
-let find_in_sigtab:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.sigelt Prims.option =
-  fun env  ->
-    fun lid  ->
-      FStar_Util.smap_try_find (sigtab env) (FStar_Ident.text_of_lid lid)
-let name_not_found: FStar_Ident.lid -> Prims.string =
-  fun l  -> FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str
-let variable_not_found: FStar_Syntax_Syntax.bv -> Prims.string =
-  fun v1  ->
-    let uu____1326 = FStar_Syntax_Print.bv_to_string v1 in
-    FStar_Util.format1 "Variable \"%s\" not found" uu____1326
-let new_u_univ: Prims.unit -> FStar_Syntax_Syntax.universe =
-  fun uu____1329  ->
-    let uu____1330 = FStar_Unionfind.fresh None in
-    FStar_Syntax_Syntax.U_unif uu____1330
-let inst_tscheme_with:
-  FStar_Syntax_Syntax.tscheme ->
-    FStar_Syntax_Syntax.universes ->
-      (FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.term)
-  =
-  fun ts  ->
-    fun us  ->
-      match (ts, us) with
-      | (([],t),[]) -> ([], t)
-      | ((formals,t),uu____1353) ->
-          let n1 = (FStar_List.length formals) - (Prims.parse_int "1") in
-          let vs =
-            FStar_All.pipe_right us
-              (FStar_List.mapi
-                 (fun i  -> fun u  -> FStar_Syntax_Syntax.UN ((n1 - i), u))) in
-          let uu____1369 = FStar_Syntax_Subst.subst vs t in (us, uu____1369)
-let inst_tscheme:
-  FStar_Syntax_Syntax.tscheme ->
-    (FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.term)
-  =
-  fun uu___96_1374  ->
-    match uu___96_1374 with
-    | ([],t) -> ([], t)
-    | (us,t) ->
-        let us' =
-          FStar_All.pipe_right us
-            (FStar_List.map (fun uu____1388  -> new_u_univ ())) in
-        inst_tscheme_with (us, t) us'
-let inst_tscheme_with_range:
-  FStar_Range.range ->
-    FStar_Syntax_Syntax.tscheme ->
-      (FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.term)
-  =
-  fun r  ->
-    fun t  ->
-      let uu____1398 = inst_tscheme t in
-      match uu____1398 with
-      | (us,t1) ->
-          let uu____1405 = FStar_Syntax_Subst.set_use_range r t1 in
-          (us, uu____1405)
-let inst_effect_fun_with:
-  FStar_Syntax_Syntax.universes ->
-    env ->
-      FStar_Syntax_Syntax.eff_decl ->
-        FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.term
-  =
-  fun insts  ->
-    fun env  ->
-      fun ed  ->
-        fun uu____1417  ->
-          match uu____1417 with
-          | (us,t) ->
-              (match ed.FStar_Syntax_Syntax.binders with
-               | [] ->
-                   let univs1 =
-                     FStar_List.append ed.FStar_Syntax_Syntax.univs us in
-                   (if
-                      (FStar_List.length insts) <> (FStar_List.length univs1)
-                    then
-                      (let uu____1431 =
-                         let uu____1432 =
-                           FStar_All.pipe_left FStar_Util.string_of_int
-                             (FStar_List.length univs1) in
-                         let uu____1435 =
-                           FStar_All.pipe_left FStar_Util.string_of_int
-                             (FStar_List.length insts) in
-                         let uu____1438 =
-                           FStar_Syntax_Print.lid_to_string
-                             ed.FStar_Syntax_Syntax.mname in
-                         let uu____1439 = FStar_Syntax_Print.term_to_string t in
-                         FStar_Util.format4
-                           "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
-                           uu____1432 uu____1435 uu____1438 uu____1439 in
-                       failwith uu____1431)
-                    else ();
-                    (let uu____1441 =
-                       inst_tscheme_with
-                         ((FStar_List.append ed.FStar_Syntax_Syntax.univs us),
-                           t) insts in
-                     Prims.snd uu____1441))
-               | uu____1445 ->
-                   let uu____1446 =
-                     let uu____1447 =
-                       FStar_Syntax_Print.lid_to_string
-                         ed.FStar_Syntax_Syntax.mname in
-                     FStar_Util.format1
-                       "Unexpected use of an uninstantiated effect: %s\n"
-                       uu____1447 in
-                   failwith uu____1446)
+(Prims.string * env * FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * FStar_Range.range) Prims.list
+
+
+type env_t =
+env
+
+
+type sigtable =
+FStar_Syntax_Syntax.sigelt FStar_Util.smap
+
+
+let should_verify : env  ->  Prims.bool = (fun env -> (((not (env.lax)) && (not (env.admit))) && (FStar_Options.should_verify env.curmodule.FStar_Ident.str)))
+
+
+let visible_at : delta_level  ->  FStar_Syntax_Syntax.qualifier  ->  Prims.bool = (fun d q -> (match (((d), (q))) with
+| ((NoDelta, _)) | ((Eager_unfolding_only, FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) | ((Unfold (_), FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) | ((Unfold (_), FStar_Syntax_Syntax.Visible_default)) -> begin
+true
+end
+| (Inlining, FStar_Syntax_Syntax.Inline_for_extraction) -> begin
+true
+end
+| uu____839 -> begin
+false
+end))
+
+
+let default_table_size : Prims.int = (Prims.parse_int "200")
+
+
+let new_sigtab = (fun uu____849 -> (FStar_Util.smap_create default_table_size))
+
+
+let new_gamma_cache = (fun uu____857 -> (FStar_Util.smap_create (Prims.parse_int "100")))
+
+
+let initial_env : (env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * guard_t))  ->  (env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.universe)  ->  solver_t  ->  FStar_Ident.lident  ->  env = (fun type_of universe_of solver module_lid -> (
+
+let uu____896 = (new_gamma_cache ())
+in (
+
+let uu____898 = (new_sigtab ())
+in {solver = solver; range = FStar_Range.dummyRange; curmodule = module_lid; gamma = []; gamma_cache = uu____896; modules = []; expected_typ = None; sigtab = uu____898; is_pattern = false; instantiate_imp = true; effects = {decls = []; order = []; joins = []}; generalize = true; letrecs = []; top_level = false; check_uvars = false; use_eq = false; is_iface = false; admit = false; lax = false; lax_universes = false; type_of = type_of; universe_of = universe_of; use_bv_sorts = false; qname_and_index = None})))
+
+
+let sigtab : env  ->  FStar_Syntax_Syntax.sigelt FStar_Util.smap = (fun env -> env.sigtab)
+
+
+let gamma_cache : env  ->  cached_elt FStar_Util.smap = (fun env -> env.gamma_cache)
+
+
+let query_indices : (FStar_Ident.lident * Prims.int) Prims.list Prims.list FStar_ST.ref = (FStar_Util.mk_ref (([])::[]))
+
+
+let push_query_indices : Prims.unit  ->  Prims.unit = (fun uu____938 -> (
+
+let uu____939 = (FStar_ST.read query_indices)
+in (match (uu____939) with
+| [] -> begin
+(failwith "Empty query indices!")
+end
+| uu____953 -> begin
+(
+
+let uu____958 = (
+
+let uu____963 = (
+
+let uu____967 = (FStar_ST.read query_indices)
+in (FStar_List.hd uu____967))
+in (
+
+let uu____981 = (FStar_ST.read query_indices)
+in (uu____963)::uu____981))
+in (FStar_ST.write query_indices uu____958))
+end)))
+
+
+let pop_query_indices : Prims.unit  ->  Prims.unit = (fun uu____1003 -> (
+
+let uu____1004 = (FStar_ST.read query_indices)
+in (match (uu____1004) with
+| [] -> begin
+(failwith "Empty query indices!")
+end
+| (hd1)::tl1 -> begin
+(FStar_ST.write query_indices tl1)
+end)))
+
+
+let add_query_index : (FStar_Ident.lident * Prims.int)  ->  Prims.unit = (fun uu____1040 -> (match (uu____1040) with
+| (l, n1) -> begin
+(
+
+let uu____1045 = (FStar_ST.read query_indices)
+in (match (uu____1045) with
+| (hd1)::tl1 -> begin
+(FStar_ST.write query_indices (((((l), (n1)))::hd1)::tl1))
+end
+| uu____1079 -> begin
+(failwith "Empty query indices")
+end))
+end))
+
+
+let peek_query_indices : Prims.unit  ->  (FStar_Ident.lident * Prims.int) Prims.list = (fun uu____1089 -> (
+
+let uu____1090 = (FStar_ST.read query_indices)
+in (FStar_List.hd uu____1090)))
+
+
+let commit_query_index_mark : Prims.unit  ->  Prims.unit = (fun uu____1106 -> (
+
+let uu____1107 = (FStar_ST.read query_indices)
+in (match (uu____1107) with
+| (hd1)::(uu____1119)::tl1 -> begin
+(FStar_ST.write query_indices ((hd1)::tl1))
+end
+| uu____1146 -> begin
+(failwith "Unmarked query index stack")
+end)))
+
+
+let stack : env Prims.list FStar_ST.ref = (FStar_Util.mk_ref [])
+
+
+let push_stack : env  ->  env = (fun env -> ((
+
+let uu____1160 = (
+
+let uu____1162 = (FStar_ST.read stack)
+in (env)::uu____1162)
+in (FStar_ST.write stack uu____1160));
+(
+
+let uu___108_1170 = env
+in (
+
+let uu____1171 = (FStar_Util.smap_copy (gamma_cache env))
+in (
+
+let uu____1173 = (FStar_Util.smap_copy (sigtab env))
+in {solver = uu___108_1170.solver; range = uu___108_1170.range; curmodule = uu___108_1170.curmodule; gamma = uu___108_1170.gamma; gamma_cache = uu____1171; modules = uu___108_1170.modules; expected_typ = uu___108_1170.expected_typ; sigtab = uu____1173; is_pattern = uu___108_1170.is_pattern; instantiate_imp = uu___108_1170.instantiate_imp; effects = uu___108_1170.effects; generalize = uu___108_1170.generalize; letrecs = uu___108_1170.letrecs; top_level = uu___108_1170.top_level; check_uvars = uu___108_1170.check_uvars; use_eq = uu___108_1170.use_eq; is_iface = uu___108_1170.is_iface; admit = uu___108_1170.admit; lax = uu___108_1170.lax; lax_universes = uu___108_1170.lax_universes; type_of = uu___108_1170.type_of; universe_of = uu___108_1170.universe_of; use_bv_sorts = uu___108_1170.use_bv_sorts; qname_and_index = uu___108_1170.qname_and_index})));
+))
+
+
+let pop_stack : Prims.unit  ->  env = (fun uu____1177 -> (
+
+let uu____1178 = (FStar_ST.read stack)
+in (match (uu____1178) with
+| (env)::tl1 -> begin
+((FStar_ST.write stack tl1);
+env;
+)
+end
+| uu____1190 -> begin
+(failwith "Impossible: Too many pops")
+end)))
+
+
+let cleanup_interactive : env  ->  Prims.unit = (fun env -> (env.solver.pop ""))
+
+
+let push : env  ->  Prims.string  ->  env = (fun env msg -> ((push_query_indices ());
+(env.solver.push msg);
+(push_stack env);
+))
+
+
+let pop : env  ->  Prims.string  ->  env = (fun env msg -> ((env.solver.pop msg);
+(pop_query_indices ());
+(pop_stack ());
+))
+
+
+let mark : env  ->  env = (fun env -> ((env.solver.mark "USER MARK");
+(push_query_indices ());
+(push_stack env);
+))
+
+
+let commit_mark : env  ->  env = (fun env -> ((commit_query_index_mark ());
+(env.solver.commit_mark "USER MARK");
+(
+
+let uu____1222 = (pop_stack ())
+in ());
+env;
+))
+
+
+let reset_mark : env  ->  env = (fun env -> ((env.solver.reset_mark "USER MARK");
+(pop_query_indices ());
+(pop_stack ());
+))
+
+
+let incr_query_index : env  ->  env = (fun env -> (
+
+let qix = (peek_query_indices ())
+in (match (env.qname_and_index) with
+| None -> begin
+env
+end
+| Some (l, n1) -> begin
+(
+
+let uu____1241 = (FStar_All.pipe_right qix (FStar_List.tryFind (fun uu____1253 -> (match (uu____1253) with
+| (m, uu____1257) -> begin
+(FStar_Ident.lid_equals l m)
+end))))
+in (match (uu____1241) with
+| None -> begin
+(
+
+let next = (n1 + (Prims.parse_int "1"))
+in ((add_query_index ((l), (next)));
+(
+
+let uu___109_1262 = env
+in {solver = uu___109_1262.solver; range = uu___109_1262.range; curmodule = uu___109_1262.curmodule; gamma = uu___109_1262.gamma; gamma_cache = uu___109_1262.gamma_cache; modules = uu___109_1262.modules; expected_typ = uu___109_1262.expected_typ; sigtab = uu___109_1262.sigtab; is_pattern = uu___109_1262.is_pattern; instantiate_imp = uu___109_1262.instantiate_imp; effects = uu___109_1262.effects; generalize = uu___109_1262.generalize; letrecs = uu___109_1262.letrecs; top_level = uu___109_1262.top_level; check_uvars = uu___109_1262.check_uvars; use_eq = uu___109_1262.use_eq; is_iface = uu___109_1262.is_iface; admit = uu___109_1262.admit; lax = uu___109_1262.lax; lax_universes = uu___109_1262.lax_universes; type_of = uu___109_1262.type_of; universe_of = uu___109_1262.universe_of; use_bv_sorts = uu___109_1262.use_bv_sorts; qname_and_index = Some (((l), (next)))});
+))
+end
+| Some (uu____1265, m) -> begin
+(
+
+let next = (m + (Prims.parse_int "1"))
+in ((add_query_index ((l), (next)));
+(
+
+let uu___110_1271 = env
+in {solver = uu___110_1271.solver; range = uu___110_1271.range; curmodule = uu___110_1271.curmodule; gamma = uu___110_1271.gamma; gamma_cache = uu___110_1271.gamma_cache; modules = uu___110_1271.modules; expected_typ = uu___110_1271.expected_typ; sigtab = uu___110_1271.sigtab; is_pattern = uu___110_1271.is_pattern; instantiate_imp = uu___110_1271.instantiate_imp; effects = uu___110_1271.effects; generalize = uu___110_1271.generalize; letrecs = uu___110_1271.letrecs; top_level = uu___110_1271.top_level; check_uvars = uu___110_1271.check_uvars; use_eq = uu___110_1271.use_eq; is_iface = uu___110_1271.is_iface; admit = uu___110_1271.admit; lax = uu___110_1271.lax; lax_universes = uu___110_1271.lax_universes; type_of = uu___110_1271.type_of; universe_of = uu___110_1271.universe_of; use_bv_sorts = uu___110_1271.use_bv_sorts; qname_and_index = Some (((l), (next)))});
+))
+end))
+end)))
+
+
+let debug : env  ->  FStar_Options.debug_level_t  ->  Prims.bool = (fun env l -> (FStar_Options.debug_at_level env.curmodule.FStar_Ident.str l))
+
+
+let set_range : env  ->  FStar_Range.range  ->  env = (fun e r -> (match ((r = FStar_Range.dummyRange)) with
+| true -> begin
+e
+end
+| uu____1286 -> begin
+(
+
+let uu___111_1287 = e
+in {solver = uu___111_1287.solver; range = r; curmodule = uu___111_1287.curmodule; gamma = uu___111_1287.gamma; gamma_cache = uu___111_1287.gamma_cache; modules = uu___111_1287.modules; expected_typ = uu___111_1287.expected_typ; sigtab = uu___111_1287.sigtab; is_pattern = uu___111_1287.is_pattern; instantiate_imp = uu___111_1287.instantiate_imp; effects = uu___111_1287.effects; generalize = uu___111_1287.generalize; letrecs = uu___111_1287.letrecs; top_level = uu___111_1287.top_level; check_uvars = uu___111_1287.check_uvars; use_eq = uu___111_1287.use_eq; is_iface = uu___111_1287.is_iface; admit = uu___111_1287.admit; lax = uu___111_1287.lax; lax_universes = uu___111_1287.lax_universes; type_of = uu___111_1287.type_of; universe_of = uu___111_1287.universe_of; use_bv_sorts = uu___111_1287.use_bv_sorts; qname_and_index = uu___111_1287.qname_and_index})
+end))
+
+
+let get_range : env  ->  FStar_Range.range = (fun e -> e.range)
+
+
+let modules : env  ->  FStar_Syntax_Syntax.modul Prims.list = (fun env -> env.modules)
+
+
+let current_module : env  ->  FStar_Ident.lident = (fun env -> env.curmodule)
+
+
+let set_current_module : env  ->  FStar_Ident.lident  ->  env = (fun env lid -> (
+
+let uu___112_1304 = env
+in {solver = uu___112_1304.solver; range = uu___112_1304.range; curmodule = lid; gamma = uu___112_1304.gamma; gamma_cache = uu___112_1304.gamma_cache; modules = uu___112_1304.modules; expected_typ = uu___112_1304.expected_typ; sigtab = uu___112_1304.sigtab; is_pattern = uu___112_1304.is_pattern; instantiate_imp = uu___112_1304.instantiate_imp; effects = uu___112_1304.effects; generalize = uu___112_1304.generalize; letrecs = uu___112_1304.letrecs; top_level = uu___112_1304.top_level; check_uvars = uu___112_1304.check_uvars; use_eq = uu___112_1304.use_eq; is_iface = uu___112_1304.is_iface; admit = uu___112_1304.admit; lax = uu___112_1304.lax; lax_universes = uu___112_1304.lax_universes; type_of = uu___112_1304.type_of; universe_of = uu___112_1304.universe_of; use_bv_sorts = uu___112_1304.use_bv_sorts; qname_and_index = uu___112_1304.qname_and_index}))
+
+
+let has_interface : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env l -> (FStar_All.pipe_right env.modules (FStar_Util.for_some (fun m -> (m.FStar_Syntax_Syntax.is_interface && (FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name l))))))
+
+
+let find_in_sigtab : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.sigelt Prims.option = (fun env lid -> (FStar_Util.smap_try_find (sigtab env) (FStar_Ident.text_of_lid lid)))
+
+
+let name_not_found : FStar_Ident.lid  ->  Prims.string = (fun l -> (FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str))
+
+
+let variable_not_found : FStar_Syntax_Syntax.bv  ->  Prims.string = (fun v1 -> (
+
+let uu____1326 = (FStar_Syntax_Print.bv_to_string v1)
+in (FStar_Util.format1 "Variable \"%s\" not found" uu____1326)))
+
+
+let new_u_univ : Prims.unit  ->  FStar_Syntax_Syntax.universe = (fun uu____1329 -> (
+
+let uu____1330 = (FStar_Unionfind.fresh None)
+in FStar_Syntax_Syntax.U_unif (uu____1330)))
+
+
+let inst_tscheme_with : FStar_Syntax_Syntax.tscheme  ->  FStar_Syntax_Syntax.universes  ->  (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term) = (fun ts us -> (match (((ts), (us))) with
+| (([], t), []) -> begin
+(([]), (t))
+end
+| ((formals, t), uu____1353) -> begin
+(
+
+let n1 = ((FStar_List.length formals) - (Prims.parse_int "1"))
+in (
+
+let vs = (FStar_All.pipe_right us (FStar_List.mapi (fun i u -> FStar_Syntax_Syntax.UN ((((n1 - i)), (u))))))
+in (
+
+let uu____1369 = (FStar_Syntax_Subst.subst vs t)
+in ((us), (uu____1369)))))
+end))
+
+
+let inst_tscheme : FStar_Syntax_Syntax.tscheme  ->  (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term) = (fun uu___96_1374 -> (match (uu___96_1374) with
+| ([], t) -> begin
+(([]), (t))
+end
+| (us, t) -> begin
+(
+
+let us' = (FStar_All.pipe_right us (FStar_List.map (fun uu____1388 -> (new_u_univ ()))))
+in (inst_tscheme_with ((us), (t)) us'))
+end))
+
+
+let inst_tscheme_with_range : FStar_Range.range  ->  FStar_Syntax_Syntax.tscheme  ->  (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term) = (fun r t -> (
+
+let uu____1398 = (inst_tscheme t)
+in (match (uu____1398) with
+| (us, t1) -> begin
+(
+
+let uu____1405 = (FStar_Syntax_Subst.set_use_range r t1)
+in ((us), (uu____1405)))
+end)))
+
+
+let inst_effect_fun_with : FStar_Syntax_Syntax.universes  ->  env  ->  FStar_Syntax_Syntax.eff_decl  ->  FStar_Syntax_Syntax.tscheme  ->  FStar_Syntax_Syntax.term = (fun insts env ed uu____1417 -> (match (uu____1417) with
+| (us, t) -> begin
+(match (ed.FStar_Syntax_Syntax.binders) with
+| [] -> begin
+(
+
+let univs1 = (FStar_List.append ed.FStar_Syntax_Syntax.univs us)
+in ((match (((FStar_List.length insts) <> (FStar_List.length univs1))) with
+| true -> begin
+(
+
+let uu____1431 = (
+
+let uu____1432 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length univs1))
+in (
+
+let uu____1435 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length insts))
+in (
+
+let uu____1438 = (FStar_Syntax_Print.lid_to_string ed.FStar_Syntax_Syntax.mname)
+in (
+
+let uu____1439 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format4 "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n" uu____1432 uu____1435 uu____1438 uu____1439)))))
+in (failwith uu____1431))
+end
+| uu____1440 -> begin
+()
+end);
+(
+
+let uu____1441 = (inst_tscheme_with (((FStar_List.append ed.FStar_Syntax_Syntax.univs us)), (t)) insts)
+in (Prims.snd uu____1441));
+))
+end
+| uu____1445 -> begin
+(
+
+let uu____1446 = (
+
+let uu____1447 = (FStar_Syntax_Print.lid_to_string ed.FStar_Syntax_Syntax.mname)
+in (FStar_Util.format1 "Unexpected use of an uninstantiated effect: %s\n" uu____1447))
+in (failwith uu____1446))
+end)
+end))
+
 type tri =
-  | Yes
-  | No
-  | Maybe
-let uu___is_Yes: tri -> Prims.bool =
-  fun projectee  -> match projectee with | Yes  -> true | uu____1451 -> false
-let uu___is_No: tri -> Prims.bool =
-  fun projectee  -> match projectee with | No  -> true | uu____1455 -> false
-let uu___is_Maybe: tri -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Maybe  -> true | uu____1459 -> false
-let in_cur_mod: env -> FStar_Ident.lident -> tri =
-  fun env  ->
-    fun l  ->
-      let cur = current_module env in
-      if l.FStar_Ident.nsstr = cur.FStar_Ident.str
-      then Yes
-      else
-        if FStar_Util.starts_with l.FStar_Ident.nsstr cur.FStar_Ident.str
-        then
-          (let lns = FStar_List.append l.FStar_Ident.ns [l.FStar_Ident.ident] in
-           let cur1 =
-             FStar_List.append cur.FStar_Ident.ns [cur.FStar_Ident.ident] in
-           let rec aux c l1 =
-             match (c, l1) with
-             | ([],uu____1485) -> Maybe
-             | (uu____1489,[]) -> No
-             | (hd1::tl1,hd'::tl') when
-                 hd1.FStar_Ident.idText = hd'.FStar_Ident.idText ->
-                 aux tl1 tl'
-             | uu____1501 -> No in
-           aux cur1 lns)
-        else No
-let lookup_qname:
-  env ->
-    FStar_Ident.lident ->
-      (((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ),(FStar_Syntax_Syntax.sigelt*
-                                                                   FStar_Syntax_Syntax.universes
-                                                                   Prims.option))
-        FStar_Util.either* FStar_Range.range) Prims.option
-  =
-  fun env  ->
-    fun lid  ->
-      let cur_mod = in_cur_mod env lid in
-      let cache t =
-        FStar_Util.smap_add (gamma_cache env) lid.FStar_Ident.str t; Some t in
-      let found =
-        if cur_mod <> No
-        then
-          let uu____1561 =
-            FStar_Util.smap_try_find (gamma_cache env) lid.FStar_Ident.str in
-          match uu____1561 with
-          | None  ->
-              FStar_Util.find_map env.gamma
-                (fun uu___97_1582  ->
-                   match uu___97_1582 with
-                   | Binding_lid (l,t) ->
-                       if FStar_Ident.lid_equals lid l
-                       then
-                         let uu____1605 =
-                           let uu____1615 =
-                             let uu____1623 = inst_tscheme t in
-                             FStar_Util.Inl uu____1623 in
-                           (uu____1615, (FStar_Ident.range_of_lid l)) in
-                         Some uu____1605
-                       else None
-                   | Binding_sig
-                       (uu____1657,FStar_Syntax_Syntax.Sig_bundle
-                        (ses,uu____1659,uu____1660,uu____1661))
-                       ->
-                       FStar_Util.find_map ses
-                         (fun se  ->
-                            let uu____1671 =
-                              FStar_All.pipe_right
-                                (FStar_Syntax_Util.lids_of_sigelt se)
-                                (FStar_Util.for_some
-                                   (FStar_Ident.lid_equals lid)) in
-                            if uu____1671
-                            then
-                              cache
-                                ((FStar_Util.Inr (se, None)),
-                                  (FStar_Syntax_Util.range_of_sigelt se))
-                            else None)
-                   | Binding_sig (lids,s) ->
-                       let maybe_cache t =
-                         match s with
-                         | FStar_Syntax_Syntax.Sig_declare_typ uu____1698 ->
-                             Some t
-                         | uu____1705 -> cache t in
-                       let uu____1706 =
-                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids in
-                       (match uu____1706 with
-                        | None  -> None
-                        | Some l ->
-                            maybe_cache
-                              ((FStar_Util.Inr (s, None)),
-                                (FStar_Ident.range_of_lid l)))
-                   | Binding_sig_inst (lids,s,us) ->
-                       let uu____1746 =
-                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids in
-                       (match uu____1746 with
-                        | None  -> None
-                        | Some l ->
-                            Some
-                              ((FStar_Util.Inr (s, (Some us))),
-                                (FStar_Ident.range_of_lid l)))
-                   | uu____1790 -> None)
-          | se -> se
-        else None in
-      if FStar_Util.is_some found
-      then found
-      else
-        (let uu____1832 =
-           (cur_mod <> Yes) || (has_interface env env.curmodule) in
-         if uu____1832
-         then
-           let uu____1843 = find_in_sigtab env lid in
-           match uu____1843 with
-           | Some se ->
-               Some
-                 ((FStar_Util.Inr (se, None)),
-                   (FStar_Syntax_Util.range_of_sigelt se))
-           | None  -> None
-         else None)
-let rec add_sigelt: env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
-  fun env  ->
-    fun se  ->
-      match se with
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____1909,uu____1910,uu____1911)
-          -> add_sigelts env ses
-      | uu____1918 ->
-          let lids = FStar_Syntax_Util.lids_of_sigelt se in
-          (FStar_List.iter
-             (fun l  -> FStar_Util.smap_add (sigtab env) l.FStar_Ident.str se)
-             lids;
-           (match se with
-            | FStar_Syntax_Syntax.Sig_new_effect (ne,uu____1924) ->
-                FStar_All.pipe_right ne.FStar_Syntax_Syntax.actions
-                  (FStar_List.iter
-                     (fun a  ->
-                        let se_let =
-                          FStar_Syntax_Util.action_as_lb
-                            ne.FStar_Syntax_Syntax.mname a in
-                        FStar_Util.smap_add (sigtab env)
-                          (a.FStar_Syntax_Syntax.action_name).FStar_Ident.str
-                          se_let))
-            | uu____1928 -> ()))
-and add_sigelts: env -> FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit =
-  fun env  ->
-    fun ses  -> FStar_All.pipe_right ses (FStar_List.iter (add_sigelt env))
-let try_lookup_bv:
-  env ->
-    FStar_Syntax_Syntax.bv ->
-      ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax* FStar_Range.range) Prims.option
-  =
-  fun env  ->
-    fun bv  ->
-      FStar_Util.find_map env.gamma
-        (fun uu___98_1946  ->
-           match uu___98_1946 with
-           | Binding_var id when FStar_Syntax_Syntax.bv_eq id bv ->
-               Some
-                 ((id.FStar_Syntax_Syntax.sort),
-                   ((id.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-           | uu____1959 -> None)
-let lookup_type_of_let:
-  FStar_Syntax_Syntax.sigelt ->
-    FStar_Ident.lident ->
-      ((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.term)*
-        FStar_Range.range) Prims.option
-  =
-  fun se  ->
-    fun lid  ->
-      match se with
-      | FStar_Syntax_Syntax.Sig_let
-          ((uu____1980,lb::[]),uu____1982,uu____1983,uu____1984,uu____1985)
-          ->
-          let uu____1996 =
-            let uu____2001 =
-              inst_tscheme
-                ((lb.FStar_Syntax_Syntax.lbunivs),
-                  (lb.FStar_Syntax_Syntax.lbtyp)) in
-            let uu____2007 =
-              FStar_Syntax_Syntax.range_of_lbname
-                lb.FStar_Syntax_Syntax.lbname in
-            (uu____2001, uu____2007) in
-          Some uu____1996
-      | FStar_Syntax_Syntax.Sig_let
-          ((uu____2014,lbs),uu____2016,uu____2017,uu____2018,uu____2019) ->
-          FStar_Util.find_map lbs
-            (fun lb  ->
-               match lb.FStar_Syntax_Syntax.lbname with
-               | FStar_Util.Inl uu____2041 -> failwith "impossible"
-               | FStar_Util.Inr fv ->
-                   let uu____2048 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
-                   if uu____2048
-                   then
-                     let uu____2054 =
-                       let uu____2059 =
-                         inst_tscheme
-                           ((lb.FStar_Syntax_Syntax.lbunivs),
-                             (lb.FStar_Syntax_Syntax.lbtyp)) in
-                       let uu____2065 = FStar_Syntax_Syntax.range_of_fv fv in
-                       (uu____2059, uu____2065) in
-                     Some uu____2054
-                   else None)
-      | uu____2077 -> None
-let effect_signature:
-  FStar_Syntax_Syntax.sigelt ->
-    ((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.term)*
-      FStar_Range.range) Prims.option
-  =
-  fun se  ->
-    match se with
-    | FStar_Syntax_Syntax.Sig_new_effect (ne,r) ->
-        let uu____2097 =
-          let uu____2102 =
-            let uu____2105 =
-              let uu____2106 =
-                let uu____2109 =
-                  FStar_Syntax_Syntax.mk_Total
-                    ne.FStar_Syntax_Syntax.signature in
-                FStar_Syntax_Util.arrow ne.FStar_Syntax_Syntax.binders
-                  uu____2109 in
-              ((ne.FStar_Syntax_Syntax.univs), uu____2106) in
-            inst_tscheme uu____2105 in
-          (uu____2102, r) in
-        Some uu____2097
-    | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (lid,us,binders,uu____2123,uu____2124,uu____2125,r) ->
-        let uu____2131 =
-          let uu____2136 =
-            let uu____2139 =
-              let uu____2140 =
-                let uu____2143 =
-                  FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff in
-                FStar_Syntax_Util.arrow binders uu____2143 in
-              (us, uu____2140) in
-            inst_tscheme uu____2139 in
-          (uu____2136, r) in
-        Some uu____2131
-    | uu____2154 -> None
-let try_lookup_lid_aux:
-  env ->
-    FStar_Ident.lident ->
-      ((FStar_Syntax_Syntax.universes*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax)* FStar_Range.range) Prims.option
-  =
-  fun env  ->
-    fun lid  ->
-      let mapper uu____2189 =
-        match uu____2189 with
-        | (lr,rng) ->
-            (match lr with
-             | FStar_Util.Inl t -> Some (t, rng)
-             | FStar_Util.Inr
-                 (FStar_Syntax_Syntax.Sig_datacon
-                  (uu____2239,uvs,t,uu____2242,uu____2243,uu____2244,uu____2245,uu____2246),None
-                  )
-                 ->
-                 let uu____2257 =
-                   let uu____2262 = inst_tscheme (uvs, t) in
-                   (uu____2262, rng) in
-                 Some uu____2257
-             | FStar_Util.Inr
-                 (FStar_Syntax_Syntax.Sig_declare_typ
-                  (l,uvs,t,qs,uu____2275),None )
-                 ->
-                 let uu____2284 =
-                   let uu____2285 = in_cur_mod env l in uu____2285 = Yes in
-                 if uu____2284
-                 then
-                   let uu____2291 =
-                     (FStar_All.pipe_right qs
-                        (FStar_List.contains FStar_Syntax_Syntax.Assumption))
-                       || env.is_iface in
-                   (if uu____2291
-                    then
-                      let uu____2298 =
-                        let uu____2303 = inst_tscheme (uvs, t) in
-                        (uu____2303, rng) in
-                      Some uu____2298
-                    else None)
-                 else
-                   (let uu____2318 =
-                      let uu____2323 = inst_tscheme (uvs, t) in
-                      (uu____2323, rng) in
-                    Some uu____2318)
-             | FStar_Util.Inr
-                 (FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid1,uvs,tps,k,uu____2336,uu____2337,uu____2338,uu____2339),None
-                  )
-                 ->
-                 (match tps with
-                  | [] ->
-                      let uu____2359 =
-                        let uu____2364 = inst_tscheme (uvs, k) in
-                        (uu____2364, rng) in
-                      Some uu____2359
-                  | uu____2373 ->
-                      let uu____2374 =
-                        let uu____2379 =
-                          let uu____2382 =
-                            let uu____2383 =
-                              let uu____2386 = FStar_Syntax_Syntax.mk_Total k in
-                              FStar_Syntax_Util.flat_arrow tps uu____2386 in
-                            (uvs, uu____2383) in
-                          inst_tscheme uu____2382 in
-                        (uu____2379, rng) in
-                      Some uu____2374)
-             | FStar_Util.Inr
-                 (FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid1,uvs,tps,k,uu____2401,uu____2402,uu____2403,uu____2404),Some
-                  us)
-                 ->
-                 (match tps with
-                  | [] ->
-                      let uu____2425 =
-                        let uu____2430 = inst_tscheme_with (uvs, k) us in
-                        (uu____2430, rng) in
-                      Some uu____2425
-                  | uu____2439 ->
-                      let uu____2440 =
-                        let uu____2445 =
-                          let uu____2448 =
-                            let uu____2449 =
-                              let uu____2452 = FStar_Syntax_Syntax.mk_Total k in
-                              FStar_Syntax_Util.flat_arrow tps uu____2452 in
-                            (uvs, uu____2449) in
-                          inst_tscheme_with uu____2448 us in
-                        (uu____2445, rng) in
-                      Some uu____2440)
-             | FStar_Util.Inr se ->
-                 (match se with
-                  | (FStar_Syntax_Syntax.Sig_let uu____2477,None ) ->
-                      lookup_type_of_let (Prims.fst se) lid
-                  | uu____2488 -> effect_signature (Prims.fst se))) in
-      let uu____2493 =
-        let uu____2499 = lookup_qname env lid in
-        FStar_Util.bind_opt uu____2499 mapper in
-      match uu____2493 with
-      | Some ((us,t),r) ->
-          Some
-            ((us,
-               (let uu___113_2551 = t in
-                {
-                  FStar_Syntax_Syntax.n =
-                    (uu___113_2551.FStar_Syntax_Syntax.n);
-                  FStar_Syntax_Syntax.tk =
-                    (uu___113_2551.FStar_Syntax_Syntax.tk);
-                  FStar_Syntax_Syntax.pos = (FStar_Ident.range_of_lid lid);
-                  FStar_Syntax_Syntax.vars =
-                    (uu___113_2551.FStar_Syntax_Syntax.vars)
-                })), r)
-      | None  -> None
-let lid_exists: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun l  ->
-      let uu____2572 = lookup_qname env l in
-      match uu____2572 with | None  -> false | Some uu____2592 -> true
-let lookup_bv:
-  env ->
-    FStar_Syntax_Syntax.bv -> (FStar_Syntax_Syntax.typ* FStar_Range.range)
-  =
-  fun env  ->
-    fun bv  ->
-      let bvr = FStar_Syntax_Syntax.range_of_bv bv in
-      let uu____2620 = try_lookup_bv env bv in
-      match uu____2620 with
-      | None  ->
-          let uu____2628 =
-            let uu____2629 =
-              let uu____2632 = variable_not_found bv in (uu____2632, bvr) in
-            FStar_Errors.Error uu____2629 in
-          Prims.raise uu____2628
-      | Some (t,r) ->
-          let uu____2639 = FStar_Syntax_Subst.set_use_range bvr t in
-          let uu____2640 = FStar_Range.set_use_range r bvr in
-          (uu____2639, uu____2640)
-let try_lookup_lid:
-  env ->
-    FStar_Ident.lident ->
-      ((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ)*
-        FStar_Range.range) Prims.option
-  =
-  fun env  ->
-    fun l  ->
-      let uu____2652 = try_lookup_lid_aux env l in
-      match uu____2652 with
-      | None  -> None
-      | Some ((us,t),r) ->
-          let use_range = FStar_Ident.range_of_lid l in
-          let r1 = FStar_Range.set_use_range r use_range in
-          let uu____2694 =
-            let uu____2699 =
-              let uu____2702 = FStar_Syntax_Subst.set_use_range use_range t in
-              (us, uu____2702) in
-            (uu____2699, r1) in
-          Some uu____2694
-let lookup_lid:
-  env ->
-    FStar_Ident.lident ->
-      ((FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ)*
-        FStar_Range.range)
-  =
-  fun env  ->
-    fun l  ->
-      let uu____2719 = try_lookup_lid env l in
-      match uu____2719 with
-      | None  ->
-          let uu____2733 =
-            let uu____2734 =
-              let uu____2737 = name_not_found l in
-              (uu____2737, (FStar_Ident.range_of_lid l)) in
-            FStar_Errors.Error uu____2734 in
-          Prims.raise uu____2733
-      | Some ((us,t),r) -> ((us, t), r)
-let lookup_univ: env -> FStar_Syntax_Syntax.univ_name -> Prims.bool =
-  fun env  ->
-    fun x  ->
-      FStar_All.pipe_right
-        (FStar_List.find
-           (fun uu___99_2760  ->
-              match uu___99_2760 with
-              | Binding_univ y -> x.FStar_Ident.idText = y.FStar_Ident.idText
-              | uu____2762 -> false) env.gamma) FStar_Option.isSome
-let try_lookup_val_decl:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.tscheme* FStar_Syntax_Syntax.qualifier Prims.list)
-        Prims.option
-  =
-  fun env  ->
-    fun lid  ->
-      let uu____2773 = lookup_qname env lid in
-      match uu____2773 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_declare_typ
-            (uu____2788,uvs,t,q,uu____2792),None ),uu____2793)
-          ->
-          let uu____2818 =
-            let uu____2824 =
-              let uu____2827 =
-                FStar_Syntax_Subst.set_use_range
-                  (FStar_Ident.range_of_lid lid) t in
-              (uvs, uu____2827) in
-            (uu____2824, q) in
-          Some uu____2818
-      | uu____2836 -> None
-let lookup_val_decl:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ)
-  =
-  fun env  ->
-    fun lid  ->
-      let uu____2858 = lookup_qname env lid in
-      match uu____2858 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_declare_typ
-            (uu____2871,uvs,t,uu____2874,uu____2875),None ),uu____2876)
-          -> inst_tscheme_with_range (FStar_Ident.range_of_lid lid) (uvs, t)
-      | uu____2901 ->
-          let uu____2912 =
-            let uu____2913 =
-              let uu____2916 = name_not_found lid in
-              (uu____2916, (FStar_Ident.range_of_lid lid)) in
-            FStar_Errors.Error uu____2913 in
-          Prims.raise uu____2912
-let lookup_datacon:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.universes* FStar_Syntax_Syntax.typ)
-  =
-  fun env  ->
-    fun lid  ->
-      let uu____2927 = lookup_qname env lid in
-      match uu____2927 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_datacon
-            (uu____2940,uvs,t,uu____2943,uu____2944,uu____2945,uu____2946,uu____2947),None
-            ),uu____2948)
-          -> inst_tscheme_with_range (FStar_Ident.range_of_lid lid) (uvs, t)
-      | uu____2975 ->
-          let uu____2986 =
-            let uu____2987 =
-              let uu____2990 = name_not_found lid in
-              (uu____2990, (FStar_Ident.range_of_lid lid)) in
-            FStar_Errors.Error uu____2987 in
-          Prims.raise uu____2986
-let datacons_of_typ:
-  env -> FStar_Ident.lident -> (Prims.bool* FStar_Ident.lident Prims.list) =
-  fun env  ->
-    fun lid  ->
-      let uu____3002 = lookup_qname env lid in
-      match uu____3002 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_inductive_typ
-            (uu____3016,uu____3017,uu____3018,uu____3019,uu____3020,dcs,uu____3022,uu____3023),uu____3024),uu____3025)
-          -> (true, dcs)
-      | uu____3056 -> (false, [])
-let typ_of_datacon: env -> FStar_Ident.lident -> FStar_Ident.lident =
-  fun env  ->
-    fun lid  ->
-      let uu____3074 = lookup_qname env lid in
-      match uu____3074 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_datacon
-            (uu____3085,uu____3086,uu____3087,l,uu____3089,uu____3090,uu____3091,uu____3092),uu____3093),uu____3094)
-          -> l
-      | uu____3122 ->
-          let uu____3133 =
-            let uu____3134 = FStar_Syntax_Print.lid_to_string lid in
-            FStar_Util.format1 "Not a datacon: %s" uu____3134 in
-          failwith uu____3133
-let lookup_definition:
-  delta_level Prims.list ->
-    env ->
-      FStar_Ident.lident ->
-        (FStar_Syntax_Syntax.univ_names* FStar_Syntax_Syntax.term)
-          Prims.option
-  =
-  fun delta_levels  ->
-    fun env  ->
-      fun lid  ->
-        let visible quals =
-          FStar_All.pipe_right delta_levels
-            (FStar_Util.for_some
-               (fun dl  ->
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_some (visible_at dl)))) in
-        let uu____3158 = lookup_qname env lid in
-        match uu____3158 with
-        | Some (FStar_Util.Inr (se,None ),uu____3173) ->
-            (match se with
-             | FStar_Syntax_Syntax.Sig_let
-                 ((uu____3199,lbs),uu____3201,uu____3202,quals,uu____3204)
-                 when visible quals ->
-                 FStar_Util.find_map lbs
-                   (fun lb  ->
-                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                      let uu____3221 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
-                      if uu____3221
-                      then
-                        let uu____3226 =
-                          let uu____3230 =
-                            let uu____3231 =
-                              FStar_Syntax_Util.unascribe
-                                lb.FStar_Syntax_Syntax.lbdef in
-                            FStar_Syntax_Subst.set_use_range
-                              (FStar_Ident.range_of_lid lid) uu____3231 in
-                          ((lb.FStar_Syntax_Syntax.lbunivs), uu____3230) in
-                        Some uu____3226
-                      else None)
-             | uu____3240 -> None)
-        | uu____3243 -> None
-let try_lookup_effect_lid:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.typ Prims.option =
-  fun env  ->
-    fun ftv  ->
-      let uu____3264 = lookup_qname env ftv in
-      match uu____3264 with
-      | Some (FStar_Util.Inr (se,None ),uu____3277) ->
-          let uu____3300 = effect_signature se in
-          (match uu____3300 with
-           | None  -> None
-           | Some ((uu____3311,t),r) ->
-               let uu____3320 =
-                 FStar_Syntax_Subst.set_use_range
-                   (FStar_Ident.range_of_lid ftv) t in
-               Some uu____3320)
-      | uu____3321 -> None
-let lookup_effect_lid: env -> FStar_Ident.lident -> FStar_Syntax_Syntax.typ =
-  fun env  ->
-    fun ftv  ->
-      let uu____3338 = try_lookup_effect_lid env ftv in
-      match uu____3338 with
-      | None  ->
-          let uu____3340 =
-            let uu____3341 =
-              let uu____3344 = name_not_found ftv in
-              (uu____3344, (FStar_Ident.range_of_lid ftv)) in
-            FStar_Errors.Error uu____3341 in
-          Prims.raise uu____3340
-      | Some k -> k
-let lookup_effect_abbrev:
-  env ->
-    FStar_Syntax_Syntax.universes ->
-      FStar_Ident.lident ->
-        (FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.comp) Prims.option
-  =
-  fun env  ->
-    fun univ_insts  ->
-      fun lid0  ->
-        let uu____3358 = lookup_qname env lid0 in
-        match uu____3358 with
-        | Some
-            (FStar_Util.Inr
-             (FStar_Syntax_Syntax.Sig_effect_abbrev
-              (lid,univs1,binders,c,quals,uu____3377,uu____3378),None ),uu____3379)
-            ->
-            let lid1 =
-              let uu____3407 =
-                FStar_Range.set_use_range (FStar_Ident.range_of_lid lid)
-                  (FStar_Ident.range_of_lid lid0) in
-              FStar_Ident.set_lid_range lid uu____3407 in
-            let uu____3408 =
-              FStar_All.pipe_right quals
-                (FStar_Util.for_some
-                   (fun uu___100_3410  ->
-                      match uu___100_3410 with
-                      | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____3411 -> false)) in
-            if uu____3408
-            then None
-            else
-              (let insts =
-                 if
-                   (FStar_List.length univ_insts) =
-                     (FStar_List.length univs1)
-                 then univ_insts
-                 else
-                   if
-                     (FStar_Ident.lid_equals lid1
-                        FStar_Syntax_Const.effect_Lemma_lid)
-                       &&
-                       ((FStar_List.length univ_insts) =
-                          (Prims.parse_int "1"))
-                   then
-                     FStar_List.append univ_insts
-                       [FStar_Syntax_Syntax.U_zero]
-                   else
-                     (let uu____3427 =
-                        let uu____3428 =
-                          FStar_Syntax_Print.lid_to_string lid1 in
-                        let uu____3429 =
-                          FStar_All.pipe_right (FStar_List.length univ_insts)
-                            FStar_Util.string_of_int in
-                        FStar_Util.format2
-                          "Unexpected instantiation of effect %s with %s universes"
-                          uu____3428 uu____3429 in
-                      failwith uu____3427) in
-               match (binders, univs1) with
-               | ([],uu____3435) ->
-                   failwith
-                     "Unexpected effect abbreviation with no arguments"
-               | (uu____3444,uu____3445::uu____3446::uu____3447) when
-                   Prims.op_Negation
-                     (FStar_Ident.lid_equals lid1
-                        FStar_Syntax_Const.effect_Lemma_lid)
-                   ->
-                   let uu____3450 =
-                     let uu____3451 = FStar_Syntax_Print.lid_to_string lid1 in
-                     let uu____3452 =
-                       FStar_All.pipe_left FStar_Util.string_of_int
-                         (FStar_List.length univs1) in
-                     FStar_Util.format2
-                       "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____3451 uu____3452 in
-                   failwith uu____3450
-               | uu____3458 ->
-                   let uu____3461 =
-                     let uu____3464 =
-                       let uu____3465 = FStar_Syntax_Util.arrow binders c in
-                       (univs1, uu____3465) in
-                     inst_tscheme_with uu____3464 insts in
-                   (match uu____3461 with
-                    | (uu____3473,t) ->
-                        let t1 =
-                          FStar_Syntax_Subst.set_use_range
-                            (FStar_Ident.range_of_lid lid1) t in
-                        let uu____3476 =
-                          let uu____3477 = FStar_Syntax_Subst.compress t1 in
-                          uu____3477.FStar_Syntax_Syntax.n in
-                        (match uu____3476 with
-                         | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
-                             Some (binders1, c1)
-                         | uu____3507 -> failwith "Impossible")))
-        | uu____3511 -> None
-let norm_eff_name: env -> FStar_Ident.lident -> FStar_Ident.lident =
-  let cache = FStar_Util.smap_create (Prims.parse_int "20") in
-  fun env  ->
-    fun l  ->
-      let rec find1 l1 =
-        let uu____3537 =
-          lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1 in
-        match uu____3537 with
-        | None  -> None
-        | Some (uu____3544,c) ->
-            let l2 = FStar_Syntax_Util.comp_effect_name c in
-            let uu____3549 = find1 l2 in
-            (match uu____3549 with | None  -> Some l2 | Some l' -> Some l') in
-      let res =
-        let uu____3554 = FStar_Util.smap_try_find cache l.FStar_Ident.str in
-        match uu____3554 with
-        | Some l1 -> l1
-        | None  ->
-            let uu____3557 = find1 l in
-            (match uu____3557 with
-             | None  -> l
-             | Some m -> (FStar_Util.smap_add cache l.FStar_Ident.str m; m)) in
-      FStar_Ident.set_lid_range res (FStar_Ident.range_of_lid l)
-let lookup_effect_quals:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list =
-  fun env  ->
-    fun l  ->
-      let l1 = norm_eff_name env l in
-      let uu____3569 = lookup_qname env l1 in
-      match uu____3569 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_new_effect (ne,uu____3582),uu____3583),uu____3584)
-          -> ne.FStar_Syntax_Syntax.qualifiers
-      | uu____3608 -> []
-let lookup_projector:
-  env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident =
-  fun env  ->
-    fun lid  ->
-      fun i  ->
-        let fail uu____3631 =
-          let uu____3632 =
-            let uu____3633 = FStar_Util.string_of_int i in
-            let uu____3634 = FStar_Syntax_Print.lid_to_string lid in
-            FStar_Util.format2
-              "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____3633 uu____3634 in
-          failwith uu____3632 in
-        let uu____3635 = lookup_datacon env lid in
-        match uu____3635 with
-        | (uu____3638,t) ->
-            let uu____3640 =
-              let uu____3641 = FStar_Syntax_Subst.compress t in
-              uu____3641.FStar_Syntax_Syntax.n in
-            (match uu____3640 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____3645) ->
-                 if
-                   (i < (Prims.parse_int "0")) ||
-                     (i >= (FStar_List.length binders))
-                 then fail ()
-                 else
-                   (let b = FStar_List.nth binders i in
-                    let uu____3666 =
-                      FStar_Syntax_Util.mk_field_projector_name lid
-                        (Prims.fst b) i in
-                    FStar_All.pipe_right uu____3666 Prims.fst)
-             | uu____3671 -> fail ())
-let is_projector: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun l  ->
-      let uu____3678 = lookup_qname env l in
-      match uu____3678 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_declare_typ
-            (uu____3689,uu____3690,uu____3691,quals,uu____3693),uu____3694),uu____3695)
-          ->
-          FStar_Util.for_some
-            (fun uu___101_3721  ->
-               match uu___101_3721 with
-               | FStar_Syntax_Syntax.Projector uu____3722 -> true
-               | uu____3725 -> false) quals
-      | uu____3726 -> false
-let is_datacon: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      let uu____3743 = lookup_qname env lid in
-      match uu____3743 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_datacon
-            (uu____3754,uu____3755,uu____3756,uu____3757,uu____3758,uu____3759,uu____3760,uu____3761),uu____3762),uu____3763)
-          -> true
-      | uu____3791 -> false
-let is_record: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      let uu____3808 = lookup_qname env lid in
-      match uu____3808 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_inductive_typ
-            (uu____3819,uu____3820,uu____3821,uu____3822,uu____3823,uu____3824,tags,uu____3826),uu____3827),uu____3828)
-          ->
-          FStar_Util.for_some
-            (fun uu___102_3858  ->
-               match uu___102_3858 with
-               | FStar_Syntax_Syntax.RecordType _
-                 |FStar_Syntax_Syntax.RecordConstructor _ -> true
-               | uu____3861 -> false) tags
-      | uu____3862 -> false
-let is_action: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      let uu____3879 = lookup_qname env lid in
-      match uu____3879 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_let
-            (uu____3890,uu____3891,uu____3892,tags,uu____3894),uu____3895),uu____3896)
-          ->
-          FStar_Util.for_some
-            (fun uu___103_3926  ->
-               match uu___103_3926 with
-               | FStar_Syntax_Syntax.Action uu____3927 -> true
-               | uu____3928 -> false) tags
-      | uu____3929 -> false
-let is_interpreted: env -> FStar_Syntax_Syntax.term -> Prims.bool =
-  let interpreted_symbols =
-    [FStar_Syntax_Const.op_Eq;
-    FStar_Syntax_Const.op_notEq;
-    FStar_Syntax_Const.op_LT;
-    FStar_Syntax_Const.op_LTE;
-    FStar_Syntax_Const.op_GT;
-    FStar_Syntax_Const.op_GTE;
-    FStar_Syntax_Const.op_Subtraction;
-    FStar_Syntax_Const.op_Minus;
-    FStar_Syntax_Const.op_Addition;
-    FStar_Syntax_Const.op_Multiply;
-    FStar_Syntax_Const.op_Division;
-    FStar_Syntax_Const.op_Modulus;
-    FStar_Syntax_Const.op_And;
-    FStar_Syntax_Const.op_Or;
-    FStar_Syntax_Const.op_Negation] in
-  fun env  ->
-    fun head1  ->
-      let uu____3948 =
-        let uu____3949 = FStar_Syntax_Util.un_uinst head1 in
-        uu____3949.FStar_Syntax_Syntax.n in
-      match uu____3948 with
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          fv.FStar_Syntax_Syntax.fv_delta =
-            FStar_Syntax_Syntax.Delta_equational
-      | uu____3953 -> false
-let is_type_constructor: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun lid  ->
-      let mapper x =
-        match Prims.fst x with
-        | FStar_Util.Inl uu____3991 -> Some false
-        | FStar_Util.Inr (se,uu____4000) ->
-            (match se with
-             | FStar_Syntax_Syntax.Sig_declare_typ
-                 (uu____4009,uu____4010,uu____4011,qs,uu____4013) ->
-                 Some (FStar_List.contains FStar_Syntax_Syntax.New qs)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____4016 -> Some true
-             | uu____4028 -> Some false) in
-      let uu____4029 =
-        let uu____4031 = lookup_qname env lid in
-        FStar_Util.bind_opt uu____4031 mapper in
-      match uu____4029 with | Some b -> b | None  -> false
-let num_inductive_ty_params: env -> FStar_Ident.lident -> Prims.int =
-  fun env  ->
-    fun lid  ->
-      let uu____4058 = lookup_qname env lid in
-      match uu____4058 with
-      | Some
-          (FStar_Util.Inr
-           (FStar_Syntax_Syntax.Sig_inductive_typ
-            (uu____4069,uu____4070,tps,uu____4072,uu____4073,uu____4074,uu____4075,uu____4076),uu____4077),uu____4078)
-          -> FStar_List.length tps
-      | uu____4111 ->
-          let uu____4122 =
-            let uu____4123 =
-              let uu____4126 = name_not_found lid in
-              (uu____4126, (FStar_Ident.range_of_lid lid)) in
-            FStar_Errors.Error uu____4123 in
-          Prims.raise uu____4122
-let effect_decl_opt:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl Prims.option =
-  fun env  ->
-    fun l  ->
-      FStar_All.pipe_right (env.effects).decls
-        (FStar_Util.find_opt
-           (fun d  -> FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
-let get_effect_decl:
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl =
-  fun env  ->
-    fun l  ->
-      let uu____4143 = effect_decl_opt env l in
-      match uu____4143 with
-      | None  ->
-          let uu____4145 =
-            let uu____4146 =
-              let uu____4149 = name_not_found l in
-              (uu____4149, (FStar_Ident.range_of_lid l)) in
-            FStar_Errors.Error uu____4146 in
-          Prims.raise uu____4145
-      | Some md -> md
-let identity_mlift: mlift =
-  {
-    mlift_wp = (fun t  -> fun wp  -> wp);
-    mlift_term = (Some (fun t  -> fun wp  -> fun e  -> e))
-  }
-let join:
-  env ->
-    FStar_Ident.lident ->
-      FStar_Ident.lident -> (FStar_Ident.lident* mlift* mlift)
-  =
-  fun env  ->
-    fun l1  ->
-      fun l2  ->
-        if FStar_Ident.lid_equals l1 l2
-        then (l1, identity_mlift, identity_mlift)
-        else
-          if
-            ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GTot_lid)
-               &&
-               (FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_Tot_lid))
-              ||
-              ((FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_GTot_lid)
-                 &&
-                 (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_Tot_lid))
-          then
-            (FStar_Syntax_Const.effect_GTot_lid, identity_mlift,
-              identity_mlift)
-          else
-            (let uu____4185 =
-               FStar_All.pipe_right (env.effects).joins
-                 (FStar_Util.find_opt
-                    (fun uu____4209  ->
-                       match uu____4209 with
-                       | (m1,m2,uu____4217,uu____4218,uu____4219) ->
-                           (FStar_Ident.lid_equals l1 m1) &&
-                             (FStar_Ident.lid_equals l2 m2))) in
-             match uu____4185 with
-             | None  ->
-                 let uu____4228 =
-                   let uu____4229 =
-                     let uu____4232 =
-                       let uu____4233 = FStar_Syntax_Print.lid_to_string l1 in
-                       let uu____4234 = FStar_Syntax_Print.lid_to_string l2 in
-                       FStar_Util.format2
-                         "Effects %s and %s cannot be composed" uu____4233
-                         uu____4234 in
-                     (uu____4232, (env.range)) in
-                   FStar_Errors.Error uu____4229 in
-                 Prims.raise uu____4228
-             | Some (uu____4238,uu____4239,m3,j1,j2) -> (m3, j1, j2))
-let monad_leq:
-  env -> FStar_Ident.lident -> FStar_Ident.lident -> edge Prims.option =
-  fun env  ->
-    fun l1  ->
-      fun l2  ->
-        if
-          (FStar_Ident.lid_equals l1 l2) ||
-            ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_Tot_lid) &&
-               (FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_GTot_lid))
-        then Some { msource = l1; mtarget = l2; mlift = identity_mlift }
-        else
-          FStar_All.pipe_right (env.effects).order
-            (FStar_Util.find_opt
-               (fun e  ->
-                  (FStar_Ident.lid_equals l1 e.msource) &&
-                    (FStar_Ident.lid_equals l2 e.mtarget)))
-let wp_sig_aux:
-  FStar_Syntax_Syntax.eff_decl Prims.list ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.bv*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax)
-  =
-  fun decls  ->
-    fun m  ->
-      let uu____4276 =
-        FStar_All.pipe_right decls
-          (FStar_Util.find_opt
-             (fun d  -> FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m)) in
-      match uu____4276 with
-      | None  ->
-          let uu____4285 =
-            FStar_Util.format1
-              "Impossible: declaration for monad %s not found"
-              m.FStar_Ident.str in
-          failwith uu____4285
-      | Some md ->
-          let uu____4291 =
-            inst_tscheme
-              ((md.FStar_Syntax_Syntax.univs),
-                (md.FStar_Syntax_Syntax.signature)) in
-          (match uu____4291 with
-           | (uu____4298,s) ->
-               let s1 = FStar_Syntax_Subst.compress s in
-               (match ((md.FStar_Syntax_Syntax.binders),
-                        (s1.FStar_Syntax_Syntax.n))
-                with
-                | ([],FStar_Syntax_Syntax.Tm_arrow
-                   ((a,uu____4306)::(wp,uu____4308)::[],c)) when
-                    FStar_Syntax_Syntax.is_teff
-                      (FStar_Syntax_Util.comp_result c)
-                    -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____4330 -> failwith "Impossible"))
-let wp_signature:
-  env ->
-    FStar_Ident.lident ->
-      (FStar_Syntax_Syntax.bv*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax)
-  = fun env  -> fun m  -> wp_sig_aux (env.effects).decls m
-let null_wp_for_eff:
-  env ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp
-  =
-  fun env  ->
-    fun eff_name  ->
-      fun res_u  ->
-        fun res_t  ->
-          if
-            FStar_Ident.lid_equals eff_name FStar_Syntax_Const.effect_Tot_lid
-          then FStar_Syntax_Syntax.mk_Total' res_t (Some res_u)
-          else
-            if
-              FStar_Ident.lid_equals eff_name
-                FStar_Syntax_Const.effect_GTot_lid
-            then FStar_Syntax_Syntax.mk_GTotal' res_t (Some res_u)
-            else
-              (let eff_name1 = norm_eff_name env eff_name in
-               let ed = get_effect_decl env eff_name1 in
-               let null_wp =
-                 inst_effect_fun_with [res_u] env ed
-                   ed.FStar_Syntax_Syntax.null_wp in
-               let null_wp_res =
-                 let uu____4365 = get_range env in
-                 let uu____4366 =
-                   let uu____4369 =
-                     let uu____4370 =
-                       let uu____4380 =
-                         let uu____4382 = FStar_Syntax_Syntax.as_arg res_t in
-                         [uu____4382] in
-                       (null_wp, uu____4380) in
-                     FStar_Syntax_Syntax.Tm_app uu____4370 in
-                   FStar_Syntax_Syntax.mk uu____4369 in
-                 uu____4366 None uu____4365 in
-               let uu____4392 =
-                 let uu____4393 =
-                   let uu____4399 = FStar_Syntax_Syntax.as_arg null_wp_res in
-                   [uu____4399] in
-                 {
-                   FStar_Syntax_Syntax.comp_univs = [res_u];
-                   FStar_Syntax_Syntax.effect_name = eff_name1;
-                   FStar_Syntax_Syntax.result_typ = res_t;
-                   FStar_Syntax_Syntax.effect_args = uu____4393;
-                   FStar_Syntax_Syntax.flags = []
-                 } in
-               FStar_Syntax_Syntax.mk_Comp uu____4392)
-let build_lattice: env -> FStar_Syntax_Syntax.sigelt -> env =
-  fun env  ->
-    fun se  ->
-      match se with
-      | FStar_Syntax_Syntax.Sig_new_effect (ne,uu____4407) ->
-          let effects =
-            let uu___114_4409 = env.effects in
-            {
-              decls = (ne :: ((env.effects).decls));
-              order = (uu___114_4409.order);
-              joins = (uu___114_4409.joins)
-            } in
-          let uu___115_4410 = env in
-          {
-            solver = (uu___115_4410.solver);
-            range = (uu___115_4410.range);
-            curmodule = (uu___115_4410.curmodule);
-            gamma = (uu___115_4410.gamma);
-            gamma_cache = (uu___115_4410.gamma_cache);
-            modules = (uu___115_4410.modules);
-            expected_typ = (uu___115_4410.expected_typ);
-            sigtab = (uu___115_4410.sigtab);
-            is_pattern = (uu___115_4410.is_pattern);
-            instantiate_imp = (uu___115_4410.instantiate_imp);
-            effects;
-            generalize = (uu___115_4410.generalize);
-            letrecs = (uu___115_4410.letrecs);
-            top_level = (uu___115_4410.top_level);
-            check_uvars = (uu___115_4410.check_uvars);
-            use_eq = (uu___115_4410.use_eq);
-            is_iface = (uu___115_4410.is_iface);
-            admit = (uu___115_4410.admit);
-            lax = (uu___115_4410.lax);
-            lax_universes = (uu___115_4410.lax_universes);
-            type_of = (uu___115_4410.type_of);
-            universe_of = (uu___115_4410.universe_of);
-            use_bv_sorts = (uu___115_4410.use_bv_sorts);
-            qname_and_index = (uu___115_4410.qname_and_index)
-          }
-      | FStar_Syntax_Syntax.Sig_sub_effect (sub1,uu____4412) ->
-          let compose_edges e1 e2 =
-            let composed_lift =
-              let mlift_wp r wp1 =
-                let uu____4428 = (e1.mlift).mlift_wp r wp1 in
-                (e2.mlift).mlift_wp r uu____4428 in
-              let mlift_term =
-                match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
-                | (Some l1,Some l2) ->
-                    Some
-                      ((fun t  ->
-                          fun wp  ->
-                            fun e  ->
-                              let uu____4507 = (e1.mlift).mlift_wp t wp in
-                              let uu____4508 = l1 t wp e in
-                              l2 t uu____4507 uu____4508))
-                | uu____4509 -> None in
-              { mlift_wp; mlift_term } in
-            {
-              msource = (e1.msource);
-              mtarget = (e2.mtarget);
-              mlift = composed_lift
-            } in
-          let mk_mlift_wp lift_t r wp1 =
-            let uu____4544 = inst_tscheme lift_t in
-            match uu____4544 with
-            | (uu____4549,lift_t1) ->
-                let uu____4551 =
-                  let uu____4554 =
-                    let uu____4555 =
-                      let uu____4565 =
-                        let uu____4567 = FStar_Syntax_Syntax.as_arg r in
-                        let uu____4568 =
-                          let uu____4570 = FStar_Syntax_Syntax.as_arg wp1 in
-                          [uu____4570] in
-                        uu____4567 :: uu____4568 in
-                      (lift_t1, uu____4565) in
-                    FStar_Syntax_Syntax.Tm_app uu____4555 in
-                  FStar_Syntax_Syntax.mk uu____4554 in
-                uu____4551 None wp1.FStar_Syntax_Syntax.pos in
-          let sub_mlift_wp =
-            match sub1.FStar_Syntax_Syntax.lift_wp with
-            | Some sub_lift_wp -> mk_mlift_wp sub_lift_wp
-            | None  ->
-                failwith "sub effect should've been elaborated at this stage" in
-          let mk_mlift_term lift_t r wp1 e =
-            let uu____4615 = inst_tscheme lift_t in
-            match uu____4615 with
-            | (uu____4620,lift_t1) ->
-                let uu____4622 =
-                  let uu____4625 =
-                    let uu____4626 =
-                      let uu____4636 =
-                        let uu____4638 = FStar_Syntax_Syntax.as_arg r in
-                        let uu____4639 =
-                          let uu____4641 = FStar_Syntax_Syntax.as_arg wp1 in
-                          let uu____4642 =
-                            let uu____4644 = FStar_Syntax_Syntax.as_arg e in
-                            [uu____4644] in
-                          uu____4641 :: uu____4642 in
-                        uu____4638 :: uu____4639 in
-                      (lift_t1, uu____4636) in
-                    FStar_Syntax_Syntax.Tm_app uu____4626 in
-                  FStar_Syntax_Syntax.mk uu____4625 in
-                uu____4622 None e.FStar_Syntax_Syntax.pos in
-          let sub_mlift_term =
-            FStar_Util.map_opt sub1.FStar_Syntax_Syntax.lift mk_mlift_term in
-          let edge =
-            {
-              msource = (sub1.FStar_Syntax_Syntax.source);
-              mtarget = (sub1.FStar_Syntax_Syntax.target);
-              mlift =
-                { mlift_wp = sub_mlift_wp; mlift_term = sub_mlift_term }
-            } in
-          let id_edge l =
-            {
-              msource = (sub1.FStar_Syntax_Syntax.source);
-              mtarget = (sub1.FStar_Syntax_Syntax.target);
-              mlift = identity_mlift
-            } in
-          let print_mlift l =
-            let bogus_term s =
-              let uu____4685 =
-                let uu____4686 =
-                  FStar_Ident.lid_of_path [s] FStar_Range.dummyRange in
-                FStar_Syntax_Syntax.lid_as_fv uu____4686
-                  FStar_Syntax_Syntax.Delta_constant None in
-              FStar_Syntax_Syntax.fv_to_tm uu____4685 in
-            let arg = bogus_term "ARG" in
-            let wp = bogus_term "WP" in
-            let e = bogus_term "COMP" in
-            let uu____4690 =
-              let uu____4691 = l.mlift_wp arg wp in
-              FStar_Syntax_Print.term_to_string uu____4691 in
-            let uu____4692 =
-              let uu____4693 =
-                FStar_Util.map_opt l.mlift_term
-                  (fun l1  ->
-                     let uu____4708 = l1 arg wp e in
-                     FStar_Syntax_Print.term_to_string uu____4708) in
-              FStar_Util.dflt "none" uu____4693 in
-            FStar_Util.format2 "{ wp : %s ; term : %s }" uu____4690
-              uu____4692 in
-          let order = edge :: ((env.effects).order) in
-          let ms =
-            FStar_All.pipe_right (env.effects).decls
-              (FStar_List.map (fun e  -> e.FStar_Syntax_Syntax.mname)) in
-          let find_edge order1 uu____4726 =
-            match uu____4726 with
-            | (i,j) ->
-                if FStar_Ident.lid_equals i j
-                then
-                  FStar_All.pipe_right (id_edge i) (fun _0_28  -> Some _0_28)
-                else
-                  FStar_All.pipe_right order1
-                    (FStar_Util.find_opt
-                       (fun e  ->
-                          (FStar_Ident.lid_equals e.msource i) &&
-                            (FStar_Ident.lid_equals e.mtarget j))) in
-          let order1 =
-            let fold_fun order1 k =
-              let uu____4751 =
-                FStar_All.pipe_right ms
-                  (FStar_List.collect
-                     (fun i  ->
-                        if FStar_Ident.lid_equals i k
-                        then []
-                        else
-                          FStar_All.pipe_right ms
-                            (FStar_List.collect
-                               (fun j  ->
-                                  if FStar_Ident.lid_equals j k
-                                  then []
-                                  else
-                                    (let uu____4763 =
-                                       let uu____4768 =
-                                         find_edge order1 (i, k) in
-                                       let uu____4770 =
-                                         find_edge order1 (k, j) in
-                                       (uu____4768, uu____4770) in
-                                     match uu____4763 with
-                                     | (Some e1,Some e2) ->
-                                         let uu____4779 = compose_edges e1 e2 in
-                                         [uu____4779]
-                                     | uu____4780 -> []))))) in
-              FStar_List.append order1 uu____4751 in
-            FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order) in
-          let order2 =
-            FStar_Util.remove_dups
-              (fun e1  ->
-                 fun e2  ->
-                   (FStar_Ident.lid_equals e1.msource e2.msource) &&
-                     (FStar_Ident.lid_equals e1.mtarget e2.mtarget)) order1 in
-          (FStar_All.pipe_right order2
-             (FStar_List.iter
-                (fun edge1  ->
-                   let uu____4795 =
-                     (FStar_Ident.lid_equals edge1.msource
-                        FStar_Syntax_Const.effect_DIV_lid)
-                       &&
-                       (let uu____4796 =
-                          lookup_effect_quals env edge1.mtarget in
-                        FStar_All.pipe_right uu____4796
-                          (FStar_List.contains
-                             FStar_Syntax_Syntax.TotalEffect)) in
-                   if uu____4795
-                   then
-                     let uu____4799 =
-                       let uu____4800 =
-                         let uu____4803 =
-                           FStar_Util.format1
-                             "Divergent computations cannot be included in an effect %s marked 'total'"
-                             (edge1.mtarget).FStar_Ident.str in
-                         let uu____4804 = get_range env in
-                         (uu____4803, uu____4804) in
-                       FStar_Errors.Error uu____4800 in
-                     Prims.raise uu____4799
-                   else ()));
-           (let joins =
-              FStar_All.pipe_right ms
-                (FStar_List.collect
-                   (fun i  ->
-                      FStar_All.pipe_right ms
-                        (FStar_List.collect
-                           (fun j  ->
-                              let join_opt =
-                                if FStar_Ident.lid_equals i j
-                                then Some (i, (id_edge i), (id_edge i))
-                                else
-                                  FStar_All.pipe_right ms
-                                    (FStar_List.fold_left
-                                       (fun bopt  ->
-                                          fun k  ->
-                                            let uu____4867 =
-                                              let uu____4872 =
-                                                find_edge order2 (i, k) in
-                                              let uu____4874 =
-                                                find_edge order2 (j, k) in
-                                              (uu____4872, uu____4874) in
-                                            match uu____4867 with
-                                            | (Some ik,Some jk) ->
-                                                (match bopt with
-                                                 | None  -> Some (k, ik, jk)
-                                                 | Some
-                                                     (ub,uu____4897,uu____4898)
-                                                     ->
-                                                     let uu____4902 =
-                                                       let uu____4905 =
-                                                         let uu____4906 =
-                                                           find_edge order2
-                                                             (k, ub) in
-                                                         FStar_Util.is_some
-                                                           uu____4906 in
-                                                       let uu____4908 =
-                                                         let uu____4909 =
-                                                           find_edge order2
-                                                             (ub, k) in
-                                                         FStar_Util.is_some
-                                                           uu____4909 in
-                                                       (uu____4905,
-                                                         uu____4908) in
-                                                     (match uu____4902 with
-                                                      | (true ,true ) ->
-                                                          if
-                                                            FStar_Ident.lid_equals
-                                                              k ub
-                                                          then
-                                                            (FStar_Util.print_warning
-                                                               "Looking multiple times at the same upper bound candidate";
-                                                             bopt)
-                                                          else
-                                                            failwith
-                                                              "Found a cycle in the lattice"
-                                                      | (false ,false ) ->
-                                                          bopt
-                                                      | (true ,false ) ->
-                                                          Some (k, ik, jk)
-                                                      | (false ,true ) ->
-                                                          bopt))
-                                            | uu____4928 -> bopt) None) in
-                              match join_opt with
-                              | None  -> []
-                              | Some (k,e1,e2) ->
-                                  [(i, j, k, (e1.mlift), (e2.mlift))])))) in
-            let effects =
-              let uu___116_4967 = env.effects in
-              { decls = (uu___116_4967.decls); order = order2; joins } in
-            let uu___117_4968 = env in
-            {
-              solver = (uu___117_4968.solver);
-              range = (uu___117_4968.range);
-              curmodule = (uu___117_4968.curmodule);
-              gamma = (uu___117_4968.gamma);
-              gamma_cache = (uu___117_4968.gamma_cache);
-              modules = (uu___117_4968.modules);
-              expected_typ = (uu___117_4968.expected_typ);
-              sigtab = (uu___117_4968.sigtab);
-              is_pattern = (uu___117_4968.is_pattern);
-              instantiate_imp = (uu___117_4968.instantiate_imp);
-              effects;
-              generalize = (uu___117_4968.generalize);
-              letrecs = (uu___117_4968.letrecs);
-              top_level = (uu___117_4968.top_level);
-              check_uvars = (uu___117_4968.check_uvars);
-              use_eq = (uu___117_4968.use_eq);
-              is_iface = (uu___117_4968.is_iface);
-              admit = (uu___117_4968.admit);
-              lax = (uu___117_4968.lax);
-              lax_universes = (uu___117_4968.lax_universes);
-              type_of = (uu___117_4968.type_of);
-              universe_of = (uu___117_4968.universe_of);
-              use_bv_sorts = (uu___117_4968.use_bv_sorts);
-              qname_and_index = (uu___117_4968.qname_and_index)
-            }))
-      | uu____4969 -> env
-let comp_to_comp_typ:
-  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
-  fun env  ->
-    fun c  ->
-      let c1 =
-        match c.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total (t,None ) ->
-            let u = env.universe_of env t in
-            FStar_Syntax_Syntax.mk_Total' t (Some u)
-        | FStar_Syntax_Syntax.GTotal (t,None ) ->
-            let u = env.universe_of env t in
-            FStar_Syntax_Syntax.mk_GTotal' t (Some u)
-        | uu____4991 -> c in
-      FStar_Syntax_Util.comp_to_comp_typ c1
-let rec unfold_effect_abbrev:
-  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
-  fun env  ->
-    fun comp  ->
-      let c = comp_to_comp_typ env comp in
-      let uu____4999 =
-        lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs
-          c.FStar_Syntax_Syntax.effect_name in
-      match uu____4999 with
-      | None  -> c
-      | Some (binders,cdef) ->
-          let uu____5009 = FStar_Syntax_Subst.open_comp binders cdef in
-          (match uu____5009 with
-           | (binders1,cdef1) ->
-               (if
-                  (FStar_List.length binders1) <>
-                    ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
-                       (Prims.parse_int "1"))
-                then
-                  (let uu____5026 =
-                     let uu____5027 =
-                       let uu____5030 =
-                         let uu____5031 =
-                           FStar_Util.string_of_int
-                             (FStar_List.length binders1) in
-                         let uu____5037 =
-                           FStar_Util.string_of_int
-                             ((FStar_List.length
-                                 c.FStar_Syntax_Syntax.effect_args)
-                                + (Prims.parse_int "1")) in
-                         let uu____5045 =
-                           let uu____5046 = FStar_Syntax_Syntax.mk_Comp c in
-                           FStar_Syntax_Print.comp_to_string uu____5046 in
-                         FStar_Util.format3
-                           "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                           uu____5031 uu____5037 uu____5045 in
-                       (uu____5030, (comp.FStar_Syntax_Syntax.pos)) in
-                     FStar_Errors.Error uu____5027 in
-                   Prims.raise uu____5026)
-                else ();
-                (let inst1 =
-                   let uu____5050 =
-                     let uu____5056 =
-                       FStar_Syntax_Syntax.as_arg
-                         c.FStar_Syntax_Syntax.result_typ in
-                     uu____5056 :: (c.FStar_Syntax_Syntax.effect_args) in
-                   FStar_List.map2
-                     (fun uu____5063  ->
-                        fun uu____5064  ->
-                          match (uu____5063, uu____5064) with
-                          | ((x,uu____5078),(t,uu____5080)) ->
-                              FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____5050 in
-                 let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1 in
-                 let c2 =
-                   let uu____5095 =
-                     let uu___118_5096 = comp_to_comp_typ env c1 in
-                     {
-                       FStar_Syntax_Syntax.comp_univs =
-                         (uu___118_5096.FStar_Syntax_Syntax.comp_univs);
-                       FStar_Syntax_Syntax.effect_name =
-                         (uu___118_5096.FStar_Syntax_Syntax.effect_name);
-                       FStar_Syntax_Syntax.result_typ =
-                         (uu___118_5096.FStar_Syntax_Syntax.result_typ);
-                       FStar_Syntax_Syntax.effect_args =
-                         (uu___118_5096.FStar_Syntax_Syntax.effect_args);
-                       FStar_Syntax_Syntax.flags =
-                         (c.FStar_Syntax_Syntax.flags)
-                     } in
-                   FStar_All.pipe_right uu____5095
-                     FStar_Syntax_Syntax.mk_Comp in
-                 unfold_effect_abbrev env c2)))
-let effect_repr_aux only_reifiable env c u_c =
-  let uu____5126 =
-    let uu____5128 = norm_eff_name env (FStar_Syntax_Util.comp_effect_name c) in
-    effect_decl_opt env uu____5128 in
-  match uu____5126 with
-  | None  -> None
-  | Some ed ->
-      let uu____5135 =
-        only_reifiable &&
-          (let uu____5136 =
-             FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers
-               (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
-           Prims.op_Negation uu____5136) in
-      if uu____5135
-      then None
-      else
-        (match (ed.FStar_Syntax_Syntax.repr).FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_unknown  -> None
-         | uu____5149 ->
-             let c1 = unfold_effect_abbrev env c in
-             let uu____5151 =
-               let uu____5160 =
-                 FStar_List.hd c1.FStar_Syntax_Syntax.effect_args in
-               ((c1.FStar_Syntax_Syntax.result_typ), uu____5160) in
-             (match uu____5151 with
-              | (res_typ,wp) ->
-                  let repr =
-                    inst_effect_fun_with [u_c] env ed
-                      ([], (ed.FStar_Syntax_Syntax.repr)) in
-                  let uu____5194 =
-                    let uu____5197 = get_range env in
-                    let uu____5198 =
-                      let uu____5201 =
-                        let uu____5202 =
-                          let uu____5212 =
-                            let uu____5214 =
-                              FStar_Syntax_Syntax.as_arg res_typ in
-                            [uu____5214; wp] in
-                          (repr, uu____5212) in
-                        FStar_Syntax_Syntax.Tm_app uu____5202 in
-                      FStar_Syntax_Syntax.mk uu____5201 in
-                    uu____5198 None uu____5197 in
-                  Some uu____5194))
-let effect_repr:
-  env ->
-    FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.universe ->
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax Prims.option
-  = fun env  -> fun c  -> fun u_c  -> effect_repr_aux false env c u_c
-let reify_comp:
-  env ->
-    FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun c  ->
-      fun u_c  ->
-        let no_reify l =
-          let uu____5258 =
-            let uu____5259 =
-              let uu____5262 =
-                let uu____5263 = FStar_Ident.string_of_lid l in
-                FStar_Util.format1 "Effect %s cannot be reified" uu____5263 in
-              let uu____5264 = get_range env in (uu____5262, uu____5264) in
-            FStar_Errors.Error uu____5259 in
-          Prims.raise uu____5258 in
-        let uu____5265 = effect_repr_aux true env c u_c in
-        match uu____5265 with
-        | None  -> no_reify (FStar_Syntax_Util.comp_effect_name c)
-        | Some tm -> tm
-let is_reifiable_effect: env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun effect_lid  ->
-      let quals = lookup_effect_quals env effect_lid in
-      FStar_List.contains FStar_Syntax_Syntax.Reifiable quals
-let is_reifiable:
-  env ->
-    (FStar_Syntax_Syntax.lcomp,FStar_Syntax_Syntax.residual_comp)
-      FStar_Util.either -> Prims.bool
-  =
-  fun env  ->
-    fun c  ->
-      let effect_lid =
-        match c with
-        | FStar_Util.Inl lc -> lc.FStar_Syntax_Syntax.eff_name
-        | FStar_Util.Inr (eff_name,uu____5297) -> eff_name in
-      is_reifiable_effect env effect_lid
-let is_reifiable_comp: env -> FStar_Syntax_Syntax.comp -> Prims.bool =
-  fun env  ->
-    fun c  ->
-      match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Comp ct ->
-          is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name
-      | uu____5310 -> false
-let is_reifiable_function: env -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun env  ->
-    fun t  ->
-      let uu____5317 =
-        let uu____5318 = FStar_Syntax_Subst.compress t in
-        uu____5318.FStar_Syntax_Syntax.n in
-      match uu____5317 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____5321,c) ->
-          is_reifiable_comp env c
-      | uu____5333 -> false
-let push_in_gamma: env -> binding -> env =
-  fun env  ->
-    fun s  ->
-      let rec push1 x rest =
-        match rest with
-        | (Binding_sig _)::_|(Binding_sig_inst _)::_ -> x :: rest
-        | [] -> [x]
-        | local::rest1 ->
-            let uu____5358 = push1 x rest1 in local :: uu____5358 in
-      let uu___119_5360 = env in
-      let uu____5361 = push1 s env.gamma in
-      {
-        solver = (uu___119_5360.solver);
-        range = (uu___119_5360.range);
-        curmodule = (uu___119_5360.curmodule);
-        gamma = uu____5361;
-        gamma_cache = (uu___119_5360.gamma_cache);
-        modules = (uu___119_5360.modules);
-        expected_typ = (uu___119_5360.expected_typ);
-        sigtab = (uu___119_5360.sigtab);
-        is_pattern = (uu___119_5360.is_pattern);
-        instantiate_imp = (uu___119_5360.instantiate_imp);
-        effects = (uu___119_5360.effects);
-        generalize = (uu___119_5360.generalize);
-        letrecs = (uu___119_5360.letrecs);
-        top_level = (uu___119_5360.top_level);
-        check_uvars = (uu___119_5360.check_uvars);
-        use_eq = (uu___119_5360.use_eq);
-        is_iface = (uu___119_5360.is_iface);
-        admit = (uu___119_5360.admit);
-        lax = (uu___119_5360.lax);
-        lax_universes = (uu___119_5360.lax_universes);
-        type_of = (uu___119_5360.type_of);
-        universe_of = (uu___119_5360.universe_of);
-        use_bv_sorts = (uu___119_5360.use_bv_sorts);
-        qname_and_index = (uu___119_5360.qname_and_index)
-      }
-let push_sigelt: env -> FStar_Syntax_Syntax.sigelt -> env =
-  fun env  ->
-    fun s  ->
-      let env1 =
-        push_in_gamma env
-          (Binding_sig ((FStar_Syntax_Util.lids_of_sigelt s), s)) in
-      build_lattice env1 s
-let push_sigelt_inst:
-  env -> FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.universes -> env =
-  fun env  ->
-    fun s  ->
-      fun us  ->
-        let env1 =
-          push_in_gamma env
-            (Binding_sig_inst ((FStar_Syntax_Util.lids_of_sigelt s), s, us)) in
-        build_lattice env1 s
-let push_local_binding: env -> binding -> env =
-  fun env  ->
-    fun b  ->
-      let uu___120_5388 = env in
-      {
-        solver = (uu___120_5388.solver);
-        range = (uu___120_5388.range);
-        curmodule = (uu___120_5388.curmodule);
-        gamma = (b :: (env.gamma));
-        gamma_cache = (uu___120_5388.gamma_cache);
-        modules = (uu___120_5388.modules);
-        expected_typ = (uu___120_5388.expected_typ);
-        sigtab = (uu___120_5388.sigtab);
-        is_pattern = (uu___120_5388.is_pattern);
-        instantiate_imp = (uu___120_5388.instantiate_imp);
-        effects = (uu___120_5388.effects);
-        generalize = (uu___120_5388.generalize);
-        letrecs = (uu___120_5388.letrecs);
-        top_level = (uu___120_5388.top_level);
-        check_uvars = (uu___120_5388.check_uvars);
-        use_eq = (uu___120_5388.use_eq);
-        is_iface = (uu___120_5388.is_iface);
-        admit = (uu___120_5388.admit);
-        lax = (uu___120_5388.lax);
-        lax_universes = (uu___120_5388.lax_universes);
-        type_of = (uu___120_5388.type_of);
-        universe_of = (uu___120_5388.universe_of);
-        use_bv_sorts = (uu___120_5388.use_bv_sorts);
-        qname_and_index = (uu___120_5388.qname_and_index)
-      }
-let push_bv: env -> FStar_Syntax_Syntax.bv -> env =
-  fun env  -> fun x  -> push_local_binding env (Binding_var x)
-let pop_bv: env -> (FStar_Syntax_Syntax.bv* env) Prims.option =
-  fun env  ->
-    match env.gamma with
-    | (Binding_var x)::rest ->
-        Some
-          (x,
-            (let uu___121_5409 = env in
-             {
-               solver = (uu___121_5409.solver);
-               range = (uu___121_5409.range);
-               curmodule = (uu___121_5409.curmodule);
-               gamma = rest;
-               gamma_cache = (uu___121_5409.gamma_cache);
-               modules = (uu___121_5409.modules);
-               expected_typ = (uu___121_5409.expected_typ);
-               sigtab = (uu___121_5409.sigtab);
-               is_pattern = (uu___121_5409.is_pattern);
-               instantiate_imp = (uu___121_5409.instantiate_imp);
-               effects = (uu___121_5409.effects);
-               generalize = (uu___121_5409.generalize);
-               letrecs = (uu___121_5409.letrecs);
-               top_level = (uu___121_5409.top_level);
-               check_uvars = (uu___121_5409.check_uvars);
-               use_eq = (uu___121_5409.use_eq);
-               is_iface = (uu___121_5409.is_iface);
-               admit = (uu___121_5409.admit);
-               lax = (uu___121_5409.lax);
-               lax_universes = (uu___121_5409.lax_universes);
-               type_of = (uu___121_5409.type_of);
-               universe_of = (uu___121_5409.universe_of);
-               use_bv_sorts = (uu___121_5409.use_bv_sorts);
-               qname_and_index = (uu___121_5409.qname_and_index)
-             }))
-    | uu____5410 -> None
-let push_binders: env -> FStar_Syntax_Syntax.binders -> env =
-  fun env  ->
-    fun bs  ->
-      FStar_List.fold_left
-        (fun env1  ->
-           fun uu____5423  ->
-             match uu____5423 with | (x,uu____5427) -> push_bv env1 x) env bs
-let binding_of_lb:
-  FStar_Syntax_Syntax.lbname ->
-    (FStar_Syntax_Syntax.univ_name Prims.list*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax) -> binding
-  =
-  fun x  ->
-    fun t  ->
-      match x with
-      | FStar_Util.Inl x1 ->
-          let x2 =
-            let uu___122_5447 = x1 in
-            {
-              FStar_Syntax_Syntax.ppname =
-                (uu___122_5447.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___122_5447.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = (Prims.snd t)
-            } in
-          Binding_var x2
-      | FStar_Util.Inr fv ->
-          Binding_lid
-            (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v), t)
-let push_let_binding:
-  env -> FStar_Syntax_Syntax.lbname -> FStar_Syntax_Syntax.tscheme -> env =
-  fun env  ->
-    fun lb  -> fun ts  -> push_local_binding env (binding_of_lb lb ts)
-let push_module: env -> FStar_Syntax_Syntax.modul -> env =
-  fun env  ->
-    fun m  ->
-      add_sigelts env m.FStar_Syntax_Syntax.exports;
-      (let uu___123_5477 = env in
-       {
-         solver = (uu___123_5477.solver);
-         range = (uu___123_5477.range);
-         curmodule = (uu___123_5477.curmodule);
-         gamma = [];
-         gamma_cache = (uu___123_5477.gamma_cache);
-         modules = (m :: (env.modules));
-         expected_typ = None;
-         sigtab = (uu___123_5477.sigtab);
-         is_pattern = (uu___123_5477.is_pattern);
-         instantiate_imp = (uu___123_5477.instantiate_imp);
-         effects = (uu___123_5477.effects);
-         generalize = (uu___123_5477.generalize);
-         letrecs = (uu___123_5477.letrecs);
-         top_level = (uu___123_5477.top_level);
-         check_uvars = (uu___123_5477.check_uvars);
-         use_eq = (uu___123_5477.use_eq);
-         is_iface = (uu___123_5477.is_iface);
-         admit = (uu___123_5477.admit);
-         lax = (uu___123_5477.lax);
-         lax_universes = (uu___123_5477.lax_universes);
-         type_of = (uu___123_5477.type_of);
-         universe_of = (uu___123_5477.universe_of);
-         use_bv_sorts = (uu___123_5477.use_bv_sorts);
-         qname_and_index = (uu___123_5477.qname_and_index)
-       })
-let push_univ_vars: env_t -> FStar_Syntax_Syntax.univ_names -> env =
-  fun env  ->
-    fun xs  ->
-      FStar_List.fold_left
-        (fun env1  -> fun x  -> push_local_binding env1 (Binding_univ x)) env
-        xs
-let set_expected_typ: env -> FStar_Syntax_Syntax.typ -> env =
-  fun env  ->
-    fun t  ->
-      let uu___124_5492 = env in
-      {
-        solver = (uu___124_5492.solver);
-        range = (uu___124_5492.range);
-        curmodule = (uu___124_5492.curmodule);
-        gamma = (uu___124_5492.gamma);
-        gamma_cache = (uu___124_5492.gamma_cache);
-        modules = (uu___124_5492.modules);
-        expected_typ = (Some t);
-        sigtab = (uu___124_5492.sigtab);
-        is_pattern = (uu___124_5492.is_pattern);
-        instantiate_imp = (uu___124_5492.instantiate_imp);
-        effects = (uu___124_5492.effects);
-        generalize = (uu___124_5492.generalize);
-        letrecs = (uu___124_5492.letrecs);
-        top_level = (uu___124_5492.top_level);
-        check_uvars = (uu___124_5492.check_uvars);
-        use_eq = false;
-        is_iface = (uu___124_5492.is_iface);
-        admit = (uu___124_5492.admit);
-        lax = (uu___124_5492.lax);
-        lax_universes = (uu___124_5492.lax_universes);
-        type_of = (uu___124_5492.type_of);
-        universe_of = (uu___124_5492.universe_of);
-        use_bv_sorts = (uu___124_5492.use_bv_sorts);
-        qname_and_index = (uu___124_5492.qname_and_index)
-      }
-let expected_typ: env -> FStar_Syntax_Syntax.typ Prims.option =
-  fun env  -> match env.expected_typ with | None  -> None | Some t -> Some t
-let clear_expected_typ: env -> (env* FStar_Syntax_Syntax.typ Prims.option) =
-  fun env_  ->
-    let uu____5508 = expected_typ env_ in
-    ((let uu___125_5511 = env_ in
-      {
-        solver = (uu___125_5511.solver);
-        range = (uu___125_5511.range);
-        curmodule = (uu___125_5511.curmodule);
-        gamma = (uu___125_5511.gamma);
-        gamma_cache = (uu___125_5511.gamma_cache);
-        modules = (uu___125_5511.modules);
-        expected_typ = None;
-        sigtab = (uu___125_5511.sigtab);
-        is_pattern = (uu___125_5511.is_pattern);
-        instantiate_imp = (uu___125_5511.instantiate_imp);
-        effects = (uu___125_5511.effects);
-        generalize = (uu___125_5511.generalize);
-        letrecs = (uu___125_5511.letrecs);
-        top_level = (uu___125_5511.top_level);
-        check_uvars = (uu___125_5511.check_uvars);
-        use_eq = false;
-        is_iface = (uu___125_5511.is_iface);
-        admit = (uu___125_5511.admit);
-        lax = (uu___125_5511.lax);
-        lax_universes = (uu___125_5511.lax_universes);
-        type_of = (uu___125_5511.type_of);
-        universe_of = (uu___125_5511.universe_of);
-        use_bv_sorts = (uu___125_5511.use_bv_sorts);
-        qname_and_index = (uu___125_5511.qname_and_index)
-      }), uu____5508)
-let finish_module: env -> FStar_Syntax_Syntax.modul -> env =
-  let empty_lid = FStar_Ident.lid_of_ids [FStar_Ident.id_of_text ""] in
-  fun env  ->
-    fun m  ->
-      let sigs =
-        if
-          FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
-            FStar_Syntax_Const.prims_lid
-        then
-          let uu____5522 =
-            FStar_All.pipe_right env.gamma
-              (FStar_List.collect
-                 (fun uu___104_5526  ->
-                    match uu___104_5526 with
-                    | Binding_sig (uu____5528,se) -> [se]
-                    | uu____5532 -> [])) in
-          FStar_All.pipe_right uu____5522 FStar_List.rev
-        else m.FStar_Syntax_Syntax.exports in
-      add_sigelts env sigs;
-      (let uu___126_5537 = env in
-       {
-         solver = (uu___126_5537.solver);
-         range = (uu___126_5537.range);
-         curmodule = empty_lid;
-         gamma = [];
-         gamma_cache = (uu___126_5537.gamma_cache);
-         modules = (m :: (env.modules));
-         expected_typ = (uu___126_5537.expected_typ);
-         sigtab = (uu___126_5537.sigtab);
-         is_pattern = (uu___126_5537.is_pattern);
-         instantiate_imp = (uu___126_5537.instantiate_imp);
-         effects = (uu___126_5537.effects);
-         generalize = (uu___126_5537.generalize);
-         letrecs = (uu___126_5537.letrecs);
-         top_level = (uu___126_5537.top_level);
-         check_uvars = (uu___126_5537.check_uvars);
-         use_eq = (uu___126_5537.use_eq);
-         is_iface = (uu___126_5537.is_iface);
-         admit = (uu___126_5537.admit);
-         lax = (uu___126_5537.lax);
-         lax_universes = (uu___126_5537.lax_universes);
-         type_of = (uu___126_5537.type_of);
-         universe_of = (uu___126_5537.universe_of);
-         use_bv_sorts = (uu___126_5537.use_bv_sorts);
-         qname_and_index = (uu___126_5537.qname_and_index)
-       })
-let uvars_in_env:
-  env -> (FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.typ) FStar_Util.set =
-  fun env  ->
-    let no_uvs1 = FStar_Syntax_Syntax.new_uv_set () in
-    let ext out uvs = FStar_Util.set_union out uvs in
-    let rec aux out g =
-      match g with
-      | [] -> out
-      | (Binding_univ uu____5587)::tl1 -> aux out tl1
-      | (Binding_lid (_,(_,t)))::tl1|(Binding_var
-        { FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-          FStar_Syntax_Syntax.sort = t;_})::tl1 ->
-          let uu____5602 =
-            let uu____5606 = FStar_Syntax_Free.uvars t in ext out uu____5606 in
-          aux uu____5602 tl1
-      | (Binding_sig _)::_|(Binding_sig_inst _)::_ -> out in
-    aux no_uvs1 env.gamma
-let univ_vars: env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set =
-  fun env  ->
-    let no_univs = FStar_Syntax_Syntax.no_universe_uvars in
-    let ext out uvs = FStar_Util.set_union out uvs in
-    let rec aux out g =
-      match g with
-      | [] -> out
-      | (Binding_sig_inst _)::tl1|(Binding_univ _)::tl1 -> aux out tl1
-      | (Binding_lid (_,(_,t)))::tl1|(Binding_var
-        { FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-          FStar_Syntax_Syntax.sort = t;_})::tl1 ->
-          let uu____5662 =
-            let uu____5664 = FStar_Syntax_Free.univs t in ext out uu____5664 in
-          aux uu____5662 tl1
-      | (Binding_sig uu____5666)::uu____5667 -> out in
-    aux no_univs env.gamma
-let univnames: env -> FStar_Syntax_Syntax.univ_name FStar_Util.set =
-  fun env  ->
-    let no_univ_names = FStar_Syntax_Syntax.no_universe_names in
-    let ext out uvs = FStar_Util.set_union out uvs in
-    let rec aux out g =
-      match g with
-      | [] -> out
-      | (Binding_sig_inst uu____5704)::tl1 -> aux out tl1
-      | (Binding_univ uname)::tl1 ->
-          let uu____5714 = FStar_Util.set_add uname out in aux uu____5714 tl1
-      | (Binding_lid (_,(_,t)))::tl1|(Binding_var
-        { FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-          FStar_Syntax_Syntax.sort = t;_})::tl1 ->
-          let uu____5728 =
-            let uu____5730 = FStar_Syntax_Free.univnames t in
-            ext out uu____5730 in
-          aux uu____5728 tl1
-      | (Binding_sig uu____5732)::uu____5733 -> out in
-    aux no_univ_names env.gamma
-let bound_vars_of_bindings:
-  binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list =
-  fun bs  ->
-    FStar_All.pipe_right bs
-      (FStar_List.collect
-         (fun uu___105_5749  ->
-            match uu___105_5749 with
-            | Binding_var x -> [x]
-            | Binding_lid _|Binding_sig _|Binding_univ _|Binding_sig_inst _
-                -> []))
-let binders_of_bindings:
-  binding Prims.list -> FStar_Syntax_Syntax.binder Prims.list =
-  fun bs  ->
-    let uu____5761 =
-      let uu____5763 = bound_vars_of_bindings bs in
-      FStar_All.pipe_right uu____5763
-        (FStar_List.map FStar_Syntax_Syntax.mk_binder) in
-    FStar_All.pipe_right uu____5761 FStar_List.rev
-let bound_vars: env -> FStar_Syntax_Syntax.bv Prims.list =
-  fun env  -> bound_vars_of_bindings env.gamma
-let all_binders: env -> FStar_Syntax_Syntax.binders =
-  fun env  -> binders_of_bindings env.gamma
-let print_gamma: env -> Prims.unit =
-  fun env  ->
-    let uu____5779 =
-      let uu____5780 =
-        FStar_All.pipe_right env.gamma
-          (FStar_List.map
-             (fun uu___106_5784  ->
-                match uu___106_5784 with
-                | Binding_var x ->
-                    let uu____5786 = FStar_Syntax_Print.bv_to_string x in
-                    Prims.strcat "Binding_var " uu____5786
-                | Binding_univ u ->
-                    Prims.strcat "Binding_univ " u.FStar_Ident.idText
-                | Binding_lid (l,uu____5789) ->
-                    let uu____5790 = FStar_Ident.string_of_lid l in
-                    Prims.strcat "Binding_lid " uu____5790
-                | Binding_sig (ls,uu____5792) ->
-                    let uu____5795 =
-                      let uu____5796 =
-                        FStar_All.pipe_right ls
-                          (FStar_List.map FStar_Ident.string_of_lid) in
-                      FStar_All.pipe_right uu____5796
-                        (FStar_String.concat ", ") in
-                    Prims.strcat "Binding_sig " uu____5795
-                | Binding_sig_inst (ls,uu____5802,uu____5803) ->
-                    let uu____5806 =
-                      let uu____5807 =
-                        FStar_All.pipe_right ls
-                          (FStar_List.map FStar_Ident.string_of_lid) in
-                      FStar_All.pipe_right uu____5807
-                        (FStar_String.concat ", ") in
-                    Prims.strcat "Binding_sig_inst " uu____5806)) in
-      FStar_All.pipe_right uu____5780 (FStar_String.concat "::\n") in
-    FStar_All.pipe_right uu____5779 (FStar_Util.print1 "%s\n")
-let eq_gamma: env -> env -> Prims.bool =
-  fun env  ->
-    fun env'  ->
-      let uu____5819 = FStar_Util.physical_equality env.gamma env'.gamma in
-      if uu____5819
-      then true
-      else
-        (let g = all_binders env in
-         let g' = all_binders env' in
-         ((FStar_List.length g) = (FStar_List.length g')) &&
-           (FStar_List.forall2
-              (fun uu____5836  ->
-                 fun uu____5837  ->
-                   match (uu____5836, uu____5837) with
-                   | ((b1,uu____5847),(b2,uu____5849)) ->
-                       FStar_Syntax_Syntax.bv_eq b1 b2) g g'))
-let fold_env env f a =
-  FStar_List.fold_right (fun e  -> fun a1  -> f a1 e) env.gamma a
-let lidents: env -> FStar_Ident.lident Prims.list =
-  fun env  ->
-    let keys =
-      FStar_List.fold_left
-        (fun keys  ->
-           fun uu___107_5892  ->
-             match uu___107_5892 with
-             | Binding_sig (lids,uu____5896) -> FStar_List.append lids keys
-             | uu____5899 -> keys) [] env.gamma in
-    FStar_Util.smap_fold (sigtab env)
-      (fun uu____5901  ->
-         fun v1  ->
-           fun keys1  ->
-             FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)
-      keys
-let dummy_solver: solver_t =
-  {
-    init = (fun uu____5905  -> ());
-    push = (fun uu____5906  -> ());
-    pop = (fun uu____5907  -> ());
-    mark = (fun uu____5908  -> ());
-    reset_mark = (fun uu____5909  -> ());
-    commit_mark = (fun uu____5910  -> ());
-    encode_modul = (fun uu____5911  -> fun uu____5912  -> ());
-    encode_sig = (fun uu____5913  -> fun uu____5914  -> ());
-    preprocess = (fun e  -> fun g  -> [(e, g)]);
-    solve = (fun uu____5921  -> fun uu____5922  -> fun uu____5923  -> ());
-    is_trivial = (fun uu____5927  -> fun uu____5928  -> false);
-    finish = (fun uu____5929  -> ());
-    refresh = (fun uu____5930  -> ())
-  }
+| Yes
+| No
+| Maybe
+
+
+let uu___is_Yes : tri  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Yes -> begin
+true
+end
+| uu____1451 -> begin
+false
+end))
+
+
+let uu___is_No : tri  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| No -> begin
+true
+end
+| uu____1455 -> begin
+false
+end))
+
+
+let uu___is_Maybe : tri  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Maybe -> begin
+true
+end
+| uu____1459 -> begin
+false
+end))
+
+
+let in_cur_mod : env  ->  FStar_Ident.lident  ->  tri = (fun env l -> (
+
+let cur = (current_module env)
+in (match ((l.FStar_Ident.nsstr = cur.FStar_Ident.str)) with
+| true -> begin
+Yes
+end
+| uu____1467 -> begin
+(match ((FStar_Util.starts_with l.FStar_Ident.nsstr cur.FStar_Ident.str)) with
+| true -> begin
+(
+
+let lns = (FStar_List.append l.FStar_Ident.ns ((l.FStar_Ident.ident)::[]))
+in (
+
+let cur1 = (FStar_List.append cur.FStar_Ident.ns ((cur.FStar_Ident.ident)::[]))
+in (
+
+let rec aux = (fun c l1 -> (match (((c), (l1))) with
+| ([], uu____1485) -> begin
+Maybe
+end
+| (uu____1489, []) -> begin
+No
+end
+| ((hd1)::tl1, (hd')::tl') when (hd1.FStar_Ident.idText = hd'.FStar_Ident.idText) -> begin
+(aux tl1 tl')
+end
+| uu____1501 -> begin
+No
+end))
+in (aux cur1 lns))))
+end
+| uu____1506 -> begin
+No
+end)
+end)))
+
+
+let lookup_qname : env  ->  FStar_Ident.lident  ->  (((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ), (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes Prims.option)) FStar_Util.either * FStar_Range.range) Prims.option = (fun env lid -> (
+
+let cur_mod = (in_cur_mod env lid)
+in (
+
+let cache = (fun t -> ((FStar_Util.smap_add (gamma_cache env) lid.FStar_Ident.str t);
+Some (t);
+))
+in (
+
+let found = (match ((cur_mod <> No)) with
+| true -> begin
+(
+
+let uu____1561 = (FStar_Util.smap_try_find (gamma_cache env) lid.FStar_Ident.str)
+in (match (uu____1561) with
+| None -> begin
+(FStar_Util.find_map env.gamma (fun uu___97_1582 -> (match (uu___97_1582) with
+| Binding_lid (l, t) -> begin
+(match ((FStar_Ident.lid_equals lid l)) with
+| true -> begin
+(
+
+let uu____1605 = (
+
+let uu____1615 = (
+
+let uu____1623 = (inst_tscheme t)
+in FStar_Util.Inl (uu____1623))
+in ((uu____1615), ((FStar_Ident.range_of_lid l))))
+in Some (uu____1605))
+end
+| uu____1647 -> begin
+None
+end)
+end
+| Binding_sig (uu____1657, {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle (ses, uu____1659, uu____1660); FStar_Syntax_Syntax.sigdoc = uu____1661; FStar_Syntax_Syntax.sigrng = uu____1662}) -> begin
+(FStar_Util.find_map ses (fun se -> (
+
+let uu____1673 = (FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se) (FStar_Util.for_some (FStar_Ident.lid_equals lid)))
+in (match (uu____1673) with
+| true -> begin
+(cache ((FStar_Util.Inr (((se), (None)))), ((FStar_Syntax_Util.range_of_sigelt se))))
+end
+| uu____1689 -> begin
+None
+end))))
+end
+| Binding_sig (lids, s) -> begin
+(
+
+let maybe_cache = (fun t -> (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_declare_typ (uu____1700) -> begin
+Some (t)
+end
+| uu____1706 -> begin
+(cache t)
+end))
+in (
+
+let uu____1707 = (FStar_List.tryFind (FStar_Ident.lid_equals lid) lids)
+in (match (uu____1707) with
+| None -> begin
+None
+end
+| Some (l) -> begin
+(maybe_cache ((FStar_Util.Inr (((s), (None)))), ((FStar_Ident.range_of_lid l))))
+end)))
+end
+| Binding_sig_inst (lids, s, us) -> begin
+(
+
+let uu____1747 = (FStar_List.tryFind (FStar_Ident.lid_equals lid) lids)
+in (match (uu____1747) with
+| None -> begin
+None
+end
+| Some (l) -> begin
+Some (((FStar_Util.Inr (((s), (Some (us))))), ((FStar_Ident.range_of_lid l))))
+end))
+end
+| uu____1791 -> begin
+None
+end)))
+end
+| se -> begin
+se
+end))
+end
+| uu____1803 -> begin
+None
+end)
+in (match ((FStar_Util.is_some found)) with
+| true -> begin
+found
+end
+| uu____1832 -> begin
+(
+
+let uu____1833 = ((cur_mod <> Yes) || (has_interface env env.curmodule))
+in (match (uu____1833) with
+| true -> begin
+(
+
+let uu____1844 = (find_in_sigtab env lid)
+in (match (uu____1844) with
+| Some (se) -> begin
+Some (((FStar_Util.Inr (((se), (None)))), ((FStar_Syntax_Util.range_of_sigelt se))))
+end
+| None -> begin
+None
+end))
+end
+| uu____1888 -> begin
+None
+end))
+end)))))
+
+
+let rec add_sigelt : env  ->  FStar_Syntax_Syntax.sigelt  ->  Prims.unit = (fun env se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (ses, uu____1910, uu____1911) -> begin
+(add_sigelts env ses)
+end
+| uu____1918 -> begin
+(
+
+let lids = (FStar_Syntax_Util.lids_of_sigelt se)
+in ((FStar_List.iter (fun l -> (FStar_Util.smap_add (sigtab env) l.FStar_Ident.str se)) lids);
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_new_effect (ne) -> begin
+(FStar_All.pipe_right ne.FStar_Syntax_Syntax.actions (FStar_List.iter (fun a -> (
+
+let se_let = (FStar_Syntax_Util.action_as_lb ne.FStar_Syntax_Syntax.mname a)
+in (FStar_Util.smap_add (sigtab env) a.FStar_Syntax_Syntax.action_name.FStar_Ident.str se_let)))))
+end
+| uu____1927 -> begin
+()
+end);
+))
+end))
+and add_sigelts : env  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  Prims.unit = (fun env ses -> (FStar_All.pipe_right ses (FStar_List.iter (add_sigelt env))))
+
+
+let try_lookup_bv : env  ->  FStar_Syntax_Syntax.bv  ->  (FStar_Syntax_Syntax.typ * FStar_Range.range) Prims.option = (fun env bv -> (FStar_Util.find_map env.gamma (fun uu___98_1945 -> (match (uu___98_1945) with
+| Binding_var (id) when (FStar_Syntax_Syntax.bv_eq id bv) -> begin
+Some (((id.FStar_Syntax_Syntax.sort), (id.FStar_Syntax_Syntax.ppname.FStar_Ident.idRange)))
+end
+| uu____1958 -> begin
+None
+end))))
+
+
+let lookup_type_of_let : FStar_Syntax_Syntax.sigelt  ->  FStar_Ident.lident  ->  ((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term) * FStar_Range.range) Prims.option = (fun se lid -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____1979, (lb)::[]), uu____1981, uu____1982, uu____1983) -> begin
+(
+
+let uu____1994 = (
+
+let uu____1999 = (inst_tscheme ((lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp)))
+in (
+
+let uu____2005 = (FStar_Syntax_Syntax.range_of_lbname lb.FStar_Syntax_Syntax.lbname)
+in ((uu____1999), (uu____2005))))
+in Some (uu____1994))
+end
+| FStar_Syntax_Syntax.Sig_let ((uu____2012, lbs), uu____2014, uu____2015, uu____2016) -> begin
+(FStar_Util.find_map lbs (fun lb -> (match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inl (uu____2038) -> begin
+(failwith "impossible")
+end
+| FStar_Util.Inr (fv) -> begin
+(
+
+let uu____2045 = (FStar_Syntax_Syntax.fv_eq_lid fv lid)
+in (match (uu____2045) with
+| true -> begin
+(
+
+let uu____2051 = (
+
+let uu____2056 = (inst_tscheme ((lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp)))
+in (
+
+let uu____2062 = (FStar_Syntax_Syntax.range_of_fv fv)
+in ((uu____2056), (uu____2062))))
+in Some (uu____2051))
+end
+| uu____2069 -> begin
+None
+end))
+end)))
+end
+| uu____2074 -> begin
+None
+end))
+
+
+let effect_signature : FStar_Syntax_Syntax.sigelt  ->  ((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term) * FStar_Range.range) Prims.option = (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_new_effect (ne) -> begin
+(
+
+let uu____2093 = (
+
+let uu____2098 = (
+
+let uu____2101 = (
+
+let uu____2102 = (
+
+let uu____2105 = (FStar_Syntax_Syntax.mk_Total ne.FStar_Syntax_Syntax.signature)
+in (FStar_Syntax_Util.arrow ne.FStar_Syntax_Syntax.binders uu____2105))
+in ((ne.FStar_Syntax_Syntax.univs), (uu____2102)))
+in (inst_tscheme uu____2101))
+in ((uu____2098), (se.FStar_Syntax_Syntax.sigrng)))
+in Some (uu____2093))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (lid, us, binders, uu____2119, uu____2120, uu____2121) -> begin
+(
+
+let uu____2126 = (
+
+let uu____2131 = (
+
+let uu____2134 = (
+
+let uu____2135 = (
+
+let uu____2138 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff)
+in (FStar_Syntax_Util.arrow binders uu____2138))
+in ((us), (uu____2135)))
+in (inst_tscheme uu____2134))
+in ((uu____2131), (se.FStar_Syntax_Syntax.sigrng)))
+in Some (uu____2126))
+end
+| uu____2149 -> begin
+None
+end))
+
+
+let try_lookup_lid_aux : env  ->  FStar_Ident.lident  ->  ((FStar_Syntax_Syntax.universes * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) * FStar_Range.range) Prims.option = (fun env lid -> (
+
+let mapper = (fun uu____2184 -> (match (uu____2184) with
+| (lr, rng) -> begin
+(match (lr) with
+| FStar_Util.Inl (t) -> begin
+Some (((t), (rng)))
+end
+| FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____2234, uvs, t, uu____2237, uu____2238, uu____2239, uu____2240); FStar_Syntax_Syntax.sigdoc = uu____2241; FStar_Syntax_Syntax.sigrng = uu____2242}, None) -> begin
+(
+
+let uu____2254 = (
+
+let uu____2259 = (inst_tscheme ((uvs), (t)))
+in ((uu____2259), (rng)))
+in Some (uu____2254))
+end
+| FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (l, uvs, t, qs); FStar_Syntax_Syntax.sigdoc = uu____2272; FStar_Syntax_Syntax.sigrng = uu____2273}, None) -> begin
+(
+
+let uu____2283 = (
+
+let uu____2284 = (in_cur_mod env l)
+in (uu____2284 = Yes))
+in (match (uu____2283) with
+| true -> begin
+(
+
+let uu____2290 = ((FStar_All.pipe_right qs (FStar_List.contains FStar_Syntax_Syntax.Assumption)) || env.is_iface)
+in (match (uu____2290) with
+| true -> begin
+(
+
+let uu____2297 = (
+
+let uu____2302 = (inst_tscheme ((uvs), (t)))
+in ((uu____2302), (rng)))
+in Some (uu____2297))
+end
+| uu____2311 -> begin
+None
+end))
+end
+| uu____2316 -> begin
+(
+
+let uu____2317 = (
+
+let uu____2322 = (inst_tscheme ((uvs), (t)))
+in ((uu____2322), (rng)))
+in Some (uu____2317))
+end))
+end
+| FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (lid1, uvs, tps, k, uu____2335, uu____2336, uu____2337); FStar_Syntax_Syntax.sigdoc = uu____2338; FStar_Syntax_Syntax.sigrng = uu____2339}, None) -> begin
+(match (tps) with
+| [] -> begin
+(
+
+let uu____2360 = (
+
+let uu____2365 = (inst_tscheme ((uvs), (k)))
+in ((uu____2365), (rng)))
+in Some (uu____2360))
+end
+| uu____2374 -> begin
+(
+
+let uu____2375 = (
+
+let uu____2380 = (
+
+let uu____2383 = (
+
+let uu____2384 = (
+
+let uu____2387 = (FStar_Syntax_Syntax.mk_Total k)
+in (FStar_Syntax_Util.flat_arrow tps uu____2387))
+in ((uvs), (uu____2384)))
+in (inst_tscheme uu____2383))
+in ((uu____2380), (rng)))
+in Some (uu____2375))
+end)
+end
+| FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (lid1, uvs, tps, k, uu____2402, uu____2403, uu____2404); FStar_Syntax_Syntax.sigdoc = uu____2405; FStar_Syntax_Syntax.sigrng = uu____2406}, Some (us)) -> begin
+(match (tps) with
+| [] -> begin
+(
+
+let uu____2428 = (
+
+let uu____2433 = (inst_tscheme_with ((uvs), (k)) us)
+in ((uu____2433), (rng)))
+in Some (uu____2428))
+end
+| uu____2442 -> begin
+(
+
+let uu____2443 = (
+
+let uu____2448 = (
+
+let uu____2451 = (
+
+let uu____2452 = (
+
+let uu____2455 = (FStar_Syntax_Syntax.mk_Total k)
+in (FStar_Syntax_Util.flat_arrow tps uu____2455))
+in ((uvs), (uu____2452)))
+in (inst_tscheme_with uu____2451 us))
+in ((uu____2448), (rng)))
+in Some (uu____2443))
+end)
+end
+| FStar_Util.Inr (se) -> begin
+(match (se) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let (uu____2480); FStar_Syntax_Syntax.sigdoc = uu____2481; FStar_Syntax_Syntax.sigrng = uu____2482}, None) -> begin
+(lookup_type_of_let (Prims.fst se) lid)
+end
+| uu____2493 -> begin
+(effect_signature (Prims.fst se))
+end)
+end)
+end))
+in (
+
+let uu____2498 = (
+
+let uu____2504 = (lookup_qname env lid)
+in (FStar_Util.bind_opt uu____2504 mapper))
+in (match (uu____2498) with
+| Some ((us, t), r) -> begin
+Some (((((us), ((
+
+let uu___113_2556 = t
+in {FStar_Syntax_Syntax.n = uu___113_2556.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___113_2556.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = (FStar_Ident.range_of_lid lid); FStar_Syntax_Syntax.vars = uu___113_2556.FStar_Syntax_Syntax.vars})))), (r)))
+end
+| None -> begin
+None
+end))))
+
+
+let lid_exists : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env l -> (
+
+let uu____2577 = (lookup_qname env l)
+in (match (uu____2577) with
+| None -> begin
+false
+end
+| Some (uu____2597) -> begin
+true
+end)))
+
+
+let lookup_bv : env  ->  FStar_Syntax_Syntax.bv  ->  (FStar_Syntax_Syntax.typ * FStar_Range.range) = (fun env bv -> (
+
+let bvr = (FStar_Syntax_Syntax.range_of_bv bv)
+in (
+
+let uu____2625 = (try_lookup_bv env bv)
+in (match (uu____2625) with
+| None -> begin
+(
+
+let uu____2633 = (
+
+let uu____2634 = (
+
+let uu____2637 = (variable_not_found bv)
+in ((uu____2637), (bvr)))
+in FStar_Errors.Error (uu____2634))
+in (Prims.raise uu____2633))
+end
+| Some (t, r) -> begin
+(
+
+let uu____2644 = (FStar_Syntax_Subst.set_use_range bvr t)
+in (
+
+let uu____2645 = (FStar_Range.set_use_range r bvr)
+in ((uu____2644), (uu____2645))))
+end))))
+
+
+let try_lookup_lid : env  ->  FStar_Ident.lident  ->  ((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ) * FStar_Range.range) Prims.option = (fun env l -> (
+
+let uu____2657 = (try_lookup_lid_aux env l)
+in (match (uu____2657) with
+| None -> begin
+None
+end
+| Some ((us, t), r) -> begin
+(
+
+let use_range = (FStar_Ident.range_of_lid l)
+in (
+
+let r1 = (FStar_Range.set_use_range r use_range)
+in (
+
+let uu____2699 = (
+
+let uu____2704 = (
+
+let uu____2707 = (FStar_Syntax_Subst.set_use_range use_range t)
+in ((us), (uu____2707)))
+in ((uu____2704), (r1)))
+in Some (uu____2699))))
+end)))
+
+
+let lookup_lid : env  ->  FStar_Ident.lident  ->  ((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ) * FStar_Range.range) = (fun env l -> (
+
+let uu____2724 = (try_lookup_lid env l)
+in (match (uu____2724) with
+| None -> begin
+(
+
+let uu____2738 = (
+
+let uu____2739 = (
+
+let uu____2742 = (name_not_found l)
+in ((uu____2742), ((FStar_Ident.range_of_lid l))))
+in FStar_Errors.Error (uu____2739))
+in (Prims.raise uu____2738))
+end
+| Some ((us, t), r) -> begin
+((((us), (t))), (r))
+end)))
+
+
+let lookup_univ : env  ->  FStar_Syntax_Syntax.univ_name  ->  Prims.bool = (fun env x -> (FStar_All.pipe_right (FStar_List.find (fun uu___99_2765 -> (match (uu___99_2765) with
+| Binding_univ (y) -> begin
+(x.FStar_Ident.idText = y.FStar_Ident.idText)
+end
+| uu____2767 -> begin
+false
+end)) env.gamma) FStar_Option.isSome))
+
+
+let try_lookup_val_decl : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.tscheme * FStar_Syntax_Syntax.qualifier Prims.list) Prims.option = (fun env lid -> (
+
+let uu____2778 = (lookup_qname env lid)
+in (match (uu____2778) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (uu____2793, uvs, t, q); FStar_Syntax_Syntax.sigdoc = uu____2797; FStar_Syntax_Syntax.sigrng = uu____2798}, None), uu____2799) -> begin
+(
+
+let uu____2825 = (
+
+let uu____2831 = (
+
+let uu____2834 = (FStar_Syntax_Subst.set_use_range (FStar_Ident.range_of_lid lid) t)
+in ((uvs), (uu____2834)))
+in ((uu____2831), (q)))
+in Some (uu____2825))
+end
+| uu____2843 -> begin
+None
+end)))
+
+
+let lookup_val_decl : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ) = (fun env lid -> (
+
+let uu____2865 = (lookup_qname env lid)
+in (match (uu____2865) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (uu____2878, uvs, t, uu____2881); FStar_Syntax_Syntax.sigdoc = uu____2882; FStar_Syntax_Syntax.sigrng = uu____2883}, None), uu____2884) -> begin
+(inst_tscheme_with_range (FStar_Ident.range_of_lid lid) ((uvs), (t)))
+end
+| uu____2910 -> begin
+(
+
+let uu____2921 = (
+
+let uu____2922 = (
+
+let uu____2925 = (name_not_found lid)
+in ((uu____2925), ((FStar_Ident.range_of_lid lid))))
+in FStar_Errors.Error (uu____2922))
+in (Prims.raise uu____2921))
+end)))
+
+
+let lookup_datacon : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ) = (fun env lid -> (
+
+let uu____2936 = (lookup_qname env lid)
+in (match (uu____2936) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____2949, uvs, t, uu____2952, uu____2953, uu____2954, uu____2955); FStar_Syntax_Syntax.sigdoc = uu____2956; FStar_Syntax_Syntax.sigrng = uu____2957}, None), uu____2958) -> begin
+(inst_tscheme_with_range (FStar_Ident.range_of_lid lid) ((uvs), (t)))
+end
+| uu____2986 -> begin
+(
+
+let uu____2997 = (
+
+let uu____2998 = (
+
+let uu____3001 = (name_not_found lid)
+in ((uu____3001), ((FStar_Ident.range_of_lid lid))))
+in FStar_Errors.Error (uu____2998))
+in (Prims.raise uu____2997))
+end)))
+
+
+let datacons_of_typ : env  ->  FStar_Ident.lident  ->  (Prims.bool * FStar_Ident.lident Prims.list) = (fun env lid -> (
+
+let uu____3013 = (lookup_qname env lid)
+in (match (uu____3013) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (uu____3027, uu____3028, uu____3029, uu____3030, uu____3031, dcs, uu____3033); FStar_Syntax_Syntax.sigdoc = uu____3034; FStar_Syntax_Syntax.sigrng = uu____3035}, uu____3036), uu____3037) -> begin
+((true), (dcs))
+end
+| uu____3069 -> begin
+((false), ([]))
+end)))
+
+
+let typ_of_datacon : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident = (fun env lid -> (
+
+let uu____3087 = (lookup_qname env lid)
+in (match (uu____3087) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____3098, uu____3099, uu____3100, l, uu____3102, uu____3103, uu____3104); FStar_Syntax_Syntax.sigdoc = uu____3105; FStar_Syntax_Syntax.sigrng = uu____3106}, uu____3107), uu____3108) -> begin
+l
+end
+| uu____3137 -> begin
+(
+
+let uu____3148 = (
+
+let uu____3149 = (FStar_Syntax_Print.lid_to_string lid)
+in (FStar_Util.format1 "Not a datacon: %s" uu____3149))
+in (failwith uu____3148))
+end)))
+
+
+let lookup_definition : delta_level Prims.list  ->  env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.term) Prims.option = (fun delta_levels env lid -> (
+
+let visible = (fun quals -> (FStar_All.pipe_right delta_levels (FStar_Util.for_some (fun dl -> (FStar_All.pipe_right quals (FStar_Util.for_some (visible_at dl)))))))
+in (
+
+let uu____3173 = (lookup_qname env lid)
+in (match (uu____3173) with
+| Some (FStar_Util.Inr (se, None), uu____3188) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((uu____3214, lbs), uu____3216, quals, uu____3218) when (visible quals) -> begin
+(FStar_Util.find_map lbs (fun lb -> (
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____3235 = (FStar_Syntax_Syntax.fv_eq_lid fv lid)
+in (match (uu____3235) with
+| true -> begin
+(
+
+let uu____3240 = (
+
+let uu____3244 = (
+
+let uu____3245 = (FStar_Syntax_Util.unascribe lb.FStar_Syntax_Syntax.lbdef)
+in (FStar_Syntax_Subst.set_use_range (FStar_Ident.range_of_lid lid) uu____3245))
+in ((lb.FStar_Syntax_Syntax.lbunivs), (uu____3244)))
+in Some (uu____3240))
+end
+| uu____3250 -> begin
+None
+end)))))
+end
+| uu____3254 -> begin
+None
+end)
+end
+| uu____3257 -> begin
+None
+end))))
+
+
+let try_lookup_effect_lid : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term Prims.option = (fun env ftv -> (
+
+let uu____3278 = (lookup_qname env ftv)
+in (match (uu____3278) with
+| Some (FStar_Util.Inr (se, None), uu____3291) -> begin
+(
+
+let uu____3314 = (effect_signature se)
+in (match (uu____3314) with
+| None -> begin
+None
+end
+| Some ((uu____3325, t), r) -> begin
+(
+
+let uu____3334 = (FStar_Syntax_Subst.set_use_range (FStar_Ident.range_of_lid ftv) t)
+in Some (uu____3334))
+end))
+end
+| uu____3335 -> begin
+None
+end)))
+
+
+let lookup_effect_lid : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term = (fun env ftv -> (
+
+let uu____3352 = (try_lookup_effect_lid env ftv)
+in (match (uu____3352) with
+| None -> begin
+(
+
+let uu____3354 = (
+
+let uu____3355 = (
+
+let uu____3358 = (name_not_found ftv)
+in ((uu____3358), ((FStar_Ident.range_of_lid ftv))))
+in FStar_Errors.Error (uu____3355))
+in (Prims.raise uu____3354))
+end
+| Some (k) -> begin
+k
+end)))
+
+
+let lookup_effect_abbrev : env  ->  FStar_Syntax_Syntax.universes  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp) Prims.option = (fun env univ_insts lid0 -> (
+
+let uu____3372 = (lookup_qname env lid0)
+in (match (uu____3372) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_effect_abbrev (lid, univs1, binders, c, quals, uu____3391); FStar_Syntax_Syntax.sigdoc = uu____3392; FStar_Syntax_Syntax.sigrng = uu____3393}, None), uu____3394) -> begin
+(
+
+let lid1 = (
+
+let uu____3423 = (FStar_Range.set_use_range (FStar_Ident.range_of_lid lid) (FStar_Ident.range_of_lid lid0))
+in (FStar_Ident.set_lid_range lid uu____3423))
+in (
+
+let uu____3424 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___100_3426 -> (match (uu___100_3426) with
+| FStar_Syntax_Syntax.Irreducible -> begin
+true
+end
+| uu____3427 -> begin
+false
+end))))
+in (match (uu____3424) with
+| true -> begin
+None
+end
+| uu____3433 -> begin
+(
+
+let insts = (match (((FStar_List.length univ_insts) = (FStar_List.length univs1))) with
+| true -> begin
+univ_insts
+end
+| uu____3439 -> begin
+(match (((FStar_Ident.lid_equals lid1 FStar_Syntax_Const.effect_Lemma_lid) && ((FStar_List.length univ_insts) = (Prims.parse_int "1")))) with
+| true -> begin
+(FStar_List.append univ_insts ((FStar_Syntax_Syntax.U_zero)::[]))
+end
+| uu____3442 -> begin
+(
+
+let uu____3443 = (
+
+let uu____3444 = (FStar_Syntax_Print.lid_to_string lid1)
+in (
+
+let uu____3445 = (FStar_All.pipe_right (FStar_List.length univ_insts) FStar_Util.string_of_int)
+in (FStar_Util.format2 "Unexpected instantiation of effect %s with %s universes" uu____3444 uu____3445)))
+in (failwith uu____3443))
+end)
+end)
+in (match (((binders), (univs1))) with
+| ([], uu____3451) -> begin
+(failwith "Unexpected effect abbreviation with no arguments")
+end
+| (uu____3460, (uu____3461)::(uu____3462)::uu____3463) when (not ((FStar_Ident.lid_equals lid1 FStar_Syntax_Const.effect_Lemma_lid))) -> begin
+(
+
+let uu____3466 = (
+
+let uu____3467 = (FStar_Syntax_Print.lid_to_string lid1)
+in (
+
+let uu____3468 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length univs1))
+in (FStar_Util.format2 "Unexpected effect abbreviation %s; polymorphic in %s universes" uu____3467 uu____3468)))
+in (failwith uu____3466))
+end
+| uu____3474 -> begin
+(
+
+let uu____3477 = (
+
+let uu____3480 = (
+
+let uu____3481 = (FStar_Syntax_Util.arrow binders c)
+in ((univs1), (uu____3481)))
+in (inst_tscheme_with uu____3480 insts))
+in (match (uu____3477) with
+| (uu____3489, t) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.set_use_range (FStar_Ident.range_of_lid lid1) t)
+in (
+
+let uu____3492 = (
+
+let uu____3493 = (FStar_Syntax_Subst.compress t1)
+in uu____3493.FStar_Syntax_Syntax.n)
+in (match (uu____3492) with
+| FStar_Syntax_Syntax.Tm_arrow (binders1, c1) -> begin
+Some (((binders1), (c1)))
+end
+| uu____3523 -> begin
+(failwith "Impossible")
+end)))
+end))
+end))
+end)))
+end
+| uu____3527 -> begin
+None
+end)))
+
+
+let norm_eff_name : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident = (
+
+let cache = (FStar_Util.smap_create (Prims.parse_int "20"))
+in (fun env l -> (
+
+let rec find1 = (fun l1 -> (
+
+let uu____3553 = (lookup_effect_abbrev env ((FStar_Syntax_Syntax.U_unknown)::[]) l1)
+in (match (uu____3553) with
+| None -> begin
+None
+end
+| Some (uu____3560, c) -> begin
+(
+
+let l2 = (FStar_Syntax_Util.comp_effect_name c)
+in (
+
+let uu____3565 = (find1 l2)
+in (match (uu____3565) with
+| None -> begin
+Some (l2)
+end
+| Some (l') -> begin
+Some (l')
+end)))
+end)))
+in (
+
+let res = (
+
+let uu____3570 = (FStar_Util.smap_try_find cache l.FStar_Ident.str)
+in (match (uu____3570) with
+| Some (l1) -> begin
+l1
+end
+| None -> begin
+(
+
+let uu____3573 = (find1 l)
+in (match (uu____3573) with
+| None -> begin
+l
+end
+| Some (m) -> begin
+((FStar_Util.smap_add cache l.FStar_Ident.str m);
+m;
+)
+end))
+end))
+in (FStar_Ident.set_lid_range res (FStar_Ident.range_of_lid l))))))
+
+
+let lookup_effect_quals : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.qualifier Prims.list = (fun env l -> (
+
+let l1 = (norm_eff_name env l)
+in (
+
+let uu____3585 = (lookup_qname env l1)
+in (match (uu____3585) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne); FStar_Syntax_Syntax.sigdoc = uu____3598; FStar_Syntax_Syntax.sigrng = uu____3599}, uu____3600), uu____3601) -> begin
+ne.FStar_Syntax_Syntax.qualifiers
+end
+| uu____3626 -> begin
+[]
+end))))
+
+
+let lookup_projector : env  ->  FStar_Ident.lident  ->  Prims.int  ->  FStar_Ident.lident = (fun env lid i -> (
+
+let fail = (fun uu____3649 -> (
+
+let uu____3650 = (
+
+let uu____3651 = (FStar_Util.string_of_int i)
+in (
+
+let uu____3652 = (FStar_Syntax_Print.lid_to_string lid)
+in (FStar_Util.format2 "Impossible: projecting field #%s from constructor %s is undefined" uu____3651 uu____3652)))
+in (failwith uu____3650)))
+in (
+
+let uu____3653 = (lookup_datacon env lid)
+in (match (uu____3653) with
+| (uu____3656, t) -> begin
+(
+
+let uu____3658 = (
+
+let uu____3659 = (FStar_Syntax_Subst.compress t)
+in uu____3659.FStar_Syntax_Syntax.n)
+in (match (uu____3658) with
+| FStar_Syntax_Syntax.Tm_arrow (binders, uu____3663) -> begin
+(match (((i < (Prims.parse_int "0")) || (i >= (FStar_List.length binders)))) with
+| true -> begin
+(fail ())
+end
+| uu____3678 -> begin
+(
+
+let b = (FStar_List.nth binders i)
+in (
+
+let uu____3684 = (FStar_Syntax_Util.mk_field_projector_name lid (Prims.fst b) i)
+in (FStar_All.pipe_right uu____3684 Prims.fst)))
+end)
+end
+| uu____3689 -> begin
+(fail ())
+end))
+end))))
+
+
+let is_projector : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env l -> (
+
+let uu____3696 = (lookup_qname env l)
+in (match (uu____3696) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (uu____3707, uu____3708, uu____3709, quals); FStar_Syntax_Syntax.sigdoc = uu____3711; FStar_Syntax_Syntax.sigrng = uu____3712}, uu____3713), uu____3714) -> begin
+(FStar_Util.for_some (fun uu___101_3741 -> (match (uu___101_3741) with
+| FStar_Syntax_Syntax.Projector (uu____3742) -> begin
+true
+end
+| uu____3745 -> begin
+false
+end)) quals)
+end
+| uu____3746 -> begin
+false
+end)))
+
+
+let is_datacon : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (
+
+let uu____3763 = (lookup_qname env lid)
+in (match (uu____3763) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____3774, uu____3775, uu____3776, uu____3777, uu____3778, uu____3779, uu____3780); FStar_Syntax_Syntax.sigdoc = uu____3781; FStar_Syntax_Syntax.sigrng = uu____3782}, uu____3783), uu____3784) -> begin
+true
+end
+| uu____3813 -> begin
+false
+end)))
+
+
+let is_record : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (
+
+let uu____3830 = (lookup_qname env lid)
+in (match (uu____3830) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (uu____3841, uu____3842, uu____3843, uu____3844, uu____3845, uu____3846, tags); FStar_Syntax_Syntax.sigdoc = uu____3848; FStar_Syntax_Syntax.sigrng = uu____3849}, uu____3850), uu____3851) -> begin
+(FStar_Util.for_some (fun uu___102_3882 -> (match (uu___102_3882) with
+| (FStar_Syntax_Syntax.RecordType (_)) | (FStar_Syntax_Syntax.RecordConstructor (_)) -> begin
+true
+end
+| uu____3885 -> begin
+false
+end)) tags)
+end
+| uu____3886 -> begin
+false
+end)))
+
+
+let is_action : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (
+
+let uu____3903 = (lookup_qname env lid)
+in (match (uu____3903) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let (uu____3914, uu____3915, tags, uu____3917); FStar_Syntax_Syntax.sigdoc = uu____3918; FStar_Syntax_Syntax.sigrng = uu____3919}, uu____3920), uu____3921) -> begin
+(FStar_Util.for_some (fun uu___103_3952 -> (match (uu___103_3952) with
+| FStar_Syntax_Syntax.Action (uu____3953) -> begin
+true
+end
+| uu____3954 -> begin
+false
+end)) tags)
+end
+| uu____3955 -> begin
+false
+end)))
+
+
+let is_interpreted : env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (
+
+let interpreted_symbols = (FStar_Syntax_Const.op_Eq)::(FStar_Syntax_Const.op_notEq)::(FStar_Syntax_Const.op_LT)::(FStar_Syntax_Const.op_LTE)::(FStar_Syntax_Const.op_GT)::(FStar_Syntax_Const.op_GTE)::(FStar_Syntax_Const.op_Subtraction)::(FStar_Syntax_Const.op_Minus)::(FStar_Syntax_Const.op_Addition)::(FStar_Syntax_Const.op_Multiply)::(FStar_Syntax_Const.op_Division)::(FStar_Syntax_Const.op_Modulus)::(FStar_Syntax_Const.op_And)::(FStar_Syntax_Const.op_Or)::(FStar_Syntax_Const.op_Negation)::[]
+in (fun env head1 -> (
+
+let uu____3974 = (
+
+let uu____3975 = (FStar_Syntax_Util.un_uinst head1)
+in uu____3975.FStar_Syntax_Syntax.n)
+in (match (uu____3974) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(fv.FStar_Syntax_Syntax.fv_delta = FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____3979 -> begin
+false
+end))))
+
+
+let is_type_constructor : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env lid -> (
+
+let mapper = (fun x -> (match ((Prims.fst x)) with
+| FStar_Util.Inl (uu____4017) -> begin
+Some (false)
+end
+| FStar_Util.Inr (se, uu____4026) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_declare_typ (uu____4035, uu____4036, uu____4037, qs) -> begin
+Some ((FStar_List.contains FStar_Syntax_Syntax.New qs))
+end
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____4041) -> begin
+Some (true)
+end
+| uu____4052 -> begin
+Some (false)
+end)
+end))
+in (
+
+let uu____4053 = (
+
+let uu____4055 = (lookup_qname env lid)
+in (FStar_Util.bind_opt uu____4055 mapper))
+in (match (uu____4053) with
+| Some (b) -> begin
+b
+end
+| None -> begin
+false
+end))))
+
+
+let num_inductive_ty_params : env  ->  FStar_Ident.lident  ->  Prims.int = (fun env lid -> (
+
+let uu____4082 = (lookup_qname env lid)
+in (match (uu____4082) with
+| Some (FStar_Util.Inr ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (uu____4093, uu____4094, tps, uu____4096, uu____4097, uu____4098, uu____4099); FStar_Syntax_Syntax.sigdoc = uu____4100; FStar_Syntax_Syntax.sigrng = uu____4101}, uu____4102), uu____4103) -> begin
+(FStar_List.length tps)
+end
+| uu____4137 -> begin
+(
+
+let uu____4148 = (
+
+let uu____4149 = (
+
+let uu____4152 = (name_not_found lid)
+in ((uu____4152), ((FStar_Ident.range_of_lid lid))))
+in FStar_Errors.Error (uu____4149))
+in (Prims.raise uu____4148))
+end)))
+
+
+let effect_decl_opt : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.eff_decl Prims.option = (fun env l -> (FStar_All.pipe_right env.effects.decls (FStar_Util.find_opt (fun d -> (FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l)))))
+
+
+let get_effect_decl : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.eff_decl = (fun env l -> (
+
+let uu____4169 = (effect_decl_opt env l)
+in (match (uu____4169) with
+| None -> begin
+(
+
+let uu____4171 = (
+
+let uu____4172 = (
+
+let uu____4175 = (name_not_found l)
+in ((uu____4175), ((FStar_Ident.range_of_lid l))))
+in FStar_Errors.Error (uu____4172))
+in (Prims.raise uu____4171))
+end
+| Some (md) -> begin
+md
+end)))
+
+
+let identity_mlift : mlift = {mlift_wp = (fun t wp -> wp); mlift_term = Some ((fun t wp e -> e))}
+
+
+let join : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  (FStar_Ident.lident * mlift * mlift) = (fun env l1 l2 -> (match ((FStar_Ident.lid_equals l1 l2)) with
+| true -> begin
+((l1), (identity_mlift), (identity_mlift))
+end
+| uu____4206 -> begin
+(match ((((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GTot_lid) && (FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_Tot_lid)) || ((FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_GTot_lid) && (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_Tot_lid)))) with
+| true -> begin
+((FStar_Syntax_Const.effect_GTot_lid), (identity_mlift), (identity_mlift))
+end
+| uu____4210 -> begin
+(
+
+let uu____4211 = (FStar_All.pipe_right env.effects.joins (FStar_Util.find_opt (fun uu____4235 -> (match (uu____4235) with
+| (m1, m2, uu____4243, uu____4244, uu____4245) -> begin
+((FStar_Ident.lid_equals l1 m1) && (FStar_Ident.lid_equals l2 m2))
+end))))
+in (match (uu____4211) with
+| None -> begin
+(
+
+let uu____4254 = (
+
+let uu____4255 = (
+
+let uu____4258 = (
+
+let uu____4259 = (FStar_Syntax_Print.lid_to_string l1)
+in (
+
+let uu____4260 = (FStar_Syntax_Print.lid_to_string l2)
+in (FStar_Util.format2 "Effects %s and %s cannot be composed" uu____4259 uu____4260)))
+in ((uu____4258), (env.range)))
+in FStar_Errors.Error (uu____4255))
+in (Prims.raise uu____4254))
+end
+| Some (uu____4264, uu____4265, m3, j1, j2) -> begin
+((m3), (j1), (j2))
+end))
+end)
+end))
+
+
+let monad_leq : env  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  edge Prims.option = (fun env l1 l2 -> (match (((FStar_Ident.lid_equals l1 l2) || ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_Tot_lid) && (FStar_Ident.lid_equals l2 FStar_Syntax_Const.effect_GTot_lid)))) with
+| true -> begin
+Some ({msource = l1; mtarget = l2; mlift = identity_mlift})
+end
+| uu____4286 -> begin
+(FStar_All.pipe_right env.effects.order (FStar_Util.find_opt (fun e -> ((FStar_Ident.lid_equals l1 e.msource) && (FStar_Ident.lid_equals l2 e.mtarget)))))
+end))
+
+
+let wp_sig_aux : FStar_Syntax_Syntax.eff_decl Prims.list  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.bv * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) = (fun decls m -> (
+
+let uu____4302 = (FStar_All.pipe_right decls (FStar_Util.find_opt (fun d -> (FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))))
+in (match (uu____4302) with
+| None -> begin
+(
+
+let uu____4311 = (FStar_Util.format1 "Impossible: declaration for monad %s not found" m.FStar_Ident.str)
+in (failwith uu____4311))
+end
+| Some (md) -> begin
+(
+
+let uu____4317 = (inst_tscheme ((md.FStar_Syntax_Syntax.univs), (md.FStar_Syntax_Syntax.signature)))
+in (match (uu____4317) with
+| (uu____4324, s) -> begin
+(
+
+let s1 = (FStar_Syntax_Subst.compress s)
+in (match (((md.FStar_Syntax_Syntax.binders), (s1.FStar_Syntax_Syntax.n))) with
+| ([], FStar_Syntax_Syntax.Tm_arrow (((a, uu____4332))::((wp, uu____4334))::[], c)) when (FStar_Syntax_Syntax.is_teff (FStar_Syntax_Util.comp_result c)) -> begin
+((a), (wp.FStar_Syntax_Syntax.sort))
+end
+| uu____4356 -> begin
+(failwith "Impossible")
+end))
+end))
+end)))
+
+
+let wp_signature : env  ->  FStar_Ident.lident  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) = (fun env m -> (wp_sig_aux env.effects.decls m))
+
+
+let null_wp_for_eff : env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.comp = (fun env eff_name res_u res_t -> (match ((FStar_Ident.lid_equals eff_name FStar_Syntax_Const.effect_Tot_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total' res_t (Some (res_u)))
+end
+| uu____4383 -> begin
+(match ((FStar_Ident.lid_equals eff_name FStar_Syntax_Const.effect_GTot_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_GTotal' res_t (Some (res_u)))
+end
+| uu____4384 -> begin
+(
+
+let eff_name1 = (norm_eff_name env eff_name)
+in (
+
+let ed = (get_effect_decl env eff_name1)
+in (
+
+let null_wp = (inst_effect_fun_with ((res_u)::[]) env ed ed.FStar_Syntax_Syntax.null_wp)
+in (
+
+let null_wp_res = (
+
+let uu____4391 = (get_range env)
+in (
+
+let uu____4392 = (
+
+let uu____4395 = (
+
+let uu____4396 = (
+
+let uu____4406 = (
+
+let uu____4408 = (FStar_Syntax_Syntax.as_arg res_t)
+in (uu____4408)::[])
+in ((null_wp), (uu____4406)))
+in FStar_Syntax_Syntax.Tm_app (uu____4396))
+in (FStar_Syntax_Syntax.mk uu____4395))
+in (uu____4392 None uu____4391)))
+in (
+
+let uu____4418 = (
+
+let uu____4419 = (
+
+let uu____4425 = (FStar_Syntax_Syntax.as_arg null_wp_res)
+in (uu____4425)::[])
+in {FStar_Syntax_Syntax.comp_univs = (res_u)::[]; FStar_Syntax_Syntax.effect_name = eff_name1; FStar_Syntax_Syntax.result_typ = res_t; FStar_Syntax_Syntax.effect_args = uu____4419; FStar_Syntax_Syntax.flags = []})
+in (FStar_Syntax_Syntax.mk_Comp uu____4418))))))
+end)
+end))
+
+
+let build_lattice : env  ->  FStar_Syntax_Syntax.sigelt  ->  env = (fun env se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_new_effect (ne) -> begin
+(
+
+let effects = (
+
+let uu___114_4434 = env.effects
+in {decls = (ne)::env.effects.decls; order = uu___114_4434.order; joins = uu___114_4434.joins})
+in (
+
+let uu___115_4435 = env
+in {solver = uu___115_4435.solver; range = uu___115_4435.range; curmodule = uu___115_4435.curmodule; gamma = uu___115_4435.gamma; gamma_cache = uu___115_4435.gamma_cache; modules = uu___115_4435.modules; expected_typ = uu___115_4435.expected_typ; sigtab = uu___115_4435.sigtab; is_pattern = uu___115_4435.is_pattern; instantiate_imp = uu___115_4435.instantiate_imp; effects = effects; generalize = uu___115_4435.generalize; letrecs = uu___115_4435.letrecs; top_level = uu___115_4435.top_level; check_uvars = uu___115_4435.check_uvars; use_eq = uu___115_4435.use_eq; is_iface = uu___115_4435.is_iface; admit = uu___115_4435.admit; lax = uu___115_4435.lax; lax_universes = uu___115_4435.lax_universes; type_of = uu___115_4435.type_of; universe_of = uu___115_4435.universe_of; use_bv_sorts = uu___115_4435.use_bv_sorts; qname_and_index = uu___115_4435.qname_and_index}))
+end
+| FStar_Syntax_Syntax.Sig_sub_effect (sub1) -> begin
+(
+
+let compose_edges = (fun e1 e2 -> (
+
+let composed_lift = (
+
+let mlift_wp = (fun r wp1 -> (
+
+let uu____4452 = (e1.mlift.mlift_wp r wp1)
+in (e2.mlift.mlift_wp r uu____4452)))
+in (
+
+let mlift_term = (match (((e1.mlift.mlift_term), (e2.mlift.mlift_term))) with
+| (Some (l1), Some (l2)) -> begin
+Some ((fun t wp e -> (
+
+let uu____4531 = (e1.mlift.mlift_wp t wp)
+in (
+
+let uu____4532 = (l1 t wp e)
+in (l2 t uu____4531 uu____4532)))))
+end
+| uu____4533 -> begin
+None
+end)
+in {mlift_wp = mlift_wp; mlift_term = mlift_term}))
+in {msource = e1.msource; mtarget = e2.mtarget; mlift = composed_lift}))
+in (
+
+let mk_mlift_wp = (fun lift_t r wp1 -> (
+
+let uu____4568 = (inst_tscheme lift_t)
+in (match (uu____4568) with
+| (uu____4573, lift_t1) -> begin
+(
+
+let uu____4575 = (
+
+let uu____4578 = (
+
+let uu____4579 = (
+
+let uu____4589 = (
+
+let uu____4591 = (FStar_Syntax_Syntax.as_arg r)
+in (
+
+let uu____4592 = (
+
+let uu____4594 = (FStar_Syntax_Syntax.as_arg wp1)
+in (uu____4594)::[])
+in (uu____4591)::uu____4592))
+in ((lift_t1), (uu____4589)))
+in FStar_Syntax_Syntax.Tm_app (uu____4579))
+in (FStar_Syntax_Syntax.mk uu____4578))
+in (uu____4575 None wp1.FStar_Syntax_Syntax.pos))
+end)))
+in (
+
+let sub_mlift_wp = (match (sub1.FStar_Syntax_Syntax.lift_wp) with
+| Some (sub_lift_wp) -> begin
+(mk_mlift_wp sub_lift_wp)
+end
+| None -> begin
+(failwith "sub effect should\'ve been elaborated at this stage")
+end)
+in (
+
+let mk_mlift_term = (fun lift_t r wp1 e -> (
+
+let uu____4639 = (inst_tscheme lift_t)
+in (match (uu____4639) with
+| (uu____4644, lift_t1) -> begin
+(
+
+let uu____4646 = (
+
+let uu____4649 = (
+
+let uu____4650 = (
+
+let uu____4660 = (
+
+let uu____4662 = (FStar_Syntax_Syntax.as_arg r)
+in (
+
+let uu____4663 = (
+
+let uu____4665 = (FStar_Syntax_Syntax.as_arg wp1)
+in (
+
+let uu____4666 = (
+
+let uu____4668 = (FStar_Syntax_Syntax.as_arg e)
+in (uu____4668)::[])
+in (uu____4665)::uu____4666))
+in (uu____4662)::uu____4663))
+in ((lift_t1), (uu____4660)))
+in FStar_Syntax_Syntax.Tm_app (uu____4650))
+in (FStar_Syntax_Syntax.mk uu____4649))
+in (uu____4646 None e.FStar_Syntax_Syntax.pos))
+end)))
+in (
+
+let sub_mlift_term = (FStar_Util.map_opt sub1.FStar_Syntax_Syntax.lift mk_mlift_term)
+in (
+
+let edge = {msource = sub1.FStar_Syntax_Syntax.source; mtarget = sub1.FStar_Syntax_Syntax.target; mlift = {mlift_wp = sub_mlift_wp; mlift_term = sub_mlift_term}}
+in (
+
+let id_edge = (fun l -> {msource = sub1.FStar_Syntax_Syntax.source; mtarget = sub1.FStar_Syntax_Syntax.target; mlift = identity_mlift})
+in (
+
+let print_mlift = (fun l -> (
+
+let bogus_term = (fun s -> (
+
+let uu____4709 = (
+
+let uu____4710 = (FStar_Ident.lid_of_path ((s)::[]) FStar_Range.dummyRange)
+in (FStar_Syntax_Syntax.lid_as_fv uu____4710 FStar_Syntax_Syntax.Delta_constant None))
+in (FStar_Syntax_Syntax.fv_to_tm uu____4709)))
+in (
+
+let arg = (bogus_term "ARG")
+in (
+
+let wp = (bogus_term "WP")
+in (
+
+let e = (bogus_term "COMP")
+in (
+
+let uu____4714 = (
+
+let uu____4715 = (l.mlift_wp arg wp)
+in (FStar_Syntax_Print.term_to_string uu____4715))
+in (
+
+let uu____4716 = (
+
+let uu____4717 = (FStar_Util.map_opt l.mlift_term (fun l1 -> (
+
+let uu____4732 = (l1 arg wp e)
+in (FStar_Syntax_Print.term_to_string uu____4732))))
+in (FStar_Util.dflt "none" uu____4717))
+in (FStar_Util.format2 "{ wp : %s ; term : %s }" uu____4714 uu____4716))))))))
+in (
+
+let order = (edge)::env.effects.order
+in (
+
+let ms = (FStar_All.pipe_right env.effects.decls (FStar_List.map (fun e -> e.FStar_Syntax_Syntax.mname)))
+in (
+
+let find_edge = (fun order1 uu____4750 -> (match (uu____4750) with
+| (i, j) -> begin
+(match ((FStar_Ident.lid_equals i j)) with
+| true -> begin
+(FStar_All.pipe_right (id_edge i) (fun _0_28 -> Some (_0_28)))
+end
+| uu____4759 -> begin
+(FStar_All.pipe_right order1 (FStar_Util.find_opt (fun e -> ((FStar_Ident.lid_equals e.msource i) && (FStar_Ident.lid_equals e.mtarget j)))))
+end)
+end))
+in (
+
+let order1 = (
+
+let fold_fun = (fun order1 k -> (
+
+let uu____4775 = (FStar_All.pipe_right ms (FStar_List.collect (fun i -> (match ((FStar_Ident.lid_equals i k)) with
+| true -> begin
+[]
+end
+| uu____4781 -> begin
+(FStar_All.pipe_right ms (FStar_List.collect (fun j -> (match ((FStar_Ident.lid_equals j k)) with
+| true -> begin
+[]
+end
+| uu____4786 -> begin
+(
+
+let uu____4787 = (
+
+let uu____4792 = (find_edge order1 ((i), (k)))
+in (
+
+let uu____4794 = (find_edge order1 ((k), (j)))
+in ((uu____4792), (uu____4794))))
+in (match (uu____4787) with
+| (Some (e1), Some (e2)) -> begin
+(
+
+let uu____4803 = (compose_edges e1 e2)
+in (uu____4803)::[])
+end
+| uu____4804 -> begin
+[]
+end))
+end))))
+end))))
+in (FStar_List.append order1 uu____4775)))
+in (FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)))
+in (
+
+let order2 = (FStar_Util.remove_dups (fun e1 e2 -> ((FStar_Ident.lid_equals e1.msource e2.msource) && (FStar_Ident.lid_equals e1.mtarget e2.mtarget))) order1)
+in ((FStar_All.pipe_right order2 (FStar_List.iter (fun edge1 -> (
+
+let uu____4819 = ((FStar_Ident.lid_equals edge1.msource FStar_Syntax_Const.effect_DIV_lid) && (
+
+let uu____4820 = (lookup_effect_quals env edge1.mtarget)
+in (FStar_All.pipe_right uu____4820 (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))))
+in (match (uu____4819) with
+| true -> begin
+(
+
+let uu____4823 = (
+
+let uu____4824 = (
+
+let uu____4827 = (FStar_Util.format1 "Divergent computations cannot be included in an effect %s marked \'total\'" edge1.mtarget.FStar_Ident.str)
+in (
+
+let uu____4828 = (get_range env)
+in ((uu____4827), (uu____4828))))
+in FStar_Errors.Error (uu____4824))
+in (Prims.raise uu____4823))
+end
+| uu____4829 -> begin
+()
+end)))));
+(
+
+let joins = (FStar_All.pipe_right ms (FStar_List.collect (fun i -> (FStar_All.pipe_right ms (FStar_List.collect (fun j -> (
+
+let join_opt = (match ((FStar_Ident.lid_equals i j)) with
+| true -> begin
+Some (((i), ((id_edge i)), ((id_edge i))))
+end
+| uu____4875 -> begin
+(FStar_All.pipe_right ms (FStar_List.fold_left (fun bopt k -> (
+
+let uu____4891 = (
+
+let uu____4896 = (find_edge order2 ((i), (k)))
+in (
+
+let uu____4898 = (find_edge order2 ((j), (k)))
+in ((uu____4896), (uu____4898))))
+in (match (uu____4891) with
+| (Some (ik), Some (jk)) -> begin
+(match (bopt) with
+| None -> begin
+Some (((k), (ik), (jk)))
+end
+| Some (ub, uu____4921, uu____4922) -> begin
+(
+
+let uu____4926 = (
+
+let uu____4929 = (
+
+let uu____4930 = (find_edge order2 ((k), (ub)))
+in (FStar_Util.is_some uu____4930))
+in (
+
+let uu____4932 = (
+
+let uu____4933 = (find_edge order2 ((ub), (k)))
+in (FStar_Util.is_some uu____4933))
+in ((uu____4929), (uu____4932))))
+in (match (uu____4926) with
+| (true, true) -> begin
+(match ((FStar_Ident.lid_equals k ub)) with
+| true -> begin
+((FStar_Util.print_warning "Looking multiple times at the same upper bound candidate");
+bopt;
+)
+end
+| uu____4944 -> begin
+(failwith "Found a cycle in the lattice")
+end)
+end
+| (false, false) -> begin
+bopt
+end
+| (true, false) -> begin
+Some (((k), (ik), (jk)))
+end
+| (false, true) -> begin
+bopt
+end))
+end)
+end
+| uu____4952 -> begin
+bopt
+end))) None))
+end)
+in (match (join_opt) with
+| None -> begin
+[]
+end
+| Some (k, e1, e2) -> begin
+(((i), (j), (k), (e1.mlift), (e2.mlift)))::[]
+end))))))))
+in (
+
+let effects = (
+
+let uu___116_4991 = env.effects
+in {decls = uu___116_4991.decls; order = order2; joins = joins})
+in (
+
+let uu___117_4992 = env
+in {solver = uu___117_4992.solver; range = uu___117_4992.range; curmodule = uu___117_4992.curmodule; gamma = uu___117_4992.gamma; gamma_cache = uu___117_4992.gamma_cache; modules = uu___117_4992.modules; expected_typ = uu___117_4992.expected_typ; sigtab = uu___117_4992.sigtab; is_pattern = uu___117_4992.is_pattern; instantiate_imp = uu___117_4992.instantiate_imp; effects = effects; generalize = uu___117_4992.generalize; letrecs = uu___117_4992.letrecs; top_level = uu___117_4992.top_level; check_uvars = uu___117_4992.check_uvars; use_eq = uu___117_4992.use_eq; is_iface = uu___117_4992.is_iface; admit = uu___117_4992.admit; lax = uu___117_4992.lax; lax_universes = uu___117_4992.lax_universes; type_of = uu___117_4992.type_of; universe_of = uu___117_4992.universe_of; use_bv_sorts = uu___117_4992.use_bv_sorts; qname_and_index = uu___117_4992.qname_and_index})));
+))))))))))))))
+end
+| uu____4993 -> begin
+env
+end))
+
+
+let comp_to_comp_typ : env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp_typ = (fun env c -> (
+
+let c1 = (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, None) -> begin
+(
+
+let u = (env.universe_of env t)
+in (FStar_Syntax_Syntax.mk_Total' t (Some (u))))
+end
+| FStar_Syntax_Syntax.GTotal (t, None) -> begin
+(
+
+let u = (env.universe_of env t)
+in (FStar_Syntax_Syntax.mk_GTotal' t (Some (u))))
+end
+| uu____5015 -> begin
+c
+end)
+in (FStar_Syntax_Util.comp_to_comp_typ c1)))
+
+
+let rec unfold_effect_abbrev : env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp_typ = (fun env comp -> (
+
+let c = (comp_to_comp_typ env comp)
+in (
+
+let uu____5023 = (lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs c.FStar_Syntax_Syntax.effect_name)
+in (match (uu____5023) with
+| None -> begin
+c
+end
+| Some (binders, cdef) -> begin
+(
+
+let uu____5033 = (FStar_Syntax_Subst.open_comp binders cdef)
+in (match (uu____5033) with
+| (binders1, cdef1) -> begin
+((match (((FStar_List.length binders1) <> ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) + (Prims.parse_int "1")))) with
+| true -> begin
+(
+
+let uu____5050 = (
+
+let uu____5051 = (
+
+let uu____5054 = (
+
+let uu____5055 = (FStar_Util.string_of_int (FStar_List.length binders1))
+in (
+
+let uu____5061 = (FStar_Util.string_of_int ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) + (Prims.parse_int "1")))
+in (
+
+let uu____5069 = (
+
+let uu____5070 = (FStar_Syntax_Syntax.mk_Comp c)
+in (FStar_Syntax_Print.comp_to_string uu____5070))
+in (FStar_Util.format3 "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s" uu____5055 uu____5061 uu____5069))))
+in ((uu____5054), (comp.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____5051))
+in (Prims.raise uu____5050))
+end
+| uu____5071 -> begin
+()
+end);
+(
+
+let inst1 = (
+
+let uu____5074 = (
+
+let uu____5080 = (FStar_Syntax_Syntax.as_arg c.FStar_Syntax_Syntax.result_typ)
+in (uu____5080)::c.FStar_Syntax_Syntax.effect_args)
+in (FStar_List.map2 (fun uu____5087 uu____5088 -> (match (((uu____5087), (uu____5088))) with
+| ((x, uu____5102), (t, uu____5104)) -> begin
+FStar_Syntax_Syntax.NT (((x), (t)))
+end)) binders1 uu____5074))
+in (
+
+let c1 = (FStar_Syntax_Subst.subst_comp inst1 cdef1)
+in (
+
+let c2 = (
+
+let uu____5119 = (
+
+let uu___118_5120 = (comp_to_comp_typ env c1)
+in {FStar_Syntax_Syntax.comp_univs = uu___118_5120.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = uu___118_5120.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = uu___118_5120.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu___118_5120.FStar_Syntax_Syntax.effect_args; FStar_Syntax_Syntax.flags = c.FStar_Syntax_Syntax.flags})
+in (FStar_All.pipe_right uu____5119 FStar_Syntax_Syntax.mk_Comp))
+in (unfold_effect_abbrev env c2))));
+)
+end))
+end))))
+
+
+let effect_repr_aux = (fun only_reifiable env c u_c -> (
+
+let uu____5150 = (
+
+let uu____5152 = (norm_eff_name env (FStar_Syntax_Util.comp_effect_name c))
+in (effect_decl_opt env uu____5152))
+in (match (uu____5150) with
+| None -> begin
+None
+end
+| Some (ed) -> begin
+(
+
+let uu____5159 = (only_reifiable && (
+
+let uu____5160 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (not (uu____5160))))
+in (match (uu____5159) with
+| true -> begin
+None
+end
+| uu____5167 -> begin
+(match (ed.FStar_Syntax_Syntax.repr.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+None
+end
+| uu____5173 -> begin
+(
+
+let c1 = (unfold_effect_abbrev env c)
+in (
+
+let uu____5175 = (
+
+let uu____5184 = (FStar_List.hd c1.FStar_Syntax_Syntax.effect_args)
+in ((c1.FStar_Syntax_Syntax.result_typ), (uu____5184)))
+in (match (uu____5175) with
+| (res_typ, wp) -> begin
+(
+
+let repr = (inst_effect_fun_with ((u_c)::[]) env ed (([]), (ed.FStar_Syntax_Syntax.repr)))
+in (
+
+let uu____5218 = (
+
+let uu____5221 = (get_range env)
+in (
+
+let uu____5222 = (
+
+let uu____5225 = (
+
+let uu____5226 = (
+
+let uu____5236 = (
+
+let uu____5238 = (FStar_Syntax_Syntax.as_arg res_typ)
+in (uu____5238)::(wp)::[])
+in ((repr), (uu____5236)))
+in FStar_Syntax_Syntax.Tm_app (uu____5226))
+in (FStar_Syntax_Syntax.mk uu____5225))
+in (uu____5222 None uu____5221)))
+in Some (uu____5218)))
+end)))
+end)
+end))
+end)))
+
+
+let effect_repr : env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.term Prims.option = (fun env c u_c -> (effect_repr_aux false env c u_c))
+
+
+let reify_comp : env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.term = (fun env c u_c -> (
+
+let no_reify = (fun l -> (
+
+let uu____5282 = (
+
+let uu____5283 = (
+
+let uu____5286 = (
+
+let uu____5287 = (FStar_Ident.string_of_lid l)
+in (FStar_Util.format1 "Effect %s cannot be reified" uu____5287))
+in (
+
+let uu____5288 = (get_range env)
+in ((uu____5286), (uu____5288))))
+in FStar_Errors.Error (uu____5283))
+in (Prims.raise uu____5282)))
+in (
+
+let uu____5289 = (effect_repr_aux true env c u_c)
+in (match (uu____5289) with
+| None -> begin
+(no_reify (FStar_Syntax_Util.comp_effect_name c))
+end
+| Some (tm) -> begin
+tm
+end))))
+
+
+let is_reifiable_effect : env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env effect_lid -> (
+
+let quals = (lookup_effect_quals env effect_lid)
+in (FStar_List.contains FStar_Syntax_Syntax.Reifiable quals)))
+
+
+let is_reifiable : env  ->  (FStar_Syntax_Syntax.lcomp, FStar_Syntax_Syntax.residual_comp) FStar_Util.either  ->  Prims.bool = (fun env c -> (
+
+let effect_lid = (match (c) with
+| FStar_Util.Inl (lc) -> begin
+lc.FStar_Syntax_Syntax.eff_name
+end
+| FStar_Util.Inr (eff_name, uu____5321) -> begin
+eff_name
+end)
+in (is_reifiable_effect env effect_lid)))
+
+
+let is_reifiable_comp : env  ->  FStar_Syntax_Syntax.comp  ->  Prims.bool = (fun env c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name)
+end
+| uu____5334 -> begin
+false
+end))
+
+
+let is_reifiable_function : env  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun env t -> (
+
+let uu____5341 = (
+
+let uu____5342 = (FStar_Syntax_Subst.compress t)
+in uu____5342.FStar_Syntax_Syntax.n)
+in (match (uu____5341) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____5345, c) -> begin
+(is_reifiable_comp env c)
+end
+| uu____5357 -> begin
+false
+end)))
+
+
+let push_in_gamma : env  ->  binding  ->  env = (fun env s -> (
+
+let rec push1 = (fun x rest -> (match (rest) with
+| ((Binding_sig (_))::_) | ((Binding_sig_inst (_))::_) -> begin
+(x)::rest
+end
+| [] -> begin
+(x)::[]
+end
+| (local)::rest1 -> begin
+(
+
+let uu____5382 = (push1 x rest1)
+in (local)::uu____5382)
+end))
+in (
+
+let uu___119_5384 = env
+in (
+
+let uu____5385 = (push1 s env.gamma)
+in {solver = uu___119_5384.solver; range = uu___119_5384.range; curmodule = uu___119_5384.curmodule; gamma = uu____5385; gamma_cache = uu___119_5384.gamma_cache; modules = uu___119_5384.modules; expected_typ = uu___119_5384.expected_typ; sigtab = uu___119_5384.sigtab; is_pattern = uu___119_5384.is_pattern; instantiate_imp = uu___119_5384.instantiate_imp; effects = uu___119_5384.effects; generalize = uu___119_5384.generalize; letrecs = uu___119_5384.letrecs; top_level = uu___119_5384.top_level; check_uvars = uu___119_5384.check_uvars; use_eq = uu___119_5384.use_eq; is_iface = uu___119_5384.is_iface; admit = uu___119_5384.admit; lax = uu___119_5384.lax; lax_universes = uu___119_5384.lax_universes; type_of = uu___119_5384.type_of; universe_of = uu___119_5384.universe_of; use_bv_sorts = uu___119_5384.use_bv_sorts; qname_and_index = uu___119_5384.qname_and_index}))))
+
+
+let push_sigelt : env  ->  FStar_Syntax_Syntax.sigelt  ->  env = (fun env s -> (
+
+let env1 = (push_in_gamma env (Binding_sig ((((FStar_Syntax_Util.lids_of_sigelt s)), (s)))))
+in (build_lattice env1 s)))
+
+
+let push_sigelt_inst : env  ->  FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.universes  ->  env = (fun env s us -> (
+
+let env1 = (push_in_gamma env (Binding_sig_inst ((((FStar_Syntax_Util.lids_of_sigelt s)), (s), (us)))))
+in (build_lattice env1 s)))
+
+
+let push_local_binding : env  ->  binding  ->  env = (fun env b -> (
+
+let uu___120_5412 = env
+in {solver = uu___120_5412.solver; range = uu___120_5412.range; curmodule = uu___120_5412.curmodule; gamma = (b)::env.gamma; gamma_cache = uu___120_5412.gamma_cache; modules = uu___120_5412.modules; expected_typ = uu___120_5412.expected_typ; sigtab = uu___120_5412.sigtab; is_pattern = uu___120_5412.is_pattern; instantiate_imp = uu___120_5412.instantiate_imp; effects = uu___120_5412.effects; generalize = uu___120_5412.generalize; letrecs = uu___120_5412.letrecs; top_level = uu___120_5412.top_level; check_uvars = uu___120_5412.check_uvars; use_eq = uu___120_5412.use_eq; is_iface = uu___120_5412.is_iface; admit = uu___120_5412.admit; lax = uu___120_5412.lax; lax_universes = uu___120_5412.lax_universes; type_of = uu___120_5412.type_of; universe_of = uu___120_5412.universe_of; use_bv_sorts = uu___120_5412.use_bv_sorts; qname_and_index = uu___120_5412.qname_and_index}))
+
+
+let push_bv : env  ->  FStar_Syntax_Syntax.bv  ->  env = (fun env x -> (push_local_binding env (Binding_var (x))))
+
+
+let pop_bv : env  ->  (FStar_Syntax_Syntax.bv * env) Prims.option = (fun env -> (match (env.gamma) with
+| (Binding_var (x))::rest -> begin
+Some (((x), ((
+
+let uu___121_5433 = env
+in {solver = uu___121_5433.solver; range = uu___121_5433.range; curmodule = uu___121_5433.curmodule; gamma = rest; gamma_cache = uu___121_5433.gamma_cache; modules = uu___121_5433.modules; expected_typ = uu___121_5433.expected_typ; sigtab = uu___121_5433.sigtab; is_pattern = uu___121_5433.is_pattern; instantiate_imp = uu___121_5433.instantiate_imp; effects = uu___121_5433.effects; generalize = uu___121_5433.generalize; letrecs = uu___121_5433.letrecs; top_level = uu___121_5433.top_level; check_uvars = uu___121_5433.check_uvars; use_eq = uu___121_5433.use_eq; is_iface = uu___121_5433.is_iface; admit = uu___121_5433.admit; lax = uu___121_5433.lax; lax_universes = uu___121_5433.lax_universes; type_of = uu___121_5433.type_of; universe_of = uu___121_5433.universe_of; use_bv_sorts = uu___121_5433.use_bv_sorts; qname_and_index = uu___121_5433.qname_and_index}))))
+end
+| uu____5434 -> begin
+None
+end))
+
+
+let push_binders : env  ->  FStar_Syntax_Syntax.binders  ->  env = (fun env bs -> (FStar_List.fold_left (fun env1 uu____5447 -> (match (uu____5447) with
+| (x, uu____5451) -> begin
+(push_bv env1 x)
+end)) env bs))
+
+
+let binding_of_lb : FStar_Syntax_Syntax.lbname  ->  (FStar_Syntax_Syntax.univ_name Prims.list * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  binding = (fun x t -> (match (x) with
+| FStar_Util.Inl (x1) -> begin
+(
+
+let x2 = (
+
+let uu___122_5471 = x1
+in {FStar_Syntax_Syntax.ppname = uu___122_5471.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___122_5471.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = (Prims.snd t)})
+in Binding_var (x2))
+end
+| FStar_Util.Inr (fv) -> begin
+Binding_lid (((fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v), (t)))
+end))
+
+
+let push_let_binding : env  ->  FStar_Syntax_Syntax.lbname  ->  FStar_Syntax_Syntax.tscheme  ->  env = (fun env lb ts -> (push_local_binding env (binding_of_lb lb ts)))
+
+
+let push_module : env  ->  FStar_Syntax_Syntax.modul  ->  env = (fun env m -> ((add_sigelts env m.FStar_Syntax_Syntax.exports);
+(
+
+let uu___123_5501 = env
+in {solver = uu___123_5501.solver; range = uu___123_5501.range; curmodule = uu___123_5501.curmodule; gamma = []; gamma_cache = uu___123_5501.gamma_cache; modules = (m)::env.modules; expected_typ = None; sigtab = uu___123_5501.sigtab; is_pattern = uu___123_5501.is_pattern; instantiate_imp = uu___123_5501.instantiate_imp; effects = uu___123_5501.effects; generalize = uu___123_5501.generalize; letrecs = uu___123_5501.letrecs; top_level = uu___123_5501.top_level; check_uvars = uu___123_5501.check_uvars; use_eq = uu___123_5501.use_eq; is_iface = uu___123_5501.is_iface; admit = uu___123_5501.admit; lax = uu___123_5501.lax; lax_universes = uu___123_5501.lax_universes; type_of = uu___123_5501.type_of; universe_of = uu___123_5501.universe_of; use_bv_sorts = uu___123_5501.use_bv_sorts; qname_and_index = uu___123_5501.qname_and_index});
+))
+
+
+let push_univ_vars : env  ->  FStar_Syntax_Syntax.univ_names  ->  env = (fun env xs -> (FStar_List.fold_left (fun env1 x -> (push_local_binding env1 (Binding_univ (x)))) env xs))
+
+
+let set_expected_typ : env  ->  FStar_Syntax_Syntax.typ  ->  env = (fun env t -> (
+
+let uu___124_5516 = env
+in {solver = uu___124_5516.solver; range = uu___124_5516.range; curmodule = uu___124_5516.curmodule; gamma = uu___124_5516.gamma; gamma_cache = uu___124_5516.gamma_cache; modules = uu___124_5516.modules; expected_typ = Some (t); sigtab = uu___124_5516.sigtab; is_pattern = uu___124_5516.is_pattern; instantiate_imp = uu___124_5516.instantiate_imp; effects = uu___124_5516.effects; generalize = uu___124_5516.generalize; letrecs = uu___124_5516.letrecs; top_level = uu___124_5516.top_level; check_uvars = uu___124_5516.check_uvars; use_eq = false; is_iface = uu___124_5516.is_iface; admit = uu___124_5516.admit; lax = uu___124_5516.lax; lax_universes = uu___124_5516.lax_universes; type_of = uu___124_5516.type_of; universe_of = uu___124_5516.universe_of; use_bv_sorts = uu___124_5516.use_bv_sorts; qname_and_index = uu___124_5516.qname_and_index}))
+
+
+let expected_typ : env  ->  FStar_Syntax_Syntax.typ Prims.option = (fun env -> (match (env.expected_typ) with
+| None -> begin
+None
+end
+| Some (t) -> begin
+Some (t)
+end))
+
+
+let clear_expected_typ : env  ->  (env * FStar_Syntax_Syntax.typ Prims.option) = (fun env_ -> (
+
+let uu____5532 = (expected_typ env_)
+in (((
+
+let uu___125_5535 = env_
+in {solver = uu___125_5535.solver; range = uu___125_5535.range; curmodule = uu___125_5535.curmodule; gamma = uu___125_5535.gamma; gamma_cache = uu___125_5535.gamma_cache; modules = uu___125_5535.modules; expected_typ = None; sigtab = uu___125_5535.sigtab; is_pattern = uu___125_5535.is_pattern; instantiate_imp = uu___125_5535.instantiate_imp; effects = uu___125_5535.effects; generalize = uu___125_5535.generalize; letrecs = uu___125_5535.letrecs; top_level = uu___125_5535.top_level; check_uvars = uu___125_5535.check_uvars; use_eq = false; is_iface = uu___125_5535.is_iface; admit = uu___125_5535.admit; lax = uu___125_5535.lax; lax_universes = uu___125_5535.lax_universes; type_of = uu___125_5535.type_of; universe_of = uu___125_5535.universe_of; use_bv_sorts = uu___125_5535.use_bv_sorts; qname_and_index = uu___125_5535.qname_and_index})), (uu____5532))))
+
+
+let finish_module : env  ->  FStar_Syntax_Syntax.modul  ->  env = (
+
+let empty_lid = (FStar_Ident.lid_of_ids (((FStar_Ident.id_of_text ""))::[]))
+in (fun env m -> (
+
+let sigs = (match ((FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name FStar_Syntax_Const.prims_lid)) with
+| true -> begin
+(
+
+let uu____5546 = (FStar_All.pipe_right env.gamma (FStar_List.collect (fun uu___104_5550 -> (match (uu___104_5550) with
+| Binding_sig (uu____5552, se) -> begin
+(se)::[]
+end
+| uu____5556 -> begin
+[]
+end))))
+in (FStar_All.pipe_right uu____5546 FStar_List.rev))
+end
+| uu____5559 -> begin
+m.FStar_Syntax_Syntax.exports
+end)
+in ((add_sigelts env sigs);
+(
+
+let uu___126_5561 = env
+in {solver = uu___126_5561.solver; range = uu___126_5561.range; curmodule = empty_lid; gamma = []; gamma_cache = uu___126_5561.gamma_cache; modules = (m)::env.modules; expected_typ = uu___126_5561.expected_typ; sigtab = uu___126_5561.sigtab; is_pattern = uu___126_5561.is_pattern; instantiate_imp = uu___126_5561.instantiate_imp; effects = uu___126_5561.effects; generalize = uu___126_5561.generalize; letrecs = uu___126_5561.letrecs; top_level = uu___126_5561.top_level; check_uvars = uu___126_5561.check_uvars; use_eq = uu___126_5561.use_eq; is_iface = uu___126_5561.is_iface; admit = uu___126_5561.admit; lax = uu___126_5561.lax; lax_universes = uu___126_5561.lax_universes; type_of = uu___126_5561.type_of; universe_of = uu___126_5561.universe_of; use_bv_sorts = uu___126_5561.use_bv_sorts; qname_and_index = uu___126_5561.qname_and_index});
+))))
+
+
+let uvars_in_env : env  ->  FStar_Syntax_Syntax.uvars = (fun env -> (
+
+let no_uvs1 = (FStar_Syntax_Syntax.new_uv_set ())
+in (
+
+let ext = (fun out uvs -> (FStar_Util.set_union out uvs))
+in (
+
+let rec aux = (fun out g -> (match (g) with
+| [] -> begin
+out
+end
+| (Binding_univ (uu____5611))::tl1 -> begin
+(aux out tl1)
+end
+| ((Binding_lid (_, (_, t)))::tl1) | ((Binding_var ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t}))::tl1) -> begin
+(
+
+let uu____5626 = (
+
+let uu____5630 = (FStar_Syntax_Free.uvars t)
+in (ext out uu____5630))
+in (aux uu____5626 tl1))
+end
+| ((Binding_sig (_))::_) | ((Binding_sig_inst (_))::_) -> begin
+out
+end))
+in (aux no_uvs1 env.gamma)))))
+
+
+let univ_vars : env  ->  FStar_Syntax_Syntax.universe_uvar FStar_Util.set = (fun env -> (
+
+let no_univs = FStar_Syntax_Syntax.no_universe_uvars
+in (
+
+let ext = (fun out uvs -> (FStar_Util.set_union out uvs))
+in (
+
+let rec aux = (fun out g -> (match (g) with
+| [] -> begin
+out
+end
+| ((Binding_sig_inst (_))::tl1) | ((Binding_univ (_))::tl1) -> begin
+(aux out tl1)
+end
+| ((Binding_lid (_, (_, t)))::tl1) | ((Binding_var ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t}))::tl1) -> begin
+(
+
+let uu____5686 = (
+
+let uu____5688 = (FStar_Syntax_Free.univs t)
+in (ext out uu____5688))
+in (aux uu____5686 tl1))
+end
+| (Binding_sig (uu____5690))::uu____5691 -> begin
+out
+end))
+in (aux no_univs env.gamma)))))
+
+
+let univnames : env  ->  FStar_Syntax_Syntax.univ_name FStar_Util.set = (fun env -> (
+
+let no_univ_names = FStar_Syntax_Syntax.no_universe_names
+in (
+
+let ext = (fun out uvs -> (FStar_Util.set_union out uvs))
+in (
+
+let rec aux = (fun out g -> (match (g) with
+| [] -> begin
+out
+end
+| (Binding_sig_inst (uu____5728))::tl1 -> begin
+(aux out tl1)
+end
+| (Binding_univ (uname))::tl1 -> begin
+(
+
+let uu____5738 = (FStar_Util.set_add uname out)
+in (aux uu____5738 tl1))
+end
+| ((Binding_lid (_, (_, t)))::tl1) | ((Binding_var ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t}))::tl1) -> begin
+(
+
+let uu____5752 = (
+
+let uu____5754 = (FStar_Syntax_Free.univnames t)
+in (ext out uu____5754))
+in (aux uu____5752 tl1))
+end
+| (Binding_sig (uu____5756))::uu____5757 -> begin
+out
+end))
+in (aux no_univ_names env.gamma)))))
+
+
+let bound_vars_of_bindings : binding Prims.list  ->  FStar_Syntax_Syntax.bv Prims.list = (fun bs -> (FStar_All.pipe_right bs (FStar_List.collect (fun uu___105_5773 -> (match (uu___105_5773) with
+| Binding_var (x) -> begin
+(x)::[]
+end
+| (Binding_lid (_)) | (Binding_sig (_)) | (Binding_univ (_)) | (Binding_sig_inst (_)) -> begin
+[]
+end)))))
+
+
+let binders_of_bindings : binding Prims.list  ->  FStar_Syntax_Syntax.binders = (fun bs -> (
+
+let uu____5785 = (
+
+let uu____5787 = (bound_vars_of_bindings bs)
+in (FStar_All.pipe_right uu____5787 (FStar_List.map FStar_Syntax_Syntax.mk_binder)))
+in (FStar_All.pipe_right uu____5785 FStar_List.rev)))
+
+
+let bound_vars : env  ->  FStar_Syntax_Syntax.bv Prims.list = (fun env -> (bound_vars_of_bindings env.gamma))
+
+
+let all_binders : env  ->  FStar_Syntax_Syntax.binders = (fun env -> (binders_of_bindings env.gamma))
+
+
+let print_gamma : env  ->  Prims.unit = (fun env -> (
+
+let uu____5803 = (
+
+let uu____5804 = (FStar_All.pipe_right env.gamma (FStar_List.map (fun uu___106_5808 -> (match (uu___106_5808) with
+| Binding_var (x) -> begin
+(
+
+let uu____5810 = (FStar_Syntax_Print.bv_to_string x)
+in (Prims.strcat "Binding_var " uu____5810))
+end
+| Binding_univ (u) -> begin
+(Prims.strcat "Binding_univ " u.FStar_Ident.idText)
+end
+| Binding_lid (l, uu____5813) -> begin
+(
+
+let uu____5814 = (FStar_Ident.string_of_lid l)
+in (Prims.strcat "Binding_lid " uu____5814))
+end
+| Binding_sig (ls, uu____5816) -> begin
+(
+
+let uu____5819 = (
+
+let uu____5820 = (FStar_All.pipe_right ls (FStar_List.map FStar_Ident.string_of_lid))
+in (FStar_All.pipe_right uu____5820 (FStar_String.concat ", ")))
+in (Prims.strcat "Binding_sig " uu____5819))
+end
+| Binding_sig_inst (ls, uu____5826, uu____5827) -> begin
+(
+
+let uu____5830 = (
+
+let uu____5831 = (FStar_All.pipe_right ls (FStar_List.map FStar_Ident.string_of_lid))
+in (FStar_All.pipe_right uu____5831 (FStar_String.concat ", ")))
+in (Prims.strcat "Binding_sig_inst " uu____5830))
+end))))
+in (FStar_All.pipe_right uu____5804 (FStar_String.concat "::\n")))
+in (FStar_All.pipe_right uu____5803 (FStar_Util.print1 "%s\n"))))
+
+
+let eq_gamma : env  ->  env  ->  Prims.bool = (fun env env' -> (
+
+let uu____5843 = (FStar_Util.physical_equality env.gamma env'.gamma)
+in (match (uu____5843) with
+| true -> begin
+true
+end
+| uu____5845 -> begin
+(
+
+let g = (all_binders env)
+in (
+
+let g' = (all_binders env')
+in (((FStar_List.length g) = (FStar_List.length g')) && (FStar_List.forall2 (fun uu____5860 uu____5861 -> (match (((uu____5860), (uu____5861))) with
+| ((b1, uu____5871), (b2, uu____5873)) -> begin
+(FStar_Syntax_Syntax.bv_eq b1 b2)
+end)) g g'))))
+end)))
+
+
+let fold_env = (fun env f a -> (FStar_List.fold_right (fun e a1 -> (f a1 e)) env.gamma a))
+
+
+let lidents : env  ->  FStar_Ident.lident Prims.list = (fun env -> (
+
+let keys = (FStar_List.fold_left (fun keys uu___107_5916 -> (match (uu___107_5916) with
+| Binding_sig (lids, uu____5920) -> begin
+(FStar_List.append lids keys)
+end
+| uu____5923 -> begin
+keys
+end)) [] env.gamma)
+in (FStar_Util.smap_fold (sigtab env) (fun uu____5925 v1 keys1 -> (FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)) keys)))
+
+
+let dummy_solver : solver_t = {init = (fun uu____5929 -> ()); push = (fun uu____5930 -> ()); pop = (fun uu____5931 -> ()); mark = (fun uu____5932 -> ()); reset_mark = (fun uu____5933 -> ()); commit_mark = (fun uu____5934 -> ()); encode_modul = (fun uu____5935 uu____5936 -> ()); encode_sig = (fun uu____5937 uu____5938 -> ()); preprocess = (fun e g -> (((e), (g)))::[]); solve = (fun uu____5945 uu____5946 uu____5947 -> ()); is_trivial = (fun uu____5951 uu____5952 -> false); finish = (fun uu____5953 -> ()); refresh = (fun uu____5954 -> ())}
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Err.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Err.ml
@@ -1,437 +1,458 @@
+
 open Prims
-let format_info:
-  FStar_TypeChecker_Env.env ->
-    Prims.string ->
-      FStar_Syntax_Syntax.term -> FStar_Range.range -> Prims.string
-  =
-  fun env  ->
-    fun name  ->
-      fun typ  ->
-        fun range  ->
-          let uu____13 = FStar_Range.string_of_range range in
-          let uu____14 = FStar_TypeChecker_Normalize.term_to_string env typ in
-          FStar_Util.format3 "(defined at %s) %s : %s" uu____13 name uu____14
-let info_as_string:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.identifier_info -> Prims.string
-  =
-  fun env  ->
-    fun info  ->
-      let uu____21 =
-        match info.FStar_TypeChecker_Common.identifier with
-        | FStar_Util.Inl bv ->
-            let uu____27 = FStar_Syntax_Print.nm_to_string bv in
-            let uu____28 = FStar_Syntax_Syntax.range_of_bv bv in
-            (uu____27, uu____28)
-        | FStar_Util.Inr fv ->
-            let uu____30 =
-              let uu____31 = FStar_Syntax_Syntax.lid_of_fv fv in
-              FStar_Syntax_Print.lid_to_string uu____31 in
-            let uu____32 = FStar_Syntax_Syntax.range_of_fv fv in
-            (uu____30, uu____32) in
-      match uu____21 with
-      | (id_string,range) ->
-          format_info env id_string
-            info.FStar_TypeChecker_Common.identifier_ty range
-let info_at_pos:
-  FStar_TypeChecker_Env.env ->
-    Prims.string -> Prims.int -> Prims.int -> Prims.string Prims.option
-  =
-  fun env  ->
-    fun file  ->
-      fun row  ->
-        fun col  ->
-          let uu____48 = FStar_TypeChecker_Common.info_at_pos file row col in
-          match uu____48 with
-          | None  -> None
-          | Some i -> let uu____52 = info_as_string env i in Some uu____52
-let add_errors:
-  FStar_TypeChecker_Env.env ->
-    (Prims.string* FStar_Range.range) Prims.list -> Prims.unit
-  =
-  fun env  ->
-    fun errs  ->
-      let errs1 =
-        FStar_All.pipe_right errs
-          (FStar_List.map
-             (fun uu____79  ->
-                match uu____79 with
-                | (msg,r) ->
-                    if r = FStar_Range.dummyRange
-                    then
-                      let uu____88 = FStar_TypeChecker_Env.get_range env in
-                      (msg, uu____88)
-                    else
-                      (let r' =
-                         let uu___194_91 = r in
-                         {
-                           FStar_Range.def_range = (r.FStar_Range.use_range);
-                           FStar_Range.use_range =
-                             (uu___194_91.FStar_Range.use_range)
-                         } in
-                       let uu____92 =
-                         let uu____93 = FStar_Range.file_of_range r' in
-                         let uu____94 =
-                           let uu____95 = FStar_TypeChecker_Env.get_range env in
-                           FStar_Range.file_of_range uu____95 in
-                         uu____93 <> uu____94 in
-                       if uu____92
-                       then
-                         let uu____98 =
-                           let uu____99 =
-                             let uu____100 =
-                               let uu____101 =
-                                 FStar_Range.string_of_use_range r in
-                               Prims.strcat uu____101 ")" in
-                             Prims.strcat "(Also see: " uu____100 in
-                           Prims.strcat msg uu____99 in
-                         let uu____102 = FStar_TypeChecker_Env.get_range env in
-                         (uu____98, uu____102)
-                       else (msg, r)))) in
-      FStar_Errors.add_errors errs1
-let possibly_verbose_message:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> (Prims.string* Prims.string* Prims.string)
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let s1 = FStar_TypeChecker_Normalize.term_to_string env t1 in
-        let s2 = FStar_TypeChecker_Normalize.term_to_string env t2 in
-        let extra =
-          if s1 = s2
-          then
-            let uu____119 =
-              FStar_Options.set_options FStar_Options.Set
-                "--prn --print_universes" in
-            let s11 = FStar_TypeChecker_Normalize.term_to_string env t1 in
-            let s21 = FStar_TypeChecker_Normalize.term_to_string env t2 in
-            FStar_Util.format2
-              "\nMore precisely: expected type:\n%s\ngot:\n%s\n" s11 s21
-          else "" in
-        (s1, s2, extra)
-let exhaustiveness_check: Prims.string = "Patterns are incomplete"
-let subtyping_failed:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> Prims.unit -> Prims.string
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        fun x  ->
-          let uu____135 = possibly_verbose_message env t2 t1 in
-          match uu____135 with
-          | (s2,s1,extra) ->
-              FStar_Util.format3
-                "Subtyping check failed; expected type %s; got type %s%s" s2
-                s1 extra
-let ill_kinded_type: Prims.string = "Ill-kinded type"
-let totality_check: Prims.string = "This term may not terminate"
-let unexpected_signature_for_monad:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun m  ->
-      fun k  ->
-        let uu____151 = FStar_TypeChecker_Normalize.term_to_string env k in
-        FStar_Util.format2
-          "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type => WP a => Effect); got %s"
-          m.FStar_Ident.str uu____151
-let expected_a_term_of_type_t_got_a_function:
-  FStar_TypeChecker_Env.env ->
-    Prims.string ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun msg  ->
-      fun t  ->
-        fun e  ->
-          let uu____164 = FStar_TypeChecker_Normalize.term_to_string env t in
-          let uu____165 = FStar_Syntax_Print.term_to_string e in
-          FStar_Util.format3
-            "Expected a term of type \"%s\"; got a function \"%s\" (%s)"
-            uu____164 uu____165 msg
-let unexpected_implicit_argument: Prims.string =
-  "Unexpected instantiation of an implicit argument to a function that only expects explicit arguments"
-let expected_expression_of_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun t1  ->
-      fun e  ->
-        fun t2  ->
-          let uu____178 = FStar_TypeChecker_Normalize.term_to_string env t1 in
-          let uu____179 = FStar_Syntax_Print.term_to_string e in
-          let uu____180 = FStar_TypeChecker_Normalize.term_to_string env t2 in
-          FStar_Util.format3
-            "Expected expression of type \"%s\"; got expression \"%s\" of type \"%s\""
-            uu____178 uu____179 uu____180
-let expected_function_with_parameter_of_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> Prims.string -> Prims.string
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let uu____192 = FStar_TypeChecker_Normalize.term_to_string env t1 in
-        let uu____193 = FStar_TypeChecker_Normalize.term_to_string env t2 in
-        FStar_Util.format3
-          "Expected a function with a parameter of type \"%s\"; this function has a parameter of type \"%s\""
-          uu____192 uu____193
-let expected_pattern_of_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun t1  ->
-      fun e  ->
-        fun t2  ->
-          let uu____206 = FStar_TypeChecker_Normalize.term_to_string env t1 in
-          let uu____207 = FStar_Syntax_Print.term_to_string e in
-          let uu____208 = FStar_TypeChecker_Normalize.term_to_string env t2 in
-          FStar_Util.format3
-            "Expected pattern of type \"%s\"; got pattern \"%s\" of type \"%s\""
-            uu____206 uu____207 uu____208
-let basic_type_error:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term Prims.option ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun eopt  ->
-      fun t1  ->
-        fun t2  ->
-          let uu____223 = possibly_verbose_message env t1 t2 in
-          match uu____223 with
-          | (s1,s2,extra) ->
-              (match eopt with
-               | None  ->
-                   FStar_Util.format3
-                     "Expected type \"%s\"; got type \"%s\"%s" s1 s2 extra
-               | Some e ->
-                   let uu____231 = FStar_Syntax_Print.term_to_string e in
-                   FStar_Util.format4
-                     "Expected type \"%s\"; but \"%s\" has type \"%s\"%s" s1
-                     uu____231 s2 extra)
-let occurs_check: Prims.string =
-  "Possibly infinite typ (occurs check failed)"
-let unification_well_formedness: Prims.string =
-  "Term or type of an unexpected sort"
-let incompatible_kinds:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun k1  ->
-      fun k2  ->
-        let uu____241 = FStar_TypeChecker_Normalize.term_to_string env k1 in
-        let uu____242 = FStar_TypeChecker_Normalize.term_to_string env k2 in
-        FStar_Util.format2 "Kinds \"%s\" and \"%s\" are incompatible"
-          uu____241 uu____242
-let constructor_builds_the_wrong_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun d  ->
-      fun t  ->
-        fun t'  ->
-          let uu____255 = FStar_Syntax_Print.term_to_string d in
-          let uu____256 = FStar_TypeChecker_Normalize.term_to_string env t in
-          let uu____257 = FStar_TypeChecker_Normalize.term_to_string env t' in
-          FStar_Util.format3
-            "Constructor \"%s\" builds a value of type \"%s\"; expected \"%s\""
-            uu____255 uu____256 uu____257
-let constructor_fails_the_positivity_check env d l =
-  let uu____275 = FStar_Syntax_Print.term_to_string d in
-  let uu____276 = FStar_Syntax_Print.lid_to_string l in
-  FStar_Util.format2
-    "Constructor \"%s\" fails the strict positivity check; the constructed type \"%s\" occurs to the left of a pure function type"
-    uu____275 uu____276
-let inline_type_annotation_and_val_decl: FStar_Ident.lid -> Prims.string =
-  fun l  ->
-    let uu____280 = FStar_Syntax_Print.lid_to_string l in
-    FStar_Util.format1
-      "\"%s\" has a val declaration as well as an inlined type annotation; remove one"
-      uu____280
-let inferred_type_causes_variable_to_escape:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv -> Prims.string
-  =
-  fun env  ->
-    fun t  ->
-      fun x  ->
-        let uu____290 = FStar_TypeChecker_Normalize.term_to_string env t in
-        let uu____291 = FStar_Syntax_Print.bv_to_string x in
-        FStar_Util.format2
-          "Inferred type \"%s\" causes variable \"%s\" to escape its scope"
-          uu____290 uu____291
-let expected_typ_of_kind:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun k1  ->
-      fun t  ->
-        fun k2  ->
-          let uu____304 = FStar_TypeChecker_Normalize.term_to_string env k1 in
-          let uu____305 = FStar_TypeChecker_Normalize.term_to_string env t in
-          let uu____306 = FStar_TypeChecker_Normalize.term_to_string env k2 in
-          FStar_Util.format3
-            "Expected type of kind \"%s\"; got \"%s\" of kind \"%s\""
-            uu____304 uu____305 uu____306
-let expected_tcon_kind:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun t  ->
-      fun k  ->
-        let uu____316 = FStar_TypeChecker_Normalize.term_to_string env t in
-        let uu____317 = FStar_TypeChecker_Normalize.term_to_string env k in
-        FStar_Util.format2
-          "Expected a type-to-type constructor or function; got a type \"%s\" of kind \"%s\""
-          uu____316 uu____317
-let expected_dcon_kind:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun t  ->
-      fun k  ->
-        let uu____327 = FStar_TypeChecker_Normalize.term_to_string env t in
-        let uu____328 = FStar_TypeChecker_Normalize.term_to_string env k in
-        FStar_Util.format2
-          "Expected a term-to-type constructor or function; got a type \"%s\" of kind \"%s\""
-          uu____327 uu____328
-let expected_function_typ:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
-  fun env  ->
-    fun t  ->
-      let uu____335 = FStar_TypeChecker_Normalize.term_to_string env t in
-      FStar_Util.format1
-        "Expected a function; got an expression of type \"%s\"" uu____335
-let expected_poly_typ:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.string
-  =
-  fun env  ->
-    fun f  ->
-      fun t  ->
-        fun targ  ->
-          let uu____348 = FStar_Syntax_Print.term_to_string f in
-          let uu____349 = FStar_TypeChecker_Normalize.term_to_string env t in
-          let uu____350 = FStar_TypeChecker_Normalize.term_to_string env targ in
-          FStar_Util.format3
-            "Expected a polymorphic function; got an expression \"%s\" of type \"%s\" applied to a type \"%s\""
-            uu____348 uu____349 uu____350
-let nonlinear_pattern_variable: FStar_Syntax_Syntax.bv -> Prims.string =
-  fun x  ->
-    let m = FStar_Syntax_Print.bv_to_string x in
-    FStar_Util.format1 "The pattern variable \"%s\" was used more than once"
-      m
-let disjunctive_pattern_vars:
-  FStar_Syntax_Syntax.bv Prims.list ->
-    FStar_Syntax_Syntax.bv Prims.list -> Prims.string
-  =
-  fun v1  ->
-    fun v2  ->
-      let vars v3 =
-        let uu____371 =
-          FStar_All.pipe_right v3
-            (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-        FStar_All.pipe_right uu____371 (FStar_String.concat ", ") in
-      let uu____376 = vars v1 in
-      let uu____377 = vars v2 in
-      FStar_Util.format2
-        "Every alternative of an 'or' pattern must bind the same variables; here one branch binds (\"%s\") and another (\"%s\")"
-        uu____376 uu____377
-let name_and_result c =
-  match c.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Total (t,uu____394) -> ("Tot", t)
-  | FStar_Syntax_Syntax.GTotal (t,uu____404) -> ("GTot", t)
-  | FStar_Syntax_Syntax.Comp ct ->
-      let uu____414 =
-        FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name in
-      (uu____414, (ct.FStar_Syntax_Syntax.result_typ))
-let computed_computation_type_does_not_match_annotation env e c c' =
-  let uu____451 = name_and_result c in
-  match uu____451 with
-  | (f1,r1) ->
-      let uu____462 = name_and_result c' in
-      (match uu____462 with
-       | (f2,r2) ->
-           let uu____473 = FStar_TypeChecker_Normalize.term_to_string env r1 in
-           let uu____474 = FStar_TypeChecker_Normalize.term_to_string env r2 in
-           FStar_Util.format4
-             "Computed type \"%s\" and effect \"%s\" is not compatible with the annotated type \"%s\" effect \"%s\""
-             uu____473 f1 uu____474 f2)
-let unexpected_non_trivial_precondition_on_term:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
-  fun env  ->
-    fun f  ->
-      let uu____481 = FStar_TypeChecker_Normalize.term_to_string env f in
-      FStar_Util.format1
-        "Term has an unexpected non-trivial pre-condition: %s" uu____481
-let expected_pure_expression e c =
-  let uu____498 = FStar_Syntax_Print.term_to_string e in
-  let uu____499 =
-    let uu____500 = name_and_result c in
-    FStar_All.pipe_left Prims.fst uu____500 in
-  FStar_Util.format2
-    "Expected a pure expression; got an expression \"%s\" with effect \"%s\""
-    uu____498 uu____499
-let expected_ghost_expression e c =
-  let uu____527 = FStar_Syntax_Print.term_to_string e in
-  let uu____528 =
-    let uu____529 = name_and_result c in
-    FStar_All.pipe_left Prims.fst uu____529 in
-  FStar_Util.format2
-    "Expected a ghost expression; got an expression \"%s\" with effect \"%s\""
-    uu____527 uu____528
-let expected_effect_1_got_effect_2:
-  FStar_Ident.lident -> FStar_Ident.lident -> Prims.string =
-  fun c1  ->
-    fun c2  ->
-      let uu____546 = FStar_Syntax_Print.lid_to_string c1 in
-      let uu____547 = FStar_Syntax_Print.lid_to_string c2 in
-      FStar_Util.format2
-        "Expected a computation with effect %s; but it has effect %s"
-        uu____546 uu____547
-let failed_to_prove_specification_of:
-  FStar_Syntax_Syntax.lbname -> Prims.string Prims.list -> Prims.string =
-  fun l  ->
-    fun lbls  ->
-      let uu____556 = FStar_Syntax_Print.lbname_to_string l in
-      let uu____557 = FStar_All.pipe_right lbls (FStar_String.concat ", ") in
-      FStar_Util.format2
-        "Failed to prove specification of %s; assertions at [%s] may fail"
-        uu____556 uu____557
-let failed_to_prove_specification: Prims.string Prims.list -> Prims.string =
-  fun lbls  ->
-    match lbls with
-    | [] ->
-        "An unknown assertion in the term at this location was not provable"
-    | uu____564 ->
-        let uu____566 =
-          FStar_All.pipe_right lbls (FStar_String.concat "\n\t") in
-        FStar_Util.format1 "The following problems were found:\n\t%s"
-          uu____566
-let top_level_effect: Prims.string =
-  "Top-level let-bindings must be total; this term may have effects"
-let cardinality_constraint_violated l a =
-  let uu____584 = FStar_Syntax_Print.lid_to_string l in
-  let uu____585 = FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v in
-  FStar_Util.format2
-    "Constructor %s violates the cardinality of Type at parameter '%s'; type arguments are not allowed"
-    uu____584 uu____585
+
+let format_info : FStar_TypeChecker_Env.env  ->  Prims.string  ->  FStar_Syntax_Syntax.term  ->  FStar_Range.range  ->  Prims.string = (fun env name typ range -> (
+
+let uu____13 = (FStar_Range.string_of_range range)
+in (
+
+let uu____14 = (FStar_TypeChecker_Normalize.term_to_string env typ)
+in (FStar_Util.format3 "(defined at %s) %s : %s" uu____13 name uu____14))))
+
+
+let info_as_string : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.identifier_info  ->  Prims.string = (fun env info -> (
+
+let uu____21 = (match (info.FStar_TypeChecker_Common.identifier) with
+| FStar_Util.Inl (bv) -> begin
+(
+
+let uu____27 = (FStar_Syntax_Print.nm_to_string bv)
+in (
+
+let uu____28 = (FStar_Syntax_Syntax.range_of_bv bv)
+in ((uu____27), (uu____28))))
+end
+| FStar_Util.Inr (fv) -> begin
+(
+
+let uu____30 = (
+
+let uu____31 = (FStar_Syntax_Syntax.lid_of_fv fv)
+in (FStar_Syntax_Print.lid_to_string uu____31))
+in (
+
+let uu____32 = (FStar_Syntax_Syntax.range_of_fv fv)
+in ((uu____30), (uu____32))))
+end)
+in (match (uu____21) with
+| (id_string, range) -> begin
+(format_info env id_string info.FStar_TypeChecker_Common.identifier_ty range)
+end)))
+
+
+let info_at_pos : FStar_TypeChecker_Env.env  ->  Prims.string  ->  Prims.int  ->  Prims.int  ->  Prims.string Prims.option = (fun env file row col -> (
+
+let uu____48 = (FStar_TypeChecker_Common.info_at_pos file row col)
+in (match (uu____48) with
+| None -> begin
+None
+end
+| Some (i) -> begin
+(
+
+let uu____52 = (info_as_string env i)
+in Some (uu____52))
+end)))
+
+
+let add_errors : FStar_TypeChecker_Env.env  ->  (Prims.string * FStar_Range.range) Prims.list  ->  Prims.unit = (fun env errs -> (
+
+let errs1 = (FStar_All.pipe_right errs (FStar_List.map (fun uu____79 -> (match (uu____79) with
+| (msg, r) -> begin
+(match ((r = FStar_Range.dummyRange)) with
+| true -> begin
+(
+
+let uu____88 = (FStar_TypeChecker_Env.get_range env)
+in ((msg), (uu____88)))
+end
+| uu____89 -> begin
+(
+
+let r' = (
+
+let uu___194_91 = r
+in {FStar_Range.def_range = r.FStar_Range.use_range; FStar_Range.use_range = uu___194_91.FStar_Range.use_range})
+in (
+
+let uu____92 = (
+
+let uu____93 = (FStar_Range.file_of_range r')
+in (
+
+let uu____94 = (
+
+let uu____95 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_Range.file_of_range uu____95))
+in (uu____93 <> uu____94)))
+in (match (uu____92) with
+| true -> begin
+(
+
+let uu____98 = (
+
+let uu____99 = (
+
+let uu____100 = (
+
+let uu____101 = (FStar_Range.string_of_use_range r)
+in (Prims.strcat uu____101 ")"))
+in (Prims.strcat "(Also see: " uu____100))
+in (Prims.strcat msg uu____99))
+in (
+
+let uu____102 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____98), (uu____102))))
+end
+| uu____103 -> begin
+((msg), (r))
+end)))
+end)
+end))))
+in (FStar_Errors.add_errors errs1)))
+
+
+let possibly_verbose_message : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  (Prims.string * Prims.string * Prims.string) = (fun env t1 t2 -> (
+
+let s1 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let s2 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (
+
+let extra = (match ((s1 = s2)) with
+| true -> begin
+(
+
+let uu____119 = (FStar_Options.set_options FStar_Options.Set "--prn --print_universes")
+in (
+
+let s11 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let s21 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (FStar_Util.format2 "\nMore precisely: expected type:\n%s\ngot:\n%s\n" s11 s21))))
+end
+| uu____122 -> begin
+""
+end)
+in ((s1), (s2), (extra))))))
+
+
+let exhaustiveness_check : Prims.string = "Patterns are incomplete"
+
+
+let subtyping_failed : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit  ->  Prims.string = (fun env t1 t2 x -> (
+
+let uu____135 = (possibly_verbose_message env t2 t1)
+in (match (uu____135) with
+| (s2, s1, extra) -> begin
+(FStar_Util.format3 "Subtyping check failed; expected type %s; got type %s%s" s2 s1 extra)
+end)))
+
+
+let ill_kinded_type : Prims.string = "Ill-kinded type"
+
+
+let totality_check : Prims.string = "This term may not terminate"
+
+
+let unexpected_signature_for_monad : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env m k -> (
+
+let uu____151 = (FStar_TypeChecker_Normalize.term_to_string env k)
+in (FStar_Util.format2 "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type => WP a => Effect); got %s" m.FStar_Ident.str uu____151)))
+
+
+let expected_a_term_of_type_t_got_a_function : FStar_TypeChecker_Env.env  ->  Prims.string  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env msg t e -> (
+
+let uu____164 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____165 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format3 "Expected a term of type \"%s\"; got a function \"%s\" (%s)" uu____164 uu____165 msg))))
+
+
+let unexpected_implicit_argument : Prims.string = "Unexpected instantiation of an implicit argument to a function that only expects explicit arguments"
+
+
+let expected_expression_of_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t1 e t2 -> (
+
+let uu____178 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let uu____179 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____180 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (FStar_Util.format3 "Expected expression of type \"%s\"; got expression \"%s\" of type \"%s\"" uu____178 uu____179 uu____180)))))
+
+
+let expected_function_with_parameter_of_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string  ->  Prims.string = (fun env t1 t2 -> (
+
+let uu____192 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let uu____193 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (FStar_Util.format3 "Expected a function with a parameter of type \"%s\"; this function has a parameter of type \"%s\"" uu____192 uu____193))))
+
+
+let expected_pattern_of_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t1 e t2 -> (
+
+let uu____206 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let uu____207 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____208 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (FStar_Util.format3 "Expected pattern of type \"%s\"; got pattern \"%s\" of type \"%s\"" uu____206 uu____207 uu____208)))))
+
+
+let basic_type_error : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term Prims.option  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env eopt t1 t2 -> (
+
+let uu____223 = (possibly_verbose_message env t1 t2)
+in (match (uu____223) with
+| (s1, s2, extra) -> begin
+(match (eopt) with
+| None -> begin
+(FStar_Util.format3 "Expected type \"%s\"; got type \"%s\"%s" s1 s2 extra)
+end
+| Some (e) -> begin
+(
+
+let uu____231 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format4 "Expected type \"%s\"; but \"%s\" has type \"%s\"%s" s1 uu____231 s2 extra))
+end)
+end)))
+
+
+let occurs_check : Prims.string = "Possibly infinite typ (occurs check failed)"
+
+
+let unification_well_formedness : Prims.string = "Term or type of an unexpected sort"
+
+
+let incompatible_kinds : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env k1 k2 -> (
+
+let uu____241 = (FStar_TypeChecker_Normalize.term_to_string env k1)
+in (
+
+let uu____242 = (FStar_TypeChecker_Normalize.term_to_string env k2)
+in (FStar_Util.format2 "Kinds \"%s\" and \"%s\" are incompatible" uu____241 uu____242))))
+
+
+let constructor_builds_the_wrong_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env d t t' -> (
+
+let uu____255 = (FStar_Syntax_Print.term_to_string d)
+in (
+
+let uu____256 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____257 = (FStar_TypeChecker_Normalize.term_to_string env t')
+in (FStar_Util.format3 "Constructor \"%s\" builds a value of type \"%s\"; expected \"%s\"" uu____255 uu____256 uu____257)))))
+
+
+let constructor_fails_the_positivity_check = (fun env d l -> (
+
+let uu____275 = (FStar_Syntax_Print.term_to_string d)
+in (
+
+let uu____276 = (FStar_Syntax_Print.lid_to_string l)
+in (FStar_Util.format2 "Constructor \"%s\" fails the strict positivity check; the constructed type \"%s\" occurs to the left of a pure function type" uu____275 uu____276))))
+
+
+let inline_type_annotation_and_val_decl : FStar_Ident.lid  ->  Prims.string = (fun l -> (
+
+let uu____280 = (FStar_Syntax_Print.lid_to_string l)
+in (FStar_Util.format1 "\"%s\" has a val declaration as well as an inlined type annotation; remove one" uu____280)))
+
+
+let inferred_type_causes_variable_to_escape : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.bv  ->  Prims.string = (fun env t x -> (
+
+let uu____290 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____291 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format2 "Inferred type \"%s\" causes variable \"%s\" to escape its scope" uu____290 uu____291))))
+
+
+let expected_typ_of_kind : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env k1 t k2 -> (
+
+let uu____304 = (FStar_TypeChecker_Normalize.term_to_string env k1)
+in (
+
+let uu____305 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____306 = (FStar_TypeChecker_Normalize.term_to_string env k2)
+in (FStar_Util.format3 "Expected type of kind \"%s\"; got \"%s\" of kind \"%s\"" uu____304 uu____305 uu____306)))))
+
+
+let expected_tcon_kind : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t k -> (
+
+let uu____316 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____317 = (FStar_TypeChecker_Normalize.term_to_string env k)
+in (FStar_Util.format2 "Expected a type-to-type constructor or function; got a type \"%s\" of kind \"%s\"" uu____316 uu____317))))
+
+
+let expected_dcon_kind : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t k -> (
+
+let uu____327 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____328 = (FStar_TypeChecker_Normalize.term_to_string env k)
+in (FStar_Util.format2 "Expected a term-to-type constructor or function; got a type \"%s\" of kind \"%s\"" uu____327 uu____328))))
+
+
+let expected_function_typ : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t -> (
+
+let uu____335 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (FStar_Util.format1 "Expected a function; got an expression of type \"%s\"" uu____335)))
+
+
+let expected_poly_typ : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env f t targ -> (
+
+let uu____348 = (FStar_Syntax_Print.term_to_string f)
+in (
+
+let uu____349 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____350 = (FStar_TypeChecker_Normalize.term_to_string env targ)
+in (FStar_Util.format3 "Expected a polymorphic function; got an expression \"%s\" of type \"%s\" applied to a type \"%s\"" uu____348 uu____349 uu____350)))))
+
+
+let nonlinear_pattern_variable : FStar_Syntax_Syntax.bv  ->  Prims.string = (fun x -> (
+
+let m = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format1 "The pattern variable \"%s\" was used more than once" m)))
+
+
+let disjunctive_pattern_vars : FStar_Syntax_Syntax.bv Prims.list  ->  FStar_Syntax_Syntax.bv Prims.list  ->  Prims.string = (fun v1 v2 -> (
+
+let vars = (fun v3 -> (
+
+let uu____371 = (FStar_All.pipe_right v3 (FStar_List.map FStar_Syntax_Print.bv_to_string))
+in (FStar_All.pipe_right uu____371 (FStar_String.concat ", "))))
+in (
+
+let uu____376 = (vars v1)
+in (
+
+let uu____377 = (vars v2)
+in (FStar_Util.format2 "Every alternative of an \'or\' pattern must bind the same variables; here one branch binds (\"%s\") and another (\"%s\")" uu____376 uu____377)))))
+
+
+let name_and_result = (fun c -> (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uu____394) -> begin
+(("Tot"), (t))
+end
+| FStar_Syntax_Syntax.GTotal (t, uu____404) -> begin
+(("GTot"), (t))
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let uu____414 = (FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name)
+in ((uu____414), (ct.FStar_Syntax_Syntax.result_typ)))
+end))
+
+
+let computed_computation_type_does_not_match_annotation = (fun env e c c' -> (
+
+let uu____451 = (name_and_result c)
+in (match (uu____451) with
+| (f1, r1) -> begin
+(
+
+let uu____462 = (name_and_result c')
+in (match (uu____462) with
+| (f2, r2) -> begin
+(
+
+let uu____473 = (FStar_TypeChecker_Normalize.term_to_string env r1)
+in (
+
+let uu____474 = (FStar_TypeChecker_Normalize.term_to_string env r2)
+in (FStar_Util.format4 "Computed type \"%s\" and effect \"%s\" is not compatible with the annotated type \"%s\" effect \"%s\"" uu____473 f1 uu____474 f2)))
+end))
+end)))
+
+
+let unexpected_non_trivial_precondition_on_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env f -> (
+
+let uu____481 = (FStar_TypeChecker_Normalize.term_to_string env f)
+in (FStar_Util.format1 "Term has an unexpected non-trivial pre-condition: %s" uu____481)))
+
+
+let expected_pure_expression = (fun e c -> (
+
+let uu____498 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____499 = (
+
+let uu____500 = (name_and_result c)
+in (FStar_All.pipe_left Prims.fst uu____500))
+in (FStar_Util.format2 "Expected a pure expression; got an expression \"%s\" with effect \"%s\"" uu____498 uu____499))))
+
+
+let expected_ghost_expression = (fun e c -> (
+
+let uu____527 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____528 = (
+
+let uu____529 = (name_and_result c)
+in (FStar_All.pipe_left Prims.fst uu____529))
+in (FStar_Util.format2 "Expected a ghost expression; got an expression \"%s\" with effect \"%s\"" uu____527 uu____528))))
+
+
+let expected_effect_1_got_effect_2 : FStar_Ident.lident  ->  FStar_Ident.lident  ->  Prims.string = (fun c1 c2 -> (
+
+let uu____546 = (FStar_Syntax_Print.lid_to_string c1)
+in (
+
+let uu____547 = (FStar_Syntax_Print.lid_to_string c2)
+in (FStar_Util.format2 "Expected a computation with effect %s; but it has effect %s" uu____546 uu____547))))
+
+
+let failed_to_prove_specification_of : FStar_Syntax_Syntax.lbname  ->  Prims.string Prims.list  ->  Prims.string = (fun l lbls -> (
+
+let uu____556 = (FStar_Syntax_Print.lbname_to_string l)
+in (
+
+let uu____557 = (FStar_All.pipe_right lbls (FStar_String.concat ", "))
+in (FStar_Util.format2 "Failed to prove specification of %s; assertions at [%s] may fail" uu____556 uu____557))))
+
+
+let failed_to_prove_specification : Prims.string Prims.list  ->  Prims.string = (fun lbls -> (match (lbls) with
+| [] -> begin
+"An unknown assertion in the term at this location was not provable"
+end
+| uu____564 -> begin
+(
+
+let uu____566 = (FStar_All.pipe_right lbls (FStar_String.concat "\n\t"))
+in (FStar_Util.format1 "The following problems were found:\n\t%s" uu____566))
+end))
+
+
+let top_level_effect : Prims.string = "Top-level let-bindings must be total; this term may have effects"
+
+
+let cardinality_constraint_violated = (fun l a -> (
+
+let uu____584 = (FStar_Syntax_Print.lid_to_string l)
+in (
+
+let uu____585 = (FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v)
+in (FStar_Util.format2 "Constructor %s violates the cardinality of Type at parameter \'%s\'; type arguments are not allowed" uu____584 uu____585))))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -1,3710 +1,4202 @@
+
 open Prims
 type step =
-  | Beta
-  | Iota
-  | Zeta
-  | Exclude of step
-  | WHNF
-  | Primops
-  | Eager_unfolding
-  | Inlining
-  | NoDeltaSteps
-  | UnfoldUntil of FStar_Syntax_Syntax.delta_depth
-  | PureSubtermsWithinComputations
-  | Simplify
-  | EraseUniverses
-  | AllowUnboundUniverses
-  | Reify
-  | CompressUvars
-  | NoFullNorm
-let uu___is_Beta: step -> Prims.bool =
-  fun projectee  -> match projectee with | Beta  -> true | uu____10 -> false
-let uu___is_Iota: step -> Prims.bool =
-  fun projectee  -> match projectee with | Iota  -> true | uu____14 -> false
-let uu___is_Zeta: step -> Prims.bool =
-  fun projectee  -> match projectee with | Zeta  -> true | uu____18 -> false
-let uu___is_Exclude: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Exclude _0 -> true | uu____23 -> false
-let __proj__Exclude__item___0: step -> step =
-  fun projectee  -> match projectee with | Exclude _0 -> _0
-let uu___is_WHNF: step -> Prims.bool =
-  fun projectee  -> match projectee with | WHNF  -> true | uu____34 -> false
-let uu___is_Primops: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Primops  -> true | uu____38 -> false
-let uu___is_Eager_unfolding: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eager_unfolding  -> true | uu____42 -> false
-let uu___is_Inlining: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Inlining  -> true | uu____46 -> false
-let uu___is_NoDeltaSteps: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoDeltaSteps  -> true | uu____50 -> false
-let uu___is_UnfoldUntil: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UnfoldUntil _0 -> true | uu____55 -> false
-let __proj__UnfoldUntil__item___0: step -> FStar_Syntax_Syntax.delta_depth =
-  fun projectee  -> match projectee with | UnfoldUntil _0 -> _0
-let uu___is_PureSubtermsWithinComputations: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with
-    | PureSubtermsWithinComputations  -> true
-    | uu____66 -> false
-let uu___is_Simplify: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Simplify  -> true | uu____70 -> false
-let uu___is_EraseUniverses: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EraseUniverses  -> true | uu____74 -> false
-let uu___is_AllowUnboundUniverses: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | AllowUnboundUniverses  -> true | uu____78 -> false
-let uu___is_Reify: step -> Prims.bool =
-  fun projectee  -> match projectee with | Reify  -> true | uu____82 -> false
-let uu___is_CompressUvars: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CompressUvars  -> true | uu____86 -> false
-let uu___is_NoFullNorm: step -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoFullNorm  -> true | uu____90 -> false
-type steps = step Prims.list
+| Beta
+| Iota
+| Zeta
+| Exclude of step
+| WHNF
+| Primops
+| Eager_unfolding
+| Inlining
+| NoDeltaSteps
+| UnfoldUntil of FStar_Syntax_Syntax.delta_depth
+| PureSubtermsWithinComputations
+| Simplify
+| EraseUniverses
+| AllowUnboundUniverses
+| Reify
+| CompressUvars
+| NoFullNorm
+
+
+let uu___is_Beta : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Beta -> begin
+true
+end
+| uu____10 -> begin
+false
+end))
+
+
+let uu___is_Iota : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Iota -> begin
+true
+end
+| uu____14 -> begin
+false
+end))
+
+
+let uu___is_Zeta : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Zeta -> begin
+true
+end
+| uu____18 -> begin
+false
+end))
+
+
+let uu___is_Exclude : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Exclude (_0) -> begin
+true
+end
+| uu____23 -> begin
+false
+end))
+
+
+let __proj__Exclude__item___0 : step  ->  step = (fun projectee -> (match (projectee) with
+| Exclude (_0) -> begin
+_0
+end))
+
+
+let uu___is_WHNF : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| WHNF -> begin
+true
+end
+| uu____34 -> begin
+false
+end))
+
+
+let uu___is_Primops : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Primops -> begin
+true
+end
+| uu____38 -> begin
+false
+end))
+
+
+let uu___is_Eager_unfolding : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Eager_unfolding -> begin
+true
+end
+| uu____42 -> begin
+false
+end))
+
+
+let uu___is_Inlining : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Inlining -> begin
+true
+end
+| uu____46 -> begin
+false
+end))
+
+
+let uu___is_NoDeltaSteps : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoDeltaSteps -> begin
+true
+end
+| uu____50 -> begin
+false
+end))
+
+
+let uu___is_UnfoldUntil : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UnfoldUntil (_0) -> begin
+true
+end
+| uu____55 -> begin
+false
+end))
+
+
+let __proj__UnfoldUntil__item___0 : step  ->  FStar_Syntax_Syntax.delta_depth = (fun projectee -> (match (projectee) with
+| UnfoldUntil (_0) -> begin
+_0
+end))
+
+
+let uu___is_PureSubtermsWithinComputations : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| PureSubtermsWithinComputations -> begin
+true
+end
+| uu____66 -> begin
+false
+end))
+
+
+let uu___is_Simplify : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Simplify -> begin
+true
+end
+| uu____70 -> begin
+false
+end))
+
+
+let uu___is_EraseUniverses : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| EraseUniverses -> begin
+true
+end
+| uu____74 -> begin
+false
+end))
+
+
+let uu___is_AllowUnboundUniverses : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| AllowUnboundUniverses -> begin
+true
+end
+| uu____78 -> begin
+false
+end))
+
+
+let uu___is_Reify : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Reify -> begin
+true
+end
+| uu____82 -> begin
+false
+end))
+
+
+let uu___is_CompressUvars : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CompressUvars -> begin
+true
+end
+| uu____86 -> begin
+false
+end))
+
+
+let uu___is_NoFullNorm : step  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| NoFullNorm -> begin
+true
+end
+| uu____90 -> begin
+false
+end))
+
+
+type steps =
+step Prims.list
+
 type primitive_step =
-  {
-  name: FStar_Ident.lid;
-  arity: Prims.int;
-  strong_reduction_ok: Prims.bool;
-  interpretation:
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term Prims.option;}
+{name : FStar_Ident.lid; arity : Prims.int; strong_reduction_ok : Prims.bool; interpretation : FStar_Syntax_Syntax.args  ->  FStar_Syntax_Syntax.term Prims.option}
+
 type closure =
-  | Clos of (closure Prims.list* FStar_Syntax_Syntax.term* (closure
-  Prims.list* FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo*
-  Prims.bool)
-  | Univ of FStar_Syntax_Syntax.universe
-  | Dummy
-let uu___is_Clos: closure -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Clos _0 -> true | uu____158 -> false
-let __proj__Clos__item___0:
-  closure ->
-    (closure Prims.list* FStar_Syntax_Syntax.term* (closure Prims.list*
-      FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo* Prims.bool)
-  = fun projectee  -> match projectee with | Clos _0 -> _0
-let uu___is_Univ: closure -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Univ _0 -> true | uu____197 -> false
-let __proj__Univ__item___0: closure -> FStar_Syntax_Syntax.universe =
-  fun projectee  -> match projectee with | Univ _0 -> _0
-let uu___is_Dummy: closure -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Dummy  -> true | uu____208 -> false
-type env = closure Prims.list
-let closure_to_string: closure -> Prims.string =
-  fun uu___127_212  ->
-    match uu___127_212 with
-    | Clos (uu____213,t,uu____215,uu____216) ->
-        FStar_Syntax_Print.term_to_string t
-    | Univ uu____227 -> "Univ"
-    | Dummy  -> "dummy"
+| Clos of (closure Prims.list * FStar_Syntax_Syntax.term * (closure Prims.list * FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo * Prims.bool)
+| Univ of FStar_Syntax_Syntax.universe
+| Dummy
+
+
+let uu___is_Clos : closure  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Clos (_0) -> begin
+true
+end
+| uu____158 -> begin
+false
+end))
+
+
+let __proj__Clos__item___0 : closure  ->  (closure Prims.list * FStar_Syntax_Syntax.term * (closure Prims.list * FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo * Prims.bool) = (fun projectee -> (match (projectee) with
+| Clos (_0) -> begin
+_0
+end))
+
+
+let uu___is_Univ : closure  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Univ (_0) -> begin
+true
+end
+| uu____197 -> begin
+false
+end))
+
+
+let __proj__Univ__item___0 : closure  ->  FStar_Syntax_Syntax.universe = (fun projectee -> (match (projectee) with
+| Univ (_0) -> begin
+_0
+end))
+
+
+let uu___is_Dummy : closure  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Dummy -> begin
+true
+end
+| uu____208 -> begin
+false
+end))
+
+
+type env =
+closure Prims.list
+
+
+let closure_to_string : closure  ->  Prims.string = (fun uu___127_212 -> (match (uu___127_212) with
+| Clos (uu____213, t, uu____215, uu____216) -> begin
+(FStar_Syntax_Print.term_to_string t)
+end
+| Univ (uu____227) -> begin
+"Univ"
+end
+| Dummy -> begin
+"dummy"
+end))
+
 type cfg =
-  {
-  steps: steps;
-  tcenv: FStar_TypeChecker_Env.env;
-  delta_level: FStar_TypeChecker_Env.delta_level Prims.list;
-  primitive_steps: primitive_step Prims.list;}
+{steps : steps; tcenv : FStar_TypeChecker_Env.env; delta_level : FStar_TypeChecker_Env.delta_level Prims.list; primitive_steps : primitive_step Prims.list}
+
+
 type branches =
-  (FStar_Syntax_Syntax.pat* FStar_Syntax_Syntax.term Prims.option*
-    FStar_Syntax_Syntax.term) Prims.list
-type subst_t = FStar_Syntax_Syntax.subst_elt Prims.list
+(FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term Prims.option * FStar_Syntax_Syntax.term) Prims.list
+
+
+type subst_t =
+FStar_Syntax_Syntax.subst_elt Prims.list
+
 type stack_elt =
-  | Arg of (closure* FStar_Syntax_Syntax.aqual* FStar_Range.range)
-  | UnivArgs of (FStar_Syntax_Syntax.universe Prims.list* FStar_Range.range)
-  | MemoLazy of (env* FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo
-  | Match of (env* branches* FStar_Range.range)
-  | Abs of (env* FStar_Syntax_Syntax.binders* env*
-  (FStar_Syntax_Syntax.lcomp,FStar_Syntax_Syntax.residual_comp)
-  FStar_Util.either Prims.option* FStar_Range.range)
-  | App of (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual*
-  FStar_Range.range)
-  | Meta of (FStar_Syntax_Syntax.metadata* FStar_Range.range)
-  | Let of (env* FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.letbinding*
-  FStar_Range.range)
-  | Steps of (steps* primitive_step Prims.list*
-  FStar_TypeChecker_Env.delta_level Prims.list)
-  | Debug of FStar_Syntax_Syntax.term
-let uu___is_Arg: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Arg _0 -> true | uu____340 -> false
-let __proj__Arg__item___0:
-  stack_elt -> (closure* FStar_Syntax_Syntax.aqual* FStar_Range.range) =
-  fun projectee  -> match projectee with | Arg _0 -> _0
-let uu___is_UnivArgs: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UnivArgs _0 -> true | uu____364 -> false
-let __proj__UnivArgs__item___0:
-  stack_elt -> (FStar_Syntax_Syntax.universe Prims.list* FStar_Range.range) =
-  fun projectee  -> match projectee with | UnivArgs _0 -> _0
-let uu___is_MemoLazy: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MemoLazy _0 -> true | uu____388 -> false
-let __proj__MemoLazy__item___0:
-  stack_elt -> (env* FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo =
-  fun projectee  -> match projectee with | MemoLazy _0 -> _0
-let uu___is_Match: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Match _0 -> true | uu____415 -> false
-let __proj__Match__item___0: stack_elt -> (env* branches* FStar_Range.range)
-  = fun projectee  -> match projectee with | Match _0 -> _0
-let uu___is_Abs: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Abs _0 -> true | uu____444 -> false
-let __proj__Abs__item___0:
-  stack_elt ->
-    (env* FStar_Syntax_Syntax.binders* env*
-      (FStar_Syntax_Syntax.lcomp,FStar_Syntax_Syntax.residual_comp)
-      FStar_Util.either Prims.option* FStar_Range.range)
-  = fun projectee  -> match projectee with | Abs _0 -> _0
-let uu___is_App: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | App _0 -> true | uu____483 -> false
-let __proj__App__item___0:
-  stack_elt ->
-    (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual* FStar_Range.range)
-  = fun projectee  -> match projectee with | App _0 -> _0
-let uu___is_Meta: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Meta _0 -> true | uu____506 -> false
-let __proj__Meta__item___0:
-  stack_elt -> (FStar_Syntax_Syntax.metadata* FStar_Range.range) =
-  fun projectee  -> match projectee with | Meta _0 -> _0
-let uu___is_Let: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Let _0 -> true | uu____528 -> false
-let __proj__Let__item___0:
-  stack_elt ->
-    (env* FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.letbinding*
-      FStar_Range.range)
-  = fun projectee  -> match projectee with | Let _0 -> _0
-let uu___is_Steps: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Steps _0 -> true | uu____557 -> false
-let __proj__Steps__item___0:
-  stack_elt ->
-    (steps* primitive_step Prims.list* FStar_TypeChecker_Env.delta_level
-      Prims.list)
-  = fun projectee  -> match projectee with | Steps _0 -> _0
-let uu___is_Debug: stack_elt -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Debug _0 -> true | uu____584 -> false
-let __proj__Debug__item___0: stack_elt -> FStar_Syntax_Syntax.term =
-  fun projectee  -> match projectee with | Debug _0 -> _0
-type stack = stack_elt Prims.list
-let mk t r = FStar_Syntax_Syntax.mk t None r
-let set_memo r t =
-  let uu____632 = FStar_ST.read r in
-  match uu____632 with
-  | Some uu____637 -> failwith "Unexpected set_memo: thunk already evaluated"
-  | None  -> FStar_ST.write r (Some t)
-let env_to_string: closure Prims.list -> Prims.string =
-  fun env  ->
-    let uu____646 = FStar_List.map closure_to_string env in
-    FStar_All.pipe_right uu____646 (FStar_String.concat "; ")
-let stack_elt_to_string: stack_elt -> Prims.string =
-  fun uu___128_651  ->
-    match uu___128_651 with
-    | Arg (c,uu____653,uu____654) ->
-        let uu____655 = closure_to_string c in
-        FStar_Util.format1 "Closure %s" uu____655
-    | MemoLazy uu____656 -> "MemoLazy"
-    | Abs (uu____660,bs,uu____662,uu____663,uu____664) ->
-        let uu____671 =
-          FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs) in
-        FStar_Util.format1 "Abs %s" uu____671
-    | UnivArgs uu____676 -> "UnivArgs"
-    | Match uu____680 -> "Match"
-    | App (t,uu____685,uu____686) ->
-        let uu____687 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "App %s" uu____687
-    | Meta (m,uu____689) -> "Meta"
-    | Let uu____690 -> "Let"
-    | Steps (uu____695,uu____696,uu____697) -> "Steps"
-    | Debug t ->
-        let uu____703 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "Debug %s" uu____703
-let stack_to_string: stack_elt Prims.list -> Prims.string =
-  fun s  ->
-    let uu____709 = FStar_List.map stack_elt_to_string s in
-    FStar_All.pipe_right uu____709 (FStar_String.concat "; ")
-let log: cfg -> (Prims.unit -> Prims.unit) -> Prims.unit =
-  fun cfg  ->
-    fun f  ->
-      let uu____723 =
-        FStar_TypeChecker_Env.debug cfg.tcenv (FStar_Options.Other "Norm") in
-      if uu____723 then f () else ()
-let is_empty uu___129_732 =
-  match uu___129_732 with | [] -> true | uu____734 -> false
-let lookup_bvar env x =
-  try FStar_List.nth env x.FStar_Syntax_Syntax.index
-  with
-  | uu____752 ->
-      let uu____753 =
-        let uu____754 = FStar_Syntax_Print.db_to_string x in
-        FStar_Util.format1 "Failed to find %s\n" uu____754 in
-      failwith uu____753
-let downgrade_ghost_effect_name:
-  FStar_Ident.lident -> FStar_Ident.lident Prims.option =
-  fun l  ->
-    if FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Ghost_lid
-    then Some FStar_Syntax_Const.effect_Pure_lid
-    else
-      if FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GTot_lid
-      then Some FStar_Syntax_Const.effect_Tot_lid
-      else
-        if FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GHOST_lid
-        then Some FStar_Syntax_Const.effect_PURE_lid
-        else None
-let norm_universe:
-  cfg ->
-    closure Prims.list ->
-      FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
-  =
-  fun cfg  ->
-    fun env  ->
-      fun u  ->
-        let norm_univs us =
-          let us1 = FStar_Util.sort_with FStar_Syntax_Util.compare_univs us in
-          let uu____785 =
-            FStar_List.fold_left
-              (fun uu____794  ->
-                 fun u1  ->
-                   match uu____794 with
-                   | (cur_kernel,cur_max,out) ->
-                       let uu____809 = FStar_Syntax_Util.univ_kernel u1 in
-                       (match uu____809 with
-                        | (k_u,n1) ->
-                            let uu____818 =
-                              FStar_Syntax_Util.eq_univs cur_kernel k_u in
-                            if uu____818
-                            then (cur_kernel, u1, out)
-                            else (k_u, u1, (cur_max :: out))))
-              (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero, [])
-              us1 in
-          match uu____785 with
-          | (uu____828,u1,out) -> FStar_List.rev (u1 :: out) in
-        let rec aux u1 =
-          let u2 = FStar_Syntax_Subst.compress_univ u1 in
-          match u2 with
-          | FStar_Syntax_Syntax.U_bvar x ->
-              (try
-                 let uu____844 = FStar_List.nth env x in
-                 match uu____844 with
-                 | Univ u3 -> aux u3
-                 | Dummy  -> [u2]
-                 | uu____847 ->
-                     failwith "Impossible: universe variable bound to a term"
-               with
-               | uu____851 ->
-                   let uu____852 =
-                     FStar_All.pipe_right cfg.steps
-                       (FStar_List.contains AllowUnboundUniverses) in
-                   if uu____852
-                   then [FStar_Syntax_Syntax.U_unknown]
-                   else failwith "Universe variable not found")
-          | FStar_Syntax_Syntax.U_zero 
-            |FStar_Syntax_Syntax.U_unif _
-             |FStar_Syntax_Syntax.U_name _|FStar_Syntax_Syntax.U_unknown  ->
-              [u2]
-          | FStar_Syntax_Syntax.U_max [] -> [FStar_Syntax_Syntax.U_zero]
-          | FStar_Syntax_Syntax.U_max us ->
-              let us1 =
-                let uu____862 = FStar_List.collect aux us in
-                FStar_All.pipe_right uu____862 norm_univs in
-              (match us1 with
-               | u_k::hd1::rest ->
-                   let rest1 = hd1 :: rest in
-                   let uu____873 = FStar_Syntax_Util.univ_kernel u_k in
-                   (match uu____873 with
-                    | (FStar_Syntax_Syntax.U_zero ,n1) ->
-                        let uu____878 =
-                          FStar_All.pipe_right rest1
-                            (FStar_List.for_all
-                               (fun u3  ->
-                                  let uu____881 =
-                                    FStar_Syntax_Util.univ_kernel u3 in
-                                  match uu____881 with
-                                  | (uu____884,m) -> n1 <= m)) in
-                        if uu____878 then rest1 else us1
-                    | uu____888 -> us1)
-               | uu____891 -> us1)
-          | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____894 = aux u3 in
-              FStar_List.map (fun _0_29  -> FStar_Syntax_Syntax.U_succ _0_29)
-                uu____894 in
-        let uu____896 =
-          FStar_All.pipe_right cfg.steps (FStar_List.contains EraseUniverses) in
-        if uu____896
-        then FStar_Syntax_Syntax.U_unknown
-        else
-          (let uu____898 = aux u in
-           match uu____898 with
-           | []|(FStar_Syntax_Syntax.U_zero )::[] ->
-               FStar_Syntax_Syntax.U_zero
-           | (FStar_Syntax_Syntax.U_zero )::u1::[] -> u1
-           | (FStar_Syntax_Syntax.U_zero )::us ->
-               FStar_Syntax_Syntax.U_max us
-           | u1::[] -> u1
-           | us -> FStar_Syntax_Syntax.U_max us)
-let rec closure_as_term:
-  cfg ->
-    closure Prims.list ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun cfg  ->
-    fun env  ->
-      fun t  ->
-        log cfg
-          (fun uu____995  ->
-             let uu____996 = FStar_Syntax_Print.tag_of_term t in
-             let uu____997 = FStar_Syntax_Print.term_to_string t in
-             FStar_Util.print2 ">>> %s Closure_as_term %s\n" uu____996
-               uu____997);
-        (match env with
-         | [] when
-             FStar_All.pipe_left Prims.op_Negation
-               (FStar_List.contains CompressUvars cfg.steps)
-             -> t
-         | uu____998 ->
-             let t1 = FStar_Syntax_Subst.compress t in
-             (match t1.FStar_Syntax_Syntax.n with
-              | FStar_Syntax_Syntax.Tm_delayed uu____1001 ->
-                  failwith "Impossible"
-              | FStar_Syntax_Syntax.Tm_unknown 
-                |FStar_Syntax_Syntax.Tm_constant _
-                 |FStar_Syntax_Syntax.Tm_name _|FStar_Syntax_Syntax.Tm_fvar _
-                  -> t1
-              | FStar_Syntax_Syntax.Tm_uvar uu____1025 -> t1
-              | FStar_Syntax_Syntax.Tm_type u ->
-                  let uu____1035 =
-                    let uu____1036 = norm_universe cfg env u in
-                    FStar_Syntax_Syntax.Tm_type uu____1036 in
-                  mk uu____1035 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_uinst (t2,us) ->
-                  let uu____1043 = FStar_List.map (norm_universe cfg env) us in
-                  FStar_Syntax_Syntax.mk_Tm_uinst t2 uu____1043
-              | FStar_Syntax_Syntax.Tm_bvar x ->
-                  let uu____1045 = lookup_bvar env x in
-                  (match uu____1045 with
-                   | Univ uu____1046 ->
-                       failwith
-                         "Impossible: term variable is bound to a universe"
-                   | Dummy  -> t1
-                   | Clos (env1,t0,r,uu____1050) ->
-                       closure_as_term cfg env1 t0)
-              | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-                  let head2 = closure_as_term_delayed cfg env head1 in
-                  let args1 = closures_as_args_delayed cfg env args in
-                  mk (FStar_Syntax_Syntax.Tm_app (head2, args1))
-                    t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-                  let uu____1118 = closures_as_binders_delayed cfg env bs in
-                  (match uu____1118 with
-                   | (bs1,env1) ->
-                       let body1 = closure_as_term_delayed cfg env1 body in
-                       let uu____1138 =
-                         let uu____1139 =
-                           let uu____1154 = close_lcomp_opt cfg env1 lopt in
-                           (bs1, body1, uu____1154) in
-                         FStar_Syntax_Syntax.Tm_abs uu____1139 in
-                       mk uu____1138 t1.FStar_Syntax_Syntax.pos)
-              | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                  let uu____1184 = closures_as_binders_delayed cfg env bs in
-                  (match uu____1184 with
-                   | (bs1,env1) ->
-                       let c1 = close_comp cfg env1 c in
-                       mk (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
-                         t1.FStar_Syntax_Syntax.pos)
-              | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-                  let uu____1215 =
-                    let uu____1222 =
-                      let uu____1226 = FStar_Syntax_Syntax.mk_binder x in
-                      [uu____1226] in
-                    closures_as_binders_delayed cfg env uu____1222 in
-                  (match uu____1215 with
-                   | (x1,env1) ->
-                       let phi1 = closure_as_term_delayed cfg env1 phi in
-                       let uu____1240 =
-                         let uu____1241 =
-                           let uu____1246 =
-                             let uu____1247 = FStar_List.hd x1 in
-                             FStar_All.pipe_right uu____1247 Prims.fst in
-                           (uu____1246, phi1) in
-                         FStar_Syntax_Syntax.Tm_refine uu____1241 in
-                       mk uu____1240 t1.FStar_Syntax_Syntax.pos)
-              | FStar_Syntax_Syntax.Tm_ascribed (t11,(annot,tacopt),lopt) ->
-                  let annot1 =
-                    match annot with
-                    | FStar_Util.Inl t2 ->
-                        let uu____1315 = closure_as_term_delayed cfg env t2 in
-                        FStar_Util.Inl uu____1315
-                    | FStar_Util.Inr c ->
-                        let uu____1329 = close_comp cfg env c in
-                        FStar_Util.Inr uu____1329 in
-                  let tacopt1 =
-                    FStar_Util.map_opt tacopt
-                      (closure_as_term_delayed cfg env) in
-                  let uu____1344 =
-                    let uu____1345 =
-                      let uu____1363 = closure_as_term_delayed cfg env t11 in
-                      (uu____1363, (annot1, tacopt1), lopt) in
-                    FStar_Syntax_Syntax.Tm_ascribed uu____1345 in
-                  mk uu____1344 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_meta
-                  (t',FStar_Syntax_Syntax.Meta_pattern args) ->
-                  let uu____1401 =
-                    let uu____1402 =
-                      let uu____1407 = closure_as_term_delayed cfg env t' in
-                      let uu____1410 =
-                        let uu____1411 =
-                          FStar_All.pipe_right args
-                            (FStar_List.map
-                               (closures_as_args_delayed cfg env)) in
-                        FStar_Syntax_Syntax.Meta_pattern uu____1411 in
-                      (uu____1407, uu____1410) in
-                    FStar_Syntax_Syntax.Tm_meta uu____1402 in
-                  mk uu____1401 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_meta
-                  (t',FStar_Syntax_Syntax.Meta_monadic (m,tbody)) ->
-                  let uu____1453 =
-                    let uu____1454 =
-                      let uu____1459 = closure_as_term_delayed cfg env t' in
-                      let uu____1462 =
-                        let uu____1463 =
-                          let uu____1468 =
-                            closure_as_term_delayed cfg env tbody in
-                          (m, uu____1468) in
-                        FStar_Syntax_Syntax.Meta_monadic uu____1463 in
-                      (uu____1459, uu____1462) in
-                    FStar_Syntax_Syntax.Tm_meta uu____1454 in
-                  mk uu____1453 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_meta
-                  (t',FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,tbody)) ->
-                  let uu____1487 =
-                    let uu____1488 =
-                      let uu____1493 = closure_as_term_delayed cfg env t' in
-                      let uu____1496 =
-                        let uu____1497 =
-                          let uu____1503 =
-                            closure_as_term_delayed cfg env tbody in
-                          (m1, m2, uu____1503) in
-                        FStar_Syntax_Syntax.Meta_monadic_lift uu____1497 in
-                      (uu____1493, uu____1496) in
-                    FStar_Syntax_Syntax.Tm_meta uu____1488 in
-                  mk uu____1487 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_meta (t',m) ->
-                  let uu____1516 =
-                    let uu____1517 =
-                      let uu____1522 = closure_as_term_delayed cfg env t' in
-                      (uu____1522, m) in
-                    FStar_Syntax_Syntax.Tm_meta uu____1517 in
-                  mk uu____1516 t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                  let env0 = env in
-                  let env1 =
-                    FStar_List.fold_left
-                      (fun env1  -> fun uu____1543  -> Dummy :: env1) env
-                      lb.FStar_Syntax_Syntax.lbunivs in
-                  let typ =
-                    closure_as_term_delayed cfg env1
-                      lb.FStar_Syntax_Syntax.lbtyp in
-                  let def =
-                    closure_as_term cfg env1 lb.FStar_Syntax_Syntax.lbdef in
-                  let body1 =
-                    match lb.FStar_Syntax_Syntax.lbname with
-                    | FStar_Util.Inr uu____1554 -> body
-                    | FStar_Util.Inl uu____1555 ->
-                        closure_as_term cfg (Dummy :: env0) body in
-                  let lb1 =
-                    let uu___142_1557 = lb in
-                    {
-                      FStar_Syntax_Syntax.lbname =
-                        (uu___142_1557.FStar_Syntax_Syntax.lbname);
-                      FStar_Syntax_Syntax.lbunivs =
-                        (uu___142_1557.FStar_Syntax_Syntax.lbunivs);
-                      FStar_Syntax_Syntax.lbtyp = typ;
-                      FStar_Syntax_Syntax.lbeff =
-                        (uu___142_1557.FStar_Syntax_Syntax.lbeff);
-                      FStar_Syntax_Syntax.lbdef = def
-                    } in
-                  mk (FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1))
-                    t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_let ((uu____1564,lbs),body) ->
-                  let norm_one_lb env1 lb =
-                    let env_univs =
-                      FStar_List.fold_right
-                        (fun uu____1588  -> fun env2  -> Dummy :: env2)
-                        lb.FStar_Syntax_Syntax.lbunivs env1 in
-                    let env2 =
-                      let uu____1593 = FStar_Syntax_Syntax.is_top_level lbs in
-                      if uu____1593
-                      then env_univs
-                      else
-                        FStar_List.fold_right
-                          (fun uu____1597  -> fun env2  -> Dummy :: env2) lbs
-                          env_univs in
-                    let uu___143_1600 = lb in
-                    let uu____1601 =
-                      closure_as_term cfg env_univs
-                        lb.FStar_Syntax_Syntax.lbtyp in
-                    let uu____1604 =
-                      closure_as_term cfg env2 lb.FStar_Syntax_Syntax.lbdef in
-                    {
-                      FStar_Syntax_Syntax.lbname =
-                        (uu___143_1600.FStar_Syntax_Syntax.lbname);
-                      FStar_Syntax_Syntax.lbunivs =
-                        (uu___143_1600.FStar_Syntax_Syntax.lbunivs);
-                      FStar_Syntax_Syntax.lbtyp = uu____1601;
-                      FStar_Syntax_Syntax.lbeff =
-                        (uu___143_1600.FStar_Syntax_Syntax.lbeff);
-                      FStar_Syntax_Syntax.lbdef = uu____1604
-                    } in
-                  let lbs1 =
-                    FStar_All.pipe_right lbs
-                      (FStar_List.map (norm_one_lb env)) in
-                  let body1 =
-                    let body_env =
-                      FStar_List.fold_right
-                        (fun uu____1615  -> fun env1  -> Dummy :: env1) lbs1
-                        env in
-                    closure_as_term cfg body_env body in
-                  mk (FStar_Syntax_Syntax.Tm_let ((true, lbs1), body1))
-                    t1.FStar_Syntax_Syntax.pos
-              | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
-                  let head2 = closure_as_term cfg env head1 in
-                  let norm_one_branch env1 uu____1670 =
-                    match uu____1670 with
-                    | (pat,w_opt,tm) ->
-                        let rec norm_pat env2 p =
-                          match p.FStar_Syntax_Syntax.v with
-                          | FStar_Syntax_Syntax.Pat_constant uu____1716 ->
-                              (p, env2)
-                          | FStar_Syntax_Syntax.Pat_disj [] ->
-                              failwith "Impossible"
-                          | FStar_Syntax_Syntax.Pat_disj (hd1::tl1) ->
-                              let uu____1736 = norm_pat env2 hd1 in
-                              (match uu____1736 with
-                               | (hd2,env') ->
-                                   let tl2 =
-                                     FStar_All.pipe_right tl1
-                                       (FStar_List.map
-                                          (fun p1  ->
-                                             let uu____1772 =
-                                               norm_pat env2 p1 in
-                                             Prims.fst uu____1772)) in
-                                   ((let uu___144_1784 = p in
-                                     {
-                                       FStar_Syntax_Syntax.v =
-                                         (FStar_Syntax_Syntax.Pat_disj (hd2
-                                            :: tl2));
-                                       FStar_Syntax_Syntax.ty =
-                                         (uu___144_1784.FStar_Syntax_Syntax.ty);
-                                       FStar_Syntax_Syntax.p =
-                                         (uu___144_1784.FStar_Syntax_Syntax.p)
-                                     }), env'))
-                          | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-                              let uu____1801 =
-                                FStar_All.pipe_right pats
-                                  (FStar_List.fold_left
-                                     (fun uu____1835  ->
-                                        fun uu____1836  ->
-                                          match (uu____1835, uu____1836) with
-                                          | ((pats1,env3),(p1,b)) ->
-                                              let uu____1901 =
-                                                norm_pat env3 p1 in
-                                              (match uu____1901 with
-                                               | (p2,env4) ->
-                                                   (((p2, b) :: pats1), env4)))
-                                     ([], env2)) in
-                              (match uu____1801 with
-                               | (pats1,env3) ->
-                                   ((let uu___145_1967 = p in
-                                     {
-                                       FStar_Syntax_Syntax.v =
-                                         (FStar_Syntax_Syntax.Pat_cons
-                                            (fv, (FStar_List.rev pats1)));
-                                       FStar_Syntax_Syntax.ty =
-                                         (uu___145_1967.FStar_Syntax_Syntax.ty);
-                                       FStar_Syntax_Syntax.p =
-                                         (uu___145_1967.FStar_Syntax_Syntax.p)
-                                     }), env3))
-                          | FStar_Syntax_Syntax.Pat_var x ->
-                              let x1 =
-                                let uu___146_1981 = x in
-                                let uu____1982 =
-                                  closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___146_1981.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index =
-                                    (uu___146_1981.FStar_Syntax_Syntax.index);
-                                  FStar_Syntax_Syntax.sort = uu____1982
-                                } in
-                              ((let uu___147_1988 = p in
-                                {
-                                  FStar_Syntax_Syntax.v =
-                                    (FStar_Syntax_Syntax.Pat_var x1);
-                                  FStar_Syntax_Syntax.ty =
-                                    (uu___147_1988.FStar_Syntax_Syntax.ty);
-                                  FStar_Syntax_Syntax.p =
-                                    (uu___147_1988.FStar_Syntax_Syntax.p)
-                                }), (Dummy :: env2))
-                          | FStar_Syntax_Syntax.Pat_wild x ->
-                              let x1 =
-                                let uu___148_1993 = x in
-                                let uu____1994 =
-                                  closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___148_1993.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index =
-                                    (uu___148_1993.FStar_Syntax_Syntax.index);
-                                  FStar_Syntax_Syntax.sort = uu____1994
-                                } in
-                              ((let uu___149_2000 = p in
-                                {
-                                  FStar_Syntax_Syntax.v =
-                                    (FStar_Syntax_Syntax.Pat_wild x1);
-                                  FStar_Syntax_Syntax.ty =
-                                    (uu___149_2000.FStar_Syntax_Syntax.ty);
-                                  FStar_Syntax_Syntax.p =
-                                    (uu___149_2000.FStar_Syntax_Syntax.p)
-                                }), (Dummy :: env2))
-                          | FStar_Syntax_Syntax.Pat_dot_term (x,t2) ->
-                              let x1 =
-                                let uu___150_2010 = x in
-                                let uu____2011 =
-                                  closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___150_2010.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index =
-                                    (uu___150_2010.FStar_Syntax_Syntax.index);
-                                  FStar_Syntax_Syntax.sort = uu____2011
-                                } in
-                              let t3 = closure_as_term cfg env2 t2 in
-                              ((let uu___151_2018 = p in
-                                {
-                                  FStar_Syntax_Syntax.v =
-                                    (FStar_Syntax_Syntax.Pat_dot_term
-                                       (x1, t3));
-                                  FStar_Syntax_Syntax.ty =
-                                    (uu___151_2018.FStar_Syntax_Syntax.ty);
-                                  FStar_Syntax_Syntax.p =
-                                    (uu___151_2018.FStar_Syntax_Syntax.p)
-                                }), env2) in
-                        let uu____2021 = norm_pat env1 pat in
-                        (match uu____2021 with
-                         | (pat1,env2) ->
-                             let w_opt1 =
-                               match w_opt with
-                               | None  -> None
-                               | Some w ->
-                                   let uu____2045 =
-                                     closure_as_term cfg env2 w in
-                                   Some uu____2045 in
-                             let tm1 = closure_as_term cfg env2 tm in
-                             (pat1, w_opt1, tm1)) in
-                  let uu____2050 =
-                    let uu____2051 =
-                      let uu____2067 =
-                        FStar_All.pipe_right branches
-                          (FStar_List.map (norm_one_branch env)) in
-                      (head2, uu____2067) in
-                    FStar_Syntax_Syntax.Tm_match uu____2051 in
-                  mk uu____2050 t1.FStar_Syntax_Syntax.pos))
-and closure_as_term_delayed:
-  cfg ->
-    closure Prims.list ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term
-  =
-  fun cfg  ->
-    fun env  ->
-      fun t  ->
-        match env with
-        | [] when
-            FStar_All.pipe_left Prims.op_Negation
-              (FStar_List.contains CompressUvars cfg.steps)
-            -> t
-        | uu____2120 -> closure_as_term cfg env t
-and closures_as_args_delayed:
-  cfg ->
-    closure Prims.list ->
-      ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list ->
-        ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun cfg  ->
-    fun env  ->
-      fun args  ->
-        match env with
-        | [] when
-            FStar_All.pipe_left Prims.op_Negation
-              (FStar_List.contains CompressUvars cfg.steps)
-            -> args
-        | uu____2136 ->
-            FStar_List.map
-              (fun uu____2146  ->
-                 match uu____2146 with
-                 | (x,imp) ->
-                     let uu____2161 = closure_as_term_delayed cfg env x in
-                     (uu____2161, imp)) args
-and closures_as_binders_delayed:
-  cfg ->
-    closure Prims.list ->
-      (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-        ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list*
-          closure Prims.list)
-  =
-  fun cfg  ->
-    fun env  ->
-      fun bs  ->
-        let uu____2173 =
-          FStar_All.pipe_right bs
-            (FStar_List.fold_left
-               (fun uu____2197  ->
-                  fun uu____2198  ->
-                    match (uu____2197, uu____2198) with
-                    | ((env1,out),(b,imp)) ->
-                        let b1 =
-                          let uu___152_2242 = b in
-                          let uu____2243 =
-                            closure_as_term_delayed cfg env1
-                              b.FStar_Syntax_Syntax.sort in
-                          {
-                            FStar_Syntax_Syntax.ppname =
-                              (uu___152_2242.FStar_Syntax_Syntax.ppname);
-                            FStar_Syntax_Syntax.index =
-                              (uu___152_2242.FStar_Syntax_Syntax.index);
-                            FStar_Syntax_Syntax.sort = uu____2243
-                          } in
-                        let env2 = Dummy :: env1 in
-                        (env2, ((b1, imp) :: out))) (env, [])) in
-        match uu____2173 with | (env1,bs1) -> ((FStar_List.rev bs1), env1)
-and close_comp:
-  cfg ->
-    closure Prims.list ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-        (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun cfg  ->
-    fun env  ->
-      fun c  ->
-        match env with
-        | [] when
-            FStar_All.pipe_left Prims.op_Negation
-              (FStar_List.contains CompressUvars cfg.steps)
-            -> c
-        | uu____2290 ->
-            (match c.FStar_Syntax_Syntax.n with
-             | FStar_Syntax_Syntax.Total (t,uopt) ->
-                 let uu____2302 = closure_as_term_delayed cfg env t in
-                 let uu____2303 =
-                   FStar_Option.map (norm_universe cfg env) uopt in
-                 FStar_Syntax_Syntax.mk_Total' uu____2302 uu____2303
-             | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-                 let uu____2313 = closure_as_term_delayed cfg env t in
-                 let uu____2314 =
-                   FStar_Option.map (norm_universe cfg env) uopt in
-                 FStar_Syntax_Syntax.mk_GTotal' uu____2313 uu____2314
-             | FStar_Syntax_Syntax.Comp c1 ->
-                 let rt =
-                   closure_as_term_delayed cfg env
-                     c1.FStar_Syntax_Syntax.result_typ in
-                 let args =
-                   closures_as_args_delayed cfg env
-                     c1.FStar_Syntax_Syntax.effect_args in
-                 let flags =
-                   FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-                     (FStar_List.map
-                        (fun uu___130_2330  ->
-                           match uu___130_2330 with
-                           | FStar_Syntax_Syntax.DECREASES t ->
-                               let uu____2334 =
-                                 closure_as_term_delayed cfg env t in
-                               FStar_Syntax_Syntax.DECREASES uu____2334
-                           | f -> f)) in
-                 let uu____2338 =
-                   let uu___153_2339 = c1 in
-                   let uu____2340 =
-                     FStar_List.map (norm_universe cfg env)
-                       c1.FStar_Syntax_Syntax.comp_univs in
-                   {
-                     FStar_Syntax_Syntax.comp_univs = uu____2340;
-                     FStar_Syntax_Syntax.effect_name =
-                       (uu___153_2339.FStar_Syntax_Syntax.effect_name);
-                     FStar_Syntax_Syntax.result_typ = rt;
-                     FStar_Syntax_Syntax.effect_args = args;
-                     FStar_Syntax_Syntax.flags = flags
-                   } in
-                 FStar_Syntax_Syntax.mk_Comp uu____2338)
-and filter_out_lcomp_cflags:
-  FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.cflags Prims.list =
-  fun lc  ->
-    FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
-      (FStar_List.filter
-         (fun uu___131_2344  ->
-            match uu___131_2344 with
-            | FStar_Syntax_Syntax.DECREASES uu____2345 -> false
-            | uu____2348 -> true))
-and close_lcomp_opt:
-  cfg ->
-    closure Prims.list ->
-      (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                   FStar_Syntax_Syntax.cflags Prims.list))
-        FStar_Util.either Prims.option ->
-        (FStar_Syntax_Syntax.lcomp,(FStar_Ident.lident*
-                                     FStar_Syntax_Syntax.cflags Prims.list))
-          FStar_Util.either Prims.option
-  =
-  fun cfg  ->
-    fun env  ->
-      fun lopt  ->
-        match lopt with
-        | Some (FStar_Util.Inl lc) ->
-            let flags = filter_out_lcomp_cflags lc in
-            let uu____2376 = FStar_Syntax_Util.is_total_lcomp lc in
-            if uu____2376
-            then
-              Some
-                (FStar_Util.Inr (FStar_Syntax_Const.effect_Tot_lid, flags))
-            else
-              (let uu____2393 = FStar_Syntax_Util.is_tot_or_gtot_lcomp lc in
-               if uu____2393
-               then
-                 Some
-                   (FStar_Util.Inr
-                      (FStar_Syntax_Const.effect_GTot_lid, flags))
-               else
-                 Some
-                   (FStar_Util.Inr ((lc.FStar_Syntax_Syntax.eff_name), flags)))
-        | uu____2419 -> lopt
-let built_in_primitive_steps: primitive_step Prims.list =
-  let const_as_tm c p = mk (FStar_Syntax_Syntax.Tm_constant c) p in
-  let interp_math_op f args =
-    match args with
-    | (a1,uu____2459)::(a2,uu____2461)::[] ->
-        let uu____2482 =
-          let uu____2485 =
-            let uu____2486 = FStar_Syntax_Subst.compress a1 in
-            uu____2486.FStar_Syntax_Syntax.n in
-          let uu____2489 =
-            let uu____2490 = FStar_Syntax_Subst.compress a2 in
-            uu____2490.FStar_Syntax_Syntax.n in
-          (uu____2485, uu____2489) in
-        (match uu____2482 with
-         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
-            (i,None )),FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
-            (j,None ))) ->
-             let uu____2506 =
-               let uu____2509 =
-                 let uu____2510 = FStar_Util.int_of_string i in
-                 let uu____2511 = FStar_Util.int_of_string j in
-                 f uu____2510 uu____2511 in
-               const_as_tm uu____2509 a2.FStar_Syntax_Syntax.pos in
-             Some uu____2506
-         | uu____2514 -> None)
-    | uu____2517 -> failwith "Unexpected number of arguments" in
-  let interp_bounded_op f args =
-    match args with
-    | (a1,uu____2542)::(a2,uu____2544)::[] ->
-        let uu____2565 =
-          let uu____2568 =
-            let uu____2569 = FStar_Syntax_Subst.compress a1 in
-            uu____2569.FStar_Syntax_Syntax.n in
-          let uu____2572 =
-            let uu____2573 = FStar_Syntax_Subst.compress a2 in
-            uu____2573.FStar_Syntax_Syntax.n in
-          (uu____2568, uu____2572) in
-        (match uu____2565 with
-         | (FStar_Syntax_Syntax.Tm_app
-            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv1;
-               FStar_Syntax_Syntax.tk = uu____2578;
-               FStar_Syntax_Syntax.pos = uu____2579;
-               FStar_Syntax_Syntax.vars = uu____2580;_},({
-                                                           FStar_Syntax_Syntax.n
-                                                             =
-                                                             FStar_Syntax_Syntax.Tm_constant
-                                                             (FStar_Const.Const_int
-                                                             (i,None ));
-                                                           FStar_Syntax_Syntax.tk
-                                                             = uu____2582;
-                                                           FStar_Syntax_Syntax.pos
-                                                             = uu____2583;
-                                                           FStar_Syntax_Syntax.vars
-                                                             = uu____2584;_},uu____2585)::[]),FStar_Syntax_Syntax.Tm_app
-            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv2;
-               FStar_Syntax_Syntax.tk = uu____2587;
-               FStar_Syntax_Syntax.pos = uu____2588;
-               FStar_Syntax_Syntax.vars = uu____2589;_},({
-                                                           FStar_Syntax_Syntax.n
-                                                             =
-                                                             FStar_Syntax_Syntax.Tm_constant
-                                                             (FStar_Const.Const_int
-                                                             (j,None ));
-                                                           FStar_Syntax_Syntax.tk
-                                                             = uu____2591;
-                                                           FStar_Syntax_Syntax.pos
-                                                             = uu____2592;
-                                                           FStar_Syntax_Syntax.vars
-                                                             = uu____2593;_},uu____2594)::[]))
-             when
-             (FStar_Util.ends_with
-                (FStar_Ident.text_of_lid
-                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                "int_to_t")
-               &&
-               (FStar_Util.ends_with
-                  (FStar_Ident.text_of_lid
-                     (fv2.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                  "int_to_t")
-             ->
-             let n1 =
-               let uu____2658 =
-                 let uu____2659 = FStar_Util.int_of_string i in
-                 let uu____2660 = FStar_Util.int_of_string j in
-                 f uu____2659 uu____2660 in
-               const_as_tm uu____2658 a2.FStar_Syntax_Syntax.pos in
-             let uu____2661 =
-               let uu____2664 =
-                 mk (FStar_Syntax_Syntax.Tm_fvar fv1)
-                   a2.FStar_Syntax_Syntax.pos in
-               FStar_Syntax_Util.mk_app uu____2664 [(n1, None)] in
-             Some uu____2661
-         | uu____2682 -> None)
-    | uu____2685 -> failwith "Unexpected number of arguments" in
-  let as_primitive_step arity mk1 uu____2719 =
-    match uu____2719 with
-    | (l,f) ->
-        let uu____2747 = mk1 f in
-        {
-          name = l;
-          arity;
-          strong_reduction_ok = true;
-          interpretation = uu____2747
-        } in
-  let int_as_const i =
-    let uu____2755 =
-      let uu____2761 = FStar_Util.string_of_int i in (uu____2761, None) in
-    FStar_Const.Const_int uu____2755 in
-  let bool_as_const b = FStar_Const.Const_bool b in
-  let basic_arith =
-    FStar_List.map (as_primitive_step (Prims.parse_int "2") interp_math_op)
-      [(FStar_Syntax_Const.op_Addition,
-         ((fun x  -> fun y  -> int_as_const (x + y))));
-      (FStar_Syntax_Const.op_Subtraction,
-        ((fun x  -> fun y  -> int_as_const (x - y))));
-      (FStar_Syntax_Const.op_Multiply,
-        ((fun x  -> fun y  -> int_as_const (x * y))));
-      (FStar_Syntax_Const.op_Division,
-        ((fun x  -> fun y  -> int_as_const (x / y))));
-      (FStar_Syntax_Const.op_LT,
-        ((fun x  -> fun y  -> bool_as_const (x < y))));
-      (FStar_Syntax_Const.op_LTE,
-        ((fun x  -> fun y  -> bool_as_const (x <= y))));
-      (FStar_Syntax_Const.op_GT,
-        ((fun x  -> fun y  -> bool_as_const (x > y))));
-      (FStar_Syntax_Const.op_GTE,
-        ((fun x  -> fun y  -> bool_as_const (x >= y))));
-      (FStar_Syntax_Const.op_Modulus,
-        ((fun x  -> fun y  -> int_as_const (x mod y))))] in
-  let bounded_arith =
-    let uu____2912 =
-      let uu____2920 =
-        FStar_List.map
-          (fun m  ->
-             let uu____2937 =
-               let uu____2944 = FStar_Syntax_Const.p2l ["FStar"; m; "add"] in
-               (uu____2944, (fun x  -> fun y  -> int_as_const (x + y))) in
-             let uu____2951 =
-               let uu____2959 =
-                 let uu____2966 = FStar_Syntax_Const.p2l ["FStar"; m; "sub"] in
-                 (uu____2966, (fun x  -> fun y  -> int_as_const (x - y))) in
-               let uu____2973 =
-                 let uu____2981 =
-                   let uu____2988 =
-                     FStar_Syntax_Const.p2l ["FStar"; m; "mul"] in
-                   (uu____2988, (fun x  -> fun y  -> int_as_const (x * y))) in
-                 [uu____2981] in
-               uu____2959 :: uu____2973 in
-             uu____2937 :: uu____2951)
-          ["Int8";
-          "UInt8";
-          "Int16";
-          "UInt16";
-          "Int32";
-          "UInt32";
-          "Int64";
-          "UInt64";
-          "UInt128"] in
-      FStar_List.flatten uu____2920 in
-    FStar_List.map
-      (as_primitive_step (Prims.parse_int "2") interp_bounded_op) uu____2912 in
-  let unary_string_ops =
-    let mk1 x = mk x FStar_Range.dummyRange in
-    let name l =
-      let uu____3045 =
-        let uu____3046 =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-            None in
-        FStar_Syntax_Syntax.Tm_fvar uu____3046 in
-      mk1 uu____3045 in
-    let ctor l =
-      let uu____3053 =
-        let uu____3054 =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-            (Some FStar_Syntax_Syntax.Data_ctor) in
-        FStar_Syntax_Syntax.Tm_fvar uu____3054 in
-      mk1 uu____3053 in
-    let interp args =
-      match args with
-      | (a,uu____3063)::[] ->
-          let uu____3076 =
-            let uu____3077 = FStar_Syntax_Subst.compress a in
-            uu____3077.FStar_Syntax_Syntax.n in
-          (match uu____3076 with
-           | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-               (bytes,uu____3082)) ->
-               let s = FStar_Util.string_of_bytes bytes in
-               let char_t = name FStar_Syntax_Const.char_lid in
-               let nil_char =
-                 let uu____3092 =
-                   let uu____3093 =
-                     let uu____3094 = ctor FStar_Syntax_Const.nil_lid in
-                     FStar_Syntax_Syntax.mk_Tm_uinst uu____3094
-                       [FStar_Syntax_Syntax.U_zero] in
-                   let uu____3095 =
-                     let uu____3096 = FStar_Syntax_Syntax.iarg char_t in
-                     [uu____3096] in
-                   FStar_Syntax_Syntax.mk_Tm_app uu____3093 uu____3095 in
-                 uu____3092 None FStar_Range.dummyRange in
-               let uu____3101 =
-                 let uu____3102 = FStar_String.list_of_string s in
-                 FStar_List.fold_right
-                   (fun c  ->
-                      fun a1  ->
-                        let uu____3108 =
-                          let uu____3109 =
-                            let uu____3110 = ctor FStar_Syntax_Const.cons_lid in
-                            FStar_Syntax_Syntax.mk_Tm_uinst uu____3110
-                              [FStar_Syntax_Syntax.U_zero] in
-                          let uu____3111 =
-                            let uu____3112 = FStar_Syntax_Syntax.iarg char_t in
-                            let uu____3113 =
-                              let uu____3115 =
-                                let uu____3116 =
-                                  mk1
-                                    (FStar_Syntax_Syntax.Tm_constant
-                                       (FStar_Const.Const_char c)) in
-                                FStar_Syntax_Syntax.as_arg uu____3116 in
-                              let uu____3117 =
-                                let uu____3119 =
-                                  FStar_Syntax_Syntax.as_arg a1 in
-                                [uu____3119] in
-                              uu____3115 :: uu____3117 in
-                            uu____3112 :: uu____3113 in
-                          FStar_Syntax_Syntax.mk_Tm_app uu____3109 uu____3111 in
-                        uu____3108 None FStar_Range.dummyRange) uu____3102
-                   nil_char in
-               Some uu____3101
-           | uu____3124 -> None)
-      | uu____3125 -> failwith "Unexpected number of arguments" in
-    let uu____3127 =
-      let uu____3128 =
-        FStar_Syntax_Const.p2l ["FStar"; "String"; "list_of_string"] in
-      {
-        name = uu____3128;
-        arity = (Prims.parse_int "1");
-        strong_reduction_ok = true;
-        interpretation = interp
-      } in
-    [uu____3127] in
-  FStar_List.append basic_arith
-    (FStar_List.append bounded_arith unary_string_ops)
-let equality_ops: primitive_step Prims.list =
-  let interp_bool args =
-    match args with
-    | (_typ,uu____3138)::(a1,uu____3140)::(a2,uu____3142)::[] ->
-        let uu____3171 = FStar_Syntax_Util.eq_tm a1 a2 in
-        (match uu____3171 with
-         | FStar_Syntax_Util.Equal  ->
-             let uu____3173 =
-               mk
-                 (FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_bool true)) a2.FStar_Syntax_Syntax.pos in
-             Some uu____3173
-         | FStar_Syntax_Util.NotEqual  ->
-             let uu____3178 =
-               mk
-                 (FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_bool false))
-                 a2.FStar_Syntax_Syntax.pos in
-             Some uu____3178
-         | uu____3183 -> None)
-    | uu____3184 -> failwith "Unexpected number of arguments" in
-  let interp_prop args =
-    match args with
-    | (_typ,_)::(a1,_)::(a2,_)::[]|(_typ,_)::_::(a1,_)::(a2,_)::[] ->
-        let uu____3263 = FStar_Syntax_Util.eq_tm a1 a2 in
-        (match uu____3263 with
-         | FStar_Syntax_Util.Equal  -> Some FStar_Syntax_Util.t_true
-         | FStar_Syntax_Util.NotEqual  -> Some FStar_Syntax_Util.t_false
-         | uu____3265 -> None)
-    | uu____3266 -> failwith "Unexpected number of arguments" in
-  let decidable_equality =
-    {
-      name = FStar_Syntax_Const.op_Eq;
-      arity = (Prims.parse_int "3");
-      strong_reduction_ok = true;
-      interpretation = interp_bool
-    } in
-  let propositional_equality =
-    {
-      name = FStar_Syntax_Const.eq2_lid;
-      arity = (Prims.parse_int "3");
-      strong_reduction_ok = true;
-      interpretation = interp_prop
-    } in
-  let hetero_propositional_equality =
-    {
-      name = FStar_Syntax_Const.eq3_lid;
-      arity = (Prims.parse_int "4");
-      strong_reduction_ok = true;
-      interpretation = interp_prop
-    } in
-  [decidable_equality; propositional_equality; hetero_propositional_equality]
-let reduce_primops:
-  cfg -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun cfg  ->
-    fun tm  ->
-      let uu____3277 =
-        FStar_All.pipe_left Prims.op_Negation
-          (FStar_List.contains Primops cfg.steps) in
-      if uu____3277
-      then tm
-      else
-        (let uu____3279 = FStar_Syntax_Util.head_and_args tm in
-         match uu____3279 with
-         | (head1,args) ->
-             let uu____3305 =
-               let uu____3306 = FStar_Syntax_Util.un_uinst head1 in
-               uu____3306.FStar_Syntax_Syntax.n in
-             (match uu____3305 with
-              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                  let uu____3310 =
-                    FStar_List.tryFind
-                      (fun ps  -> FStar_Syntax_Syntax.fv_eq_lid fv ps.name)
-                      cfg.primitive_steps in
-                  (match uu____3310 with
-                   | None  -> tm
-                   | Some prim_step ->
-                       if (FStar_List.length args) < prim_step.arity
-                       then tm
-                       else
-                         (let uu____3322 = prim_step.interpretation args in
-                          match uu____3322 with
-                          | None  -> tm
-                          | Some reduced -> reduced))
-              | uu____3325 -> tm))
-let reduce_equality:
-  cfg -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
-  fun cfg  ->
-    fun tm  ->
-      reduce_primops
-        (let uu___154_3332 = cfg in
-         {
-           steps = [Primops];
-           tcenv = (uu___154_3332.tcenv);
-           delta_level = (uu___154_3332.delta_level);
-           primitive_steps = equality_ops
-         }) tm
-let maybe_simplify:
-  cfg ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term
-  =
-  fun cfg  ->
-    fun tm  ->
-      let steps = cfg.steps in
-      let w t =
-        let uu___155_3354 = t in
-        {
-          FStar_Syntax_Syntax.n = (uu___155_3354.FStar_Syntax_Syntax.n);
-          FStar_Syntax_Syntax.tk = (uu___155_3354.FStar_Syntax_Syntax.tk);
-          FStar_Syntax_Syntax.pos = (tm.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (uu___155_3354.FStar_Syntax_Syntax.vars)
-        } in
-      let simp_t t =
-        match t.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_fvar fv when
-            FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.true_lid ->
-            Some true
-        | FStar_Syntax_Syntax.Tm_fvar fv when
-            FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.false_lid ->
-            Some false
-        | uu____3373 -> None in
-      let simplify arg = ((simp_t (Prims.fst arg)), arg) in
-      let uu____3400 =
-        FStar_All.pipe_left Prims.op_Negation
-          (FStar_List.contains Simplify steps) in
-      if uu____3400
-      then reduce_primops cfg tm
-      else
-        (match tm.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
-                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                   FStar_Syntax_Syntax.vars = _;_},_);
-              FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-              FStar_Syntax_Syntax.vars = _;_},args)
-           |FStar_Syntax_Syntax.Tm_app
-           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-              FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-              FStar_Syntax_Syntax.vars = _;_},args)
-             ->
-             let uu____3440 =
-               FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.and_lid in
-             if uu____3440
-             then
-               let uu____3441 =
-                 FStar_All.pipe_right args (FStar_List.map simplify) in
-               (match uu____3441 with
-                | (Some (true ),_)::(_,(arg,_))::[]
-                  |(_,(arg,_))::(Some (true ),_)::[] -> arg
-                | (Some (false ),_)::_::[]|_::(Some (false ),_)::[] ->
-                    w FStar_Syntax_Util.t_false
-                | uu____3607 -> tm)
-             else
-               (let uu____3617 =
-                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.or_lid in
-                if uu____3617
-                then
-                  let uu____3618 =
-                    FStar_All.pipe_right args (FStar_List.map simplify) in
-                  match uu____3618 with
-                  | (Some (true ),_)::_::[]|_::(Some (true ),_)::[] ->
-                      w FStar_Syntax_Util.t_true
-                  | (Some (false ),_)::(_,(arg,_))::[]
-                    |(_,(arg,_))::(Some (false ),_)::[] -> arg
-                  | uu____3784 -> tm
-                else
-                  (let uu____3794 =
-                     FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Syntax_Const.imp_lid in
-                   if uu____3794
-                   then
-                     let uu____3795 =
-                       FStar_All.pipe_right args (FStar_List.map simplify) in
-                     match uu____3795 with
-                     | _::(Some (true ),_)::[]|(Some (false ),_)::_::[] ->
-                         w FStar_Syntax_Util.t_true
-                     | (Some (true ),uu____3884)::(uu____3885,(arg,uu____3887))::[]
-                         -> arg
-                     | uu____3928 -> tm
-                   else
-                     (let uu____3938 =
-                        FStar_Syntax_Syntax.fv_eq_lid fv
-                          FStar_Syntax_Const.not_lid in
-                      if uu____3938
-                      then
-                        let uu____3939 =
-                          FStar_All.pipe_right args (FStar_List.map simplify) in
-                        match uu____3939 with
-                        | (Some (true ),uu____3972)::[] ->
-                            w FStar_Syntax_Util.t_false
-                        | (Some (false ),uu____3996)::[] ->
-                            w FStar_Syntax_Util.t_true
-                        | uu____4020 -> tm
-                      else
-                        (let uu____4030 =
-                           (FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Syntax_Const.forall_lid)
-                             ||
-                             (FStar_Syntax_Syntax.fv_eq_lid fv
-                                FStar_Syntax_Const.exists_lid) in
-                         if uu____4030
-                         then
-                           match args with
-                           | (t,_)::[]
-                             |(_,Some (FStar_Syntax_Syntax.Implicit _))::
-                             (t,_)::[] ->
-                               let uu____4071 =
-                                 let uu____4072 =
-                                   FStar_Syntax_Subst.compress t in
-                                 uu____4072.FStar_Syntax_Syntax.n in
-                               (match uu____4071 with
-                                | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____4075::[],body,uu____4077) ->
-                                    (match simp_t body with
-                                     | Some (true ) ->
-                                         w FStar_Syntax_Util.t_true
-                                     | Some (false ) ->
-                                         w FStar_Syntax_Util.t_false
-                                     | uu____4103 -> tm)
-                                | uu____4105 -> tm)
-                           | uu____4106 -> tm
-                         else reduce_equality cfg tm))))
-         | uu____4113 -> tm)
-let is_norm_request hd1 args =
-  let uu____4128 =
-    let uu____4132 =
-      let uu____4133 = FStar_Syntax_Util.un_uinst hd1 in
-      uu____4133.FStar_Syntax_Syntax.n in
-    (uu____4132, args) in
-  match uu____4128 with
-  | (FStar_Syntax_Syntax.Tm_fvar fv,uu____4138::uu____4139::[]) ->
-      FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.normalize_term
-  | (FStar_Syntax_Syntax.Tm_fvar fv,uu____4142::[]) ->
-      FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.normalize
-  | uu____4144 -> false
-let get_norm_request args =
-  match args with
-  | _::(tm,_)::[]|(tm,_)::[] -> tm
-  | uu____4177 -> failwith "Impossible"
-let is_reify_head: stack_elt Prims.list -> Prims.bool =
-  fun uu___132_4184  ->
-    match uu___132_4184 with
-    | (App
-        ({
-           FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-             (FStar_Const.Const_reify );
-           FStar_Syntax_Syntax.tk = uu____4186;
-           FStar_Syntax_Syntax.pos = uu____4187;
-           FStar_Syntax_Syntax.vars = uu____4188;_},uu____4189,uu____4190))::uu____4191
-        -> true
-    | uu____4197 -> false
-let is_fstar_tactics_quote: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____4202 =
-      let uu____4203 = FStar_Syntax_Util.un_uinst t in
-      uu____4203.FStar_Syntax_Syntax.n in
-    match uu____4202 with
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        FStar_Syntax_Syntax.fv_eq_lid fv
-          FStar_Syntax_Const.fstar_tactics_quote_lid
-    | uu____4207 -> false
-let rec norm:
-  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun cfg  ->
-    fun env  ->
-      fun stack1  ->
-        fun t  ->
-          let t1 = FStar_Syntax_Subst.compress t in
-          let firstn k l =
-            if (FStar_List.length l) < k
-            then (l, [])
-            else FStar_Util.first_N k l in
-          log cfg
-            (fun uu____4323  ->
-               let uu____4324 = FStar_Syntax_Print.tag_of_term t1 in
-               let uu____4325 = FStar_Syntax_Print.term_to_string t1 in
-               let uu____4326 =
-                 let uu____4327 =
-                   let uu____4329 = firstn (Prims.parse_int "4") stack1 in
-                   FStar_All.pipe_left Prims.fst uu____4329 in
-                 stack_to_string uu____4327 in
-               FStar_Util.print3
-                 ">>> %s\nNorm %s with top of the stack %s \n" uu____4324
-                 uu____4325 uu____4326);
-          (match t1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_delayed uu____4341 ->
-               failwith "Impossible"
-           | FStar_Syntax_Syntax.Tm_unknown 
-             |FStar_Syntax_Syntax.Tm_uvar _
-              |FStar_Syntax_Syntax.Tm_constant _
-               |FStar_Syntax_Syntax.Tm_name _
-                |FStar_Syntax_Syntax.Tm_fvar
-                 { FStar_Syntax_Syntax.fv_name = _;
-                   FStar_Syntax_Syntax.fv_delta =
-                     FStar_Syntax_Syntax.Delta_constant ;
-                   FStar_Syntax_Syntax.fv_qual = _;_}
-                 |FStar_Syntax_Syntax.Tm_fvar
-                  { FStar_Syntax_Syntax.fv_name = _;
-                    FStar_Syntax_Syntax.fv_delta = _;
-                    FStar_Syntax_Syntax.fv_qual = Some
-                      (FStar_Syntax_Syntax.Data_ctor );_}
-                  |FStar_Syntax_Syntax.Tm_fvar
-                  { FStar_Syntax_Syntax.fv_name = _;
-                    FStar_Syntax_Syntax.fv_delta = _;
-                    FStar_Syntax_Syntax.fv_qual = Some
-                      (FStar_Syntax_Syntax.Record_ctor _);_}
-               -> rebuild cfg env stack1 t1
-           | FStar_Syntax_Syntax.Tm_app
-               ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.tk = uu____4373;
-                  FStar_Syntax_Syntax.pos = uu____4374;
-                  FStar_Syntax_Syntax.vars = uu____4375;_},uu____4376)
-               when
-               FStar_Syntax_Syntax.fv_eq_lid fv
-                 FStar_Syntax_Const.fstar_tactics_embed_lid
-               -> rebuild cfg env stack1 t1
-           | FStar_Syntax_Syntax.Tm_app (hd1,args) when
-               is_fstar_tactics_quote hd1 ->
-               let args1 = closures_as_args_delayed cfg env args in
-               let t2 =
-                 let uu___156_4416 = t1 in
-                 {
-                   FStar_Syntax_Syntax.n =
-                     (FStar_Syntax_Syntax.Tm_app (hd1, args1));
-                   FStar_Syntax_Syntax.tk =
-                     (uu___156_4416.FStar_Syntax_Syntax.tk);
-                   FStar_Syntax_Syntax.pos =
-                     (uu___156_4416.FStar_Syntax_Syntax.pos);
-                   FStar_Syntax_Syntax.vars =
-                     (uu___156_4416.FStar_Syntax_Syntax.vars)
-                 } in
-               let t3 = reduce_primops cfg t2 in rebuild cfg env stack1 t3
-           | FStar_Syntax_Syntax.Tm_app (hd1,args) when
-               ((let uu____4445 =
-                   FStar_All.pipe_right cfg.steps
-                     (FStar_List.contains NoFullNorm) in
-                 Prims.op_Negation uu____4445) && (is_norm_request hd1 args))
-                 &&
-                 (Prims.op_Negation
-                    (FStar_Ident.lid_equals
-                       (cfg.tcenv).FStar_TypeChecker_Env.curmodule
-                       FStar_Syntax_Const.prims_lid))
-               ->
-               let tm = get_norm_request args in
-               let s =
-                 [Reify;
-                 Beta;
-                 UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
-                 Zeta;
-                 Iota;
-                 Primops] in
-               let cfg' =
-                 let uu___157_4458 = cfg in
-                 {
-                   steps = s;
-                   tcenv = (uu___157_4458.tcenv);
-                   delta_level =
-                     [FStar_TypeChecker_Env.Unfold
-                        FStar_Syntax_Syntax.Delta_constant];
-                   primitive_steps = (uu___157_4458.primitive_steps)
-                 } in
-               let stack' = (Debug t1) ::
-                 (Steps
-                    ((cfg.steps), (cfg.primitive_steps), (cfg.delta_level)))
-                 :: stack1 in
-               norm cfg' env stack' tm
-           | FStar_Syntax_Syntax.Tm_app
-               ({
-                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_reify );
-                  FStar_Syntax_Syntax.tk = uu____4463;
-                  FStar_Syntax_Syntax.pos = uu____4464;
-                  FStar_Syntax_Syntax.vars = uu____4465;_},a1::a2::rest)
-               ->
-               let uu____4499 = FStar_Syntax_Util.head_and_args t1 in
-               (match uu____4499 with
-                | (hd1,uu____4510) ->
-                    let t' =
-                      FStar_Syntax_Syntax.mk
-                        (FStar_Syntax_Syntax.Tm_app (hd1, [a1])) None
-                        t1.FStar_Syntax_Syntax.pos in
-                    let t2 =
-                      FStar_Syntax_Syntax.mk
-                        (FStar_Syntax_Syntax.Tm_app (t', (a2 :: rest))) None
-                        t1.FStar_Syntax_Syntax.pos in
-                    norm cfg env stack1 t2)
-           | FStar_Syntax_Syntax.Tm_app
-               ({
-                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_reflect uu____4565);
-                  FStar_Syntax_Syntax.tk = uu____4566;
-                  FStar_Syntax_Syntax.pos = uu____4567;
-                  FStar_Syntax_Syntax.vars = uu____4568;_},a::[])
-               when
-               (FStar_All.pipe_right cfg.steps (FStar_List.contains Reify))
-                 && (is_reify_head stack1)
-               ->
-               let uu____4591 = FStar_List.tl stack1 in
-               norm cfg env uu____4591 (Prims.fst a)
-           | FStar_Syntax_Syntax.Tm_app
-               ({
-                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                    (FStar_Const.Const_reify );
-                  FStar_Syntax_Syntax.tk = uu____4594;
-                  FStar_Syntax_Syntax.pos = uu____4595;
-                  FStar_Syntax_Syntax.vars = uu____4596;_},a::[])
-               when
-               FStar_All.pipe_right cfg.steps (FStar_List.contains Reify) ->
-               let uu____4619 = FStar_Syntax_Util.head_and_args t1 in
-               (match uu____4619 with
-                | (reify_head,uu____4630) ->
-                    let a1 =
-                      let uu____4646 =
-                        FStar_All.pipe_left FStar_Syntax_Util.unascribe
-                          (Prims.fst a) in
-                      FStar_Syntax_Subst.compress uu____4646 in
-                    (match a1.FStar_Syntax_Syntax.n with
-                     | FStar_Syntax_Syntax.Tm_app
-                         ({
-                            FStar_Syntax_Syntax.n =
-                              FStar_Syntax_Syntax.Tm_constant
-                              (FStar_Const.Const_reflect uu____4649);
-                            FStar_Syntax_Syntax.tk = uu____4650;
-                            FStar_Syntax_Syntax.pos = uu____4651;
-                            FStar_Syntax_Syntax.vars = uu____4652;_},a2::[])
-                         -> norm cfg env stack1 (Prims.fst a2)
-                     | uu____4677 ->
-                         let stack2 =
-                           (App
-                              (reify_head, None,
-                                (t1.FStar_Syntax_Syntax.pos)))
-                           :: stack1 in
-                         norm cfg env stack2 a1))
-           | FStar_Syntax_Syntax.Tm_type u ->
-               let u1 = norm_universe cfg env u in
-               let uu____4685 =
-                 mk (FStar_Syntax_Syntax.Tm_type u1)
-                   t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env stack1 uu____4685
-           | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
-               let uu____4692 =
-                 FStar_All.pipe_right cfg.steps
-                   (FStar_List.contains EraseUniverses) in
-               if uu____4692
-               then norm cfg env stack1 t'
-               else
-                 (let us1 =
-                    let uu____4695 =
-                      let uu____4699 =
-                        FStar_List.map (norm_universe cfg env) us in
-                      (uu____4699, (t1.FStar_Syntax_Syntax.pos)) in
-                    UnivArgs uu____4695 in
-                  let stack2 = us1 :: stack1 in norm cfg env stack2 t')
-           | FStar_Syntax_Syntax.Tm_fvar f ->
-               let t0 = t1 in
-               let should_delta =
-                 FStar_All.pipe_right cfg.delta_level
-                   (FStar_Util.for_some
-                      (fun uu___133_4708  ->
-                         match uu___133_4708 with
-                         | FStar_TypeChecker_Env.NoDelta  -> false
-                         | FStar_TypeChecker_Env.Inlining 
-                           |FStar_TypeChecker_Env.Eager_unfolding_only  ->
-                             true
-                         | FStar_TypeChecker_Env.Unfold l ->
-                             FStar_TypeChecker_Common.delta_depth_greater_than
-                               f.FStar_Syntax_Syntax.fv_delta l)) in
-               if Prims.op_Negation should_delta
-               then rebuild cfg env stack1 t1
-               else
-                 (let r_env =
-                    let uu____4712 = FStar_Syntax_Syntax.range_of_fv f in
-                    FStar_TypeChecker_Env.set_range cfg.tcenv uu____4712 in
-                  let uu____4713 =
-                    FStar_TypeChecker_Env.lookup_definition cfg.delta_level
-                      r_env
-                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  match uu____4713 with
-                  | None  ->
-                      (log cfg
-                         (fun uu____4724  ->
-                            FStar_Util.print "Tm_fvar case 2\n" []);
-                       rebuild cfg env stack1 t1)
-                  | Some (us,t2) ->
-                      (log cfg
-                         (fun uu____4730  ->
-                            let uu____4731 =
-                              FStar_Syntax_Print.term_to_string t0 in
-                            let uu____4732 =
-                              FStar_Syntax_Print.term_to_string t2 in
-                            FStar_Util.print2 ">>> Unfolded %s to %s\n"
-                              uu____4731 uu____4732);
-                       (let n1 = FStar_List.length us in
-                        if n1 > (Prims.parse_int "0")
-                        then
-                          match stack1 with
-                          | (UnivArgs (us',uu____4739))::stack2 ->
-                              let env1 =
-                                FStar_All.pipe_right us'
-                                  (FStar_List.fold_left
-                                     (fun env1  -> fun u  -> (Univ u) :: env1)
-                                     env) in
-                              norm cfg env1 stack2 t2
-                          | uu____4752 when
-                              FStar_All.pipe_right cfg.steps
-                                (FStar_List.contains EraseUniverses)
-                              -> norm cfg env stack1 t2
-                          | uu____4753 ->
-                              let uu____4754 =
-                                let uu____4755 =
-                                  FStar_Syntax_Print.lid_to_string
-                                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                FStar_Util.format1
-                                  "Impossible: missing universe instantiation on %s"
-                                  uu____4755 in
-                              failwith uu____4754
-                        else norm cfg env stack1 t2)))
-           | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____4762 = lookup_bvar env x in
-               (match uu____4762 with
-                | Univ uu____4763 ->
-                    failwith
-                      "Impossible: term variable is bound to a universe"
-                | Dummy  -> failwith "Term variable not found"
-                | Clos (env1,t0,r,fix) ->
-                    if
-                      (Prims.op_Negation fix) ||
-                        (Prims.op_Negation
-                           (FStar_List.contains (Exclude Zeta) cfg.steps))
-                    then
-                      let uu____4778 = FStar_ST.read r in
-                      (match uu____4778 with
-                       | Some (env2,t') ->
-                           (log cfg
-                              (fun uu____4797  ->
-                                 let uu____4798 =
-                                   FStar_Syntax_Print.term_to_string t1 in
-                                 let uu____4799 =
-                                   FStar_Syntax_Print.term_to_string t' in
-                                 FStar_Util.print2
-                                   "Lazy hit: %s cached to %s\n" uu____4798
-                                   uu____4799);
-                            (let uu____4800 =
-                               let uu____4801 =
-                                 FStar_Syntax_Subst.compress t' in
-                               uu____4801.FStar_Syntax_Syntax.n in
-                             match uu____4800 with
-                             | FStar_Syntax_Syntax.Tm_abs uu____4804 ->
-                                 norm cfg env2 stack1 t'
-                             | uu____4819 -> rebuild cfg env2 stack1 t'))
-                       | None  -> norm cfg env1 ((MemoLazy r) :: stack1) t0)
-                    else norm cfg env1 stack1 t0)
-           | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-               (match stack1 with
-                | (UnivArgs uu____4852)::uu____4853 ->
-                    failwith
-                      "Ill-typed term: universes cannot be applied to term abstraction"
-                | (Match uu____4858)::uu____4859 ->
-                    failwith
-                      "Ill-typed term: cannot pattern match an abstraction"
-                | (Arg (c,uu____4865,uu____4866))::stack_rest ->
-                    (match c with
-                     | Univ uu____4869 -> norm cfg (c :: env) stack_rest t1
-                     | uu____4870 ->
-                         (match bs with
-                          | [] -> failwith "Impossible"
-                          | uu____4873::[] ->
-                              (match lopt with
-                               | None  when FStar_Options.__unit_tests () ->
-                                   (log cfg
-                                      (fun uu____4886  ->
-                                         let uu____4887 = closure_to_string c in
-                                         FStar_Util.print1 "\tShifted %s\n"
-                                           uu____4887);
-                                    norm cfg (c :: env) stack_rest body)
-                               | Some (FStar_Util.Inr (l,cflags)) when
-                                   ((FStar_Ident.lid_equals l
-                                       FStar_Syntax_Const.effect_Tot_lid)
-                                      ||
-                                      (FStar_Ident.lid_equals l
-                                         FStar_Syntax_Const.effect_GTot_lid))
-                                     ||
-                                     (FStar_All.pipe_right cflags
-                                        (FStar_Util.for_some
-                                           (fun uu___134_4901  ->
-                                              match uu___134_4901 with
-                                              | FStar_Syntax_Syntax.TOTAL  ->
-                                                  true
-                                              | uu____4902 -> false)))
-                                   ->
-                                   (log cfg
-                                      (fun uu____4904  ->
-                                         let uu____4905 = closure_to_string c in
-                                         FStar_Util.print1 "\tShifted %s\n"
-                                           uu____4905);
-                                    norm cfg (c :: env) stack_rest body)
-                               | Some (FStar_Util.Inl lc) when
-                                   FStar_Syntax_Util.is_tot_or_gtot_lcomp lc
-                                   ->
-                                   (log cfg
-                                      (fun uu____4916  ->
-                                         let uu____4917 = closure_to_string c in
-                                         FStar_Util.print1 "\tShifted %s\n"
-                                           uu____4917);
-                                    norm cfg (c :: env) stack_rest body)
-                               | uu____4918 when
-                                   FStar_All.pipe_right cfg.steps
-                                     (FStar_List.contains Reify)
-                                   -> norm cfg (c :: env) stack_rest body
-                               | uu____4925 ->
-                                   let cfg1 =
-                                     let uu___158_4933 = cfg in
-                                     {
-                                       steps = (WHNF :: (Exclude Iota) ::
-                                         (Exclude Zeta) :: (cfg.steps));
-                                       tcenv = (uu___158_4933.tcenv);
-                                       delta_level =
-                                         (uu___158_4933.delta_level);
-                                       primitive_steps =
-                                         (uu___158_4933.primitive_steps)
-                                     } in
-                                   let uu____4934 =
-                                     closure_as_term cfg1 env t1 in
-                                   rebuild cfg1 env stack1 uu____4934)
-                          | uu____4935::tl1 ->
-                              (log cfg
-                                 (fun uu____4945  ->
-                                    let uu____4946 = closure_to_string c in
-                                    FStar_Util.print1 "\tShifted %s\n"
-                                      uu____4946);
-                               (let body1 =
-                                  mk
-                                    (FStar_Syntax_Syntax.Tm_abs
-                                       (tl1, body, lopt))
-                                    t1.FStar_Syntax_Syntax.pos in
-                                norm cfg (c :: env) stack_rest body1))))
-                | (Steps (s,ps,dl))::stack2 ->
-                    norm
-                      (let uu___159_4970 = cfg in
-                       {
-                         steps = s;
-                         tcenv = (uu___159_4970.tcenv);
-                         delta_level = dl;
-                         primitive_steps = ps
-                       }) env stack2 t1
-                | (MemoLazy r)::stack2 ->
-                    (set_memo r (env, t1);
-                     log cfg
-                       (fun uu____4983  ->
-                          let uu____4984 =
-                            FStar_Syntax_Print.term_to_string t1 in
-                          FStar_Util.print1 "\tSet memo %s\n" uu____4984);
-                     norm cfg env stack2 t1)
-                | (Debug _)::_
-                  |(Meta _)::_|(Let _)::_|(App _)::_|(Abs _)::_|[] ->
-                    if FStar_List.contains WHNF cfg.steps
-                    then
-                      let uu____4995 = closure_as_term cfg env t1 in
-                      rebuild cfg env stack1 uu____4995
-                    else
-                      (let uu____4997 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____4997 with
-                       | (bs1,body1,opening) ->
-                           let lopt1 =
-                             match lopt with
-                             | Some (FStar_Util.Inl l) ->
-                                 let uu____5026 =
-                                   let uu____5032 =
-                                     let uu____5033 =
-                                       let uu____5034 =
-                                         l.FStar_Syntax_Syntax.comp () in
-                                       FStar_Syntax_Subst.subst_comp opening
-                                         uu____5034 in
-                                     FStar_All.pipe_right uu____5033
-                                       FStar_Syntax_Util.lcomp_of_comp in
-                                   FStar_All.pipe_right uu____5032
-                                     (fun _0_30  -> FStar_Util.Inl _0_30) in
-                                 FStar_All.pipe_right uu____5026
-                                   (fun _0_31  -> Some _0_31)
-                             | uu____5059 -> lopt in
-                           let env' =
-                             FStar_All.pipe_right bs1
-                               (FStar_List.fold_left
-                                  (fun env1  ->
-                                     fun uu____5073  -> Dummy :: env1) env) in
-                           (log cfg
-                              (fun uu____5078  ->
-                                 let uu____5079 =
-                                   FStar_All.pipe_left
-                                     FStar_Util.string_of_int
-                                     (FStar_List.length bs1) in
-                                 FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____5079);
-                            (let stack2 =
-                               (Steps
-                                  ((cfg.steps), (cfg.primitive_steps),
-                                    (cfg.delta_level)))
-                               :: stack1 in
-                             let cfg1 =
-                               let uu___160_5089 = cfg in
-                               let uu____5090 =
-                                 FStar_List.filter
-                                   (fun ps  -> ps.strong_reduction_ok)
-                                   cfg.primitive_steps in
-                               {
-                                 steps = (uu___160_5089.steps);
-                                 tcenv = (uu___160_5089.tcenv);
-                                 delta_level = (uu___160_5089.delta_level);
-                                 primitive_steps = uu____5090
-                               } in
-                             norm cfg1 env'
-                               ((Abs
-                                   (env, bs1, env', lopt1,
-                                     (t1.FStar_Syntax_Syntax.pos))) ::
-                               stack2) body1))))
-           | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-               let stack2 =
-                 FStar_All.pipe_right stack1
-                   (FStar_List.fold_right
-                      (fun uu____5122  ->
-                         fun stack2  ->
-                           match uu____5122 with
-                           | (a,aq) ->
-                               let uu____5130 =
-                                 let uu____5131 =
-                                   let uu____5135 =
-                                     let uu____5136 =
-                                       let uu____5146 =
-                                         FStar_Util.mk_ref None in
-                                       (env, a, uu____5146, false) in
-                                     Clos uu____5136 in
-                                   (uu____5135, aq,
-                                     (t1.FStar_Syntax_Syntax.pos)) in
-                                 Arg uu____5131 in
-                               uu____5130 :: stack2) args) in
-               (log cfg
-                  (fun uu____5168  ->
-                     let uu____5169 =
-                       FStar_All.pipe_left FStar_Util.string_of_int
-                         (FStar_List.length args) in
-                     FStar_Util.print1 "\tPushed %s arguments\n" uu____5169);
-                norm cfg env stack2 head1)
-           | FStar_Syntax_Syntax.Tm_refine (x,f) ->
-               if FStar_List.contains WHNF cfg.steps
-               then
-                 (match (env, stack1) with
-                  | ([],[]) ->
-                      let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort in
-                      let t2 =
-                        mk
-                          (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___161_5190 = x in
-                               {
-                                 FStar_Syntax_Syntax.ppname =
-                                   (uu___161_5190.FStar_Syntax_Syntax.ppname);
-                                 FStar_Syntax_Syntax.index =
-                                   (uu___161_5190.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = t_x
-                               }), f)) t1.FStar_Syntax_Syntax.pos in
-                      rebuild cfg env stack1 t2
-                  | uu____5191 ->
-                      let uu____5194 = closure_as_term cfg env t1 in
-                      rebuild cfg env stack1 uu____5194)
-               else
-                 (let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort in
-                  let uu____5197 = FStar_Syntax_Subst.open_term [(x, None)] f in
-                  match uu____5197 with
-                  | (closing,f1) ->
-                      let f2 = norm cfg (Dummy :: env) [] f1 in
-                      let t2 =
-                        let uu____5213 =
-                          let uu____5214 =
-                            let uu____5219 =
-                              FStar_Syntax_Subst.close closing f2 in
-                            ((let uu___162_5220 = x in
-                              {
-                                FStar_Syntax_Syntax.ppname =
-                                  (uu___162_5220.FStar_Syntax_Syntax.ppname);
-                                FStar_Syntax_Syntax.index =
-                                  (uu___162_5220.FStar_Syntax_Syntax.index);
-                                FStar_Syntax_Syntax.sort = t_x
-                              }), uu____5219) in
-                          FStar_Syntax_Syntax.Tm_refine uu____5214 in
-                        mk uu____5213 t1.FStar_Syntax_Syntax.pos in
-                      rebuild cfg env stack1 t2)
-           | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-               if FStar_List.contains WHNF cfg.steps
-               then
-                 let uu____5233 = closure_as_term cfg env t1 in
-                 rebuild cfg env stack1 uu____5233
-               else
-                 (let uu____5235 = FStar_Syntax_Subst.open_comp bs c in
-                  match uu____5235 with
-                  | (bs1,c1) ->
-                      let c2 =
-                        let uu____5241 =
-                          FStar_All.pipe_right bs1
-                            (FStar_List.fold_left
-                               (fun env1  -> fun uu____5247  -> Dummy :: env1)
-                               env) in
-                        norm_comp cfg uu____5241 c1 in
-                      let t2 =
-                        let uu____5254 = norm_binders cfg env bs1 in
-                        FStar_Syntax_Util.arrow uu____5254 c2 in
-                      rebuild cfg env stack1 t2)
-           | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) ->
-               (match stack1 with
-                | (Match _)::_
-                  |(Arg _)::_
-                   |(App
-                    ({
-                       FStar_Syntax_Syntax.n =
-                         FStar_Syntax_Syntax.Tm_constant
-                         (FStar_Const.Const_reify );
-                       FStar_Syntax_Syntax.tk = _;
-                       FStar_Syntax_Syntax.pos = _;
-                       FStar_Syntax_Syntax.vars = _;_},_,_))::_|(MemoLazy
-                    _)::_ -> norm cfg env stack1 t11
-                | uu____5311 ->
-                    let t12 = norm cfg env [] t11 in
-                    (log cfg
-                       (fun uu____5314  ->
-                          FStar_Util.print_string
-                            "+++ Normalizing ascription \n");
-                     (let tc1 =
-                        match tc with
-                        | FStar_Util.Inl t2 ->
-                            let uu____5327 = norm cfg env [] t2 in
-                            FStar_Util.Inl uu____5327
-                        | FStar_Util.Inr c ->
-                            let uu____5335 = norm_comp cfg env c in
-                            FStar_Util.Inr uu____5335 in
-                      let tacopt1 =
-                        FStar_Util.map_opt tacopt (norm cfg env []) in
-                      let uu____5340 =
-                        mk
-                          (FStar_Syntax_Syntax.Tm_ascribed
-                             (t12, (tc1, tacopt1), l))
-                          t1.FStar_Syntax_Syntax.pos in
-                      rebuild cfg env stack1 uu____5340)))
-           | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
-               let stack2 =
-                 (Match (env, branches, (t1.FStar_Syntax_Syntax.pos))) ::
-                 stack1 in
-               norm cfg env stack2 head1
-           | FStar_Syntax_Syntax.Tm_let
-               ((uu____5391,{
-                              FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                                uu____5392;
-                              FStar_Syntax_Syntax.lbunivs = uu____5393;
-                              FStar_Syntax_Syntax.lbtyp = uu____5394;
-                              FStar_Syntax_Syntax.lbeff = uu____5395;
-                              FStar_Syntax_Syntax.lbdef = uu____5396;_}::uu____5397),uu____5398)
-               -> rebuild cfg env stack1 t1
-           | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-               let n1 =
-                 FStar_TypeChecker_Env.norm_eff_name cfg.tcenv
-                   lb.FStar_Syntax_Syntax.lbeff in
-               let uu____5424 =
-                 (let uu____5425 =
-                    FStar_All.pipe_right cfg.steps
-                      (FStar_List.contains NoDeltaSteps) in
-                  Prims.op_Negation uu____5425) &&
-                   ((FStar_Syntax_Util.is_pure_effect n1) ||
-                      ((FStar_Syntax_Util.is_ghost_effect n1) &&
-                         (let uu____5426 =
-                            FStar_All.pipe_right cfg.steps
-                              (FStar_List.contains
-                                 PureSubtermsWithinComputations) in
-                          Prims.op_Negation uu____5426))) in
-               if uu____5424
-               then
-                 let env1 =
-                   let uu____5429 =
-                     let uu____5430 =
-                       let uu____5440 = FStar_Util.mk_ref None in
-                       (env, (lb.FStar_Syntax_Syntax.lbdef), uu____5440,
-                         false) in
-                     Clos uu____5430 in
-                   uu____5429 :: env in
-                 norm cfg env1 stack1 body
-               else
-                 (let uu____5464 =
-                    let uu____5467 =
-                      let uu____5468 =
-                        let uu____5469 =
-                          FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbname
-                            FStar_Util.left in
-                        FStar_All.pipe_right uu____5469
-                          FStar_Syntax_Syntax.mk_binder in
-                      [uu____5468] in
-                    FStar_Syntax_Subst.open_term uu____5467 body in
-                  match uu____5464 with
-                  | (bs,body1) ->
-                      let lb1 =
-                        let uu___163_5475 = lb in
-                        let uu____5476 =
-                          let uu____5479 =
-                            let uu____5480 = FStar_List.hd bs in
-                            FStar_All.pipe_right uu____5480 Prims.fst in
-                          FStar_All.pipe_right uu____5479
-                            (fun _0_32  -> FStar_Util.Inl _0_32) in
-                        let uu____5489 =
-                          norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp in
-                        let uu____5492 =
-                          norm cfg env [] lb.FStar_Syntax_Syntax.lbdef in
-                        {
-                          FStar_Syntax_Syntax.lbname = uu____5476;
-                          FStar_Syntax_Syntax.lbunivs =
-                            (uu___163_5475.FStar_Syntax_Syntax.lbunivs);
-                          FStar_Syntax_Syntax.lbtyp = uu____5489;
-                          FStar_Syntax_Syntax.lbeff =
-                            (uu___163_5475.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5492
-                        } in
-                      let env' =
-                        FStar_All.pipe_right bs
-                          (FStar_List.fold_left
-                             (fun env1  -> fun uu____5502  -> Dummy :: env1)
-                             env) in
-                      norm cfg env'
-                        ((Let (env, bs, lb1, (t1.FStar_Syntax_Syntax.pos)))
-                        :: stack1) body1)
-           | FStar_Syntax_Syntax.Tm_let (lbs,body) when
-               FStar_List.contains (Exclude Zeta) cfg.steps ->
-               let uu____5518 = closure_as_term cfg env t1 in
-               rebuild cfg env stack1 uu____5518
-           | FStar_Syntax_Syntax.Tm_let (lbs,body) ->
-               let uu____5531 =
-                 FStar_List.fold_right
-                   (fun lb  ->
-                      fun uu____5553  ->
-                        match uu____5553 with
-                        | (rec_env,memos,i) ->
-                            let f_i =
-                              let uu____5592 =
-                                let uu___164_5593 =
-                                  FStar_Util.left
-                                    lb.FStar_Syntax_Syntax.lbname in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___164_5593.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index = i;
-                                  FStar_Syntax_Syntax.sort =
-                                    (uu___164_5593.FStar_Syntax_Syntax.sort)
-                                } in
-                              FStar_Syntax_Syntax.bv_to_tm uu____5592 in
-                            let fix_f_i =
-                              mk (FStar_Syntax_Syntax.Tm_let (lbs, f_i))
-                                t1.FStar_Syntax_Syntax.pos in
-                            let memo = FStar_Util.mk_ref None in
-                            let rec_env1 = (Clos (env, fix_f_i, memo, true))
-                              :: rec_env in
-                            (rec_env1, (memo :: memos),
-                              (i + (Prims.parse_int "1")))) (Prims.snd lbs)
-                   (env, [], (Prims.parse_int "0")) in
-               (match uu____5531 with
-                | (rec_env,memos,uu____5653) ->
-                    let uu____5668 =
-                      FStar_List.map2
-                        (fun lb  ->
-                           fun memo  ->
-                             FStar_ST.write memo
-                               (Some
-                                  (rec_env, (lb.FStar_Syntax_Syntax.lbdef))))
-                        (Prims.snd lbs) memos in
-                    let body_env =
-                      FStar_List.fold_right
-                        (fun lb  ->
-                           fun env1  ->
-                             let uu____5710 =
-                               let uu____5711 =
-                                 let uu____5721 = FStar_Util.mk_ref None in
-                                 (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                   uu____5721, false) in
-                               Clos uu____5711 in
-                             uu____5710 :: env1) (Prims.snd lbs) env in
-                    norm cfg body_env stack1 body)
-           | FStar_Syntax_Syntax.Tm_meta (head1,m) ->
-               (match m with
-                | FStar_Syntax_Syntax.Meta_monadic (m1,t2) ->
-                    let should_reify =
-                      match stack1 with
-                      | (App
-                          ({
-                             FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_reify );
-                             FStar_Syntax_Syntax.tk = uu____5759;
-                             FStar_Syntax_Syntax.pos = uu____5760;
-                             FStar_Syntax_Syntax.vars = uu____5761;_},uu____5762,uu____5763))::uu____5764
-                          ->
-                          FStar_All.pipe_right cfg.steps
-                            (FStar_List.contains Reify)
-                      | uu____5770 -> false in
-                    if Prims.op_Negation should_reify
-                    then
-                      let t3 = norm cfg env [] t2 in
-                      let stack2 =
-                        (Steps
-                           ((cfg.steps), (cfg.primitive_steps),
-                             (cfg.delta_level)))
-                        :: stack1 in
-                      let cfg1 =
-                        let uu____5777 =
-                          FStar_All.pipe_right cfg.steps
-                            (FStar_List.contains
-                               PureSubtermsWithinComputations) in
-                        if uu____5777
-                        then
-                          let uu___165_5778 = cfg in
-                          {
-                            steps =
-                              [PureSubtermsWithinComputations;
-                              Primops;
-                              AllowUnboundUniverses;
-                              EraseUniverses;
-                              Exclude Zeta;
-                              NoDeltaSteps];
-                            tcenv = (uu___165_5778.tcenv);
-                            delta_level =
-                              [FStar_TypeChecker_Env.Inlining;
-                              FStar_TypeChecker_Env.Eager_unfolding_only];
-                            primitive_steps = (uu___165_5778.primitive_steps)
-                          }
-                        else
-                          (let uu___166_5780 = cfg in
-                           {
-                             steps =
-                               (FStar_List.append
-                                  [NoDeltaSteps; Exclude Zeta] cfg.steps);
-                             tcenv = (uu___166_5780.tcenv);
-                             delta_level = [FStar_TypeChecker_Env.NoDelta];
-                             primitive_steps =
-                               (uu___166_5780.primitive_steps)
-                           }) in
-                      norm cfg1 env
-                        ((Meta
-                            ((FStar_Syntax_Syntax.Meta_monadic (m1, t3)),
-                              (t3.FStar_Syntax_Syntax.pos))) :: stack2) head1
-                    else
-                      (let uu____5782 =
-                         let uu____5783 = FStar_Syntax_Subst.compress head1 in
-                         uu____5783.FStar_Syntax_Syntax.n in
-                       match uu____5782 with
-                       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                           let ed =
-                             FStar_TypeChecker_Env.get_effect_decl cfg.tcenv
-                               m1 in
-                           let uu____5797 = ed.FStar_Syntax_Syntax.bind_repr in
-                           (match uu____5797 with
-                            | (uu____5798,bind_repr) ->
-                                (match lb.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____5802 ->
-                                     failwith
-                                       "Cannot reify a top-level let binding"
-                                 | FStar_Util.Inl x ->
-                                     let is_return e =
-                                       let uu____5809 =
-                                         let uu____5810 =
-                                           FStar_Syntax_Subst.compress e in
-                                         uu____5810.FStar_Syntax_Syntax.n in
-                                       match uu____5809 with
-                                       | FStar_Syntax_Syntax.Tm_meta
-                                           (e1,FStar_Syntax_Syntax.Meta_monadic
-                                            (uu____5815,uu____5816))
-                                           ->
-                                           let uu____5825 =
-                                             let uu____5826 =
-                                               FStar_Syntax_Subst.compress e1 in
-                                             uu____5826.FStar_Syntax_Syntax.n in
-                                           (match uu____5825 with
-                                            | FStar_Syntax_Syntax.Tm_meta
-                                                (e2,FStar_Syntax_Syntax.Meta_monadic_lift
-                                                 (uu____5831,msrc,uu____5833))
-                                                when
-                                                FStar_Syntax_Util.is_pure_effect
-                                                  msrc
-                                                ->
-                                                let uu____5842 =
-                                                  FStar_Syntax_Subst.compress
-                                                    e2 in
-                                                Some uu____5842
-                                            | uu____5843 -> None)
-                                       | uu____5844 -> None in
-                                     let uu____5845 =
-                                       is_return lb.FStar_Syntax_Syntax.lbdef in
-                                     (match uu____5845 with
-                                      | Some e ->
-                                          let lb1 =
-                                            let uu___167_5849 = lb in
-                                            {
-                                              FStar_Syntax_Syntax.lbname =
-                                                (uu___167_5849.FStar_Syntax_Syntax.lbname);
-                                              FStar_Syntax_Syntax.lbunivs =
-                                                (uu___167_5849.FStar_Syntax_Syntax.lbunivs);
-                                              FStar_Syntax_Syntax.lbtyp =
-                                                (uu___167_5849.FStar_Syntax_Syntax.lbtyp);
-                                              FStar_Syntax_Syntax.lbeff =
-                                                FStar_Syntax_Const.effect_PURE_lid;
-                                              FStar_Syntax_Syntax.lbdef = e
-                                            } in
-                                          let uu____5850 =
-                                            FStar_List.tl stack1 in
-                                          let uu____5851 =
-                                            let uu____5852 =
-                                              let uu____5855 =
-                                                let uu____5856 =
-                                                  let uu____5864 =
-                                                    FStar_Syntax_Util.mk_reify
-                                                      body in
-                                                  ((false, [lb1]),
-                                                    uu____5864) in
-                                                FStar_Syntax_Syntax.Tm_let
-                                                  uu____5856 in
-                                              FStar_Syntax_Syntax.mk
-                                                uu____5855 in
-                                            uu____5852 None
-                                              head1.FStar_Syntax_Syntax.pos in
-                                          norm cfg env uu____5850 uu____5851
-                                      | None  ->
-                                          let uu____5881 =
-                                            let uu____5882 = is_return body in
-                                            match uu____5882 with
-                                            | Some
-                                                {
-                                                  FStar_Syntax_Syntax.n =
-                                                    FStar_Syntax_Syntax.Tm_bvar
-                                                    y;
-                                                  FStar_Syntax_Syntax.tk =
-                                                    uu____5885;
-                                                  FStar_Syntax_Syntax.pos =
-                                                    uu____5886;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu____5887;_}
-                                                ->
-                                                FStar_Syntax_Syntax.bv_eq x y
-                                            | uu____5892 -> false in
-                                          if uu____5881
-                                          then
-                                            norm cfg env stack1
-                                              lb.FStar_Syntax_Syntax.lbdef
-                                          else
-                                            (let head2 =
-                                               FStar_All.pipe_left
-                                                 FStar_Syntax_Util.mk_reify
-                                                 lb.FStar_Syntax_Syntax.lbdef in
-                                             let body1 =
-                                               FStar_All.pipe_left
-                                                 FStar_Syntax_Util.mk_reify
-                                                 body in
-                                             let body2 =
-                                               let uu____5912 =
-                                                 let uu____5915 =
-                                                   let uu____5916 =
-                                                     let uu____5931 =
-                                                       let uu____5933 =
-                                                         FStar_Syntax_Syntax.mk_binder
-                                                           x in
-                                                       [uu____5933] in
-                                                     (uu____5931, body1,
-                                                       (Some
-                                                          (FStar_Util.Inr
-                                                             (m1, [])))) in
-                                                   FStar_Syntax_Syntax.Tm_abs
-                                                     uu____5916 in
-                                                 FStar_Syntax_Syntax.mk
-                                                   uu____5915 in
-                                               uu____5912 None
-                                                 body1.FStar_Syntax_Syntax.pos in
-                                             let bind_inst =
-                                               let uu____5963 =
-                                                 let uu____5964 =
-                                                   FStar_Syntax_Subst.compress
-                                                     bind_repr in
-                                                 uu____5964.FStar_Syntax_Syntax.n in
-                                               match uu____5963 with
-                                               | FStar_Syntax_Syntax.Tm_uinst
-                                                   (bind1,uu____5970::uu____5971::[])
-                                                   ->
-                                                   let uu____5977 =
-                                                     let uu____5980 =
-                                                       let uu____5981 =
-                                                         let uu____5986 =
-                                                           let uu____5988 =
-                                                             (cfg.tcenv).FStar_TypeChecker_Env.universe_of
-                                                               cfg.tcenv
-                                                               lb.FStar_Syntax_Syntax.lbtyp in
-                                                           let uu____5989 =
-                                                             let uu____5991 =
-                                                               (cfg.tcenv).FStar_TypeChecker_Env.universe_of
-                                                                 cfg.tcenv t2 in
-                                                             [uu____5991] in
-                                                           uu____5988 ::
-                                                             uu____5989 in
-                                                         (bind1, uu____5986) in
-                                                       FStar_Syntax_Syntax.Tm_uinst
-                                                         uu____5981 in
-                                                     FStar_Syntax_Syntax.mk
-                                                       uu____5980 in
-                                                   uu____5977 None
-                                                     t2.FStar_Syntax_Syntax.pos
-                                               | uu____6003 ->
-                                                   failwith
-                                                     "NIY : Reification of indexed effects" in
-                                             let reified =
-                                               let uu____6009 =
-                                                 let uu____6012 =
-                                                   let uu____6013 =
-                                                     let uu____6023 =
-                                                       let uu____6025 =
-                                                         FStar_Syntax_Syntax.as_arg
-                                                           lb.FStar_Syntax_Syntax.lbtyp in
-                                                       let uu____6026 =
-                                                         let uu____6028 =
-                                                           FStar_Syntax_Syntax.as_arg
-                                                             t2 in
-                                                         let uu____6029 =
-                                                           let uu____6031 =
-                                                             FStar_Syntax_Syntax.as_arg
-                                                               FStar_Syntax_Syntax.tun in
-                                                           let uu____6032 =
-                                                             let uu____6034 =
-                                                               FStar_Syntax_Syntax.as_arg
-                                                                 head2 in
-                                                             let uu____6035 =
-                                                               let uu____6037
-                                                                 =
-                                                                 FStar_Syntax_Syntax.as_arg
-                                                                   FStar_Syntax_Syntax.tun in
-                                                               let uu____6038
-                                                                 =
-                                                                 let uu____6040
-                                                                   =
-                                                                   FStar_Syntax_Syntax.as_arg
-                                                                    body2 in
-                                                                 [uu____6040] in
-                                                               uu____6037 ::
-                                                                 uu____6038 in
-                                                             uu____6034 ::
-                                                               uu____6035 in
-                                                           uu____6031 ::
-                                                             uu____6032 in
-                                                         uu____6028 ::
-                                                           uu____6029 in
-                                                       uu____6025 ::
-                                                         uu____6026 in
-                                                     (bind_inst, uu____6023) in
-                                                   FStar_Syntax_Syntax.Tm_app
-                                                     uu____6013 in
-                                                 FStar_Syntax_Syntax.mk
-                                                   uu____6012 in
-                                               uu____6009 None
-                                                 t2.FStar_Syntax_Syntax.pos in
-                                             let uu____6052 =
-                                               FStar_List.tl stack1 in
-                                             norm cfg env uu____6052 reified))))
-                       | FStar_Syntax_Syntax.Tm_app (head_app,args) ->
-                           let ed =
-                             FStar_TypeChecker_Env.get_effect_decl cfg.tcenv
-                               m1 in
-                           let uu____6070 = ed.FStar_Syntax_Syntax.bind_repr in
-                           (match uu____6070 with
-                            | (uu____6071,bind_repr) ->
-                                let maybe_unfold_action head2 =
-                                  let maybe_extract_fv t3 =
-                                    let t4 =
-                                      let uu____6094 =
-                                        let uu____6095 =
-                                          FStar_Syntax_Subst.compress t3 in
-                                        uu____6095.FStar_Syntax_Syntax.n in
-                                      match uu____6094 with
-                                      | FStar_Syntax_Syntax.Tm_uinst
-                                          (t4,uu____6101) -> t4
-                                      | uu____6106 -> head2 in
-                                    let uu____6107 =
-                                      let uu____6108 =
-                                        FStar_Syntax_Subst.compress t4 in
-                                      uu____6108.FStar_Syntax_Syntax.n in
-                                    match uu____6107 with
-                                    | FStar_Syntax_Syntax.Tm_fvar x -> Some x
-                                    | uu____6113 -> None in
-                                  let uu____6114 = maybe_extract_fv head2 in
-                                  match uu____6114 with
-                                  | Some x when
-                                      let uu____6120 =
-                                        FStar_Syntax_Syntax.lid_of_fv x in
-                                      FStar_TypeChecker_Env.is_action
-                                        cfg.tcenv uu____6120
-                                      ->
-                                      let head3 = norm cfg env [] head2 in
-                                      let action_unfolded =
-                                        let uu____6124 =
-                                          maybe_extract_fv head3 in
-                                        match uu____6124 with
-                                        | Some uu____6127 -> Some true
-                                        | uu____6128 -> Some false in
-                                      (head3, action_unfolded)
-                                  | uu____6131 -> (head2, None) in
-                                ((let is_arg_impure uu____6142 =
-                                    match uu____6142 with
-                                    | (e,q) ->
-                                        let uu____6147 =
-                                          let uu____6148 =
-                                            FStar_Syntax_Subst.compress e in
-                                          uu____6148.FStar_Syntax_Syntax.n in
-                                        (match uu____6147 with
-                                         | FStar_Syntax_Syntax.Tm_meta
-                                             (e0,FStar_Syntax_Syntax.Meta_monadic_lift
-                                              (m11,m2,t'))
-                                             ->
-                                             Prims.op_Negation
-                                               (FStar_Syntax_Util.is_pure_effect
-                                                  m11)
-                                         | uu____6163 -> false) in
-                                  let uu____6164 =
-                                    let uu____6165 =
-                                      let uu____6169 =
-                                        FStar_Syntax_Syntax.as_arg head_app in
-                                      uu____6169 :: args in
-                                    FStar_Util.for_some is_arg_impure
-                                      uu____6165 in
-                                  if uu____6164
-                                  then
-                                    let uu____6172 =
-                                      let uu____6173 =
-                                        FStar_Syntax_Print.term_to_string
-                                          head1 in
-                                      FStar_Util.format1
-                                        "Incompability between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                        uu____6173 in
-                                    failwith uu____6172
-                                  else ());
-                                 (let uu____6175 =
-                                    maybe_unfold_action head_app in
-                                  match uu____6175 with
-                                  | (head_app1,found_action) ->
-                                      let mk1 tm =
-                                        FStar_Syntax_Syntax.mk tm None
-                                          t2.FStar_Syntax_Syntax.pos in
-                                      let body =
-                                        mk1
-                                          (FStar_Syntax_Syntax.Tm_app
-                                             (head_app1, args)) in
-                                      let body1 =
-                                        match found_action with
-                                        | None  ->
-                                            FStar_Syntax_Util.mk_reify body
-                                        | Some (false ) ->
-                                            mk1
-                                              (FStar_Syntax_Syntax.Tm_meta
-                                                 (body,
-                                                   (FStar_Syntax_Syntax.Meta_monadic
-                                                      (m1, t2))))
-                                        | Some (true ) -> body in
-                                      let uu____6210 = FStar_List.tl stack1 in
-                                      norm cfg env uu____6210 body1)))
-                       | FStar_Syntax_Syntax.Tm_meta
-                           (e,FStar_Syntax_Syntax.Meta_monadic_lift
-                            (msrc,mtgt,t'))
-                           ->
-                           let lifted = reify_lift cfg.tcenv e msrc mtgt t' in
-                           let uu____6224 = FStar_List.tl stack1 in
-                           norm cfg env uu____6224 lifted
-                       | FStar_Syntax_Syntax.Tm_match (e,branches) ->
-                           let branches1 =
-                             FStar_All.pipe_right branches
-                               (FStar_List.map
-                                  (fun uu____6307  ->
-                                     match uu____6307 with
-                                     | (pat,wopt,tm) ->
-                                         let uu____6345 =
-                                           FStar_Syntax_Util.mk_reify tm in
-                                         (pat, wopt, uu____6345))) in
-                           let tm =
-                             mk (FStar_Syntax_Syntax.Tm_match (e, branches1))
-                               t2.FStar_Syntax_Syntax.pos in
-                           let uu____6371 = FStar_List.tl stack1 in
-                           norm cfg env uu____6371 tm
-                       | uu____6372 -> norm cfg env stack1 head1)
-                | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m',t2) ->
-                    let should_reify =
-                      match stack1 with
-                      | (App
-                          ({
-                             FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_reify );
-                             FStar_Syntax_Syntax.tk = uu____6381;
-                             FStar_Syntax_Syntax.pos = uu____6382;
-                             FStar_Syntax_Syntax.vars = uu____6383;_},uu____6384,uu____6385))::uu____6386
-                          ->
-                          FStar_All.pipe_right cfg.steps
-                            (FStar_List.contains Reify)
-                      | uu____6392 -> false in
-                    if should_reify
-                    then
-                      let uu____6393 = FStar_List.tl stack1 in
-                      let uu____6394 = reify_lift cfg.tcenv head1 m1 m' t2 in
-                      norm cfg env uu____6393 uu____6394
-                    else
-                      (let uu____6396 =
-                         ((FStar_Syntax_Util.is_pure_effect m1) ||
-                            (FStar_Syntax_Util.is_ghost_effect m1))
-                           &&
-                           (FStar_All.pipe_right cfg.steps
-                              (FStar_List.contains
-                                 PureSubtermsWithinComputations)) in
-                       if uu____6396
-                       then
-                         let stack2 =
-                           (Steps
-                              ((cfg.steps), (cfg.primitive_steps),
-                                (cfg.delta_level)))
-                           :: stack1 in
-                         let cfg1 =
-                           let uu___168_6402 = cfg in
-                           {
-                             steps =
-                               [PureSubtermsWithinComputations;
-                               Primops;
-                               AllowUnboundUniverses;
-                               EraseUniverses;
-                               Exclude Zeta];
-                             tcenv = (uu___168_6402.tcenv);
-                             delta_level =
-                               [FStar_TypeChecker_Env.Inlining;
-                               FStar_TypeChecker_Env.Eager_unfolding_only];
-                             primitive_steps =
-                               (uu___168_6402.primitive_steps)
-                           } in
-                         norm cfg1 env
-                           ((Meta
-                               ((FStar_Syntax_Syntax.Meta_monadic_lift
-                                   (m1, m', t2)),
-                                 (head1.FStar_Syntax_Syntax.pos))) :: stack2)
-                           head1
-                       else
-                         norm cfg env
-                           ((Meta
-                               ((FStar_Syntax_Syntax.Meta_monadic_lift
-                                   (m1, m', t2)),
-                                 (head1.FStar_Syntax_Syntax.pos))) :: stack1)
-                           head1)
-                | uu____6408 ->
-                    (match stack1 with
-                     | uu____6409::uu____6410 ->
-                         (match m with
-                          | FStar_Syntax_Syntax.Meta_labeled (l,r,uu____6414)
-                              -> norm cfg env ((Meta (m, r)) :: stack1) head1
-                          | FStar_Syntax_Syntax.Meta_pattern args ->
-                              let args1 = norm_pattern_args cfg env args in
-                              norm cfg env
-                                ((Meta
-                                    ((FStar_Syntax_Syntax.Meta_pattern args1),
-                                      (t1.FStar_Syntax_Syntax.pos))) ::
-                                stack1) head1
-                          | uu____6429 -> norm cfg env stack1 head1)
-                     | [] ->
-                         let head2 = norm cfg env [] head1 in
-                         let m1 =
-                           match m with
-                           | FStar_Syntax_Syntax.Meta_pattern args ->
-                               let uu____6439 =
-                                 norm_pattern_args cfg env args in
-                               FStar_Syntax_Syntax.Meta_pattern uu____6439
-                           | uu____6446 -> m in
-                         let t2 =
-                           mk (FStar_Syntax_Syntax.Tm_meta (head2, m1))
-                             t1.FStar_Syntax_Syntax.pos in
-                         rebuild cfg env stack1 t2)))
-and reify_lift:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.monad_name ->
-        FStar_Syntax_Syntax.monad_name ->
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun e  ->
-      fun msrc  ->
-        fun mtgt  ->
-          fun t  ->
-            if FStar_Syntax_Util.is_pure_effect msrc
-            then
-              let ed = FStar_TypeChecker_Env.get_effect_decl env mtgt in
-              let uu____6460 = ed.FStar_Syntax_Syntax.return_repr in
-              match uu____6460 with
-              | (uu____6461,return_repr) ->
-                  let return_inst =
-                    let uu____6468 =
-                      let uu____6469 =
-                        FStar_Syntax_Subst.compress return_repr in
-                      uu____6469.FStar_Syntax_Syntax.n in
-                    match uu____6468 with
-                    | FStar_Syntax_Syntax.Tm_uinst (return_tm,uu____6475::[])
-                        ->
-                        let uu____6481 =
-                          let uu____6484 =
-                            let uu____6485 =
-                              let uu____6490 =
-                                let uu____6492 =
-                                  env.FStar_TypeChecker_Env.universe_of env t in
-                                [uu____6492] in
-                              (return_tm, uu____6490) in
-                            FStar_Syntax_Syntax.Tm_uinst uu____6485 in
-                          FStar_Syntax_Syntax.mk uu____6484 in
-                        uu____6481 None e.FStar_Syntax_Syntax.pos
-                    | uu____6504 ->
-                        failwith "NIY : Reification of indexed effects" in
-                  let uu____6507 =
-                    let uu____6510 =
-                      let uu____6511 =
-                        let uu____6521 =
-                          let uu____6523 = FStar_Syntax_Syntax.as_arg t in
-                          let uu____6524 =
-                            let uu____6526 = FStar_Syntax_Syntax.as_arg e in
-                            [uu____6526] in
-                          uu____6523 :: uu____6524 in
-                        (return_inst, uu____6521) in
-                      FStar_Syntax_Syntax.Tm_app uu____6511 in
-                    FStar_Syntax_Syntax.mk uu____6510 in
-                  uu____6507 None e.FStar_Syntax_Syntax.pos
-            else
-              (let uu____6539 = FStar_TypeChecker_Env.monad_leq env msrc mtgt in
-               match uu____6539 with
-               | None  ->
-                   let uu____6541 =
-                     FStar_Util.format2
-                       "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                       (FStar_Ident.text_of_lid msrc)
-                       (FStar_Ident.text_of_lid mtgt) in
-                   failwith uu____6541
-               | Some
-                   { FStar_TypeChecker_Env.msource = uu____6542;
-                     FStar_TypeChecker_Env.mtarget = uu____6543;
-                     FStar_TypeChecker_Env.mlift =
-                       { FStar_TypeChecker_Env.mlift_wp = uu____6544;
-                         FStar_TypeChecker_Env.mlift_term = None ;_};_}
-                   ->
-                   failwith
-                     "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-               | Some
-                   { FStar_TypeChecker_Env.msource = uu____6555;
-                     FStar_TypeChecker_Env.mtarget = uu____6556;
-                     FStar_TypeChecker_Env.mlift =
-                       { FStar_TypeChecker_Env.mlift_wp = uu____6557;
-                         FStar_TypeChecker_Env.mlift_term = Some lift;_};_}
-                   ->
-                   let uu____6575 = FStar_Syntax_Util.mk_reify e in
-                   lift t FStar_Syntax_Syntax.tun uu____6575)
-and norm_pattern_args:
-  cfg ->
-    env ->
-      ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-        Prims.list ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) Prims.list
-          Prims.list
-  =
-  fun cfg  ->
-    fun env  ->
-      fun args  ->
-        FStar_All.pipe_right args
-          (FStar_List.map
-             (FStar_List.map
-                (fun uu____6605  ->
-                   match uu____6605 with
-                   | (a,imp) ->
-                       let uu____6612 = norm cfg env [] a in
-                       (uu____6612, imp))))
-and norm_comp:
-  cfg -> env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp =
-  fun cfg  ->
-    fun env  ->
-      fun comp  ->
-        let comp1 = ghost_to_pure_aux cfg env comp in
-        match comp1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total (t,uopt) ->
-            let uu___169_6627 = comp1 in
-            let uu____6630 =
-              let uu____6631 =
-                let uu____6637 = norm cfg env [] t in
-                let uu____6638 =
-                  FStar_Option.map (norm_universe cfg env) uopt in
-                (uu____6637, uu____6638) in
-              FStar_Syntax_Syntax.Total uu____6631 in
-            {
-              FStar_Syntax_Syntax.n = uu____6630;
-              FStar_Syntax_Syntax.tk = (uu___169_6627.FStar_Syntax_Syntax.tk);
-              FStar_Syntax_Syntax.pos =
-                (uu___169_6627.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___169_6627.FStar_Syntax_Syntax.vars)
-            }
-        | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-            let uu___170_6653 = comp1 in
-            let uu____6656 =
-              let uu____6657 =
-                let uu____6663 = norm cfg env [] t in
-                let uu____6664 =
-                  FStar_Option.map (norm_universe cfg env) uopt in
-                (uu____6663, uu____6664) in
-              FStar_Syntax_Syntax.GTotal uu____6657 in
-            {
-              FStar_Syntax_Syntax.n = uu____6656;
-              FStar_Syntax_Syntax.tk = (uu___170_6653.FStar_Syntax_Syntax.tk);
-              FStar_Syntax_Syntax.pos =
-                (uu___170_6653.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___170_6653.FStar_Syntax_Syntax.vars)
-            }
-        | FStar_Syntax_Syntax.Comp ct ->
-            let norm_args args =
-              FStar_All.pipe_right args
-                (FStar_List.map
-                   (fun uu____6695  ->
-                      match uu____6695 with
-                      | (a,i) ->
-                          let uu____6702 = norm cfg env [] a in
-                          (uu____6702, i))) in
-            let flags =
-              FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
-                (FStar_List.map
-                   (fun uu___135_6707  ->
-                      match uu___135_6707 with
-                      | FStar_Syntax_Syntax.DECREASES t ->
-                          let uu____6711 = norm cfg env [] t in
-                          FStar_Syntax_Syntax.DECREASES uu____6711
-                      | f -> f)) in
-            let uu___171_6715 = comp1 in
-            let uu____6718 =
-              let uu____6719 =
-                let uu___172_6720 = ct in
-                let uu____6721 =
-                  FStar_List.map (norm_universe cfg env)
-                    ct.FStar_Syntax_Syntax.comp_univs in
-                let uu____6722 =
-                  norm cfg env [] ct.FStar_Syntax_Syntax.result_typ in
-                let uu____6725 = norm_args ct.FStar_Syntax_Syntax.effect_args in
-                {
-                  FStar_Syntax_Syntax.comp_univs = uu____6721;
-                  FStar_Syntax_Syntax.effect_name =
-                    (uu___172_6720.FStar_Syntax_Syntax.effect_name);
-                  FStar_Syntax_Syntax.result_typ = uu____6722;
-                  FStar_Syntax_Syntax.effect_args = uu____6725;
-                  FStar_Syntax_Syntax.flags = flags
-                } in
-              FStar_Syntax_Syntax.Comp uu____6719 in
-            {
-              FStar_Syntax_Syntax.n = uu____6718;
-              FStar_Syntax_Syntax.tk = (uu___171_6715.FStar_Syntax_Syntax.tk);
-              FStar_Syntax_Syntax.pos =
-                (uu___171_6715.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___171_6715.FStar_Syntax_Syntax.vars)
-            }
-and ghost_to_pure_aux:
-  cfg ->
-    env ->
-      FStar_Syntax_Syntax.comp ->
-        (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun cfg  ->
-    fun env  ->
-      fun c  ->
-        let norm1 t =
-          norm
-            (let uu___173_6742 = cfg in
-             {
-               steps =
-                 [Eager_unfolding;
-                 UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
-                 AllowUnboundUniverses];
-               tcenv = (uu___173_6742.tcenv);
-               delta_level = (uu___173_6742.delta_level);
-               primitive_steps = (uu___173_6742.primitive_steps)
-             }) env [] t in
-        let non_info t =
-          let uu____6747 = norm1 t in
-          FStar_Syntax_Util.non_informative uu____6747 in
-        match c.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total uu____6750 -> c
-        | FStar_Syntax_Syntax.GTotal (t,uopt) when non_info t ->
-            let uu___174_6764 = c in
-            {
-              FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
-              FStar_Syntax_Syntax.tk = (uu___174_6764.FStar_Syntax_Syntax.tk);
-              FStar_Syntax_Syntax.pos =
-                (uu___174_6764.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___174_6764.FStar_Syntax_Syntax.vars)
-            }
-        | FStar_Syntax_Syntax.Comp ct ->
-            let l =
-              FStar_TypeChecker_Env.norm_eff_name cfg.tcenv
-                ct.FStar_Syntax_Syntax.effect_name in
-            let uu____6774 =
-              (FStar_Syntax_Util.is_ghost_effect l) &&
-                (non_info ct.FStar_Syntax_Syntax.result_typ) in
-            if uu____6774
-            then
-              let ct1 =
-                match downgrade_ghost_effect_name
-                        ct.FStar_Syntax_Syntax.effect_name
-                with
-                | Some pure_eff ->
-                    let uu___175_6779 = ct in
-                    {
-                      FStar_Syntax_Syntax.comp_univs =
-                        (uu___175_6779.FStar_Syntax_Syntax.comp_univs);
-                      FStar_Syntax_Syntax.effect_name = pure_eff;
-                      FStar_Syntax_Syntax.result_typ =
-                        (uu___175_6779.FStar_Syntax_Syntax.result_typ);
-                      FStar_Syntax_Syntax.effect_args =
-                        (uu___175_6779.FStar_Syntax_Syntax.effect_args);
-                      FStar_Syntax_Syntax.flags =
-                        (uu___175_6779.FStar_Syntax_Syntax.flags)
-                    }
-                | None  ->
-                    let ct1 =
-                      FStar_TypeChecker_Env.unfold_effect_abbrev cfg.tcenv c in
-                    let uu___176_6781 = ct1 in
-                    {
-                      FStar_Syntax_Syntax.comp_univs =
-                        (uu___176_6781.FStar_Syntax_Syntax.comp_univs);
-                      FStar_Syntax_Syntax.effect_name =
-                        FStar_Syntax_Const.effect_PURE_lid;
-                      FStar_Syntax_Syntax.result_typ =
-                        (uu___176_6781.FStar_Syntax_Syntax.result_typ);
-                      FStar_Syntax_Syntax.effect_args =
-                        (uu___176_6781.FStar_Syntax_Syntax.effect_args);
-                      FStar_Syntax_Syntax.flags =
-                        (uu___176_6781.FStar_Syntax_Syntax.flags)
-                    } in
-              let uu___177_6782 = c in
-              {
-                FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-                FStar_Syntax_Syntax.tk =
-                  (uu___177_6782.FStar_Syntax_Syntax.tk);
-                FStar_Syntax_Syntax.pos =
-                  (uu___177_6782.FStar_Syntax_Syntax.pos);
-                FStar_Syntax_Syntax.vars =
-                  (uu___177_6782.FStar_Syntax_Syntax.vars)
-              }
-            else c
-        | uu____6788 -> c
-and norm_binder:
-  cfg ->
-    env ->
-      FStar_Syntax_Syntax.binder ->
-        (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual)
-  =
-  fun cfg  ->
-    fun env  ->
-      fun uu____6791  ->
-        match uu____6791 with
-        | (x,imp) ->
-            let uu____6794 =
-              let uu___178_6795 = x in
-              let uu____6796 = norm cfg env [] x.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname =
-                  (uu___178_6795.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___178_6795.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____6796
-              } in
-            (uu____6794, imp)
-and norm_binders:
-  cfg -> env -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders =
-  fun cfg  ->
-    fun env  ->
-      fun bs  ->
-        let uu____6802 =
-          FStar_List.fold_left
-            (fun uu____6809  ->
-               fun b  ->
-                 match uu____6809 with
-                 | (nbs',env1) ->
-                     let b1 = norm_binder cfg env1 b in
-                     ((b1 :: nbs'), (Dummy :: env1))) ([], env) bs in
-        match uu____6802 with | (nbs,uu____6826) -> FStar_List.rev nbs
-and norm_lcomp_opt:
-  cfg ->
-    env ->
-      (FStar_Syntax_Syntax.lcomp,FStar_Syntax_Syntax.residual_comp)
-        FStar_Util.either Prims.option ->
-        (FStar_Syntax_Syntax.lcomp,FStar_Syntax_Syntax.residual_comp)
-          FStar_Util.either Prims.option
-  =
-  fun cfg  ->
-    fun env  ->
-      fun lopt  ->
-        match lopt with
-        | Some (FStar_Util.Inl lc) ->
-            let flags = filter_out_lcomp_cflags lc in
-            let uu____6843 = FStar_Syntax_Util.is_tot_or_gtot_lcomp lc in
-            if uu____6843
-            then
-              let t = norm cfg env [] lc.FStar_Syntax_Syntax.res_typ in
-              let uu____6848 = FStar_Syntax_Util.is_total_lcomp lc in
-              (if uu____6848
-               then
-                 let uu____6852 =
-                   let uu____6855 =
-                     let uu____6856 =
-                       let uu____6859 = FStar_Syntax_Syntax.mk_Total t in
-                       FStar_Syntax_Util.comp_set_flags uu____6859 flags in
-                     FStar_Syntax_Util.lcomp_of_comp uu____6856 in
-                   FStar_Util.Inl uu____6855 in
-                 Some uu____6852
-               else
-                 (let uu____6863 =
-                    let uu____6866 =
-                      let uu____6867 =
-                        let uu____6870 = FStar_Syntax_Syntax.mk_GTotal t in
-                        FStar_Syntax_Util.comp_set_flags uu____6870 flags in
-                      FStar_Syntax_Util.lcomp_of_comp uu____6867 in
-                    FStar_Util.Inl uu____6866 in
-                  Some uu____6863))
-            else
-              Some
-                (FStar_Util.Inr ((lc.FStar_Syntax_Syntax.eff_name), flags))
-        | uu____6883 -> lopt
-and rebuild:
-  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun cfg  ->
-    fun env  ->
-      fun stack1  ->
-        fun t  ->
-          match stack1 with
-          | [] -> t
-          | (Debug tm)::stack2 ->
-              ((let uu____6895 =
-                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug cfg.tcenv)
-                    (FStar_Options.Other "print_normalized_terms") in
-                if uu____6895
-                then
-                  let uu____6896 = FStar_Syntax_Print.term_to_string tm in
-                  let uu____6897 = FStar_Syntax_Print.term_to_string t in
-                  FStar_Util.print2 "Normalized %s to %s\n" uu____6896
-                    uu____6897
-                else ());
-               rebuild cfg env stack2 t)
-          | (Steps (s,ps,dl))::stack2 ->
-              rebuild
-                (let uu___179_6908 = cfg in
-                 {
-                   steps = s;
-                   tcenv = (uu___179_6908.tcenv);
-                   delta_level = dl;
-                   primitive_steps = ps
-                 }) env stack2 t
-          | (Meta (m,r))::stack2 ->
-              let t1 = mk (FStar_Syntax_Syntax.Tm_meta (t, m)) r in
-              rebuild cfg env stack2 t1
-          | (MemoLazy r)::stack2 ->
-              (set_memo r (env, t);
-               log cfg
-                 (fun uu____6928  ->
-                    let uu____6929 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1 "\tSet memo %s\n" uu____6929);
-               rebuild cfg env stack2 t)
-          | (Let (env',bs,lb,r))::stack2 ->
-              let body = FStar_Syntax_Subst.close bs t in
-              let t1 =
-                FStar_Syntax_Syntax.mk
-                  (FStar_Syntax_Syntax.Tm_let ((false, [lb]), body)) None r in
-              rebuild cfg env' stack2 t1
-          | (Abs (env',bs,env'',lopt,r))::stack2 ->
-              let bs1 = norm_binders cfg env' bs in
-              let lopt1 = norm_lcomp_opt cfg env'' lopt in
-              let uu____6966 =
-                let uu___180_6967 = FStar_Syntax_Util.abs bs1 t lopt1 in
-                {
-                  FStar_Syntax_Syntax.n =
-                    (uu___180_6967.FStar_Syntax_Syntax.n);
-                  FStar_Syntax_Syntax.tk =
-                    (uu___180_6967.FStar_Syntax_Syntax.tk);
-                  FStar_Syntax_Syntax.pos = r;
-                  FStar_Syntax_Syntax.vars =
-                    (uu___180_6967.FStar_Syntax_Syntax.vars)
-                } in
-              rebuild cfg env stack2 uu____6966
-          | (Arg (Univ _,_,_))::_|(Arg (Dummy ,_,_))::_ ->
-              failwith "Impossible"
-          | (UnivArgs (us,r))::stack2 ->
-              let t1 = FStar_Syntax_Syntax.mk_Tm_uinst t us in
-              rebuild cfg env stack2 t1
-          | (Arg (Clos (env1,tm,m,uu____6989),aq,r))::stack2 ->
-              (log cfg
-                 (fun uu____7005  ->
-                    let uu____7006 = FStar_Syntax_Print.term_to_string tm in
-                    FStar_Util.print1 "Rebuilding with arg %s\n" uu____7006);
-               if FStar_List.contains (Exclude Iota) cfg.steps
-               then
-                 (if FStar_List.contains WHNF cfg.steps
-                  then
-                    let arg = closure_as_term cfg env1 tm in
-                    let t1 =
-                      FStar_Syntax_Syntax.extend_app t (arg, aq) None r in
-                    rebuild cfg env1 stack2 t1
-                  else
-                    (let stack3 = (App (t, aq, r)) :: stack2 in
-                     norm cfg env1 stack3 tm))
-               else
-                 (let uu____7017 = FStar_ST.read m in
-                  match uu____7017 with
-                  | None  ->
-                      if FStar_List.contains WHNF cfg.steps
-                      then
-                        let arg = closure_as_term cfg env1 tm in
-                        let t1 =
-                          FStar_Syntax_Syntax.extend_app t (arg, aq) None r in
-                        rebuild cfg env1 stack2 t1
-                      else
-                        (let stack3 = (MemoLazy m) :: (App (t, aq, r)) ::
-                           stack2 in
-                         norm cfg env1 stack3 tm)
-                  | Some (uu____7043,a) ->
-                      let t1 =
-                        FStar_Syntax_Syntax.extend_app t (a, aq) None r in
-                      rebuild cfg env1 stack2 t1))
-          | (App (head1,aq,r))::stack2 ->
-              let t1 = FStar_Syntax_Syntax.extend_app head1 (t, aq) None r in
-              let uu____7065 = maybe_simplify cfg t1 in
-              rebuild cfg env stack2 uu____7065
-          | (Match (env1,branches,r))::stack2 ->
-              (log cfg
-                 (fun uu____7072  ->
-                    let uu____7073 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1
-                      "Rebuilding with match, scrutinee is %s ...\n"
-                      uu____7073);
-               (let scrutinee = t in
-                let norm_and_rebuild_match uu____7078 =
-                  log cfg
-                    (fun uu____7080  ->
-                       let uu____7081 =
-                         FStar_Syntax_Print.term_to_string scrutinee in
-                       let uu____7082 =
-                         let uu____7083 =
-                           FStar_All.pipe_right branches
-                             (FStar_List.map
-                                (fun uu____7090  ->
-                                   match uu____7090 with
-                                   | (p,uu____7096,uu____7097) ->
-                                       FStar_Syntax_Print.pat_to_string p)) in
-                         FStar_All.pipe_right uu____7083
-                           (FStar_String.concat "\n\t") in
-                       FStar_Util.print2
-                         "match is irreducible: scrutinee=%s\nbranches=%s\n"
-                         uu____7081 uu____7082);
-                  (let whnf = FStar_List.contains WHNF cfg.steps in
-                   let cfg_exclude_iota_zeta =
-                     let new_delta =
-                       FStar_All.pipe_right cfg.delta_level
-                         (FStar_List.filter
-                            (fun uu___136_7107  ->
-                               match uu___136_7107 with
-                               | FStar_TypeChecker_Env.Inlining 
-                                 |FStar_TypeChecker_Env.Eager_unfolding_only 
-                                   -> true
-                               | uu____7108 -> false)) in
-                     let steps' =
-                       let uu____7111 =
-                         FStar_All.pipe_right cfg.steps
-                           (FStar_List.contains
-                              PureSubtermsWithinComputations) in
-                       if uu____7111
-                       then [Exclude Zeta]
-                       else [Exclude Iota; Exclude Zeta] in
-                     let uu___181_7114 = cfg in
-                     {
-                       steps = (FStar_List.append steps' cfg.steps);
-                       tcenv = (uu___181_7114.tcenv);
-                       delta_level = new_delta;
-                       primitive_steps = (uu___181_7114.primitive_steps)
-                     } in
-                   let norm_or_whnf env2 t1 =
-                     if whnf
-                     then closure_as_term cfg_exclude_iota_zeta env2 t1
-                     else norm cfg_exclude_iota_zeta env2 [] t1 in
-                   let rec norm_pat env2 p =
-                     match p.FStar_Syntax_Syntax.v with
-                     | FStar_Syntax_Syntax.Pat_constant uu____7148 ->
-                         (p, env2)
-                     | FStar_Syntax_Syntax.Pat_disj [] ->
-                         failwith "Impossible"
-                     | FStar_Syntax_Syntax.Pat_disj (hd1::tl1) ->
-                         let uu____7168 = norm_pat env2 hd1 in
-                         (match uu____7168 with
-                          | (hd2,env') ->
-                              let tl2 =
-                                FStar_All.pipe_right tl1
-                                  (FStar_List.map
-                                     (fun p1  ->
-                                        let uu____7204 = norm_pat env2 p1 in
-                                        Prims.fst uu____7204)) in
-                              ((let uu___182_7216 = p in
-                                {
-                                  FStar_Syntax_Syntax.v =
-                                    (FStar_Syntax_Syntax.Pat_disj (hd2 ::
-                                       tl2));
-                                  FStar_Syntax_Syntax.ty =
-                                    (uu___182_7216.FStar_Syntax_Syntax.ty);
-                                  FStar_Syntax_Syntax.p =
-                                    (uu___182_7216.FStar_Syntax_Syntax.p)
-                                }), env'))
-                     | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-                         let uu____7233 =
-                           FStar_All.pipe_right pats
-                             (FStar_List.fold_left
-                                (fun uu____7267  ->
-                                   fun uu____7268  ->
-                                     match (uu____7267, uu____7268) with
-                                     | ((pats1,env3),(p1,b)) ->
-                                         let uu____7333 = norm_pat env3 p1 in
-                                         (match uu____7333 with
-                                          | (p2,env4) ->
-                                              (((p2, b) :: pats1), env4)))
-                                ([], env2)) in
-                         (match uu____7233 with
-                          | (pats1,env3) ->
-                              ((let uu___183_7399 = p in
-                                {
-                                  FStar_Syntax_Syntax.v =
-                                    (FStar_Syntax_Syntax.Pat_cons
-                                       (fv, (FStar_List.rev pats1)));
-                                  FStar_Syntax_Syntax.ty =
-                                    (uu___183_7399.FStar_Syntax_Syntax.ty);
-                                  FStar_Syntax_Syntax.p =
-                                    (uu___183_7399.FStar_Syntax_Syntax.p)
-                                }), env3))
-                     | FStar_Syntax_Syntax.Pat_var x ->
-                         let x1 =
-                           let uu___184_7413 = x in
-                           let uu____7414 =
-                             norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
-                           {
-                             FStar_Syntax_Syntax.ppname =
-                               (uu___184_7413.FStar_Syntax_Syntax.ppname);
-                             FStar_Syntax_Syntax.index =
-                               (uu___184_7413.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____7414
-                           } in
-                         ((let uu___185_7420 = p in
-                           {
-                             FStar_Syntax_Syntax.v =
-                               (FStar_Syntax_Syntax.Pat_var x1);
-                             FStar_Syntax_Syntax.ty =
-                               (uu___185_7420.FStar_Syntax_Syntax.ty);
-                             FStar_Syntax_Syntax.p =
-                               (uu___185_7420.FStar_Syntax_Syntax.p)
-                           }), (Dummy :: env2))
-                     | FStar_Syntax_Syntax.Pat_wild x ->
-                         let x1 =
-                           let uu___186_7425 = x in
-                           let uu____7426 =
-                             norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
-                           {
-                             FStar_Syntax_Syntax.ppname =
-                               (uu___186_7425.FStar_Syntax_Syntax.ppname);
-                             FStar_Syntax_Syntax.index =
-                               (uu___186_7425.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____7426
-                           } in
-                         ((let uu___187_7432 = p in
-                           {
-                             FStar_Syntax_Syntax.v =
-                               (FStar_Syntax_Syntax.Pat_wild x1);
-                             FStar_Syntax_Syntax.ty =
-                               (uu___187_7432.FStar_Syntax_Syntax.ty);
-                             FStar_Syntax_Syntax.p =
-                               (uu___187_7432.FStar_Syntax_Syntax.p)
-                           }), (Dummy :: env2))
-                     | FStar_Syntax_Syntax.Pat_dot_term (x,t1) ->
-                         let x1 =
-                           let uu___188_7442 = x in
-                           let uu____7443 =
-                             norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
-                           {
-                             FStar_Syntax_Syntax.ppname =
-                               (uu___188_7442.FStar_Syntax_Syntax.ppname);
-                             FStar_Syntax_Syntax.index =
-                               (uu___188_7442.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____7443
-                           } in
-                         let t2 = norm_or_whnf env2 t1 in
-                         ((let uu___189_7450 = p in
-                           {
-                             FStar_Syntax_Syntax.v =
-                               (FStar_Syntax_Syntax.Pat_dot_term (x1, t2));
-                             FStar_Syntax_Syntax.ty =
-                               (uu___189_7450.FStar_Syntax_Syntax.ty);
-                             FStar_Syntax_Syntax.p =
-                               (uu___189_7450.FStar_Syntax_Syntax.p)
-                           }), env2) in
-                   let branches1 =
-                     match env1 with
-                     | [] when whnf -> branches
-                     | uu____7454 ->
-                         FStar_All.pipe_right branches
-                           (FStar_List.map
-                              (fun branch1  ->
-                                 let uu____7457 =
-                                   FStar_Syntax_Subst.open_branch branch1 in
-                                 match uu____7457 with
-                                 | (p,wopt,e) ->
-                                     let uu____7475 = norm_pat env1 p in
-                                     (match uu____7475 with
-                                      | (p1,env2) ->
-                                          let wopt1 =
-                                            match wopt with
-                                            | None  -> None
-                                            | Some w ->
-                                                let uu____7499 =
-                                                  norm_or_whnf env2 w in
-                                                Some uu____7499 in
-                                          let e1 = norm_or_whnf env2 e in
-                                          FStar_Syntax_Util.branch
-                                            (p1, wopt1, e1)))) in
-                   let uu____7504 =
-                     mk (FStar_Syntax_Syntax.Tm_match (scrutinee, branches1))
-                       r in
-                   rebuild cfg env1 stack2 uu____7504) in
-                let rec is_cons head1 =
-                  match head1.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_uinst (h,uu____7514) -> is_cons h
-                  | FStar_Syntax_Syntax.Tm_constant _
-                    |FStar_Syntax_Syntax.Tm_fvar
-                     { FStar_Syntax_Syntax.fv_name = _;
-                       FStar_Syntax_Syntax.fv_delta = _;
-                       FStar_Syntax_Syntax.fv_qual = Some
-                         (FStar_Syntax_Syntax.Data_ctor );_}
-                     |FStar_Syntax_Syntax.Tm_fvar
-                     { FStar_Syntax_Syntax.fv_name = _;
-                       FStar_Syntax_Syntax.fv_delta = _;
-                       FStar_Syntax_Syntax.fv_qual = Some
-                         (FStar_Syntax_Syntax.Record_ctor _);_}
-                      -> true
-                  | uu____7525 -> false in
-                let guard_when_clause wopt b rest =
-                  match wopt with
-                  | None  -> b
-                  | Some w ->
-                      let then_branch = b in
-                      let else_branch =
-                        mk (FStar_Syntax_Syntax.Tm_match (scrutinee, rest)) r in
-                      FStar_Syntax_Util.if_then_else w then_branch
-                        else_branch in
-                let rec matches_pat scrutinee1 p =
-                  let scrutinee2 = FStar_Syntax_Util.unmeta scrutinee1 in
-                  let uu____7624 = FStar_Syntax_Util.head_and_args scrutinee2 in
-                  match uu____7624 with
-                  | (head1,args) ->
-                      (match p.FStar_Syntax_Syntax.v with
-                       | FStar_Syntax_Syntax.Pat_disj ps ->
-                           let mopt =
-                             FStar_Util.find_map ps
-                               (fun p1  ->
-                                  let m = matches_pat scrutinee2 p1 in
-                                  match m with
-                                  | FStar_Util.Inl uu____7681 -> Some m
-                                  | FStar_Util.Inr (true ) -> Some m
-                                  | FStar_Util.Inr (false ) -> None) in
-                           (match mopt with
-                            | None  -> FStar_Util.Inr false
-                            | Some m -> m)
-                       | FStar_Syntax_Syntax.Pat_var _
-                         |FStar_Syntax_Syntax.Pat_wild _ ->
-                           FStar_Util.Inl [scrutinee2]
-                       | FStar_Syntax_Syntax.Pat_dot_term uu____7712 ->
-                           FStar_Util.Inl []
-                       | FStar_Syntax_Syntax.Pat_constant s ->
-                           (match scrutinee2.FStar_Syntax_Syntax.n with
-                            | FStar_Syntax_Syntax.Tm_constant s' when 
-                                s = s' -> FStar_Util.Inl []
-                            | uu____7724 ->
-                                let uu____7725 =
-                                  let uu____7726 = is_cons head1 in
-                                  Prims.op_Negation uu____7726 in
-                                FStar_Util.Inr uu____7725)
-                       | FStar_Syntax_Syntax.Pat_cons (fv,arg_pats) ->
-                           let uu____7740 =
-                             let uu____7741 =
-                               FStar_Syntax_Util.un_uinst head1 in
-                             uu____7741.FStar_Syntax_Syntax.n in
-                           (match uu____7740 with
-                            | FStar_Syntax_Syntax.Tm_fvar fv' when
-                                FStar_Syntax_Syntax.fv_eq fv fv' ->
-                                matches_args [] args arg_pats
-                            | uu____7748 ->
-                                let uu____7749 =
-                                  let uu____7750 = is_cons head1 in
-                                  Prims.op_Negation uu____7750 in
-                                FStar_Util.Inr uu____7749))
-                and matches_args out a p =
-                  match (a, p) with
-                  | ([],[]) -> FStar_Util.Inl out
-                  | ((t1,uu____7784)::rest_a,(p1,uu____7787)::rest_p) ->
-                      let uu____7815 = matches_pat t1 p1 in
-                      (match uu____7815 with
-                       | FStar_Util.Inl s ->
-                           matches_args (FStar_List.append out s) rest_a
-                             rest_p
-                       | m -> m)
-                  | uu____7829 -> FStar_Util.Inr false in
-                let rec matches scrutinee1 p =
-                  match p with
-                  | [] -> norm_and_rebuild_match ()
-                  | (p1,wopt,b)::rest ->
-                      let uu____7900 = matches_pat scrutinee1 p1 in
-                      (match uu____7900 with
-                       | FStar_Util.Inr (false ) -> matches scrutinee1 rest
-                       | FStar_Util.Inr (true ) -> norm_and_rebuild_match ()
-                       | FStar_Util.Inl s ->
-                           (log cfg
-                              (fun uu____7910  ->
-                                 let uu____7911 =
-                                   FStar_Syntax_Print.pat_to_string p1 in
-                                 let uu____7912 =
-                                   let uu____7913 =
-                                     FStar_List.map
-                                       FStar_Syntax_Print.term_to_string s in
-                                   FStar_All.pipe_right uu____7913
-                                     (FStar_String.concat "; ") in
-                                 FStar_Util.print2
-                                   "Matches pattern %s with subst = %s\n"
-                                   uu____7911 uu____7912);
-                            (let env2 =
-                               FStar_List.fold_left
-                                 (fun env2  ->
-                                    fun t1  ->
-                                      let uu____7922 =
-                                        let uu____7923 =
-                                          let uu____7933 =
-                                            FStar_Util.mk_ref (Some ([], t1)) in
-                                          ([], t1, uu____7933, false) in
-                                        Clos uu____7923 in
-                                      uu____7922 :: env2) env1 s in
-                             let uu____7956 = guard_when_clause wopt b rest in
-                             norm cfg env2 stack2 uu____7956))) in
-                let uu____7957 =
-                  FStar_All.pipe_right cfg.steps
-                    (FStar_List.contains (Exclude Iota)) in
-                if uu____7957
-                then norm_and_rebuild_match ()
-                else matches scrutinee branches))
-let config: step Prims.list -> FStar_TypeChecker_Env.env -> cfg =
-  fun s  ->
-    fun e  ->
-      let d =
-        FStar_All.pipe_right s
-          (FStar_List.collect
-             (fun uu___137_7971  ->
-                match uu___137_7971 with
-                | UnfoldUntil k -> [FStar_TypeChecker_Env.Unfold k]
-                | Eager_unfolding  ->
-                    [FStar_TypeChecker_Env.Eager_unfolding_only]
-                | Inlining  -> [FStar_TypeChecker_Env.Inlining]
-                | uu____7974 -> [])) in
-      let d1 =
-        match d with
-        | [] -> [FStar_TypeChecker_Env.NoDelta]
-        | uu____7978 -> d in
-      {
-        steps = s;
-        tcenv = e;
-        delta_level = d1;
-        primitive_steps =
-          (FStar_List.append built_in_primitive_steps equality_ops)
-      }
-let normalize_with_primitive_steps:
-  primitive_step Prims.list ->
-    step Prims.list ->
-      FStar_TypeChecker_Env.env ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun ps  ->
-    fun s  ->
-      fun e  ->
-        fun t  ->
-          let c = config s e in
-          let c1 =
-            let uu___190_7998 = config s e in
-            {
-              steps = (uu___190_7998.steps);
-              tcenv = (uu___190_7998.tcenv);
-              delta_level = (uu___190_7998.delta_level);
-              primitive_steps = (FStar_List.append c.primitive_steps ps)
-            } in
-          norm c1 [] [] t
-let normalize:
-  steps ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  = fun s  -> fun e  -> fun t  -> normalize_with_primitive_steps [] s e t
-let normalize_comp:
-  steps ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
-  =
-  fun s  ->
-    fun e  ->
-      fun t  -> let uu____8017 = config s e in norm_comp uu____8017 [] t
-let normalize_universe:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
-  =
-  fun env  ->
-    fun u  -> let uu____8024 = config [] env in norm_universe uu____8024 [] u
-let ghost_to_pure:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    fun c  ->
-      let uu____8031 = config [] env in ghost_to_pure_aux uu____8031 [] c
-let ghost_to_pure_lcomp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun lc  ->
-      let cfg =
-        config
-          [Eager_unfolding;
-          UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
-          EraseUniverses;
-          AllowUnboundUniverses] env in
-      let non_info t =
-        let uu____8043 = norm cfg [] [] t in
-        FStar_Syntax_Util.non_informative uu____8043 in
-      let uu____8044 =
-        (FStar_Syntax_Util.is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
-          && (non_info lc.FStar_Syntax_Syntax.res_typ) in
-      if uu____8044
-      then
-        match downgrade_ghost_effect_name lc.FStar_Syntax_Syntax.eff_name
-        with
-        | Some pure_eff ->
-            let uu___191_8046 = lc in
-            {
-              FStar_Syntax_Syntax.eff_name = pure_eff;
-              FStar_Syntax_Syntax.res_typ =
-                (uu___191_8046.FStar_Syntax_Syntax.res_typ);
-              FStar_Syntax_Syntax.cflags =
-                (uu___191_8046.FStar_Syntax_Syntax.cflags);
-              FStar_Syntax_Syntax.comp =
-                ((fun uu____8047  ->
-                    let uu____8048 = lc.FStar_Syntax_Syntax.comp () in
-                    ghost_to_pure env uu____8048))
-            }
-        | None  -> lc
-      else lc
-let term_to_string:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
-  fun env  ->
-    fun t  ->
-      let uu____8056 = normalize [AllowUnboundUniverses] env t in
-      FStar_Syntax_Print.term_to_string uu____8056
-let comp_to_string:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.comp -> Prims.string =
-  fun env  ->
-    fun c  ->
-      let uu____8063 =
-        let uu____8064 = config [AllowUnboundUniverses] env in
-        norm_comp uu____8064 [] c in
-      FStar_Syntax_Print.comp_to_string uu____8063
-let normalize_refinement:
-  steps ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax
-  =
-  fun steps  ->
-    fun env  ->
-      fun t0  ->
-        let t = normalize (FStar_List.append steps [Beta]) env t0 in
-        let rec aux t1 =
-          let t2 = FStar_Syntax_Subst.compress t1 in
-          match t2.FStar_Syntax_Syntax.n with
-          | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-              let t01 = aux x.FStar_Syntax_Syntax.sort in
-              (match t01.FStar_Syntax_Syntax.n with
-               | FStar_Syntax_Syntax.Tm_refine (y,phi1) ->
-                   let uu____8101 =
-                     let uu____8102 =
-                       let uu____8107 = FStar_Syntax_Util.mk_conj phi1 phi in
-                       (y, uu____8107) in
-                     FStar_Syntax_Syntax.Tm_refine uu____8102 in
-                   mk uu____8101 t01.FStar_Syntax_Syntax.pos
-               | uu____8112 -> t2)
-          | uu____8113 -> t2 in
-        aux t
-let eta_expand_with_type:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun t  ->
-    fun sort  ->
-      let uu____8120 = FStar_Syntax_Util.arrow_formals_comp sort in
-      match uu____8120 with
-      | (binders,c) ->
-          (match binders with
-           | [] -> t
-           | uu____8136 ->
-               let uu____8140 =
-                 FStar_All.pipe_right binders
-                   FStar_Syntax_Util.args_of_binders in
-               (match uu____8140 with
-                | (binders1,args) ->
-                    let uu____8150 =
-                      (FStar_Syntax_Syntax.mk_Tm_app t args) None
-                        t.FStar_Syntax_Syntax.pos in
-                    let uu____8155 =
-                      let uu____8162 =
-                        FStar_All.pipe_right
-                          (FStar_Syntax_Util.lcomp_of_comp c)
-                          (fun _0_33  -> FStar_Util.Inl _0_33) in
-                      FStar_All.pipe_right uu____8162
-                        (fun _0_34  -> Some _0_34) in
-                    FStar_Syntax_Util.abs binders1 uu____8150 uu____8155))
-let eta_expand:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-  =
-  fun env  ->
-    fun t  ->
-      let uu____8198 =
-        let uu____8202 = FStar_ST.read t.FStar_Syntax_Syntax.tk in
-        (uu____8202, (t.FStar_Syntax_Syntax.n)) in
-      match uu____8198 with
-      | (Some sort,uu____8209) ->
-          let uu____8211 = mk sort t.FStar_Syntax_Syntax.pos in
-          eta_expand_with_type t uu____8211
-      | (uu____8212,FStar_Syntax_Syntax.Tm_name x) ->
-          eta_expand_with_type t x.FStar_Syntax_Syntax.sort
-      | uu____8216 ->
-          let uu____8220 = FStar_Syntax_Util.head_and_args t in
-          (match uu____8220 with
-           | (head1,args) ->
-               let uu____8246 =
-                 let uu____8247 = FStar_Syntax_Subst.compress head1 in
-                 uu____8247.FStar_Syntax_Syntax.n in
-               (match uu____8246 with
-                | FStar_Syntax_Syntax.Tm_uvar (uu____8250,thead) ->
-                    let uu____8264 = FStar_Syntax_Util.arrow_formals thead in
-                    (match uu____8264 with
-                     | (formals,tres) ->
-                         if
-                           (FStar_List.length formals) =
-                             (FStar_List.length args)
-                         then t
-                         else
-                           (let uu____8295 =
-                              env.FStar_TypeChecker_Env.type_of
-                                (let uu___192_8299 = env in
-                                 {
-                                   FStar_TypeChecker_Env.solver =
-                                     (uu___192_8299.FStar_TypeChecker_Env.solver);
-                                   FStar_TypeChecker_Env.range =
-                                     (uu___192_8299.FStar_TypeChecker_Env.range);
-                                   FStar_TypeChecker_Env.curmodule =
-                                     (uu___192_8299.FStar_TypeChecker_Env.curmodule);
-                                   FStar_TypeChecker_Env.gamma =
-                                     (uu___192_8299.FStar_TypeChecker_Env.gamma);
-                                   FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___192_8299.FStar_TypeChecker_Env.gamma_cache);
-                                   FStar_TypeChecker_Env.modules =
-                                     (uu___192_8299.FStar_TypeChecker_Env.modules);
-                                   FStar_TypeChecker_Env.expected_typ = None;
-                                   FStar_TypeChecker_Env.sigtab =
-                                     (uu___192_8299.FStar_TypeChecker_Env.sigtab);
-                                   FStar_TypeChecker_Env.is_pattern =
-                                     (uu___192_8299.FStar_TypeChecker_Env.is_pattern);
-                                   FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___192_8299.FStar_TypeChecker_Env.instantiate_imp);
-                                   FStar_TypeChecker_Env.effects =
-                                     (uu___192_8299.FStar_TypeChecker_Env.effects);
-                                   FStar_TypeChecker_Env.generalize =
-                                     (uu___192_8299.FStar_TypeChecker_Env.generalize);
-                                   FStar_TypeChecker_Env.letrecs =
-                                     (uu___192_8299.FStar_TypeChecker_Env.letrecs);
-                                   FStar_TypeChecker_Env.top_level =
-                                     (uu___192_8299.FStar_TypeChecker_Env.top_level);
-                                   FStar_TypeChecker_Env.check_uvars =
-                                     (uu___192_8299.FStar_TypeChecker_Env.check_uvars);
-                                   FStar_TypeChecker_Env.use_eq =
-                                     (uu___192_8299.FStar_TypeChecker_Env.use_eq);
-                                   FStar_TypeChecker_Env.is_iface =
-                                     (uu___192_8299.FStar_TypeChecker_Env.is_iface);
-                                   FStar_TypeChecker_Env.admit =
-                                     (uu___192_8299.FStar_TypeChecker_Env.admit);
-                                   FStar_TypeChecker_Env.lax = true;
-                                   FStar_TypeChecker_Env.lax_universes =
-                                     (uu___192_8299.FStar_TypeChecker_Env.lax_universes);
-                                   FStar_TypeChecker_Env.type_of =
-                                     (uu___192_8299.FStar_TypeChecker_Env.type_of);
-                                   FStar_TypeChecker_Env.universe_of =
-                                     (uu___192_8299.FStar_TypeChecker_Env.universe_of);
-                                   FStar_TypeChecker_Env.use_bv_sorts = true;
-                                   FStar_TypeChecker_Env.qname_and_index =
-                                     (uu___192_8299.FStar_TypeChecker_Env.qname_and_index)
-                                 }) t in
-                            match uu____8295 with
-                            | (uu____8300,ty,uu____8302) ->
-                                eta_expand_with_type t ty))
-                | uu____8303 ->
-                    let uu____8304 =
-                      env.FStar_TypeChecker_Env.type_of
-                        (let uu___193_8308 = env in
-                         {
-                           FStar_TypeChecker_Env.solver =
-                             (uu___193_8308.FStar_TypeChecker_Env.solver);
-                           FStar_TypeChecker_Env.range =
-                             (uu___193_8308.FStar_TypeChecker_Env.range);
-                           FStar_TypeChecker_Env.curmodule =
-                             (uu___193_8308.FStar_TypeChecker_Env.curmodule);
-                           FStar_TypeChecker_Env.gamma =
-                             (uu___193_8308.FStar_TypeChecker_Env.gamma);
-                           FStar_TypeChecker_Env.gamma_cache =
-                             (uu___193_8308.FStar_TypeChecker_Env.gamma_cache);
-                           FStar_TypeChecker_Env.modules =
-                             (uu___193_8308.FStar_TypeChecker_Env.modules);
-                           FStar_TypeChecker_Env.expected_typ = None;
-                           FStar_TypeChecker_Env.sigtab =
-                             (uu___193_8308.FStar_TypeChecker_Env.sigtab);
-                           FStar_TypeChecker_Env.is_pattern =
-                             (uu___193_8308.FStar_TypeChecker_Env.is_pattern);
-                           FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___193_8308.FStar_TypeChecker_Env.instantiate_imp);
-                           FStar_TypeChecker_Env.effects =
-                             (uu___193_8308.FStar_TypeChecker_Env.effects);
-                           FStar_TypeChecker_Env.generalize =
-                             (uu___193_8308.FStar_TypeChecker_Env.generalize);
-                           FStar_TypeChecker_Env.letrecs =
-                             (uu___193_8308.FStar_TypeChecker_Env.letrecs);
-                           FStar_TypeChecker_Env.top_level =
-                             (uu___193_8308.FStar_TypeChecker_Env.top_level);
-                           FStar_TypeChecker_Env.check_uvars =
-                             (uu___193_8308.FStar_TypeChecker_Env.check_uvars);
-                           FStar_TypeChecker_Env.use_eq =
-                             (uu___193_8308.FStar_TypeChecker_Env.use_eq);
-                           FStar_TypeChecker_Env.is_iface =
-                             (uu___193_8308.FStar_TypeChecker_Env.is_iface);
-                           FStar_TypeChecker_Env.admit =
-                             (uu___193_8308.FStar_TypeChecker_Env.admit);
-                           FStar_TypeChecker_Env.lax = true;
-                           FStar_TypeChecker_Env.lax_universes =
-                             (uu___193_8308.FStar_TypeChecker_Env.lax_universes);
-                           FStar_TypeChecker_Env.type_of =
-                             (uu___193_8308.FStar_TypeChecker_Env.type_of);
-                           FStar_TypeChecker_Env.universe_of =
-                             (uu___193_8308.FStar_TypeChecker_Env.universe_of);
-                           FStar_TypeChecker_Env.use_bv_sorts = true;
-                           FStar_TypeChecker_Env.qname_and_index =
-                             (uu___193_8308.FStar_TypeChecker_Env.qname_and_index)
-                         }) t in
-                    (match uu____8304 with
-                     | (uu____8309,ty,uu____8311) ->
-                         eta_expand_with_type t ty)))
+| Arg of (closure * FStar_Syntax_Syntax.aqual * FStar_Range.range)
+| UnivArgs of (FStar_Syntax_Syntax.universe Prims.list * FStar_Range.range)
+| MemoLazy of (env * FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo
+| Match of (env * branches * FStar_Range.range)
+| Abs of (env * FStar_Syntax_Syntax.binders * env * (FStar_Syntax_Syntax.lcomp, FStar_Syntax_Syntax.residual_comp) FStar_Util.either Prims.option * FStar_Range.range)
+| App of (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual * FStar_Range.range)
+| Meta of (FStar_Syntax_Syntax.metadata * FStar_Range.range)
+| Let of (env * FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.letbinding * FStar_Range.range)
+| Steps of (steps * primitive_step Prims.list * FStar_TypeChecker_Env.delta_level Prims.list)
+| Debug of FStar_Syntax_Syntax.term
+
+
+let uu___is_Arg : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Arg (_0) -> begin
+true
+end
+| uu____340 -> begin
+false
+end))
+
+
+let __proj__Arg__item___0 : stack_elt  ->  (closure * FStar_Syntax_Syntax.aqual * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Arg (_0) -> begin
+_0
+end))
+
+
+let uu___is_UnivArgs : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UnivArgs (_0) -> begin
+true
+end
+| uu____364 -> begin
+false
+end))
+
+
+let __proj__UnivArgs__item___0 : stack_elt  ->  (FStar_Syntax_Syntax.universe Prims.list * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| UnivArgs (_0) -> begin
+_0
+end))
+
+
+let uu___is_MemoLazy : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MemoLazy (_0) -> begin
+true
+end
+| uu____388 -> begin
+false
+end))
+
+
+let __proj__MemoLazy__item___0 : stack_elt  ->  (env * FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo = (fun projectee -> (match (projectee) with
+| MemoLazy (_0) -> begin
+_0
+end))
+
+
+let uu___is_Match : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Match (_0) -> begin
+true
+end
+| uu____415 -> begin
+false
+end))
+
+
+let __proj__Match__item___0 : stack_elt  ->  (env * branches * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Match (_0) -> begin
+_0
+end))
+
+
+let uu___is_Abs : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Abs (_0) -> begin
+true
+end
+| uu____444 -> begin
+false
+end))
+
+
+let __proj__Abs__item___0 : stack_elt  ->  (env * FStar_Syntax_Syntax.binders * env * (FStar_Syntax_Syntax.lcomp, FStar_Syntax_Syntax.residual_comp) FStar_Util.either Prims.option * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Abs (_0) -> begin
+_0
+end))
+
+
+let uu___is_App : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+true
+end
+| uu____483 -> begin
+false
+end))
+
+
+let __proj__App__item___0 : stack_elt  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| App (_0) -> begin
+_0
+end))
+
+
+let uu___is_Meta : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Meta (_0) -> begin
+true
+end
+| uu____506 -> begin
+false
+end))
+
+
+let __proj__Meta__item___0 : stack_elt  ->  (FStar_Syntax_Syntax.metadata * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Meta (_0) -> begin
+_0
+end))
+
+
+let uu___is_Let : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+true
+end
+| uu____528 -> begin
+false
+end))
+
+
+let __proj__Let__item___0 : stack_elt  ->  (env * FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.letbinding * FStar_Range.range) = (fun projectee -> (match (projectee) with
+| Let (_0) -> begin
+_0
+end))
+
+
+let uu___is_Steps : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Steps (_0) -> begin
+true
+end
+| uu____557 -> begin
+false
+end))
+
+
+let __proj__Steps__item___0 : stack_elt  ->  (steps * primitive_step Prims.list * FStar_TypeChecker_Env.delta_level Prims.list) = (fun projectee -> (match (projectee) with
+| Steps (_0) -> begin
+_0
+end))
+
+
+let uu___is_Debug : stack_elt  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Debug (_0) -> begin
+true
+end
+| uu____584 -> begin
+false
+end))
+
+
+let __proj__Debug__item___0 : stack_elt  ->  FStar_Syntax_Syntax.term = (fun projectee -> (match (projectee) with
+| Debug (_0) -> begin
+_0
+end))
+
+
+type stack =
+stack_elt Prims.list
+
+
+let mk = (fun t r -> (FStar_Syntax_Syntax.mk t None r))
+
+
+let set_memo = (fun r t -> (
+
+let uu____632 = (FStar_ST.read r)
+in (match (uu____632) with
+| Some (uu____637) -> begin
+(failwith "Unexpected set_memo: thunk already evaluated")
+end
+| None -> begin
+(FStar_ST.write r (Some (t)))
+end)))
+
+
+let env_to_string : closure Prims.list  ->  Prims.string = (fun env -> (
+
+let uu____646 = (FStar_List.map closure_to_string env)
+in (FStar_All.pipe_right uu____646 (FStar_String.concat "; "))))
+
+
+let stack_elt_to_string : stack_elt  ->  Prims.string = (fun uu___128_651 -> (match (uu___128_651) with
+| Arg (c, uu____653, uu____654) -> begin
+(
+
+let uu____655 = (closure_to_string c)
+in (FStar_Util.format1 "Closure %s" uu____655))
+end
+| MemoLazy (uu____656) -> begin
+"MemoLazy"
+end
+| Abs (uu____660, bs, uu____662, uu____663, uu____664) -> begin
+(
+
+let uu____671 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs))
+in (FStar_Util.format1 "Abs %s" uu____671))
+end
+| UnivArgs (uu____676) -> begin
+"UnivArgs"
+end
+| Match (uu____680) -> begin
+"Match"
+end
+| App (t, uu____685, uu____686) -> begin
+(
+
+let uu____687 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format1 "App %s" uu____687))
+end
+| Meta (m, uu____689) -> begin
+"Meta"
+end
+| Let (uu____690) -> begin
+"Let"
+end
+| Steps (uu____695, uu____696, uu____697) -> begin
+"Steps"
+end
+| Debug (t) -> begin
+(
+
+let uu____703 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format1 "Debug %s" uu____703))
+end))
+
+
+let stack_to_string : stack_elt Prims.list  ->  Prims.string = (fun s -> (
+
+let uu____709 = (FStar_List.map stack_elt_to_string s)
+in (FStar_All.pipe_right uu____709 (FStar_String.concat "; "))))
+
+
+let log : cfg  ->  (Prims.unit  ->  Prims.unit)  ->  Prims.unit = (fun cfg f -> (
+
+let uu____723 = (FStar_TypeChecker_Env.debug cfg.tcenv (FStar_Options.Other ("Norm")))
+in (match (uu____723) with
+| true -> begin
+(f ())
+end
+| uu____724 -> begin
+()
+end)))
+
+
+let is_empty = (fun uu___129_732 -> (match (uu___129_732) with
+| [] -> begin
+true
+end
+| uu____734 -> begin
+false
+end))
+
+
+let lookup_bvar = (fun env x -> try
+(match (()) with
+| () -> begin
+(FStar_List.nth env x.FStar_Syntax_Syntax.index)
+end)
+with
+| uu____752 -> begin
+(
+
+let uu____753 = (
+
+let uu____754 = (FStar_Syntax_Print.db_to_string x)
+in (FStar_Util.format1 "Failed to find %s\n" uu____754))
+in (failwith uu____753))
+end)
+
+
+let downgrade_ghost_effect_name : FStar_Ident.lident  ->  FStar_Ident.lident Prims.option = (fun l -> (match ((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Ghost_lid)) with
+| true -> begin
+Some (FStar_Syntax_Const.effect_Pure_lid)
+end
+| uu____760 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GTot_lid)) with
+| true -> begin
+Some (FStar_Syntax_Const.effect_Tot_lid)
+end
+| uu____762 -> begin
+(match ((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GHOST_lid)) with
+| true -> begin
+Some (FStar_Syntax_Const.effect_PURE_lid)
+end
+| uu____764 -> begin
+None
+end)
+end)
+end))
+
+
+let norm_universe : cfg  ->  closure Prims.list  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun cfg env u -> (
+
+let norm_univs = (fun us -> (
+
+let us1 = (FStar_Util.sort_with FStar_Syntax_Util.compare_univs us)
+in (
+
+let uu____785 = (FStar_List.fold_left (fun uu____794 u1 -> (match (uu____794) with
+| (cur_kernel, cur_max, out) -> begin
+(
+
+let uu____809 = (FStar_Syntax_Util.univ_kernel u1)
+in (match (uu____809) with
+| (k_u, n1) -> begin
+(
+
+let uu____818 = (FStar_Syntax_Util.eq_univs cur_kernel k_u)
+in (match (uu____818) with
+| true -> begin
+((cur_kernel), (u1), (out))
+end
+| uu____824 -> begin
+((k_u), (u1), ((cur_max)::out))
+end))
+end))
+end)) ((FStar_Syntax_Syntax.U_zero), (FStar_Syntax_Syntax.U_zero), ([])) us1)
+in (match (uu____785) with
+| (uu____828, u1, out) -> begin
+(FStar_List.rev ((u1)::out))
+end))))
+in (
+
+let rec aux = (fun u1 -> (
+
+let u2 = (FStar_Syntax_Subst.compress_univ u1)
+in (match (u2) with
+| FStar_Syntax_Syntax.U_bvar (x) -> begin
+try
+(match (()) with
+| () -> begin
+(
+
+let uu____844 = (FStar_List.nth env x)
+in (match (uu____844) with
+| Univ (u3) -> begin
+(aux u3)
+end
+| Dummy -> begin
+(u2)::[]
+end
+| uu____847 -> begin
+(failwith "Impossible: universe variable bound to a term")
+end))
+end)
+with
+| uu____851 -> begin
+(
+
+let uu____852 = (FStar_All.pipe_right cfg.steps (FStar_List.contains AllowUnboundUniverses))
+in (match (uu____852) with
+| true -> begin
+(FStar_Syntax_Syntax.U_unknown)::[]
+end
+| uu____854 -> begin
+(failwith "Universe variable not found")
+end))
+end
+end
+| (FStar_Syntax_Syntax.U_zero) | (FStar_Syntax_Syntax.U_unif (_)) | (FStar_Syntax_Syntax.U_name (_)) | (FStar_Syntax_Syntax.U_unknown) -> begin
+(u2)::[]
+end
+| FStar_Syntax_Syntax.U_max ([]) -> begin
+(FStar_Syntax_Syntax.U_zero)::[]
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(
+
+let us1 = (
+
+let uu____862 = (FStar_List.collect aux us)
+in (FStar_All.pipe_right uu____862 norm_univs))
+in (match (us1) with
+| (u_k)::(hd1)::rest -> begin
+(
+
+let rest1 = (hd1)::rest
+in (
+
+let uu____873 = (FStar_Syntax_Util.univ_kernel u_k)
+in (match (uu____873) with
+| (FStar_Syntax_Syntax.U_zero, n1) -> begin
+(
+
+let uu____878 = (FStar_All.pipe_right rest1 (FStar_List.for_all (fun u3 -> (
+
+let uu____881 = (FStar_Syntax_Util.univ_kernel u3)
+in (match (uu____881) with
+| (uu____884, m) -> begin
+(n1 <= m)
+end)))))
+in (match (uu____878) with
+| true -> begin
+rest1
+end
+| uu____887 -> begin
+us1
+end))
+end
+| uu____888 -> begin
+us1
+end)))
+end
+| uu____891 -> begin
+us1
+end))
+end
+| FStar_Syntax_Syntax.U_succ (u3) -> begin
+(
+
+let uu____894 = (aux u3)
+in (FStar_List.map (fun _0_29 -> FStar_Syntax_Syntax.U_succ (_0_29)) uu____894))
+end)))
+in (
+
+let uu____896 = (FStar_All.pipe_right cfg.steps (FStar_List.contains EraseUniverses))
+in (match (uu____896) with
+| true -> begin
+FStar_Syntax_Syntax.U_unknown
+end
+| uu____897 -> begin
+(
+
+let uu____898 = (aux u)
+in (match (uu____898) with
+| ([]) | ((FStar_Syntax_Syntax.U_zero)::[]) -> begin
+FStar_Syntax_Syntax.U_zero
+end
+| (FStar_Syntax_Syntax.U_zero)::(u1)::[] -> begin
+u1
+end
+| (FStar_Syntax_Syntax.U_zero)::us -> begin
+FStar_Syntax_Syntax.U_max (us)
+end
+| (u1)::[] -> begin
+u1
+end
+| us -> begin
+FStar_Syntax_Syntax.U_max (us)
+end))
+end)))))
+
+
+let rec closure_as_term : cfg  ->  closure Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun cfg env t -> ((log cfg (fun uu____995 -> (
+
+let uu____996 = (FStar_Syntax_Print.tag_of_term t)
+in (
+
+let uu____997 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print2 ">>> %s Closure_as_term %s\n" uu____996 uu____997)))));
+(match (env) with
+| [] when (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains CompressUvars cfg.steps)) -> begin
+t
+end
+| uu____998 -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____1001) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+t1
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____1025) -> begin
+t1
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(
+
+let uu____1035 = (
+
+let uu____1036 = (norm_universe cfg env u)
+in FStar_Syntax_Syntax.Tm_type (uu____1036))
+in (mk uu____1035 t1.FStar_Syntax_Syntax.pos))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t2, us) -> begin
+(
+
+let uu____1043 = (FStar_List.map (norm_universe cfg env) us)
+in (FStar_Syntax_Syntax.mk_Tm_uinst t2 uu____1043))
+end
+| FStar_Syntax_Syntax.Tm_bvar (x) -> begin
+(
+
+let uu____1045 = (lookup_bvar env x)
+in (match (uu____1045) with
+| Univ (uu____1046) -> begin
+(failwith "Impossible: term variable is bound to a universe")
+end
+| Dummy -> begin
+t1
+end
+| Clos (env1, t0, r, uu____1050) -> begin
+(closure_as_term cfg env1 t0)
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let head2 = (closure_as_term_delayed cfg env head1)
+in (
+
+let args1 = (closures_as_args_delayed cfg env args)
+in (mk (FStar_Syntax_Syntax.Tm_app (((head2), (args1)))) t1.FStar_Syntax_Syntax.pos)))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) -> begin
+(
+
+let uu____1118 = (closures_as_binders_delayed cfg env bs)
+in (match (uu____1118) with
+| (bs1, env1) -> begin
+(
+
+let body1 = (closure_as_term_delayed cfg env1 body)
+in (
+
+let uu____1138 = (
+
+let uu____1139 = (
+
+let uu____1154 = (close_lcomp_opt cfg env1 lopt)
+in ((bs1), (body1), (uu____1154)))
+in FStar_Syntax_Syntax.Tm_abs (uu____1139))
+in (mk uu____1138 t1.FStar_Syntax_Syntax.pos)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____1184 = (closures_as_binders_delayed cfg env bs)
+in (match (uu____1184) with
+| (bs1, env1) -> begin
+(
+
+let c1 = (close_comp cfg env1 c)
+in (mk (FStar_Syntax_Syntax.Tm_arrow (((bs1), (c1)))) t1.FStar_Syntax_Syntax.pos))
+end))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, phi) -> begin
+(
+
+let uu____1215 = (
+
+let uu____1222 = (
+
+let uu____1226 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____1226)::[])
+in (closures_as_binders_delayed cfg env uu____1222))
+in (match (uu____1215) with
+| (x1, env1) -> begin
+(
+
+let phi1 = (closure_as_term_delayed cfg env1 phi)
+in (
+
+let uu____1240 = (
+
+let uu____1241 = (
+
+let uu____1246 = (
+
+let uu____1247 = (FStar_List.hd x1)
+in (FStar_All.pipe_right uu____1247 Prims.fst))
+in ((uu____1246), (phi1)))
+in FStar_Syntax_Syntax.Tm_refine (uu____1241))
+in (mk uu____1240 t1.FStar_Syntax_Syntax.pos)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t11, (annot, tacopt), lopt) -> begin
+(
+
+let annot1 = (match (annot) with
+| FStar_Util.Inl (t2) -> begin
+(
+
+let uu____1315 = (closure_as_term_delayed cfg env t2)
+in FStar_Util.Inl (uu____1315))
+end
+| FStar_Util.Inr (c) -> begin
+(
+
+let uu____1329 = (close_comp cfg env c)
+in FStar_Util.Inr (uu____1329))
+end)
+in (
+
+let tacopt1 = (FStar_Util.map_opt tacopt (closure_as_term_delayed cfg env))
+in (
+
+let uu____1344 = (
+
+let uu____1345 = (
+
+let uu____1363 = (closure_as_term_delayed cfg env t11)
+in ((uu____1363), (((annot1), (tacopt1))), (lopt)))
+in FStar_Syntax_Syntax.Tm_ascribed (uu____1345))
+in (mk uu____1344 t1.FStar_Syntax_Syntax.pos))))
+end
+| FStar_Syntax_Syntax.Tm_meta (t', FStar_Syntax_Syntax.Meta_pattern (args)) -> begin
+(
+
+let uu____1401 = (
+
+let uu____1402 = (
+
+let uu____1407 = (closure_as_term_delayed cfg env t')
+in (
+
+let uu____1410 = (
+
+let uu____1411 = (FStar_All.pipe_right args (FStar_List.map (closures_as_args_delayed cfg env)))
+in FStar_Syntax_Syntax.Meta_pattern (uu____1411))
+in ((uu____1407), (uu____1410))))
+in FStar_Syntax_Syntax.Tm_meta (uu____1402))
+in (mk uu____1401 t1.FStar_Syntax_Syntax.pos))
+end
+| FStar_Syntax_Syntax.Tm_meta (t', FStar_Syntax_Syntax.Meta_monadic (m, tbody)) -> begin
+(
+
+let uu____1453 = (
+
+let uu____1454 = (
+
+let uu____1459 = (closure_as_term_delayed cfg env t')
+in (
+
+let uu____1462 = (
+
+let uu____1463 = (
+
+let uu____1468 = (closure_as_term_delayed cfg env tbody)
+in ((m), (uu____1468)))
+in FStar_Syntax_Syntax.Meta_monadic (uu____1463))
+in ((uu____1459), (uu____1462))))
+in FStar_Syntax_Syntax.Tm_meta (uu____1454))
+in (mk uu____1453 t1.FStar_Syntax_Syntax.pos))
+end
+| FStar_Syntax_Syntax.Tm_meta (t', FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, tbody)) -> begin
+(
+
+let uu____1487 = (
+
+let uu____1488 = (
+
+let uu____1493 = (closure_as_term_delayed cfg env t')
+in (
+
+let uu____1496 = (
+
+let uu____1497 = (
+
+let uu____1503 = (closure_as_term_delayed cfg env tbody)
+in ((m1), (m2), (uu____1503)))
+in FStar_Syntax_Syntax.Meta_monadic_lift (uu____1497))
+in ((uu____1493), (uu____1496))))
+in FStar_Syntax_Syntax.Tm_meta (uu____1488))
+in (mk uu____1487 t1.FStar_Syntax_Syntax.pos))
+end
+| FStar_Syntax_Syntax.Tm_meta (t', m) -> begin
+(
+
+let uu____1516 = (
+
+let uu____1517 = (
+
+let uu____1522 = (closure_as_term_delayed cfg env t')
+in ((uu____1522), (m)))
+in FStar_Syntax_Syntax.Tm_meta (uu____1517))
+in (mk uu____1516 t1.FStar_Syntax_Syntax.pos))
+end
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), body) -> begin
+(
+
+let env0 = env
+in (
+
+let env1 = (FStar_List.fold_left (fun env1 uu____1543 -> (Dummy)::env1) env lb.FStar_Syntax_Syntax.lbunivs)
+in (
+
+let typ = (closure_as_term_delayed cfg env1 lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let def = (closure_as_term cfg env1 lb.FStar_Syntax_Syntax.lbdef)
+in (
+
+let body1 = (match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inr (uu____1554) -> begin
+body
+end
+| FStar_Util.Inl (uu____1555) -> begin
+(closure_as_term cfg ((Dummy)::env0) body)
+end)
+in (
+
+let lb1 = (
+
+let uu___142_1557 = lb
+in {FStar_Syntax_Syntax.lbname = uu___142_1557.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___142_1557.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = typ; FStar_Syntax_Syntax.lbeff = uu___142_1557.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = def})
+in (mk (FStar_Syntax_Syntax.Tm_let (((((false), ((lb1)::[]))), (body1)))) t1.FStar_Syntax_Syntax.pos)))))))
+end
+| FStar_Syntax_Syntax.Tm_let ((uu____1564, lbs), body) -> begin
+(
+
+let norm_one_lb = (fun env1 lb -> (
+
+let env_univs = (FStar_List.fold_right (fun uu____1588 env2 -> (Dummy)::env2) lb.FStar_Syntax_Syntax.lbunivs env1)
+in (
+
+let env2 = (
+
+let uu____1593 = (FStar_Syntax_Syntax.is_top_level lbs)
+in (match (uu____1593) with
+| true -> begin
+env_univs
+end
+| uu____1595 -> begin
+(FStar_List.fold_right (fun uu____1597 env2 -> (Dummy)::env2) lbs env_univs)
+end))
+in (
+
+let uu___143_1600 = lb
+in (
+
+let uu____1601 = (closure_as_term cfg env_univs lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____1604 = (closure_as_term cfg env2 lb.FStar_Syntax_Syntax.lbdef)
+in {FStar_Syntax_Syntax.lbname = uu___143_1600.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___143_1600.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu____1601; FStar_Syntax_Syntax.lbeff = uu___143_1600.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____1604}))))))
+in (
+
+let lbs1 = (FStar_All.pipe_right lbs (FStar_List.map (norm_one_lb env)))
+in (
+
+let body1 = (
+
+let body_env = (FStar_List.fold_right (fun uu____1615 env1 -> (Dummy)::env1) lbs1 env)
+in (closure_as_term cfg body_env body))
+in (mk (FStar_Syntax_Syntax.Tm_let (((((true), (lbs1))), (body1)))) t1.FStar_Syntax_Syntax.pos))))
+end
+| FStar_Syntax_Syntax.Tm_match (head1, branches) -> begin
+(
+
+let head2 = (closure_as_term cfg env head1)
+in (
+
+let norm_one_branch = (fun env1 uu____1670 -> (match (uu____1670) with
+| (pat, w_opt, tm) -> begin
+(
+
+let rec norm_pat = (fun env2 p -> (match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_constant (uu____1716) -> begin
+((p), (env2))
+end
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Pat_disj ((hd1)::tl1) -> begin
+(
+
+let uu____1736 = (norm_pat env2 hd1)
+in (match (uu____1736) with
+| (hd2, env') -> begin
+(
+
+let tl2 = (FStar_All.pipe_right tl1 (FStar_List.map (fun p1 -> (
+
+let uu____1772 = (norm_pat env2 p1)
+in (Prims.fst uu____1772)))))
+in (((
+
+let uu___144_1784 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((hd2)::tl2); FStar_Syntax_Syntax.ty = uu___144_1784.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___144_1784.FStar_Syntax_Syntax.p})), (env')))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____1801 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____1835 uu____1836 -> (match (((uu____1835), (uu____1836))) with
+| ((pats1, env3), (p1, b)) -> begin
+(
+
+let uu____1901 = (norm_pat env3 p1)
+in (match (uu____1901) with
+| (p2, env4) -> begin
+(((((p2), (b)))::pats1), (env4))
+end))
+end)) (([]), (env2))))
+in (match (uu____1801) with
+| (pats1, env3) -> begin
+(((
+
+let uu___145_1967 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___145_1967.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___145_1967.FStar_Syntax_Syntax.p})), (env3))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let x1 = (
+
+let uu___146_1981 = x
+in (
+
+let uu____1982 = (closure_as_term cfg env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___146_1981.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___146_1981.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1982}))
+in (((
+
+let uu___147_1988 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (x1); FStar_Syntax_Syntax.ty = uu___147_1988.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___147_1988.FStar_Syntax_Syntax.p})), ((Dummy)::env2)))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let x1 = (
+
+let uu___148_1993 = x
+in (
+
+let uu____1994 = (closure_as_term cfg env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___148_1993.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___148_1993.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1994}))
+in (((
+
+let uu___149_2000 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x1); FStar_Syntax_Syntax.ty = uu___149_2000.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___149_2000.FStar_Syntax_Syntax.p})), ((Dummy)::env2)))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t2) -> begin
+(
+
+let x1 = (
+
+let uu___150_2010 = x
+in (
+
+let uu____2011 = (closure_as_term cfg env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___150_2010.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___150_2010.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2011}))
+in (
+
+let t3 = (closure_as_term cfg env2 t2)
+in (((
+
+let uu___151_2018 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t3))); FStar_Syntax_Syntax.ty = uu___151_2018.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___151_2018.FStar_Syntax_Syntax.p})), (env2))))
+end))
+in (
+
+let uu____2021 = (norm_pat env1 pat)
+in (match (uu____2021) with
+| (pat1, env2) -> begin
+(
+
+let w_opt1 = (match (w_opt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____2045 = (closure_as_term cfg env2 w)
+in Some (uu____2045))
+end)
+in (
+
+let tm1 = (closure_as_term cfg env2 tm)
+in ((pat1), (w_opt1), (tm1))))
+end)))
+end))
+in (
+
+let uu____2050 = (
+
+let uu____2051 = (
+
+let uu____2067 = (FStar_All.pipe_right branches (FStar_List.map (norm_one_branch env)))
+in ((head2), (uu____2067)))
+in FStar_Syntax_Syntax.Tm_match (uu____2051))
+in (mk uu____2050 t1.FStar_Syntax_Syntax.pos))))
+end))
+end);
+))
+and closure_as_term_delayed : cfg  ->  closure Prims.list  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun cfg env t -> (match (env) with
+| [] when (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains CompressUvars cfg.steps)) -> begin
+t
+end
+| uu____2120 -> begin
+(closure_as_term cfg env t)
+end))
+and closures_as_args_delayed : cfg  ->  closure Prims.list  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list = (fun cfg env args -> (match (env) with
+| [] when (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains CompressUvars cfg.steps)) -> begin
+args
+end
+| uu____2136 -> begin
+(FStar_List.map (fun uu____2146 -> (match (uu____2146) with
+| (x, imp) -> begin
+(
+
+let uu____2161 = (closure_as_term_delayed cfg env x)
+in ((uu____2161), (imp)))
+end)) args)
+end))
+and closures_as_binders_delayed : cfg  ->  closure Prims.list  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list * closure Prims.list) = (fun cfg env bs -> (
+
+let uu____2173 = (FStar_All.pipe_right bs (FStar_List.fold_left (fun uu____2197 uu____2198 -> (match (((uu____2197), (uu____2198))) with
+| ((env1, out), (b, imp)) -> begin
+(
+
+let b1 = (
+
+let uu___152_2242 = b
+in (
+
+let uu____2243 = (closure_as_term_delayed cfg env1 b.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___152_2242.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___152_2242.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____2243}))
+in (
+
+let env2 = (Dummy)::env1
+in ((env2), ((((b1), (imp)))::out))))
+end)) ((env), ([]))))
+in (match (uu____2173) with
+| (env1, bs1) -> begin
+(((FStar_List.rev bs1)), (env1))
+end)))
+and close_comp : cfg  ->  closure Prims.list  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun cfg env c -> (match (env) with
+| [] when (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains CompressUvars cfg.steps)) -> begin
+c
+end
+| uu____2290 -> begin
+(match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uopt) -> begin
+(
+
+let uu____2302 = (closure_as_term_delayed cfg env t)
+in (
+
+let uu____2303 = (FStar_Option.map (norm_universe cfg env) uopt)
+in (FStar_Syntax_Syntax.mk_Total' uu____2302 uu____2303)))
+end
+| FStar_Syntax_Syntax.GTotal (t, uopt) -> begin
+(
+
+let uu____2313 = (closure_as_term_delayed cfg env t)
+in (
+
+let uu____2314 = (FStar_Option.map (norm_universe cfg env) uopt)
+in (FStar_Syntax_Syntax.mk_GTotal' uu____2313 uu____2314)))
+end
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+(
+
+let rt = (closure_as_term_delayed cfg env c1.FStar_Syntax_Syntax.result_typ)
+in (
+
+let args = (closures_as_args_delayed cfg env c1.FStar_Syntax_Syntax.effect_args)
+in (
+
+let flags = (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_List.map (fun uu___130_2330 -> (match (uu___130_2330) with
+| FStar_Syntax_Syntax.DECREASES (t) -> begin
+(
+
+let uu____2334 = (closure_as_term_delayed cfg env t)
+in FStar_Syntax_Syntax.DECREASES (uu____2334))
+end
+| f -> begin
+f
+end))))
+in (
+
+let uu____2338 = (
+
+let uu___153_2339 = c1
+in (
+
+let uu____2340 = (FStar_List.map (norm_universe cfg env) c1.FStar_Syntax_Syntax.comp_univs)
+in {FStar_Syntax_Syntax.comp_univs = uu____2340; FStar_Syntax_Syntax.effect_name = uu___153_2339.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = rt; FStar_Syntax_Syntax.effect_args = args; FStar_Syntax_Syntax.flags = flags}))
+in (FStar_Syntax_Syntax.mk_Comp uu____2338)))))
+end)
+end))
+and filter_out_lcomp_cflags : FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.cflags Prims.list = (fun lc -> (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags (FStar_List.filter (fun uu___131_2344 -> (match (uu___131_2344) with
+| FStar_Syntax_Syntax.DECREASES (uu____2345) -> begin
+false
+end
+| uu____2348 -> begin
+true
+end)))))
+and close_lcomp_opt : cfg  ->  closure Prims.list  ->  (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option  ->  (FStar_Syntax_Syntax.lcomp, (FStar_Ident.lident * FStar_Syntax_Syntax.cflags Prims.list)) FStar_Util.either Prims.option = (fun cfg env lopt -> (match (lopt) with
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let flags = (filter_out_lcomp_cflags lc)
+in (
+
+let uu____2376 = (FStar_Syntax_Util.is_total_lcomp lc)
+in (match (uu____2376) with
+| true -> begin
+Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), (flags))))
+end
+| uu____2392 -> begin
+(
+
+let uu____2393 = (FStar_Syntax_Util.is_tot_or_gtot_lcomp lc)
+in (match (uu____2393) with
+| true -> begin
+Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_GTot_lid), (flags))))
+end
+| uu____2409 -> begin
+Some (FStar_Util.Inr (((lc.FStar_Syntax_Syntax.eff_name), (flags))))
+end))
+end)))
+end
+| uu____2419 -> begin
+lopt
+end))
+
+
+let built_in_primitive_steps : primitive_step Prims.list = (
+
+let const_as_tm = (fun c p -> (mk (FStar_Syntax_Syntax.Tm_constant (c)) p))
+in (
+
+let interp_math_op = (fun f args -> (match (args) with
+| ((a1, uu____2459))::((a2, uu____2461))::[] -> begin
+(
+
+let uu____2482 = (
+
+let uu____2485 = (
+
+let uu____2486 = (FStar_Syntax_Subst.compress a1)
+in uu____2486.FStar_Syntax_Syntax.n)
+in (
+
+let uu____2489 = (
+
+let uu____2490 = (FStar_Syntax_Subst.compress a2)
+in uu____2490.FStar_Syntax_Syntax.n)
+in ((uu____2485), (uu____2489))))
+in (match (uu____2482) with
+| (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (i, None)), FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (j, None))) -> begin
+(
+
+let uu____2506 = (
+
+let uu____2509 = (
+
+let uu____2510 = (FStar_Util.int_of_string i)
+in (
+
+let uu____2511 = (FStar_Util.int_of_string j)
+in (f uu____2510 uu____2511)))
+in (const_as_tm uu____2509 a2.FStar_Syntax_Syntax.pos))
+in Some (uu____2506))
+end
+| uu____2514 -> begin
+None
+end))
+end
+| uu____2517 -> begin
+(failwith "Unexpected number of arguments")
+end))
+in (
+
+let interp_bounded_op = (fun f args -> (match (args) with
+| ((a1, uu____2542))::((a2, uu____2544))::[] -> begin
+(
+
+let uu____2565 = (
+
+let uu____2568 = (
+
+let uu____2569 = (FStar_Syntax_Subst.compress a1)
+in uu____2569.FStar_Syntax_Syntax.n)
+in (
+
+let uu____2572 = (
+
+let uu____2573 = (FStar_Syntax_Subst.compress a2)
+in uu____2573.FStar_Syntax_Syntax.n)
+in ((uu____2568), (uu____2572))))
+in (match (uu____2565) with
+| (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv1); FStar_Syntax_Syntax.tk = uu____2578; FStar_Syntax_Syntax.pos = uu____2579; FStar_Syntax_Syntax.vars = uu____2580}, (({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (i, None)); FStar_Syntax_Syntax.tk = uu____2582; FStar_Syntax_Syntax.pos = uu____2583; FStar_Syntax_Syntax.vars = uu____2584}, uu____2585))::[]), FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv2); FStar_Syntax_Syntax.tk = uu____2587; FStar_Syntax_Syntax.pos = uu____2588; FStar_Syntax_Syntax.vars = uu____2589}, (({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (j, None)); FStar_Syntax_Syntax.tk = uu____2591; FStar_Syntax_Syntax.pos = uu____2592; FStar_Syntax_Syntax.vars = uu____2593}, uu____2594))::[])) when ((FStar_Util.ends_with (FStar_Ident.text_of_lid fv1.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v) "int_to_t") && (FStar_Util.ends_with (FStar_Ident.text_of_lid fv2.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v) "int_to_t")) -> begin
+(
+
+let n1 = (
+
+let uu____2658 = (
+
+let uu____2659 = (FStar_Util.int_of_string i)
+in (
+
+let uu____2660 = (FStar_Util.int_of_string j)
+in (f uu____2659 uu____2660)))
+in (const_as_tm uu____2658 a2.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____2661 = (
+
+let uu____2664 = (mk (FStar_Syntax_Syntax.Tm_fvar (fv1)) a2.FStar_Syntax_Syntax.pos)
+in (FStar_Syntax_Util.mk_app uu____2664 ((((n1), (None)))::[])))
+in Some (uu____2661)))
+end
+| uu____2682 -> begin
+None
+end))
+end
+| uu____2685 -> begin
+(failwith "Unexpected number of arguments")
+end))
+in (
+
+let as_primitive_step = (fun arity mk1 uu____2719 -> (match (uu____2719) with
+| (l, f) -> begin
+(
+
+let uu____2747 = (mk1 f)
+in {name = l; arity = arity; strong_reduction_ok = true; interpretation = uu____2747})
+end))
+in (
+
+let int_as_const = (fun i -> (
+
+let uu____2755 = (
+
+let uu____2761 = (FStar_Util.string_of_int i)
+in ((uu____2761), (None)))
+in FStar_Const.Const_int (uu____2755)))
+in (
+
+let bool_as_const = (fun b -> FStar_Const.Const_bool (b))
+in (
+
+let basic_arith = (FStar_List.map (as_primitive_step (Prims.parse_int "2") interp_math_op) ((((FStar_Syntax_Const.op_Addition), ((fun x y -> (int_as_const (x + y))))))::(((FStar_Syntax_Const.op_Subtraction), ((fun x y -> (int_as_const (x - y))))))::(((FStar_Syntax_Const.op_Multiply), ((fun x y -> (int_as_const (x * y))))))::(((FStar_Syntax_Const.op_Division), ((fun x y -> (int_as_const (x / y))))))::(((FStar_Syntax_Const.op_LT), ((fun x y -> (bool_as_const (x < y))))))::(((FStar_Syntax_Const.op_LTE), ((fun x y -> (bool_as_const (x <= y))))))::(((FStar_Syntax_Const.op_GT), ((fun x y -> (bool_as_const (x > y))))))::(((FStar_Syntax_Const.op_GTE), ((fun x y -> (bool_as_const (x >= y))))))::(((FStar_Syntax_Const.op_Modulus), ((fun x y -> (int_as_const (x mod y))))))::[]))
+in (
+
+let bounded_arith = (
+
+let uu____2912 = (
+
+let uu____2920 = (FStar_List.map (fun m -> (
+
+let uu____2937 = (
+
+let uu____2944 = (FStar_Syntax_Const.p2l (("FStar")::(m)::("add")::[]))
+in ((uu____2944), ((fun x y -> (int_as_const (x + y))))))
+in (
+
+let uu____2951 = (
+
+let uu____2959 = (
+
+let uu____2966 = (FStar_Syntax_Const.p2l (("FStar")::(m)::("sub")::[]))
+in ((uu____2966), ((fun x y -> (int_as_const (x - y))))))
+in (
+
+let uu____2973 = (
+
+let uu____2981 = (
+
+let uu____2988 = (FStar_Syntax_Const.p2l (("FStar")::(m)::("mul")::[]))
+in ((uu____2988), ((fun x y -> (int_as_const (x * y))))))
+in (uu____2981)::[])
+in (uu____2959)::uu____2973))
+in (uu____2937)::uu____2951))) (("Int8")::("UInt8")::("Int16")::("UInt16")::("Int32")::("UInt32")::("Int64")::("UInt64")::("UInt128")::[]))
+in (FStar_List.flatten uu____2920))
+in (FStar_List.map (as_primitive_step (Prims.parse_int "2") interp_bounded_op) uu____2912))
+in (
+
+let unary_string_ops = (
+
+let mk1 = (fun x -> (mk x FStar_Range.dummyRange))
+in (
+
+let name = (fun l -> (
+
+let uu____3045 = (
+
+let uu____3046 = (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant None)
+in FStar_Syntax_Syntax.Tm_fvar (uu____3046))
+in (mk1 uu____3045)))
+in (
+
+let ctor = (fun l -> (
+
+let uu____3053 = (
+
+let uu____3054 = (FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant (Some (FStar_Syntax_Syntax.Data_ctor)))
+in FStar_Syntax_Syntax.Tm_fvar (uu____3054))
+in (mk1 uu____3053)))
+in (
+
+let interp = (fun args -> (match (args) with
+| ((a, uu____3063))::[] -> begin
+(
+
+let uu____3076 = (
+
+let uu____3077 = (FStar_Syntax_Subst.compress a)
+in uu____3077.FStar_Syntax_Syntax.n)
+in (match (uu____3076) with
+| FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (bytes, uu____3082)) -> begin
+(
+
+let s = (FStar_Util.string_of_bytes bytes)
+in (
+
+let char_t = (name FStar_Syntax_Const.char_lid)
+in (
+
+let nil_char = (
+
+let uu____3092 = (
+
+let uu____3093 = (
+
+let uu____3094 = (ctor FStar_Syntax_Const.nil_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____3094 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____3095 = (
+
+let uu____3096 = (FStar_Syntax_Syntax.iarg char_t)
+in (uu____3096)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3093 uu____3095)))
+in (uu____3092 None FStar_Range.dummyRange))
+in (
+
+let uu____3101 = (
+
+let uu____3102 = (FStar_String.list_of_string s)
+in (FStar_List.fold_right (fun c a1 -> (
+
+let uu____3108 = (
+
+let uu____3109 = (
+
+let uu____3110 = (ctor FStar_Syntax_Const.cons_lid)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____3110 ((FStar_Syntax_Syntax.U_zero)::[])))
+in (
+
+let uu____3111 = (
+
+let uu____3112 = (FStar_Syntax_Syntax.iarg char_t)
+in (
+
+let uu____3113 = (
+
+let uu____3115 = (
+
+let uu____3116 = (mk1 (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char (c))))
+in (FStar_Syntax_Syntax.as_arg uu____3116))
+in (
+
+let uu____3117 = (
+
+let uu____3119 = (FStar_Syntax_Syntax.as_arg a1)
+in (uu____3119)::[])
+in (uu____3115)::uu____3117))
+in (uu____3112)::uu____3113))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3109 uu____3111)))
+in (uu____3108 None FStar_Range.dummyRange))) uu____3102 nil_char))
+in Some (uu____3101)))))
+end
+| uu____3124 -> begin
+None
+end))
+end
+| uu____3125 -> begin
+(failwith "Unexpected number of arguments")
+end))
+in (
+
+let uu____3127 = (
+
+let uu____3128 = (FStar_Syntax_Const.p2l (("FStar")::("String")::("list_of_string")::[]))
+in {name = uu____3128; arity = (Prims.parse_int "1"); strong_reduction_ok = true; interpretation = interp})
+in (uu____3127)::[])))))
+in (FStar_List.append basic_arith (FStar_List.append bounded_arith unary_string_ops)))))))))))
+
+
+let equality_ops : primitive_step Prims.list = (
+
+let interp_bool = (fun args -> (match (args) with
+| ((_typ, uu____3138))::((a1, uu____3140))::((a2, uu____3142))::[] -> begin
+(
+
+let uu____3171 = (FStar_Syntax_Util.eq_tm a1 a2)
+in (match (uu____3171) with
+| FStar_Syntax_Util.Equal -> begin
+(
+
+let uu____3173 = (mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool (true))) a2.FStar_Syntax_Syntax.pos)
+in Some (uu____3173))
+end
+| FStar_Syntax_Util.NotEqual -> begin
+(
+
+let uu____3178 = (mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool (false))) a2.FStar_Syntax_Syntax.pos)
+in Some (uu____3178))
+end
+| uu____3183 -> begin
+None
+end))
+end
+| uu____3184 -> begin
+(failwith "Unexpected number of arguments")
+end))
+in (
+
+let interp_prop = (fun args -> (match (args) with
+| (((_typ, _))::((a1, _))::((a2, _))::[]) | (((_typ, _))::(_)::((a1, _))::((a2, _))::[]) -> begin
+(
+
+let uu____3263 = (FStar_Syntax_Util.eq_tm a1 a2)
+in (match (uu____3263) with
+| FStar_Syntax_Util.Equal -> begin
+Some (FStar_Syntax_Util.t_true)
+end
+| FStar_Syntax_Util.NotEqual -> begin
+Some (FStar_Syntax_Util.t_false)
+end
+| uu____3265 -> begin
+None
+end))
+end
+| uu____3266 -> begin
+(failwith "Unexpected number of arguments")
+end))
+in (
+
+let decidable_equality = {name = FStar_Syntax_Const.op_Eq; arity = (Prims.parse_int "3"); strong_reduction_ok = true; interpretation = interp_bool}
+in (
+
+let propositional_equality = {name = FStar_Syntax_Const.eq2_lid; arity = (Prims.parse_int "3"); strong_reduction_ok = true; interpretation = interp_prop}
+in (
+
+let hetero_propositional_equality = {name = FStar_Syntax_Const.eq3_lid; arity = (Prims.parse_int "4"); strong_reduction_ok = true; interpretation = interp_prop}
+in (decidable_equality)::(propositional_equality)::(hetero_propositional_equality)::[])))))
+
+
+let reduce_primops : cfg  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun cfg tm -> (
+
+let uu____3277 = (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains Primops cfg.steps))
+in (match (uu____3277) with
+| true -> begin
+tm
+end
+| uu____3278 -> begin
+(
+
+let uu____3279 = (FStar_Syntax_Util.head_and_args tm)
+in (match (uu____3279) with
+| (head1, args) -> begin
+(
+
+let uu____3305 = (
+
+let uu____3306 = (FStar_Syntax_Util.un_uinst head1)
+in uu____3306.FStar_Syntax_Syntax.n)
+in (match (uu____3305) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____3310 = (FStar_List.tryFind (fun ps -> (FStar_Syntax_Syntax.fv_eq_lid fv ps.name)) cfg.primitive_steps)
+in (match (uu____3310) with
+| None -> begin
+tm
+end
+| Some (prim_step) -> begin
+(match (((FStar_List.length args) < prim_step.arity)) with
+| true -> begin
+tm
+end
+| uu____3321 -> begin
+(
+
+let uu____3322 = (prim_step.interpretation args)
+in (match (uu____3322) with
+| None -> begin
+tm
+end
+| Some (reduced) -> begin
+reduced
+end))
+end)
+end))
+end
+| uu____3325 -> begin
+tm
+end))
+end))
+end)))
+
+
+let reduce_equality : cfg  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun cfg tm -> (reduce_primops (
+
+let uu___154_3332 = cfg
+in {steps = (Primops)::[]; tcenv = uu___154_3332.tcenv; delta_level = uu___154_3332.delta_level; primitive_steps = equality_ops}) tm))
+
+
+let maybe_simplify : cfg  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term = (fun cfg tm -> (
+
+let steps = cfg.steps
+in (
+
+let w = (fun t -> (
+
+let uu___155_3354 = t
+in {FStar_Syntax_Syntax.n = uu___155_3354.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___155_3354.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = tm.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___155_3354.FStar_Syntax_Syntax.vars}))
+in (
+
+let simp_t = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.true_lid) -> begin
+Some (true)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.false_lid) -> begin
+Some (false)
+end
+| uu____3373 -> begin
+None
+end))
+in (
+
+let simplify = (fun arg -> (((simp_t (Prims.fst arg))), (arg)))
+in (
+
+let uu____3400 = (FStar_All.pipe_left Prims.op_Negation (FStar_List.contains Simplify steps))
+in (match (uu____3400) with
+| true -> begin
+(reduce_primops cfg tm)
+end
+| uu____3401 -> begin
+(match (tm.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, args)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, args)) -> begin
+(
+
+let uu____3440 = (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.and_lid)
+in (match (uu____3440) with
+| true -> begin
+(
+
+let uu____3441 = (FStar_All.pipe_right args (FStar_List.map simplify))
+in (match (uu____3441) with
+| (((Some (true), _))::((_, (arg, _)))::[]) | (((_, (arg, _)))::((Some (true), _))::[]) -> begin
+arg
+end
+| (((Some (false), _))::(_)::[]) | ((_)::((Some (false), _))::[]) -> begin
+(w FStar_Syntax_Util.t_false)
+end
+| uu____3607 -> begin
+tm
+end))
+end
+| uu____3616 -> begin
+(
+
+let uu____3617 = (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.or_lid)
+in (match (uu____3617) with
+| true -> begin
+(
+
+let uu____3618 = (FStar_All.pipe_right args (FStar_List.map simplify))
+in (match (uu____3618) with
+| (((Some (true), _))::(_)::[]) | ((_)::((Some (true), _))::[]) -> begin
+(w FStar_Syntax_Util.t_true)
+end
+| (((Some (false), _))::((_, (arg, _)))::[]) | (((_, (arg, _)))::((Some (false), _))::[]) -> begin
+arg
+end
+| uu____3784 -> begin
+tm
+end))
+end
+| uu____3793 -> begin
+(
+
+let uu____3794 = (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.imp_lid)
+in (match (uu____3794) with
+| true -> begin
+(
+
+let uu____3795 = (FStar_All.pipe_right args (FStar_List.map simplify))
+in (match (uu____3795) with
+| ((_)::((Some (true), _))::[]) | (((Some (false), _))::(_)::[]) -> begin
+(w FStar_Syntax_Util.t_true)
+end
+| ((Some (true), uu____3884))::((uu____3885, (arg, uu____3887)))::[] -> begin
+arg
+end
+| uu____3928 -> begin
+tm
+end))
+end
+| uu____3937 -> begin
+(
+
+let uu____3938 = (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.not_lid)
+in (match (uu____3938) with
+| true -> begin
+(
+
+let uu____3939 = (FStar_All.pipe_right args (FStar_List.map simplify))
+in (match (uu____3939) with
+| ((Some (true), uu____3972))::[] -> begin
+(w FStar_Syntax_Util.t_false)
+end
+| ((Some (false), uu____3996))::[] -> begin
+(w FStar_Syntax_Util.t_true)
+end
+| uu____4020 -> begin
+tm
+end))
+end
+| uu____4029 -> begin
+(
+
+let uu____4030 = ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.forall_lid) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.exists_lid))
+in (match (uu____4030) with
+| true -> begin
+(match (args) with
+| (((t, _))::[]) | (((_, Some (FStar_Syntax_Syntax.Implicit (_))))::((t, _))::[]) -> begin
+(
+
+let uu____4071 = (
+
+let uu____4072 = (FStar_Syntax_Subst.compress t)
+in uu____4072.FStar_Syntax_Syntax.n)
+in (match (uu____4071) with
+| FStar_Syntax_Syntax.Tm_abs ((uu____4075)::[], body, uu____4077) -> begin
+(match ((simp_t body)) with
+| Some (true) -> begin
+(w FStar_Syntax_Util.t_true)
+end
+| Some (false) -> begin
+(w FStar_Syntax_Util.t_false)
+end
+| uu____4103 -> begin
+tm
+end)
+end
+| uu____4105 -> begin
+tm
+end))
+end
+| uu____4106 -> begin
+tm
+end)
+end
+| uu____4112 -> begin
+(reduce_equality cfg tm)
+end))
+end))
+end))
+end))
+end))
+end
+| uu____4113 -> begin
+tm
+end)
+end)))))))
+
+
+let is_norm_request = (fun hd1 args -> (
+
+let uu____4128 = (
+
+let uu____4132 = (
+
+let uu____4133 = (FStar_Syntax_Util.un_uinst hd1)
+in uu____4133.FStar_Syntax_Syntax.n)
+in ((uu____4132), (args)))
+in (match (uu____4128) with
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____4138)::(uu____4139)::[]) -> begin
+(FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.normalize_term)
+end
+| (FStar_Syntax_Syntax.Tm_fvar (fv), (uu____4142)::[]) -> begin
+(FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.normalize)
+end
+| uu____4144 -> begin
+false
+end)))
+
+
+let get_norm_request = (fun args -> (match (args) with
+| ((_)::((tm, _))::[]) | (((tm, _))::[]) -> begin
+tm
+end
+| uu____4177 -> begin
+(failwith "Impossible")
+end))
+
+
+let is_reify_head : stack_elt Prims.list  ->  Prims.bool = (fun uu___132_4184 -> (match (uu___132_4184) with
+| (App ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____4186; FStar_Syntax_Syntax.pos = uu____4187; FStar_Syntax_Syntax.vars = uu____4188}, uu____4189, uu____4190))::uu____4191 -> begin
+true
+end
+| uu____4197 -> begin
+false
+end))
+
+
+let is_fstar_tactics_quote : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____4202 = (
+
+let uu____4203 = (FStar_Syntax_Util.un_uinst t)
+in uu____4203.FStar_Syntax_Syntax.n)
+in (match (uu____4202) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.fstar_tactics_quote_lid)
+end
+| uu____4207 -> begin
+false
+end)))
+
+
+let rec norm : cfg  ->  env  ->  stack  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun cfg env stack1 t -> (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (
+
+let firstn = (fun k l -> (match (((FStar_List.length l) < k)) with
+| true -> begin
+((l), ([]))
+end
+| uu____4321 -> begin
+(FStar_Util.first_N k l)
+end))
+in ((log cfg (fun uu____4323 -> (
+
+let uu____4324 = (FStar_Syntax_Print.tag_of_term t1)
+in (
+
+let uu____4325 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____4326 = (
+
+let uu____4327 = (
+
+let uu____4329 = (firstn (Prims.parse_int "4") stack1)
+in (FStar_All.pipe_left Prims.fst uu____4329))
+in (stack_to_string uu____4327))
+in (FStar_Util.print3 ">>> %s\nNorm %s with top of the stack %s \n" uu____4324 uu____4325 uu____4326))))));
+(match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____4341) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = FStar_Syntax_Syntax.Delta_constant; FStar_Syntax_Syntax.fv_qual = _})) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Data_ctor)})) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Record_ctor (_))})) -> begin
+(rebuild cfg env stack1 t1)
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____4373; FStar_Syntax_Syntax.pos = uu____4374; FStar_Syntax_Syntax.vars = uu____4375}, uu____4376) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.fstar_tactics_embed_lid) -> begin
+(rebuild cfg env stack1 t1)
+end
+| FStar_Syntax_Syntax.Tm_app (hd1, args) when (is_fstar_tactics_quote hd1) -> begin
+(
+
+let args1 = (closures_as_args_delayed cfg env args)
+in (
+
+let t2 = (
+
+let uu___156_4416 = t1
+in {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app (((hd1), (args1))); FStar_Syntax_Syntax.tk = uu___156_4416.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___156_4416.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___156_4416.FStar_Syntax_Syntax.vars})
+in (
+
+let t3 = (reduce_primops cfg t2)
+in (rebuild cfg env stack1 t3))))
+end
+| FStar_Syntax_Syntax.Tm_app (hd1, args) when (((
+
+let uu____4445 = (FStar_All.pipe_right cfg.steps (FStar_List.contains NoFullNorm))
+in (not (uu____4445))) && (is_norm_request hd1 args)) && (not ((FStar_Ident.lid_equals cfg.tcenv.FStar_TypeChecker_Env.curmodule FStar_Syntax_Const.prims_lid)))) -> begin
+(
+
+let tm = (get_norm_request args)
+in (
+
+let s = (Reify)::(Beta)::(UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(Zeta)::(Iota)::(Primops)::[]
+in (
+
+let cfg' = (
+
+let uu___157_4458 = cfg
+in {steps = s; tcenv = uu___157_4458.tcenv; delta_level = (FStar_TypeChecker_Env.Unfold (FStar_Syntax_Syntax.Delta_constant))::[]; primitive_steps = uu___157_4458.primitive_steps})
+in (
+
+let stack' = (Debug (t1))::(Steps (((cfg.steps), (cfg.primitive_steps), (cfg.delta_level))))::stack1
+in (norm cfg' env stack' tm)))))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____4463; FStar_Syntax_Syntax.pos = uu____4464; FStar_Syntax_Syntax.vars = uu____4465}, (a1)::(a2)::rest) -> begin
+(
+
+let uu____4499 = (FStar_Syntax_Util.head_and_args t1)
+in (match (uu____4499) with
+| (hd1, uu____4510) -> begin
+(
+
+let t' = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((hd1), ((a1)::[])))) None t1.FStar_Syntax_Syntax.pos)
+in (
+
+let t2 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((t'), ((a2)::rest)))) None t1.FStar_Syntax_Syntax.pos)
+in (norm cfg env stack1 t2)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (uu____4565)); FStar_Syntax_Syntax.tk = uu____4566; FStar_Syntax_Syntax.pos = uu____4567; FStar_Syntax_Syntax.vars = uu____4568}, (a)::[]) when ((FStar_All.pipe_right cfg.steps (FStar_List.contains Reify)) && (is_reify_head stack1)) -> begin
+(
+
+let uu____4591 = (FStar_List.tl stack1)
+in (norm cfg env uu____4591 (Prims.fst a)))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____4594; FStar_Syntax_Syntax.pos = uu____4595; FStar_Syntax_Syntax.vars = uu____4596}, (a)::[]) when (FStar_All.pipe_right cfg.steps (FStar_List.contains Reify)) -> begin
+(
+
+let uu____4619 = (FStar_Syntax_Util.head_and_args t1)
+in (match (uu____4619) with
+| (reify_head, uu____4630) -> begin
+(
+
+let a1 = (
+
+let uu____4646 = (FStar_All.pipe_left FStar_Syntax_Util.unascribe (Prims.fst a))
+in (FStar_Syntax_Subst.compress uu____4646))
+in (match (a1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (uu____4649)); FStar_Syntax_Syntax.tk = uu____4650; FStar_Syntax_Syntax.pos = uu____4651; FStar_Syntax_Syntax.vars = uu____4652}, (a2)::[]) -> begin
+(norm cfg env stack1 (Prims.fst a2))
+end
+| uu____4677 -> begin
+(
+
+let stack2 = (App (((reify_head), (None), (t1.FStar_Syntax_Syntax.pos))))::stack1
+in (norm cfg env stack2 a1))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(
+
+let u1 = (norm_universe cfg env u)
+in (
+
+let uu____4685 = (mk (FStar_Syntax_Syntax.Tm_type (u1)) t1.FStar_Syntax_Syntax.pos)
+in (rebuild cfg env stack1 uu____4685)))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t', us) -> begin
+(
+
+let uu____4692 = (FStar_All.pipe_right cfg.steps (FStar_List.contains EraseUniverses))
+in (match (uu____4692) with
+| true -> begin
+(norm cfg env stack1 t')
+end
+| uu____4693 -> begin
+(
+
+let us1 = (
+
+let uu____4695 = (
+
+let uu____4699 = (FStar_List.map (norm_universe cfg env) us)
+in ((uu____4699), (t1.FStar_Syntax_Syntax.pos)))
+in UnivArgs (uu____4695))
+in (
+
+let stack2 = (us1)::stack1
+in (norm cfg env stack2 t')))
+end))
+end
+| FStar_Syntax_Syntax.Tm_fvar (f) -> begin
+(
+
+let t0 = t1
+in (
+
+let should_delta = (FStar_All.pipe_right cfg.delta_level (FStar_Util.for_some (fun uu___133_4708 -> (match (uu___133_4708) with
+| FStar_TypeChecker_Env.NoDelta -> begin
+false
+end
+| (FStar_TypeChecker_Env.Inlining) | (FStar_TypeChecker_Env.Eager_unfolding_only) -> begin
+true
+end
+| FStar_TypeChecker_Env.Unfold (l) -> begin
+(FStar_TypeChecker_Common.delta_depth_greater_than f.FStar_Syntax_Syntax.fv_delta l)
+end))))
+in (match ((not (should_delta))) with
+| true -> begin
+(rebuild cfg env stack1 t1)
+end
+| uu____4710 -> begin
+(
+
+let r_env = (
+
+let uu____4712 = (FStar_Syntax_Syntax.range_of_fv f)
+in (FStar_TypeChecker_Env.set_range cfg.tcenv uu____4712))
+in (
+
+let uu____4713 = (FStar_TypeChecker_Env.lookup_definition cfg.delta_level r_env f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____4713) with
+| None -> begin
+((log cfg (fun uu____4724 -> (FStar_Util.print "Tm_fvar case 2\n" [])));
+(rebuild cfg env stack1 t1);
+)
+end
+| Some (us, t2) -> begin
+((log cfg (fun uu____4730 -> (
+
+let uu____4731 = (FStar_Syntax_Print.term_to_string t0)
+in (
+
+let uu____4732 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.print2 ">>> Unfolded %s to %s\n" uu____4731 uu____4732)))));
+(
+
+let n1 = (FStar_List.length us)
+in (match ((n1 > (Prims.parse_int "0"))) with
+| true -> begin
+(match (stack1) with
+| (UnivArgs (us', uu____4739))::stack2 -> begin
+(
+
+let env1 = (FStar_All.pipe_right us' (FStar_List.fold_left (fun env1 u -> (Univ (u))::env1) env))
+in (norm cfg env1 stack2 t2))
+end
+| uu____4752 when (FStar_All.pipe_right cfg.steps (FStar_List.contains EraseUniverses)) -> begin
+(norm cfg env stack1 t2)
+end
+| uu____4753 -> begin
+(
+
+let uu____4754 = (
+
+let uu____4755 = (FStar_Syntax_Print.lid_to_string f.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_Util.format1 "Impossible: missing universe instantiation on %s" uu____4755))
+in (failwith uu____4754))
+end)
+end
+| uu____4760 -> begin
+(norm cfg env stack1 t2)
+end));
+)
+end)))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_bvar (x) -> begin
+(
+
+let uu____4762 = (lookup_bvar env x)
+in (match (uu____4762) with
+| Univ (uu____4763) -> begin
+(failwith "Impossible: term variable is bound to a universe")
+end
+| Dummy -> begin
+(failwith "Term variable not found")
+end
+| Clos (env1, t0, r, fix) -> begin
+(match (((not (fix)) || (not ((FStar_List.contains (Exclude (Zeta)) cfg.steps))))) with
+| true -> begin
+(
+
+let uu____4778 = (FStar_ST.read r)
+in (match (uu____4778) with
+| Some (env2, t') -> begin
+((log cfg (fun uu____4797 -> (
+
+let uu____4798 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____4799 = (FStar_Syntax_Print.term_to_string t')
+in (FStar_Util.print2 "Lazy hit: %s cached to %s\n" uu____4798 uu____4799)))));
+(
+
+let uu____4800 = (
+
+let uu____4801 = (FStar_Syntax_Subst.compress t')
+in uu____4801.FStar_Syntax_Syntax.n)
+in (match (uu____4800) with
+| FStar_Syntax_Syntax.Tm_abs (uu____4804) -> begin
+(norm cfg env2 stack1 t')
+end
+| uu____4819 -> begin
+(rebuild cfg env2 stack1 t')
+end));
+)
+end
+| None -> begin
+(norm cfg env1 ((MemoLazy (r))::stack1) t0)
+end))
+end
+| uu____4826 -> begin
+(norm cfg env1 stack1 t0)
+end)
+end))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) -> begin
+(match (stack1) with
+| (UnivArgs (uu____4852))::uu____4853 -> begin
+(failwith "Ill-typed term: universes cannot be applied to term abstraction")
+end
+| (Match (uu____4858))::uu____4859 -> begin
+(failwith "Ill-typed term: cannot pattern match an abstraction")
+end
+| (Arg (c, uu____4865, uu____4866))::stack_rest -> begin
+(match (c) with
+| Univ (uu____4869) -> begin
+(norm cfg ((c)::env) stack_rest t1)
+end
+| uu____4870 -> begin
+(match (bs) with
+| [] -> begin
+(failwith "Impossible")
+end
+| (uu____4873)::[] -> begin
+(match (lopt) with
+| None when (FStar_Options.__unit_tests ()) -> begin
+((log cfg (fun uu____4886 -> (
+
+let uu____4887 = (closure_to_string c)
+in (FStar_Util.print1 "\tShifted %s\n" uu____4887))));
+(norm cfg ((c)::env) stack_rest body);
+)
+end
+| Some (FStar_Util.Inr (l, cflags)) when (((FStar_Ident.lid_equals l FStar_Syntax_Const.effect_Tot_lid) || (FStar_Ident.lid_equals l FStar_Syntax_Const.effect_GTot_lid)) || (FStar_All.pipe_right cflags (FStar_Util.for_some (fun uu___134_4901 -> (match (uu___134_4901) with
+| FStar_Syntax_Syntax.TOTAL -> begin
+true
+end
+| uu____4902 -> begin
+false
+end))))) -> begin
+((log cfg (fun uu____4904 -> (
+
+let uu____4905 = (closure_to_string c)
+in (FStar_Util.print1 "\tShifted %s\n" uu____4905))));
+(norm cfg ((c)::env) stack_rest body);
+)
+end
+| Some (FStar_Util.Inl (lc)) when (FStar_Syntax_Util.is_tot_or_gtot_lcomp lc) -> begin
+((log cfg (fun uu____4916 -> (
+
+let uu____4917 = (closure_to_string c)
+in (FStar_Util.print1 "\tShifted %s\n" uu____4917))));
+(norm cfg ((c)::env) stack_rest body);
+)
+end
+| uu____4918 when (FStar_All.pipe_right cfg.steps (FStar_List.contains Reify)) -> begin
+(norm cfg ((c)::env) stack_rest body)
+end
+| uu____4925 -> begin
+(
+
+let cfg1 = (
+
+let uu___158_4933 = cfg
+in {steps = (WHNF)::(Exclude (Iota))::(Exclude (Zeta))::cfg.steps; tcenv = uu___158_4933.tcenv; delta_level = uu___158_4933.delta_level; primitive_steps = uu___158_4933.primitive_steps})
+in (
+
+let uu____4934 = (closure_as_term cfg1 env t1)
+in (rebuild cfg1 env stack1 uu____4934)))
+end)
+end
+| (uu____4935)::tl1 -> begin
+((log cfg (fun uu____4945 -> (
+
+let uu____4946 = (closure_to_string c)
+in (FStar_Util.print1 "\tShifted %s\n" uu____4946))));
+(
+
+let body1 = (mk (FStar_Syntax_Syntax.Tm_abs (((tl1), (body), (lopt)))) t1.FStar_Syntax_Syntax.pos)
+in (norm cfg ((c)::env) stack_rest body1));
+)
+end)
+end)
+end
+| (Steps (s, ps, dl))::stack2 -> begin
+(norm (
+
+let uu___159_4970 = cfg
+in {steps = s; tcenv = uu___159_4970.tcenv; delta_level = dl; primitive_steps = ps}) env stack2 t1)
+end
+| (MemoLazy (r))::stack2 -> begin
+((set_memo r ((env), (t1)));
+(log cfg (fun uu____4983 -> (
+
+let uu____4984 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print1 "\tSet memo %s\n" uu____4984))));
+(norm cfg env stack2 t1);
+)
+end
+| ((Debug (_))::_) | ((Meta (_))::_) | ((Let (_))::_) | ((App (_))::_) | ((Abs (_))::_) | ([]) -> begin
+(match ((FStar_List.contains WHNF cfg.steps)) with
+| true -> begin
+(
+
+let uu____4995 = (closure_as_term cfg env t1)
+in (rebuild cfg env stack1 uu____4995))
+end
+| uu____4996 -> begin
+(
+
+let uu____4997 = (FStar_Syntax_Subst.open_term' bs body)
+in (match (uu____4997) with
+| (bs1, body1, opening) -> begin
+(
+
+let lopt1 = (match (lopt) with
+| Some (FStar_Util.Inl (l)) -> begin
+(
+
+let uu____5026 = (
+
+let uu____5032 = (
+
+let uu____5033 = (
+
+let uu____5034 = (l.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Subst.subst_comp opening uu____5034))
+in (FStar_All.pipe_right uu____5033 FStar_Syntax_Util.lcomp_of_comp))
+in (FStar_All.pipe_right uu____5032 (fun _0_30 -> FStar_Util.Inl (_0_30))))
+in (FStar_All.pipe_right uu____5026 (fun _0_31 -> Some (_0_31))))
+end
+| uu____5059 -> begin
+lopt
+end)
+in (
+
+let env' = (FStar_All.pipe_right bs1 (FStar_List.fold_left (fun env1 uu____5073 -> (Dummy)::env1) env))
+in ((log cfg (fun uu____5078 -> (
+
+let uu____5079 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs1))
+in (FStar_Util.print1 "\tShifted %s dummies\n" uu____5079))));
+(
+
+let stack2 = (Steps (((cfg.steps), (cfg.primitive_steps), (cfg.delta_level))))::stack1
+in (
+
+let cfg1 = (
+
+let uu___160_5089 = cfg
+in (
+
+let uu____5090 = (FStar_List.filter (fun ps -> ps.strong_reduction_ok) cfg.primitive_steps)
+in {steps = uu___160_5089.steps; tcenv = uu___160_5089.tcenv; delta_level = uu___160_5089.delta_level; primitive_steps = uu____5090}))
+in (norm cfg1 env' ((Abs (((env), (bs1), (env'), (lopt1), (t1.FStar_Syntax_Syntax.pos))))::stack2) body1)));
+)))
+end))
+end)
+end)
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let stack2 = (FStar_All.pipe_right stack1 (FStar_List.fold_right (fun uu____5122 stack2 -> (match (uu____5122) with
+| (a, aq) -> begin
+(
+
+let uu____5130 = (
+
+let uu____5131 = (
+
+let uu____5135 = (
+
+let uu____5136 = (
+
+let uu____5146 = (FStar_Util.mk_ref None)
+in ((env), (a), (uu____5146), (false)))
+in Clos (uu____5136))
+in ((uu____5135), (aq), (t1.FStar_Syntax_Syntax.pos)))
+in Arg (uu____5131))
+in (uu____5130)::stack2)
+end)) args))
+in ((log cfg (fun uu____5168 -> (
+
+let uu____5169 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length args))
+in (FStar_Util.print1 "\tPushed %s arguments\n" uu____5169))));
+(norm cfg env stack2 head1);
+))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, f) -> begin
+(match ((FStar_List.contains WHNF cfg.steps)) with
+| true -> begin
+(match (((env), (stack1))) with
+| ([], []) -> begin
+(
+
+let t_x = (norm cfg env [] x.FStar_Syntax_Syntax.sort)
+in (
+
+let t2 = (mk (FStar_Syntax_Syntax.Tm_refine ((((
+
+let uu___161_5190 = x
+in {FStar_Syntax_Syntax.ppname = uu___161_5190.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___161_5190.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t_x})), (f)))) t1.FStar_Syntax_Syntax.pos)
+in (rebuild cfg env stack1 t2)))
+end
+| uu____5191 -> begin
+(
+
+let uu____5194 = (closure_as_term cfg env t1)
+in (rebuild cfg env stack1 uu____5194))
+end)
+end
+| uu____5195 -> begin
+(
+
+let t_x = (norm cfg env [] x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____5197 = (FStar_Syntax_Subst.open_term ((((x), (None)))::[]) f)
+in (match (uu____5197) with
+| (closing, f1) -> begin
+(
+
+let f2 = (norm cfg ((Dummy)::env) [] f1)
+in (
+
+let t2 = (
+
+let uu____5213 = (
+
+let uu____5214 = (
+
+let uu____5219 = (FStar_Syntax_Subst.close closing f2)
+in (((
+
+let uu___162_5220 = x
+in {FStar_Syntax_Syntax.ppname = uu___162_5220.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___162_5220.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t_x})), (uu____5219)))
+in FStar_Syntax_Syntax.Tm_refine (uu____5214))
+in (mk uu____5213 t1.FStar_Syntax_Syntax.pos))
+in (rebuild cfg env stack1 t2)))
+end)))
+end)
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(match ((FStar_List.contains WHNF cfg.steps)) with
+| true -> begin
+(
+
+let uu____5233 = (closure_as_term cfg env t1)
+in (rebuild cfg env stack1 uu____5233))
+end
+| uu____5234 -> begin
+(
+
+let uu____5235 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____5235) with
+| (bs1, c1) -> begin
+(
+
+let c2 = (
+
+let uu____5241 = (FStar_All.pipe_right bs1 (FStar_List.fold_left (fun env1 uu____5247 -> (Dummy)::env1) env))
+in (norm_comp cfg uu____5241 c1))
+in (
+
+let t2 = (
+
+let uu____5254 = (norm_binders cfg env bs1)
+in (FStar_Syntax_Util.arrow uu____5254 c2))
+in (rebuild cfg env stack1 t2)))
+end))
+end)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t11, (tc, tacopt), l) -> begin
+(match (stack1) with
+| ((Match (_))::_) | ((Arg (_))::_) | ((App ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _, _))::_) | ((MemoLazy (_))::_) -> begin
+(norm cfg env stack1 t11)
+end
+| uu____5311 -> begin
+(
+
+let t12 = (norm cfg env [] t11)
+in ((log cfg (fun uu____5314 -> (FStar_Util.print_string "+++ Normalizing ascription \n")));
+(
+
+let tc1 = (match (tc) with
+| FStar_Util.Inl (t2) -> begin
+(
+
+let uu____5327 = (norm cfg env [] t2)
+in FStar_Util.Inl (uu____5327))
+end
+| FStar_Util.Inr (c) -> begin
+(
+
+let uu____5335 = (norm_comp cfg env c)
+in FStar_Util.Inr (uu____5335))
+end)
+in (
+
+let tacopt1 = (FStar_Util.map_opt tacopt (norm cfg env []))
+in (
+
+let uu____5340 = (mk (FStar_Syntax_Syntax.Tm_ascribed (((t12), (((tc1), (tacopt1))), (l)))) t1.FStar_Syntax_Syntax.pos)
+in (rebuild cfg env stack1 uu____5340))));
+))
+end)
+end
+| FStar_Syntax_Syntax.Tm_match (head1, branches) -> begin
+(
+
+let stack2 = (Match (((env), (branches), (t1.FStar_Syntax_Syntax.pos))))::stack1
+in (norm cfg env stack2 head1))
+end
+| FStar_Syntax_Syntax.Tm_let ((uu____5391, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (uu____5392); FStar_Syntax_Syntax.lbunivs = uu____5393; FStar_Syntax_Syntax.lbtyp = uu____5394; FStar_Syntax_Syntax.lbeff = uu____5395; FStar_Syntax_Syntax.lbdef = uu____5396})::uu____5397), uu____5398) -> begin
+(rebuild cfg env stack1 t1)
+end
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), body) -> begin
+(
+
+let n1 = (FStar_TypeChecker_Env.norm_eff_name cfg.tcenv lb.FStar_Syntax_Syntax.lbeff)
+in (
+
+let uu____5424 = ((
+
+let uu____5425 = (FStar_All.pipe_right cfg.steps (FStar_List.contains NoDeltaSteps))
+in (not (uu____5425))) && ((FStar_Syntax_Util.is_pure_effect n1) || ((FStar_Syntax_Util.is_ghost_effect n1) && (
+
+let uu____5426 = (FStar_All.pipe_right cfg.steps (FStar_List.contains PureSubtermsWithinComputations))
+in (not (uu____5426))))))
+in (match (uu____5424) with
+| true -> begin
+(
+
+let env1 = (
+
+let uu____5429 = (
+
+let uu____5430 = (
+
+let uu____5440 = (FStar_Util.mk_ref None)
+in ((env), (lb.FStar_Syntax_Syntax.lbdef), (uu____5440), (false)))
+in Clos (uu____5430))
+in (uu____5429)::env)
+in (norm cfg env1 stack1 body))
+end
+| uu____5463 -> begin
+(
+
+let uu____5464 = (
+
+let uu____5467 = (
+
+let uu____5468 = (
+
+let uu____5469 = (FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbname FStar_Util.left)
+in (FStar_All.pipe_right uu____5469 FStar_Syntax_Syntax.mk_binder))
+in (uu____5468)::[])
+in (FStar_Syntax_Subst.open_term uu____5467 body))
+in (match (uu____5464) with
+| (bs, body1) -> begin
+(
+
+let lb1 = (
+
+let uu___163_5475 = lb
+in (
+
+let uu____5476 = (
+
+let uu____5479 = (
+
+let uu____5480 = (FStar_List.hd bs)
+in (FStar_All.pipe_right uu____5480 Prims.fst))
+in (FStar_All.pipe_right uu____5479 (fun _0_32 -> FStar_Util.Inl (_0_32))))
+in (
+
+let uu____5489 = (norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____5492 = (norm cfg env [] lb.FStar_Syntax_Syntax.lbdef)
+in {FStar_Syntax_Syntax.lbname = uu____5476; FStar_Syntax_Syntax.lbunivs = uu___163_5475.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu____5489; FStar_Syntax_Syntax.lbeff = uu___163_5475.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____5492}))))
+in (
+
+let env' = (FStar_All.pipe_right bs (FStar_List.fold_left (fun env1 uu____5502 -> (Dummy)::env1) env))
+in (norm cfg env' ((Let (((env), (bs), (lb1), (t1.FStar_Syntax_Syntax.pos))))::stack1) body1)))
+end))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_let (lbs, body) when (FStar_List.contains (Exclude (Zeta)) cfg.steps) -> begin
+(
+
+let uu____5518 = (closure_as_term cfg env t1)
+in (rebuild cfg env stack1 uu____5518))
+end
+| FStar_Syntax_Syntax.Tm_let (lbs, body) -> begin
+(
+
+let uu____5531 = (FStar_List.fold_right (fun lb uu____5553 -> (match (uu____5553) with
+| (rec_env, memos, i) -> begin
+(
+
+let f_i = (
+
+let uu____5592 = (
+
+let uu___164_5593 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in {FStar_Syntax_Syntax.ppname = uu___164_5593.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = i; FStar_Syntax_Syntax.sort = uu___164_5593.FStar_Syntax_Syntax.sort})
+in (FStar_Syntax_Syntax.bv_to_tm uu____5592))
+in (
+
+let fix_f_i = (mk (FStar_Syntax_Syntax.Tm_let (((lbs), (f_i)))) t1.FStar_Syntax_Syntax.pos)
+in (
+
+let memo = (FStar_Util.mk_ref None)
+in (
+
+let rec_env1 = (Clos (((env), (fix_f_i), (memo), (true))))::rec_env
+in ((rec_env1), ((memo)::memos), ((i + (Prims.parse_int "1"))))))))
+end)) (Prims.snd lbs) ((env), ([]), ((Prims.parse_int "0"))))
+in (match (uu____5531) with
+| (rec_env, memos, uu____5653) -> begin
+(
+
+let uu____5668 = (FStar_List.map2 (fun lb memo -> (FStar_ST.write memo (Some (((rec_env), (lb.FStar_Syntax_Syntax.lbdef)))))) (Prims.snd lbs) memos)
+in (
+
+let body_env = (FStar_List.fold_right (fun lb env1 -> (
+
+let uu____5710 = (
+
+let uu____5711 = (
+
+let uu____5721 = (FStar_Util.mk_ref None)
+in ((rec_env), (lb.FStar_Syntax_Syntax.lbdef), (uu____5721), (false)))
+in Clos (uu____5711))
+in (uu____5710)::env1)) (Prims.snd lbs) env)
+in (norm cfg body_env stack1 body)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (head1, m) -> begin
+(match (m) with
+| FStar_Syntax_Syntax.Meta_monadic (m1, t2) -> begin
+(
+
+let should_reify = (match (stack1) with
+| (App ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____5759; FStar_Syntax_Syntax.pos = uu____5760; FStar_Syntax_Syntax.vars = uu____5761}, uu____5762, uu____5763))::uu____5764 -> begin
+(FStar_All.pipe_right cfg.steps (FStar_List.contains Reify))
+end
+| uu____5770 -> begin
+false
+end)
+in (match ((not (should_reify))) with
+| true -> begin
+(
+
+let t3 = (norm cfg env [] t2)
+in (
+
+let stack2 = (Steps (((cfg.steps), (cfg.primitive_steps), (cfg.delta_level))))::stack1
+in (
+
+let cfg1 = (
+
+let uu____5777 = (FStar_All.pipe_right cfg.steps (FStar_List.contains PureSubtermsWithinComputations))
+in (match (uu____5777) with
+| true -> begin
+(
+
+let uu___165_5778 = cfg
+in {steps = (PureSubtermsWithinComputations)::(Primops)::(AllowUnboundUniverses)::(EraseUniverses)::(Exclude (Zeta))::(NoDeltaSteps)::[]; tcenv = uu___165_5778.tcenv; delta_level = (FStar_TypeChecker_Env.Inlining)::(FStar_TypeChecker_Env.Eager_unfolding_only)::[]; primitive_steps = uu___165_5778.primitive_steps})
+end
+| uu____5779 -> begin
+(
+
+let uu___166_5780 = cfg
+in {steps = (FStar_List.append ((NoDeltaSteps)::(Exclude (Zeta))::[]) cfg.steps); tcenv = uu___166_5780.tcenv; delta_level = (FStar_TypeChecker_Env.NoDelta)::[]; primitive_steps = uu___166_5780.primitive_steps})
+end))
+in (norm cfg1 env ((Meta (((FStar_Syntax_Syntax.Meta_monadic (((m1), (t3)))), (t3.FStar_Syntax_Syntax.pos))))::stack2) head1))))
+end
+| uu____5781 -> begin
+(
+
+let uu____5782 = (
+
+let uu____5783 = (FStar_Syntax_Subst.compress head1)
+in uu____5783.FStar_Syntax_Syntax.n)
+in (match (uu____5782) with
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), body) -> begin
+(
+
+let ed = (FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m1)
+in (
+
+let uu____5797 = ed.FStar_Syntax_Syntax.bind_repr
+in (match (uu____5797) with
+| (uu____5798, bind_repr) -> begin
+(match (lb.FStar_Syntax_Syntax.lbname) with
+| FStar_Util.Inr (uu____5802) -> begin
+(failwith "Cannot reify a top-level let binding")
+end
+| FStar_Util.Inl (x) -> begin
+(
+
+let is_return = (fun e -> (
+
+let uu____5809 = (
+
+let uu____5810 = (FStar_Syntax_Subst.compress e)
+in uu____5810.FStar_Syntax_Syntax.n)
+in (match (uu____5809) with
+| FStar_Syntax_Syntax.Tm_meta (e1, FStar_Syntax_Syntax.Meta_monadic (uu____5815, uu____5816)) -> begin
+(
+
+let uu____5825 = (
+
+let uu____5826 = (FStar_Syntax_Subst.compress e1)
+in uu____5826.FStar_Syntax_Syntax.n)
+in (match (uu____5825) with
+| FStar_Syntax_Syntax.Tm_meta (e2, FStar_Syntax_Syntax.Meta_monadic_lift (uu____5831, msrc, uu____5833)) when (FStar_Syntax_Util.is_pure_effect msrc) -> begin
+(
+
+let uu____5842 = (FStar_Syntax_Subst.compress e2)
+in Some (uu____5842))
+end
+| uu____5843 -> begin
+None
+end))
+end
+| uu____5844 -> begin
+None
+end)))
+in (
+
+let uu____5845 = (is_return lb.FStar_Syntax_Syntax.lbdef)
+in (match (uu____5845) with
+| Some (e) -> begin
+(
+
+let lb1 = (
+
+let uu___167_5849 = lb
+in {FStar_Syntax_Syntax.lbname = uu___167_5849.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___167_5849.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___167_5849.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_PURE_lid; FStar_Syntax_Syntax.lbdef = e})
+in (
+
+let uu____5850 = (FStar_List.tl stack1)
+in (
+
+let uu____5851 = (
+
+let uu____5852 = (
+
+let uu____5855 = (
+
+let uu____5856 = (
+
+let uu____5864 = (FStar_Syntax_Util.mk_reify body)
+in ((((false), ((lb1)::[]))), (uu____5864)))
+in FStar_Syntax_Syntax.Tm_let (uu____5856))
+in (FStar_Syntax_Syntax.mk uu____5855))
+in (uu____5852 None head1.FStar_Syntax_Syntax.pos))
+in (norm cfg env uu____5850 uu____5851))))
+end
+| None -> begin
+(
+
+let uu____5881 = (
+
+let uu____5882 = (is_return body)
+in (match (uu____5882) with
+| Some ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_bvar (y); FStar_Syntax_Syntax.tk = uu____5885; FStar_Syntax_Syntax.pos = uu____5886; FStar_Syntax_Syntax.vars = uu____5887}) -> begin
+(FStar_Syntax_Syntax.bv_eq x y)
+end
+| uu____5892 -> begin
+false
+end))
+in (match (uu____5881) with
+| true -> begin
+(norm cfg env stack1 lb.FStar_Syntax_Syntax.lbdef)
+end
+| uu____5894 -> begin
+(
+
+let head2 = (FStar_All.pipe_left FStar_Syntax_Util.mk_reify lb.FStar_Syntax_Syntax.lbdef)
+in (
+
+let body1 = (FStar_All.pipe_left FStar_Syntax_Util.mk_reify body)
+in (
+
+let body2 = (
+
+let uu____5912 = (
+
+let uu____5915 = (
+
+let uu____5916 = (
+
+let uu____5931 = (
+
+let uu____5933 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____5933)::[])
+in ((uu____5931), (body1), (Some (FStar_Util.Inr (((m1), ([])))))))
+in FStar_Syntax_Syntax.Tm_abs (uu____5916))
+in (FStar_Syntax_Syntax.mk uu____5915))
+in (uu____5912 None body1.FStar_Syntax_Syntax.pos))
+in (
+
+let bind_inst = (
+
+let uu____5963 = (
+
+let uu____5964 = (FStar_Syntax_Subst.compress bind_repr)
+in uu____5964.FStar_Syntax_Syntax.n)
+in (match (uu____5963) with
+| FStar_Syntax_Syntax.Tm_uinst (bind1, (uu____5970)::(uu____5971)::[]) -> begin
+(
+
+let uu____5977 = (
+
+let uu____5980 = (
+
+let uu____5981 = (
+
+let uu____5986 = (
+
+let uu____5988 = (cfg.tcenv.FStar_TypeChecker_Env.universe_of cfg.tcenv lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____5989 = (
+
+let uu____5991 = (cfg.tcenv.FStar_TypeChecker_Env.universe_of cfg.tcenv t2)
+in (uu____5991)::[])
+in (uu____5988)::uu____5989))
+in ((bind1), (uu____5986)))
+in FStar_Syntax_Syntax.Tm_uinst (uu____5981))
+in (FStar_Syntax_Syntax.mk uu____5980))
+in (uu____5977 None t2.FStar_Syntax_Syntax.pos))
+end
+| uu____6003 -> begin
+(failwith "NIY : Reification of indexed effects")
+end))
+in (
+
+let reified = (
+
+let uu____6009 = (
+
+let uu____6012 = (
+
+let uu____6013 = (
+
+let uu____6023 = (
+
+let uu____6025 = (FStar_Syntax_Syntax.as_arg lb.FStar_Syntax_Syntax.lbtyp)
+in (
+
+let uu____6026 = (
+
+let uu____6028 = (FStar_Syntax_Syntax.as_arg t2)
+in (
+
+let uu____6029 = (
+
+let uu____6031 = (FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun)
+in (
+
+let uu____6032 = (
+
+let uu____6034 = (FStar_Syntax_Syntax.as_arg head2)
+in (
+
+let uu____6035 = (
+
+let uu____6037 = (FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun)
+in (
+
+let uu____6038 = (
+
+let uu____6040 = (FStar_Syntax_Syntax.as_arg body2)
+in (uu____6040)::[])
+in (uu____6037)::uu____6038))
+in (uu____6034)::uu____6035))
+in (uu____6031)::uu____6032))
+in (uu____6028)::uu____6029))
+in (uu____6025)::uu____6026))
+in ((bind_inst), (uu____6023)))
+in FStar_Syntax_Syntax.Tm_app (uu____6013))
+in (FStar_Syntax_Syntax.mk uu____6012))
+in (uu____6009 None t2.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____6052 = (FStar_List.tl stack1)
+in (norm cfg env uu____6052 reified)))))))
+end))
+end)))
+end)
+end)))
+end
+| FStar_Syntax_Syntax.Tm_app (head_app, args) -> begin
+(
+
+let ed = (FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m1)
+in (
+
+let uu____6070 = ed.FStar_Syntax_Syntax.bind_repr
+in (match (uu____6070) with
+| (uu____6071, bind_repr) -> begin
+(
+
+let maybe_unfold_action = (fun head2 -> (
+
+let maybe_extract_fv = (fun t3 -> (
+
+let t4 = (
+
+let uu____6094 = (
+
+let uu____6095 = (FStar_Syntax_Subst.compress t3)
+in uu____6095.FStar_Syntax_Syntax.n)
+in (match (uu____6094) with
+| FStar_Syntax_Syntax.Tm_uinst (t4, uu____6101) -> begin
+t4
+end
+| uu____6106 -> begin
+head2
+end))
+in (
+
+let uu____6107 = (
+
+let uu____6108 = (FStar_Syntax_Subst.compress t4)
+in uu____6108.FStar_Syntax_Syntax.n)
+in (match (uu____6107) with
+| FStar_Syntax_Syntax.Tm_fvar (x) -> begin
+Some (x)
+end
+| uu____6113 -> begin
+None
+end))))
+in (
+
+let uu____6114 = (maybe_extract_fv head2)
+in (match (uu____6114) with
+| Some (x) when (
+
+let uu____6120 = (FStar_Syntax_Syntax.lid_of_fv x)
+in (FStar_TypeChecker_Env.is_action cfg.tcenv uu____6120)) -> begin
+(
+
+let head3 = (norm cfg env [] head2)
+in (
+
+let action_unfolded = (
+
+let uu____6124 = (maybe_extract_fv head3)
+in (match (uu____6124) with
+| Some (uu____6127) -> begin
+Some (true)
+end
+| uu____6128 -> begin
+Some (false)
+end))
+in ((head3), (action_unfolded))))
+end
+| uu____6131 -> begin
+((head2), (None))
+end))))
+in ((
+
+let is_arg_impure = (fun uu____6142 -> (match (uu____6142) with
+| (e, q) -> begin
+(
+
+let uu____6147 = (
+
+let uu____6148 = (FStar_Syntax_Subst.compress e)
+in uu____6148.FStar_Syntax_Syntax.n)
+in (match (uu____6147) with
+| FStar_Syntax_Syntax.Tm_meta (e0, FStar_Syntax_Syntax.Meta_monadic_lift (m11, m2, t')) -> begin
+(not ((FStar_Syntax_Util.is_pure_effect m11)))
+end
+| uu____6163 -> begin
+false
+end))
+end))
+in (
+
+let uu____6164 = (
+
+let uu____6165 = (
+
+let uu____6169 = (FStar_Syntax_Syntax.as_arg head_app)
+in (uu____6169)::args)
+in (FStar_Util.for_some is_arg_impure uu____6165))
+in (match (uu____6164) with
+| true -> begin
+(
+
+let uu____6172 = (
+
+let uu____6173 = (FStar_Syntax_Print.term_to_string head1)
+in (FStar_Util.format1 "Incompability between typechecker and normalizer; this monadic application contains impure terms %s\n" uu____6173))
+in (failwith uu____6172))
+end
+| uu____6174 -> begin
+()
+end)));
+(
+
+let uu____6175 = (maybe_unfold_action head_app)
+in (match (uu____6175) with
+| (head_app1, found_action) -> begin
+(
+
+let mk1 = (fun tm -> (FStar_Syntax_Syntax.mk tm None t2.FStar_Syntax_Syntax.pos))
+in (
+
+let body = (mk1 (FStar_Syntax_Syntax.Tm_app (((head_app1), (args)))))
+in (
+
+let body1 = (match (found_action) with
+| None -> begin
+(FStar_Syntax_Util.mk_reify body)
+end
+| Some (false) -> begin
+(mk1 (FStar_Syntax_Syntax.Tm_meta (((body), (FStar_Syntax_Syntax.Meta_monadic (((m1), (t2))))))))
+end
+| Some (true) -> begin
+body
+end)
+in (
+
+let uu____6210 = (FStar_List.tl stack1)
+in (norm cfg env uu____6210 body1)))))
+end));
+))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_meta (e, FStar_Syntax_Syntax.Meta_monadic_lift (msrc, mtgt, t')) -> begin
+(
+
+let lifted = (reify_lift cfg.tcenv e msrc mtgt t')
+in (
+
+let uu____6224 = (FStar_List.tl stack1)
+in (norm cfg env uu____6224 lifted)))
+end
+| FStar_Syntax_Syntax.Tm_match (e, branches) -> begin
+(
+
+let branches1 = (FStar_All.pipe_right branches (FStar_List.map (fun uu____6307 -> (match (uu____6307) with
+| (pat, wopt, tm) -> begin
+(
+
+let uu____6345 = (FStar_Syntax_Util.mk_reify tm)
+in ((pat), (wopt), (uu____6345)))
+end))))
+in (
+
+let tm = (mk (FStar_Syntax_Syntax.Tm_match (((e), (branches1)))) t2.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____6371 = (FStar_List.tl stack1)
+in (norm cfg env uu____6371 tm))))
+end
+| uu____6372 -> begin
+(norm cfg env stack1 head1)
+end))
+end))
+end
+| FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t2) -> begin
+(
+
+let should_reify = (match (stack1) with
+| (App ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____6381; FStar_Syntax_Syntax.pos = uu____6382; FStar_Syntax_Syntax.vars = uu____6383}, uu____6384, uu____6385))::uu____6386 -> begin
+(FStar_All.pipe_right cfg.steps (FStar_List.contains Reify))
+end
+| uu____6392 -> begin
+false
+end)
+in (match (should_reify) with
+| true -> begin
+(
+
+let uu____6393 = (FStar_List.tl stack1)
+in (
+
+let uu____6394 = (reify_lift cfg.tcenv head1 m1 m' t2)
+in (norm cfg env uu____6393 uu____6394)))
+end
+| uu____6395 -> begin
+(
+
+let uu____6396 = (((FStar_Syntax_Util.is_pure_effect m1) || (FStar_Syntax_Util.is_ghost_effect m1)) && (FStar_All.pipe_right cfg.steps (FStar_List.contains PureSubtermsWithinComputations)))
+in (match (uu____6396) with
+| true -> begin
+(
+
+let stack2 = (Steps (((cfg.steps), (cfg.primitive_steps), (cfg.delta_level))))::stack1
+in (
+
+let cfg1 = (
+
+let uu___168_6402 = cfg
+in {steps = (PureSubtermsWithinComputations)::(Primops)::(AllowUnboundUniverses)::(EraseUniverses)::(Exclude (Zeta))::[]; tcenv = uu___168_6402.tcenv; delta_level = (FStar_TypeChecker_Env.Inlining)::(FStar_TypeChecker_Env.Eager_unfolding_only)::[]; primitive_steps = uu___168_6402.primitive_steps})
+in (norm cfg1 env ((Meta (((FStar_Syntax_Syntax.Meta_monadic_lift (((m1), (m'), (t2)))), (head1.FStar_Syntax_Syntax.pos))))::stack2) head1)))
+end
+| uu____6405 -> begin
+(norm cfg env ((Meta (((FStar_Syntax_Syntax.Meta_monadic_lift (((m1), (m'), (t2)))), (head1.FStar_Syntax_Syntax.pos))))::stack1) head1)
+end))
+end))
+end
+| uu____6408 -> begin
+(match (stack1) with
+| (uu____6409)::uu____6410 -> begin
+(match (m) with
+| FStar_Syntax_Syntax.Meta_labeled (l, r, uu____6414) -> begin
+(norm cfg env ((Meta (((m), (r))))::stack1) head1)
+end
+| FStar_Syntax_Syntax.Meta_pattern (args) -> begin
+(
+
+let args1 = (norm_pattern_args cfg env args)
+in (norm cfg env ((Meta (((FStar_Syntax_Syntax.Meta_pattern (args1)), (t1.FStar_Syntax_Syntax.pos))))::stack1) head1))
+end
+| uu____6429 -> begin
+(norm cfg env stack1 head1)
+end)
+end
+| [] -> begin
+(
+
+let head2 = (norm cfg env [] head1)
+in (
+
+let m1 = (match (m) with
+| FStar_Syntax_Syntax.Meta_pattern (args) -> begin
+(
+
+let uu____6439 = (norm_pattern_args cfg env args)
+in FStar_Syntax_Syntax.Meta_pattern (uu____6439))
+end
+| uu____6446 -> begin
+m
+end)
+in (
+
+let t2 = (mk (FStar_Syntax_Syntax.Tm_meta (((head2), (m1)))) t1.FStar_Syntax_Syntax.pos)
+in (rebuild cfg env stack1 t2))))
+end)
+end)
+end);
+))))
+and reify_lift : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.monad_name  ->  FStar_Syntax_Syntax.monad_name  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term = (fun env e msrc mtgt t -> (match ((FStar_Syntax_Util.is_pure_effect msrc)) with
+| true -> begin
+(
+
+let ed = (FStar_TypeChecker_Env.get_effect_decl env mtgt)
+in (
+
+let uu____6460 = ed.FStar_Syntax_Syntax.return_repr
+in (match (uu____6460) with
+| (uu____6461, return_repr) -> begin
+(
+
+let return_inst = (
+
+let uu____6468 = (
+
+let uu____6469 = (FStar_Syntax_Subst.compress return_repr)
+in uu____6469.FStar_Syntax_Syntax.n)
+in (match (uu____6468) with
+| FStar_Syntax_Syntax.Tm_uinst (return_tm, (uu____6475)::[]) -> begin
+(
+
+let uu____6481 = (
+
+let uu____6484 = (
+
+let uu____6485 = (
+
+let uu____6490 = (
+
+let uu____6492 = (env.FStar_TypeChecker_Env.universe_of env t)
+in (uu____6492)::[])
+in ((return_tm), (uu____6490)))
+in FStar_Syntax_Syntax.Tm_uinst (uu____6485))
+in (FStar_Syntax_Syntax.mk uu____6484))
+in (uu____6481 None e.FStar_Syntax_Syntax.pos))
+end
+| uu____6504 -> begin
+(failwith "NIY : Reification of indexed effects")
+end))
+in (
+
+let uu____6507 = (
+
+let uu____6510 = (
+
+let uu____6511 = (
+
+let uu____6521 = (
+
+let uu____6523 = (FStar_Syntax_Syntax.as_arg t)
+in (
+
+let uu____6524 = (
+
+let uu____6526 = (FStar_Syntax_Syntax.as_arg e)
+in (uu____6526)::[])
+in (uu____6523)::uu____6524))
+in ((return_inst), (uu____6521)))
+in FStar_Syntax_Syntax.Tm_app (uu____6511))
+in (FStar_Syntax_Syntax.mk uu____6510))
+in (uu____6507 None e.FStar_Syntax_Syntax.pos)))
+end)))
+end
+| uu____6538 -> begin
+(
+
+let uu____6539 = (FStar_TypeChecker_Env.monad_leq env msrc mtgt)
+in (match (uu____6539) with
+| None -> begin
+(
+
+let uu____6541 = (FStar_Util.format2 "Impossible : trying to reify a lift between unrelated effects (%s and %s)" (FStar_Ident.text_of_lid msrc) (FStar_Ident.text_of_lid mtgt))
+in (failwith uu____6541))
+end
+| Some ({FStar_TypeChecker_Env.msource = uu____6542; FStar_TypeChecker_Env.mtarget = uu____6543; FStar_TypeChecker_Env.mlift = {FStar_TypeChecker_Env.mlift_wp = uu____6544; FStar_TypeChecker_Env.mlift_term = None}}) -> begin
+(failwith "Impossible : trying to reify a non-reifiable lift (from %s to %s)")
+end
+| Some ({FStar_TypeChecker_Env.msource = uu____6555; FStar_TypeChecker_Env.mtarget = uu____6556; FStar_TypeChecker_Env.mlift = {FStar_TypeChecker_Env.mlift_wp = uu____6557; FStar_TypeChecker_Env.mlift_term = Some (lift)}}) -> begin
+(
+
+let uu____6575 = (FStar_Syntax_Util.mk_reify e)
+in (lift t FStar_Syntax_Syntax.tun uu____6575))
+end))
+end))
+and norm_pattern_args : cfg  ->  env  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list Prims.list  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list Prims.list = (fun cfg env args -> (FStar_All.pipe_right args (FStar_List.map (FStar_List.map (fun uu____6605 -> (match (uu____6605) with
+| (a, imp) -> begin
+(
+
+let uu____6612 = (norm cfg env [] a)
+in ((uu____6612), (imp)))
+end))))))
+and norm_comp : cfg  ->  env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun cfg env comp -> (
+
+let comp1 = (ghost_to_pure_aux cfg env comp)
+in (match (comp1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uopt) -> begin
+(
+
+let uu___169_6627 = comp1
+in (
+
+let uu____6630 = (
+
+let uu____6631 = (
+
+let uu____6637 = (norm cfg env [] t)
+in (
+
+let uu____6638 = (FStar_Option.map (norm_universe cfg env) uopt)
+in ((uu____6637), (uu____6638))))
+in FStar_Syntax_Syntax.Total (uu____6631))
+in {FStar_Syntax_Syntax.n = uu____6630; FStar_Syntax_Syntax.tk = uu___169_6627.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___169_6627.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___169_6627.FStar_Syntax_Syntax.vars}))
+end
+| FStar_Syntax_Syntax.GTotal (t, uopt) -> begin
+(
+
+let uu___170_6653 = comp1
+in (
+
+let uu____6656 = (
+
+let uu____6657 = (
+
+let uu____6663 = (norm cfg env [] t)
+in (
+
+let uu____6664 = (FStar_Option.map (norm_universe cfg env) uopt)
+in ((uu____6663), (uu____6664))))
+in FStar_Syntax_Syntax.GTotal (uu____6657))
+in {FStar_Syntax_Syntax.n = uu____6656; FStar_Syntax_Syntax.tk = uu___170_6653.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___170_6653.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___170_6653.FStar_Syntax_Syntax.vars}))
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let norm_args = (fun args -> (FStar_All.pipe_right args (FStar_List.map (fun uu____6695 -> (match (uu____6695) with
+| (a, i) -> begin
+(
+
+let uu____6702 = (norm cfg env [] a)
+in ((uu____6702), (i)))
+end)))))
+in (
+
+let flags = (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags (FStar_List.map (fun uu___135_6707 -> (match (uu___135_6707) with
+| FStar_Syntax_Syntax.DECREASES (t) -> begin
+(
+
+let uu____6711 = (norm cfg env [] t)
+in FStar_Syntax_Syntax.DECREASES (uu____6711))
+end
+| f -> begin
+f
+end))))
+in (
+
+let uu___171_6715 = comp1
+in (
+
+let uu____6718 = (
+
+let uu____6719 = (
+
+let uu___172_6720 = ct
+in (
+
+let uu____6721 = (FStar_List.map (norm_universe cfg env) ct.FStar_Syntax_Syntax.comp_univs)
+in (
+
+let uu____6722 = (norm cfg env [] ct.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____6725 = (norm_args ct.FStar_Syntax_Syntax.effect_args)
+in {FStar_Syntax_Syntax.comp_univs = uu____6721; FStar_Syntax_Syntax.effect_name = uu___172_6720.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = uu____6722; FStar_Syntax_Syntax.effect_args = uu____6725; FStar_Syntax_Syntax.flags = flags}))))
+in FStar_Syntax_Syntax.Comp (uu____6719))
+in {FStar_Syntax_Syntax.n = uu____6718; FStar_Syntax_Syntax.tk = uu___171_6715.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___171_6715.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___171_6715.FStar_Syntax_Syntax.vars}))))
+end)))
+and ghost_to_pure_aux : cfg  ->  env  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun cfg env c -> (
+
+let norm1 = (fun t -> (norm (
+
+let uu___173_6742 = cfg
+in {steps = (Eager_unfolding)::(UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(AllowUnboundUniverses)::[]; tcenv = uu___173_6742.tcenv; delta_level = uu___173_6742.delta_level; primitive_steps = uu___173_6742.primitive_steps}) env [] t))
+in (
+
+let non_info = (fun t -> (
+
+let uu____6747 = (norm1 t)
+in (FStar_Syntax_Util.non_informative uu____6747)))
+in (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (uu____6750) -> begin
+c
+end
+| FStar_Syntax_Syntax.GTotal (t, uopt) when (non_info t) -> begin
+(
+
+let uu___174_6764 = c
+in {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total (((t), (uopt))); FStar_Syntax_Syntax.tk = uu___174_6764.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___174_6764.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___174_6764.FStar_Syntax_Syntax.vars})
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(
+
+let l = (FStar_TypeChecker_Env.norm_eff_name cfg.tcenv ct.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____6774 = ((FStar_Syntax_Util.is_ghost_effect l) && (non_info ct.FStar_Syntax_Syntax.result_typ))
+in (match (uu____6774) with
+| true -> begin
+(
+
+let ct1 = (match ((downgrade_ghost_effect_name ct.FStar_Syntax_Syntax.effect_name)) with
+| Some (pure_eff) -> begin
+(
+
+let uu___175_6779 = ct
+in {FStar_Syntax_Syntax.comp_univs = uu___175_6779.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = pure_eff; FStar_Syntax_Syntax.result_typ = uu___175_6779.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu___175_6779.FStar_Syntax_Syntax.effect_args; FStar_Syntax_Syntax.flags = uu___175_6779.FStar_Syntax_Syntax.flags})
+end
+| None -> begin
+(
+
+let ct1 = (FStar_TypeChecker_Env.unfold_effect_abbrev cfg.tcenv c)
+in (
+
+let uu___176_6781 = ct1
+in {FStar_Syntax_Syntax.comp_univs = uu___176_6781.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = FStar_Syntax_Const.effect_PURE_lid; FStar_Syntax_Syntax.result_typ = uu___176_6781.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu___176_6781.FStar_Syntax_Syntax.effect_args; FStar_Syntax_Syntax.flags = uu___176_6781.FStar_Syntax_Syntax.flags}))
+end)
+in (
+
+let uu___177_6782 = c
+in {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Comp (ct1); FStar_Syntax_Syntax.tk = uu___177_6782.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___177_6782.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___177_6782.FStar_Syntax_Syntax.vars}))
+end
+| uu____6787 -> begin
+c
+end)))
+end
+| uu____6788 -> begin
+c
+end))))
+and norm_binder : cfg  ->  env  ->  FStar_Syntax_Syntax.binder  ->  FStar_Syntax_Syntax.binder = (fun cfg env uu____6791 -> (match (uu____6791) with
+| (x, imp) -> begin
+(
+
+let uu____6794 = (
+
+let uu___178_6795 = x
+in (
+
+let uu____6796 = (norm cfg env [] x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___178_6795.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___178_6795.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____6796}))
+in ((uu____6794), (imp)))
+end))
+and norm_binders : cfg  ->  env  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun cfg env bs -> (
+
+let uu____6802 = (FStar_List.fold_left (fun uu____6809 b -> (match (uu____6809) with
+| (nbs', env1) -> begin
+(
+
+let b1 = (norm_binder cfg env1 b)
+in (((b1)::nbs'), ((Dummy)::env1)))
+end)) (([]), (env)) bs)
+in (match (uu____6802) with
+| (nbs, uu____6826) -> begin
+(FStar_List.rev nbs)
+end)))
+and norm_lcomp_opt : cfg  ->  env  ->  (FStar_Syntax_Syntax.lcomp, FStar_Syntax_Syntax.residual_comp) FStar_Util.either Prims.option  ->  (FStar_Syntax_Syntax.lcomp, FStar_Syntax_Syntax.residual_comp) FStar_Util.either Prims.option = (fun cfg env lopt -> (match (lopt) with
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let flags = (filter_out_lcomp_cflags lc)
+in (
+
+let uu____6843 = (FStar_Syntax_Util.is_tot_or_gtot_lcomp lc)
+in (match (uu____6843) with
+| true -> begin
+(
+
+let t = (norm cfg env [] lc.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____6848 = (FStar_Syntax_Util.is_total_lcomp lc)
+in (match (uu____6848) with
+| true -> begin
+(
+
+let uu____6852 = (
+
+let uu____6855 = (
+
+let uu____6856 = (
+
+let uu____6859 = (FStar_Syntax_Syntax.mk_Total t)
+in (FStar_Syntax_Util.comp_set_flags uu____6859 flags))
+in (FStar_Syntax_Util.lcomp_of_comp uu____6856))
+in FStar_Util.Inl (uu____6855))
+in Some (uu____6852))
+end
+| uu____6862 -> begin
+(
+
+let uu____6863 = (
+
+let uu____6866 = (
+
+let uu____6867 = (
+
+let uu____6870 = (FStar_Syntax_Syntax.mk_GTotal t)
+in (FStar_Syntax_Util.comp_set_flags uu____6870 flags))
+in (FStar_Syntax_Util.lcomp_of_comp uu____6867))
+in FStar_Util.Inl (uu____6866))
+in Some (uu____6863))
+end)))
+end
+| uu____6873 -> begin
+Some (FStar_Util.Inr (((lc.FStar_Syntax_Syntax.eff_name), (flags))))
+end)))
+end
+| uu____6883 -> begin
+lopt
+end))
+and rebuild : cfg  ->  env  ->  stack  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun cfg env stack1 t -> (match (stack1) with
+| [] -> begin
+t
+end
+| (Debug (tm))::stack2 -> begin
+((
+
+let uu____6895 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug cfg.tcenv) (FStar_Options.Other ("print_normalized_terms")))
+in (match (uu____6895) with
+| true -> begin
+(
+
+let uu____6896 = (FStar_Syntax_Print.term_to_string tm)
+in (
+
+let uu____6897 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print2 "Normalized %s to %s\n" uu____6896 uu____6897)))
+end
+| uu____6898 -> begin
+()
+end));
+(rebuild cfg env stack2 t);
+)
+end
+| (Steps (s, ps, dl))::stack2 -> begin
+(rebuild (
+
+let uu___179_6908 = cfg
+in {steps = s; tcenv = uu___179_6908.tcenv; delta_level = dl; primitive_steps = ps}) env stack2 t)
+end
+| (Meta (m, r))::stack2 -> begin
+(
+
+let t1 = (mk (FStar_Syntax_Syntax.Tm_meta (((t), (m)))) r)
+in (rebuild cfg env stack2 t1))
+end
+| (MemoLazy (r))::stack2 -> begin
+((set_memo r ((env), (t)));
+(log cfg (fun uu____6928 -> (
+
+let uu____6929 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print1 "\tSet memo %s\n" uu____6929))));
+(rebuild cfg env stack2 t);
+)
+end
+| (Let (env', bs, lb, r))::stack2 -> begin
+(
+
+let body = (FStar_Syntax_Subst.close bs t)
+in (
+
+let t1 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_let (((((false), ((lb)::[]))), (body)))) None r)
+in (rebuild cfg env' stack2 t1)))
+end
+| (Abs (env', bs, env'', lopt, r))::stack2 -> begin
+(
+
+let bs1 = (norm_binders cfg env' bs)
+in (
+
+let lopt1 = (norm_lcomp_opt cfg env'' lopt)
+in (
+
+let uu____6966 = (
+
+let uu___180_6967 = (FStar_Syntax_Util.abs bs1 t lopt1)
+in {FStar_Syntax_Syntax.n = uu___180_6967.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___180_6967.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = r; FStar_Syntax_Syntax.vars = uu___180_6967.FStar_Syntax_Syntax.vars})
+in (rebuild cfg env stack2 uu____6966))))
+end
+| ((Arg (Univ (_), _, _))::_) | ((Arg (Dummy, _, _))::_) -> begin
+(failwith "Impossible")
+end
+| (UnivArgs (us, r))::stack2 -> begin
+(
+
+let t1 = (FStar_Syntax_Syntax.mk_Tm_uinst t us)
+in (rebuild cfg env stack2 t1))
+end
+| (Arg (Clos (env1, tm, m, uu____6989), aq, r))::stack2 -> begin
+((log cfg (fun uu____7005 -> (
+
+let uu____7006 = (FStar_Syntax_Print.term_to_string tm)
+in (FStar_Util.print1 "Rebuilding with arg %s\n" uu____7006))));
+(match ((FStar_List.contains (Exclude (Iota)) cfg.steps)) with
+| true -> begin
+(match ((FStar_List.contains WHNF cfg.steps)) with
+| true -> begin
+(
+
+let arg = (closure_as_term cfg env1 tm)
+in (
+
+let t1 = (FStar_Syntax_Syntax.extend_app t ((arg), (aq)) None r)
+in (rebuild cfg env1 stack2 t1)))
+end
+| uu____7013 -> begin
+(
+
+let stack3 = (App (((t), (aq), (r))))::stack2
+in (norm cfg env1 stack3 tm))
+end)
+end
+| uu____7016 -> begin
+(
+
+let uu____7017 = (FStar_ST.read m)
+in (match (uu____7017) with
+| None -> begin
+(match ((FStar_List.contains WHNF cfg.steps)) with
+| true -> begin
+(
+
+let arg = (closure_as_term cfg env1 tm)
+in (
+
+let t1 = (FStar_Syntax_Syntax.extend_app t ((arg), (aq)) None r)
+in (rebuild cfg env1 stack2 t1)))
+end
+| uu____7037 -> begin
+(
+
+let stack3 = (MemoLazy (m))::(App (((t), (aq), (r))))::stack2
+in (norm cfg env1 stack3 tm))
+end)
+end
+| Some (uu____7043, a) -> begin
+(
+
+let t1 = (FStar_Syntax_Syntax.extend_app t ((a), (aq)) None r)
+in (rebuild cfg env1 stack2 t1))
+end))
+end);
+)
+end
+| (App (head1, aq, r))::stack2 -> begin
+(
+
+let t1 = (FStar_Syntax_Syntax.extend_app head1 ((t), (aq)) None r)
+in (
+
+let uu____7065 = (maybe_simplify cfg t1)
+in (rebuild cfg env stack2 uu____7065)))
+end
+| (Match (env1, branches, r))::stack2 -> begin
+((log cfg (fun uu____7072 -> (
+
+let uu____7073 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print1 "Rebuilding with match, scrutinee is %s ...\n" uu____7073))));
+(
+
+let scrutinee = t
+in (
+
+let norm_and_rebuild_match = (fun uu____7078 -> ((log cfg (fun uu____7080 -> (
+
+let uu____7081 = (FStar_Syntax_Print.term_to_string scrutinee)
+in (
+
+let uu____7082 = (
+
+let uu____7083 = (FStar_All.pipe_right branches (FStar_List.map (fun uu____7090 -> (match (uu____7090) with
+| (p, uu____7096, uu____7097) -> begin
+(FStar_Syntax_Print.pat_to_string p)
+end))))
+in (FStar_All.pipe_right uu____7083 (FStar_String.concat "\n\t")))
+in (FStar_Util.print2 "match is irreducible: scrutinee=%s\nbranches=%s\n" uu____7081 uu____7082)))));
+(
+
+let whnf = (FStar_List.contains WHNF cfg.steps)
+in (
+
+let cfg_exclude_iota_zeta = (
+
+let new_delta = (FStar_All.pipe_right cfg.delta_level (FStar_List.filter (fun uu___136_7107 -> (match (uu___136_7107) with
+| (FStar_TypeChecker_Env.Inlining) | (FStar_TypeChecker_Env.Eager_unfolding_only) -> begin
+true
+end
+| uu____7108 -> begin
+false
+end))))
+in (
+
+let steps' = (
+
+let uu____7111 = (FStar_All.pipe_right cfg.steps (FStar_List.contains PureSubtermsWithinComputations))
+in (match (uu____7111) with
+| true -> begin
+(Exclude (Zeta))::[]
+end
+| uu____7113 -> begin
+(Exclude (Iota))::(Exclude (Zeta))::[]
+end))
+in (
+
+let uu___181_7114 = cfg
+in {steps = (FStar_List.append steps' cfg.steps); tcenv = uu___181_7114.tcenv; delta_level = new_delta; primitive_steps = uu___181_7114.primitive_steps})))
+in (
+
+let norm_or_whnf = (fun env2 t1 -> (match (whnf) with
+| true -> begin
+(closure_as_term cfg_exclude_iota_zeta env2 t1)
+end
+| uu____7124 -> begin
+(norm cfg_exclude_iota_zeta env2 [] t1)
+end))
+in (
+
+let rec norm_pat = (fun env2 p -> (match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_constant (uu____7148) -> begin
+((p), (env2))
+end
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Pat_disj ((hd1)::tl1) -> begin
+(
+
+let uu____7168 = (norm_pat env2 hd1)
+in (match (uu____7168) with
+| (hd2, env') -> begin
+(
+
+let tl2 = (FStar_All.pipe_right tl1 (FStar_List.map (fun p1 -> (
+
+let uu____7204 = (norm_pat env2 p1)
+in (Prims.fst uu____7204)))))
+in (((
+
+let uu___182_7216 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((hd2)::tl2); FStar_Syntax_Syntax.ty = uu___182_7216.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___182_7216.FStar_Syntax_Syntax.p})), (env')))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____7233 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____7267 uu____7268 -> (match (((uu____7267), (uu____7268))) with
+| ((pats1, env3), (p1, b)) -> begin
+(
+
+let uu____7333 = (norm_pat env3 p1)
+in (match (uu____7333) with
+| (p2, env4) -> begin
+(((((p2), (b)))::pats1), (env4))
+end))
+end)) (([]), (env2))))
+in (match (uu____7233) with
+| (pats1, env3) -> begin
+(((
+
+let uu___183_7399 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___183_7399.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___183_7399.FStar_Syntax_Syntax.p})), (env3))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let x1 = (
+
+let uu___184_7413 = x
+in (
+
+let uu____7414 = (norm_or_whnf env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___184_7413.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___184_7413.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____7414}))
+in (((
+
+let uu___185_7420 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var (x1); FStar_Syntax_Syntax.ty = uu___185_7420.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___185_7420.FStar_Syntax_Syntax.p})), ((Dummy)::env2)))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let x1 = (
+
+let uu___186_7425 = x
+in (
+
+let uu____7426 = (norm_or_whnf env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___186_7425.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___186_7425.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____7426}))
+in (((
+
+let uu___187_7432 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild (x1); FStar_Syntax_Syntax.ty = uu___187_7432.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___187_7432.FStar_Syntax_Syntax.p})), ((Dummy)::env2)))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, t1) -> begin
+(
+
+let x1 = (
+
+let uu___188_7442 = x
+in (
+
+let uu____7443 = (norm_or_whnf env2 x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___188_7442.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___188_7442.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____7443}))
+in (
+
+let t2 = (norm_or_whnf env2 t1)
+in (((
+
+let uu___189_7450 = p
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (t2))); FStar_Syntax_Syntax.ty = uu___189_7450.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___189_7450.FStar_Syntax_Syntax.p})), (env2))))
+end))
+in (
+
+let branches1 = (match (env1) with
+| [] when whnf -> begin
+branches
+end
+| uu____7454 -> begin
+(FStar_All.pipe_right branches (FStar_List.map (fun branch1 -> (
+
+let uu____7457 = (FStar_Syntax_Subst.open_branch branch1)
+in (match (uu____7457) with
+| (p, wopt, e) -> begin
+(
+
+let uu____7475 = (norm_pat env1 p)
+in (match (uu____7475) with
+| (p1, env2) -> begin
+(
+
+let wopt1 = (match (wopt) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____7499 = (norm_or_whnf env2 w)
+in Some (uu____7499))
+end)
+in (
+
+let e1 = (norm_or_whnf env2 e)
+in (FStar_Syntax_Util.branch ((p1), (wopt1), (e1)))))
+end))
+end)))))
+end)
+in (
+
+let uu____7504 = (mk (FStar_Syntax_Syntax.Tm_match (((scrutinee), (branches1)))) r)
+in (rebuild cfg env1 stack2 uu____7504)))))));
+))
+in (
+
+let rec is_cons = (fun head1 -> (match (head1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uinst (h, uu____7514) -> begin
+(is_cons h)
+end
+| (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Data_ctor)})) | (FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = _; FStar_Syntax_Syntax.fv_delta = _; FStar_Syntax_Syntax.fv_qual = Some (FStar_Syntax_Syntax.Record_ctor (_))})) -> begin
+true
+end
+| uu____7525 -> begin
+false
+end))
+in (
+
+let guard_when_clause = (fun wopt b rest -> (match (wopt) with
+| None -> begin
+b
+end
+| Some (w) -> begin
+(
+
+let then_branch = b
+in (
+
+let else_branch = (mk (FStar_Syntax_Syntax.Tm_match (((scrutinee), (rest)))) r)
+in (FStar_Syntax_Util.if_then_else w then_branch else_branch)))
+end))
+in (
+
+let rec matches_pat = (fun scrutinee1 p -> (
+
+let scrutinee2 = (FStar_Syntax_Util.unmeta scrutinee1)
+in (
+
+let uu____7624 = (FStar_Syntax_Util.head_and_args scrutinee2)
+in (match (uu____7624) with
+| (head1, args) -> begin
+(match (p.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (ps) -> begin
+(
+
+let mopt = (FStar_Util.find_map ps (fun p1 -> (
+
+let m = (matches_pat scrutinee2 p1)
+in (match (m) with
+| FStar_Util.Inl (uu____7681) -> begin
+Some (m)
+end
+| FStar_Util.Inr (true) -> begin
+Some (m)
+end
+| FStar_Util.Inr (false) -> begin
+None
+end))))
+in (match (mopt) with
+| None -> begin
+FStar_Util.Inr (false)
+end
+| Some (m) -> begin
+m
+end))
+end
+| (FStar_Syntax_Syntax.Pat_var (_)) | (FStar_Syntax_Syntax.Pat_wild (_)) -> begin
+FStar_Util.Inl ((scrutinee2)::[])
+end
+| FStar_Syntax_Syntax.Pat_dot_term (uu____7712) -> begin
+FStar_Util.Inl ([])
+end
+| FStar_Syntax_Syntax.Pat_constant (s) -> begin
+(match (scrutinee2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_constant (s') when (s = s') -> begin
+FStar_Util.Inl ([])
+end
+| uu____7724 -> begin
+(
+
+let uu____7725 = (
+
+let uu____7726 = (is_cons head1)
+in (not (uu____7726)))
+in FStar_Util.Inr (uu____7725))
+end)
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, arg_pats) -> begin
+(
+
+let uu____7740 = (
+
+let uu____7741 = (FStar_Syntax_Util.un_uinst head1)
+in uu____7741.FStar_Syntax_Syntax.n)
+in (match (uu____7740) with
+| FStar_Syntax_Syntax.Tm_fvar (fv') when (FStar_Syntax_Syntax.fv_eq fv fv') -> begin
+(matches_args [] args arg_pats)
+end
+| uu____7748 -> begin
+(
+
+let uu____7749 = (
+
+let uu____7750 = (is_cons head1)
+in (not (uu____7750)))
+in FStar_Util.Inr (uu____7749))
+end))
+end)
+end))))
+and matches_args = (fun out a p -> (match (((a), (p))) with
+| ([], []) -> begin
+FStar_Util.Inl (out)
+end
+| (((t1, uu____7784))::rest_a, ((p1, uu____7787))::rest_p) -> begin
+(
+
+let uu____7815 = (matches_pat t1 p1)
+in (match (uu____7815) with
+| FStar_Util.Inl (s) -> begin
+(matches_args (FStar_List.append out s) rest_a rest_p)
+end
+| m -> begin
+m
+end))
+end
+| uu____7829 -> begin
+FStar_Util.Inr (false)
+end))
+in (
+
+let rec matches = (fun scrutinee1 p -> (match (p) with
+| [] -> begin
+(norm_and_rebuild_match ())
+end
+| ((p1, wopt, b))::rest -> begin
+(
+
+let uu____7900 = (matches_pat scrutinee1 p1)
+in (match (uu____7900) with
+| FStar_Util.Inr (false) -> begin
+(matches scrutinee1 rest)
+end
+| FStar_Util.Inr (true) -> begin
+(norm_and_rebuild_match ())
+end
+| FStar_Util.Inl (s) -> begin
+((log cfg (fun uu____7910 -> (
+
+let uu____7911 = (FStar_Syntax_Print.pat_to_string p1)
+in (
+
+let uu____7912 = (
+
+let uu____7913 = (FStar_List.map FStar_Syntax_Print.term_to_string s)
+in (FStar_All.pipe_right uu____7913 (FStar_String.concat "; ")))
+in (FStar_Util.print2 "Matches pattern %s with subst = %s\n" uu____7911 uu____7912)))));
+(
+
+let env2 = (FStar_List.fold_left (fun env2 t1 -> (
+
+let uu____7922 = (
+
+let uu____7923 = (
+
+let uu____7933 = (FStar_Util.mk_ref (Some ((([]), (t1)))))
+in (([]), (t1), (uu____7933), (false)))
+in Clos (uu____7923))
+in (uu____7922)::env2)) env1 s)
+in (
+
+let uu____7956 = (guard_when_clause wopt b rest)
+in (norm cfg env2 stack2 uu____7956)));
+)
+end))
+end))
+in (
+
+let uu____7957 = (FStar_All.pipe_right cfg.steps (FStar_List.contains (Exclude (Iota))))
+in (match (uu____7957) with
+| true -> begin
+(norm_and_rebuild_match ())
+end
+| uu____7958 -> begin
+(matches scrutinee branches)
+end))))))));
+)
+end))
+
+
+let config : step Prims.list  ->  FStar_TypeChecker_Env.env  ->  cfg = (fun s e -> (
+
+let d = (FStar_All.pipe_right s (FStar_List.collect (fun uu___137_7971 -> (match (uu___137_7971) with
+| UnfoldUntil (k) -> begin
+(FStar_TypeChecker_Env.Unfold (k))::[]
+end
+| Eager_unfolding -> begin
+(FStar_TypeChecker_Env.Eager_unfolding_only)::[]
+end
+| Inlining -> begin
+(FStar_TypeChecker_Env.Inlining)::[]
+end
+| uu____7974 -> begin
+[]
+end))))
+in (
+
+let d1 = (match (d) with
+| [] -> begin
+(FStar_TypeChecker_Env.NoDelta)::[]
+end
+| uu____7978 -> begin
+d
+end)
+in {steps = s; tcenv = e; delta_level = d1; primitive_steps = (FStar_List.append built_in_primitive_steps equality_ops)})))
+
+
+let normalize_with_primitive_steps : primitive_step Prims.list  ->  step Prims.list  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun ps s e t -> (
+
+let c = (config s e)
+in (
+
+let c1 = (
+
+let uu___190_7998 = (config s e)
+in {steps = uu___190_7998.steps; tcenv = uu___190_7998.tcenv; delta_level = uu___190_7998.delta_level; primitive_steps = (FStar_List.append c.primitive_steps ps)})
+in (norm c1 [] [] t))))
+
+
+let normalize : steps  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun s e t -> (normalize_with_primitive_steps [] s e t))
+
+
+let normalize_comp : steps  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun s e t -> (
+
+let uu____8017 = (config s e)
+in (norm_comp uu____8017 [] t)))
+
+
+let normalize_universe : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun env u -> (
+
+let uu____8024 = (config [] env)
+in (norm_universe uu____8024 [] u)))
+
+
+let ghost_to_pure : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun env c -> (
+
+let uu____8031 = (config [] env)
+in (ghost_to_pure_aux uu____8031 [] c)))
+
+
+let ghost_to_pure_lcomp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun env lc -> (
+
+let cfg = (config ((Eager_unfolding)::(UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(EraseUniverses)::(AllowUnboundUniverses)::[]) env)
+in (
+
+let non_info = (fun t -> (
+
+let uu____8043 = (norm cfg [] [] t)
+in (FStar_Syntax_Util.non_informative uu____8043)))
+in (
+
+let uu____8044 = ((FStar_Syntax_Util.is_ghost_effect lc.FStar_Syntax_Syntax.eff_name) && (non_info lc.FStar_Syntax_Syntax.res_typ))
+in (match (uu____8044) with
+| true -> begin
+(match ((downgrade_ghost_effect_name lc.FStar_Syntax_Syntax.eff_name)) with
+| Some (pure_eff) -> begin
+(
+
+let uu___191_8046 = lc
+in {FStar_Syntax_Syntax.eff_name = pure_eff; FStar_Syntax_Syntax.res_typ = uu___191_8046.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = uu___191_8046.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____8047 -> (
+
+let uu____8048 = (lc.FStar_Syntax_Syntax.comp ())
+in (ghost_to_pure env uu____8048)))})
+end
+| None -> begin
+lc
+end)
+end
+| uu____8049 -> begin
+lc
+end)))))
+
+
+let term_to_string : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  Prims.string = (fun env t -> (
+
+let uu____8056 = (normalize ((AllowUnboundUniverses)::[]) env t)
+in (FStar_Syntax_Print.term_to_string uu____8056)))
+
+
+let comp_to_string : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  Prims.string = (fun env c -> (
+
+let uu____8063 = (
+
+let uu____8064 = (config ((AllowUnboundUniverses)::[]) env)
+in (norm_comp uu____8064 [] c))
+in (FStar_Syntax_Print.comp_to_string uu____8063)))
+
+
+let normalize_refinement : steps  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun steps env t0 -> (
+
+let t = (normalize (FStar_List.append steps ((Beta)::[])) env t0)
+in (
+
+let rec aux = (fun t1 -> (
+
+let t2 = (FStar_Syntax_Subst.compress t1)
+in (match (t2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_refine (x, phi) -> begin
+(
+
+let t01 = (aux x.FStar_Syntax_Syntax.sort)
+in (match (t01.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_refine (y, phi1) -> begin
+(
+
+let uu____8101 = (
+
+let uu____8102 = (
+
+let uu____8107 = (FStar_Syntax_Util.mk_conj phi1 phi)
+in ((y), (uu____8107)))
+in FStar_Syntax_Syntax.Tm_refine (uu____8102))
+in (mk uu____8101 t01.FStar_Syntax_Syntax.pos))
+end
+| uu____8112 -> begin
+t2
+end))
+end
+| uu____8113 -> begin
+t2
+end)))
+in (aux t))))
+
+
+let eta_expand_with_type : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun t sort -> (
+
+let uu____8120 = (FStar_Syntax_Util.arrow_formals_comp sort)
+in (match (uu____8120) with
+| (binders, c) -> begin
+(match (binders) with
+| [] -> begin
+t
+end
+| uu____8136 -> begin
+(
+
+let uu____8140 = (FStar_All.pipe_right binders FStar_Syntax_Util.args_of_binders)
+in (match (uu____8140) with
+| (binders1, args) -> begin
+(
+
+let uu____8150 = ((FStar_Syntax_Syntax.mk_Tm_app t args) None t.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____8155 = (
+
+let uu____8162 = (FStar_All.pipe_right (FStar_Syntax_Util.lcomp_of_comp c) (fun _0_33 -> FStar_Util.Inl (_0_33)))
+in (FStar_All.pipe_right uu____8162 (fun _0_34 -> Some (_0_34))))
+in (FStar_Syntax_Util.abs binders1 uu____8150 uu____8155)))
+end))
+end)
+end)))
+
+
+let eta_expand : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let uu____8198 = (
+
+let uu____8202 = (FStar_ST.read t.FStar_Syntax_Syntax.tk)
+in ((uu____8202), (t.FStar_Syntax_Syntax.n)))
+in (match (uu____8198) with
+| (Some (sort), uu____8209) -> begin
+(
+
+let uu____8211 = (mk sort t.FStar_Syntax_Syntax.pos)
+in (eta_expand_with_type t uu____8211))
+end
+| (uu____8212, FStar_Syntax_Syntax.Tm_name (x)) -> begin
+(eta_expand_with_type t x.FStar_Syntax_Syntax.sort)
+end
+| uu____8216 -> begin
+(
+
+let uu____8220 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____8220) with
+| (head1, args) -> begin
+(
+
+let uu____8246 = (
+
+let uu____8247 = (FStar_Syntax_Subst.compress head1)
+in uu____8247.FStar_Syntax_Syntax.n)
+in (match (uu____8246) with
+| FStar_Syntax_Syntax.Tm_uvar (uu____8250, thead) -> begin
+(
+
+let uu____8264 = (FStar_Syntax_Util.arrow_formals thead)
+in (match (uu____8264) with
+| (formals, tres) -> begin
+(match (((FStar_List.length formals) = (FStar_List.length args))) with
+| true -> begin
+t
+end
+| uu____8294 -> begin
+(
+
+let uu____8295 = (env.FStar_TypeChecker_Env.type_of (
+
+let uu___192_8299 = env
+in {FStar_TypeChecker_Env.solver = uu___192_8299.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___192_8299.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___192_8299.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___192_8299.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___192_8299.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___192_8299.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = None; FStar_TypeChecker_Env.sigtab = uu___192_8299.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___192_8299.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___192_8299.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___192_8299.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___192_8299.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___192_8299.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___192_8299.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___192_8299.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___192_8299.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___192_8299.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___192_8299.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___192_8299.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___192_8299.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___192_8299.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = true; FStar_TypeChecker_Env.qname_and_index = uu___192_8299.FStar_TypeChecker_Env.qname_and_index}) t)
+in (match (uu____8295) with
+| (uu____8300, ty, uu____8302) -> begin
+(eta_expand_with_type t ty)
+end))
+end)
+end))
+end
+| uu____8303 -> begin
+(
+
+let uu____8304 = (env.FStar_TypeChecker_Env.type_of (
+
+let uu___193_8308 = env
+in {FStar_TypeChecker_Env.solver = uu___193_8308.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___193_8308.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___193_8308.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___193_8308.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___193_8308.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___193_8308.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = None; FStar_TypeChecker_Env.sigtab = uu___193_8308.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___193_8308.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___193_8308.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___193_8308.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___193_8308.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___193_8308.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___193_8308.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___193_8308.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___193_8308.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___193_8308.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___193_8308.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___193_8308.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___193_8308.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___193_8308.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = true; FStar_TypeChecker_Env.qname_and_index = uu___193_8308.FStar_TypeChecker_Env.qname_and_index}) t)
+in (match (uu____8304) with
+| (uu____8309, ty, uu____8311) -> begin
+(eta_expand_with_type t ty)
+end))
+end))
+end))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -1,6482 +1,7314 @@
+
 open Prims
-let guard_of_guard_formula:
-  FStar_TypeChecker_Common.guard_formula -> FStar_TypeChecker_Env.guard_t =
-  fun g  ->
-    {
-      FStar_TypeChecker_Env.guard_f = g;
-      FStar_TypeChecker_Env.deferred = [];
-      FStar_TypeChecker_Env.univ_ineqs = ([], []);
-      FStar_TypeChecker_Env.implicits = []
-    }
-let guard_form:
-  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Common.guard_formula =
-  fun g  -> g.FStar_TypeChecker_Env.guard_f
-let is_trivial: FStar_TypeChecker_Env.guard_t -> Prims.bool =
-  fun g  ->
-    match g with
-    | { FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial ;
-        FStar_TypeChecker_Env.deferred = [];
-        FStar_TypeChecker_Env.univ_ineqs = uu____20;
-        FStar_TypeChecker_Env.implicits = uu____21;_} -> true
-    | uu____35 -> false
-let trivial_guard: FStar_TypeChecker_Env.guard_t =
-  {
-    FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial;
-    FStar_TypeChecker_Env.deferred = [];
-    FStar_TypeChecker_Env.univ_ineqs = ([], []);
-    FStar_TypeChecker_Env.implicits = []
-  }
-let abstract_guard:
-  FStar_Syntax_Syntax.bv ->
-    FStar_TypeChecker_Env.guard_t Prims.option ->
-      FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun x  ->
-    fun g  ->
-      match g with
-      | None |Some
-        { FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial ;
-          FStar_TypeChecker_Env.deferred = _;
-          FStar_TypeChecker_Env.univ_ineqs = _;
-          FStar_TypeChecker_Env.implicits = _;_} -> g
-      | Some g1 ->
-          let f =
-            match g1.FStar_TypeChecker_Env.guard_f with
-            | FStar_TypeChecker_Common.NonTrivial f -> f
-            | uu____62 -> failwith "impossible" in
-          let uu____63 =
-            let uu___130_64 = g1 in
-            let uu____65 =
-              let uu____66 =
-                let uu____67 =
-                  let uu____71 = FStar_Syntax_Syntax.mk_binder x in
-                  [uu____71] in
-                let uu____72 =
-                  let uu____79 =
-                    let uu____85 =
-                      let uu____86 =
-                        FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-                      FStar_All.pipe_right uu____86
-                        FStar_Syntax_Util.lcomp_of_comp in
-                    FStar_All.pipe_right uu____85
-                      (fun _0_28  -> FStar_Util.Inl _0_28) in
-                  Some uu____79 in
-                FStar_Syntax_Util.abs uu____67 f uu____72 in
-              FStar_All.pipe_left
-                (fun _0_29  -> FStar_TypeChecker_Common.NonTrivial _0_29)
-                uu____66 in
-            {
-              FStar_TypeChecker_Env.guard_f = uu____65;
-              FStar_TypeChecker_Env.deferred =
-                (uu___130_64.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (uu___130_64.FStar_TypeChecker_Env.univ_ineqs);
-              FStar_TypeChecker_Env.implicits =
-                (uu___130_64.FStar_TypeChecker_Env.implicits)
-            } in
-          Some uu____63
-let apply_guard:
-  FStar_TypeChecker_Env.guard_t ->
-    FStar_Syntax_Syntax.term -> FStar_TypeChecker_Env.guard_t
-  =
-  fun g  ->
-    fun e  ->
-      match g.FStar_TypeChecker_Env.guard_f with
-      | FStar_TypeChecker_Common.Trivial  -> g
-      | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___131_107 = g in
-          let uu____108 =
-            let uu____109 =
-              let uu____110 =
-                let uu____113 =
-                  let uu____114 =
-                    let uu____124 =
-                      let uu____126 = FStar_Syntax_Syntax.as_arg e in
-                      [uu____126] in
-                    (f, uu____124) in
-                  FStar_Syntax_Syntax.Tm_app uu____114 in
-                FStar_Syntax_Syntax.mk uu____113 in
-              uu____110
-                (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                f.FStar_Syntax_Syntax.pos in
-            FStar_All.pipe_left
-              (fun _0_30  -> FStar_TypeChecker_Common.NonTrivial _0_30)
-              uu____109 in
-          {
-            FStar_TypeChecker_Env.guard_f = uu____108;
-            FStar_TypeChecker_Env.deferred =
-              (uu___131_107.FStar_TypeChecker_Env.deferred);
-            FStar_TypeChecker_Env.univ_ineqs =
-              (uu___131_107.FStar_TypeChecker_Env.univ_ineqs);
-            FStar_TypeChecker_Env.implicits =
-              (uu___131_107.FStar_TypeChecker_Env.implicits)
-          }
-let map_guard:
-  FStar_TypeChecker_Env.guard_t ->
-    (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-      FStar_TypeChecker_Env.guard_t
-  =
-  fun g  ->
-    fun map1  ->
-      match g.FStar_TypeChecker_Env.guard_f with
-      | FStar_TypeChecker_Common.Trivial  -> g
-      | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___132_148 = g in
-          let uu____149 =
-            let uu____150 = map1 f in
-            FStar_TypeChecker_Common.NonTrivial uu____150 in
-          {
-            FStar_TypeChecker_Env.guard_f = uu____149;
-            FStar_TypeChecker_Env.deferred =
-              (uu___132_148.FStar_TypeChecker_Env.deferred);
-            FStar_TypeChecker_Env.univ_ineqs =
-              (uu___132_148.FStar_TypeChecker_Env.univ_ineqs);
-            FStar_TypeChecker_Env.implicits =
-              (uu___132_148.FStar_TypeChecker_Env.implicits)
-          }
-let trivial: FStar_TypeChecker_Common.guard_formula -> Prims.unit =
-  fun t  ->
-    match t with
-    | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____154 -> failwith "impossible"
-let conj_guard_f:
-  FStar_TypeChecker_Common.guard_formula ->
-    FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula
-  =
-  fun g1  ->
-    fun g2  ->
-      match (g1, g2) with
-      | (FStar_TypeChecker_Common.Trivial ,g)
-        |(g,FStar_TypeChecker_Common.Trivial ) -> g
-      | (FStar_TypeChecker_Common.NonTrivial
-         f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let uu____164 = FStar_Syntax_Util.mk_conj f1 f2 in
-          FStar_TypeChecker_Common.NonTrivial uu____164
-let check_trivial:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax -> FStar_TypeChecker_Common.guard_formula
-  =
-  fun t  ->
-    match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_fvar tc when
-        FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid ->
-        FStar_TypeChecker_Common.Trivial
-    | uu____173 -> FStar_TypeChecker_Common.NonTrivial t
-let imp_guard_f:
-  FStar_TypeChecker_Common.guard_formula ->
-    FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula
-  =
-  fun g1  ->
-    fun g2  ->
-      match (g1, g2) with
-      | (FStar_TypeChecker_Common.Trivial ,g) -> g
-      | (g,FStar_TypeChecker_Common.Trivial ) ->
-          FStar_TypeChecker_Common.Trivial
-      | (FStar_TypeChecker_Common.NonTrivial
-         f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let imp = FStar_Syntax_Util.mk_imp f1 f2 in check_trivial imp
-let binop_guard:
-  (FStar_TypeChecker_Common.guard_formula ->
-     FStar_TypeChecker_Common.guard_formula ->
-       FStar_TypeChecker_Common.guard_formula)
-    ->
-    FStar_TypeChecker_Env.guard_t ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun f  ->
-    fun g1  ->
-      fun g2  ->
-        let uu____204 =
-          f g1.FStar_TypeChecker_Env.guard_f g2.FStar_TypeChecker_Env.guard_f in
-        {
-          FStar_TypeChecker_Env.guard_f = uu____204;
-          FStar_TypeChecker_Env.deferred =
-            (FStar_List.append g1.FStar_TypeChecker_Env.deferred
-               g2.FStar_TypeChecker_Env.deferred);
-          FStar_TypeChecker_Env.univ_ineqs =
-            ((FStar_List.append
-                (Prims.fst g1.FStar_TypeChecker_Env.univ_ineqs)
-                (Prims.fst g2.FStar_TypeChecker_Env.univ_ineqs)),
-              (FStar_List.append
-                 (Prims.snd g1.FStar_TypeChecker_Env.univ_ineqs)
-                 (Prims.snd g2.FStar_TypeChecker_Env.univ_ineqs)));
-          FStar_TypeChecker_Env.implicits =
-            (FStar_List.append g1.FStar_TypeChecker_Env.implicits
-               g2.FStar_TypeChecker_Env.implicits)
-        }
-let conj_guard:
-  FStar_TypeChecker_Env.guard_t ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  = fun g1  -> fun g2  -> binop_guard conj_guard_f g1 g2
-let imp_guard:
-  FStar_TypeChecker_Env.guard_t ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  = fun g1  -> fun g2  -> binop_guard imp_guard_f g1 g2
-let close_guard_univs:
-  FStar_Syntax_Syntax.universes ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun us  ->
-    fun bs  ->
-      fun g  ->
-        match g.FStar_TypeChecker_Env.guard_f with
-        | FStar_TypeChecker_Common.Trivial  -> g
-        | FStar_TypeChecker_Common.NonTrivial f ->
-            let f1 =
-              FStar_List.fold_right2
-                (fun u  ->
-                   fun b  ->
-                     fun f1  ->
-                       let uu____249 = FStar_Syntax_Syntax.is_null_binder b in
-                       if uu____249
-                       then f1
-                       else FStar_Syntax_Util.mk_forall u (Prims.fst b) f1)
-                us bs f in
-            let uu___133_251 = g in
-            {
-              FStar_TypeChecker_Env.guard_f =
-                (FStar_TypeChecker_Common.NonTrivial f1);
-              FStar_TypeChecker_Env.deferred =
-                (uu___133_251.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (uu___133_251.FStar_TypeChecker_Env.univ_ineqs);
-              FStar_TypeChecker_Env.implicits =
-                (uu___133_251.FStar_TypeChecker_Env.implicits)
-            }
-let close_forall:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binder Prims.list ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-  =
-  fun env  ->
-    fun bs  ->
-      fun f  ->
-        FStar_List.fold_right
-          (fun b  ->
-             fun f1  ->
-               let uu____265 = FStar_Syntax_Syntax.is_null_binder b in
-               if uu____265
-               then f1
-               else
-                 (let u =
-                    env.FStar_TypeChecker_Env.universe_of env
-                      (Prims.fst b).FStar_Syntax_Syntax.sort in
-                  FStar_Syntax_Util.mk_forall u (Prims.fst b) f1)) bs f
-let close_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun env  ->
-    fun binders  ->
-      fun g  ->
-        match g.FStar_TypeChecker_Env.guard_f with
-        | FStar_TypeChecker_Common.Trivial  -> g
-        | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___134_278 = g in
-            let uu____279 =
-              let uu____280 = close_forall env binders f in
-              FStar_TypeChecker_Common.NonTrivial uu____280 in
-            {
-              FStar_TypeChecker_Env.guard_f = uu____279;
-              FStar_TypeChecker_Env.deferred =
-                (uu___134_278.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (uu___134_278.FStar_TypeChecker_Env.univ_ineqs);
-              FStar_TypeChecker_Env.implicits =
-                (uu___134_278.FStar_TypeChecker_Env.implicits)
-            }
-let new_uvar:
-  FStar_Range.range ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.typ)
-  =
-  fun r  ->
-    fun binders  ->
-      fun k  ->
-        let uv = FStar_Unionfind.fresh FStar_Syntax_Syntax.Uvar in
-        match binders with
-        | [] ->
-            let uv1 =
-              (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (uv, k)))
-                (Some (k.FStar_Syntax_Syntax.n)) r in
-            (uv1, uv1)
-        | uu____325 ->
-            let args =
-              FStar_All.pipe_right binders
-                (FStar_List.map FStar_Syntax_Util.arg_of_non_null_binder) in
-            let k' =
-              let uu____340 = FStar_Syntax_Syntax.mk_Total k in
-              FStar_Syntax_Util.arrow binders uu____340 in
-            let uv1 =
-              (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (uv, k')))
-                None r in
-            let uu____360 =
-              (FStar_Syntax_Syntax.mk
-                 (FStar_Syntax_Syntax.Tm_app (uv1, args)))
-                (Some (k.FStar_Syntax_Syntax.n)) r in
-            (uu____360, uv1)
-let mk_eq2:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let uu____393 = FStar_Syntax_Util.type_u () in
-        match uu____393 with
-        | (t_type,u) ->
-            let uu____398 =
-              let uu____401 = FStar_TypeChecker_Env.all_binders env in
-              new_uvar t1.FStar_Syntax_Syntax.pos uu____401 t_type in
-            (match uu____398 with
-             | (tt,uu____403) -> FStar_Syntax_Util.mk_eq2 u tt t1 t2)
+
+let guard_of_guard_formula : FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Env.guard_t = (fun g -> {FStar_TypeChecker_Env.guard_f = g; FStar_TypeChecker_Env.deferred = []; FStar_TypeChecker_Env.univ_ineqs = (([]), ([])); FStar_TypeChecker_Env.implicits = []})
+
+
+let guard_form : FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Common.guard_formula = (fun g -> g.FStar_TypeChecker_Env.guard_f)
+
+
+let is_trivial : FStar_TypeChecker_Env.guard_t  ->  Prims.bool = (fun g -> (match (g) with
+| {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = []; FStar_TypeChecker_Env.univ_ineqs = uu____20; FStar_TypeChecker_Env.implicits = uu____21} -> begin
+true
+end
+| uu____35 -> begin
+false
+end))
+
+
+let trivial_guard : FStar_TypeChecker_Env.guard_t = {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = []; FStar_TypeChecker_Env.univ_ineqs = (([]), ([])); FStar_TypeChecker_Env.implicits = []}
+
+
+let abstract_guard : FStar_Syntax_Syntax.bv  ->  FStar_TypeChecker_Env.guard_t Prims.option  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun x g -> (match (g) with
+| (None) | (Some ({FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = _; FStar_TypeChecker_Env.univ_ineqs = _; FStar_TypeChecker_Env.implicits = _})) -> begin
+g
+end
+| Some (g1) -> begin
+(
+
+let f = (match (g1.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+f
+end
+| uu____62 -> begin
+(failwith "impossible")
+end)
+in (
+
+let uu____63 = (
+
+let uu___130_64 = g1
+in (
+
+let uu____65 = (
+
+let uu____66 = (
+
+let uu____67 = (
+
+let uu____71 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____71)::[])
+in (
+
+let uu____72 = (
+
+let uu____79 = (
+
+let uu____85 = (
+
+let uu____86 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_All.pipe_right uu____86 FStar_Syntax_Util.lcomp_of_comp))
+in (FStar_All.pipe_right uu____85 (fun _0_28 -> FStar_Util.Inl (_0_28))))
+in Some (uu____79))
+in (FStar_Syntax_Util.abs uu____67 f uu____72)))
+in (FStar_All.pipe_left (fun _0_29 -> FStar_TypeChecker_Common.NonTrivial (_0_29)) uu____66))
+in {FStar_TypeChecker_Env.guard_f = uu____65; FStar_TypeChecker_Env.deferred = uu___130_64.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___130_64.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___130_64.FStar_TypeChecker_Env.implicits}))
+in Some (uu____63)))
+end))
+
+
+let apply_guard : FStar_TypeChecker_Env.guard_t  ->  FStar_Syntax_Syntax.term  ->  FStar_TypeChecker_Env.guard_t = (fun g e -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu___131_107 = g
+in (
+
+let uu____108 = (
+
+let uu____109 = (
+
+let uu____110 = (
+
+let uu____113 = (
+
+let uu____114 = (
+
+let uu____124 = (
+
+let uu____126 = (FStar_Syntax_Syntax.as_arg e)
+in (uu____126)::[])
+in ((f), (uu____124)))
+in FStar_Syntax_Syntax.Tm_app (uu____114))
+in (FStar_Syntax_Syntax.mk uu____113))
+in (uu____110 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) f.FStar_Syntax_Syntax.pos))
+in (FStar_All.pipe_left (fun _0_30 -> FStar_TypeChecker_Common.NonTrivial (_0_30)) uu____109))
+in {FStar_TypeChecker_Env.guard_f = uu____108; FStar_TypeChecker_Env.deferred = uu___131_107.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___131_107.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___131_107.FStar_TypeChecker_Env.implicits}))
+end))
+
+
+let map_guard : FStar_TypeChecker_Env.guard_t  ->  (FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term)  ->  FStar_TypeChecker_Env.guard_t = (fun g map1 -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu___132_148 = g
+in (
+
+let uu____149 = (
+
+let uu____150 = (map1 f)
+in FStar_TypeChecker_Common.NonTrivial (uu____150))
+in {FStar_TypeChecker_Env.guard_f = uu____149; FStar_TypeChecker_Env.deferred = uu___132_148.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___132_148.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___132_148.FStar_TypeChecker_Env.implicits}))
+end))
+
+
+let trivial : FStar_TypeChecker_Common.guard_formula  ->  Prims.unit = (fun t -> (match (t) with
+| FStar_TypeChecker_Common.Trivial -> begin
+()
+end
+| FStar_TypeChecker_Common.NonTrivial (uu____154) -> begin
+(failwith "impossible")
+end))
+
+
+let conj_guard_f : FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula = (fun g1 g2 -> (match (((g1), (g2))) with
+| ((FStar_TypeChecker_Common.Trivial, g)) | ((g, FStar_TypeChecker_Common.Trivial)) -> begin
+g
+end
+| (FStar_TypeChecker_Common.NonTrivial (f1), FStar_TypeChecker_Common.NonTrivial (f2)) -> begin
+(
+
+let uu____164 = (FStar_Syntax_Util.mk_conj f1 f2)
+in FStar_TypeChecker_Common.NonTrivial (uu____164))
+end))
+
+
+let check_trivial : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_TypeChecker_Common.guard_formula = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (tc) when (FStar_Syntax_Syntax.fv_eq_lid tc FStar_Syntax_Const.true_lid) -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| uu____173 -> begin
+FStar_TypeChecker_Common.NonTrivial (t)
+end))
+
+
+let imp_guard_f : FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula = (fun g1 g2 -> (match (((g1), (g2))) with
+| (FStar_TypeChecker_Common.Trivial, g) -> begin
+g
+end
+| (g, FStar_TypeChecker_Common.Trivial) -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| (FStar_TypeChecker_Common.NonTrivial (f1), FStar_TypeChecker_Common.NonTrivial (f2)) -> begin
+(
+
+let imp = (FStar_Syntax_Util.mk_imp f1 f2)
+in (check_trivial imp))
+end))
+
+
+let binop_guard : (FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula)  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun f g1 g2 -> (
+
+let uu____204 = (f g1.FStar_TypeChecker_Env.guard_f g2.FStar_TypeChecker_Env.guard_f)
+in {FStar_TypeChecker_Env.guard_f = uu____204; FStar_TypeChecker_Env.deferred = (FStar_List.append g1.FStar_TypeChecker_Env.deferred g2.FStar_TypeChecker_Env.deferred); FStar_TypeChecker_Env.univ_ineqs = (((FStar_List.append (Prims.fst g1.FStar_TypeChecker_Env.univ_ineqs) (Prims.fst g2.FStar_TypeChecker_Env.univ_ineqs))), ((FStar_List.append (Prims.snd g1.FStar_TypeChecker_Env.univ_ineqs) (Prims.snd g2.FStar_TypeChecker_Env.univ_ineqs)))); FStar_TypeChecker_Env.implicits = (FStar_List.append g1.FStar_TypeChecker_Env.implicits g2.FStar_TypeChecker_Env.implicits)}))
+
+
+let conj_guard : FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun g1 g2 -> (binop_guard conj_guard_f g1 g2))
+
+
+let imp_guard : FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun g1 g2 -> (binop_guard imp_guard_f g1 g2))
+
+
+let close_guard_univs : FStar_Syntax_Syntax.universes  ->  FStar_Syntax_Syntax.binders  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun us bs g -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let f1 = (FStar_List.fold_right2 (fun u b f1 -> (
+
+let uu____249 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____249) with
+| true -> begin
+f1
+end
+| uu____250 -> begin
+(FStar_Syntax_Util.mk_forall u (Prims.fst b) f1)
+end))) us bs f)
+in (
+
+let uu___133_251 = g
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.NonTrivial (f1); FStar_TypeChecker_Env.deferred = uu___133_251.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___133_251.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___133_251.FStar_TypeChecker_Env.implicits}))
+end))
+
+
+let close_forall : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binder Prims.list  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun env bs f -> (FStar_List.fold_right (fun b f1 -> (
+
+let uu____265 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____265) with
+| true -> begin
+f1
+end
+| uu____266 -> begin
+(
+
+let u = (env.FStar_TypeChecker_Env.universe_of env (Prims.fst b).FStar_Syntax_Syntax.sort)
+in (FStar_Syntax_Util.mk_forall u (Prims.fst b) f1))
+end))) bs f))
+
+
+let close_guard : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun env binders g -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu___134_278 = g
+in (
+
+let uu____279 = (
+
+let uu____280 = (close_forall env binders f)
+in FStar_TypeChecker_Common.NonTrivial (uu____280))
+in {FStar_TypeChecker_Env.guard_f = uu____279; FStar_TypeChecker_Env.deferred = uu___134_278.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___134_278.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___134_278.FStar_TypeChecker_Env.implicits}))
+end))
+
+
+let new_uvar : FStar_Range.range  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.typ) = (fun r binders k -> (
+
+let uv = (FStar_Unionfind.fresh FStar_Syntax_Syntax.Uvar)
+in (match (binders) with
+| [] -> begin
+(
+
+let uv1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (((uv), (k))))) (Some (k.FStar_Syntax_Syntax.n)) r)
+in ((uv1), (uv1)))
+end
+| uu____325 -> begin
+(
+
+let args = (FStar_All.pipe_right binders (FStar_List.map FStar_Syntax_Util.arg_of_non_null_binder))
+in (
+
+let k' = (
+
+let uu____340 = (FStar_Syntax_Syntax.mk_Total k)
+in (FStar_Syntax_Util.arrow binders uu____340))
+in (
+
+let uv1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (((uv), (k'))))) None r)
+in (
+
+let uu____360 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((uv1), (args))))) (Some (k.FStar_Syntax_Syntax.n)) r)
+in ((uu____360), (uv1))))))
+end)))
+
+
+let mk_eq2 : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t1 t2 -> (
+
+let uu____393 = (FStar_Syntax_Util.type_u ())
+in (match (uu____393) with
+| (t_type, u) -> begin
+(
+
+let uu____398 = (
+
+let uu____401 = (FStar_TypeChecker_Env.all_binders env)
+in (new_uvar t1.FStar_Syntax_Syntax.pos uu____401 t_type))
+in (match (uu____398) with
+| (tt, uu____403) -> begin
+(FStar_Syntax_Util.mk_eq2 u tt t1 t2)
+end))
+end)))
+
 type uvi =
-  | TERM of ((FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.typ)*
-  FStar_Syntax_Syntax.term)
-  | UNIV of (FStar_Syntax_Syntax.universe_uvar* FStar_Syntax_Syntax.universe)
-let uu___is_TERM: uvi -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TERM _0 -> true | uu____424 -> false
-let __proj__TERM__item___0:
-  uvi ->
-    ((FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.typ)*
-      FStar_Syntax_Syntax.term)
-  = fun projectee  -> match projectee with | TERM _0 -> _0
-let uu___is_UNIV: uvi -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UNIV _0 -> true | uu____450 -> false
-let __proj__UNIV__item___0:
-  uvi -> (FStar_Syntax_Syntax.universe_uvar* FStar_Syntax_Syntax.universe) =
-  fun projectee  -> match projectee with | UNIV _0 -> _0
+| TERM of ((FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.typ) * FStar_Syntax_Syntax.term)
+| UNIV of (FStar_Syntax_Syntax.universe_uvar * FStar_Syntax_Syntax.universe)
+
+
+let uu___is_TERM : uvi  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| TERM (_0) -> begin
+true
+end
+| uu____424 -> begin
+false
+end))
+
+
+let __proj__TERM__item___0 : uvi  ->  ((FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.typ) * FStar_Syntax_Syntax.term) = (fun projectee -> (match (projectee) with
+| TERM (_0) -> begin
+_0
+end))
+
+
+let uu___is_UNIV : uvi  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UNIV (_0) -> begin
+true
+end
+| uu____450 -> begin
+false
+end))
+
+
+let __proj__UNIV__item___0 : uvi  ->  (FStar_Syntax_Syntax.universe_uvar * FStar_Syntax_Syntax.universe) = (fun projectee -> (match (projectee) with
+| UNIV (_0) -> begin
+_0
+end))
+
 type worklist =
-  {
-  attempting: FStar_TypeChecker_Common.probs;
-  wl_deferred:
-    (Prims.int* Prims.string* FStar_TypeChecker_Common.prob) Prims.list;
-  ctr: Prims.int;
-  defer_ok: Prims.bool;
-  smt_ok: Prims.bool;
-  tcenv: FStar_TypeChecker_Env.env;}
+{attempting : FStar_TypeChecker_Common.probs; wl_deferred : (Prims.int * Prims.string * FStar_TypeChecker_Common.prob) Prims.list; ctr : Prims.int; defer_ok : Prims.bool; smt_ok : Prims.bool; tcenv : FStar_TypeChecker_Env.env}
+
 type solution =
-  | Success of FStar_TypeChecker_Common.deferred
-  | Failed of (FStar_TypeChecker_Common.prob* Prims.string)
-let uu___is_Success: solution -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Success _0 -> true | uu____530 -> false
-let __proj__Success__item___0: solution -> FStar_TypeChecker_Common.deferred
-  = fun projectee  -> match projectee with | Success _0 -> _0
-let uu___is_Failed: solution -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Failed _0 -> true | uu____544 -> false
-let __proj__Failed__item___0:
-  solution -> (FStar_TypeChecker_Common.prob* Prims.string) =
-  fun projectee  -> match projectee with | Failed _0 -> _0
+| Success of FStar_TypeChecker_Common.deferred
+| Failed of (FStar_TypeChecker_Common.prob * Prims.string)
+
+
+let uu___is_Success : solution  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Success (_0) -> begin
+true
+end
+| uu____530 -> begin
+false
+end))
+
+
+let __proj__Success__item___0 : solution  ->  FStar_TypeChecker_Common.deferred = (fun projectee -> (match (projectee) with
+| Success (_0) -> begin
+_0
+end))
+
+
+let uu___is_Failed : solution  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| Failed (_0) -> begin
+true
+end
+| uu____544 -> begin
+false
+end))
+
+
+let __proj__Failed__item___0 : solution  ->  (FStar_TypeChecker_Common.prob * Prims.string) = (fun projectee -> (match (projectee) with
+| Failed (_0) -> begin
+_0
+end))
+
 type variance =
-  | COVARIANT
-  | CONTRAVARIANT
-  | INVARIANT
-let uu___is_COVARIANT: variance -> Prims.bool =
-  fun projectee  ->
-    match projectee with | COVARIANT  -> true | uu____561 -> false
-let uu___is_CONTRAVARIANT: variance -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CONTRAVARIANT  -> true | uu____565 -> false
-let uu___is_INVARIANT: variance -> Prims.bool =
-  fun projectee  ->
-    match projectee with | INVARIANT  -> true | uu____569 -> false
+| COVARIANT
+| CONTRAVARIANT
+| INVARIANT
+
+
+let uu___is_COVARIANT : variance  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| COVARIANT -> begin
+true
+end
+| uu____561 -> begin
+false
+end))
+
+
+let uu___is_CONTRAVARIANT : variance  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| CONTRAVARIANT -> begin
+true
+end
+| uu____565 -> begin
+false
+end))
+
+
+let uu___is_INVARIANT : variance  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| INVARIANT -> begin
+true
+end
+| uu____569 -> begin
+false
+end))
+
+
 type tprob =
-  (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term)
-    FStar_TypeChecker_Common.problem
+(FStar_Syntax_Syntax.typ, FStar_Syntax_Syntax.term) FStar_TypeChecker_Common.problem
+
+
 type cprob =
-  (FStar_Syntax_Syntax.comp,Prims.unit) FStar_TypeChecker_Common.problem
-type ('a,'b) problem_t = ('a,'b) FStar_TypeChecker_Common.problem
-let rel_to_string: FStar_TypeChecker_Common.rel -> Prims.string =
-  fun uu___102_580  ->
-    match uu___102_580 with
-    | FStar_TypeChecker_Common.EQ  -> "="
-    | FStar_TypeChecker_Common.SUB  -> "<:"
-    | FStar_TypeChecker_Common.SUBINV  -> ":>"
-let term_to_string env t =
-  let uu____593 =
-    let uu____594 = FStar_Syntax_Subst.compress t in
-    uu____594.FStar_Syntax_Syntax.n in
-  match uu____593 with
-  | FStar_Syntax_Syntax.Tm_uvar (u,t1) ->
-      let uu____611 = FStar_Syntax_Print.uvar_to_string u in
-      let uu____615 = FStar_Syntax_Print.term_to_string t1 in
-      FStar_Util.format2 "(%s:%s)" uu____611 uu____615
-  | FStar_Syntax_Syntax.Tm_app
-      ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (u,ty);
-         FStar_Syntax_Syntax.tk = uu____618;
-         FStar_Syntax_Syntax.pos = uu____619;
-         FStar_Syntax_Syntax.vars = uu____620;_},args)
-      ->
-      let uu____648 = FStar_Syntax_Print.uvar_to_string u in
-      let uu____652 = FStar_Syntax_Print.term_to_string ty in
-      let uu____653 = FStar_Syntax_Print.args_to_string args in
-      FStar_Util.format3 "(%s:%s) %s" uu____648 uu____652 uu____653
-  | uu____654 -> FStar_Syntax_Print.term_to_string t
-let prob_to_string:
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> Prims.string
-  =
-  fun env  ->
-    fun uu___103_660  ->
-      match uu___103_660 with
-      | FStar_TypeChecker_Common.TProb p ->
-          let uu____664 =
-            let uu____666 =
-              FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
-            let uu____667 =
-              let uu____669 =
-                term_to_string env p.FStar_TypeChecker_Common.lhs in
-              let uu____670 =
-                let uu____672 =
-                  FStar_Syntax_Print.tag_of_term
-                    p.FStar_TypeChecker_Common.lhs in
-                let uu____673 =
-                  let uu____675 =
-                    let uu____677 =
-                      term_to_string env p.FStar_TypeChecker_Common.rhs in
-                    let uu____678 =
-                      let uu____680 =
-                        FStar_Syntax_Print.tag_of_term
-                          p.FStar_TypeChecker_Common.rhs in
-                      let uu____681 =
-                        let uu____683 =
-                          FStar_TypeChecker_Normalize.term_to_string env
-                            (Prims.fst
-                               p.FStar_TypeChecker_Common.logical_guard) in
-                        let uu____684 =
-                          let uu____686 =
-                            FStar_All.pipe_right
-                              p.FStar_TypeChecker_Common.reason
-                              (FStar_String.concat "\n\t\t\t") in
-                          [uu____686] in
-                        uu____683 :: uu____684 in
-                      uu____680 :: uu____681 in
-                    uu____677 :: uu____678 in
-                  (rel_to_string p.FStar_TypeChecker_Common.relation) ::
-                    uu____675 in
-                uu____672 :: uu____673 in
-              uu____669 :: uu____670 in
-            uu____666 :: uu____667 in
-          FStar_Util.format
-            "\t%s: %s (%s)\n\t\t%s\n\t%s (%s) (guard %s)\n\t\t<Reason>\n\t\t\t%s\n\t\t</Reason>"
-            uu____664
-      | FStar_TypeChecker_Common.CProb p ->
-          let uu____691 =
-            FStar_TypeChecker_Normalize.comp_to_string env
-              p.FStar_TypeChecker_Common.lhs in
-          let uu____692 =
-            FStar_TypeChecker_Normalize.comp_to_string env
-              p.FStar_TypeChecker_Common.rhs in
-          FStar_Util.format3 "\t%s \n\t\t%s\n\t%s" uu____691
-            (rel_to_string p.FStar_TypeChecker_Common.relation) uu____692
-let uvi_to_string: FStar_TypeChecker_Env.env -> uvi -> Prims.string =
-  fun env  ->
-    fun uu___104_698  ->
-      match uu___104_698 with
-      | UNIV (u,t) ->
-          let x =
-            let uu____702 = FStar_Options.hide_uvar_nums () in
-            if uu____702
-            then "?"
-            else
-              (let uu____704 = FStar_Unionfind.uvar_id u in
-               FStar_All.pipe_right uu____704 FStar_Util.string_of_int) in
-          let uu____706 = FStar_Syntax_Print.univ_to_string t in
-          FStar_Util.format2 "UNIV %s %s" x uu____706
-      | TERM ((u,uu____708),t) ->
-          let x =
-            let uu____713 = FStar_Options.hide_uvar_nums () in
-            if uu____713
-            then "?"
-            else
-              (let uu____715 = FStar_Unionfind.uvar_id u in
-               FStar_All.pipe_right uu____715 FStar_Util.string_of_int) in
-          let uu____719 = FStar_TypeChecker_Normalize.term_to_string env t in
-          FStar_Util.format2 "TERM %s %s" x uu____719
-let uvis_to_string:
-  FStar_TypeChecker_Env.env -> uvi Prims.list -> Prims.string =
-  fun env  ->
-    fun uvis  ->
-      let uu____728 = FStar_List.map (uvi_to_string env) uvis in
-      FStar_All.pipe_right uu____728 (FStar_String.concat ", ")
-let names_to_string: FStar_Syntax_Syntax.bv FStar_Util.set -> Prims.string =
-  fun nms  ->
-    let uu____736 =
-      let uu____738 = FStar_Util.set_elements nms in
-      FStar_All.pipe_right uu____738
-        (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-    FStar_All.pipe_right uu____736 (FStar_String.concat ", ")
-let args_to_string args =
-  let uu____756 =
-    FStar_All.pipe_right args
-      (FStar_List.map
-         (fun uu____764  ->
-            match uu____764 with
-            | (x,uu____768) -> FStar_Syntax_Print.term_to_string x)) in
-  FStar_All.pipe_right uu____756 (FStar_String.concat " ")
-let empty_worklist: FStar_TypeChecker_Env.env -> worklist =
-  fun env  ->
-    let uu____773 =
-      let uu____774 = FStar_Options.eager_inference () in
-      Prims.op_Negation uu____774 in
-    {
-      attempting = [];
-      wl_deferred = [];
-      ctr = (Prims.parse_int "0");
-      defer_ok = uu____773;
-      smt_ok = true;
-      tcenv = env
-    }
-let singleton':
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> Prims.bool -> worklist
-  =
-  fun env  ->
-    fun prob  ->
-      fun smt_ok  ->
-        let uu___135_787 = empty_worklist env in
-        {
-          attempting = [prob];
-          wl_deferred = (uu___135_787.wl_deferred);
-          ctr = (uu___135_787.ctr);
-          defer_ok = (uu___135_787.defer_ok);
-          smt_ok;
-          tcenv = (uu___135_787.tcenv)
-        }
-let singleton:
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> worklist =
-  fun env  -> fun prob  -> singleton' env prob true
-let wl_of_guard env g =
-  let uu___136_812 = empty_worklist env in
-  let uu____813 = FStar_List.map Prims.snd g in
-  {
-    attempting = uu____813;
-    wl_deferred = (uu___136_812.wl_deferred);
-    ctr = (uu___136_812.ctr);
-    defer_ok = false;
-    smt_ok = (uu___136_812.smt_ok);
-    tcenv = (uu___136_812.tcenv)
-  }
-let defer:
-  Prims.string -> FStar_TypeChecker_Common.prob -> worklist -> worklist =
-  fun reason  ->
-    fun prob  ->
-      fun wl  ->
-        let uu___137_825 = wl in
-        {
-          attempting = (uu___137_825.attempting);
-          wl_deferred = (((wl.ctr), reason, prob) :: (wl.wl_deferred));
-          ctr = (uu___137_825.ctr);
-          defer_ok = (uu___137_825.defer_ok);
-          smt_ok = (uu___137_825.smt_ok);
-          tcenv = (uu___137_825.tcenv)
-        }
-let attempt: FStar_TypeChecker_Common.prob Prims.list -> worklist -> worklist
-  =
-  fun probs  ->
-    fun wl  ->
-      let uu___138_837 = wl in
-      {
-        attempting = (FStar_List.append probs wl.attempting);
-        wl_deferred = (uu___138_837.wl_deferred);
-        ctr = (uu___138_837.ctr);
-        defer_ok = (uu___138_837.defer_ok);
-        smt_ok = (uu___138_837.smt_ok);
-        tcenv = (uu___138_837.tcenv)
-      }
-let giveup:
-  FStar_TypeChecker_Env.env ->
-    Prims.string -> FStar_TypeChecker_Common.prob -> solution
-  =
-  fun env  ->
-    fun reason  ->
-      fun prob  ->
-        (let uu____848 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel") in
-         if uu____848
-         then
-           let uu____849 = prob_to_string env prob in
-           FStar_Util.print2 "Failed %s:\n%s\n" reason uu____849
-         else ());
-        Failed (prob, reason)
-let invert_rel: FStar_TypeChecker_Common.rel -> FStar_TypeChecker_Common.rel
-  =
-  fun uu___105_853  ->
-    match uu___105_853 with
-    | FStar_TypeChecker_Common.EQ  -> FStar_TypeChecker_Common.EQ
-    | FStar_TypeChecker_Common.SUB  -> FStar_TypeChecker_Common.SUBINV
-    | FStar_TypeChecker_Common.SUBINV  -> FStar_TypeChecker_Common.SUB
-let invert p =
-  let uu___139_869 = p in
-  {
-    FStar_TypeChecker_Common.pid =
-      (uu___139_869.FStar_TypeChecker_Common.pid);
-    FStar_TypeChecker_Common.lhs = (p.FStar_TypeChecker_Common.rhs);
-    FStar_TypeChecker_Common.relation =
-      (invert_rel p.FStar_TypeChecker_Common.relation);
-    FStar_TypeChecker_Common.rhs = (p.FStar_TypeChecker_Common.lhs);
-    FStar_TypeChecker_Common.element =
-      (uu___139_869.FStar_TypeChecker_Common.element);
-    FStar_TypeChecker_Common.logical_guard =
-      (uu___139_869.FStar_TypeChecker_Common.logical_guard);
-    FStar_TypeChecker_Common.scope =
-      (uu___139_869.FStar_TypeChecker_Common.scope);
-    FStar_TypeChecker_Common.reason =
-      (uu___139_869.FStar_TypeChecker_Common.reason);
-    FStar_TypeChecker_Common.loc =
-      (uu___139_869.FStar_TypeChecker_Common.loc);
-    FStar_TypeChecker_Common.rank =
-      (uu___139_869.FStar_TypeChecker_Common.rank)
-  }
-let maybe_invert p =
-  if p.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.SUBINV
-  then invert p
-  else p
-let maybe_invert_p:
-  FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob =
-  fun uu___106_890  ->
-    match uu___106_890 with
-    | FStar_TypeChecker_Common.TProb p ->
-        FStar_All.pipe_right (maybe_invert p)
-          (fun _0_31  -> FStar_TypeChecker_Common.TProb _0_31)
-    | FStar_TypeChecker_Common.CProb p ->
-        FStar_All.pipe_right (maybe_invert p)
-          (fun _0_32  -> FStar_TypeChecker_Common.CProb _0_32)
-let vary_rel:
-  FStar_TypeChecker_Common.rel -> variance -> FStar_TypeChecker_Common.rel =
-  fun rel  ->
-    fun uu___107_906  ->
-      match uu___107_906 with
-      | INVARIANT  -> FStar_TypeChecker_Common.EQ
-      | CONTRAVARIANT  -> invert_rel rel
-      | COVARIANT  -> rel
-let p_pid: FStar_TypeChecker_Common.prob -> Prims.int =
-  fun uu___108_909  ->
-    match uu___108_909 with
-    | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.pid
-    | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.pid
-let p_rel: FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.rel =
-  fun uu___109_918  ->
-    match uu___109_918 with
-    | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.relation
-    | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.relation
-let p_reason: FStar_TypeChecker_Common.prob -> Prims.string Prims.list =
-  fun uu___110_928  ->
-    match uu___110_928 with
-    | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.reason
-    | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.reason
-let p_loc: FStar_TypeChecker_Common.prob -> FStar_Range.range =
-  fun uu___111_938  ->
-    match uu___111_938 with
-    | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.loc
-    | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.loc
-let p_guard:
-  FStar_TypeChecker_Common.prob ->
-    (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.term)
-  =
-  fun uu___112_949  ->
-    match uu___112_949 with
-    | FStar_TypeChecker_Common.TProb p ->
-        p.FStar_TypeChecker_Common.logical_guard
-    | FStar_TypeChecker_Common.CProb p ->
-        p.FStar_TypeChecker_Common.logical_guard
-let p_scope: FStar_TypeChecker_Common.prob -> FStar_Syntax_Syntax.binders =
-  fun uu___113_960  ->
-    match uu___113_960 with
-    | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.scope
-    | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.scope
-let p_invert: FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob
-  =
-  fun uu___114_969  ->
-    match uu___114_969 with
-    | FStar_TypeChecker_Common.TProb p ->
-        FStar_All.pipe_left
-          (fun _0_33  -> FStar_TypeChecker_Common.TProb _0_33) (invert p)
-    | FStar_TypeChecker_Common.CProb p ->
-        FStar_All.pipe_left
-          (fun _0_34  -> FStar_TypeChecker_Common.CProb _0_34) (invert p)
-let is_top_level_prob: FStar_TypeChecker_Common.prob -> Prims.bool =
-  fun p  ->
-    let uu____983 = FStar_All.pipe_right (p_reason p) FStar_List.length in
-    uu____983 = (Prims.parse_int "1")
-let next_pid: Prims.unit -> Prims.int =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
-  fun uu____994  -> FStar_Util.incr ctr; FStar_ST.read ctr
-let mk_problem scope orig lhs rel rhs elt reason =
-  let uu____1044 = next_pid () in
-  let uu____1045 =
-    new_uvar FStar_Range.dummyRange scope FStar_Syntax_Util.ktype0 in
-  {
-    FStar_TypeChecker_Common.pid = uu____1044;
-    FStar_TypeChecker_Common.lhs = lhs;
-    FStar_TypeChecker_Common.relation = rel;
-    FStar_TypeChecker_Common.rhs = rhs;
-    FStar_TypeChecker_Common.element = elt;
-    FStar_TypeChecker_Common.logical_guard = uu____1045;
-    FStar_TypeChecker_Common.scope = scope;
-    FStar_TypeChecker_Common.reason = (reason :: (p_reason orig));
-    FStar_TypeChecker_Common.loc = (p_loc orig);
-    FStar_TypeChecker_Common.rank = None
-  }
-let new_problem env lhs rel rhs elt loc reason =
-  let scope = FStar_TypeChecker_Env.all_binders env in
-  let uu____1092 = next_pid () in
-  let uu____1093 =
-    new_uvar FStar_Range.dummyRange scope FStar_Syntax_Util.ktype0 in
-  {
-    FStar_TypeChecker_Common.pid = uu____1092;
-    FStar_TypeChecker_Common.lhs = lhs;
-    FStar_TypeChecker_Common.relation = rel;
-    FStar_TypeChecker_Common.rhs = rhs;
-    FStar_TypeChecker_Common.element = elt;
-    FStar_TypeChecker_Common.logical_guard = uu____1093;
-    FStar_TypeChecker_Common.scope = scope;
-    FStar_TypeChecker_Common.reason = [reason];
-    FStar_TypeChecker_Common.loc = loc;
-    FStar_TypeChecker_Common.rank = None
-  }
-let problem_using_guard orig lhs rel rhs elt reason =
-  let uu____1134 = next_pid () in
-  {
-    FStar_TypeChecker_Common.pid = uu____1134;
-    FStar_TypeChecker_Common.lhs = lhs;
-    FStar_TypeChecker_Common.relation = rel;
-    FStar_TypeChecker_Common.rhs = rhs;
-    FStar_TypeChecker_Common.element = elt;
-    FStar_TypeChecker_Common.logical_guard = (p_guard orig);
-    FStar_TypeChecker_Common.scope = (p_scope orig);
-    FStar_TypeChecker_Common.reason = (reason :: (p_reason orig));
-    FStar_TypeChecker_Common.loc = (p_loc orig);
-    FStar_TypeChecker_Common.rank = None
-  }
-let guard_on_element wl problem x phi =
-  match problem.FStar_TypeChecker_Common.element with
-  | None  ->
-      let u =
-        (wl.tcenv).FStar_TypeChecker_Env.universe_of wl.tcenv
-          x.FStar_Syntax_Syntax.sort in
-      FStar_Syntax_Util.mk_forall u x phi
-  | Some e -> FStar_Syntax_Subst.subst [FStar_Syntax_Syntax.NT (x, e)] phi
-let explain:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> Prims.string -> Prims.string
-  =
-  fun env  ->
-    fun d  ->
-      fun s  ->
-        let uu____1186 =
-          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-            (FStar_Options.Other "ExplainRel") in
-        if uu____1186
-        then
-          let uu____1187 =
-            FStar_All.pipe_left FStar_Range.string_of_range (p_loc d) in
-          let uu____1188 = prob_to_string env d in
-          let uu____1189 =
-            FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>") in
-          FStar_Util.format4
-            "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n"
-            uu____1187 uu____1188 uu____1189 s
-        else
-          (let d1 = maybe_invert_p d in
-           let rel =
-             match p_rel d1 with
-             | FStar_TypeChecker_Common.EQ  -> "equal to"
-             | FStar_TypeChecker_Common.SUB  -> "a subtype of"
-             | uu____1194 -> failwith "impossible" in
-           let uu____1195 =
-             match d1 with
-             | FStar_TypeChecker_Common.TProb tp ->
-                 let uu____1203 =
-                   FStar_TypeChecker_Normalize.term_to_string env
-                     tp.FStar_TypeChecker_Common.lhs in
-                 let uu____1204 =
-                   FStar_TypeChecker_Normalize.term_to_string env
-                     tp.FStar_TypeChecker_Common.rhs in
-                 (uu____1203, uu____1204)
-             | FStar_TypeChecker_Common.CProb cp ->
-                 let uu____1208 =
-                   FStar_TypeChecker_Normalize.comp_to_string env
-                     cp.FStar_TypeChecker_Common.lhs in
-                 let uu____1209 =
-                   FStar_TypeChecker_Normalize.comp_to_string env
-                     cp.FStar_TypeChecker_Common.rhs in
-                 (uu____1208, uu____1209) in
-           match uu____1195 with
-           | (lhs,rhs) ->
-               FStar_Util.format3 "%s is not %s the expected type %s" lhs rel
-                 rhs)
-let commit: uvi Prims.list -> Prims.unit =
-  fun uvis  ->
-    FStar_All.pipe_right uvis
-      (FStar_List.iter
-         (fun uu___115_1218  ->
-            match uu___115_1218 with
-            | UNIV (u,t) ->
-                (match t with
-                 | FStar_Syntax_Syntax.U_unif u' ->
-                     FStar_Unionfind.union u u'
-                 | uu____1225 -> FStar_Unionfind.change u (Some t))
-            | TERM ((u,uu____1228),t) -> FStar_Syntax_Util.set_uvar u t))
-let find_term_uvar:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax FStar_Syntax_Syntax.uvar_basis
-    FStar_Unionfind.uvar ->
-    uvi Prims.list -> FStar_Syntax_Syntax.term Prims.option
-  =
-  fun uv  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___116_1251  ->
-           match uu___116_1251 with
-           | UNIV uu____1253 -> None
-           | TERM ((u,uu____1257),t) ->
-               let uu____1261 = FStar_Unionfind.equivalent uv u in
-               if uu____1261 then Some t else None)
-let find_univ_uvar:
-  FStar_Syntax_Syntax.universe Prims.option FStar_Unionfind.uvar ->
-    uvi Prims.list -> FStar_Syntax_Syntax.universe Prims.option
-  =
-  fun u  ->
-    fun s  ->
-      FStar_Util.find_map s
-        (fun uu___117_1280  ->
-           match uu___117_1280 with
-           | UNIV (u',t) ->
-               let uu____1284 = FStar_Unionfind.equivalent u u' in
-               if uu____1284 then Some t else None
-           | uu____1288 -> None)
-let whnf:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      let uu____1295 =
-        let uu____1296 = FStar_Syntax_Util.unmeta t in
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.WHNF] env uu____1296 in
-      FStar_Syntax_Subst.compress uu____1295
-let sn:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      let uu____1303 =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta] env t in
-      FStar_Syntax_Subst.compress uu____1303
-let norm_arg env t =
-  let uu____1322 = sn env (Prims.fst t) in (uu____1322, (Prims.snd t))
-let sn_binders:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun env  ->
-    fun binders  ->
-      FStar_All.pipe_right binders
-        (FStar_List.map
-           (fun uu____1339  ->
-              match uu____1339 with
-              | (x,imp) ->
-                  let uu____1346 =
-                    let uu___140_1347 = x in
-                    let uu____1348 = sn env x.FStar_Syntax_Syntax.sort in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___140_1347.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index =
-                        (uu___140_1347.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu____1348
-                    } in
-                  (uu____1346, imp)))
-let norm_univ:
-  worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe =
-  fun wl  ->
-    fun u  ->
-      let rec aux u1 =
-        let u2 = FStar_Syntax_Subst.compress_univ u1 in
-        match u2 with
-        | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____1363 = aux u3 in FStar_Syntax_Syntax.U_succ uu____1363
-        | FStar_Syntax_Syntax.U_max us ->
-            let uu____1366 = FStar_List.map aux us in
-            FStar_Syntax_Syntax.U_max uu____1366
-        | uu____1368 -> u2 in
-      let uu____1369 = aux u in
-      FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____1369
-let normalize_refinement steps env wl t0 =
-  FStar_TypeChecker_Normalize.normalize_refinement steps env t0
-let base_and_refinement env wl t1 =
-  let rec aux norm t11 =
-    match t11.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-        if norm
-        then ((x.FStar_Syntax_Syntax.sort), (Some (x, phi)))
-        else
-          (let uu____1476 =
-             normalize_refinement [FStar_TypeChecker_Normalize.WHNF] env wl
-               t11 in
-           match uu____1476 with
-           | {
-               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
-                 (x1,phi1);
-               FStar_Syntax_Syntax.tk = uu____1488;
-               FStar_Syntax_Syntax.pos = uu____1489;
-               FStar_Syntax_Syntax.vars = uu____1490;_} ->
-               ((x1.FStar_Syntax_Syntax.sort), (Some (x1, phi1)))
-           | tt ->
-               let uu____1511 =
-                 let uu____1512 = FStar_Syntax_Print.term_to_string tt in
-                 let uu____1513 = FStar_Syntax_Print.tag_of_term tt in
-                 FStar_Util.format2 "impossible: Got %s ... %s\n" uu____1512
-                   uu____1513 in
-               failwith uu____1511)
-    | FStar_Syntax_Syntax.Tm_uinst _
-      |FStar_Syntax_Syntax.Tm_fvar _|FStar_Syntax_Syntax.Tm_app _ ->
-        if norm
-        then (t11, None)
-        else
-          (let t1' =
-             normalize_refinement [FStar_TypeChecker_Normalize.WHNF] env wl
-               t11 in
-           let uu____1548 =
-             let uu____1549 = FStar_Syntax_Subst.compress t1' in
-             uu____1549.FStar_Syntax_Syntax.n in
-           match uu____1548 with
-           | FStar_Syntax_Syntax.Tm_refine uu____1561 -> aux true t1'
-           | uu____1566 -> (t11, None))
-    | FStar_Syntax_Syntax.Tm_type _
-      |FStar_Syntax_Syntax.Tm_constant _
-       |FStar_Syntax_Syntax.Tm_name _
-        |FStar_Syntax_Syntax.Tm_bvar _
-         |FStar_Syntax_Syntax.Tm_arrow _
-          |FStar_Syntax_Syntax.Tm_abs _
-           |FStar_Syntax_Syntax.Tm_uvar _
-            |FStar_Syntax_Syntax.Tm_let _|FStar_Syntax_Syntax.Tm_match _
-        -> (t11, None)
-    | FStar_Syntax_Syntax.Tm_meta _
-      |FStar_Syntax_Syntax.Tm_ascribed _
-       |FStar_Syntax_Syntax.Tm_delayed _|FStar_Syntax_Syntax.Tm_unknown  ->
-        let uu____1601 =
-          let uu____1602 = FStar_Syntax_Print.term_to_string t11 in
-          let uu____1603 = FStar_Syntax_Print.tag_of_term t11 in
-          FStar_Util.format2 "impossible (outer): Got %s ... %s\n" uu____1602
-            uu____1603 in
-        failwith uu____1601 in
-  let uu____1613 = whnf env t1 in aux false uu____1613
-let unrefine:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    fun t  ->
-      let uu____1622 =
-        let uu____1632 = empty_worklist env in
-        base_and_refinement env uu____1632 t in
-      FStar_All.pipe_right uu____1622 Prims.fst
-let trivial_refinement:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.term)
-  =
-  fun t  ->
-    let uu____1656 = FStar_Syntax_Syntax.null_bv t in
-    (uu____1656, FStar_Syntax_Util.t_true)
-let as_refinement env wl t =
-  let uu____1676 = base_and_refinement env wl t in
-  match uu____1676 with
-  | (t_base,refinement) ->
-      (match refinement with
-       | None  -> trivial_refinement t_base
-       | Some (x,phi) -> (x, phi))
-let force_refinement uu____1735 =
-  match uu____1735 with
-  | (t_base,refopt) ->
-      let uu____1749 =
-        match refopt with
-        | Some (y,phi) -> (y, phi)
-        | None  -> trivial_refinement t_base in
-      (match uu____1749 with
-       | (y,phi) ->
-           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (y, phi))
-             None t_base.FStar_Syntax_Syntax.pos)
-let wl_prob_to_string:
-  worklist -> FStar_TypeChecker_Common.prob -> Prims.string =
-  fun wl  ->
-    fun uu___118_1773  ->
-      match uu___118_1773 with
-      | FStar_TypeChecker_Common.TProb p ->
-          let uu____1777 =
-            FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
-          let uu____1778 =
-            let uu____1779 = whnf wl.tcenv p.FStar_TypeChecker_Common.lhs in
-            FStar_Syntax_Print.term_to_string uu____1779 in
-          let uu____1780 =
-            let uu____1781 = whnf wl.tcenv p.FStar_TypeChecker_Common.rhs in
-            FStar_Syntax_Print.term_to_string uu____1781 in
-          FStar_Util.format4 "%s: %s  (%s)  %s" uu____1777 uu____1778
-            (rel_to_string p.FStar_TypeChecker_Common.relation) uu____1780
-      | FStar_TypeChecker_Common.CProb p ->
-          let uu____1785 =
-            FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
-          let uu____1786 =
-            FStar_TypeChecker_Normalize.comp_to_string wl.tcenv
-              p.FStar_TypeChecker_Common.lhs in
-          let uu____1787 =
-            FStar_TypeChecker_Normalize.comp_to_string wl.tcenv
-              p.FStar_TypeChecker_Common.rhs in
-          FStar_Util.format4 "%s: %s  (%s)  %s" uu____1785 uu____1786
-            (rel_to_string p.FStar_TypeChecker_Common.relation) uu____1787
-let wl_to_string: worklist -> Prims.string =
-  fun wl  ->
-    let uu____1791 =
-      let uu____1793 =
-        let uu____1795 =
-          FStar_All.pipe_right wl.wl_deferred
-            (FStar_List.map
-               (fun uu____1805  ->
-                  match uu____1805 with | (uu____1809,uu____1810,x) -> x)) in
-        FStar_List.append wl.attempting uu____1795 in
-      FStar_List.map (wl_prob_to_string wl) uu____1793 in
-    FStar_All.pipe_right uu____1791 (FStar_String.concat "\n\t")
-let u_abs:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun k  ->
-    fun ys  ->
-      fun t  ->
-        let uu____1828 =
-          let uu____1838 =
-            let uu____1839 = FStar_Syntax_Subst.compress k in
-            uu____1839.FStar_Syntax_Syntax.n in
-          match uu____1838 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-              if (FStar_List.length bs) = (FStar_List.length ys)
-              then
-                let uu____1880 = FStar_Syntax_Subst.open_comp bs c in
-                ((ys, t), uu____1880)
-              else
-                (let uu____1894 = FStar_Syntax_Util.abs_formals t in
-                 match uu____1894 with
-                 | (ys',t1,uu____1915) ->
-                     let uu____1928 = FStar_Syntax_Util.arrow_formals_comp k in
-                     (((FStar_List.append ys ys'), t1), uu____1928))
-          | uu____1949 ->
-              let uu____1950 =
-                let uu____1956 = FStar_Syntax_Syntax.mk_Total k in
-                ([], uu____1956) in
-              ((ys, t), uu____1950) in
-        match uu____1828 with
-        | ((ys1,t1),(xs,c)) ->
-            if (FStar_List.length xs) <> (FStar_List.length ys1)
-            then
-              FStar_Syntax_Util.abs ys1 t1
-                (Some
-                   (FStar_Util.Inr (FStar_Syntax_Const.effect_Tot_lid, [])))
-            else
-              (let c1 =
-                 let uu____2011 = FStar_Syntax_Util.rename_binders xs ys1 in
-                 FStar_Syntax_Subst.subst_comp uu____2011 c in
-               let uu____2013 =
-                 let uu____2020 =
-                   FStar_All.pipe_right (FStar_Syntax_Util.lcomp_of_comp c1)
-                     (fun _0_35  -> FStar_Util.Inl _0_35) in
-                 FStar_All.pipe_right uu____2020 (fun _0_36  -> Some _0_36) in
-               FStar_Syntax_Util.abs ys1 t1 uu____2013)
-let solve_prob':
-  Prims.bool ->
-    FStar_TypeChecker_Common.prob ->
-      FStar_Syntax_Syntax.term Prims.option ->
-        uvi Prims.list -> worklist -> worklist
-  =
-  fun resolve_ok  ->
-    fun prob  ->
-      fun logical_guard  ->
-        fun uvis  ->
-          fun wl  ->
-            let phi =
-              match logical_guard with
-              | None  -> FStar_Syntax_Util.t_true
-              | Some phi -> phi in
-            let uu____2071 = p_guard prob in
-            match uu____2071 with
-            | (uu____2074,uv) ->
-                ((let uu____2077 =
-                    let uu____2078 = FStar_Syntax_Subst.compress uv in
-                    uu____2078.FStar_Syntax_Syntax.n in
-                  match uu____2077 with
-                  | FStar_Syntax_Syntax.Tm_uvar (uvar,k) ->
-                      let bs = p_scope prob in
-                      let phi1 = u_abs k bs phi in
-                      ((let uu____2098 =
-                          FStar_All.pipe_left
-                            (FStar_TypeChecker_Env.debug wl.tcenv)
-                            (FStar_Options.Other "Rel") in
-                        if uu____2098
-                        then
-                          let uu____2099 =
-                            FStar_Util.string_of_int (p_pid prob) in
-                          let uu____2100 =
-                            FStar_Syntax_Print.term_to_string uv in
-                          let uu____2101 =
-                            FStar_Syntax_Print.term_to_string phi1 in
-                          FStar_Util.print3
-                            "Solving %s (%s) with formula %s\n" uu____2099
-                            uu____2100 uu____2101
-                        else ());
-                       FStar_Syntax_Util.set_uvar uvar phi1)
-                  | uu____2105 ->
-                      if Prims.op_Negation resolve_ok
-                      then
-                        failwith
-                          "Impossible: this instance has already been assigned a solution"
-                      else ());
-                 commit uvis;
-                 (let uu___141_2108 = wl in
-                  {
-                    attempting = (uu___141_2108.attempting);
-                    wl_deferred = (uu___141_2108.wl_deferred);
-                    ctr = (wl.ctr + (Prims.parse_int "1"));
-                    defer_ok = (uu___141_2108.defer_ok);
-                    smt_ok = (uu___141_2108.smt_ok);
-                    tcenv = (uu___141_2108.tcenv)
-                  }))
-let extend_solution: Prims.int -> uvi Prims.list -> worklist -> worklist =
-  fun pid  ->
-    fun sol  ->
-      fun wl  ->
-        (let uu____2121 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
-             (FStar_Options.Other "RelCheck") in
-         if uu____2121
-         then
-           let uu____2122 = FStar_Util.string_of_int pid in
-           let uu____2123 =
-             let uu____2124 = FStar_List.map (uvi_to_string wl.tcenv) sol in
-             FStar_All.pipe_right uu____2124 (FStar_String.concat ", ") in
-           FStar_Util.print2 "Solving %s: with %s\n" uu____2122 uu____2123
-         else ());
-        commit sol;
-        (let uu___142_2129 = wl in
-         {
-           attempting = (uu___142_2129.attempting);
-           wl_deferred = (uu___142_2129.wl_deferred);
-           ctr = (wl.ctr + (Prims.parse_int "1"));
-           defer_ok = (uu___142_2129.defer_ok);
-           smt_ok = (uu___142_2129.smt_ok);
-           tcenv = (uu___142_2129.tcenv)
-         })
-let solve_prob:
-  FStar_TypeChecker_Common.prob ->
-    FStar_Syntax_Syntax.term Prims.option ->
-      uvi Prims.list -> worklist -> worklist
-  =
-  fun prob  ->
-    fun logical_guard  ->
-      fun uvis  ->
-        fun wl  ->
-          let conj_guard1 t g =
-            match (t, g) with
-            | (uu____2158,FStar_TypeChecker_Common.Trivial ) -> t
-            | (None ,FStar_TypeChecker_Common.NonTrivial f) -> Some f
-            | (Some t1,FStar_TypeChecker_Common.NonTrivial f) ->
-                let uu____2166 = FStar_Syntax_Util.mk_conj t1 f in
-                Some uu____2166 in
-          (let uu____2172 =
-             FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
-               (FStar_Options.Other "RelCheck") in
-           if uu____2172
-           then
-             let uu____2173 =
-               FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob) in
-             let uu____2174 =
-               let uu____2175 = FStar_List.map (uvi_to_string wl.tcenv) uvis in
-               FStar_All.pipe_right uu____2175 (FStar_String.concat ", ") in
-             FStar_Util.print2 "Solving %s: with %s\n" uu____2173 uu____2174
-           else ());
-          solve_prob' false prob logical_guard uvis wl
-let rec occurs wl uk t =
-  let uu____2200 =
-    let uu____2204 = FStar_Syntax_Free.uvars t in
-    FStar_All.pipe_right uu____2204 FStar_Util.set_elements in
-  FStar_All.pipe_right uu____2200
-    (FStar_Util.for_some
-       (fun uu____2225  ->
-          match uu____2225 with
-          | (uv,uu____2233) -> FStar_Unionfind.equivalent uv (Prims.fst uk)))
-let occurs_check env wl uk t =
-  let occurs_ok =
-    let uu____2277 = occurs wl uk t in Prims.op_Negation uu____2277 in
-  let msg =
-    if occurs_ok
-    then None
-    else
-      (let uu____2282 =
-         let uu____2283 = FStar_Syntax_Print.uvar_to_string (Prims.fst uk) in
-         let uu____2287 = FStar_Syntax_Print.term_to_string t in
-         FStar_Util.format2 "occurs-check failed (%s occurs in %s)"
-           uu____2283 uu____2287 in
-       Some uu____2282) in
-  (occurs_ok, msg)
-let occurs_and_freevars_check env wl uk fvs t =
-  let fvs_t = FStar_Syntax_Free.names t in
-  let uu____2335 = occurs_check env wl uk t in
-  match uu____2335 with
-  | (occurs_ok,msg) ->
-      let uu____2352 = FStar_Util.set_is_subset_of fvs_t fvs in
-      (occurs_ok, uu____2352, (msg, fvs, fvs_t))
-let intersect_vars v1 v2 =
-  let as_set v3 =
-    FStar_All.pipe_right v3
-      (FStar_List.fold_left
-         (fun out  -> fun x  -> FStar_Util.set_add (Prims.fst x) out)
-         FStar_Syntax_Syntax.no_names) in
-  let v1_set = as_set v1 in
-  let uu____2416 =
-    FStar_All.pipe_right v2
-      (FStar_List.fold_left
-         (fun uu____2440  ->
-            fun uu____2441  ->
-              match (uu____2440, uu____2441) with
-              | ((isect,isect_set),(x,imp)) ->
-                  let uu____2484 =
-                    let uu____2485 = FStar_Util.set_mem x v1_set in
-                    FStar_All.pipe_left Prims.op_Negation uu____2485 in
-                  if uu____2484
-                  then (isect, isect_set)
-                  else
-                    (let fvs =
-                       FStar_Syntax_Free.names x.FStar_Syntax_Syntax.sort in
-                     let uu____2499 =
-                       FStar_Util.set_is_subset_of fvs isect_set in
-                     if uu____2499
-                     then
-                       let uu____2506 = FStar_Util.set_add x isect_set in
-                       (((x, imp) :: isect), uu____2506)
-                     else (isect, isect_set)))
-         ([], FStar_Syntax_Syntax.no_names)) in
-  match uu____2416 with | (isect,uu____2528) -> FStar_List.rev isect
-let binders_eq v1 v2 =
-  ((FStar_List.length v1) = (FStar_List.length v2)) &&
-    (FStar_List.forall2
-       (fun uu____2577  ->
-          fun uu____2578  ->
-            match (uu____2577, uu____2578) with
-            | ((a,uu____2588),(b,uu____2590)) ->
-                FStar_Syntax_Syntax.bv_eq a b) v1 v2)
-let pat_var_opt env seen arg =
-  let hd1 = norm_arg env arg in
-  match (Prims.fst hd1).FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_name a ->
-      let uu____2634 =
-        FStar_All.pipe_right seen
-          (FStar_Util.for_some
-             (fun uu____2640  ->
-                match uu____2640 with
-                | (b,uu____2644) -> FStar_Syntax_Syntax.bv_eq a b)) in
-      if uu____2634 then None else Some (a, (Prims.snd hd1))
-  | uu____2653 -> None
-let rec pat_vars:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.aqual) Prims.list ->
-        FStar_Syntax_Syntax.binders Prims.option
-  =
-  fun env  ->
-    fun seen  ->
-      fun args  ->
-        match args with
-        | [] -> Some (FStar_List.rev seen)
-        | hd1::rest ->
-            let uu____2696 = pat_var_opt env seen hd1 in
-            (match uu____2696 with
-             | None  ->
-                 ((let uu____2704 =
-                     FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       (FStar_Options.Other "Rel") in
-                   if uu____2704
-                   then
-                     let uu____2705 =
-                       FStar_All.pipe_left FStar_Syntax_Print.term_to_string
-                         (Prims.fst hd1) in
-                     FStar_Util.print1 "Not a pattern: %s\n" uu____2705
-                   else ());
-                  None)
-             | Some x -> pat_vars env (x :: seen) rest)
-let is_flex: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____2717 =
-      let uu____2718 = FStar_Syntax_Subst.compress t in
-      uu____2718.FStar_Syntax_Syntax.n in
-    match uu____2717 with
-    | FStar_Syntax_Syntax.Tm_uvar _|FStar_Syntax_Syntax.Tm_app
-      ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-         FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-         FStar_Syntax_Syntax.vars = _;_},_)
-        -> true
-    | uu____2734 -> false
-let destruct_flex_t t =
-  match t.FStar_Syntax_Syntax.n with
-  | FStar_Syntax_Syntax.Tm_uvar (uv,k) -> (t, uv, k, [])
-  | FStar_Syntax_Syntax.Tm_app
-      ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (uv,k);
-         FStar_Syntax_Syntax.tk = uu____2796;
-         FStar_Syntax_Syntax.pos = uu____2797;
-         FStar_Syntax_Syntax.vars = uu____2798;_},args)
-      -> (t, uv, k, args)
-  | uu____2839 -> failwith "Not a flex-uvar"
-let destruct_flex_pattern env t =
-  let uu____2893 = destruct_flex_t t in
-  match uu____2893 with
-  | (t1,uv,k,args) ->
-      let uu____2961 = pat_vars env [] args in
-      (match uu____2961 with
-       | Some vars -> ((t1, uv, k, args), (Some vars))
-       | uu____3017 -> ((t1, uv, k, args), None))
+(FStar_Syntax_Syntax.comp, Prims.unit) FStar_TypeChecker_Common.problem
+
+
+type ('a, 'b) problem_t =
+('a, 'b) FStar_TypeChecker_Common.problem
+
+
+let rel_to_string : FStar_TypeChecker_Common.rel  ->  Prims.string = (fun uu___102_580 -> (match (uu___102_580) with
+| FStar_TypeChecker_Common.EQ -> begin
+"="
+end
+| FStar_TypeChecker_Common.SUB -> begin
+"<:"
+end
+| FStar_TypeChecker_Common.SUBINV -> begin
+":>"
+end))
+
+
+let term_to_string = (fun env t -> (
+
+let uu____593 = (
+
+let uu____594 = (FStar_Syntax_Subst.compress t)
+in uu____594.FStar_Syntax_Syntax.n)
+in (match (uu____593) with
+| FStar_Syntax_Syntax.Tm_uvar (u, t1) -> begin
+(
+
+let uu____611 = (FStar_Syntax_Print.uvar_to_string u)
+in (
+
+let uu____615 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format2 "(%s:%s)" uu____611 uu____615)))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (u, ty); FStar_Syntax_Syntax.tk = uu____618; FStar_Syntax_Syntax.pos = uu____619; FStar_Syntax_Syntax.vars = uu____620}, args) -> begin
+(
+
+let uu____648 = (FStar_Syntax_Print.uvar_to_string u)
+in (
+
+let uu____652 = (FStar_Syntax_Print.term_to_string ty)
+in (
+
+let uu____653 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.format3 "(%s:%s) %s" uu____648 uu____652 uu____653))))
+end
+| uu____654 -> begin
+(FStar_Syntax_Print.term_to_string t)
+end)))
+
+
+let prob_to_string : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  Prims.string = (fun env uu___103_660 -> (match (uu___103_660) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(
+
+let uu____664 = (
+
+let uu____666 = (FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid)
+in (
+
+let uu____667 = (
+
+let uu____669 = (term_to_string env p.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____670 = (
+
+let uu____672 = (FStar_Syntax_Print.tag_of_term p.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____673 = (
+
+let uu____675 = (
+
+let uu____677 = (term_to_string env p.FStar_TypeChecker_Common.rhs)
+in (
+
+let uu____678 = (
+
+let uu____680 = (FStar_Syntax_Print.tag_of_term p.FStar_TypeChecker_Common.rhs)
+in (
+
+let uu____681 = (
+
+let uu____683 = (FStar_TypeChecker_Normalize.term_to_string env (Prims.fst p.FStar_TypeChecker_Common.logical_guard))
+in (
+
+let uu____684 = (
+
+let uu____686 = (FStar_All.pipe_right p.FStar_TypeChecker_Common.reason (FStar_String.concat "\n\t\t\t"))
+in (uu____686)::[])
+in (uu____683)::uu____684))
+in (uu____680)::uu____681))
+in (uu____677)::uu____678))
+in ((rel_to_string p.FStar_TypeChecker_Common.relation))::uu____675)
+in (uu____672)::uu____673))
+in (uu____669)::uu____670))
+in (uu____666)::uu____667))
+in (FStar_Util.format "\t%s: %s (%s)\n\t\t%s\n\t%s (%s) (guard %s)\n\t\t<Reason>\n\t\t\t%s\n\t\t</Reason>" uu____664))
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+(
+
+let uu____691 = (FStar_TypeChecker_Normalize.comp_to_string env p.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____692 = (FStar_TypeChecker_Normalize.comp_to_string env p.FStar_TypeChecker_Common.rhs)
+in (FStar_Util.format3 "\t%s \n\t\t%s\n\t%s" uu____691 (rel_to_string p.FStar_TypeChecker_Common.relation) uu____692)))
+end))
+
+
+let uvi_to_string : FStar_TypeChecker_Env.env  ->  uvi  ->  Prims.string = (fun env uu___104_698 -> (match (uu___104_698) with
+| UNIV (u, t) -> begin
+(
+
+let x = (
+
+let uu____702 = (FStar_Options.hide_uvar_nums ())
+in (match (uu____702) with
+| true -> begin
+"?"
+end
+| uu____703 -> begin
+(
+
+let uu____704 = (FStar_Unionfind.uvar_id u)
+in (FStar_All.pipe_right uu____704 FStar_Util.string_of_int))
+end))
+in (
+
+let uu____706 = (FStar_Syntax_Print.univ_to_string t)
+in (FStar_Util.format2 "UNIV %s %s" x uu____706)))
+end
+| TERM ((u, uu____708), t) -> begin
+(
+
+let x = (
+
+let uu____713 = (FStar_Options.hide_uvar_nums ())
+in (match (uu____713) with
+| true -> begin
+"?"
+end
+| uu____714 -> begin
+(
+
+let uu____715 = (FStar_Unionfind.uvar_id u)
+in (FStar_All.pipe_right uu____715 FStar_Util.string_of_int))
+end))
+in (
+
+let uu____719 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (FStar_Util.format2 "TERM %s %s" x uu____719)))
+end))
+
+
+let uvis_to_string : FStar_TypeChecker_Env.env  ->  uvi Prims.list  ->  Prims.string = (fun env uvis -> (
+
+let uu____728 = (FStar_List.map (uvi_to_string env) uvis)
+in (FStar_All.pipe_right uu____728 (FStar_String.concat ", "))))
+
+
+let names_to_string : FStar_Syntax_Syntax.bv FStar_Util.set  ->  Prims.string = (fun nms -> (
+
+let uu____736 = (
+
+let uu____738 = (FStar_Util.set_elements nms)
+in (FStar_All.pipe_right uu____738 (FStar_List.map FStar_Syntax_Print.bv_to_string)))
+in (FStar_All.pipe_right uu____736 (FStar_String.concat ", "))))
+
+
+let args_to_string = (fun args -> (
+
+let uu____756 = (FStar_All.pipe_right args (FStar_List.map (fun uu____764 -> (match (uu____764) with
+| (x, uu____768) -> begin
+(FStar_Syntax_Print.term_to_string x)
+end))))
+in (FStar_All.pipe_right uu____756 (FStar_String.concat " "))))
+
+
+let empty_worklist : FStar_TypeChecker_Env.env  ->  worklist = (fun env -> (
+
+let uu____773 = (
+
+let uu____774 = (FStar_Options.eager_inference ())
+in (not (uu____774)))
+in {attempting = []; wl_deferred = []; ctr = (Prims.parse_int "0"); defer_ok = uu____773; smt_ok = true; tcenv = env}))
+
+
+let singleton' : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  Prims.bool  ->  worklist = (fun env prob smt_ok -> (
+
+let uu___135_787 = (empty_worklist env)
+in {attempting = (prob)::[]; wl_deferred = uu___135_787.wl_deferred; ctr = uu___135_787.ctr; defer_ok = uu___135_787.defer_ok; smt_ok = smt_ok; tcenv = uu___135_787.tcenv}))
+
+
+let singleton : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  worklist = (fun env prob -> (singleton' env prob true))
+
+
+let wl_of_guard = (fun env g -> (
+
+let uu___136_812 = (empty_worklist env)
+in (
+
+let uu____813 = (FStar_List.map Prims.snd g)
+in {attempting = uu____813; wl_deferred = uu___136_812.wl_deferred; ctr = uu___136_812.ctr; defer_ok = false; smt_ok = uu___136_812.smt_ok; tcenv = uu___136_812.tcenv})))
+
+
+let defer : Prims.string  ->  FStar_TypeChecker_Common.prob  ->  worklist  ->  worklist = (fun reason prob wl -> (
+
+let uu___137_825 = wl
+in {attempting = uu___137_825.attempting; wl_deferred = (((wl.ctr), (reason), (prob)))::wl.wl_deferred; ctr = uu___137_825.ctr; defer_ok = uu___137_825.defer_ok; smt_ok = uu___137_825.smt_ok; tcenv = uu___137_825.tcenv}))
+
+
+let attempt : FStar_TypeChecker_Common.prob Prims.list  ->  worklist  ->  worklist = (fun probs wl -> (
+
+let uu___138_837 = wl
+in {attempting = (FStar_List.append probs wl.attempting); wl_deferred = uu___138_837.wl_deferred; ctr = uu___138_837.ctr; defer_ok = uu___138_837.defer_ok; smt_ok = uu___138_837.smt_ok; tcenv = uu___138_837.tcenv}))
+
+
+let giveup : FStar_TypeChecker_Env.env  ->  Prims.string  ->  FStar_TypeChecker_Common.prob  ->  solution = (fun env reason prob -> ((
+
+let uu____848 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____848) with
+| true -> begin
+(
+
+let uu____849 = (prob_to_string env prob)
+in (FStar_Util.print2 "Failed %s:\n%s\n" reason uu____849))
+end
+| uu____850 -> begin
+()
+end));
+Failed (((prob), (reason)));
+))
+
+
+let invert_rel : FStar_TypeChecker_Common.rel  ->  FStar_TypeChecker_Common.rel = (fun uu___105_853 -> (match (uu___105_853) with
+| FStar_TypeChecker_Common.EQ -> begin
+FStar_TypeChecker_Common.EQ
+end
+| FStar_TypeChecker_Common.SUB -> begin
+FStar_TypeChecker_Common.SUBINV
+end
+| FStar_TypeChecker_Common.SUBINV -> begin
+FStar_TypeChecker_Common.SUB
+end))
+
+
+let invert = (fun p -> (
+
+let uu___139_869 = p
+in {FStar_TypeChecker_Common.pid = uu___139_869.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = p.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.relation = (invert_rel p.FStar_TypeChecker_Common.relation); FStar_TypeChecker_Common.rhs = p.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.element = uu___139_869.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___139_869.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___139_869.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___139_869.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___139_869.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___139_869.FStar_TypeChecker_Common.rank}))
+
+
+let maybe_invert = (fun p -> (match ((p.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.SUBINV)) with
+| true -> begin
+(invert p)
+end
+| uu____887 -> begin
+p
+end))
+
+
+let maybe_invert_p : FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Common.prob = (fun uu___106_890 -> (match (uu___106_890) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(FStar_All.pipe_right (maybe_invert p) (fun _0_31 -> FStar_TypeChecker_Common.TProb (_0_31)))
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+(FStar_All.pipe_right (maybe_invert p) (fun _0_32 -> FStar_TypeChecker_Common.CProb (_0_32)))
+end))
+
+
+let vary_rel : FStar_TypeChecker_Common.rel  ->  variance  ->  FStar_TypeChecker_Common.rel = (fun rel uu___107_906 -> (match (uu___107_906) with
+| INVARIANT -> begin
+FStar_TypeChecker_Common.EQ
+end
+| CONTRAVARIANT -> begin
+(invert_rel rel)
+end
+| COVARIANT -> begin
+rel
+end))
+
+
+let p_pid : FStar_TypeChecker_Common.prob  ->  Prims.int = (fun uu___108_909 -> (match (uu___108_909) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.pid
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.pid
+end))
+
+
+let p_rel : FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Common.rel = (fun uu___109_918 -> (match (uu___109_918) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.relation
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.relation
+end))
+
+
+let p_reason : FStar_TypeChecker_Common.prob  ->  Prims.string Prims.list = (fun uu___110_928 -> (match (uu___110_928) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.reason
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.reason
+end))
+
+
+let p_loc : FStar_TypeChecker_Common.prob  ->  FStar_Range.range = (fun uu___111_938 -> (match (uu___111_938) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.loc
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.loc
+end))
+
+
+let p_guard : FStar_TypeChecker_Common.prob  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term) = (fun uu___112_949 -> (match (uu___112_949) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.logical_guard
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.logical_guard
+end))
+
+
+let p_scope : FStar_TypeChecker_Common.prob  ->  FStar_Syntax_Syntax.binders = (fun uu___113_960 -> (match (uu___113_960) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+p.FStar_TypeChecker_Common.scope
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+p.FStar_TypeChecker_Common.scope
+end))
+
+
+let p_invert : FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Common.prob = (fun uu___114_969 -> (match (uu___114_969) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(FStar_All.pipe_left (fun _0_33 -> FStar_TypeChecker_Common.TProb (_0_33)) (invert p))
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+(FStar_All.pipe_left (fun _0_34 -> FStar_TypeChecker_Common.CProb (_0_34)) (invert p))
+end))
+
+
+let is_top_level_prob : FStar_TypeChecker_Common.prob  ->  Prims.bool = (fun p -> (
+
+let uu____983 = (FStar_All.pipe_right (p_reason p) FStar_List.length)
+in (uu____983 = (Prims.parse_int "1"))))
+
+
+let next_pid : Prims.unit  ->  Prims.int = (
+
+let ctr = (FStar_Util.mk_ref (Prims.parse_int "0"))
+in (fun uu____994 -> ((FStar_Util.incr ctr);
+(FStar_ST.read ctr);
+)))
+
+
+let mk_problem = (fun scope orig lhs rel rhs elt reason -> (
+
+let uu____1044 = (next_pid ())
+in (
+
+let uu____1045 = (new_uvar FStar_Range.dummyRange scope FStar_Syntax_Util.ktype0)
+in {FStar_TypeChecker_Common.pid = uu____1044; FStar_TypeChecker_Common.lhs = lhs; FStar_TypeChecker_Common.relation = rel; FStar_TypeChecker_Common.rhs = rhs; FStar_TypeChecker_Common.element = elt; FStar_TypeChecker_Common.logical_guard = uu____1045; FStar_TypeChecker_Common.scope = scope; FStar_TypeChecker_Common.reason = (reason)::(p_reason orig); FStar_TypeChecker_Common.loc = (p_loc orig); FStar_TypeChecker_Common.rank = None})))
+
+
+let new_problem = (fun env lhs rel rhs elt loc reason -> (
+
+let scope = (FStar_TypeChecker_Env.all_binders env)
+in (
+
+let uu____1092 = (next_pid ())
+in (
+
+let uu____1093 = (new_uvar FStar_Range.dummyRange scope FStar_Syntax_Util.ktype0)
+in {FStar_TypeChecker_Common.pid = uu____1092; FStar_TypeChecker_Common.lhs = lhs; FStar_TypeChecker_Common.relation = rel; FStar_TypeChecker_Common.rhs = rhs; FStar_TypeChecker_Common.element = elt; FStar_TypeChecker_Common.logical_guard = uu____1093; FStar_TypeChecker_Common.scope = scope; FStar_TypeChecker_Common.reason = (reason)::[]; FStar_TypeChecker_Common.loc = loc; FStar_TypeChecker_Common.rank = None}))))
+
+
+let problem_using_guard = (fun orig lhs rel rhs elt reason -> (
+
+let uu____1134 = (next_pid ())
+in {FStar_TypeChecker_Common.pid = uu____1134; FStar_TypeChecker_Common.lhs = lhs; FStar_TypeChecker_Common.relation = rel; FStar_TypeChecker_Common.rhs = rhs; FStar_TypeChecker_Common.element = elt; FStar_TypeChecker_Common.logical_guard = (p_guard orig); FStar_TypeChecker_Common.scope = (p_scope orig); FStar_TypeChecker_Common.reason = (reason)::(p_reason orig); FStar_TypeChecker_Common.loc = (p_loc orig); FStar_TypeChecker_Common.rank = None}))
+
+
+let guard_on_element = (fun wl problem x phi -> (match (problem.FStar_TypeChecker_Common.element) with
+| None -> begin
+(
+
+let u = (wl.tcenv.FStar_TypeChecker_Env.universe_of wl.tcenv x.FStar_Syntax_Syntax.sort)
+in (FStar_Syntax_Util.mk_forall u x phi))
+end
+| Some (e) -> begin
+(FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.NT (((x), (e))))::[]) phi)
+end))
+
+
+let explain : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  Prims.string  ->  Prims.string = (fun env d s -> (
+
+let uu____1186 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("ExplainRel")))
+in (match (uu____1186) with
+| true -> begin
+(
+
+let uu____1187 = (FStar_All.pipe_left FStar_Range.string_of_range (p_loc d))
+in (
+
+let uu____1188 = (prob_to_string env d)
+in (
+
+let uu____1189 = (FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>"))
+in (FStar_Util.format4 "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n" uu____1187 uu____1188 uu____1189 s))))
+end
+| uu____1191 -> begin
+(
+
+let d1 = (maybe_invert_p d)
+in (
+
+let rel = (match ((p_rel d1)) with
+| FStar_TypeChecker_Common.EQ -> begin
+"equal to"
+end
+| FStar_TypeChecker_Common.SUB -> begin
+"a subtype of"
+end
+| uu____1194 -> begin
+(failwith "impossible")
+end)
+in (
+
+let uu____1195 = (match (d1) with
+| FStar_TypeChecker_Common.TProb (tp) -> begin
+(
+
+let uu____1203 = (FStar_TypeChecker_Normalize.term_to_string env tp.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____1204 = (FStar_TypeChecker_Normalize.term_to_string env tp.FStar_TypeChecker_Common.rhs)
+in ((uu____1203), (uu____1204))))
+end
+| FStar_TypeChecker_Common.CProb (cp) -> begin
+(
+
+let uu____1208 = (FStar_TypeChecker_Normalize.comp_to_string env cp.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____1209 = (FStar_TypeChecker_Normalize.comp_to_string env cp.FStar_TypeChecker_Common.rhs)
+in ((uu____1208), (uu____1209))))
+end)
+in (match (uu____1195) with
+| (lhs, rhs) -> begin
+(FStar_Util.format3 "%s is not %s the expected type %s" lhs rel rhs)
+end))))
+end)))
+
+
+let commit : uvi Prims.list  ->  Prims.unit = (fun uvis -> (FStar_All.pipe_right uvis (FStar_List.iter (fun uu___115_1218 -> (match (uu___115_1218) with
+| UNIV (u, t) -> begin
+(match (t) with
+| FStar_Syntax_Syntax.U_unif (u') -> begin
+(FStar_Unionfind.union u u')
+end
+| uu____1225 -> begin
+(FStar_Unionfind.change u (Some (t)))
+end)
+end
+| TERM ((u, uu____1228), t) -> begin
+(FStar_Syntax_Util.set_uvar u t)
+end)))))
+
+
+let find_term_uvar : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax FStar_Syntax_Syntax.uvar_basis FStar_Unionfind.uvar  ->  uvi Prims.list  ->  FStar_Syntax_Syntax.term Prims.option = (fun uv s -> (FStar_Util.find_map s (fun uu___116_1251 -> (match (uu___116_1251) with
+| UNIV (uu____1253) -> begin
+None
+end
+| TERM ((u, uu____1257), t) -> begin
+(
+
+let uu____1261 = (FStar_Unionfind.equivalent uv u)
+in (match (uu____1261) with
+| true -> begin
+Some (t)
+end
+| uu____1266 -> begin
+None
+end))
+end))))
+
+
+let find_univ_uvar : FStar_Syntax_Syntax.universe Prims.option FStar_Unionfind.uvar  ->  uvi Prims.list  ->  FStar_Syntax_Syntax.universe Prims.option = (fun u s -> (FStar_Util.find_map s (fun uu___117_1280 -> (match (uu___117_1280) with
+| UNIV (u', t) -> begin
+(
+
+let uu____1284 = (FStar_Unionfind.equivalent u u')
+in (match (uu____1284) with
+| true -> begin
+Some (t)
+end
+| uu____1287 -> begin
+None
+end))
+end
+| uu____1288 -> begin
+None
+end))))
+
+
+let whnf : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let uu____1295 = (
+
+let uu____1296 = (FStar_Syntax_Util.unmeta t)
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.WHNF)::[]) env uu____1296))
+in (FStar_Syntax_Subst.compress uu____1295)))
+
+
+let sn : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (
+
+let uu____1303 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env t)
+in (FStar_Syntax_Subst.compress uu____1303)))
+
+
+let norm_arg = (fun env t -> (
+
+let uu____1322 = (sn env (Prims.fst t))
+in ((uu____1322), ((Prims.snd t)))))
+
+
+let sn_binders : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list = (fun env binders -> (FStar_All.pipe_right binders (FStar_List.map (fun uu____1339 -> (match (uu____1339) with
+| (x, imp) -> begin
+(
+
+let uu____1346 = (
+
+let uu___140_1347 = x
+in (
+
+let uu____1348 = (sn env x.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___140_1347.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___140_1347.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1348}))
+in ((uu____1346), (imp)))
+end)))))
+
+
+let norm_univ : worklist  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun wl u -> (
+
+let rec aux = (fun u1 -> (
+
+let u2 = (FStar_Syntax_Subst.compress_univ u1)
+in (match (u2) with
+| FStar_Syntax_Syntax.U_succ (u3) -> begin
+(
+
+let uu____1363 = (aux u3)
+in FStar_Syntax_Syntax.U_succ (uu____1363))
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(
+
+let uu____1366 = (FStar_List.map aux us)
+in FStar_Syntax_Syntax.U_max (uu____1366))
+end
+| uu____1368 -> begin
+u2
+end)))
+in (
+
+let uu____1369 = (aux u)
+in (FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____1369))))
+
+
+let normalize_refinement = (fun steps env wl t0 -> (FStar_TypeChecker_Normalize.normalize_refinement steps env t0))
+
+
+let base_and_refinement = (fun env wl t1 -> (
+
+let rec aux = (fun norm t11 -> (match (t11.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_refine (x, phi) -> begin
+(match (norm) with
+| true -> begin
+((x.FStar_Syntax_Syntax.sort), (Some (((x), (phi)))))
+end
+| uu____1475 -> begin
+(
+
+let uu____1476 = (normalize_refinement ((FStar_TypeChecker_Normalize.WHNF)::[]) env wl t11)
+in (match (uu____1476) with
+| {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine (x1, phi1); FStar_Syntax_Syntax.tk = uu____1488; FStar_Syntax_Syntax.pos = uu____1489; FStar_Syntax_Syntax.vars = uu____1490} -> begin
+((x1.FStar_Syntax_Syntax.sort), (Some (((x1), (phi1)))))
+end
+| tt -> begin
+(
+
+let uu____1511 = (
+
+let uu____1512 = (FStar_Syntax_Print.term_to_string tt)
+in (
+
+let uu____1513 = (FStar_Syntax_Print.tag_of_term tt)
+in (FStar_Util.format2 "impossible: Got %s ... %s\n" uu____1512 uu____1513)))
+in (failwith uu____1511))
+end))
+end)
+end
+| (FStar_Syntax_Syntax.Tm_uinst (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_app (_)) -> begin
+(match (norm) with
+| true -> begin
+((t11), (None))
+end
+| uu____1546 -> begin
+(
+
+let t1' = (normalize_refinement ((FStar_TypeChecker_Normalize.WHNF)::[]) env wl t11)
+in (
+
+let uu____1548 = (
+
+let uu____1549 = (FStar_Syntax_Subst.compress t1')
+in uu____1549.FStar_Syntax_Syntax.n)
+in (match (uu____1548) with
+| FStar_Syntax_Syntax.Tm_refine (uu____1561) -> begin
+(aux true t1')
+end
+| uu____1566 -> begin
+((t11), (None))
+end)))
+end)
+end
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_let (_)) | (FStar_Syntax_Syntax.Tm_match (_)) -> begin
+((t11), (None))
+end
+| (FStar_Syntax_Syntax.Tm_meta (_)) | (FStar_Syntax_Syntax.Tm_ascribed (_)) | (FStar_Syntax_Syntax.Tm_delayed (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+(
+
+let uu____1601 = (
+
+let uu____1602 = (FStar_Syntax_Print.term_to_string t11)
+in (
+
+let uu____1603 = (FStar_Syntax_Print.tag_of_term t11)
+in (FStar_Util.format2 "impossible (outer): Got %s ... %s\n" uu____1602 uu____1603)))
+in (failwith uu____1601))
+end))
+in (
+
+let uu____1613 = (whnf env t1)
+in (aux false uu____1613))))
+
+
+let unrefine : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun env t -> (
+
+let uu____1622 = (
+
+let uu____1632 = (empty_worklist env)
+in (base_and_refinement env uu____1632 t))
+in (FStar_All.pipe_right uu____1622 Prims.fst)))
+
+
+let trivial_refinement : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) = (fun t -> (
+
+let uu____1656 = (FStar_Syntax_Syntax.null_bv t)
+in ((uu____1656), (FStar_Syntax_Util.t_true))))
+
+
+let as_refinement = (fun env wl t -> (
+
+let uu____1676 = (base_and_refinement env wl t)
+in (match (uu____1676) with
+| (t_base, refinement) -> begin
+(match (refinement) with
+| None -> begin
+(trivial_refinement t_base)
+end
+| Some (x, phi) -> begin
+((x), (phi))
+end)
+end)))
+
+
+let force_refinement = (fun uu____1735 -> (match (uu____1735) with
+| (t_base, refopt) -> begin
+(
+
+let uu____1749 = (match (refopt) with
+| Some (y, phi) -> begin
+((y), (phi))
+end
+| None -> begin
+(trivial_refinement t_base)
+end)
+in (match (uu____1749) with
+| (y, phi) -> begin
+(FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (((y), (phi)))) None t_base.FStar_Syntax_Syntax.pos)
+end))
+end))
+
+
+let wl_prob_to_string : worklist  ->  FStar_TypeChecker_Common.prob  ->  Prims.string = (fun wl uu___118_1773 -> (match (uu___118_1773) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(
+
+let uu____1777 = (FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid)
+in (
+
+let uu____1778 = (
+
+let uu____1779 = (whnf wl.tcenv p.FStar_TypeChecker_Common.lhs)
+in (FStar_Syntax_Print.term_to_string uu____1779))
+in (
+
+let uu____1780 = (
+
+let uu____1781 = (whnf wl.tcenv p.FStar_TypeChecker_Common.rhs)
+in (FStar_Syntax_Print.term_to_string uu____1781))
+in (FStar_Util.format4 "%s: %s  (%s)  %s" uu____1777 uu____1778 (rel_to_string p.FStar_TypeChecker_Common.relation) uu____1780))))
+end
+| FStar_TypeChecker_Common.CProb (p) -> begin
+(
+
+let uu____1785 = (FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid)
+in (
+
+let uu____1786 = (FStar_TypeChecker_Normalize.comp_to_string wl.tcenv p.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____1787 = (FStar_TypeChecker_Normalize.comp_to_string wl.tcenv p.FStar_TypeChecker_Common.rhs)
+in (FStar_Util.format4 "%s: %s  (%s)  %s" uu____1785 uu____1786 (rel_to_string p.FStar_TypeChecker_Common.relation) uu____1787))))
+end))
+
+
+let wl_to_string : worklist  ->  Prims.string = (fun wl -> (
+
+let uu____1791 = (
+
+let uu____1793 = (
+
+let uu____1795 = (FStar_All.pipe_right wl.wl_deferred (FStar_List.map (fun uu____1805 -> (match (uu____1805) with
+| (uu____1809, uu____1810, x) -> begin
+x
+end))))
+in (FStar_List.append wl.attempting uu____1795))
+in (FStar_List.map (wl_prob_to_string wl) uu____1793))
+in (FStar_All.pipe_right uu____1791 (FStar_String.concat "\n\t"))))
+
+
+let u_abs : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun k ys t -> (
+
+let uu____1828 = (
+
+let uu____1838 = (
+
+let uu____1839 = (FStar_Syntax_Subst.compress k)
+in uu____1839.FStar_Syntax_Syntax.n)
+in (match (uu____1838) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(match (((FStar_List.length bs) = (FStar_List.length ys))) with
+| true -> begin
+(
+
+let uu____1880 = (FStar_Syntax_Subst.open_comp bs c)
+in ((((ys), (t))), (uu____1880)))
+end
+| uu____1893 -> begin
+(
+
+let uu____1894 = (FStar_Syntax_Util.abs_formals t)
+in (match (uu____1894) with
+| (ys', t1, uu____1915) -> begin
+(
+
+let uu____1928 = (FStar_Syntax_Util.arrow_formals_comp k)
+in (((((FStar_List.append ys ys')), (t1))), (uu____1928)))
+end))
+end)
+end
+| uu____1949 -> begin
+(
+
+let uu____1950 = (
+
+let uu____1956 = (FStar_Syntax_Syntax.mk_Total k)
+in (([]), (uu____1956)))
+in ((((ys), (t))), (uu____1950)))
+end))
+in (match (uu____1828) with
+| ((ys1, t1), (xs, c)) -> begin
+(match (((FStar_List.length xs) <> (FStar_List.length ys1))) with
+| true -> begin
+(FStar_Syntax_Util.abs ys1 t1 (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ([]))))))
+end
+| uu____2009 -> begin
+(
+
+let c1 = (
+
+let uu____2011 = (FStar_Syntax_Util.rename_binders xs ys1)
+in (FStar_Syntax_Subst.subst_comp uu____2011 c))
+in (
+
+let uu____2013 = (
+
+let uu____2020 = (FStar_All.pipe_right (FStar_Syntax_Util.lcomp_of_comp c1) (fun _0_35 -> FStar_Util.Inl (_0_35)))
+in (FStar_All.pipe_right uu____2020 (fun _0_36 -> Some (_0_36))))
+in (FStar_Syntax_Util.abs ys1 t1 uu____2013)))
+end)
+end)))
+
+
+let solve_prob' : Prims.bool  ->  FStar_TypeChecker_Common.prob  ->  FStar_Syntax_Syntax.term Prims.option  ->  uvi Prims.list  ->  worklist  ->  worklist = (fun resolve_ok prob logical_guard uvis wl -> (
+
+let phi = (match (logical_guard) with
+| None -> begin
+FStar_Syntax_Util.t_true
+end
+| Some (phi) -> begin
+phi
+end)
+in (
+
+let uu____2071 = (p_guard prob)
+in (match (uu____2071) with
+| (uu____2074, uv) -> begin
+((
+
+let uu____2077 = (
+
+let uu____2078 = (FStar_Syntax_Subst.compress uv)
+in uu____2078.FStar_Syntax_Syntax.n)
+in (match (uu____2077) with
+| FStar_Syntax_Syntax.Tm_uvar (uvar, k) -> begin
+(
+
+let bs = (p_scope prob)
+in (
+
+let phi1 = (u_abs k bs phi)
+in ((
+
+let uu____2098 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv) (FStar_Options.Other ("Rel")))
+in (match (uu____2098) with
+| true -> begin
+(
+
+let uu____2099 = (FStar_Util.string_of_int (p_pid prob))
+in (
+
+let uu____2100 = (FStar_Syntax_Print.term_to_string uv)
+in (
+
+let uu____2101 = (FStar_Syntax_Print.term_to_string phi1)
+in (FStar_Util.print3 "Solving %s (%s) with formula %s\n" uu____2099 uu____2100 uu____2101))))
+end
+| uu____2102 -> begin
+()
+end));
+(FStar_Syntax_Util.set_uvar uvar phi1);
+)))
+end
+| uu____2105 -> begin
+(match ((not (resolve_ok))) with
+| true -> begin
+(failwith "Impossible: this instance has already been assigned a solution")
+end
+| uu____2106 -> begin
+()
+end)
+end));
+(commit uvis);
+(
+
+let uu___141_2108 = wl
+in {attempting = uu___141_2108.attempting; wl_deferred = uu___141_2108.wl_deferred; ctr = (wl.ctr + (Prims.parse_int "1")); defer_ok = uu___141_2108.defer_ok; smt_ok = uu___141_2108.smt_ok; tcenv = uu___141_2108.tcenv});
+)
+end))))
+
+
+let extend_solution : Prims.int  ->  uvi Prims.list  ->  worklist  ->  worklist = (fun pid sol wl -> ((
+
+let uu____2121 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv) (FStar_Options.Other ("RelCheck")))
+in (match (uu____2121) with
+| true -> begin
+(
+
+let uu____2122 = (FStar_Util.string_of_int pid)
+in (
+
+let uu____2123 = (
+
+let uu____2124 = (FStar_List.map (uvi_to_string wl.tcenv) sol)
+in (FStar_All.pipe_right uu____2124 (FStar_String.concat ", ")))
+in (FStar_Util.print2 "Solving %s: with %s\n" uu____2122 uu____2123)))
+end
+| uu____2127 -> begin
+()
+end));
+(commit sol);
+(
+
+let uu___142_2129 = wl
+in {attempting = uu___142_2129.attempting; wl_deferred = uu___142_2129.wl_deferred; ctr = (wl.ctr + (Prims.parse_int "1")); defer_ok = uu___142_2129.defer_ok; smt_ok = uu___142_2129.smt_ok; tcenv = uu___142_2129.tcenv});
+))
+
+
+let solve_prob : FStar_TypeChecker_Common.prob  ->  FStar_Syntax_Syntax.term Prims.option  ->  uvi Prims.list  ->  worklist  ->  worklist = (fun prob logical_guard uvis wl -> (
+
+let conj_guard1 = (fun t g -> (match (((t), (g))) with
+| (uu____2158, FStar_TypeChecker_Common.Trivial) -> begin
+t
+end
+| (None, FStar_TypeChecker_Common.NonTrivial (f)) -> begin
+Some (f)
+end
+| (Some (t1), FStar_TypeChecker_Common.NonTrivial (f)) -> begin
+(
+
+let uu____2166 = (FStar_Syntax_Util.mk_conj t1 f)
+in Some (uu____2166))
+end))
+in ((
+
+let uu____2172 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv) (FStar_Options.Other ("RelCheck")))
+in (match (uu____2172) with
+| true -> begin
+(
+
+let uu____2173 = (FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob))
+in (
+
+let uu____2174 = (
+
+let uu____2175 = (FStar_List.map (uvi_to_string wl.tcenv) uvis)
+in (FStar_All.pipe_right uu____2175 (FStar_String.concat ", ")))
+in (FStar_Util.print2 "Solving %s: with %s\n" uu____2173 uu____2174)))
+end
+| uu____2178 -> begin
+()
+end));
+(solve_prob' false prob logical_guard uvis wl);
+)))
+
+
+let rec occurs = (fun wl uk t -> (
+
+let uu____2200 = (
+
+let uu____2204 = (FStar_Syntax_Free.uvars t)
+in (FStar_All.pipe_right uu____2204 FStar_Util.set_elements))
+in (FStar_All.pipe_right uu____2200 (FStar_Util.for_some (fun uu____2225 -> (match (uu____2225) with
+| (uv, uu____2233) -> begin
+(FStar_Unionfind.equivalent uv (Prims.fst uk))
+end))))))
+
+
+let occurs_check = (fun env wl uk t -> (
+
+let occurs_ok = (
+
+let uu____2277 = (occurs wl uk t)
+in (not (uu____2277)))
+in (
+
+let msg = (match (occurs_ok) with
+| true -> begin
+None
+end
+| uu____2281 -> begin
+(
+
+let uu____2282 = (
+
+let uu____2283 = (FStar_Syntax_Print.uvar_to_string (Prims.fst uk))
+in (
+
+let uu____2287 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format2 "occurs-check failed (%s occurs in %s)" uu____2283 uu____2287)))
+in Some (uu____2282))
+end)
+in ((occurs_ok), (msg)))))
+
+
+let occurs_and_freevars_check = (fun env wl uk fvs t -> (
+
+let fvs_t = (FStar_Syntax_Free.names t)
+in (
+
+let uu____2335 = (occurs_check env wl uk t)
+in (match (uu____2335) with
+| (occurs_ok, msg) -> begin
+(
+
+let uu____2352 = (FStar_Util.set_is_subset_of fvs_t fvs)
+in ((occurs_ok), (uu____2352), (((msg), (fvs), (fvs_t)))))
+end))))
+
+
+let intersect_vars = (fun v1 v2 -> (
+
+let as_set = (fun v3 -> (FStar_All.pipe_right v3 (FStar_List.fold_left (fun out x -> (FStar_Util.set_add (Prims.fst x) out)) FStar_Syntax_Syntax.no_names)))
+in (
+
+let v1_set = (as_set v1)
+in (
+
+let uu____2416 = (FStar_All.pipe_right v2 (FStar_List.fold_left (fun uu____2440 uu____2441 -> (match (((uu____2440), (uu____2441))) with
+| ((isect, isect_set), (x, imp)) -> begin
+(
+
+let uu____2484 = (
+
+let uu____2485 = (FStar_Util.set_mem x v1_set)
+in (FStar_All.pipe_left Prims.op_Negation uu____2485))
+in (match (uu____2484) with
+| true -> begin
+((isect), (isect_set))
+end
+| uu____2496 -> begin
+(
+
+let fvs = (FStar_Syntax_Free.names x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____2499 = (FStar_Util.set_is_subset_of fvs isect_set)
+in (match (uu____2499) with
+| true -> begin
+(
+
+let uu____2506 = (FStar_Util.set_add x isect_set)
+in (((((x), (imp)))::isect), (uu____2506)))
+end
+| uu____2514 -> begin
+((isect), (isect_set))
+end)))
+end))
+end)) (([]), (FStar_Syntax_Syntax.no_names))))
+in (match (uu____2416) with
+| (isect, uu____2528) -> begin
+(FStar_List.rev isect)
+end)))))
+
+
+let binders_eq = (fun v1 v2 -> (((FStar_List.length v1) = (FStar_List.length v2)) && (FStar_List.forall2 (fun uu____2577 uu____2578 -> (match (((uu____2577), (uu____2578))) with
+| ((a, uu____2588), (b, uu____2590)) -> begin
+(FStar_Syntax_Syntax.bv_eq a b)
+end)) v1 v2)))
+
+
+let pat_var_opt = (fun env seen arg -> (
+
+let hd1 = (norm_arg env arg)
+in (match ((Prims.fst hd1).FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_name (a) -> begin
+(
+
+let uu____2634 = (FStar_All.pipe_right seen (FStar_Util.for_some (fun uu____2640 -> (match (uu____2640) with
+| (b, uu____2644) -> begin
+(FStar_Syntax_Syntax.bv_eq a b)
+end))))
+in (match (uu____2634) with
+| true -> begin
+None
+end
+| uu____2650 -> begin
+Some (((a), ((Prims.snd hd1))))
+end))
+end
+| uu____2653 -> begin
+None
+end)))
+
+
+let rec pat_vars : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.binders Prims.option = (fun env seen args -> (match (args) with
+| [] -> begin
+Some ((FStar_List.rev seen))
+end
+| (hd1)::rest -> begin
+(
+
+let uu____2696 = (pat_var_opt env seen hd1)
+in (match (uu____2696) with
+| None -> begin
+((
+
+let uu____2704 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____2704) with
+| true -> begin
+(
+
+let uu____2705 = (FStar_All.pipe_left FStar_Syntax_Print.term_to_string (Prims.fst hd1))
+in (FStar_Util.print1 "Not a pattern: %s\n" uu____2705))
+end
+| uu____2706 -> begin
+()
+end));
+None;
+)
+end
+| Some (x) -> begin
+(pat_vars env ((x)::seen) rest)
+end))
+end))
+
+
+let is_flex : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____2717 = (
+
+let uu____2718 = (FStar_Syntax_Subst.compress t)
+in uu____2718.FStar_Syntax_Syntax.n)
+in (match (uu____2717) with
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) -> begin
+true
+end
+| uu____2734 -> begin
+false
+end)))
+
+
+let destruct_flex_t = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uvar (uv, k) -> begin
+((t), (uv), (k), ([]))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (uv, k); FStar_Syntax_Syntax.tk = uu____2796; FStar_Syntax_Syntax.pos = uu____2797; FStar_Syntax_Syntax.vars = uu____2798}, args) -> begin
+((t), (uv), (k), (args))
+end
+| uu____2839 -> begin
+(failwith "Not a flex-uvar")
+end))
+
+
+let destruct_flex_pattern = (fun env t -> (
+
+let uu____2893 = (destruct_flex_t t)
+in (match (uu____2893) with
+| (t1, uv, k, args) -> begin
+(
+
+let uu____2961 = (pat_vars env [] args)
+in (match (uu____2961) with
+| Some (vars) -> begin
+((((t1), (uv), (k), (args))), (Some (vars)))
+end
+| uu____3017 -> begin
+((((t1), (uv), (k), (args))), (None))
+end))
+end)))
+
 type match_result =
-  | MisMatch of (FStar_Syntax_Syntax.delta_depth Prims.option*
-  FStar_Syntax_Syntax.delta_depth Prims.option)
-  | HeadMatch
-  | FullMatch
-let uu___is_MisMatch: match_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MisMatch _0 -> true | uu____3065 -> false
-let __proj__MisMatch__item___0:
-  match_result ->
-    (FStar_Syntax_Syntax.delta_depth Prims.option*
-      FStar_Syntax_Syntax.delta_depth Prims.option)
-  = fun projectee  -> match projectee with | MisMatch _0 -> _0
-let uu___is_HeadMatch: match_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | HeadMatch  -> true | uu____3088 -> false
-let uu___is_FullMatch: match_result -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FullMatch  -> true | uu____3092 -> false
-let head_match: match_result -> match_result =
-  fun uu___119_3095  ->
-    match uu___119_3095 with
-    | MisMatch (i,j) -> MisMatch (i, j)
-    | uu____3104 -> HeadMatch
-let fv_delta_depth:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth
-  =
-  fun env  ->
-    fun fv  ->
-      match fv.FStar_Syntax_Syntax.fv_delta with
-      | FStar_Syntax_Syntax.Delta_abstract d ->
-          if
-            (env.FStar_TypeChecker_Env.curmodule).FStar_Ident.str =
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-          then d
-          else FStar_Syntax_Syntax.Delta_constant
-      | FStar_Syntax_Syntax.Delta_defined_at_level uu____3117 ->
-          let uu____3118 =
-            FStar_TypeChecker_Env.lookup_definition
-              [FStar_TypeChecker_Env.Unfold
-                 FStar_Syntax_Syntax.Delta_constant] env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____3118 with
-           | None  -> FStar_Syntax_Syntax.Delta_constant
-           | uu____3128 -> fv.FStar_Syntax_Syntax.fv_delta)
-      | d -> d
-let rec delta_depth_of_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth Prims.option
-  =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta _|FStar_Syntax_Syntax.Tm_delayed _ ->
-          failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_unknown 
-        |FStar_Syntax_Syntax.Tm_bvar _
-         |FStar_Syntax_Syntax.Tm_name _
-          |FStar_Syntax_Syntax.Tm_uvar _
-           |FStar_Syntax_Syntax.Tm_let _|FStar_Syntax_Syntax.Tm_match _
-          -> None
-      | FStar_Syntax_Syntax.Tm_uinst (t2,_)
-        |FStar_Syntax_Syntax.Tm_ascribed (t2,_,_)
-         |FStar_Syntax_Syntax.Tm_app (t2,_)|FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _;
-             FStar_Syntax_Syntax.sort = t2;_},_)
-          -> delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_constant _
-        |FStar_Syntax_Syntax.Tm_type _
-         |FStar_Syntax_Syntax.Tm_arrow _|FStar_Syntax_Syntax.Tm_abs _ ->
-          Some FStar_Syntax_Syntax.Delta_constant
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____3196 = fv_delta_depth env fv in Some uu____3196
-let rec head_matches:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> match_result
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let t11 = FStar_Syntax_Util.unmeta t1 in
-        let t21 = FStar_Syntax_Util.unmeta t2 in
-        match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
-        | (FStar_Syntax_Syntax.Tm_name x,FStar_Syntax_Syntax.Tm_name y) ->
-            if FStar_Syntax_Syntax.bv_eq x y
-            then FullMatch
-            else MisMatch (None, None)
-        | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____3215 = FStar_Syntax_Syntax.fv_eq f g in
-            if uu____3215
-            then FullMatch
-            else
-              (let uu____3217 =
-                 let uu____3222 =
-                   let uu____3224 = fv_delta_depth env f in Some uu____3224 in
-                 let uu____3225 =
-                   let uu____3227 = fv_delta_depth env g in Some uu____3227 in
-                 (uu____3222, uu____3225) in
-               MisMatch uu____3217)
-        | (FStar_Syntax_Syntax.Tm_uinst
-           (f,uu____3231),FStar_Syntax_Syntax.Tm_uinst (g,uu____3233)) ->
-            let uu____3242 = head_matches env f g in
-            FStar_All.pipe_right uu____3242 head_match
-        | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant
-           d) -> if c = d then FullMatch else MisMatch (None, None)
-        | (FStar_Syntax_Syntax.Tm_uvar
-           (uv,uu____3249),FStar_Syntax_Syntax.Tm_uvar (uv',uu____3251)) ->
-            let uu____3276 = FStar_Unionfind.equivalent uv uv' in
-            if uu____3276 then FullMatch else MisMatch (None, None)
-        | (FStar_Syntax_Syntax.Tm_refine
-           (x,uu____3284),FStar_Syntax_Syntax.Tm_refine (y,uu____3286)) ->
-            let uu____3295 =
-              head_matches env x.FStar_Syntax_Syntax.sort
-                y.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____3295 head_match
-        | (FStar_Syntax_Syntax.Tm_refine (x,uu____3297),uu____3298) ->
-            let uu____3303 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
-            FStar_All.pipe_right uu____3303 head_match
-        | (uu____3304,FStar_Syntax_Syntax.Tm_refine (x,uu____3306)) ->
-            let uu____3311 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____3311 head_match
-        | (FStar_Syntax_Syntax.Tm_type _,FStar_Syntax_Syntax.Tm_type _)
-          |(FStar_Syntax_Syntax.Tm_arrow _,FStar_Syntax_Syntax.Tm_arrow _) ->
-            HeadMatch
-        | (FStar_Syntax_Syntax.Tm_app
-           (head1,uu____3317),FStar_Syntax_Syntax.Tm_app (head',uu____3319))
-            ->
-            let uu____3348 = head_matches env head1 head' in
-            FStar_All.pipe_right uu____3348 head_match
-        | (FStar_Syntax_Syntax.Tm_app (head1,uu____3350),uu____3351) ->
-            let uu____3366 = head_matches env head1 t21 in
-            FStar_All.pipe_right uu____3366 head_match
-        | (uu____3367,FStar_Syntax_Syntax.Tm_app (head1,uu____3369)) ->
-            let uu____3384 = head_matches env t11 head1 in
-            FStar_All.pipe_right uu____3384 head_match
-        | uu____3385 ->
-            let uu____3388 =
-              let uu____3393 = delta_depth_of_term env t11 in
-              let uu____3395 = delta_depth_of_term env t21 in
-              (uu____3393, uu____3395) in
-            MisMatch uu____3388
-let head_matches_delta env wl t1 t2 =
-  let maybe_inline t =
-    let uu____3431 = FStar_Syntax_Util.head_and_args t in
-    match uu____3431 with
-    | (head1,uu____3443) ->
-        let uu____3458 =
-          let uu____3459 = FStar_Syntax_Util.un_uinst head1 in
-          uu____3459.FStar_Syntax_Syntax.n in
-        (match uu____3458 with
-         | FStar_Syntax_Syntax.Tm_fvar fv ->
-             let uu____3464 =
-               let uu____3465 =
-                 FStar_TypeChecker_Env.lookup_definition
-                   [FStar_TypeChecker_Env.Eager_unfolding_only] env
-                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-               FStar_All.pipe_right uu____3465 FStar_Option.isSome in
-             if uu____3464
-             then
-               let uu____3479 =
-                 FStar_TypeChecker_Normalize.normalize
-                   [FStar_TypeChecker_Normalize.Beta;
-                   FStar_TypeChecker_Normalize.Eager_unfolding] env t in
-               FStar_All.pipe_right uu____3479 (fun _0_37  -> Some _0_37)
-             else None
-         | uu____3482 -> None) in
-  let success d r t11 t21 =
-    (r, (if d > (Prims.parse_int "0") then Some (t11, t21) else None)) in
-  let fail r = (r, None) in
-  let rec aux retry n_delta t11 t21 =
-    let r = head_matches env t11 t21 in
-    match r with
-    | MisMatch (Some (FStar_Syntax_Syntax.Delta_equational ),_)|MisMatch
-      (_,Some (FStar_Syntax_Syntax.Delta_equational )) ->
-        if Prims.op_Negation retry
-        then fail r
-        else
-          (let uu____3562 =
-             let uu____3567 = maybe_inline t11 in
-             let uu____3569 = maybe_inline t21 in (uu____3567, uu____3569) in
-           match uu____3562 with
-           | (None ,None ) -> fail r
-           | (Some t12,None ) ->
-               aux false (n_delta + (Prims.parse_int "1")) t12 t21
-           | (None ,Some t22) ->
-               aux false (n_delta + (Prims.parse_int "1")) t11 t22
-           | (Some t12,Some t22) ->
-               aux false (n_delta + (Prims.parse_int "1")) t12 t22)
-    | MisMatch (Some d1,Some d2) when d1 = d2 ->
-        let uu____3594 = FStar_TypeChecker_Common.decr_delta_depth d1 in
-        (match uu____3594 with
-         | None  -> fail r
-         | Some d ->
-             let t12 =
-               normalize_refinement
-                 [FStar_TypeChecker_Normalize.UnfoldUntil d;
-                 FStar_TypeChecker_Normalize.WHNF] env wl t11 in
-             let t22 =
-               normalize_refinement
-                 [FStar_TypeChecker_Normalize.UnfoldUntil d;
-                 FStar_TypeChecker_Normalize.WHNF] env wl t21 in
-             aux retry (n_delta + (Prims.parse_int "1")) t12 t22)
-    | MisMatch (Some d1,Some d2) ->
-        let d1_greater_than_d2 =
-          FStar_TypeChecker_Common.delta_depth_greater_than d1 d2 in
-        let uu____3609 =
-          if d1_greater_than_d2
-          then
-            let t1' =
-              normalize_refinement
-                [FStar_TypeChecker_Normalize.UnfoldUntil d2;
-                FStar_TypeChecker_Normalize.WHNF] env wl t11 in
-            (t1', t21)
-          else
-            (let t2' =
-               normalize_refinement
-                 [FStar_TypeChecker_Normalize.UnfoldUntil d1;
-                 FStar_TypeChecker_Normalize.WHNF] env wl t21 in
-             let uu____3617 =
-               normalize_refinement
-                 [FStar_TypeChecker_Normalize.UnfoldUntil d1;
-                 FStar_TypeChecker_Normalize.WHNF] env wl t21 in
-             (t11, uu____3617)) in
-        (match uu____3609 with
-         | (t12,t22) -> aux retry (n_delta + (Prims.parse_int "1")) t12 t22)
-    | MisMatch uu____3625 -> fail r
-    | uu____3630 -> success n_delta r t11 t21 in
-  aux true (Prims.parse_int "0") t1 t2
+| MisMatch of (FStar_Syntax_Syntax.delta_depth Prims.option * FStar_Syntax_Syntax.delta_depth Prims.option)
+| HeadMatch
+| FullMatch
+
+
+let uu___is_MisMatch : match_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| MisMatch (_0) -> begin
+true
+end
+| uu____3065 -> begin
+false
+end))
+
+
+let __proj__MisMatch__item___0 : match_result  ->  (FStar_Syntax_Syntax.delta_depth Prims.option * FStar_Syntax_Syntax.delta_depth Prims.option) = (fun projectee -> (match (projectee) with
+| MisMatch (_0) -> begin
+_0
+end))
+
+
+let uu___is_HeadMatch : match_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| HeadMatch -> begin
+true
+end
+| uu____3088 -> begin
+false
+end))
+
+
+let uu___is_FullMatch : match_result  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| FullMatch -> begin
+true
+end
+| uu____3092 -> begin
+false
+end))
+
+
+let head_match : match_result  ->  match_result = (fun uu___119_3095 -> (match (uu___119_3095) with
+| MisMatch (i, j) -> begin
+MisMatch (((i), (j)))
+end
+| uu____3104 -> begin
+HeadMatch
+end))
+
+
+let fv_delta_depth : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.fv  ->  FStar_Syntax_Syntax.delta_depth = (fun env fv -> (match (fv.FStar_Syntax_Syntax.fv_delta) with
+| FStar_Syntax_Syntax.Delta_abstract (d) -> begin
+(match ((env.FStar_TypeChecker_Env.curmodule.FStar_Ident.str = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.nsstr)) with
+| true -> begin
+d
+end
+| uu____3116 -> begin
+FStar_Syntax_Syntax.Delta_constant
+end)
+end
+| FStar_Syntax_Syntax.Delta_defined_at_level (uu____3117) -> begin
+(
+
+let uu____3118 = (FStar_TypeChecker_Env.lookup_definition ((FStar_TypeChecker_Env.Unfold (FStar_Syntax_Syntax.Delta_constant))::[]) env fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____3118) with
+| None -> begin
+FStar_Syntax_Syntax.Delta_constant
+end
+| uu____3128 -> begin
+fv.FStar_Syntax_Syntax.fv_delta
+end))
+end
+| d -> begin
+d
+end))
+
+
+let rec delta_depth_of_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.delta_depth Prims.option = (fun env t -> (
+
+let t1 = (FStar_Syntax_Util.unmeta t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_meta (_)) | (FStar_Syntax_Syntax.Tm_delayed (_)) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_let (_)) | (FStar_Syntax_Syntax.Tm_match (_)) -> begin
+None
+end
+| (FStar_Syntax_Syntax.Tm_uinst (t2, _)) | (FStar_Syntax_Syntax.Tm_ascribed (t2, _, _)) | (FStar_Syntax_Syntax.Tm_app (t2, _)) | (FStar_Syntax_Syntax.Tm_refine ({FStar_Syntax_Syntax.ppname = _; FStar_Syntax_Syntax.index = _; FStar_Syntax_Syntax.sort = t2}, _)) -> begin
+(delta_depth_of_term env t2)
+end
+| (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) -> begin
+Some (FStar_Syntax_Syntax.Delta_constant)
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____3196 = (fv_delta_depth env fv)
+in Some (uu____3196))
+end)))
+
+
+let rec head_matches : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  match_result = (fun env t1 t2 -> (
+
+let t11 = (FStar_Syntax_Util.unmeta t1)
+in (
+
+let t21 = (FStar_Syntax_Util.unmeta t2)
+in (match (((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_name (x), FStar_Syntax_Syntax.Tm_name (y)) -> begin
+(match ((FStar_Syntax_Syntax.bv_eq x y)) with
+| true -> begin
+FullMatch
+end
+| uu____3210 -> begin
+MisMatch (((None), (None)))
+end)
+end
+| (FStar_Syntax_Syntax.Tm_fvar (f), FStar_Syntax_Syntax.Tm_fvar (g)) -> begin
+(
+
+let uu____3215 = (FStar_Syntax_Syntax.fv_eq f g)
+in (match (uu____3215) with
+| true -> begin
+FullMatch
+end
+| uu____3216 -> begin
+(
+
+let uu____3217 = (
+
+let uu____3222 = (
+
+let uu____3224 = (fv_delta_depth env f)
+in Some (uu____3224))
+in (
+
+let uu____3225 = (
+
+let uu____3227 = (fv_delta_depth env g)
+in Some (uu____3227))
+in ((uu____3222), (uu____3225))))
+in MisMatch (uu____3217))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_uinst (f, uu____3231), FStar_Syntax_Syntax.Tm_uinst (g, uu____3233)) -> begin
+(
+
+let uu____3242 = (head_matches env f g)
+in (FStar_All.pipe_right uu____3242 head_match))
+end
+| (FStar_Syntax_Syntax.Tm_constant (c), FStar_Syntax_Syntax.Tm_constant (d)) -> begin
+(match ((c = d)) with
+| true -> begin
+FullMatch
+end
+| uu____3245 -> begin
+MisMatch (((None), (None)))
+end)
+end
+| (FStar_Syntax_Syntax.Tm_uvar (uv, uu____3249), FStar_Syntax_Syntax.Tm_uvar (uv', uu____3251)) -> begin
+(
+
+let uu____3276 = (FStar_Unionfind.equivalent uv uv')
+in (match (uu____3276) with
+| true -> begin
+FullMatch
+end
+| uu____3280 -> begin
+MisMatch (((None), (None)))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_refine (x, uu____3284), FStar_Syntax_Syntax.Tm_refine (y, uu____3286)) -> begin
+(
+
+let uu____3295 = (head_matches env x.FStar_Syntax_Syntax.sort y.FStar_Syntax_Syntax.sort)
+in (FStar_All.pipe_right uu____3295 head_match))
+end
+| (FStar_Syntax_Syntax.Tm_refine (x, uu____3297), uu____3298) -> begin
+(
+
+let uu____3303 = (head_matches env x.FStar_Syntax_Syntax.sort t21)
+in (FStar_All.pipe_right uu____3303 head_match))
+end
+| (uu____3304, FStar_Syntax_Syntax.Tm_refine (x, uu____3306)) -> begin
+(
+
+let uu____3311 = (head_matches env t11 x.FStar_Syntax_Syntax.sort)
+in (FStar_All.pipe_right uu____3311 head_match))
+end
+| ((FStar_Syntax_Syntax.Tm_type (_), FStar_Syntax_Syntax.Tm_type (_))) | ((FStar_Syntax_Syntax.Tm_arrow (_), FStar_Syntax_Syntax.Tm_arrow (_))) -> begin
+HeadMatch
+end
+| (FStar_Syntax_Syntax.Tm_app (head1, uu____3317), FStar_Syntax_Syntax.Tm_app (head', uu____3319)) -> begin
+(
+
+let uu____3348 = (head_matches env head1 head')
+in (FStar_All.pipe_right uu____3348 head_match))
+end
+| (FStar_Syntax_Syntax.Tm_app (head1, uu____3350), uu____3351) -> begin
+(
+
+let uu____3366 = (head_matches env head1 t21)
+in (FStar_All.pipe_right uu____3366 head_match))
+end
+| (uu____3367, FStar_Syntax_Syntax.Tm_app (head1, uu____3369)) -> begin
+(
+
+let uu____3384 = (head_matches env t11 head1)
+in (FStar_All.pipe_right uu____3384 head_match))
+end
+| uu____3385 -> begin
+(
+
+let uu____3388 = (
+
+let uu____3393 = (delta_depth_of_term env t11)
+in (
+
+let uu____3395 = (delta_depth_of_term env t21)
+in ((uu____3393), (uu____3395))))
+in MisMatch (uu____3388))
+end))))
+
+
+let head_matches_delta = (fun env wl t1 t2 -> (
+
+let maybe_inline = (fun t -> (
+
+let uu____3431 = (FStar_Syntax_Util.head_and_args t)
+in (match (uu____3431) with
+| (head1, uu____3443) -> begin
+(
+
+let uu____3458 = (
+
+let uu____3459 = (FStar_Syntax_Util.un_uinst head1)
+in uu____3459.FStar_Syntax_Syntax.n)
+in (match (uu____3458) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____3464 = (
+
+let uu____3465 = (FStar_TypeChecker_Env.lookup_definition ((FStar_TypeChecker_Env.Eager_unfolding_only)::[]) env fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (FStar_All.pipe_right uu____3465 FStar_Option.isSome))
+in (match (uu____3464) with
+| true -> begin
+(
+
+let uu____3479 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::[]) env t)
+in (FStar_All.pipe_right uu____3479 (fun _0_37 -> Some (_0_37))))
+end
+| uu____3481 -> begin
+None
+end))
+end
+| uu____3482 -> begin
+None
+end))
+end)))
+in (
+
+let success = (fun d r t11 t21 -> ((r), ((match ((d > (Prims.parse_int "0"))) with
+| true -> begin
+Some (((t11), (t21)))
+end
+| uu____3509 -> begin
+None
+end))))
+in (
+
+let fail = (fun r -> ((r), (None)))
+in (
+
+let rec aux = (fun retry n_delta t11 t21 -> (
+
+let r = (head_matches env t11 t21)
+in (match (r) with
+| (MisMatch (Some (FStar_Syntax_Syntax.Delta_equational), _)) | (MisMatch (_, Some (FStar_Syntax_Syntax.Delta_equational))) -> begin
+(match ((not (retry))) with
+| true -> begin
+(fail r)
+end
+| uu____3561 -> begin
+(
+
+let uu____3562 = (
+
+let uu____3567 = (maybe_inline t11)
+in (
+
+let uu____3569 = (maybe_inline t21)
+in ((uu____3567), (uu____3569))))
+in (match (uu____3562) with
+| (None, None) -> begin
+(fail r)
+end
+| (Some (t12), None) -> begin
+(aux false (n_delta + (Prims.parse_int "1")) t12 t21)
+end
+| (None, Some (t22)) -> begin
+(aux false (n_delta + (Prims.parse_int "1")) t11 t22)
+end
+| (Some (t12), Some (t22)) -> begin
+(aux false (n_delta + (Prims.parse_int "1")) t12 t22)
+end))
+end)
+end
+| MisMatch (Some (d1), Some (d2)) when (d1 = d2) -> begin
+(
+
+let uu____3594 = (FStar_TypeChecker_Common.decr_delta_depth d1)
+in (match (uu____3594) with
+| None -> begin
+(fail r)
+end
+| Some (d) -> begin
+(
+
+let t12 = (normalize_refinement ((FStar_TypeChecker_Normalize.UnfoldUntil (d))::(FStar_TypeChecker_Normalize.WHNF)::[]) env wl t11)
+in (
+
+let t22 = (normalize_refinement ((FStar_TypeChecker_Normalize.UnfoldUntil (d))::(FStar_TypeChecker_Normalize.WHNF)::[]) env wl t21)
+in (aux retry (n_delta + (Prims.parse_int "1")) t12 t22)))
+end))
+end
+| MisMatch (Some (d1), Some (d2)) -> begin
+(
+
+let d1_greater_than_d2 = (FStar_TypeChecker_Common.delta_depth_greater_than d1 d2)
+in (
+
+let uu____3609 = (match (d1_greater_than_d2) with
+| true -> begin
+(
+
+let t1' = (normalize_refinement ((FStar_TypeChecker_Normalize.UnfoldUntil (d2))::(FStar_TypeChecker_Normalize.WHNF)::[]) env wl t11)
+in ((t1'), (t21)))
+end
+| uu____3615 -> begin
+(
+
+let t2' = (normalize_refinement ((FStar_TypeChecker_Normalize.UnfoldUntil (d1))::(FStar_TypeChecker_Normalize.WHNF)::[]) env wl t21)
+in (
+
+let uu____3617 = (normalize_refinement ((FStar_TypeChecker_Normalize.UnfoldUntil (d1))::(FStar_TypeChecker_Normalize.WHNF)::[]) env wl t21)
+in ((t11), (uu____3617))))
+end)
+in (match (uu____3609) with
+| (t12, t22) -> begin
+(aux retry (n_delta + (Prims.parse_int "1")) t12 t22)
+end)))
+end
+| MisMatch (uu____3625) -> begin
+(fail r)
+end
+| uu____3630 -> begin
+(success n_delta r t11 t21)
+end)))
+in (aux true (Prims.parse_int "0") t1 t2))))))
+
 type tc =
-  | T of (FStar_Syntax_Syntax.term*
-  (FStar_Syntax_Syntax.binders ->
-     FStar_Range.range -> FStar_Syntax_Syntax.term))
-  | C of FStar_Syntax_Syntax.comp
-let uu___is_T: tc -> Prims.bool =
-  fun projectee  -> match projectee with | T _0 -> true | uu____3655 -> false
-let __proj__T__item___0:
-  tc ->
-    (FStar_Syntax_Syntax.term*
-      (FStar_Syntax_Syntax.binders ->
-         FStar_Range.range -> FStar_Syntax_Syntax.term))
-  = fun projectee  -> match projectee with | T _0 -> _0
-let uu___is_C: tc -> Prims.bool =
-  fun projectee  -> match projectee with | C _0 -> true | uu____3685 -> false
-let __proj__C__item___0: tc -> FStar_Syntax_Syntax.comp =
-  fun projectee  -> match projectee with | C _0 -> _0
-type tcs = tc Prims.list
-let generic_kind:
-  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ
-  =
-  fun binders  ->
-    fun r  ->
-      let uu____3700 = FStar_Syntax_Util.type_u () in
-      match uu____3700 with
-      | (t,uu____3704) ->
-          let uu____3705 = new_uvar r binders t in Prims.fst uu____3705
-let kind_type:
-  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ
-  =
-  fun binders  ->
-    fun r  ->
-      let uu____3714 = FStar_Syntax_Util.type_u () in
-      FStar_All.pipe_right uu____3714 Prims.fst
-let rec decompose:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      ((tc Prims.list -> FStar_Syntax_Syntax.term)*
-        (FStar_Syntax_Syntax.term -> Prims.bool)* (FStar_Syntax_Syntax.binder
-        Prims.option* variance* tc) Prims.list)
-  =
-  fun env  ->
-    fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t in
-      let matches t' =
-        let uu____3756 = head_matches env t1 t' in
-        match uu____3756 with
-        | MisMatch uu____3757 -> false
-        | uu____3762 -> true in
-      match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-          let rebuild args' =
-            let args1 =
-              FStar_List.map2
-                (fun x  ->
-                   fun y  ->
-                     match (x, y) with
-                     | ((uu____3822,imp),T (t2,uu____3825)) -> (t2, imp)
-                     | uu____3842 -> failwith "Bad reconstruction") args
-                args' in
-            (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (hd1, args1)))
-              None t1.FStar_Syntax_Syntax.pos in
-          let tcs =
-            FStar_All.pipe_right args
-              (FStar_List.map
-                 (fun uu____3886  ->
-                    match uu____3886 with
-                    | (t2,uu____3894) ->
-                        (None, INVARIANT, (T (t2, generic_kind))))) in
-          (rebuild, matches, tcs)
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let fail uu____3927 = failwith "Bad reconstruction" in
-          let uu____3928 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____3928 with
-           | (bs1,c1) ->
-               let rebuild tcs =
-                 let rec aux out bs2 tcs1 =
-                   match (bs2, tcs1) with
-                   | ((x,imp)::bs3,(T (t2,uu____3981))::tcs2) ->
-                       aux
-                         (((let uu___143_4003 = x in
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (uu___143_4003.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (uu___143_4003.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = t2
-                            }), imp) :: out) bs3 tcs2
-                   | ([],(C c2)::[]) ->
-                       FStar_Syntax_Util.arrow (FStar_List.rev out) c2
-                   | uu____4013 -> failwith "Bad reconstruction" in
-                 aux [] bs1 tcs in
-               let rec decompose1 out uu___120_4044 =
-                 match uu___120_4044 with
-                 | [] -> FStar_List.rev ((None, COVARIANT, (C c1)) :: out)
-                 | hd1::rest ->
-                     decompose1
-                       (((Some hd1), CONTRAVARIANT,
-                          (T
-                             (((Prims.fst hd1).FStar_Syntax_Syntax.sort),
-                               kind_type))) :: out) rest in
-               let uu____4107 = decompose1 [] bs1 in
-               (rebuild, matches, uu____4107))
-      | uu____4135 ->
-          let rebuild uu___121_4140 =
-            match uu___121_4140 with
-            | [] -> t1
-            | uu____4142 -> failwith "Bad reconstruction" in
-          (rebuild, ((fun t2  -> true)), [])
-let un_T: tc -> FStar_Syntax_Syntax.term =
-  fun uu___122_4161  ->
-    match uu___122_4161 with
-    | T (t,uu____4163) -> t
-    | uu____4172 -> failwith "Impossible"
-let arg_of_tc: tc -> FStar_Syntax_Syntax.arg =
-  fun uu___123_4175  ->
-    match uu___123_4175 with
-    | T (t,uu____4177) -> FStar_Syntax_Syntax.as_arg t
-    | uu____4186 -> failwith "Impossible"
-let imitation_sub_probs:
-  FStar_TypeChecker_Common.prob ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.binders ->
-        FStar_Syntax_Syntax.args ->
-          (FStar_Syntax_Syntax.binder Prims.option* variance* tc) Prims.list
-            ->
-            (FStar_TypeChecker_Common.prob Prims.list* tc Prims.list*
-              FStar_Syntax_Syntax.formula)
-  =
-  fun orig  ->
-    fun env  ->
-      fun scope  ->
-        fun ps  ->
-          fun qs  ->
-            let r = p_loc orig in
-            let rel = p_rel orig in
-            let sub_prob scope1 args q =
-              match q with
-              | (uu____4255,variance,T (ti,mk_kind)) ->
-                  let k = mk_kind scope1 r in
-                  let uu____4274 = new_uvar r scope1 k in
-                  (match uu____4274 with
-                   | (gi_xs,gi) ->
-                       let gi_ps =
-                         match args with
-                         | [] -> gi
-                         | uu____4286 ->
-                             (FStar_Syntax_Syntax.mk
-                                (FStar_Syntax_Syntax.Tm_app (gi, args))) None
-                               r in
-                       let uu____4305 =
-                         let uu____4306 =
-                           mk_problem scope1 orig gi_ps
-                             (vary_rel rel variance) ti None "type subterm" in
-                         FStar_All.pipe_left
-                           (fun _0_38  ->
-                              FStar_TypeChecker_Common.TProb _0_38)
-                           uu____4306 in
-                       ((T (gi_xs, mk_kind)), uu____4305))
-              | (uu____4315,uu____4316,C uu____4317) -> failwith "impos" in
-            let rec aux scope1 args qs1 =
-              match qs1 with
-              | [] -> ([], [], FStar_Syntax_Util.t_true)
-              | q::qs2 ->
-                  let uu____4404 =
-                    match q with
-                    | (bopt,variance,C
-                       {
-                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total
-                           (ti,uopt);
-                         FStar_Syntax_Syntax.tk = uu____4415;
-                         FStar_Syntax_Syntax.pos = uu____4416;
-                         FStar_Syntax_Syntax.vars = uu____4417;_})
-                        ->
-                        let uu____4432 =
-                          sub_prob scope1 args
-                            (bopt, variance, (T (ti, kind_type))) in
-                        (match uu____4432 with
-                         | (T (gi_xs,uu____4448),prob) ->
-                             let uu____4458 =
-                               let uu____4459 =
-                                 FStar_Syntax_Syntax.mk_Total' gi_xs uopt in
-                               FStar_All.pipe_left (fun _0_39  -> C _0_39)
-                                 uu____4459 in
-                             (uu____4458, [prob])
-                         | uu____4461 -> failwith "impossible")
-                    | (bopt,variance,C
-                       {
-                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal
-                           (ti,uopt);
-                         FStar_Syntax_Syntax.tk = uu____4471;
-                         FStar_Syntax_Syntax.pos = uu____4472;
-                         FStar_Syntax_Syntax.vars = uu____4473;_})
-                        ->
-                        let uu____4488 =
-                          sub_prob scope1 args
-                            (bopt, variance, (T (ti, kind_type))) in
-                        (match uu____4488 with
-                         | (T (gi_xs,uu____4504),prob) ->
-                             let uu____4514 =
-                               let uu____4515 =
-                                 FStar_Syntax_Syntax.mk_GTotal' gi_xs uopt in
-                               FStar_All.pipe_left (fun _0_40  -> C _0_40)
-                                 uu____4515 in
-                             (uu____4514, [prob])
-                         | uu____4517 -> failwith "impossible")
-                    | (uu____4523,uu____4524,C
-                       { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Comp c;
-                         FStar_Syntax_Syntax.tk = uu____4526;
-                         FStar_Syntax_Syntax.pos = uu____4527;
-                         FStar_Syntax_Syntax.vars = uu____4528;_})
-                        ->
-                        let components =
-                          FStar_All.pipe_right
-                            c.FStar_Syntax_Syntax.effect_args
-                            (FStar_List.map
-                               (fun t  ->
-                                  (None, INVARIANT,
-                                    (T ((Prims.fst t), generic_kind))))) in
-                        let components1 =
-                          (None, COVARIANT,
-                            (T
-                               ((c.FStar_Syntax_Syntax.result_typ),
-                                 kind_type)))
-                          :: components in
-                        let uu____4602 =
-                          let uu____4607 =
-                            FStar_List.map (sub_prob scope1 args) components1 in
-                          FStar_All.pipe_right uu____4607 FStar_List.unzip in
-                        (match uu____4602 with
-                         | (tcs,sub_probs) ->
-                             let gi_xs =
-                               let uu____4636 =
-                                 let uu____4637 =
-                                   let uu____4640 = FStar_List.hd tcs in
-                                   FStar_All.pipe_right uu____4640 un_T in
-                                 let uu____4641 =
-                                   let uu____4647 = FStar_List.tl tcs in
-                                   FStar_All.pipe_right uu____4647
-                                     (FStar_List.map arg_of_tc) in
-                                 {
-                                   FStar_Syntax_Syntax.comp_univs =
-                                     (c.FStar_Syntax_Syntax.comp_univs);
-                                   FStar_Syntax_Syntax.effect_name =
-                                     (c.FStar_Syntax_Syntax.effect_name);
-                                   FStar_Syntax_Syntax.result_typ =
-                                     uu____4637;
-                                   FStar_Syntax_Syntax.effect_args =
-                                     uu____4641;
-                                   FStar_Syntax_Syntax.flags =
-                                     (c.FStar_Syntax_Syntax.flags)
-                                 } in
-                               FStar_All.pipe_left
-                                 FStar_Syntax_Syntax.mk_Comp uu____4636 in
-                             ((C gi_xs), sub_probs))
-                    | uu____4652 ->
-                        let uu____4659 = sub_prob scope1 args q in
-                        (match uu____4659 with
-                         | (ktec,prob) -> (ktec, [prob])) in
-                  (match uu____4404 with
-                   | (tc,probs) ->
-                       let uu____4677 =
-                         match q with
-                         | (Some b,uu____4703,uu____4704) ->
-                             let uu____4712 =
-                               let uu____4716 =
-                                 FStar_Syntax_Util.arg_of_non_null_binder b in
-                               uu____4716 :: args in
-                             ((Some b), (b :: scope1), uu____4712)
-                         | uu____4734 -> (None, scope1, args) in
-                       (match uu____4677 with
-                        | (bopt,scope2,args1) ->
-                            let uu____4777 = aux scope2 args1 qs2 in
-                            (match uu____4777 with
-                             | (sub_probs,tcs,f) ->
-                                 let f1 =
-                                   match bopt with
-                                   | None  ->
-                                       let uu____4798 =
-                                         let uu____4800 =
-                                           FStar_All.pipe_right probs
-                                             (FStar_List.map
-                                                (fun prob  ->
-                                                   FStar_All.pipe_right
-                                                     (p_guard prob) Prims.fst)) in
-                                         f :: uu____4800 in
-                                       FStar_Syntax_Util.mk_conj_l uu____4798
-                                   | Some b ->
-                                       let u_b =
-                                         env.FStar_TypeChecker_Env.universe_of
-                                           env
-                                           (Prims.fst b).FStar_Syntax_Syntax.sort in
-                                       let uu____4813 =
-                                         let uu____4815 =
-                                           FStar_Syntax_Util.mk_forall u_b
-                                             (Prims.fst b) f in
-                                         let uu____4816 =
-                                           FStar_All.pipe_right probs
-                                             (FStar_List.map
-                                                (fun prob  ->
-                                                   FStar_All.pipe_right
-                                                     (p_guard prob) Prims.fst)) in
-                                         uu____4815 :: uu____4816 in
-                                       FStar_Syntax_Util.mk_conj_l uu____4813 in
-                                 ((FStar_List.append probs sub_probs), (tc ::
-                                   tcs), f1)))) in
-            aux scope ps qs
+| T of (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.binders  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.term))
+| C of FStar_Syntax_Syntax.comp
+
+
+let uu___is_T : tc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| T (_0) -> begin
+true
+end
+| uu____3655 -> begin
+false
+end))
+
+
+let __proj__T__item___0 : tc  ->  (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.binders  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.term)) = (fun projectee -> (match (projectee) with
+| T (_0) -> begin
+_0
+end))
+
+
+let uu___is_C : tc  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| C (_0) -> begin
+true
+end
+| uu____3685 -> begin
+false
+end))
+
+
+let __proj__C__item___0 : tc  ->  FStar_Syntax_Syntax.comp = (fun projectee -> (match (projectee) with
+| C (_0) -> begin
+_0
+end))
+
+
+type tcs =
+tc Prims.list
+
+
+let generic_kind : FStar_Syntax_Syntax.binders  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.typ = (fun binders r -> (
+
+let uu____3700 = (FStar_Syntax_Util.type_u ())
+in (match (uu____3700) with
+| (t, uu____3704) -> begin
+(
+
+let uu____3705 = (new_uvar r binders t)
+in (Prims.fst uu____3705))
+end)))
+
+
+let kind_type : FStar_Syntax_Syntax.binders  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.typ = (fun binders r -> (
+
+let uu____3714 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____3714 Prims.fst)))
+
+
+let rec decompose : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  ((tc Prims.list  ->  FStar_Syntax_Syntax.term) * (FStar_Syntax_Syntax.term  ->  Prims.bool) * (FStar_Syntax_Syntax.binder Prims.option * variance * tc) Prims.list) = (fun env t -> (
+
+let t1 = (FStar_Syntax_Util.unmeta t)
+in (
+
+let matches = (fun t' -> (
+
+let uu____3756 = (head_matches env t1 t')
+in (match (uu____3756) with
+| MisMatch (uu____3757) -> begin
+false
+end
+| uu____3762 -> begin
+true
+end)))
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_app (hd1, args) -> begin
+(
+
+let rebuild = (fun args' -> (
+
+let args1 = (FStar_List.map2 (fun x y -> (match (((x), (y))) with
+| ((uu____3822, imp), T (t2, uu____3825)) -> begin
+((t2), (imp))
+end
+| uu____3842 -> begin
+(failwith "Bad reconstruction")
+end)) args args')
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((hd1), (args1))))) None t1.FStar_Syntax_Syntax.pos)))
+in (
+
+let tcs = (FStar_All.pipe_right args (FStar_List.map (fun uu____3886 -> (match (uu____3886) with
+| (t2, uu____3894) -> begin
+((None), (INVARIANT), (T (((t2), (generic_kind)))))
+end))))
+in ((rebuild), (matches), (tcs))))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let fail = (fun uu____3927 -> (failwith "Bad reconstruction"))
+in (
+
+let uu____3928 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____3928) with
+| (bs1, c1) -> begin
+(
+
+let rebuild = (fun tcs -> (
+
+let rec aux = (fun out bs2 tcs1 -> (match (((bs2), (tcs1))) with
+| (((x, imp))::bs3, (T (t2, uu____3981))::tcs2) -> begin
+(aux (((((
+
+let uu___143_4003 = x
+in {FStar_Syntax_Syntax.ppname = uu___143_4003.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___143_4003.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t2})), (imp)))::out) bs3 tcs2)
+end
+| ([], (C (c2))::[]) -> begin
+(FStar_Syntax_Util.arrow (FStar_List.rev out) c2)
+end
+| uu____4013 -> begin
+(failwith "Bad reconstruction")
+end))
+in (aux [] bs1 tcs)))
+in (
+
+let rec decompose1 = (fun out uu___120_4044 -> (match (uu___120_4044) with
+| [] -> begin
+(FStar_List.rev ((((None), (COVARIANT), (C (c1))))::out))
+end
+| (hd1)::rest -> begin
+(decompose1 ((((Some (hd1)), (CONTRAVARIANT), (T ((((Prims.fst hd1).FStar_Syntax_Syntax.sort), (kind_type))))))::out) rest)
+end))
+in (
+
+let uu____4107 = (decompose1 [] bs1)
+in ((rebuild), (matches), (uu____4107)))))
+end)))
+end
+| uu____4135 -> begin
+(
+
+let rebuild = (fun uu___121_4140 -> (match (uu___121_4140) with
+| [] -> begin
+t1
+end
+| uu____4142 -> begin
+(failwith "Bad reconstruction")
+end))
+in ((rebuild), ((fun t2 -> true)), ([])))
+end))))
+
+
+let un_T : tc  ->  FStar_Syntax_Syntax.term = (fun uu___122_4161 -> (match (uu___122_4161) with
+| T (t, uu____4163) -> begin
+t
+end
+| uu____4172 -> begin
+(failwith "Impossible")
+end))
+
+
+let arg_of_tc : tc  ->  FStar_Syntax_Syntax.arg = (fun uu___123_4175 -> (match (uu___123_4175) with
+| T (t, uu____4177) -> begin
+(FStar_Syntax_Syntax.as_arg t)
+end
+| uu____4186 -> begin
+(failwith "Impossible")
+end))
+
+
+let imitation_sub_probs : FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.args  ->  (FStar_Syntax_Syntax.binder Prims.option * variance * tc) Prims.list  ->  (FStar_TypeChecker_Common.prob Prims.list * tc Prims.list * FStar_Syntax_Syntax.formula) = (fun orig env scope ps qs -> (
+
+let r = (p_loc orig)
+in (
+
+let rel = (p_rel orig)
+in (
+
+let sub_prob = (fun scope1 args q -> (match (q) with
+| (uu____4255, variance, T (ti, mk_kind)) -> begin
+(
+
+let k = (mk_kind scope1 r)
+in (
+
+let uu____4274 = (new_uvar r scope1 k)
+in (match (uu____4274) with
+| (gi_xs, gi) -> begin
+(
+
+let gi_ps = (match (args) with
+| [] -> begin
+gi
+end
+| uu____4286 -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((gi), (args))))) None r)
+end)
+in (
+
+let uu____4305 = (
+
+let uu____4306 = (mk_problem scope1 orig gi_ps (vary_rel rel variance) ti None "type subterm")
+in (FStar_All.pipe_left (fun _0_38 -> FStar_TypeChecker_Common.TProb (_0_38)) uu____4306))
+in ((T (((gi_xs), (mk_kind)))), (uu____4305))))
+end)))
+end
+| (uu____4315, uu____4316, C (uu____4317)) -> begin
+(failwith "impos")
+end))
+in (
+
+let rec aux = (fun scope1 args qs1 -> (match (qs1) with
+| [] -> begin
+(([]), ([]), (FStar_Syntax_Util.t_true))
+end
+| (q)::qs2 -> begin
+(
+
+let uu____4404 = (match (q) with
+| (bopt, variance, C ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total (ti, uopt); FStar_Syntax_Syntax.tk = uu____4415; FStar_Syntax_Syntax.pos = uu____4416; FStar_Syntax_Syntax.vars = uu____4417})) -> begin
+(
+
+let uu____4432 = (sub_prob scope1 args ((bopt), (variance), (T (((ti), (kind_type))))))
+in (match (uu____4432) with
+| (T (gi_xs, uu____4448), prob) -> begin
+(
+
+let uu____4458 = (
+
+let uu____4459 = (FStar_Syntax_Syntax.mk_Total' gi_xs uopt)
+in (FStar_All.pipe_left (fun _0_39 -> C (_0_39)) uu____4459))
+in ((uu____4458), ((prob)::[])))
+end
+| uu____4461 -> begin
+(failwith "impossible")
+end))
+end
+| (bopt, variance, C ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal (ti, uopt); FStar_Syntax_Syntax.tk = uu____4471; FStar_Syntax_Syntax.pos = uu____4472; FStar_Syntax_Syntax.vars = uu____4473})) -> begin
+(
+
+let uu____4488 = (sub_prob scope1 args ((bopt), (variance), (T (((ti), (kind_type))))))
+in (match (uu____4488) with
+| (T (gi_xs, uu____4504), prob) -> begin
+(
+
+let uu____4514 = (
+
+let uu____4515 = (FStar_Syntax_Syntax.mk_GTotal' gi_xs uopt)
+in (FStar_All.pipe_left (fun _0_40 -> C (_0_40)) uu____4515))
+in ((uu____4514), ((prob)::[])))
+end
+| uu____4517 -> begin
+(failwith "impossible")
+end))
+end
+| (uu____4523, uu____4524, C ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Comp (c); FStar_Syntax_Syntax.tk = uu____4526; FStar_Syntax_Syntax.pos = uu____4527; FStar_Syntax_Syntax.vars = uu____4528})) -> begin
+(
+
+let components = (FStar_All.pipe_right c.FStar_Syntax_Syntax.effect_args (FStar_List.map (fun t -> ((None), (INVARIANT), (T ((((Prims.fst t)), (generic_kind))))))))
+in (
+
+let components1 = (((None), (COVARIANT), (T (((c.FStar_Syntax_Syntax.result_typ), (kind_type))))))::components
+in (
+
+let uu____4602 = (
+
+let uu____4607 = (FStar_List.map (sub_prob scope1 args) components1)
+in (FStar_All.pipe_right uu____4607 FStar_List.unzip))
+in (match (uu____4602) with
+| (tcs, sub_probs) -> begin
+(
+
+let gi_xs = (
+
+let uu____4636 = (
+
+let uu____4637 = (
+
+let uu____4640 = (FStar_List.hd tcs)
+in (FStar_All.pipe_right uu____4640 un_T))
+in (
+
+let uu____4641 = (
+
+let uu____4647 = (FStar_List.tl tcs)
+in (FStar_All.pipe_right uu____4647 (FStar_List.map arg_of_tc)))
+in {FStar_Syntax_Syntax.comp_univs = c.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = c.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = uu____4637; FStar_Syntax_Syntax.effect_args = uu____4641; FStar_Syntax_Syntax.flags = c.FStar_Syntax_Syntax.flags}))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp uu____4636))
+in ((C (gi_xs)), (sub_probs)))
+end))))
+end
+| uu____4652 -> begin
+(
+
+let uu____4659 = (sub_prob scope1 args q)
+in (match (uu____4659) with
+| (ktec, prob) -> begin
+((ktec), ((prob)::[]))
+end))
+end)
+in (match (uu____4404) with
+| (tc, probs) -> begin
+(
+
+let uu____4677 = (match (q) with
+| (Some (b), uu____4703, uu____4704) -> begin
+(
+
+let uu____4712 = (
+
+let uu____4716 = (FStar_Syntax_Util.arg_of_non_null_binder b)
+in (uu____4716)::args)
+in ((Some (b)), ((b)::scope1), (uu____4712)))
+end
+| uu____4734 -> begin
+((None), (scope1), (args))
+end)
+in (match (uu____4677) with
+| (bopt, scope2, args1) -> begin
+(
+
+let uu____4777 = (aux scope2 args1 qs2)
+in (match (uu____4777) with
+| (sub_probs, tcs, f) -> begin
+(
+
+let f1 = (match (bopt) with
+| None -> begin
+(
+
+let uu____4798 = (
+
+let uu____4800 = (FStar_All.pipe_right probs (FStar_List.map (fun prob -> (FStar_All.pipe_right (p_guard prob) Prims.fst))))
+in (f)::uu____4800)
+in (FStar_Syntax_Util.mk_conj_l uu____4798))
+end
+| Some (b) -> begin
+(
+
+let u_b = (env.FStar_TypeChecker_Env.universe_of env (Prims.fst b).FStar_Syntax_Syntax.sort)
+in (
+
+let uu____4813 = (
+
+let uu____4815 = (FStar_Syntax_Util.mk_forall u_b (Prims.fst b) f)
+in (
+
+let uu____4816 = (FStar_All.pipe_right probs (FStar_List.map (fun prob -> (FStar_All.pipe_right (p_guard prob) Prims.fst))))
+in (uu____4815)::uu____4816))
+in (FStar_Syntax_Util.mk_conj_l uu____4813)))
+end)
+in (((FStar_List.append probs sub_probs)), ((tc)::tcs), (f1)))
+end))
+end))
+end))
+end))
+in (aux scope ps qs))))))
+
+
 type flex_t =
-  (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.uvar*
-    FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.args)
+(FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.args)
+
+
 type im_or_proj_t =
-  (((FStar_Syntax_Syntax.uvar* FStar_Syntax_Syntax.typ)*
-    FStar_Syntax_Syntax.binders* FStar_Syntax_Syntax.comp)*
-    FStar_Syntax_Syntax.arg Prims.list*
-    ((tc Prims.list -> FStar_Syntax_Syntax.typ)*
-    (FStar_Syntax_Syntax.typ -> Prims.bool)* (FStar_Syntax_Syntax.binder
-    Prims.option* variance* tc) Prims.list))
-let rigid_rigid: Prims.int = Prims.parse_int "0"
-let flex_rigid_eq: Prims.int = Prims.parse_int "1"
-let flex_refine_inner: Prims.int = Prims.parse_int "2"
-let flex_refine: Prims.int = Prims.parse_int "3"
-let flex_rigid: Prims.int = Prims.parse_int "4"
-let rigid_flex: Prims.int = Prims.parse_int "5"
-let refine_flex: Prims.int = Prims.parse_int "6"
-let flex_flex: Prims.int = Prims.parse_int "7"
-let compress_tprob wl p =
-  let uu___144_4869 = p in
-  let uu____4872 = whnf wl.tcenv p.FStar_TypeChecker_Common.lhs in
-  let uu____4873 = whnf wl.tcenv p.FStar_TypeChecker_Common.rhs in
-  {
-    FStar_TypeChecker_Common.pid =
-      (uu___144_4869.FStar_TypeChecker_Common.pid);
-    FStar_TypeChecker_Common.lhs = uu____4872;
-    FStar_TypeChecker_Common.relation =
-      (uu___144_4869.FStar_TypeChecker_Common.relation);
-    FStar_TypeChecker_Common.rhs = uu____4873;
-    FStar_TypeChecker_Common.element =
-      (uu___144_4869.FStar_TypeChecker_Common.element);
-    FStar_TypeChecker_Common.logical_guard =
-      (uu___144_4869.FStar_TypeChecker_Common.logical_guard);
-    FStar_TypeChecker_Common.scope =
-      (uu___144_4869.FStar_TypeChecker_Common.scope);
-    FStar_TypeChecker_Common.reason =
-      (uu___144_4869.FStar_TypeChecker_Common.reason);
-    FStar_TypeChecker_Common.loc =
-      (uu___144_4869.FStar_TypeChecker_Common.loc);
-    FStar_TypeChecker_Common.rank =
-      (uu___144_4869.FStar_TypeChecker_Common.rank)
-  }
-let compress_prob:
-  worklist -> FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob
-  =
-  fun wl  ->
-    fun p  ->
-      match p with
-      | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____4883 = compress_tprob wl p1 in
-          FStar_All.pipe_right uu____4883
-            (fun _0_41  -> FStar_TypeChecker_Common.TProb _0_41)
-      | FStar_TypeChecker_Common.CProb uu____4888 -> p
-let rank:
-  worklist ->
-    FStar_TypeChecker_Common.prob ->
-      (Prims.int* FStar_TypeChecker_Common.prob)
-  =
-  fun wl  ->
-    fun pr  ->
-      let prob =
-        let uu____4902 = compress_prob wl pr in
-        FStar_All.pipe_right uu____4902 maybe_invert_p in
-      match prob with
-      | FStar_TypeChecker_Common.TProb tp ->
-          let uu____4908 =
-            FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
-          (match uu____4908 with
-           | (lh,uu____4921) ->
-               let uu____4936 =
-                 FStar_Syntax_Util.head_and_args
-                   tp.FStar_TypeChecker_Common.rhs in
-               (match uu____4936 with
-                | (rh,uu____4949) ->
-                    let uu____4964 =
-                      match ((lh.FStar_Syntax_Syntax.n),
-                              (rh.FStar_Syntax_Syntax.n))
-                      with
-                      | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____4973,FStar_Syntax_Syntax.Tm_uvar uu____4974)
-                          -> (flex_flex, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar _,_)
-                        |(_,FStar_Syntax_Syntax.Tm_uvar _) when
-                          (tp.FStar_TypeChecker_Common.relation =
-                             FStar_TypeChecker_Common.EQ)
-                            || (FStar_Options.eager_inference ())
-                          -> (flex_rigid_eq, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____4999,uu____5000)
-                          ->
-                          let uu____5009 =
-                            base_and_refinement wl.tcenv wl
-                              tp.FStar_TypeChecker_Common.rhs in
-                          (match uu____5009 with
-                           | (b,ref_opt) ->
-                               (match ref_opt with
-                                | None  -> (flex_rigid, tp)
-                                | uu____5049 ->
-                                    let rank =
-                                      let uu____5056 = is_top_level_prob prob in
-                                      if uu____5056
-                                      then flex_refine
-                                      else flex_refine_inner in
-                                    let uu____5058 =
-                                      let uu___145_5061 = tp in
-                                      let uu____5064 =
-                                        force_refinement (b, ref_opt) in
-                                      {
-                                        FStar_TypeChecker_Common.pid =
-                                          (uu___145_5061.FStar_TypeChecker_Common.pid);
-                                        FStar_TypeChecker_Common.lhs =
-                                          (uu___145_5061.FStar_TypeChecker_Common.lhs);
-                                        FStar_TypeChecker_Common.relation =
-                                          (uu___145_5061.FStar_TypeChecker_Common.relation);
-                                        FStar_TypeChecker_Common.rhs =
-                                          uu____5064;
-                                        FStar_TypeChecker_Common.element =
-                                          (uu___145_5061.FStar_TypeChecker_Common.element);
-                                        FStar_TypeChecker_Common.logical_guard
-                                          =
-                                          (uu___145_5061.FStar_TypeChecker_Common.logical_guard);
-                                        FStar_TypeChecker_Common.scope =
-                                          (uu___145_5061.FStar_TypeChecker_Common.scope);
-                                        FStar_TypeChecker_Common.reason =
-                                          (uu___145_5061.FStar_TypeChecker_Common.reason);
-                                        FStar_TypeChecker_Common.loc =
-                                          (uu___145_5061.FStar_TypeChecker_Common.loc);
-                                        FStar_TypeChecker_Common.rank =
-                                          (uu___145_5061.FStar_TypeChecker_Common.rank)
-                                      } in
-                                    (rank, uu____5058)))
-                      | (uu____5074,FStar_Syntax_Syntax.Tm_uvar uu____5075)
-                          ->
-                          let uu____5084 =
-                            base_and_refinement wl.tcenv wl
-                              tp.FStar_TypeChecker_Common.lhs in
-                          (match uu____5084 with
-                           | (b,ref_opt) ->
-                               (match ref_opt with
-                                | None  -> (rigid_flex, tp)
-                                | uu____5124 ->
-                                    let uu____5130 =
-                                      let uu___146_5135 = tp in
-                                      let uu____5138 =
-                                        force_refinement (b, ref_opt) in
-                                      {
-                                        FStar_TypeChecker_Common.pid =
-                                          (uu___146_5135.FStar_TypeChecker_Common.pid);
-                                        FStar_TypeChecker_Common.lhs =
-                                          uu____5138;
-                                        FStar_TypeChecker_Common.relation =
-                                          (uu___146_5135.FStar_TypeChecker_Common.relation);
-                                        FStar_TypeChecker_Common.rhs =
-                                          (uu___146_5135.FStar_TypeChecker_Common.rhs);
-                                        FStar_TypeChecker_Common.element =
-                                          (uu___146_5135.FStar_TypeChecker_Common.element);
-                                        FStar_TypeChecker_Common.logical_guard
-                                          =
-                                          (uu___146_5135.FStar_TypeChecker_Common.logical_guard);
-                                        FStar_TypeChecker_Common.scope =
-                                          (uu___146_5135.FStar_TypeChecker_Common.scope);
-                                        FStar_TypeChecker_Common.reason =
-                                          (uu___146_5135.FStar_TypeChecker_Common.reason);
-                                        FStar_TypeChecker_Common.loc =
-                                          (uu___146_5135.FStar_TypeChecker_Common.loc);
-                                        FStar_TypeChecker_Common.rank =
-                                          (uu___146_5135.FStar_TypeChecker_Common.rank)
-                                      } in
-                                    (refine_flex, uu____5130)))
-                      | (uu____5154,uu____5155) -> (rigid_rigid, tp) in
-                    (match uu____4964 with
-                     | (rank,tp1) ->
-                         let uu____5166 =
-                           FStar_All.pipe_right
-                             (let uu___147_5169 = tp1 in
-                              {
-                                FStar_TypeChecker_Common.pid =
-                                  (uu___147_5169.FStar_TypeChecker_Common.pid);
-                                FStar_TypeChecker_Common.lhs =
-                                  (uu___147_5169.FStar_TypeChecker_Common.lhs);
-                                FStar_TypeChecker_Common.relation =
-                                  (uu___147_5169.FStar_TypeChecker_Common.relation);
-                                FStar_TypeChecker_Common.rhs =
-                                  (uu___147_5169.FStar_TypeChecker_Common.rhs);
-                                FStar_TypeChecker_Common.element =
-                                  (uu___147_5169.FStar_TypeChecker_Common.element);
-                                FStar_TypeChecker_Common.logical_guard =
-                                  (uu___147_5169.FStar_TypeChecker_Common.logical_guard);
-                                FStar_TypeChecker_Common.scope =
-                                  (uu___147_5169.FStar_TypeChecker_Common.scope);
-                                FStar_TypeChecker_Common.reason =
-                                  (uu___147_5169.FStar_TypeChecker_Common.reason);
-                                FStar_TypeChecker_Common.loc =
-                                  (uu___147_5169.FStar_TypeChecker_Common.loc);
-                                FStar_TypeChecker_Common.rank = (Some rank)
-                              })
-                             (fun _0_42  ->
-                                FStar_TypeChecker_Common.TProb _0_42) in
-                         (rank, uu____5166))))
-      | FStar_TypeChecker_Common.CProb cp ->
-          let uu____5175 =
-            FStar_All.pipe_right
-              (let uu___148_5178 = cp in
-               {
-                 FStar_TypeChecker_Common.pid =
-                   (uu___148_5178.FStar_TypeChecker_Common.pid);
-                 FStar_TypeChecker_Common.lhs =
-                   (uu___148_5178.FStar_TypeChecker_Common.lhs);
-                 FStar_TypeChecker_Common.relation =
-                   (uu___148_5178.FStar_TypeChecker_Common.relation);
-                 FStar_TypeChecker_Common.rhs =
-                   (uu___148_5178.FStar_TypeChecker_Common.rhs);
-                 FStar_TypeChecker_Common.element =
-                   (uu___148_5178.FStar_TypeChecker_Common.element);
-                 FStar_TypeChecker_Common.logical_guard =
-                   (uu___148_5178.FStar_TypeChecker_Common.logical_guard);
-                 FStar_TypeChecker_Common.scope =
-                   (uu___148_5178.FStar_TypeChecker_Common.scope);
-                 FStar_TypeChecker_Common.reason =
-                   (uu___148_5178.FStar_TypeChecker_Common.reason);
-                 FStar_TypeChecker_Common.loc =
-                   (uu___148_5178.FStar_TypeChecker_Common.loc);
-                 FStar_TypeChecker_Common.rank = (Some rigid_rigid)
-               }) (fun _0_43  -> FStar_TypeChecker_Common.CProb _0_43) in
-          (rigid_rigid, uu____5175)
-let next_prob:
-  worklist ->
-    (FStar_TypeChecker_Common.prob Prims.option*
-      FStar_TypeChecker_Common.prob Prims.list* Prims.int)
-  =
-  fun wl  ->
-    let rec aux uu____5210 probs =
-      match uu____5210 with
-      | (min_rank,min1,out) ->
-          (match probs with
-           | [] -> (min1, out, min_rank)
-           | hd1::tl1 ->
-               let uu____5240 = rank wl hd1 in
-               (match uu____5240 with
-                | (rank1,hd2) ->
-                    if rank1 <= flex_rigid_eq
-                    then
-                      (match min1 with
-                       | None  ->
-                           ((Some hd2), (FStar_List.append out tl1), rank1)
-                       | Some m ->
-                           ((Some hd2), (FStar_List.append out (m :: tl1)),
-                             rank1))
-                    else
-                      if rank1 < min_rank
-                      then
-                        (match min1 with
-                         | None  -> aux (rank1, (Some hd2), out) tl1
-                         | Some m -> aux (rank1, (Some hd2), (m :: out)) tl1)
-                      else aux (min_rank, min1, (hd2 :: out)) tl1)) in
-    aux ((flex_flex + (Prims.parse_int "1")), None, []) wl.attempting
-let is_flex_rigid: Prims.int -> Prims.bool =
-  fun rank1  -> (flex_refine_inner <= rank1) && (rank1 <= flex_rigid)
-let is_rigid_flex: Prims.int -> Prims.bool =
-  fun rank1  -> (rigid_flex <= rank1) && (rank1 <= refine_flex)
+(((FStar_Syntax_Syntax.uvar * FStar_Syntax_Syntax.typ) * FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp) * FStar_Syntax_Syntax.arg Prims.list * ((tc Prims.list  ->  FStar_Syntax_Syntax.typ) * (FStar_Syntax_Syntax.typ  ->  Prims.bool) * (FStar_Syntax_Syntax.binder Prims.option * variance * tc) Prims.list))
+
+
+let rigid_rigid : Prims.int = (Prims.parse_int "0")
+
+
+let flex_rigid_eq : Prims.int = (Prims.parse_int "1")
+
+
+let flex_refine_inner : Prims.int = (Prims.parse_int "2")
+
+
+let flex_refine : Prims.int = (Prims.parse_int "3")
+
+
+let flex_rigid : Prims.int = (Prims.parse_int "4")
+
+
+let rigid_flex : Prims.int = (Prims.parse_int "5")
+
+
+let refine_flex : Prims.int = (Prims.parse_int "6")
+
+
+let flex_flex : Prims.int = (Prims.parse_int "7")
+
+
+let compress_tprob = (fun wl p -> (
+
+let uu___144_4869 = p
+in (
+
+let uu____4872 = (whnf wl.tcenv p.FStar_TypeChecker_Common.lhs)
+in (
+
+let uu____4873 = (whnf wl.tcenv p.FStar_TypeChecker_Common.rhs)
+in {FStar_TypeChecker_Common.pid = uu___144_4869.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu____4872; FStar_TypeChecker_Common.relation = uu___144_4869.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu____4873; FStar_TypeChecker_Common.element = uu___144_4869.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___144_4869.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___144_4869.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___144_4869.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___144_4869.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___144_4869.FStar_TypeChecker_Common.rank}))))
+
+
+let compress_prob : worklist  ->  FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Common.prob = (fun wl p -> (match (p) with
+| FStar_TypeChecker_Common.TProb (p1) -> begin
+(
+
+let uu____4883 = (compress_tprob wl p1)
+in (FStar_All.pipe_right uu____4883 (fun _0_41 -> FStar_TypeChecker_Common.TProb (_0_41))))
+end
+| FStar_TypeChecker_Common.CProb (uu____4888) -> begin
+p
+end))
+
+
+let rank : worklist  ->  FStar_TypeChecker_Common.prob  ->  (Prims.int * FStar_TypeChecker_Common.prob) = (fun wl pr -> (
+
+let prob = (
+
+let uu____4902 = (compress_prob wl pr)
+in (FStar_All.pipe_right uu____4902 maybe_invert_p))
+in (match (prob) with
+| FStar_TypeChecker_Common.TProb (tp) -> begin
+(
+
+let uu____4908 = (FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs)
+in (match (uu____4908) with
+| (lh, uu____4921) -> begin
+(
+
+let uu____4936 = (FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.rhs)
+in (match (uu____4936) with
+| (rh, uu____4949) -> begin
+(
+
+let uu____4964 = (match (((lh.FStar_Syntax_Syntax.n), (rh.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_uvar (uu____4973), FStar_Syntax_Syntax.Tm_uvar (uu____4974)) -> begin
+((flex_flex), (tp))
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), _)) | ((_, FStar_Syntax_Syntax.Tm_uvar (_))) when ((tp.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ) || (FStar_Options.eager_inference ())) -> begin
+((flex_rigid_eq), (tp))
+end
+| (FStar_Syntax_Syntax.Tm_uvar (uu____4999), uu____5000) -> begin
+(
+
+let uu____5009 = (base_and_refinement wl.tcenv wl tp.FStar_TypeChecker_Common.rhs)
+in (match (uu____5009) with
+| (b, ref_opt) -> begin
+(match (ref_opt) with
+| None -> begin
+((flex_rigid), (tp))
+end
+| uu____5049 -> begin
+(
+
+let rank = (
+
+let uu____5056 = (is_top_level_prob prob)
+in (match (uu____5056) with
+| true -> begin
+flex_refine
+end
+| uu____5057 -> begin
+flex_refine_inner
+end))
+in (
+
+let uu____5058 = (
+
+let uu___145_5061 = tp
+in (
+
+let uu____5064 = (force_refinement ((b), (ref_opt)))
+in {FStar_TypeChecker_Common.pid = uu___145_5061.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___145_5061.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___145_5061.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu____5064; FStar_TypeChecker_Common.element = uu___145_5061.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___145_5061.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___145_5061.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___145_5061.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___145_5061.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___145_5061.FStar_TypeChecker_Common.rank}))
+in ((rank), (uu____5058))))
+end)
+end))
+end
+| (uu____5074, FStar_Syntax_Syntax.Tm_uvar (uu____5075)) -> begin
+(
+
+let uu____5084 = (base_and_refinement wl.tcenv wl tp.FStar_TypeChecker_Common.lhs)
+in (match (uu____5084) with
+| (b, ref_opt) -> begin
+(match (ref_opt) with
+| None -> begin
+((rigid_flex), (tp))
+end
+| uu____5124 -> begin
+(
+
+let uu____5130 = (
+
+let uu___146_5135 = tp
+in (
+
+let uu____5138 = (force_refinement ((b), (ref_opt)))
+in {FStar_TypeChecker_Common.pid = uu___146_5135.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu____5138; FStar_TypeChecker_Common.relation = uu___146_5135.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___146_5135.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___146_5135.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___146_5135.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___146_5135.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___146_5135.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___146_5135.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___146_5135.FStar_TypeChecker_Common.rank}))
+in ((refine_flex), (uu____5130)))
+end)
+end))
+end
+| (uu____5154, uu____5155) -> begin
+((rigid_rigid), (tp))
+end)
+in (match (uu____4964) with
+| (rank, tp1) -> begin
+(
+
+let uu____5166 = (FStar_All.pipe_right (
+
+let uu___147_5169 = tp1
+in {FStar_TypeChecker_Common.pid = uu___147_5169.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___147_5169.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___147_5169.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___147_5169.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___147_5169.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___147_5169.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___147_5169.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___147_5169.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___147_5169.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = Some (rank)}) (fun _0_42 -> FStar_TypeChecker_Common.TProb (_0_42)))
+in ((rank), (uu____5166)))
+end))
+end))
+end))
+end
+| FStar_TypeChecker_Common.CProb (cp) -> begin
+(
+
+let uu____5175 = (FStar_All.pipe_right (
+
+let uu___148_5178 = cp
+in {FStar_TypeChecker_Common.pid = uu___148_5178.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___148_5178.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___148_5178.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___148_5178.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___148_5178.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___148_5178.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___148_5178.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___148_5178.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___148_5178.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = Some (rigid_rigid)}) (fun _0_43 -> FStar_TypeChecker_Common.CProb (_0_43)))
+in ((rigid_rigid), (uu____5175)))
+end)))
+
+
+let next_prob : worklist  ->  (FStar_TypeChecker_Common.prob Prims.option * FStar_TypeChecker_Common.prob Prims.list * Prims.int) = (fun wl -> (
+
+let rec aux = (fun uu____5210 probs -> (match (uu____5210) with
+| (min_rank, min1, out) -> begin
+(match (probs) with
+| [] -> begin
+((min1), (out), (min_rank))
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____5240 = (rank wl hd1)
+in (match (uu____5240) with
+| (rank1, hd2) -> begin
+(match ((rank1 <= flex_rigid_eq)) with
+| true -> begin
+(match (min1) with
+| None -> begin
+((Some (hd2)), ((FStar_List.append out tl1)), (rank1))
+end
+| Some (m) -> begin
+((Some (hd2)), ((FStar_List.append out ((m)::tl1))), (rank1))
+end)
+end
+| uu____5265 -> begin
+(match ((rank1 < min_rank)) with
+| true -> begin
+(match (min1) with
+| None -> begin
+(aux ((rank1), (Some (hd2)), (out)) tl1)
+end
+| Some (m) -> begin
+(aux ((rank1), (Some (hd2)), ((m)::out)) tl1)
+end)
+end
+| uu____5281 -> begin
+(aux ((min_rank), (min1), ((hd2)::out)) tl1)
+end)
+end)
+end))
+end)
+end))
+in (aux (((flex_flex + (Prims.parse_int "1"))), (None), ([])) wl.attempting)))
+
+
+let is_flex_rigid : Prims.int  ->  Prims.bool = (fun rank1 -> ((flex_refine_inner <= rank1) && (rank1 <= flex_rigid)))
+
+
+let is_rigid_flex : Prims.int  ->  Prims.bool = (fun rank1 -> ((rigid_flex <= rank1) && (rank1 <= refine_flex)))
+
 type univ_eq_sol =
-  | UDeferred of worklist
-  | USolved of worklist
-  | UFailed of Prims.string
-let uu___is_UDeferred: univ_eq_sol -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UDeferred _0 -> true | uu____5305 -> false
-let __proj__UDeferred__item___0: univ_eq_sol -> worklist =
-  fun projectee  -> match projectee with | UDeferred _0 -> _0
-let uu___is_USolved: univ_eq_sol -> Prims.bool =
-  fun projectee  ->
-    match projectee with | USolved _0 -> true | uu____5317 -> false
-let __proj__USolved__item___0: univ_eq_sol -> worklist =
-  fun projectee  -> match projectee with | USolved _0 -> _0
-let uu___is_UFailed: univ_eq_sol -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UFailed _0 -> true | uu____5329 -> false
-let __proj__UFailed__item___0: univ_eq_sol -> Prims.string =
-  fun projectee  -> match projectee with | UFailed _0 -> _0
-let rec really_solve_universe_eq:
-  Prims.int ->
-    worklist ->
-      FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> univ_eq_sol
-  =
-  fun pid_orig  ->
-    fun wl  ->
-      fun u1  ->
-        fun u2  ->
-          let u11 =
-            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u1 in
-          let u21 =
-            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u2 in
-          let rec occurs_univ v1 u =
-            match u with
-            | FStar_Syntax_Syntax.U_max us ->
-                FStar_All.pipe_right us
-                  (FStar_Util.for_some
-                     (fun u3  ->
-                        let uu____5366 = FStar_Syntax_Util.univ_kernel u3 in
-                        match uu____5366 with
-                        | (k,uu____5370) ->
-                            (match k with
-                             | FStar_Syntax_Syntax.U_unif v2 ->
-                                 FStar_Unionfind.equivalent v1 v2
-                             | uu____5375 -> false)))
-            | uu____5376 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
-          let try_umax_components u12 u22 msg =
-            match (u12, u22) with
-            | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2)
-                ->
-                if (FStar_List.length us1) = (FStar_List.length us2)
-                then
-                  let rec aux wl1 us11 us21 =
-                    match (us11, us21) with
-                    | (u13::us12,u23::us22) ->
-                        let uu____5419 =
-                          really_solve_universe_eq pid_orig wl1 u13 u23 in
-                        (match uu____5419 with
-                         | USolved wl2 -> aux wl2 us12 us22
-                         | failed -> failed)
-                    | uu____5422 -> USolved wl1 in
-                  aux wl us1 us2
-                else
-                  (let uu____5428 =
-                     let uu____5429 = FStar_Syntax_Print.univ_to_string u12 in
-                     let uu____5430 = FStar_Syntax_Print.univ_to_string u22 in
-                     FStar_Util.format2
-                       "Unable to unify universes: %s and %s" uu____5429
-                       uu____5430 in
-                   UFailed uu____5428)
-            | (FStar_Syntax_Syntax.U_max us,u')
-              |(u',FStar_Syntax_Syntax.U_max us) ->
-                let rec aux wl1 us1 =
-                  match us1 with
-                  | [] -> USolved wl1
-                  | u::us2 ->
-                      let uu____5447 =
-                        really_solve_universe_eq pid_orig wl1 u u' in
-                      (match uu____5447 with
-                       | USolved wl2 -> aux wl2 us2
-                       | failed -> failed) in
-                aux wl us
-            | uu____5450 ->
-                let uu____5453 =
-                  let uu____5454 = FStar_Syntax_Print.univ_to_string u12 in
-                  let uu____5455 = FStar_Syntax_Print.univ_to_string u22 in
-                  FStar_Util.format3
-                    "Unable to unify universes: %s and %s (%s)" uu____5454
-                    uu____5455 msg in
-                UFailed uu____5453 in
-          match (u11, u21) with
-          | (FStar_Syntax_Syntax.U_bvar _,_)
-            |(FStar_Syntax_Syntax.U_unknown ,_)
-             |(_,FStar_Syntax_Syntax.U_bvar _)
-              |(_,FStar_Syntax_Syntax.U_unknown ) ->
-              let uu____5462 =
-                let uu____5463 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____5464 = FStar_Syntax_Print.univ_to_string u21 in
-                FStar_Util.format2
-                  "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____5463 uu____5464 in
-              failwith uu____5462
-          | (FStar_Syntax_Syntax.U_name x,FStar_Syntax_Syntax.U_name y) ->
-              if x.FStar_Ident.idText = y.FStar_Ident.idText
-              then USolved wl
-              else UFailed "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
-              USolved wl
-          | (FStar_Syntax_Syntax.U_succ u12,FStar_Syntax_Syntax.U_succ u22)
-              -> really_solve_universe_eq pid_orig wl u12 u22
-          | (FStar_Syntax_Syntax.U_unif v1,FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____5476 = FStar_Unionfind.equivalent v1 v2 in
-              if uu____5476
-              then USolved wl
-              else
-                (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl in
-                 USolved wl1)
-          | (FStar_Syntax_Syntax.U_unif v1,u)
-            |(u,FStar_Syntax_Syntax.U_unif v1) ->
-              let u3 = norm_univ wl u in
-              let uu____5489 = occurs_univ v1 u3 in
-              if uu____5489
-              then
-                let uu____5490 =
-                  let uu____5491 =
-                    FStar_Syntax_Print.univ_to_string
-                      (FStar_Syntax_Syntax.U_unif v1) in
-                  let uu____5492 = FStar_Syntax_Print.univ_to_string u3 in
-                  FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____5491 uu____5492 in
-                try_umax_components u11 u21 uu____5490
-              else
-                (let uu____5494 = extend_solution pid_orig [UNIV (v1, u3)] wl in
-                 USolved uu____5494)
-          | (FStar_Syntax_Syntax.U_max _,_)|(_,FStar_Syntax_Syntax.U_max _)
-              ->
-              if wl.defer_ok
-              then UDeferred wl
-              else
-                (let u12 = norm_univ wl u11 in
-                 let u22 = norm_univ wl u21 in
-                 let uu____5504 = FStar_Syntax_Util.eq_univs u12 u22 in
-                 if uu____5504
-                 then USolved wl
-                 else try_umax_components u12 u22 "")
-          | (FStar_Syntax_Syntax.U_succ _,FStar_Syntax_Syntax.U_zero )
-            |(FStar_Syntax_Syntax.U_succ _,FStar_Syntax_Syntax.U_name _)
-             |(FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_succ _)
-              |(FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_name _)
-               |(FStar_Syntax_Syntax.U_name _,FStar_Syntax_Syntax.U_succ _)
-                |(FStar_Syntax_Syntax.U_name _,FStar_Syntax_Syntax.U_zero )
-              -> UFailed "Incompatible universes"
-let solve_universe_eq:
-  Prims.int ->
-    worklist ->
-      FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> univ_eq_sol
-  =
-  fun orig  ->
-    fun wl  ->
-      fun u1  ->
-        fun u2  ->
-          if (wl.tcenv).FStar_TypeChecker_Env.lax_universes
-          then USolved wl
-          else really_solve_universe_eq orig wl u1 u2
-let match_num_binders bc1 bc2 =
-  let uu____5575 = bc1 in
-  match uu____5575 with
-  | (bs1,mk_cod1) ->
-      let uu____5600 = bc2 in
-      (match uu____5600 with
-       | (bs2,mk_cod2) ->
-           let curry n1 bs mk_cod =
-             let uu____5647 = FStar_Util.first_N n1 bs in
-             match uu____5647 with
-             | (bs3,rest) ->
-                 let uu____5661 = mk_cod rest in (bs3, uu____5661) in
-           let l1 = FStar_List.length bs1 in
-           let l2 = FStar_List.length bs2 in
-           if l1 = l2
-           then
-             let uu____5679 =
-               let uu____5683 = mk_cod1 [] in (bs1, uu____5683) in
-             let uu____5685 =
-               let uu____5689 = mk_cod2 [] in (bs2, uu____5689) in
-             (uu____5679, uu____5685)
-           else
-             if l1 > l2
-             then
-               (let uu____5711 = curry l2 bs1 mk_cod1 in
-                let uu____5718 =
-                  let uu____5722 = mk_cod2 [] in (bs2, uu____5722) in
-                (uu____5711, uu____5718))
-             else
-               (let uu____5731 =
-                  let uu____5735 = mk_cod1 [] in (bs1, uu____5735) in
-                let uu____5737 = curry l1 bs2 mk_cod2 in
-                (uu____5731, uu____5737)))
-let rec solve: FStar_TypeChecker_Env.env -> worklist -> solution =
-  fun env  ->
-    fun probs  ->
-      (let uu____5841 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck") in
-       if uu____5841
-       then
-         let uu____5842 = wl_to_string probs in
-         FStar_Util.print1 "solve:\n\t%s\n" uu____5842
-       else ());
-      (let uu____5844 = next_prob probs in
-       match uu____5844 with
-       | (Some hd1,tl1,rank1) ->
-           let probs1 =
-             let uu___149_5857 = probs in
-             {
-               attempting = tl1;
-               wl_deferred = (uu___149_5857.wl_deferred);
-               ctr = (uu___149_5857.ctr);
-               defer_ok = (uu___149_5857.defer_ok);
-               smt_ok = (uu___149_5857.smt_ok);
-               tcenv = (uu___149_5857.tcenv)
-             } in
-           (match hd1 with
-            | FStar_TypeChecker_Common.CProb cp ->
-                solve_c env (maybe_invert cp) probs1
-            | FStar_TypeChecker_Common.TProb tp ->
-                if
-                  ((Prims.op_Negation probs1.defer_ok) &&
-                     (flex_refine_inner <= rank1))
-                    && (rank1 <= flex_rigid)
-                then
-                  let uu____5864 = solve_flex_rigid_join env tp probs1 in
-                  (match uu____5864 with
-                   | None  -> solve_t' env (maybe_invert tp) probs1
-                   | Some wl -> solve env wl)
-                else
-                  if
-                    ((Prims.op_Negation probs1.defer_ok) &&
-                       (rigid_flex <= rank1))
-                      && (rank1 <= refine_flex)
-                  then
-                    (let uu____5868 = solve_rigid_flex_meet env tp probs1 in
-                     match uu____5868 with
-                     | None  -> solve_t' env (maybe_invert tp) probs1
-                     | Some wl -> solve env wl)
-                  else solve_t' env (maybe_invert tp) probs1)
-       | (None ,uu____5872,uu____5873) ->
-           (match probs.wl_deferred with
-            | [] -> Success []
-            | uu____5882 ->
-                let uu____5887 =
-                  FStar_All.pipe_right probs.wl_deferred
-                    (FStar_List.partition
-                       (fun uu____5915  ->
-                          match uu____5915 with
-                          | (c,uu____5920,uu____5921) -> c < probs.ctr)) in
-                (match uu____5887 with
-                 | (attempt1,rest) ->
-                     (match attempt1 with
-                      | [] ->
-                          let uu____5943 =
-                            FStar_List.map
-                              (fun uu____5949  ->
-                                 match uu____5949 with
-                                 | (uu____5955,x,y) -> (x, y))
-                              probs.wl_deferred in
-                          Success uu____5943
-                      | uu____5958 ->
-                          let uu____5963 =
-                            let uu___150_5964 = probs in
-                            let uu____5965 =
-                              FStar_All.pipe_right attempt1
-                                (FStar_List.map
-                                   (fun uu____5974  ->
-                                      match uu____5974 with
-                                      | (uu____5978,uu____5979,y) -> y)) in
-                            {
-                              attempting = uu____5965;
-                              wl_deferred = rest;
-                              ctr = (uu___150_5964.ctr);
-                              defer_ok = (uu___150_5964.defer_ok);
-                              smt_ok = (uu___150_5964.smt_ok);
-                              tcenv = (uu___150_5964.tcenv)
-                            } in
-                          solve env uu____5963))))
-and solve_one_universe_eq:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob ->
-      FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> worklist -> solution
-  =
-  fun env  ->
-    fun orig  ->
-      fun u1  ->
-        fun u2  ->
-          fun wl  ->
-            let uu____5986 = solve_universe_eq (p_pid orig) wl u1 u2 in
-            match uu____5986 with
-            | USolved wl1 ->
-                let uu____5988 = solve_prob orig None [] wl1 in
-                solve env uu____5988
-            | UFailed msg -> giveup env msg orig
-            | UDeferred wl1 -> solve env (defer "" orig wl1)
-and solve_maybe_uinsts:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term -> worklist -> univ_eq_sol
-  =
-  fun env  ->
-    fun orig  ->
-      fun t1  ->
-        fun t2  ->
-          fun wl  ->
-            let rec aux wl1 us1 us2 =
-              match (us1, us2) with
-              | ([],[]) -> USolved wl1
-              | (u1::us11,u2::us21) ->
-                  let uu____6022 = solve_universe_eq (p_pid orig) wl1 u1 u2 in
-                  (match uu____6022 with
-                   | USolved wl2 -> aux wl2 us11 us21
-                   | failed_or_deferred -> failed_or_deferred)
-              | uu____6025 -> UFailed "Unequal number of universes" in
-            let t11 = whnf env t1 in
-            let t21 = whnf env t2 in
-            match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))
-            with
-            | (FStar_Syntax_Syntax.Tm_uinst
-               ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                  FStar_Syntax_Syntax.tk = uu____6033;
-                  FStar_Syntax_Syntax.pos = uu____6034;
-                  FStar_Syntax_Syntax.vars = uu____6035;_},us1),FStar_Syntax_Syntax.Tm_uinst
-               ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                  FStar_Syntax_Syntax.tk = uu____6038;
-                  FStar_Syntax_Syntax.pos = uu____6039;
-                  FStar_Syntax_Syntax.vars = uu____6040;_},us2))
-                -> let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
-            | (FStar_Syntax_Syntax.Tm_uinst _,_)
-              |(_,FStar_Syntax_Syntax.Tm_uinst _) ->
-                failwith "Impossible: expect head symbols to match"
-            | uu____6056 -> USolved wl
-and giveup_or_defer:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> worklist -> Prims.string -> solution
-  =
-  fun env  ->
-    fun orig  ->
-      fun wl  ->
-        fun msg  ->
-          if wl.defer_ok
-          then
-            ((let uu____6064 =
-                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel") in
-              if uu____6064
-              then
-                let uu____6065 = prob_to_string env orig in
-                FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
-                  uu____6065 msg
-              else ());
-             solve env (defer msg orig wl))
-          else giveup env msg orig
-and solve_rigid_flex_meet:
-  FStar_TypeChecker_Env.env -> tprob -> worklist -> worklist Prims.option =
-  fun env  ->
-    fun tp  ->
-      fun wl  ->
-        (let uu____6073 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelCheck") in
-         if uu____6073
-         then
-           let uu____6074 =
-             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid in
-           FStar_Util.print1 "Trying to solve by meeting refinements:%s\n"
-             uu____6074
-         else ());
-        (let uu____6076 =
-           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.rhs in
-         match uu____6076 with
-         | (u,args) ->
-             let rec disjoin t1 t2 =
-               let uu____6118 = head_matches_delta env () t1 t2 in
-               match uu____6118 with
-               | (mr,ts) ->
-                   (match mr with
-                    | MisMatch uu____6140 -> None
-                    | FullMatch  ->
-                        (match ts with
-                         | None  -> Some (t1, [])
-                         | Some (t11,t21) -> Some (t11, []))
-                    | HeadMatch  ->
-                        let uu____6166 =
-                          match ts with
-                          | Some (t11,t21) ->
-                              let uu____6175 =
-                                FStar_Syntax_Subst.compress t11 in
-                              let uu____6176 =
-                                FStar_Syntax_Subst.compress t21 in
-                              (uu____6175, uu____6176)
-                          | None  ->
-                              let uu____6179 = FStar_Syntax_Subst.compress t1 in
-                              let uu____6180 = FStar_Syntax_Subst.compress t2 in
-                              (uu____6179, uu____6180) in
-                        (match uu____6166 with
-                         | (t11,t21) ->
-                             let eq_prob t12 t22 =
-                               let uu____6202 =
-                                 new_problem env t12
-                                   FStar_TypeChecker_Common.EQ t22 None
-                                   t12.FStar_Syntax_Syntax.pos
-                                   "meeting refinements" in
-                               FStar_All.pipe_left
-                                 (fun _0_44  ->
-                                    FStar_TypeChecker_Common.TProb _0_44)
-                                 uu____6202 in
-                             (match ((t11.FStar_Syntax_Syntax.n),
-                                      (t21.FStar_Syntax_Syntax.n))
-                              with
-                              | (FStar_Syntax_Syntax.Tm_refine
-                                 (x,phi1),FStar_Syntax_Syntax.Tm_refine
-                                 (y,phi2)) ->
-                                  let uu____6225 =
-                                    let uu____6231 =
-                                      let uu____6234 =
-                                        let uu____6237 =
-                                          let uu____6238 =
-                                            let uu____6243 =
-                                              FStar_Syntax_Util.mk_disj phi1
-                                                phi2 in
-                                            (x, uu____6243) in
-                                          FStar_Syntax_Syntax.Tm_refine
-                                            uu____6238 in
-                                        FStar_Syntax_Syntax.mk uu____6237 in
-                                      uu____6234 None
-                                        t11.FStar_Syntax_Syntax.pos in
-                                    let uu____6256 =
-                                      let uu____6258 =
-                                        eq_prob x.FStar_Syntax_Syntax.sort
-                                          y.FStar_Syntax_Syntax.sort in
-                                      [uu____6258] in
-                                    (uu____6231, uu____6256) in
-                                  Some uu____6225
-                              | (uu____6267,FStar_Syntax_Syntax.Tm_refine
-                                 (x,uu____6269)) ->
-                                  let uu____6274 =
-                                    let uu____6278 =
-                                      let uu____6280 =
-                                        eq_prob x.FStar_Syntax_Syntax.sort
-                                          t11 in
-                                      [uu____6280] in
-                                    (t11, uu____6278) in
-                                  Some uu____6274
-                              | (FStar_Syntax_Syntax.Tm_refine
-                                 (x,uu____6286),uu____6287) ->
-                                  let uu____6292 =
-                                    let uu____6296 =
-                                      let uu____6298 =
-                                        eq_prob x.FStar_Syntax_Syntax.sort
-                                          t21 in
-                                      [uu____6298] in
-                                    (t21, uu____6296) in
-                                  Some uu____6292
-                              | uu____6303 ->
-                                  let uu____6306 =
-                                    FStar_Syntax_Util.head_and_args t11 in
-                                  (match uu____6306 with
-                                   | (head1,uu____6321) ->
-                                       let uu____6336 =
-                                         let uu____6337 =
-                                           FStar_Syntax_Util.un_uinst head1 in
-                                         uu____6337.FStar_Syntax_Syntax.n in
-                                       (match uu____6336 with
-                                        | FStar_Syntax_Syntax.Tm_fvar
-                                            {
-                                              FStar_Syntax_Syntax.fv_name =
-                                                uu____6344;
-                                              FStar_Syntax_Syntax.fv_delta =
-                                                FStar_Syntax_Syntax.Delta_defined_at_level
-                                                i;
-                                              FStar_Syntax_Syntax.fv_qual =
-                                                uu____6346;_}
-                                            ->
-                                            let prev =
-                                              if i > (Prims.parse_int "1")
-                                              then
-                                                FStar_Syntax_Syntax.Delta_defined_at_level
-                                                  (i - (Prims.parse_int "1"))
-                                              else
-                                                FStar_Syntax_Syntax.Delta_constant in
-                                            let t12 =
-                                              FStar_TypeChecker_Normalize.normalize
-                                                [FStar_TypeChecker_Normalize.WHNF;
-                                                FStar_TypeChecker_Normalize.UnfoldUntil
-                                                  prev] env t11 in
-                                            let t22 =
-                                              FStar_TypeChecker_Normalize.normalize
-                                                [FStar_TypeChecker_Normalize.WHNF;
-                                                FStar_TypeChecker_Normalize.UnfoldUntil
-                                                  prev] env t21 in
-                                            disjoin t12 t22
-                                        | uu____6355 -> None))))) in
-             let tt = u in
-             (match tt.FStar_Syntax_Syntax.n with
-              | FStar_Syntax_Syntax.Tm_uvar (uv,uu____6364) ->
-                  let uu____6377 =
-                    FStar_All.pipe_right wl.attempting
-                      (FStar_List.partition
-                         (fun uu___124_6386  ->
-                            match uu___124_6386 with
-                            | FStar_TypeChecker_Common.TProb tp1 ->
-                                (match tp1.FStar_TypeChecker_Common.rank with
-                                 | Some rank1 when is_rigid_flex rank1 ->
-                                     let uu____6391 =
-                                       FStar_Syntax_Util.head_and_args
-                                         tp1.FStar_TypeChecker_Common.rhs in
-                                     (match uu____6391 with
-                                      | (u',uu____6402) ->
-                                          let uu____6417 =
-                                            let uu____6418 = whnf env u' in
-                                            uu____6418.FStar_Syntax_Syntax.n in
-                                          (match uu____6417 with
-                                           | FStar_Syntax_Syntax.Tm_uvar
-                                               (uv',uu____6422) ->
-                                               FStar_Unionfind.equivalent uv
-                                                 uv'
-                                           | uu____6438 -> false))
-                                 | uu____6439 -> false)
-                            | uu____6441 -> false)) in
-                  (match uu____6377 with
-                   | (lower_bounds,rest) ->
-                       let rec make_lower_bound uu____6462 tps =
-                         match uu____6462 with
-                         | (bound,sub_probs) ->
-                             (match tps with
-                              | [] -> Some (bound, sub_probs)
-                              | (FStar_TypeChecker_Common.TProb hd1)::tl1 ->
-                                  let uu____6489 =
-                                    let uu____6494 =
-                                      whnf env
-                                        hd1.FStar_TypeChecker_Common.lhs in
-                                    disjoin bound uu____6494 in
-                                  (match uu____6489 with
-                                   | Some (bound1,sub1) ->
-                                       make_lower_bound
-                                         (bound1,
-                                           (FStar_List.append sub1 sub_probs))
-                                         tl1
-                                   | None  -> None)
-                              | uu____6513 -> None) in
-                       let uu____6518 =
-                         let uu____6523 =
-                           let uu____6527 =
-                             whnf env tp.FStar_TypeChecker_Common.lhs in
-                           (uu____6527, []) in
-                         make_lower_bound uu____6523 lower_bounds in
-                       (match uu____6518 with
-                        | None  ->
-                            ((let uu____6534 =
-                                FStar_All.pipe_left
-                                  (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "RelCheck") in
-                              if uu____6534
-                              then
-                                FStar_Util.print_string "No lower bounds\n"
-                              else ());
-                             None)
-                        | Some (lhs_bound,sub_probs) ->
-                            let eq_prob =
-                              new_problem env lhs_bound
-                                FStar_TypeChecker_Common.EQ
-                                tp.FStar_TypeChecker_Common.rhs None
-                                tp.FStar_TypeChecker_Common.loc
-                                "meeting refinements" in
-                            ((let uu____6547 =
-                                FStar_All.pipe_left
-                                  (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "RelCheck") in
-                              if uu____6547
-                              then
-                                let wl' =
-                                  let uu___151_6549 = wl in
-                                  {
-                                    attempting =
-                                      ((FStar_TypeChecker_Common.TProb
-                                          eq_prob) :: sub_probs);
-                                    wl_deferred = (uu___151_6549.wl_deferred);
-                                    ctr = (uu___151_6549.ctr);
-                                    defer_ok = (uu___151_6549.defer_ok);
-                                    smt_ok = (uu___151_6549.smt_ok);
-                                    tcenv = (uu___151_6549.tcenv)
-                                  } in
-                                let uu____6550 = wl_to_string wl' in
-                                FStar_Util.print1
-                                  "After meeting refinements: %s\n"
-                                  uu____6550
-                              else ());
-                             (let uu____6552 =
-                                solve_t env eq_prob
-                                  (let uu___152_6553 = wl in
-                                   {
-                                     attempting = sub_probs;
-                                     wl_deferred =
-                                       (uu___152_6553.wl_deferred);
-                                     ctr = (uu___152_6553.ctr);
-                                     defer_ok = (uu___152_6553.defer_ok);
-                                     smt_ok = (uu___152_6553.smt_ok);
-                                     tcenv = (uu___152_6553.tcenv)
-                                   }) in
-                              match uu____6552 with
-                              | Success uu____6555 ->
-                                  let wl1 =
-                                    let uu___153_6557 = wl in
-                                    {
-                                      attempting = rest;
-                                      wl_deferred =
-                                        (uu___153_6557.wl_deferred);
-                                      ctr = (uu___153_6557.ctr);
-                                      defer_ok = (uu___153_6557.defer_ok);
-                                      smt_ok = (uu___153_6557.smt_ok);
-                                      tcenv = (uu___153_6557.tcenv)
-                                    } in
-                                  let wl2 =
-                                    solve_prob' false
-                                      (FStar_TypeChecker_Common.TProb tp)
-                                      None [] wl1 in
-                                  let uu____6559 =
-                                    FStar_List.fold_left
-                                      (fun wl3  ->
-                                         fun p  ->
-                                           solve_prob' true p None [] wl3)
-                                      wl2 lower_bounds in
-                                  Some wl2
-                              | uu____6562 -> None))))
-              | uu____6563 -> failwith "Impossible: Not a rigid-flex"))
-and solve_flex_rigid_join:
-  FStar_TypeChecker_Env.env -> tprob -> worklist -> worklist Prims.option =
-  fun env  ->
-    fun tp  ->
-      fun wl  ->
-        (let uu____6570 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelCheck") in
-         if uu____6570
-         then
-           let uu____6571 =
-             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid in
-           FStar_Util.print1 "Trying to solve by joining refinements:%s\n"
-             uu____6571
-         else ());
-        (let uu____6573 =
-           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
-         match uu____6573 with
-         | (u,args) ->
-             let uu____6600 =
-               ((Prims.parse_int "0"), (Prims.parse_int "1"),
-                 (Prims.parse_int "2"), (Prims.parse_int "3"),
-                 (Prims.parse_int "4")) in
-             (match uu____6600 with
-              | (ok,head_match1,partial_match,fallback,failed_match) ->
-                  let max1 i j = if i < j then j else i in
-                  let base_types_match t1 t2 =
-                    let uu____6631 = FStar_Syntax_Util.head_and_args t1 in
-                    match uu____6631 with
-                    | (h1,args1) ->
-                        let uu____6659 = FStar_Syntax_Util.head_and_args t2 in
-                        (match uu____6659 with
-                         | (h2,uu____6672) ->
-                             (match ((h1.FStar_Syntax_Syntax.n),
-                                      (h2.FStar_Syntax_Syntax.n))
-                              with
-                              | (FStar_Syntax_Syntax.Tm_fvar
-                                 tc1,FStar_Syntax_Syntax.Tm_fvar tc2) ->
-                                  let uu____6691 =
-                                    FStar_Syntax_Syntax.fv_eq tc1 tc2 in
-                                  if uu____6691
-                                  then
-                                    (if
-                                       (FStar_List.length args1) =
-                                         (Prims.parse_int "0")
-                                     then Some []
-                                     else
-                                       (let uu____6704 =
-                                          let uu____6706 =
-                                            let uu____6707 =
-                                              new_problem env t1
-                                                FStar_TypeChecker_Common.EQ
-                                                t2 None
-                                                t1.FStar_Syntax_Syntax.pos
-                                                "joining refinements" in
-                                            FStar_All.pipe_left
-                                              (fun _0_45  ->
-                                                 FStar_TypeChecker_Common.TProb
-                                                   _0_45) uu____6707 in
-                                          [uu____6706] in
-                                        Some uu____6704))
-                                  else None
-                              | (FStar_Syntax_Syntax.Tm_name
-                                 a,FStar_Syntax_Syntax.Tm_name b) ->
-                                  if FStar_Syntax_Syntax.bv_eq a b
-                                  then
-                                    (if
-                                       (FStar_List.length args1) =
-                                         (Prims.parse_int "0")
-                                     then Some []
-                                     else
-                                       (let uu____6729 =
-                                          let uu____6731 =
-                                            let uu____6732 =
-                                              new_problem env t1
-                                                FStar_TypeChecker_Common.EQ
-                                                t2 None
-                                                t1.FStar_Syntax_Syntax.pos
-                                                "joining refinements" in
-                                            FStar_All.pipe_left
-                                              (fun _0_46  ->
-                                                 FStar_TypeChecker_Common.TProb
-                                                   _0_46) uu____6732 in
-                                          [uu____6731] in
-                                        Some uu____6729))
-                                  else None
-                              | uu____6740 -> None)) in
-                  let conjoin t1 t2 =
-                    match ((t1.FStar_Syntax_Syntax.n),
-                            (t2.FStar_Syntax_Syntax.n))
-                    with
-                    | (FStar_Syntax_Syntax.Tm_refine
-                       (x,phi1),FStar_Syntax_Syntax.Tm_refine (y,phi2)) ->
-                        let m =
-                          base_types_match x.FStar_Syntax_Syntax.sort
-                            y.FStar_Syntax_Syntax.sort in
-                        (match m with
-                         | None  -> None
-                         | Some m1 ->
-                             let x1 = FStar_Syntax_Syntax.freshen_bv x in
-                             let subst1 =
-                               [FStar_Syntax_Syntax.DB
-                                  ((Prims.parse_int "0"), x1)] in
-                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1 in
-                             let phi21 = FStar_Syntax_Subst.subst subst1 phi2 in
-                             let uu____6806 =
-                               let uu____6812 =
-                                 let uu____6815 =
-                                   FStar_Syntax_Util.mk_conj phi11 phi21 in
-                                 FStar_Syntax_Util.refine x1 uu____6815 in
-                               (uu____6812, m1) in
-                             Some uu____6806)
-                    | (uu____6824,FStar_Syntax_Syntax.Tm_refine
-                       (y,uu____6826)) ->
-                        let m =
-                          base_types_match t1 y.FStar_Syntax_Syntax.sort in
-                        (match m with
-                         | None  -> None
-                         | Some m1 -> Some (t2, m1))
-                    | (FStar_Syntax_Syntax.Tm_refine
-                       (x,uu____6858),uu____6859) ->
-                        let m =
-                          base_types_match x.FStar_Syntax_Syntax.sort t2 in
-                        (match m with
-                         | None  -> None
-                         | Some m1 -> Some (t1, m1))
-                    | uu____6890 ->
-                        let m = base_types_match t1 t2 in
-                        (match m with
-                         | None  -> None
-                         | Some m1 -> Some (t1, m1)) in
-                  let tt = u in
-                  (match tt.FStar_Syntax_Syntax.n with
-                   | FStar_Syntax_Syntax.Tm_uvar (uv,uu____6924) ->
-                       let uu____6937 =
-                         FStar_All.pipe_right wl.attempting
-                           (FStar_List.partition
-                              (fun uu___125_6946  ->
-                                 match uu___125_6946 with
-                                 | FStar_TypeChecker_Common.TProb tp1 ->
-                                     (match tp1.FStar_TypeChecker_Common.rank
-                                      with
-                                      | Some rank1 when is_flex_rigid rank1
-                                          ->
-                                          let uu____6951 =
-                                            FStar_Syntax_Util.head_and_args
-                                              tp1.FStar_TypeChecker_Common.lhs in
-                                          (match uu____6951 with
-                                           | (u',uu____6962) ->
-                                               let uu____6977 =
-                                                 let uu____6978 = whnf env u' in
-                                                 uu____6978.FStar_Syntax_Syntax.n in
-                                               (match uu____6977 with
-                                                | FStar_Syntax_Syntax.Tm_uvar
-                                                    (uv',uu____6982) ->
-                                                    FStar_Unionfind.equivalent
-                                                      uv uv'
-                                                | uu____6998 -> false))
-                                      | uu____6999 -> false)
-                                 | uu____7001 -> false)) in
-                       (match uu____6937 with
-                        | (upper_bounds,rest) ->
-                            let rec make_upper_bound uu____7026 tps =
-                              match uu____7026 with
-                              | (bound,sub_probs) ->
-                                  (match tps with
-                                   | [] -> Some (bound, sub_probs)
-                                   | (FStar_TypeChecker_Common.TProb
-                                       hd1)::tl1 ->
-                                       let uu____7067 =
-                                         let uu____7074 =
-                                           whnf env
-                                             hd1.FStar_TypeChecker_Common.rhs in
-                                         conjoin bound uu____7074 in
-                                       (match uu____7067 with
-                                        | Some (bound1,sub1) ->
-                                            make_upper_bound
-                                              (bound1,
-                                                (FStar_List.append sub1
-                                                   sub_probs)) tl1
-                                        | None  -> None)
-                                   | uu____7109 -> None) in
-                            let uu____7116 =
-                              let uu____7123 =
-                                let uu____7129 =
-                                  whnf env tp.FStar_TypeChecker_Common.rhs in
-                                (uu____7129, []) in
-                              make_upper_bound uu____7123 upper_bounds in
-                            (match uu____7116 with
-                             | None  ->
-                                 ((let uu____7138 =
-                                     FStar_All.pipe_left
-                                       (FStar_TypeChecker_Env.debug env)
-                                       (FStar_Options.Other "RelCheck") in
-                                   if uu____7138
-                                   then
-                                     FStar_Util.print_string
-                                       "No upper bounds\n"
-                                   else ());
-                                  None)
-                             | Some (rhs_bound,sub_probs) ->
-                                 let eq_prob =
-                                   new_problem env
-                                     tp.FStar_TypeChecker_Common.lhs
-                                     FStar_TypeChecker_Common.EQ rhs_bound
-                                     None tp.FStar_TypeChecker_Common.loc
-                                     "joining refinements" in
-                                 ((let uu____7157 =
-                                     FStar_All.pipe_left
-                                       (FStar_TypeChecker_Env.debug env)
-                                       (FStar_Options.Other "RelCheck") in
-                                   if uu____7157
-                                   then
-                                     let wl' =
-                                       let uu___154_7159 = wl in
-                                       {
-                                         attempting =
-                                           ((FStar_TypeChecker_Common.TProb
-                                               eq_prob) :: sub_probs);
-                                         wl_deferred =
-                                           (uu___154_7159.wl_deferred);
-                                         ctr = (uu___154_7159.ctr);
-                                         defer_ok = (uu___154_7159.defer_ok);
-                                         smt_ok = (uu___154_7159.smt_ok);
-                                         tcenv = (uu___154_7159.tcenv)
-                                       } in
-                                     let uu____7160 = wl_to_string wl' in
-                                     FStar_Util.print1
-                                       "After joining refinements: %s\n"
-                                       uu____7160
-                                   else ());
-                                  (let uu____7162 =
-                                     solve_t env eq_prob
-                                       (let uu___155_7163 = wl in
-                                        {
-                                          attempting = sub_probs;
-                                          wl_deferred =
-                                            (uu___155_7163.wl_deferred);
-                                          ctr = (uu___155_7163.ctr);
-                                          defer_ok = (uu___155_7163.defer_ok);
-                                          smt_ok = (uu___155_7163.smt_ok);
-                                          tcenv = (uu___155_7163.tcenv)
-                                        }) in
-                                   match uu____7162 with
-                                   | Success uu____7165 ->
-                                       let wl1 =
-                                         let uu___156_7167 = wl in
-                                         {
-                                           attempting = rest;
-                                           wl_deferred =
-                                             (uu___156_7167.wl_deferred);
-                                           ctr = (uu___156_7167.ctr);
-                                           defer_ok =
-                                             (uu___156_7167.defer_ok);
-                                           smt_ok = (uu___156_7167.smt_ok);
-                                           tcenv = (uu___156_7167.tcenv)
-                                         } in
-                                       let wl2 =
-                                         solve_prob' false
-                                           (FStar_TypeChecker_Common.TProb tp)
-                                           None [] wl1 in
-                                       let uu____7169 =
-                                         FStar_List.fold_left
-                                           (fun wl3  ->
-                                              fun p  ->
-                                                solve_prob' true p None []
-                                                  wl3) wl2 upper_bounds in
-                                       Some wl2
-                                   | uu____7172 -> None))))
-                   | uu____7173 -> failwith "Impossible: Not a flex-rigid")))
-and solve_binders:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.binders ->
-        FStar_TypeChecker_Common.prob ->
-          worklist ->
-            (FStar_Syntax_Syntax.binders ->
-               FStar_TypeChecker_Env.env ->
-                 FStar_Syntax_Syntax.subst_elt Prims.list ->
-                   FStar_TypeChecker_Common.prob)
-              -> solution
-  =
-  fun env  ->
-    fun bs1  ->
-      fun bs2  ->
-        fun orig  ->
-          fun wl  ->
-            fun rhs  ->
-              let rec aux scope env1 subst1 xs ys =
-                match (xs, ys) with
-                | ([],[]) ->
-                    let rhs_prob = rhs (FStar_List.rev scope) env1 subst1 in
-                    ((let uu____7238 =
-                        FStar_All.pipe_left
-                          (FStar_TypeChecker_Env.debug env1)
-                          (FStar_Options.Other "Rel") in
-                      if uu____7238
-                      then
-                        let uu____7239 = prob_to_string env1 rhs_prob in
-                        FStar_Util.print1 "rhs_prob = %s\n" uu____7239
-                      else ());
-                     (let formula =
-                        FStar_All.pipe_right (p_guard rhs_prob) Prims.fst in
-                      FStar_Util.Inl ([rhs_prob], formula)))
-                | ((hd1,imp)::xs1,(hd2,imp')::ys1) when imp = imp' ->
-                    let hd11 =
-                      let uu___157_7271 = hd1 in
-                      let uu____7272 =
-                        FStar_Syntax_Subst.subst subst1
-                          hd1.FStar_Syntax_Syntax.sort in
-                      {
-                        FStar_Syntax_Syntax.ppname =
-                          (uu___157_7271.FStar_Syntax_Syntax.ppname);
-                        FStar_Syntax_Syntax.index =
-                          (uu___157_7271.FStar_Syntax_Syntax.index);
-                        FStar_Syntax_Syntax.sort = uu____7272
-                      } in
-                    let hd21 =
-                      let uu___158_7276 = hd2 in
-                      let uu____7277 =
-                        FStar_Syntax_Subst.subst subst1
-                          hd2.FStar_Syntax_Syntax.sort in
-                      {
-                        FStar_Syntax_Syntax.ppname =
-                          (uu___158_7276.FStar_Syntax_Syntax.ppname);
-                        FStar_Syntax_Syntax.index =
-                          (uu___158_7276.FStar_Syntax_Syntax.index);
-                        FStar_Syntax_Syntax.sort = uu____7277
-                      } in
-                    let prob =
-                      let uu____7281 =
-                        let uu____7284 =
-                          FStar_All.pipe_left invert_rel (p_rel orig) in
-                        mk_problem scope orig hd11.FStar_Syntax_Syntax.sort
-                          uu____7284 hd21.FStar_Syntax_Syntax.sort None
-                          "Formal parameter" in
-                      FStar_All.pipe_left
-                        (fun _0_47  -> FStar_TypeChecker_Common.TProb _0_47)
-                        uu____7281 in
-                    let hd12 = FStar_Syntax_Syntax.freshen_bv hd11 in
-                    let subst2 =
-                      let uu____7292 =
-                        FStar_Syntax_Subst.shift_subst (Prims.parse_int "1")
-                          subst1 in
-                      (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), hd12))
-                        :: uu____7292 in
-                    let env2 = FStar_TypeChecker_Env.push_bv env1 hd12 in
-                    let uu____7295 =
-                      aux ((hd12, imp) :: scope) env2 subst2 xs1 ys1 in
-                    (match uu____7295 with
-                     | FStar_Util.Inl (sub_probs,phi) ->
-                         let phi1 =
-                           let uu____7313 =
-                             FStar_All.pipe_right (p_guard prob) Prims.fst in
-                           let uu____7316 =
-                             close_forall env2 [(hd12, imp)] phi in
-                           FStar_Syntax_Util.mk_conj uu____7313 uu____7316 in
-                         ((let uu____7322 =
-                             FStar_All.pipe_left
-                               (FStar_TypeChecker_Env.debug env2)
-                               (FStar_Options.Other "Rel") in
-                           if uu____7322
-                           then
-                             let uu____7323 =
-                               FStar_Syntax_Print.term_to_string phi1 in
-                             let uu____7324 =
-                               FStar_Syntax_Print.bv_to_string hd12 in
-                             FStar_Util.print2 "Formula is %s\n\thd1=%s\n"
-                               uu____7323 uu____7324
-                           else ());
-                          FStar_Util.Inl ((prob :: sub_probs), phi1))
-                     | fail -> fail)
-                | uu____7339 ->
-                    FStar_Util.Inr "arity or argument-qualifier mismatch" in
-              let scope = p_scope orig in
-              let uu____7345 = aux scope env [] bs1 bs2 in
-              match uu____7345 with
-              | FStar_Util.Inr msg -> giveup env msg orig
-              | FStar_Util.Inl (sub_probs,phi) ->
-                  let wl1 = solve_prob orig (Some phi) [] wl in
-                  solve env (attempt sub_probs wl1)
-and solve_t: FStar_TypeChecker_Env.env -> tprob -> worklist -> solution =
-  fun env  ->
-    fun problem  ->
-      fun wl  ->
-        let uu____7361 = compress_tprob wl problem in
-        solve_t' env uu____7361 wl
-and solve_t': FStar_TypeChecker_Env.env -> tprob -> worklist -> solution =
-  fun env  ->
-    fun problem  ->
-      fun wl  ->
-        let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg in
-        let rigid_rigid_delta env1 orig wl1 head1 head2 t1 t2 =
-          let uu____7394 = head_matches_delta env1 wl1 t1 t2 in
-          match uu____7394 with
-          | (m,o) ->
-              (match (m, o) with
-               | (MisMatch uu____7411,uu____7412) ->
-                   let may_relate head3 =
-                     let uu____7427 =
-                       let uu____7428 = FStar_Syntax_Util.un_uinst head3 in
-                       uu____7428.FStar_Syntax_Syntax.n in
-                     match uu____7427 with
-                     | FStar_Syntax_Syntax.Tm_name _
-                       |FStar_Syntax_Syntax.Tm_match _ -> true
-                     | FStar_Syntax_Syntax.Tm_fvar tc ->
-                         tc.FStar_Syntax_Syntax.fv_delta =
-                           FStar_Syntax_Syntax.Delta_equational
-                     | uu____7434 -> false in
-                   let uu____7435 =
-                     ((may_relate head1) || (may_relate head2)) && wl1.smt_ok in
-                   if uu____7435
-                   then
-                     let guard =
-                       if
-                         problem.FStar_TypeChecker_Common.relation =
-                           FStar_TypeChecker_Common.EQ
-                       then mk_eq2 env1 t1 t2
-                       else
-                         (let has_type_guard t11 t21 =
-                            match problem.FStar_TypeChecker_Common.element
-                            with
-                            | Some t ->
-                                FStar_Syntax_Util.mk_has_type t11 t t21
-                            | None  ->
-                                let x = FStar_Syntax_Syntax.new_bv None t11 in
-                                let u_x =
-                                  env1.FStar_TypeChecker_Env.universe_of env1
-                                    t11 in
-                                let uu____7452 =
-                                  let uu____7453 =
-                                    FStar_Syntax_Syntax.bv_to_name x in
-                                  FStar_Syntax_Util.mk_has_type t11
-                                    uu____7453 t21 in
-                                FStar_Syntax_Util.mk_forall u_x x uu____7452 in
-                          if
-                            problem.FStar_TypeChecker_Common.relation =
-                              FStar_TypeChecker_Common.SUB
-                          then has_type_guard t1 t2
-                          else has_type_guard t2 t1) in
-                     let uu____7455 = solve_prob orig (Some guard) [] wl1 in
-                     solve env1 uu____7455
-                   else giveup env1 "head mismatch" orig
-               | (uu____7457,Some (t11,t21)) ->
-                   solve_t env1
-                     (let uu___159_7465 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___159_7465.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs = t11;
-                        FStar_TypeChecker_Common.relation =
-                          (uu___159_7465.FStar_TypeChecker_Common.relation);
-                        FStar_TypeChecker_Common.rhs = t21;
-                        FStar_TypeChecker_Common.element =
-                          (uu___159_7465.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___159_7465.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___159_7465.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___159_7465.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___159_7465.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___159_7465.FStar_TypeChecker_Common.rank)
-                      }) wl1
-               | (uu____7466,None ) ->
-                   ((let uu____7473 =
-                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                         (FStar_Options.Other "Rel") in
-                     if uu____7473
-                     then
-                       let uu____7474 = FStar_Syntax_Print.term_to_string t1 in
-                       let uu____7475 = FStar_Syntax_Print.tag_of_term t1 in
-                       let uu____7476 = FStar_Syntax_Print.term_to_string t2 in
-                       let uu____7477 = FStar_Syntax_Print.tag_of_term t2 in
-                       FStar_Util.print4
-                         "Head matches: %s (%s) and %s (%s)\n" uu____7474
-                         uu____7475 uu____7476 uu____7477
-                     else ());
-                    (let uu____7479 = FStar_Syntax_Util.head_and_args t1 in
-                     match uu____7479 with
-                     | (head11,args1) ->
-                         let uu____7505 = FStar_Syntax_Util.head_and_args t2 in
-                         (match uu____7505 with
-                          | (head21,args2) ->
-                              let nargs = FStar_List.length args1 in
-                              if nargs <> (FStar_List.length args2)
-                              then
-                                let uu____7545 =
-                                  let uu____7546 =
-                                    FStar_Syntax_Print.term_to_string head11 in
-                                  let uu____7547 = args_to_string args1 in
-                                  let uu____7548 =
-                                    FStar_Syntax_Print.term_to_string head21 in
-                                  let uu____7549 = args_to_string args2 in
-                                  FStar_Util.format4
-                                    "unequal number of arguments: %s[%s] and %s[%s]"
-                                    uu____7546 uu____7547 uu____7548
-                                    uu____7549 in
-                                giveup env1 uu____7545 orig
-                              else
-                                (let uu____7551 =
-                                   (nargs = (Prims.parse_int "0")) ||
-                                     (let uu____7554 =
-                                        FStar_Syntax_Util.eq_args args1 args2 in
-                                      uu____7554 = FStar_Syntax_Util.Equal) in
-                                 if uu____7551
-                                 then
-                                   let uu____7555 =
-                                     solve_maybe_uinsts env1 orig head11
-                                       head21 wl1 in
-                                   match uu____7555 with
-                                   | USolved wl2 ->
-                                       let uu____7557 =
-                                         solve_prob orig None [] wl2 in
-                                       solve env1 uu____7557
-                                   | UFailed msg -> giveup env1 msg orig
-                                   | UDeferred wl2 ->
-                                       solve env1
-                                         (defer "universe constraints" orig
-                                            wl2)
-                                 else
-                                   (let uu____7561 =
-                                      base_and_refinement env1 wl1 t1 in
-                                    match uu____7561 with
-                                    | (base1,refinement1) ->
-                                        let uu____7587 =
-                                          base_and_refinement env1 wl1 t2 in
-                                        (match uu____7587 with
-                                         | (base2,refinement2) ->
-                                             (match (refinement1,
-                                                      refinement2)
-                                              with
-                                              | (None ,None ) ->
-                                                  let uu____7641 =
-                                                    solve_maybe_uinsts env1
-                                                      orig head11 head21 wl1 in
-                                                  (match uu____7641 with
-                                                   | UFailed msg ->
-                                                       giveup env1 msg orig
-                                                   | UDeferred wl2 ->
-                                                       solve env1
-                                                         (defer
-                                                            "universe constraints"
-                                                            orig wl2)
-                                                   | USolved wl2 ->
-                                                       let subprobs =
-                                                         FStar_List.map2
-                                                           (fun uu____7651 
-                                                              ->
-                                                              fun uu____7652 
-                                                                ->
-                                                                match 
-                                                                  (uu____7651,
-                                                                    uu____7652)
-                                                                with
-                                                                | ((a,uu____7662),
-                                                                   (a',uu____7664))
-                                                                    ->
-                                                                    let uu____7669
-                                                                    =
-                                                                    mk_problem
-                                                                    (p_scope
-                                                                    orig)
-                                                                    orig a
-                                                                    FStar_TypeChecker_Common.EQ
-                                                                    a' None
-                                                                    "index" in
-                                                                    FStar_All.pipe_left
-                                                                    (fun
-                                                                    _0_48  ->
-                                                                    FStar_TypeChecker_Common.TProb
-                                                                    _0_48)
-                                                                    uu____7669)
-                                                           args1 args2 in
-                                                       let formula =
-                                                         let uu____7675 =
-                                                           FStar_List.map
-                                                             (fun p  ->
-                                                                Prims.fst
-                                                                  (p_guard p))
-                                                             subprobs in
-                                                         FStar_Syntax_Util.mk_conj_l
-                                                           uu____7675 in
-                                                       let wl3 =
-                                                         solve_prob orig
-                                                           (Some formula) []
-                                                           wl2 in
-                                                       solve env1
-                                                         (attempt subprobs
-                                                            wl3))
-                                              | uu____7679 ->
-                                                  let lhs =
-                                                    force_refinement
-                                                      (base1, refinement1) in
-                                                  let rhs =
-                                                    force_refinement
-                                                      (base2, refinement2) in
-                                                  solve_t env1
-                                                    (let uu___160_7712 =
-                                                       problem in
-                                                     {
-                                                       FStar_TypeChecker_Common.pid
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.pid);
-                                                       FStar_TypeChecker_Common.lhs
-                                                         = lhs;
-                                                       FStar_TypeChecker_Common.relation
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.relation);
-                                                       FStar_TypeChecker_Common.rhs
-                                                         = rhs;
-                                                       FStar_TypeChecker_Common.element
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.element);
-                                                       FStar_TypeChecker_Common.logical_guard
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.logical_guard);
-                                                       FStar_TypeChecker_Common.scope
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.scope);
-                                                       FStar_TypeChecker_Common.reason
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.reason);
-                                                       FStar_TypeChecker_Common.loc
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.loc);
-                                                       FStar_TypeChecker_Common.rank
-                                                         =
-                                                         (uu___160_7712.FStar_TypeChecker_Common.rank)
-                                                     }) wl1)))))))) in
-        let imitate orig env1 wl1 p =
-          let uu____7732 = p in
-          match uu____7732 with
-          | (((u,k),xs,c),ps,(h,uu____7743,qs)) ->
-              let xs1 = sn_binders env1 xs in
-              let r = FStar_TypeChecker_Env.get_range env1 in
-              let uu____7792 = imitation_sub_probs orig env1 xs1 ps qs in
-              (match uu____7792 with
-               | (sub_probs,gs_xs,formula) ->
-                   let im =
-                     let uu____7806 = h gs_xs in
-                     let uu____7807 =
-                       let uu____7814 =
-                         FStar_All.pipe_right
-                           (FStar_Syntax_Util.lcomp_of_comp c)
-                           (fun _0_49  -> FStar_Util.Inl _0_49) in
-                       FStar_All.pipe_right uu____7814
-                         (fun _0_50  -> Some _0_50) in
-                     FStar_Syntax_Util.abs xs1 uu____7806 uu____7807 in
-                   ((let uu____7845 =
-                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                         (FStar_Options.Other "Rel") in
-                     if uu____7845
-                     then
-                       let uu____7846 =
-                         FStar_Syntax_Print.binders_to_string ", " xs1 in
-                       let uu____7847 = FStar_Syntax_Print.comp_to_string c in
-                       let uu____7848 = FStar_Syntax_Print.term_to_string im in
-                       let uu____7849 = FStar_Syntax_Print.tag_of_term im in
-                       let uu____7850 =
-                         let uu____7851 =
-                           FStar_List.map (prob_to_string env1) sub_probs in
-                         FStar_All.pipe_right uu____7851
-                           (FStar_String.concat ", ") in
-                       let uu____7854 =
-                         FStar_TypeChecker_Normalize.term_to_string env1
-                           formula in
-                       FStar_Util.print6
-                         "Imitating  binders are {%s}, comp=%s\n\t%s (%s)\nsub_probs = %s\nformula=%s\n"
-                         uu____7846 uu____7847 uu____7848 uu____7849
-                         uu____7850 uu____7854
-                     else ());
-                    (let wl2 =
-                       solve_prob orig (Some formula) [TERM ((u, k), im)] wl1 in
-                     solve env1 (attempt sub_probs wl2)))) in
-        let imitate' orig env1 wl1 uu___126_7872 =
-          match uu___126_7872 with
-          | None  -> giveup env1 "unable to compute subterms" orig
-          | Some p -> imitate orig env1 wl1 p in
-        let project orig env1 wl1 i p =
-          let uu____7901 = p in
-          match uu____7901 with
-          | ((u,xs,c),ps,(h,matches,qs)) ->
-              let r = FStar_TypeChecker_Env.get_range env1 in
-              let uu____7959 = FStar_List.nth ps i in
-              (match uu____7959 with
-               | (pi,uu____7962) ->
-                   let uu____7967 = FStar_List.nth xs i in
-                   (match uu____7967 with
-                    | (xi,uu____7974) ->
-                        let rec gs k =
-                          let uu____7983 = FStar_Syntax_Util.arrow_formals k in
-                          match uu____7983 with
-                          | (bs,k1) ->
-                              let rec aux subst1 bs1 =
-                                match bs1 with
-                                | [] -> ([], [])
-                                | (a,uu____8035)::tl1 ->
-                                    let k_a =
-                                      FStar_Syntax_Subst.subst subst1
-                                        a.FStar_Syntax_Syntax.sort in
-                                    let uu____8043 = new_uvar r xs k_a in
-                                    (match uu____8043 with
-                                     | (gi_xs,gi) ->
-                                         let gi_xs1 =
-                                           FStar_TypeChecker_Normalize.eta_expand
-                                             env1 gi_xs in
-                                         let gi_ps =
-                                           (FStar_Syntax_Syntax.mk_Tm_app gi
-                                              ps)
-                                             (Some
-                                                (k_a.FStar_Syntax_Syntax.n))
-                                             r in
-                                         let subst2 =
-                                           (FStar_Syntax_Syntax.NT
-                                              (a, gi_xs1))
-                                           :: subst1 in
-                                         let uu____8062 = aux subst2 tl1 in
-                                         (match uu____8062 with
-                                          | (gi_xs',gi_ps') ->
-                                              let uu____8077 =
-                                                let uu____8079 =
-                                                  FStar_Syntax_Syntax.as_arg
-                                                    gi_xs1 in
-                                                uu____8079 :: gi_xs' in
-                                              let uu____8080 =
-                                                let uu____8082 =
-                                                  FStar_Syntax_Syntax.as_arg
-                                                    gi_ps in
-                                                uu____8082 :: gi_ps' in
-                                              (uu____8077, uu____8080))) in
-                              aux [] bs in
-                        let uu____8085 =
-                          let uu____8086 = matches pi in
-                          FStar_All.pipe_left Prims.op_Negation uu____8086 in
-                        if uu____8085
-                        then None
-                        else
-                          (let uu____8089 = gs xi.FStar_Syntax_Syntax.sort in
-                           match uu____8089 with
-                           | (g_xs,uu____8096) ->
-                               let xi1 = FStar_Syntax_Syntax.bv_to_name xi in
-                               let proj =
-                                 let uu____8103 =
-                                   (FStar_Syntax_Syntax.mk_Tm_app xi1 g_xs)
-                                     None r in
-                                 let uu____8108 =
-                                   let uu____8115 =
-                                     FStar_All.pipe_right
-                                       (FStar_Syntax_Util.lcomp_of_comp c)
-                                       (fun _0_51  -> FStar_Util.Inl _0_51) in
-                                   FStar_All.pipe_right uu____8115
-                                     (fun _0_52  -> Some _0_52) in
-                                 FStar_Syntax_Util.abs xs uu____8103
-                                   uu____8108 in
-                               let sub1 =
-                                 let uu____8146 =
-                                   let uu____8149 =
-                                     (FStar_Syntax_Syntax.mk_Tm_app proj ps)
-                                       None r in
-                                   let uu____8156 =
-                                     let uu____8159 =
-                                       FStar_List.map
-                                         (fun uu____8165  ->
-                                            match uu____8165 with
-                                            | (uu____8170,uu____8171,y) -> y)
-                                         qs in
-                                     FStar_All.pipe_left h uu____8159 in
-                                   mk_problem (p_scope orig) orig uu____8149
-                                     (p_rel orig) uu____8156 None
-                                     "projection" in
-                                 FStar_All.pipe_left
-                                   (fun _0_53  ->
-                                      FStar_TypeChecker_Common.TProb _0_53)
-                                   uu____8146 in
-                               ((let uu____8181 =
-                                   FStar_All.pipe_left
-                                     (FStar_TypeChecker_Env.debug env1)
-                                     (FStar_Options.Other "Rel") in
-                                 if uu____8181
-                                 then
-                                   let uu____8182 =
-                                     FStar_Syntax_Print.term_to_string proj in
-                                   let uu____8183 = prob_to_string env1 sub1 in
-                                   FStar_Util.print2
-                                     "Projecting %s\n\tsubprob=%s\n"
-                                     uu____8182 uu____8183
-                                 else ());
-                                (let wl2 =
-                                   let uu____8186 =
-                                     let uu____8188 =
-                                       FStar_All.pipe_left Prims.fst
-                                         (p_guard sub1) in
-                                     Some uu____8188 in
-                                   solve_prob orig uu____8186
-                                     [TERM (u, proj)] wl1 in
-                                 let uu____8193 =
-                                   solve env1 (attempt [sub1] wl2) in
-                                 FStar_All.pipe_left
-                                   (fun _0_54  -> Some _0_54) uu____8193))))) in
-        let solve_t_flex_rigid patterns_only orig lhs t2 wl1 =
-          let uu____8217 = lhs in
-          match uu____8217 with
-          | ((t1,uv,k_uv,args_lhs),maybe_pat_vars) ->
-              let subterms ps =
-                let uu____8240 = FStar_Syntax_Util.arrow_formals_comp k_uv in
-                match uu____8240 with
-                | (xs,c) ->
-                    if (FStar_List.length xs) = (FStar_List.length ps)
-                    then
-                      let uu____8262 =
-                        let uu____8288 = decompose env t2 in
-                        (((uv, k_uv), xs, c), ps, uu____8288) in
-                      Some uu____8262
-                    else
-                      (let k_uv1 =
-                         FStar_TypeChecker_Normalize.normalize
-                           [FStar_TypeChecker_Normalize.Beta] env k_uv in
-                       let rec elim k args =
-                         let uu____8371 =
-                           let uu____8375 =
-                             let uu____8376 = FStar_Syntax_Subst.compress k in
-                             uu____8376.FStar_Syntax_Syntax.n in
-                           (uu____8375, args) in
-                         match uu____8371 with
-                         | (uu____8383,[]) ->
-                             let uu____8385 =
-                               let uu____8391 =
-                                 FStar_Syntax_Syntax.mk_Total k in
-                               ([], uu____8391) in
-                             Some uu____8385
-                         | (FStar_Syntax_Syntax.Tm_uvar _,_)
-                           |(FStar_Syntax_Syntax.Tm_app _,_) ->
-                             let uu____8408 =
-                               FStar_Syntax_Util.head_and_args k in
-                             (match uu____8408 with
-                              | (uv1,uv_args) ->
-                                  let uu____8437 =
-                                    let uu____8438 =
-                                      FStar_Syntax_Subst.compress uv1 in
-                                    uu____8438.FStar_Syntax_Syntax.n in
-                                  (match uu____8437 with
-                                   | FStar_Syntax_Syntax.Tm_uvar
-                                       (uvar,uu____8445) ->
-                                       let uu____8458 =
-                                         pat_vars env [] uv_args in
-                                       (match uu____8458 with
-                                        | None  -> None
-                                        | Some scope ->
-                                            let xs1 =
-                                              FStar_All.pipe_right args
-                                                (FStar_List.map
-                                                   (fun uu____8472  ->
-                                                      let uu____8473 =
-                                                        let uu____8474 =
-                                                          let uu____8475 =
-                                                            let uu____8478 =
-                                                              let uu____8479
-                                                                =
-                                                                FStar_Syntax_Util.type_u
-                                                                  () in
-                                                              FStar_All.pipe_right
-                                                                uu____8479
-                                                                Prims.fst in
-                                                            new_uvar
-                                                              k.FStar_Syntax_Syntax.pos
-                                                              scope
-                                                              uu____8478 in
-                                                          Prims.fst
-                                                            uu____8475 in
-                                                        FStar_Syntax_Syntax.new_bv
-                                                          (Some
-                                                             (k.FStar_Syntax_Syntax.pos))
-                                                          uu____8474 in
-                                                      FStar_All.pipe_left
-                                                        FStar_Syntax_Syntax.mk_binder
-                                                        uu____8473)) in
-                                            let c1 =
-                                              let uu____8485 =
-                                                let uu____8486 =
-                                                  let uu____8489 =
-                                                    let uu____8490 =
-                                                      FStar_Syntax_Util.type_u
-                                                        () in
-                                                    FStar_All.pipe_right
-                                                      uu____8490 Prims.fst in
-                                                  new_uvar
-                                                    k.FStar_Syntax_Syntax.pos
-                                                    scope uu____8489 in
-                                                Prims.fst uu____8486 in
-                                              FStar_Syntax_Syntax.mk_Total
-                                                uu____8485 in
-                                            let k' =
-                                              FStar_Syntax_Util.arrow xs1 c1 in
-                                            let uv_sol =
-                                              let uu____8499 =
-                                                let uu____8506 =
-                                                  let uu____8512 =
-                                                    let uu____8513 =
-                                                      let uu____8516 =
-                                                        let uu____8517 =
-                                                          FStar_Syntax_Util.type_u
-                                                            () in
-                                                        FStar_All.pipe_right
-                                                          uu____8517
-                                                          Prims.fst in
-                                                      FStar_Syntax_Syntax.mk_Total
-                                                        uu____8516 in
-                                                    FStar_All.pipe_left
-                                                      FStar_Syntax_Util.lcomp_of_comp
-                                                      uu____8513 in
-                                                  FStar_Util.Inl uu____8512 in
-                                                Some uu____8506 in
-                                              FStar_Syntax_Util.abs scope k'
-                                                uu____8499 in
-                                            (FStar_Unionfind.change uvar
-                                               (FStar_Syntax_Syntax.Fixed
-                                                  uv_sol);
-                                             Some (xs1, c1)))
-                                   | uu____8540 -> None))
-                         | (FStar_Syntax_Syntax.Tm_arrow (xs1,c1),uu____8545)
-                             ->
-                             let n_args = FStar_List.length args in
-                             let n_xs = FStar_List.length xs1 in
-                             if n_xs = n_args
-                             then
-                               let uu____8571 =
-                                 FStar_Syntax_Subst.open_comp xs1 c1 in
-                               FStar_All.pipe_right uu____8571
-                                 (fun _0_55  -> Some _0_55)
-                             else
-                               if n_xs < n_args
-                               then
-                                 (let uu____8590 =
-                                    FStar_Util.first_N n_xs args in
-                                  match uu____8590 with
-                                  | (args1,rest) ->
-                                      let uu____8606 =
-                                        FStar_Syntax_Subst.open_comp xs1 c1 in
-                                      (match uu____8606 with
-                                       | (xs2,c2) ->
-                                           let uu____8614 =
-                                             elim
-                                               (FStar_Syntax_Util.comp_result
-                                                  c2) rest in
-                                           FStar_Util.bind_opt uu____8614
-                                             (fun uu____8625  ->
-                                                match uu____8625 with
-                                                | (xs',c3) ->
-                                                    Some
-                                                      ((FStar_List.append xs2
-                                                          xs'), c3))))
-                               else
-                                 (let uu____8647 =
-                                    FStar_Util.first_N n_args xs1 in
-                                  match uu____8647 with
-                                  | (xs2,rest) ->
-                                      let t =
-                                        (FStar_Syntax_Syntax.mk
-                                           (FStar_Syntax_Syntax.Tm_arrow
-                                              (rest, c1))) None
-                                          k.FStar_Syntax_Syntax.pos in
-                                      let uu____8693 =
-                                        let uu____8696 =
-                                          FStar_Syntax_Syntax.mk_Total t in
-                                        FStar_Syntax_Subst.open_comp xs2
-                                          uu____8696 in
-                                      FStar_All.pipe_right uu____8693
-                                        (fun _0_56  -> Some _0_56))
-                         | uu____8704 ->
-                             let uu____8708 =
-                               let uu____8709 =
-                                 FStar_Syntax_Print.uvar_to_string uv in
-                               let uu____8713 =
-                                 FStar_Syntax_Print.term_to_string k in
-                               let uu____8714 =
-                                 FStar_Syntax_Print.term_to_string k_uv1 in
-                               FStar_Util.format3
-                                 "Impossible: ill-typed application %s : %s\n\t%s"
-                                 uu____8709 uu____8713 uu____8714 in
-                             failwith uu____8708 in
-                       let uu____8718 = elim k_uv1 ps in
-                       FStar_Util.bind_opt uu____8718
-                         (fun uu____8746  ->
-                            match uu____8746 with
-                            | (xs1,c1) ->
-                                let uu____8774 =
-                                  let uu____8797 = decompose env t2 in
-                                  (((uv, k_uv1), xs1, c1), ps, uu____8797) in
-                                Some uu____8774)) in
-              let rec imitate_or_project n1 stopt i =
-                if (i >= n1) || (FStar_Option.isNone stopt)
-                then
-                  giveup env
-                    "flex-rigid case failed all backtracking attempts" orig
-                else
-                  (let st = FStar_Option.get stopt in
-                   let tx = FStar_Unionfind.new_transaction () in
-                   if i = (- (Prims.parse_int "1"))
-                   then
-                     let uu____8869 = imitate orig env wl1 st in
-                     match uu____8869 with
-                     | Failed uu____8874 ->
-                         (FStar_Unionfind.rollback tx;
-                          imitate_or_project n1 stopt
-                            (i + (Prims.parse_int "1")))
-                     | sol -> sol
-                   else
-                     (let uu____8880 = project orig env wl1 i st in
-                      match uu____8880 with
-                      | None |Some (Failed _) ->
-                          (FStar_Unionfind.rollback tx;
-                           imitate_or_project n1 stopt
-                             (i + (Prims.parse_int "1")))
-                      | Some sol -> sol)) in
-              let check_head fvs1 t21 =
-                let uu____8898 = FStar_Syntax_Util.head_and_args t21 in
-                match uu____8898 with
-                | (hd1,uu____8909) ->
-                    (match hd1.FStar_Syntax_Syntax.n with
-                     | FStar_Syntax_Syntax.Tm_arrow _
-                       |FStar_Syntax_Syntax.Tm_constant _
-                        |FStar_Syntax_Syntax.Tm_abs _ -> true
-                     | uu____8927 ->
-                         let fvs_hd = FStar_Syntax_Free.names hd1 in
-                         let uu____8930 =
-                           FStar_Util.set_is_subset_of fvs_hd fvs1 in
-                         if uu____8930
-                         then true
-                         else
-                           ((let uu____8933 =
-                               FStar_All.pipe_left
-                                 (FStar_TypeChecker_Env.debug env)
-                                 (FStar_Options.Other "Rel") in
-                             if uu____8933
-                             then
-                               let uu____8934 = names_to_string fvs_hd in
-                               FStar_Util.print1 "Free variables are %s"
-                                 uu____8934
-                             else ());
-                            false)) in
-              let imitate_ok t21 =
-                let fvs_hd =
-                  let uu____8942 =
-                    let uu____8945 = FStar_Syntax_Util.head_and_args t21 in
-                    FStar_All.pipe_right uu____8945 Prims.fst in
-                  FStar_All.pipe_right uu____8942 FStar_Syntax_Free.names in
-                let uu____8976 = FStar_Util.set_is_empty fvs_hd in
-                if uu____8976
-                then - (Prims.parse_int "1")
-                else Prims.parse_int "0" in
-              (match maybe_pat_vars with
-               | Some vars ->
-                   let t11 = sn env t1 in
-                   let t21 = sn env t2 in
-                   let fvs1 = FStar_Syntax_Free.names t11 in
-                   let fvs2 = FStar_Syntax_Free.names t21 in
-                   let uu____8985 = occurs_check env wl1 (uv, k_uv) t21 in
-                   (match uu____8985 with
-                    | (occurs_ok,msg) ->
-                        if Prims.op_Negation occurs_ok
-                        then
-                          let uu____8993 =
-                            let uu____8994 = FStar_Option.get msg in
-                            Prims.strcat "occurs-check failed: " uu____8994 in
-                          giveup_or_defer1 orig uu____8993
-                        else
-                          (let uu____8996 =
-                             FStar_Util.set_is_subset_of fvs2 fvs1 in
-                           if uu____8996
-                           then
-                             let uu____8997 =
-                               ((Prims.op_Negation patterns_only) &&
-                                  (FStar_Syntax_Util.is_function_typ t21))
-                                 &&
-                                 ((p_rel orig) <> FStar_TypeChecker_Common.EQ) in
-                             (if uu____8997
-                              then
-                                let uu____8998 = subterms args_lhs in
-                                imitate' orig env wl1 uu____8998
-                              else
-                                ((let uu____9002 =
-                                    FStar_All.pipe_left
-                                      (FStar_TypeChecker_Env.debug env)
-                                      (FStar_Options.Other "Rel") in
-                                  if uu____9002
-                                  then
-                                    let uu____9003 =
-                                      FStar_Syntax_Print.term_to_string t11 in
-                                    let uu____9004 = names_to_string fvs1 in
-                                    let uu____9005 = names_to_string fvs2 in
-                                    FStar_Util.print3
-                                      "Pattern %s with fvars=%s succeeded fvar check: %s\n"
-                                      uu____9003 uu____9004 uu____9005
-                                  else ());
-                                 (let sol =
-                                    match vars with
-                                    | [] -> t21
-                                    | uu____9010 ->
-                                        let uu____9011 = sn_binders env vars in
-                                        u_abs k_uv uu____9011 t21 in
-                                  let wl2 =
-                                    solve_prob orig None
-                                      [TERM ((uv, k_uv), sol)] wl1 in
-                                  solve env wl2)))
-                           else
-                             if
-                               ((Prims.op_Negation patterns_only) &&
-                                  wl1.defer_ok)
-                                 &&
-                                 ((p_rel orig) <> FStar_TypeChecker_Common.EQ)
-                             then
-                               solve env
-                                 (defer
-                                    "flex pattern/rigid: occurs or freevar check"
-                                    orig wl1)
-                             else
-                               (let uu____9020 =
-                                  (Prims.op_Negation patterns_only) &&
-                                    (check_head fvs1 t21) in
-                                if uu____9020
-                                then
-                                  ((let uu____9022 =
-                                      FStar_All.pipe_left
-                                        (FStar_TypeChecker_Env.debug env)
-                                        (FStar_Options.Other "Rel") in
-                                    if uu____9022
-                                    then
-                                      let uu____9023 =
-                                        FStar_Syntax_Print.term_to_string t11 in
-                                      let uu____9024 = names_to_string fvs1 in
-                                      let uu____9025 = names_to_string fvs2 in
-                                      FStar_Util.print3
-                                        "Pattern %s with fvars=%s failed fvar check: %s ... imitating\n"
-                                        uu____9023 uu____9024 uu____9025
-                                    else ());
-                                   (let uu____9027 = subterms args_lhs in
-                                    imitate_or_project
-                                      (FStar_List.length args_lhs) uu____9027
-                                      (- (Prims.parse_int "1"))))
-                                else
-                                  giveup env
-                                    "free-variable check failed on a non-redex"
-                                    orig)))
-               | None  when patterns_only -> giveup env "not a pattern" orig
-               | None  ->
-                   if wl1.defer_ok
-                   then solve env (defer "not a pattern" orig wl1)
-                   else
-                     (let uu____9038 =
-                        let uu____9039 = FStar_Syntax_Free.names t1 in
-                        check_head uu____9039 t2 in
-                      if uu____9038
-                      then
-                        let im_ok = imitate_ok t2 in
-                        ((let uu____9043 =
-                            FStar_All.pipe_left
-                              (FStar_TypeChecker_Env.debug env)
-                              (FStar_Options.Other "Rel") in
-                          if uu____9043
-                          then
-                            let uu____9044 =
-                              FStar_Syntax_Print.term_to_string t1 in
-                            FStar_Util.print2 "Not a pattern (%s) ... %s\n"
-                              uu____9044
-                              (if im_ok < (Prims.parse_int "0")
-                               then "imitating"
-                               else "projecting")
-                          else ());
-                         (let uu____9047 = subterms args_lhs in
-                          imitate_or_project (FStar_List.length args_lhs)
-                            uu____9047 im_ok))
-                      else giveup env "head-symbol is free" orig)) in
-        let flex_flex1 orig lhs rhs =
-          if wl.defer_ok && ((p_rel orig) <> FStar_TypeChecker_Common.EQ)
-          then solve env (defer "flex-flex deferred" orig wl)
-          else
-            (let force_quasi_pattern xs_opt uu____9089 =
-               match uu____9089 with
-               | (t,u,k,args) ->
-                   let uu____9119 = FStar_Syntax_Util.arrow_formals k in
-                   (match uu____9119 with
-                    | (all_formals,uu____9130) ->
-                        let rec aux pat_args pattern_vars pattern_var_set
-                          formals args1 =
-                          match (formals, args1) with
-                          | ([],[]) ->
-                              let pat_args1 =
-                                FStar_All.pipe_right
-                                  (FStar_List.rev pat_args)
-                                  (FStar_List.map
-                                     (fun uu____9222  ->
-                                        match uu____9222 with
-                                        | (x,imp) ->
-                                            let uu____9229 =
-                                              FStar_Syntax_Syntax.bv_to_name
-                                                x in
-                                            (uu____9229, imp))) in
-                              let pattern_vars1 = FStar_List.rev pattern_vars in
-                              let kk =
-                                let uu____9237 = FStar_Syntax_Util.type_u () in
-                                match uu____9237 with
-                                | (t1,uu____9241) ->
-                                    let uu____9242 =
-                                      new_uvar t1.FStar_Syntax_Syntax.pos
-                                        pattern_vars1 t1 in
-                                    Prims.fst uu____9242 in
-                              let uu____9245 =
-                                new_uvar t.FStar_Syntax_Syntax.pos
-                                  pattern_vars1 kk in
-                              (match uu____9245 with
-                               | (t',tm_u1) ->
-                                   let uu____9252 = destruct_flex_t t' in
-                                   (match uu____9252 with
-                                    | (uu____9272,u1,k1,uu____9275) ->
-                                        let sol =
-                                          let uu____9303 =
-                                            let uu____9308 =
-                                              u_abs k all_formals t' in
-                                            ((u, k), uu____9308) in
-                                          TERM uu____9303 in
-                                        let t_app =
-                                          (FStar_Syntax_Syntax.mk_Tm_app
-                                             tm_u1 pat_args1) None
-                                            t.FStar_Syntax_Syntax.pos in
-                                        (sol, (t_app, u1, k1, pat_args1))))
-                          | (formal::formals1,hd1::tl1) ->
-                              let uu____9368 = pat_var_opt env pat_args hd1 in
-                              (match uu____9368 with
-                               | None  ->
-                                   aux pat_args pattern_vars pattern_var_set
-                                     formals1 tl1
-                               | Some y ->
-                                   let maybe_pat =
-                                     match xs_opt with
-                                     | None  -> true
-                                     | Some xs ->
-                                         FStar_All.pipe_right xs
-                                           (FStar_Util.for_some
-                                              (fun uu____9397  ->
-                                                 match uu____9397 with
-                                                 | (x,uu____9401) ->
-                                                     FStar_Syntax_Syntax.bv_eq
-                                                       x (Prims.fst y))) in
-                                   if Prims.op_Negation maybe_pat
-                                   then
-                                     aux pat_args pattern_vars
-                                       pattern_var_set formals1 tl1
-                                   else
-                                     (let fvs =
-                                        FStar_Syntax_Free.names
-                                          (Prims.fst y).FStar_Syntax_Syntax.sort in
-                                      let uu____9407 =
-                                        let uu____9408 =
-                                          FStar_Util.set_is_subset_of fvs
-                                            pattern_var_set in
-                                        Prims.op_Negation uu____9408 in
-                                      if uu____9407
-                                      then
-                                        aux pat_args pattern_vars
-                                          pattern_var_set formals1 tl1
-                                      else
-                                        (let uu____9412 =
-                                           FStar_Util.set_add
-                                             (Prims.fst formal)
-                                             pattern_var_set in
-                                         aux (y :: pat_args) (formal ::
-                                           pattern_vars) uu____9412 formals1
-                                           tl1)))
-                          | uu____9418 -> failwith "Impossible" in
-                        let uu____9429 = FStar_Syntax_Syntax.new_bv_set () in
-                        aux [] [] uu____9429 all_formals args) in
-             let solve_both_pats wl1 uu____9477 uu____9478 r =
-               match (uu____9477, uu____9478) with
-               | ((u1,k1,xs,args1),(u2,k2,ys,args2)) ->
-                   let uu____9632 =
-                     (FStar_Unionfind.equivalent u1 u2) && (binders_eq xs ys) in
-                   if uu____9632
-                   then
-                     let uu____9636 = solve_prob orig None [] wl1 in
-                     solve env uu____9636
-                   else
-                     (let xs1 = sn_binders env xs in
-                      let ys1 = sn_binders env ys in
-                      let zs = intersect_vars xs1 ys1 in
-                      (let uu____9651 =
-                         FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug env)
-                           (FStar_Options.Other "Rel") in
-                       if uu____9651
-                       then
-                         let uu____9652 =
-                           FStar_Syntax_Print.binders_to_string ", " xs1 in
-                         let uu____9653 =
-                           FStar_Syntax_Print.binders_to_string ", " ys1 in
-                         let uu____9654 =
-                           FStar_Syntax_Print.binders_to_string ", " zs in
-                         let uu____9655 =
-                           FStar_Syntax_Print.term_to_string k1 in
-                         let uu____9656 =
-                           FStar_Syntax_Print.term_to_string k2 in
-                         FStar_Util.print5
-                           "Flex-flex patterns: intersected %s and %s; got %s\n\tk1=%s\n\tk2=%s\n"
-                           uu____9652 uu____9653 uu____9654 uu____9655
-                           uu____9656
-                       else ());
-                      (let subst_k k xs2 args =
-                         let xs_len = FStar_List.length xs2 in
-                         let args_len = FStar_List.length args in
-                         if xs_len = args_len
-                         then
-                           let uu____9698 =
-                             FStar_Syntax_Util.subst_of_list xs2 args in
-                           FStar_Syntax_Subst.subst uu____9698 k
-                         else
-                           if args_len < xs_len
-                           then
-                             (let uu____9706 =
-                                FStar_Util.first_N args_len xs2 in
-                              match uu____9706 with
-                              | (xs3,xs_rest) ->
-                                  let k3 =
-                                    let uu____9736 =
-                                      FStar_Syntax_Syntax.mk_GTotal k in
-                                    FStar_Syntax_Util.arrow xs_rest
-                                      uu____9736 in
-                                  let uu____9739 =
-                                    FStar_Syntax_Util.subst_of_list xs3 args in
-                                  FStar_Syntax_Subst.subst uu____9739 k3)
-                           else
-                             (let uu____9742 =
-                                let uu____9743 =
-                                  FStar_Syntax_Print.term_to_string k in
-                                let uu____9744 =
-                                  FStar_Syntax_Print.binders_to_string ", "
-                                    xs2 in
-                                let uu____9745 =
-                                  FStar_Syntax_Print.args_to_string args in
-                                FStar_Util.format3
-                                  "k=%s\nxs=%s\nargs=%s\nIll-formed substitutution"
-                                  uu____9743 uu____9744 uu____9745 in
-                              failwith uu____9742) in
-                       let uu____9746 =
-                         let uu____9752 =
-                           let uu____9760 =
-                             FStar_TypeChecker_Normalize.normalize
-                               [FStar_TypeChecker_Normalize.Beta] env k1 in
-                           FStar_Syntax_Util.arrow_formals uu____9760 in
-                         match uu____9752 with
-                         | (bs,k1') ->
-                             let uu____9778 =
-                               let uu____9786 =
-                                 FStar_TypeChecker_Normalize.normalize
-                                   [FStar_TypeChecker_Normalize.Beta] env k2 in
-                               FStar_Syntax_Util.arrow_formals uu____9786 in
-                             (match uu____9778 with
-                              | (cs,k2') ->
-                                  let k1'_xs = subst_k k1' bs args1 in
-                                  let k2'_ys = subst_k k2' cs args2 in
-                                  let sub_prob =
-                                    let uu____9807 =
-                                      mk_problem (p_scope orig) orig k1'_xs
-                                        FStar_TypeChecker_Common.EQ k2'_ys
-                                        None "flex-flex kinding" in
-                                    FStar_All.pipe_left
-                                      (fun _0_57  ->
-                                         FStar_TypeChecker_Common.TProb _0_57)
-                                      uu____9807 in
-                                  let uu____9812 =
-                                    let uu____9815 =
-                                      let uu____9816 =
-                                        FStar_Syntax_Subst.compress k1' in
-                                      uu____9816.FStar_Syntax_Syntax.n in
-                                    let uu____9819 =
-                                      let uu____9820 =
-                                        FStar_Syntax_Subst.compress k2' in
-                                      uu____9820.FStar_Syntax_Syntax.n in
-                                    (uu____9815, uu____9819) in
-                                  (match uu____9812 with
-                                   | (FStar_Syntax_Syntax.Tm_type
-                                      uu____9828,uu____9829) ->
-                                       (k1', [sub_prob])
-                                   | (uu____9833,FStar_Syntax_Syntax.Tm_type
-                                      uu____9834) -> (k2', [sub_prob])
-                                   | uu____9838 ->
-                                       let uu____9841 =
-                                         FStar_Syntax_Util.type_u () in
-                                       (match uu____9841 with
-                                        | (t,uu____9850) ->
-                                            let uu____9851 = new_uvar r zs t in
-                                            (match uu____9851 with
-                                             | (k_zs,uu____9860) ->
-                                                 let kprob =
-                                                   let uu____9862 =
-                                                     mk_problem
-                                                       (p_scope orig) orig
-                                                       k1'_xs
-                                                       FStar_TypeChecker_Common.EQ
-                                                       k_zs None
-                                                       "flex-flex kinding" in
-                                                   FStar_All.pipe_left
-                                                     (fun _0_58  ->
-                                                        FStar_TypeChecker_Common.TProb
-                                                          _0_58) uu____9862 in
-                                                 (k_zs, [sub_prob; kprob]))))) in
-                       match uu____9746 with
-                       | (k_u',sub_probs) ->
-                           let uu____9876 =
-                             let uu____9884 =
-                               let uu____9885 = new_uvar r zs k_u' in
-                               FStar_All.pipe_left Prims.fst uu____9885 in
-                             let uu____9890 =
-                               let uu____9893 =
-                                 FStar_Syntax_Syntax.mk_Total k_u' in
-                               FStar_Syntax_Util.arrow xs1 uu____9893 in
-                             let uu____9896 =
-                               let uu____9899 =
-                                 FStar_Syntax_Syntax.mk_Total k_u' in
-                               FStar_Syntax_Util.arrow ys1 uu____9899 in
-                             (uu____9884, uu____9890, uu____9896) in
-                           (match uu____9876 with
-                            | (u_zs,knew1,knew2) ->
-                                let sub1 = u_abs knew1 xs1 u_zs in
-                                let uu____9918 =
-                                  occurs_check env wl1 (u1, k1) sub1 in
-                                (match uu____9918 with
-                                 | (occurs_ok,msg) ->
-                                     if Prims.op_Negation occurs_ok
-                                     then
-                                       giveup_or_defer1 orig
-                                         "flex-flex: failed occcurs check"
-                                     else
-                                       (let sol1 = TERM ((u1, k1), sub1) in
-                                        let uu____9942 =
-                                          FStar_Unionfind.equivalent u1 u2 in
-                                        if uu____9942
-                                        then
-                                          let wl2 =
-                                            solve_prob orig None [sol1] wl1 in
-                                          solve env wl2
-                                        else
-                                          (let sub2 = u_abs knew2 ys1 u_zs in
-                                           let uu____9949 =
-                                             occurs_check env wl1 (u2, k2)
-                                               sub2 in
-                                           match uu____9949 with
-                                           | (occurs_ok1,msg1) ->
-                                               if
-                                                 Prims.op_Negation occurs_ok1
-                                               then
-                                                 giveup_or_defer1 orig
-                                                   "flex-flex: failed occurs check"
-                                               else
-                                                 (let sol2 =
-                                                    TERM ((u2, k2), sub2) in
-                                                  let wl2 =
-                                                    solve_prob orig None
-                                                      [sol1; sol2] wl1 in
-                                                  solve env
-                                                    (attempt sub_probs wl2)))))))) in
-             let solve_one_pat uu____10001 uu____10002 =
-               match (uu____10001, uu____10002) with
-               | ((t1,u1,k1,xs),(t2,u2,k2,args2)) ->
-                   ((let uu____10106 =
-                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "Rel") in
-                     if uu____10106
-                     then
-                       let uu____10107 = FStar_Syntax_Print.term_to_string t1 in
-                       let uu____10108 = FStar_Syntax_Print.term_to_string t2 in
-                       FStar_Util.print2
-                         "Trying flex-flex one pattern (%s) with %s\n"
-                         uu____10107 uu____10108
-                     else ());
-                    (let uu____10110 = FStar_Unionfind.equivalent u1 u2 in
-                     if uu____10110
-                     then
-                       let sub_probs =
-                         FStar_List.map2
-                           (fun uu____10120  ->
-                              fun uu____10121  ->
-                                match (uu____10120, uu____10121) with
-                                | ((a,uu____10131),(t21,uu____10133)) ->
-                                    let uu____10138 =
-                                      let uu____10141 =
-                                        FStar_Syntax_Syntax.bv_to_name a in
-                                      mk_problem (p_scope orig) orig
-                                        uu____10141
-                                        FStar_TypeChecker_Common.EQ t21 None
-                                        "flex-flex index" in
-                                    FStar_All.pipe_right uu____10138
-                                      (fun _0_59  ->
-                                         FStar_TypeChecker_Common.TProb _0_59))
-                           xs args2 in
-                       let guard =
-                         let uu____10145 =
-                           FStar_List.map
-                             (fun p  ->
-                                FStar_All.pipe_right (p_guard p) Prims.fst)
-                             sub_probs in
-                         FStar_Syntax_Util.mk_conj_l uu____10145 in
-                       let wl1 = solve_prob orig (Some guard) [] wl in
-                       solve env (attempt sub_probs wl1)
-                     else
-                       (let t21 = sn env t2 in
-                        let rhs_vars = FStar_Syntax_Free.names t21 in
-                        let uu____10155 = occurs_check env wl (u1, k1) t21 in
-                        match uu____10155 with
-                        | (occurs_ok,uu____10164) ->
-                            let lhs_vars =
-                              FStar_Syntax_Free.names_of_binders xs in
-                            let uu____10169 =
-                              occurs_ok &&
-                                (FStar_Util.set_is_subset_of rhs_vars
-                                   lhs_vars) in
-                            if uu____10169
-                            then
-                              let sol =
-                                let uu____10171 =
-                                  let uu____10176 = u_abs k1 xs t21 in
-                                  ((u1, k1), uu____10176) in
-                                TERM uu____10171 in
-                              let wl1 = solve_prob orig None [sol] wl in
-                              solve env wl1
-                            else
-                              (let uu____10189 =
-                                 occurs_ok &&
-                                   (FStar_All.pipe_left Prims.op_Negation
-                                      wl.defer_ok) in
-                               if uu____10189
-                               then
-                                 let uu____10190 =
-                                   force_quasi_pattern (Some xs)
-                                     (t21, u2, k2, args2) in
-                                 match uu____10190 with
-                                 | (sol,(uu____10204,u21,k21,ys)) ->
-                                     let wl1 =
-                                       extend_solution (p_pid orig) [sol] wl in
-                                     ((let uu____10214 =
-                                         FStar_All.pipe_left
-                                           (FStar_TypeChecker_Env.debug env)
-                                           (FStar_Options.Other
-                                              "QuasiPattern") in
-                                       if uu____10214
-                                       then
-                                         let uu____10215 =
-                                           uvi_to_string env sol in
-                                         FStar_Util.print1
-                                           "flex-flex quasi pattern (2): %s\n"
-                                           uu____10215
-                                       else ());
-                                      (match orig with
-                                       | FStar_TypeChecker_Common.TProb p ->
-                                           solve_t env p wl1
-                                       | uu____10220 ->
-                                           giveup env "impossible" orig))
-                               else
-                                 giveup_or_defer1 orig "flex-flex constraint")))) in
-             let uu____10222 = lhs in
-             match uu____10222 with
-             | (t1,u1,k1,args1) ->
-                 let uu____10227 = rhs in
-                 (match uu____10227 with
-                  | (t2,u2,k2,args2) ->
-                      let maybe_pat_vars1 = pat_vars env [] args1 in
-                      let maybe_pat_vars2 = pat_vars env [] args2 in
-                      let r = t2.FStar_Syntax_Syntax.pos in
-                      (match (maybe_pat_vars1, maybe_pat_vars2) with
-                       | (Some xs,Some ys) ->
-                           solve_both_pats wl (u1, k1, xs, args1)
-                             (u2, k2, ys, args2) t2.FStar_Syntax_Syntax.pos
-                       | (Some xs,None ) ->
-                           solve_one_pat (t1, u1, k1, xs) rhs
-                       | (None ,Some ys) ->
-                           solve_one_pat (t2, u2, k2, ys) lhs
-                       | uu____10253 ->
-                           if wl.defer_ok
-                           then
-                             giveup_or_defer1 orig
-                               "flex-flex: neither side is a pattern"
-                           else
-                             (let uu____10259 =
-                                force_quasi_pattern None (t1, u1, k1, args1) in
-                              match uu____10259 with
-                              | (sol,uu____10266) ->
-                                  let wl1 =
-                                    extend_solution (p_pid orig) [sol] wl in
-                                  ((let uu____10269 =
-                                      FStar_All.pipe_left
-                                        (FStar_TypeChecker_Env.debug env)
-                                        (FStar_Options.Other "QuasiPattern") in
-                                    if uu____10269
-                                    then
-                                      let uu____10270 = uvi_to_string env sol in
-                                      FStar_Util.print1
-                                        "flex-flex quasi pattern (1): %s\n"
-                                        uu____10270
-                                    else ());
-                                   (match orig with
-                                    | FStar_TypeChecker_Common.TProb p ->
-                                        solve_t env p wl1
-                                    | uu____10275 ->
-                                        giveup env "impossible" orig)))))) in
-        let orig = FStar_TypeChecker_Common.TProb problem in
-        let uu____10277 =
-          FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
-            problem.FStar_TypeChecker_Common.rhs in
-        if uu____10277
-        then
-          let uu____10278 = solve_prob orig None [] wl in
-          solve env uu____10278
-        else
-          (let t1 = problem.FStar_TypeChecker_Common.lhs in
-           let t2 = problem.FStar_TypeChecker_Common.rhs in
-           let uu____10282 = FStar_Util.physical_equality t1 t2 in
-           if uu____10282
-           then
-             let uu____10283 = solve_prob orig None [] wl in
-             solve env uu____10283
-           else
-             ((let uu____10286 =
-                 FStar_TypeChecker_Env.debug env
-                   (FStar_Options.Other "RelCheck") in
-               if uu____10286
-               then
-                 let uu____10287 =
-                   FStar_Util.string_of_int
-                     problem.FStar_TypeChecker_Common.pid in
-                 FStar_Util.print1 "Attempting %s\n" uu____10287
-               else ());
-              (let r = FStar_TypeChecker_Env.get_range env in
-               match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
-               with
-               | (FStar_Syntax_Syntax.Tm_bvar _,_)
-                 |(_,FStar_Syntax_Syntax.Tm_bvar _) ->
-                   failwith
-                     "Only locally nameless! We should never see a de Bruijn variable"
-               | (FStar_Syntax_Syntax.Tm_type u1,FStar_Syntax_Syntax.Tm_type
-                  u2) -> solve_one_universe_eq env orig u1 u2 wl
-               | (FStar_Syntax_Syntax.Tm_arrow
-                  (bs1,c1),FStar_Syntax_Syntax.Tm_arrow (bs2,c2)) ->
-                   let mk_c c uu___127_10333 =
-                     match uu___127_10333 with
-                     | [] -> c
-                     | bs ->
-                         let uu____10347 =
-                           (FStar_Syntax_Syntax.mk
-                              (FStar_Syntax_Syntax.Tm_arrow (bs, c))) None
-                             c.FStar_Syntax_Syntax.pos in
-                         FStar_Syntax_Syntax.mk_Total uu____10347 in
-                   let uu____10361 =
-                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2)) in
-                   (match uu____10361 with
-                    | ((bs11,c11),(bs21,c21)) ->
-                        solve_binders env bs11 bs21 orig wl
-                          (fun scope  ->
-                             fun env1  ->
-                               fun subst1  ->
-                                 let c12 =
-                                   FStar_Syntax_Subst.subst_comp subst1 c11 in
-                                 let c22 =
-                                   FStar_Syntax_Subst.subst_comp subst1 c21 in
-                                 let rel =
-                                   let uu____10447 =
-                                     FStar_Options.use_eq_at_higher_order () in
-                                   if uu____10447
-                                   then FStar_TypeChecker_Common.EQ
-                                   else
-                                     problem.FStar_TypeChecker_Common.relation in
-                                 let uu____10449 =
-                                   mk_problem scope orig c12 rel c22 None
-                                     "function co-domain" in
-                                 FStar_All.pipe_left
-                                   (fun _0_60  ->
-                                      FStar_TypeChecker_Common.CProb _0_60)
-                                   uu____10449))
-               | (FStar_Syntax_Syntax.Tm_abs
-                  (bs1,tbody1,lopt1),FStar_Syntax_Syntax.Tm_abs
-                  (bs2,tbody2,lopt2)) ->
-                   let mk_t t l uu___128_10526 =
-                     match uu___128_10526 with
-                     | [] -> t
-                     | bs ->
-                         (FStar_Syntax_Syntax.mk
-                            (FStar_Syntax_Syntax.Tm_abs (bs, t, l))) None
-                           t.FStar_Syntax_Syntax.pos in
-                   let uu____10565 =
-                     match_num_binders (bs1, (mk_t tbody1 lopt1))
-                       (bs2, (mk_t tbody2 lopt2)) in
-                   (match uu____10565 with
-                    | ((bs11,tbody11),(bs21,tbody21)) ->
-                        solve_binders env bs11 bs21 orig wl
-                          (fun scope  ->
-                             fun env1  ->
-                               fun subst1  ->
-                                 let uu____10648 =
-                                   let uu____10651 =
-                                     FStar_Syntax_Subst.subst subst1 tbody11 in
-                                   let uu____10652 =
-                                     FStar_Syntax_Subst.subst subst1 tbody21 in
-                                   mk_problem scope orig uu____10651
-                                     problem.FStar_TypeChecker_Common.relation
-                                     uu____10652 None "lambda co-domain" in
-                                 FStar_All.pipe_left
-                                   (fun _0_61  ->
-                                      FStar_TypeChecker_Common.TProb _0_61)
-                                   uu____10648))
-               | (FStar_Syntax_Syntax.Tm_abs _,_)
-                 |(_,FStar_Syntax_Syntax.Tm_abs _) ->
-                   let is_abs t =
-                     match t.FStar_Syntax_Syntax.n with
-                     | FStar_Syntax_Syntax.Tm_abs uu____10667 -> true
-                     | uu____10682 -> false in
-                   let maybe_eta t =
-                     if is_abs t
-                     then FStar_Util.Inl t
-                     else
-                       (let t3 =
-                          FStar_TypeChecker_Normalize.eta_expand wl.tcenv t in
-                        if is_abs t3
-                        then FStar_Util.Inl t3
-                        else FStar_Util.Inr t3) in
-                   let uu____10710 =
-                     let uu____10721 = maybe_eta t1 in
-                     let uu____10726 = maybe_eta t2 in
-                     (uu____10721, uu____10726) in
-                   (match uu____10710 with
-                    | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
-                        solve_t env
-                          (let uu___161_10757 = problem in
-                           {
-                             FStar_TypeChecker_Common.pid =
-                               (uu___161_10757.FStar_TypeChecker_Common.pid);
-                             FStar_TypeChecker_Common.lhs = t11;
-                             FStar_TypeChecker_Common.relation =
-                               (uu___161_10757.FStar_TypeChecker_Common.relation);
-                             FStar_TypeChecker_Common.rhs = t21;
-                             FStar_TypeChecker_Common.element =
-                               (uu___161_10757.FStar_TypeChecker_Common.element);
-                             FStar_TypeChecker_Common.logical_guard =
-                               (uu___161_10757.FStar_TypeChecker_Common.logical_guard);
-                             FStar_TypeChecker_Common.scope =
-                               (uu___161_10757.FStar_TypeChecker_Common.scope);
-                             FStar_TypeChecker_Common.reason =
-                               (uu___161_10757.FStar_TypeChecker_Common.reason);
-                             FStar_TypeChecker_Common.loc =
-                               (uu___161_10757.FStar_TypeChecker_Common.loc);
-                             FStar_TypeChecker_Common.rank =
-                               (uu___161_10757.FStar_TypeChecker_Common.rank)
-                           }) wl
-                    | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs)
-                      |(FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
-                        let uu____10790 =
-                          (is_flex not_abs) &&
-                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                        if uu____10790
-                        then
-                          let uu____10791 = destruct_flex_pattern env not_abs in
-                          solve_t_flex_rigid true orig uu____10791 t_abs wl
-                        else
-                          giveup env
-                            "head tag mismatch: RHS is an abstraction" orig
-                    | uu____10796 ->
-                        failwith
-                          "Impossible: at least one side is an abstraction")
-               | (FStar_Syntax_Syntax.Tm_refine
-                  uu____10807,FStar_Syntax_Syntax.Tm_refine uu____10808) ->
-                   let uu____10817 = as_refinement env wl t1 in
-                   (match uu____10817 with
-                    | (x1,phi1) ->
-                        let uu____10822 = as_refinement env wl t2 in
-                        (match uu____10822 with
-                         | (x2,phi2) ->
-                             let base_prob =
-                               let uu____10828 =
-                                 mk_problem (p_scope orig) orig
-                                   x1.FStar_Syntax_Syntax.sort
-                                   problem.FStar_TypeChecker_Common.relation
-                                   x2.FStar_Syntax_Syntax.sort
-                                   problem.FStar_TypeChecker_Common.element
-                                   "refinement base type" in
-                               FStar_All.pipe_left
-                                 (fun _0_62  ->
-                                    FStar_TypeChecker_Common.TProb _0_62)
-                                 uu____10828 in
-                             let x11 = FStar_Syntax_Syntax.freshen_bv x1 in
-                             let subst1 =
-                               [FStar_Syntax_Syntax.DB
-                                  ((Prims.parse_int "0"), x11)] in
-                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1 in
-                             let phi21 = FStar_Syntax_Subst.subst subst1 phi2 in
-                             let env1 = FStar_TypeChecker_Env.push_bv env x11 in
-                             let mk_imp1 imp phi12 phi22 =
-                               let uu____10861 = imp phi12 phi22 in
-                               FStar_All.pipe_right uu____10861
-                                 (guard_on_element wl problem x11) in
-                             let fallback uu____10865 =
-                               let impl =
-                                 if
-                                   problem.FStar_TypeChecker_Common.relation
-                                     = FStar_TypeChecker_Common.EQ
-                                 then
-                                   mk_imp1 FStar_Syntax_Util.mk_iff phi11
-                                     phi21
-                                 else
-                                   mk_imp1 FStar_Syntax_Util.mk_imp phi11
-                                     phi21 in
-                               let guard =
-                                 let uu____10871 =
-                                   FStar_All.pipe_right (p_guard base_prob)
-                                     Prims.fst in
-                                 FStar_Syntax_Util.mk_conj uu____10871 impl in
-                               let wl1 = solve_prob orig (Some guard) [] wl in
-                               solve env1 (attempt [base_prob] wl1) in
-                             if
-                               problem.FStar_TypeChecker_Common.relation =
-                                 FStar_TypeChecker_Common.EQ
-                             then
-                               let ref_prob =
-                                 let uu____10878 =
-                                   let uu____10881 =
-                                     let uu____10882 =
-                                       FStar_Syntax_Syntax.mk_binder x11 in
-                                     uu____10882 :: (p_scope orig) in
-                                   mk_problem uu____10881 orig phi11
-                                     FStar_TypeChecker_Common.EQ phi21 None
-                                     "refinement formula" in
-                                 FStar_All.pipe_left
-                                   (fun _0_63  ->
-                                      FStar_TypeChecker_Common.TProb _0_63)
-                                   uu____10878 in
-                               let uu____10885 =
-                                 solve env1
-                                   (let uu___162_10886 = wl in
-                                    {
-                                      attempting = [ref_prob];
-                                      wl_deferred = [];
-                                      ctr = (uu___162_10886.ctr);
-                                      defer_ok = false;
-                                      smt_ok = (uu___162_10886.smt_ok);
-                                      tcenv = (uu___162_10886.tcenv)
-                                    }) in
-                               (match uu____10885 with
-                                | Failed uu____10890 -> fallback ()
-                                | Success uu____10893 ->
-                                    let guard =
-                                      let uu____10897 =
-                                        FStar_All.pipe_right
-                                          (p_guard base_prob) Prims.fst in
-                                      let uu____10900 =
-                                        let uu____10901 =
-                                          FStar_All.pipe_right
-                                            (p_guard ref_prob) Prims.fst in
-                                        FStar_All.pipe_right uu____10901
-                                          (guard_on_element wl problem x11) in
-                                      FStar_Syntax_Util.mk_conj uu____10897
-                                        uu____10900 in
-                                    let wl1 =
-                                      solve_prob orig (Some guard) [] wl in
-                                    let wl2 =
-                                      let uu___163_10908 = wl1 in
-                                      {
-                                        attempting =
-                                          (uu___163_10908.attempting);
-                                        wl_deferred =
-                                          (uu___163_10908.wl_deferred);
-                                        ctr =
-                                          (wl1.ctr + (Prims.parse_int "1"));
-                                        defer_ok = (uu___163_10908.defer_ok);
-                                        smt_ok = (uu___163_10908.smt_ok);
-                                        tcenv = (uu___163_10908.tcenv)
-                                      } in
-                                    solve env1 (attempt [base_prob] wl2))
-                             else fallback ()))
-               | (FStar_Syntax_Syntax.Tm_uvar _,FStar_Syntax_Syntax.Tm_uvar
-                  _)
-                 |(FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_),FStar_Syntax_Syntax.Tm_uvar
-                   _)
-                  |(FStar_Syntax_Syntax.Tm_uvar _,FStar_Syntax_Syntax.Tm_app
-                    ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                       FStar_Syntax_Syntax.tk = _;
-                       FStar_Syntax_Syntax.pos = _;
-                       FStar_Syntax_Syntax.vars = _;_},_))
-                   |(FStar_Syntax_Syntax.Tm_app
-                     ({
-                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                        FStar_Syntax_Syntax.tk = _;
-                        FStar_Syntax_Syntax.pos = _;
-                        FStar_Syntax_Syntax.vars = _;_},_),FStar_Syntax_Syntax.Tm_app
-                     ({
-                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                        FStar_Syntax_Syntax.tk = _;
-                        FStar_Syntax_Syntax.pos = _;
-                        FStar_Syntax_Syntax.vars = _;_},_))
-                   ->
-                   let uu____10962 = destruct_flex_t t1 in
-                   let uu____10963 = destruct_flex_t t2 in
-                   flex_flex1 orig uu____10962 uu____10963
-               | (FStar_Syntax_Syntax.Tm_uvar _,_)
-                 |(FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_),_)
-                   when
-                   problem.FStar_TypeChecker_Common.relation =
-                     FStar_TypeChecker_Common.EQ
-                   ->
-                   let uu____10979 = destruct_flex_pattern env t1 in
-                   solve_t_flex_rigid false orig uu____10979 t2 wl
-               | (_,FStar_Syntax_Syntax.Tm_uvar _)
-                 |(_,FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_))
-                   when
-                   problem.FStar_TypeChecker_Common.relation =
-                     FStar_TypeChecker_Common.EQ
-                   -> solve_t env (invert problem) wl
-               | (FStar_Syntax_Syntax.Tm_uvar _,FStar_Syntax_Syntax.Tm_type
-                  _)
-                 |(FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_),FStar_Syntax_Syntax.Tm_type
-                   _)
-                  |(FStar_Syntax_Syntax.Tm_uvar
-                    _,FStar_Syntax_Syntax.Tm_arrow _)
-                   |(FStar_Syntax_Syntax.Tm_app
-                     ({
-                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                        FStar_Syntax_Syntax.tk = _;
-                        FStar_Syntax_Syntax.pos = _;
-                        FStar_Syntax_Syntax.vars = _;_},_),FStar_Syntax_Syntax.Tm_arrow
-                     _)
-                   ->
-                   solve_t' env
-                     (let uu___164_11028 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___164_11028.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs =
-                          (uu___164_11028.FStar_TypeChecker_Common.lhs);
-                        FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ;
-                        FStar_TypeChecker_Common.rhs =
-                          (uu___164_11028.FStar_TypeChecker_Common.rhs);
-                        FStar_TypeChecker_Common.element =
-                          (uu___164_11028.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___164_11028.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___164_11028.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___164_11028.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___164_11028.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___164_11028.FStar_TypeChecker_Common.rank)
-                      }) wl
-               | (FStar_Syntax_Syntax.Tm_uvar _,_)
-                 |(FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_),_)
-                   ->
-                   if wl.defer_ok
-                   then
-                     solve env
-                       (defer "flex-rigid subtyping deferred" orig wl)
-                   else
-                     (let new_rel = problem.FStar_TypeChecker_Common.relation in
-                      let uu____11046 =
-                        let uu____11047 = is_top_level_prob orig in
-                        FStar_All.pipe_left Prims.op_Negation uu____11047 in
-                      if uu____11046
-                      then
-                        let uu____11048 =
-                          FStar_All.pipe_left
-                            (fun _0_64  ->
-                               FStar_TypeChecker_Common.TProb _0_64)
-                            (let uu___165_11051 = problem in
-                             {
-                               FStar_TypeChecker_Common.pid =
-                                 (uu___165_11051.FStar_TypeChecker_Common.pid);
-                               FStar_TypeChecker_Common.lhs =
-                                 (uu___165_11051.FStar_TypeChecker_Common.lhs);
-                               FStar_TypeChecker_Common.relation = new_rel;
-                               FStar_TypeChecker_Common.rhs =
-                                 (uu___165_11051.FStar_TypeChecker_Common.rhs);
-                               FStar_TypeChecker_Common.element =
-                                 (uu___165_11051.FStar_TypeChecker_Common.element);
-                               FStar_TypeChecker_Common.logical_guard =
-                                 (uu___165_11051.FStar_TypeChecker_Common.logical_guard);
-                               FStar_TypeChecker_Common.scope =
-                                 (uu___165_11051.FStar_TypeChecker_Common.scope);
-                               FStar_TypeChecker_Common.reason =
-                                 (uu___165_11051.FStar_TypeChecker_Common.reason);
-                               FStar_TypeChecker_Common.loc =
-                                 (uu___165_11051.FStar_TypeChecker_Common.loc);
-                               FStar_TypeChecker_Common.rank =
-                                 (uu___165_11051.FStar_TypeChecker_Common.rank)
-                             }) in
-                        let uu____11052 = destruct_flex_pattern env t1 in
-                        solve_t_flex_rigid false uu____11048 uu____11052 t2
-                          wl
-                      else
-                        (let uu____11057 = base_and_refinement env wl t2 in
-                         match uu____11057 with
-                         | (t_base,ref_opt) ->
-                             (match ref_opt with
-                              | None  ->
-                                  let uu____11087 =
-                                    FStar_All.pipe_left
-                                      (fun _0_65  ->
-                                         FStar_TypeChecker_Common.TProb _0_65)
-                                      (let uu___166_11090 = problem in
-                                       {
-                                         FStar_TypeChecker_Common.pid =
-                                           (uu___166_11090.FStar_TypeChecker_Common.pid);
-                                         FStar_TypeChecker_Common.lhs =
-                                           (uu___166_11090.FStar_TypeChecker_Common.lhs);
-                                         FStar_TypeChecker_Common.relation =
-                                           new_rel;
-                                         FStar_TypeChecker_Common.rhs =
-                                           (uu___166_11090.FStar_TypeChecker_Common.rhs);
-                                         FStar_TypeChecker_Common.element =
-                                           (uu___166_11090.FStar_TypeChecker_Common.element);
-                                         FStar_TypeChecker_Common.logical_guard
-                                           =
-                                           (uu___166_11090.FStar_TypeChecker_Common.logical_guard);
-                                         FStar_TypeChecker_Common.scope =
-                                           (uu___166_11090.FStar_TypeChecker_Common.scope);
-                                         FStar_TypeChecker_Common.reason =
-                                           (uu___166_11090.FStar_TypeChecker_Common.reason);
-                                         FStar_TypeChecker_Common.loc =
-                                           (uu___166_11090.FStar_TypeChecker_Common.loc);
-                                         FStar_TypeChecker_Common.rank =
-                                           (uu___166_11090.FStar_TypeChecker_Common.rank)
-                                       }) in
-                                  let uu____11091 =
-                                    destruct_flex_pattern env t1 in
-                                  solve_t_flex_rigid false uu____11087
-                                    uu____11091 t_base wl
-                              | Some (y,phi) ->
-                                  let y' =
-                                    let uu___167_11106 = y in
-                                    {
-                                      FStar_Syntax_Syntax.ppname =
-                                        (uu___167_11106.FStar_Syntax_Syntax.ppname);
-                                      FStar_Syntax_Syntax.index =
-                                        (uu___167_11106.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = t1
-                                    } in
-                                  let impl =
-                                    guard_on_element wl problem y' phi in
-                                  let base_prob =
-                                    let uu____11109 =
-                                      mk_problem
-                                        problem.FStar_TypeChecker_Common.scope
-                                        orig t1 new_rel
-                                        y.FStar_Syntax_Syntax.sort
-                                        problem.FStar_TypeChecker_Common.element
-                                        "flex-rigid: base type" in
-                                    FStar_All.pipe_left
-                                      (fun _0_66  ->
-                                         FStar_TypeChecker_Common.TProb _0_66)
-                                      uu____11109 in
-                                  let guard =
-                                    let uu____11117 =
-                                      FStar_All.pipe_right
-                                        (p_guard base_prob) Prims.fst in
-                                    FStar_Syntax_Util.mk_conj uu____11117
-                                      impl in
-                                  let wl1 =
-                                    solve_prob orig (Some guard) [] wl in
-                                  solve env (attempt [base_prob] wl1))))
-               | (_,FStar_Syntax_Syntax.Tm_uvar _)
-                 |(_,FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_))
-                   ->
-                   if wl.defer_ok
-                   then
-                     solve env
-                       (defer "rigid-flex subtyping deferred" orig wl)
-                   else
-                     (let uu____11139 = base_and_refinement env wl t1 in
-                      match uu____11139 with
-                      | (t_base,uu____11150) ->
-                          solve_t env
-                            (let uu___168_11165 = problem in
-                             {
-                               FStar_TypeChecker_Common.pid =
-                                 (uu___168_11165.FStar_TypeChecker_Common.pid);
-                               FStar_TypeChecker_Common.lhs = t_base;
-                               FStar_TypeChecker_Common.relation =
-                                 FStar_TypeChecker_Common.EQ;
-                               FStar_TypeChecker_Common.rhs =
-                                 (uu___168_11165.FStar_TypeChecker_Common.rhs);
-                               FStar_TypeChecker_Common.element =
-                                 (uu___168_11165.FStar_TypeChecker_Common.element);
-                               FStar_TypeChecker_Common.logical_guard =
-                                 (uu___168_11165.FStar_TypeChecker_Common.logical_guard);
-                               FStar_TypeChecker_Common.scope =
-                                 (uu___168_11165.FStar_TypeChecker_Common.scope);
-                               FStar_TypeChecker_Common.reason =
-                                 (uu___168_11165.FStar_TypeChecker_Common.reason);
-                               FStar_TypeChecker_Common.loc =
-                                 (uu___168_11165.FStar_TypeChecker_Common.loc);
-                               FStar_TypeChecker_Common.rank =
-                                 (uu___168_11165.FStar_TypeChecker_Common.rank)
-                             }) wl)
-               | (FStar_Syntax_Syntax.Tm_refine uu____11168,uu____11169) ->
-                   let t21 =
-                     let uu____11177 = base_and_refinement env wl t2 in
-                     FStar_All.pipe_left force_refinement uu____11177 in
-                   solve_t env
-                     (let uu___169_11190 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___169_11190.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs =
-                          (uu___169_11190.FStar_TypeChecker_Common.lhs);
-                        FStar_TypeChecker_Common.relation =
-                          (uu___169_11190.FStar_TypeChecker_Common.relation);
-                        FStar_TypeChecker_Common.rhs = t21;
-                        FStar_TypeChecker_Common.element =
-                          (uu___169_11190.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___169_11190.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___169_11190.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___169_11190.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___169_11190.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___169_11190.FStar_TypeChecker_Common.rank)
-                      }) wl
-               | (uu____11191,FStar_Syntax_Syntax.Tm_refine uu____11192) ->
-                   let t11 =
-                     let uu____11200 = base_and_refinement env wl t1 in
-                     FStar_All.pipe_left force_refinement uu____11200 in
-                   solve_t env
-                     (let uu___170_11213 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___170_11213.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs = t11;
-                        FStar_TypeChecker_Common.relation =
-                          (uu___170_11213.FStar_TypeChecker_Common.relation);
-                        FStar_TypeChecker_Common.rhs =
-                          (uu___170_11213.FStar_TypeChecker_Common.rhs);
-                        FStar_TypeChecker_Common.element =
-                          (uu___170_11213.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___170_11213.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___170_11213.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___170_11213.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___170_11213.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___170_11213.FStar_TypeChecker_Common.rank)
-                      }) wl
-               | (FStar_Syntax_Syntax.Tm_match _,_)
-                 |(FStar_Syntax_Syntax.Tm_uinst _,_)
-                  |(FStar_Syntax_Syntax.Tm_name _,_)
-                   |(FStar_Syntax_Syntax.Tm_constant _,_)
-                    |(FStar_Syntax_Syntax.Tm_fvar _,_)
-                     |(FStar_Syntax_Syntax.Tm_app _,_)
-                      |(_,FStar_Syntax_Syntax.Tm_match _)
-                       |(_,FStar_Syntax_Syntax.Tm_uinst _)
-                        |(_,FStar_Syntax_Syntax.Tm_name _)
-                         |(_,FStar_Syntax_Syntax.Tm_constant _)
-                          |(_,FStar_Syntax_Syntax.Tm_fvar _)
-                           |(_,FStar_Syntax_Syntax.Tm_app _)
-                   ->
-                   let head1 =
-                     let uu____11243 = FStar_Syntax_Util.head_and_args t1 in
-                     FStar_All.pipe_right uu____11243 Prims.fst in
-                   let head2 =
-                     let uu____11274 = FStar_Syntax_Util.head_and_args t2 in
-                     FStar_All.pipe_right uu____11274 Prims.fst in
-                   let uu____11302 =
-                     (((FStar_TypeChecker_Env.is_interpreted env head1) ||
-                         (FStar_TypeChecker_Env.is_interpreted env head2))
-                        && wl.smt_ok)
-                       &&
-                       (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ) in
-                   if uu____11302
-                   then
-                     let uv1 = FStar_Syntax_Free.uvars t1 in
-                     let uv2 = FStar_Syntax_Free.uvars t2 in
-                     let uu____11311 =
-                       (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2) in
-                     (if uu____11311
-                      then
-                        let guard =
-                          let uu____11318 =
-                            let uu____11319 = FStar_Syntax_Util.eq_tm t1 t2 in
-                            uu____11319 = FStar_Syntax_Util.Equal in
-                          if uu____11318
-                          then None
-                          else
-                            (let uu____11322 = mk_eq2 env t1 t2 in
-                             FStar_All.pipe_left (fun _0_67  -> Some _0_67)
-                               uu____11322) in
-                        let uu____11324 = solve_prob orig guard [] wl in
-                        solve env uu____11324
-                      else rigid_rigid_delta env orig wl head1 head2 t1 t2)
-                   else rigid_rigid_delta env orig wl head1 head2 t1 t2
-               | (FStar_Syntax_Syntax.Tm_ascribed
-                  (t11,uu____11328,uu____11329),uu____11330) ->
-                   solve_t' env
-                     (let uu___171_11359 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___171_11359.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs = t11;
-                        FStar_TypeChecker_Common.relation =
-                          (uu___171_11359.FStar_TypeChecker_Common.relation);
-                        FStar_TypeChecker_Common.rhs =
-                          (uu___171_11359.FStar_TypeChecker_Common.rhs);
-                        FStar_TypeChecker_Common.element =
-                          (uu___171_11359.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___171_11359.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___171_11359.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___171_11359.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___171_11359.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___171_11359.FStar_TypeChecker_Common.rank)
-                      }) wl
-               | (uu____11362,FStar_Syntax_Syntax.Tm_ascribed
-                  (t21,uu____11364,uu____11365)) ->
-                   solve_t' env
-                     (let uu___172_11394 = problem in
-                      {
-                        FStar_TypeChecker_Common.pid =
-                          (uu___172_11394.FStar_TypeChecker_Common.pid);
-                        FStar_TypeChecker_Common.lhs =
-                          (uu___172_11394.FStar_TypeChecker_Common.lhs);
-                        FStar_TypeChecker_Common.relation =
-                          (uu___172_11394.FStar_TypeChecker_Common.relation);
-                        FStar_TypeChecker_Common.rhs = t21;
-                        FStar_TypeChecker_Common.element =
-                          (uu___172_11394.FStar_TypeChecker_Common.element);
-                        FStar_TypeChecker_Common.logical_guard =
-                          (uu___172_11394.FStar_TypeChecker_Common.logical_guard);
-                        FStar_TypeChecker_Common.scope =
-                          (uu___172_11394.FStar_TypeChecker_Common.scope);
-                        FStar_TypeChecker_Common.reason =
-                          (uu___172_11394.FStar_TypeChecker_Common.reason);
-                        FStar_TypeChecker_Common.loc =
-                          (uu___172_11394.FStar_TypeChecker_Common.loc);
-                        FStar_TypeChecker_Common.rank =
-                          (uu___172_11394.FStar_TypeChecker_Common.rank)
-                      }) wl
-               | (FStar_Syntax_Syntax.Tm_let _,_)
-                 |(FStar_Syntax_Syntax.Tm_meta _,_)
-                  |(FStar_Syntax_Syntax.Tm_delayed _,_)
-                   |(_,FStar_Syntax_Syntax.Tm_meta _)
-                    |(_,FStar_Syntax_Syntax.Tm_delayed _)
-                     |(_,FStar_Syntax_Syntax.Tm_let _)
-                   ->
-                   let uu____11407 =
-                     let uu____11408 = FStar_Syntax_Print.tag_of_term t1 in
-                     let uu____11409 = FStar_Syntax_Print.tag_of_term t2 in
-                     FStar_Util.format2 "Impossible: %s and %s" uu____11408
-                       uu____11409 in
-                   failwith uu____11407
-               | uu____11410 -> giveup env "head tag mismatch" orig)))
-and solve_c:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.comp,Prims.unit) FStar_TypeChecker_Common.problem ->
-      worklist -> solution
-  =
-  fun env  ->
-    fun problem  ->
-      fun wl  ->
-        let c1 = problem.FStar_TypeChecker_Common.lhs in
-        let c2 = problem.FStar_TypeChecker_Common.rhs in
-        let orig = FStar_TypeChecker_Common.CProb problem in
-        let sub_prob t1 rel t2 reason =
-          mk_problem (p_scope orig) orig t1 rel t2 None reason in
-        let solve_eq c1_comp c2_comp =
-          (let uu____11442 =
-             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "EQ") in
-           if uu____11442
-           then
-             FStar_Util.print_string
-               "solve_c is using an equality constraint\n"
-           else ());
-          (let sub_probs =
-             FStar_List.map2
-               (fun uu____11450  ->
-                  fun uu____11451  ->
-                    match (uu____11450, uu____11451) with
-                    | ((a1,uu____11461),(a2,uu____11463)) ->
-                        let uu____11468 =
-                          sub_prob a1 FStar_TypeChecker_Common.EQ a2
-                            "effect arg" in
-                        FStar_All.pipe_left
-                          (fun _0_68  -> FStar_TypeChecker_Common.TProb _0_68)
-                          uu____11468)
-               c1_comp.FStar_Syntax_Syntax.effect_args
-               c2_comp.FStar_Syntax_Syntax.effect_args in
-           let guard =
-             let uu____11474 =
-               FStar_List.map
-                 (fun p  -> FStar_All.pipe_right (p_guard p) Prims.fst)
-                 sub_probs in
-             FStar_Syntax_Util.mk_conj_l uu____11474 in
-           let wl1 = solve_prob orig (Some guard) [] wl in
-           solve env (attempt sub_probs wl1)) in
-        let solve_sub c11 edge c21 =
-          let r = FStar_TypeChecker_Env.get_range env in
-          let lift_c1 uu____11494 =
-            let wp =
-              match c11.FStar_Syntax_Syntax.effect_args with
-              | (wp1,uu____11501)::[] -> wp1
-              | uu____11514 ->
-                  let uu____11520 =
-                    let uu____11521 =
-                      FStar_Range.string_of_range
-                        (FStar_Ident.range_of_lid
-                           c11.FStar_Syntax_Syntax.effect_name) in
-                    FStar_Util.format1
-                      "Unexpected number of indices on a normalized effect (%s)"
-                      uu____11521 in
-                  failwith uu____11520 in
-            let uu____11524 =
-              let uu____11530 =
-                let uu____11531 =
-                  (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                    c11.FStar_Syntax_Syntax.result_typ wp in
-                FStar_Syntax_Syntax.as_arg uu____11531 in
-              [uu____11530] in
-            {
-              FStar_Syntax_Syntax.comp_univs =
-                (c11.FStar_Syntax_Syntax.comp_univs);
-              FStar_Syntax_Syntax.effect_name =
-                (c21.FStar_Syntax_Syntax.effect_name);
-              FStar_Syntax_Syntax.result_typ =
-                (c11.FStar_Syntax_Syntax.result_typ);
-              FStar_Syntax_Syntax.effect_args = uu____11524;
-              FStar_Syntax_Syntax.flags = (c11.FStar_Syntax_Syntax.flags)
-            } in
-          if
-            problem.FStar_TypeChecker_Common.relation =
-              FStar_TypeChecker_Common.EQ
-          then let uu____11532 = lift_c1 () in solve_eq uu____11532 c21
-          else
-            (let is_null_wp_2 =
-               FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
-                 (FStar_Util.for_some
-                    (fun uu___129_11536  ->
-                       match uu___129_11536 with
-                       | FStar_Syntax_Syntax.TOTAL 
-                         |FStar_Syntax_Syntax.MLEFFECT 
-                          |FStar_Syntax_Syntax.SOMETRIVIAL  -> true
-                       | uu____11537 -> false)) in
-             let uu____11538 =
-               match ((c11.FStar_Syntax_Syntax.effect_args),
-                       (c21.FStar_Syntax_Syntax.effect_args))
-               with
-               | ((wp1,uu____11562)::uu____11563,(wp2,uu____11565)::uu____11566)
-                   -> (wp1, wp2)
-               | uu____11607 ->
-                   let uu____11620 =
-                     let uu____11621 =
-                       FStar_Syntax_Print.lid_to_string
-                         c11.FStar_Syntax_Syntax.effect_name in
-                     let uu____11622 =
-                       FStar_Syntax_Print.lid_to_string
-                         c21.FStar_Syntax_Syntax.effect_name in
-                     FStar_Util.format2
-                       "Got effects %s and %s, expected normalized effects"
-                       uu____11621 uu____11622 in
-                   failwith uu____11620 in
-             match uu____11538 with
-             | (wpc1,wpc2) ->
-                 let uu____11639 = FStar_Util.physical_equality wpc1 wpc2 in
-                 if uu____11639
-                 then
-                   let uu____11642 =
-                     problem_using_guard orig
-                       c11.FStar_Syntax_Syntax.result_typ
-                       problem.FStar_TypeChecker_Common.relation
-                       c21.FStar_Syntax_Syntax.result_typ None "result type" in
-                   solve_t env uu____11642 wl
-                 else
-                   (let c2_decl =
-                      FStar_TypeChecker_Env.get_effect_decl env
-                        c21.FStar_Syntax_Syntax.effect_name in
-                    let uu____11647 =
-                      FStar_All.pipe_right
-                        c2_decl.FStar_Syntax_Syntax.qualifiers
-                        (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
-                    if uu____11647
-                    then
-                      let c1_repr =
-                        let uu____11650 =
-                          let uu____11651 =
-                            let uu____11652 = lift_c1 () in
-                            FStar_Syntax_Syntax.mk_Comp uu____11652 in
-                          let uu____11653 =
-                            env.FStar_TypeChecker_Env.universe_of env
-                              c11.FStar_Syntax_Syntax.result_typ in
-                          FStar_TypeChecker_Env.reify_comp env uu____11651
-                            uu____11653 in
-                        FStar_TypeChecker_Normalize.normalize
-                          [FStar_TypeChecker_Normalize.UnfoldUntil
-                             FStar_Syntax_Syntax.Delta_constant;
-                          FStar_TypeChecker_Normalize.WHNF] env uu____11650 in
-                      let c2_repr =
-                        let uu____11655 =
-                          let uu____11656 = FStar_Syntax_Syntax.mk_Comp c21 in
-                          let uu____11657 =
-                            env.FStar_TypeChecker_Env.universe_of env
-                              c21.FStar_Syntax_Syntax.result_typ in
-                          FStar_TypeChecker_Env.reify_comp env uu____11656
-                            uu____11657 in
-                        FStar_TypeChecker_Normalize.normalize
-                          [FStar_TypeChecker_Normalize.UnfoldUntil
-                             FStar_Syntax_Syntax.Delta_constant;
-                          FStar_TypeChecker_Normalize.WHNF] env uu____11655 in
-                      let prob =
-                        let uu____11659 =
-                          let uu____11662 =
-                            let uu____11663 =
-                              FStar_Syntax_Print.term_to_string c1_repr in
-                            let uu____11664 =
-                              FStar_Syntax_Print.term_to_string c2_repr in
-                            FStar_Util.format2 "sub effect repr: %s <: %s"
-                              uu____11663 uu____11664 in
-                          sub_prob c1_repr
-                            problem.FStar_TypeChecker_Common.relation c2_repr
-                            uu____11662 in
-                        FStar_TypeChecker_Common.TProb uu____11659 in
-                      let wl1 =
-                        let uu____11666 =
-                          let uu____11668 =
-                            FStar_All.pipe_right (p_guard prob) Prims.fst in
-                          Some uu____11668 in
-                        solve_prob orig uu____11666 [] wl in
-                      solve env (attempt [prob] wl1)
-                    else
-                      (let g =
-                         if env.FStar_TypeChecker_Env.lax
-                         then FStar_Syntax_Util.t_true
-                         else
-                           if is_null_wp_2
-                           then
-                             ((let uu____11675 =
-                                 FStar_All.pipe_left
-                                   (FStar_TypeChecker_Env.debug env)
-                                   (FStar_Options.Other "Rel") in
-                               if uu____11675
-                               then
-                                 FStar_Util.print_string
-                                   "Using trivial wp ... \n"
-                               else ());
-                              (let uu____11677 =
-                                 let uu____11680 =
-                                   let uu____11681 =
-                                     let uu____11691 =
-                                       let uu____11692 =
-                                         let uu____11693 =
-                                           env.FStar_TypeChecker_Env.universe_of
-                                             env
-                                             c11.FStar_Syntax_Syntax.result_typ in
-                                         [uu____11693] in
-                                       FStar_TypeChecker_Env.inst_effect_fun_with
-                                         uu____11692 env c2_decl
-                                         c2_decl.FStar_Syntax_Syntax.trivial in
-                                     let uu____11694 =
-                                       let uu____11696 =
-                                         FStar_Syntax_Syntax.as_arg
-                                           c11.FStar_Syntax_Syntax.result_typ in
-                                       let uu____11697 =
-                                         let uu____11699 =
-                                           let uu____11700 =
-                                             (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                                               c11.FStar_Syntax_Syntax.result_typ
-                                               wpc1 in
-                                           FStar_All.pipe_left
-                                             FStar_Syntax_Syntax.as_arg
-                                             uu____11700 in
-                                         [uu____11699] in
-                                       uu____11696 :: uu____11697 in
-                                     (uu____11691, uu____11694) in
-                                   FStar_Syntax_Syntax.Tm_app uu____11681 in
-                                 FStar_Syntax_Syntax.mk uu____11680 in
-                               uu____11677
-                                 (Some
-                                    (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                                 r))
-                           else
-                             (let uu____11711 =
-                                let uu____11714 =
-                                  let uu____11715 =
-                                    let uu____11725 =
-                                      let uu____11726 =
-                                        let uu____11727 =
-                                          env.FStar_TypeChecker_Env.universe_of
-                                            env
-                                            c21.FStar_Syntax_Syntax.result_typ in
-                                        [uu____11727] in
-                                      FStar_TypeChecker_Env.inst_effect_fun_with
-                                        uu____11726 env c2_decl
-                                        c2_decl.FStar_Syntax_Syntax.stronger in
-                                    let uu____11728 =
-                                      let uu____11730 =
-                                        FStar_Syntax_Syntax.as_arg
-                                          c21.FStar_Syntax_Syntax.result_typ in
-                                      let uu____11731 =
-                                        let uu____11733 =
-                                          FStar_Syntax_Syntax.as_arg wpc2 in
-                                        let uu____11734 =
-                                          let uu____11736 =
-                                            let uu____11737 =
-                                              (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                                                c11.FStar_Syntax_Syntax.result_typ
-                                                wpc1 in
-                                            FStar_All.pipe_left
-                                              FStar_Syntax_Syntax.as_arg
-                                              uu____11737 in
-                                          [uu____11736] in
-                                        uu____11733 :: uu____11734 in
-                                      uu____11730 :: uu____11731 in
-                                    (uu____11725, uu____11728) in
-                                  FStar_Syntax_Syntax.Tm_app uu____11715 in
-                                FStar_Syntax_Syntax.mk uu____11714 in
-                              uu____11711
-                                (Some
-                                   (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                                r) in
-                       let base_prob =
-                         let uu____11748 =
-                           sub_prob c11.FStar_Syntax_Syntax.result_typ
-                             problem.FStar_TypeChecker_Common.relation
-                             c21.FStar_Syntax_Syntax.result_typ "result type" in
-                         FStar_All.pipe_left
-                           (fun _0_69  ->
-                              FStar_TypeChecker_Common.TProb _0_69)
-                           uu____11748 in
-                       let wl1 =
-                         let uu____11754 =
-                           let uu____11756 =
-                             let uu____11759 =
-                               FStar_All.pipe_right (p_guard base_prob)
-                                 Prims.fst in
-                             FStar_Syntax_Util.mk_conj uu____11759 g in
-                           FStar_All.pipe_left (fun _0_70  -> Some _0_70)
-                             uu____11756 in
-                         solve_prob orig uu____11754 [] wl in
-                       solve env (attempt [base_prob] wl1)))) in
-        let uu____11769 = FStar_Util.physical_equality c1 c2 in
-        if uu____11769
-        then
-          let uu____11770 = solve_prob orig None [] wl in
-          solve env uu____11770
-        else
-          ((let uu____11773 =
-              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "Rel") in
-            if uu____11773
-            then
-              let uu____11774 = FStar_Syntax_Print.comp_to_string c1 in
-              let uu____11775 = FStar_Syntax_Print.comp_to_string c2 in
-              FStar_Util.print3 "solve_c %s %s %s\n" uu____11774
-                (rel_to_string problem.FStar_TypeChecker_Common.relation)
-                uu____11775
-            else ());
-           (let uu____11777 =
-              let uu____11780 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c1 in
-              let uu____11781 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c2 in
-              (uu____11780, uu____11781) in
-            match uu____11777 with
-            | (c11,c21) ->
-                (match ((c11.FStar_Syntax_Syntax.n),
-                         (c21.FStar_Syntax_Syntax.n))
-                 with
-                 | (FStar_Syntax_Syntax.GTotal
-                    (t1,uu____11785),FStar_Syntax_Syntax.Total
-                    (t2,uu____11787)) when
-                     FStar_Syntax_Util.non_informative t2 ->
-                     let uu____11800 =
-                       problem_using_guard orig t1
-                         problem.FStar_TypeChecker_Common.relation t2 None
-                         "result type" in
-                     solve_t env uu____11800 wl
-                 | (FStar_Syntax_Syntax.GTotal
-                    uu____11803,FStar_Syntax_Syntax.Total uu____11804) ->
-                     giveup env "incompatible monad ordering: GTot </: Tot"
-                       orig
-                 | (FStar_Syntax_Syntax.Total
-                    (t1,_),FStar_Syntax_Syntax.Total (t2,_))
-                   |(FStar_Syntax_Syntax.GTotal
-                     (t1,_),FStar_Syntax_Syntax.GTotal (t2,_))
-                    |(FStar_Syntax_Syntax.Total
-                      (t1,_),FStar_Syntax_Syntax.GTotal (t2,_))
-                     ->
-                     let uu____11853 =
-                       problem_using_guard orig t1
-                         problem.FStar_TypeChecker_Common.relation t2 None
-                         "result type" in
-                     solve_t env uu____11853 wl
-                 | (FStar_Syntax_Syntax.GTotal _,FStar_Syntax_Syntax.Comp _)
-                   |(FStar_Syntax_Syntax.Total _,FStar_Syntax_Syntax.Comp _)
-                     ->
-                     let uu____11860 =
-                       let uu___173_11863 = problem in
-                       let uu____11866 =
-                         let uu____11867 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
-                         FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____11867 in
-                       {
-                         FStar_TypeChecker_Common.pid =
-                           (uu___173_11863.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____11866;
-                         FStar_TypeChecker_Common.relation =
-                           (uu___173_11863.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs =
-                           (uu___173_11863.FStar_TypeChecker_Common.rhs);
-                         FStar_TypeChecker_Common.element =
-                           (uu___173_11863.FStar_TypeChecker_Common.element);
-                         FStar_TypeChecker_Common.logical_guard =
-                           (uu___173_11863.FStar_TypeChecker_Common.logical_guard);
-                         FStar_TypeChecker_Common.scope =
-                           (uu___173_11863.FStar_TypeChecker_Common.scope);
-                         FStar_TypeChecker_Common.reason =
-                           (uu___173_11863.FStar_TypeChecker_Common.reason);
-                         FStar_TypeChecker_Common.loc =
-                           (uu___173_11863.FStar_TypeChecker_Common.loc);
-                         FStar_TypeChecker_Common.rank =
-                           (uu___173_11863.FStar_TypeChecker_Common.rank)
-                       } in
-                     solve_c env uu____11860 wl
-                 | (FStar_Syntax_Syntax.Comp _,FStar_Syntax_Syntax.GTotal _)
-                   |(FStar_Syntax_Syntax.Comp _,FStar_Syntax_Syntax.Total _)
-                     ->
-                     let uu____11872 =
-                       let uu___174_11875 = problem in
-                       let uu____11878 =
-                         let uu____11879 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
-                         FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____11879 in
-                       {
-                         FStar_TypeChecker_Common.pid =
-                           (uu___174_11875.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs =
-                           (uu___174_11875.FStar_TypeChecker_Common.lhs);
-                         FStar_TypeChecker_Common.relation =
-                           (uu___174_11875.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____11878;
-                         FStar_TypeChecker_Common.element =
-                           (uu___174_11875.FStar_TypeChecker_Common.element);
-                         FStar_TypeChecker_Common.logical_guard =
-                           (uu___174_11875.FStar_TypeChecker_Common.logical_guard);
-                         FStar_TypeChecker_Common.scope =
-                           (uu___174_11875.FStar_TypeChecker_Common.scope);
-                         FStar_TypeChecker_Common.reason =
-                           (uu___174_11875.FStar_TypeChecker_Common.reason);
-                         FStar_TypeChecker_Common.loc =
-                           (uu___174_11875.FStar_TypeChecker_Common.loc);
-                         FStar_TypeChecker_Common.rank =
-                           (uu___174_11875.FStar_TypeChecker_Common.rank)
-                       } in
-                     solve_c env uu____11872 wl
-                 | (FStar_Syntax_Syntax.Comp
-                    uu____11880,FStar_Syntax_Syntax.Comp uu____11881) ->
-                     let uu____11882 =
-                       ((FStar_Syntax_Util.is_ml_comp c11) &&
-                          (FStar_Syntax_Util.is_ml_comp c21))
-                         ||
-                         ((FStar_Syntax_Util.is_total_comp c11) &&
-                            ((FStar_Syntax_Util.is_total_comp c21) ||
-                               (FStar_Syntax_Util.is_ml_comp c21))) in
-                     if uu____11882
-                     then
-                       let uu____11883 =
-                         problem_using_guard orig
-                           (FStar_Syntax_Util.comp_result c11)
-                           problem.FStar_TypeChecker_Common.relation
-                           (FStar_Syntax_Util.comp_result c21) None
-                           "result type" in
-                       solve_t env uu____11883 wl
-                     else
-                       (let c1_comp =
-                          FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
-                        let c2_comp =
-                          FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
-                        if
-                          (problem.FStar_TypeChecker_Common.relation =
-                             FStar_TypeChecker_Common.EQ)
-                            &&
-                            (FStar_Ident.lid_equals
-                               c1_comp.FStar_Syntax_Syntax.effect_name
-                               c2_comp.FStar_Syntax_Syntax.effect_name)
-                        then solve_eq c1_comp c2_comp
-                        else
-                          (let c12 =
-                             FStar_TypeChecker_Env.unfold_effect_abbrev env
-                               c11 in
-                           let c22 =
-                             FStar_TypeChecker_Env.unfold_effect_abbrev env
-                               c21 in
-                           (let uu____11893 =
-                              FStar_All.pipe_left
-                                (FStar_TypeChecker_Env.debug env)
-                                (FStar_Options.Other "Rel") in
-                            if uu____11893
-                            then
-                              FStar_Util.print2 "solve_c for %s and %s\n"
-                                (c12.FStar_Syntax_Syntax.effect_name).FStar_Ident.str
-                                (c22.FStar_Syntax_Syntax.effect_name).FStar_Ident.str
-                            else ());
-                           (let uu____11895 =
-                              FStar_TypeChecker_Env.monad_leq env
-                                c12.FStar_Syntax_Syntax.effect_name
-                                c22.FStar_Syntax_Syntax.effect_name in
-                            match uu____11895 with
-                            | None  ->
-                                let uu____11897 =
-                                  ((FStar_Syntax_Util.is_ghost_effect
-                                      c12.FStar_Syntax_Syntax.effect_name)
-                                     &&
-                                     (FStar_Syntax_Util.is_pure_effect
-                                        c22.FStar_Syntax_Syntax.effect_name))
-                                    &&
-                                    (let uu____11898 =
-                                       FStar_TypeChecker_Normalize.normalize
-                                         [FStar_TypeChecker_Normalize.Eager_unfolding;
-                                         FStar_TypeChecker_Normalize.UnfoldUntil
-                                           FStar_Syntax_Syntax.Delta_constant]
-                                         env
-                                         c22.FStar_Syntax_Syntax.result_typ in
-                                     FStar_Syntax_Util.non_informative
-                                       uu____11898) in
-                                if uu____11897
-                                then
-                                  let edge =
-                                    {
-                                      FStar_TypeChecker_Env.msource =
-                                        (c12.FStar_Syntax_Syntax.effect_name);
-                                      FStar_TypeChecker_Env.mtarget =
-                                        (c22.FStar_Syntax_Syntax.effect_name);
-                                      FStar_TypeChecker_Env.mlift =
-                                        FStar_TypeChecker_Env.identity_mlift
-                                    } in
-                                  solve_sub c12 edge c22
-                                else
-                                  (let uu____11901 =
-                                     let uu____11902 =
-                                       FStar_Syntax_Print.lid_to_string
-                                         c12.FStar_Syntax_Syntax.effect_name in
-                                     let uu____11903 =
-                                       FStar_Syntax_Print.lid_to_string
-                                         c22.FStar_Syntax_Syntax.effect_name in
-                                     FStar_Util.format2
-                                       "incompatible monad ordering: %s </: %s"
-                                       uu____11902 uu____11903 in
-                                   giveup env uu____11901 orig)
-                            | Some edge -> solve_sub c12 edge c22))))))
-let print_pending_implicits: FStar_TypeChecker_Env.guard_t -> Prims.string =
-  fun g  ->
-    let uu____11908 =
-      FStar_All.pipe_right g.FStar_TypeChecker_Env.implicits
-        (FStar_List.map
-           (fun uu____11928  ->
-              match uu____11928 with
-              | (uu____11939,uu____11940,u,uu____11942,uu____11943,uu____11944)
-                  -> FStar_Syntax_Print.uvar_to_string u)) in
-    FStar_All.pipe_right uu____11908 (FStar_String.concat ", ")
-let ineqs_to_string:
-  (FStar_Syntax_Syntax.universe Prims.list* (FStar_Syntax_Syntax.universe*
-    FStar_Syntax_Syntax.universe) Prims.list) -> Prims.string
-  =
-  fun ineqs  ->
-    let vars =
-      let uu____11973 =
-        FStar_All.pipe_right (Prims.fst ineqs)
-          (FStar_List.map FStar_Syntax_Print.univ_to_string) in
-      FStar_All.pipe_right uu____11973 (FStar_String.concat ", ") in
-    let ineqs1 =
-      let uu____11983 =
-        FStar_All.pipe_right (Prims.snd ineqs)
-          (FStar_List.map
-             (fun uu____11995  ->
-                match uu____11995 with
-                | (u1,u2) ->
-                    let uu____12000 = FStar_Syntax_Print.univ_to_string u1 in
-                    let uu____12001 = FStar_Syntax_Print.univ_to_string u2 in
-                    FStar_Util.format2 "%s < %s" uu____12000 uu____12001)) in
-      FStar_All.pipe_right uu____11983 (FStar_String.concat ", ") in
-    FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
-let guard_to_string:
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.string
-  =
-  fun env  ->
-    fun g  ->
-      match ((g.FStar_TypeChecker_Env.guard_f),
-              (g.FStar_TypeChecker_Env.deferred),
-              (g.FStar_TypeChecker_Env.univ_ineqs))
-      with
-      | (FStar_TypeChecker_Common.Trivial ,[],(uu____12013,[])) -> "{}"
-      | uu____12026 ->
-          let form =
-            match g.FStar_TypeChecker_Env.guard_f with
-            | FStar_TypeChecker_Common.Trivial  -> "trivial"
-            | FStar_TypeChecker_Common.NonTrivial f ->
-                let uu____12036 =
-                  ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                      (FStar_Options.Other "Rel"))
-                     ||
-                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                        (FStar_Options.Other "Implicits")))
-                    ||
-                    (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       FStar_Options.Extreme) in
-                if uu____12036
-                then FStar_TypeChecker_Normalize.term_to_string env f
-                else "non-trivial" in
-          let carry =
-            let uu____12039 =
-              FStar_List.map
-                (fun uu____12043  ->
-                   match uu____12043 with
-                   | (uu____12046,x) -> prob_to_string env x)
-                g.FStar_TypeChecker_Env.deferred in
-            FStar_All.pipe_right uu____12039 (FStar_String.concat ",\n") in
-          let imps = print_pending_implicits g in
-          let uu____12050 =
-            ineqs_to_string g.FStar_TypeChecker_Env.univ_ineqs in
-          FStar_Util.format4
-            "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
-            form carry uu____12050 imps
-let new_t_problem env lhs rel rhs elt loc =
-  let reason =
-    let uu____12088 =
-      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-        (FStar_Options.Other "ExplainRel") in
-    if uu____12088
-    then
-      let uu____12089 = FStar_TypeChecker_Normalize.term_to_string env lhs in
-      let uu____12090 = FStar_TypeChecker_Normalize.term_to_string env rhs in
-      FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____12089
-        (rel_to_string rel) uu____12090
-    else "TOP" in
-  let p = new_problem env lhs rel rhs elt loc reason in p
-let new_t_prob:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_TypeChecker_Common.rel ->
-        FStar_Syntax_Syntax.term ->
-          (FStar_TypeChecker_Common.prob* FStar_Syntax_Syntax.bv)
-  =
-  fun env  ->
-    fun t1  ->
-      fun rel  ->
-        fun t2  ->
-          let x =
-            let uu____12110 =
-              let uu____12112 = FStar_TypeChecker_Env.get_range env in
-              FStar_All.pipe_left (fun _0_71  -> Some _0_71) uu____12112 in
-            FStar_Syntax_Syntax.new_bv uu____12110 t1 in
-          let env1 = FStar_TypeChecker_Env.push_bv env x in
-          let p =
-            let uu____12118 =
-              let uu____12120 = FStar_Syntax_Syntax.bv_to_name x in
-              FStar_All.pipe_left (fun _0_72  -> Some _0_72) uu____12120 in
-            let uu____12122 = FStar_TypeChecker_Env.get_range env1 in
-            new_t_problem env1 t1 rel t2 uu____12118 uu____12122 in
-          ((FStar_TypeChecker_Common.TProb p), x)
-let solve_and_commit:
-  FStar_TypeChecker_Env.env ->
-    worklist ->
-      ((FStar_TypeChecker_Common.prob* Prims.string) ->
-         FStar_TypeChecker_Common.deferred Prims.option)
-        -> FStar_TypeChecker_Common.deferred Prims.option
-  =
-  fun env  ->
-    fun probs  ->
-      fun err  ->
-        let probs1 =
-          let uu____12145 = FStar_Options.eager_inference () in
-          if uu____12145
-          then
-            let uu___175_12146 = probs in
-            {
-              attempting = (uu___175_12146.attempting);
-              wl_deferred = (uu___175_12146.wl_deferred);
-              ctr = (uu___175_12146.ctr);
-              defer_ok = false;
-              smt_ok = (uu___175_12146.smt_ok);
-              tcenv = (uu___175_12146.tcenv)
-            }
-          else probs in
-        let tx = FStar_Unionfind.new_transaction () in
-        let sol = solve env probs1 in
-        match sol with
-        | Success deferred -> (FStar_Unionfind.commit tx; Some deferred)
-        | Failed (d,s) ->
-            (FStar_Unionfind.rollback tx;
-             (let uu____12157 =
-                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "ExplainRel") in
-              if uu____12157
-              then
-                let uu____12158 = explain env d s in
-                FStar_All.pipe_left FStar_Util.print_string uu____12158
-              else ());
-             err (d, s))
-let simplify_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun env  ->
-    fun g  ->
-      match g.FStar_TypeChecker_Env.guard_f with
-      | FStar_TypeChecker_Common.Trivial  -> g
-      | FStar_TypeChecker_Common.NonTrivial f ->
-          ((let uu____12168 =
-              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "Simplification") in
-            if uu____12168
-            then
-              let uu____12169 = FStar_Syntax_Print.term_to_string f in
-              FStar_Util.print1 "Simplifying guard %s\n" uu____12169
-            else ());
-           (let f1 =
-              FStar_TypeChecker_Normalize.normalize
-                [FStar_TypeChecker_Normalize.Beta;
-                FStar_TypeChecker_Normalize.Eager_unfolding;
-                FStar_TypeChecker_Normalize.Simplify] env f in
-            (let uu____12173 =
-               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Simplification") in
-             if uu____12173
-             then
-               let uu____12174 = FStar_Syntax_Print.term_to_string f1 in
-               FStar_Util.print1 "Simplified guard to %s\n" uu____12174
-             else ());
-            (let f2 =
-               let uu____12177 =
-                 let uu____12178 = FStar_Syntax_Util.unmeta f1 in
-                 uu____12178.FStar_Syntax_Syntax.n in
-               match uu____12177 with
-               | FStar_Syntax_Syntax.Tm_fvar fv when
-                   FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Syntax_Const.true_lid
-                   -> FStar_TypeChecker_Common.Trivial
-               | uu____12182 -> FStar_TypeChecker_Common.NonTrivial f1 in
-             let uu___176_12183 = g in
-             {
-               FStar_TypeChecker_Env.guard_f = f2;
-               FStar_TypeChecker_Env.deferred =
-                 (uu___176_12183.FStar_TypeChecker_Env.deferred);
-               FStar_TypeChecker_Env.univ_ineqs =
-                 (uu___176_12183.FStar_TypeChecker_Env.univ_ineqs);
-               FStar_TypeChecker_Env.implicits =
-                 (uu___176_12183.FStar_TypeChecker_Env.implicits)
-             })))
-let with_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob ->
-      FStar_TypeChecker_Common.deferred Prims.option ->
-        FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun env  ->
-    fun prob  ->
-      fun dopt  ->
-        match dopt with
-        | None  -> None
-        | Some d ->
-            let uu____12198 =
-              let uu____12199 =
-                let uu____12200 =
-                  let uu____12201 =
-                    FStar_All.pipe_right (p_guard prob) Prims.fst in
-                  FStar_All.pipe_right uu____12201
-                    (fun _0_73  -> FStar_TypeChecker_Common.NonTrivial _0_73) in
-                {
-                  FStar_TypeChecker_Env.guard_f = uu____12200;
-                  FStar_TypeChecker_Env.deferred = d;
-                  FStar_TypeChecker_Env.univ_ineqs = ([], []);
-                  FStar_TypeChecker_Env.implicits = []
-                } in
-              simplify_guard env uu____12199 in
-            FStar_All.pipe_left (fun _0_74  -> Some _0_74) uu____12198
-let try_teq:
-  Prims.bool ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun smt_ok  ->
-    fun env  ->
-      fun t1  ->
-        fun t2  ->
-          (let uu____12228 =
-             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "Rel") in
-           if uu____12228
-           then
-             let uu____12229 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____12230 = FStar_Syntax_Print.term_to_string t2 in
-             FStar_Util.print2 "try_teq of %s and %s\n" uu____12229
-               uu____12230
-           else ());
-          (let prob =
-             let uu____12233 =
-               let uu____12236 = FStar_TypeChecker_Env.get_range env in
-               new_t_problem env t1 FStar_TypeChecker_Common.EQ t2 None
-                 uu____12236 in
-             FStar_All.pipe_left
-               (fun _0_75  -> FStar_TypeChecker_Common.TProb _0_75)
-               uu____12233 in
-           let g =
-             let uu____12241 =
-               let uu____12243 = singleton' env prob smt_ok in
-               solve_and_commit env uu____12243 (fun uu____12244  -> None) in
-             FStar_All.pipe_left (with_guard env prob) uu____12241 in
-           g)
-let teq:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let uu____12258 = try_teq true env t1 t2 in
-        match uu____12258 with
-        | None  ->
-            let uu____12260 =
-              let uu____12261 =
-                let uu____12264 =
-                  FStar_TypeChecker_Err.basic_type_error env None t2 t1 in
-                let uu____12265 = FStar_TypeChecker_Env.get_range env in
-                (uu____12264, uu____12265) in
-              FStar_Errors.Error uu____12261 in
-            Prims.raise uu____12260
-        | Some g ->
-            ((let uu____12268 =
-                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel") in
-              if uu____12268
-              then
-                let uu____12269 = FStar_Syntax_Print.term_to_string t1 in
-                let uu____12270 = FStar_Syntax_Print.term_to_string t2 in
-                let uu____12271 = guard_to_string env g in
-                FStar_Util.print3
-                  "teq of %s and %s succeeded with guard %s\n" uu____12269
-                  uu____12270 uu____12271
-              else ());
-             g)
-let try_subtype':
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ ->
-        Prims.bool -> FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        fun smt_ok  ->
-          (let uu____12287 =
-             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "Rel") in
-           if uu____12287
-           then
-             let uu____12288 =
-               FStar_TypeChecker_Normalize.term_to_string env t1 in
-             let uu____12289 =
-               FStar_TypeChecker_Normalize.term_to_string env t2 in
-             FStar_Util.print2 "try_subtype of %s and %s\n" uu____12288
-               uu____12289
-           else ());
-          (let uu____12291 =
-             new_t_prob env t1 FStar_TypeChecker_Common.SUB t2 in
-           match uu____12291 with
-           | (prob,x) ->
-               let g =
-                 let uu____12299 =
-                   let uu____12301 = singleton' env prob smt_ok in
-                   solve_and_commit env uu____12301
-                     (fun uu____12302  -> None) in
-                 FStar_All.pipe_left (with_guard env prob) uu____12299 in
-               ((let uu____12308 =
-                   (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                      (FStar_Options.Other "Rel"))
-                     && (FStar_Util.is_some g) in
-                 if uu____12308
-                 then
-                   let uu____12309 =
-                     FStar_TypeChecker_Normalize.term_to_string env t1 in
-                   let uu____12310 =
-                     FStar_TypeChecker_Normalize.term_to_string env t2 in
-                   let uu____12311 =
-                     let uu____12312 = FStar_Util.must g in
-                     guard_to_string env uu____12312 in
-                   FStar_Util.print3
-                     "try_subtype succeeded: %s <: %s\n\tguard is %s\n"
-                     uu____12309 uu____12310 uu____12311
-                 else ());
-                abstract_guard x g))
-let try_subtype:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t Prims.option
-  = fun env  -> fun t1  -> fun t2  -> try_subtype' env t1 t2 true
-let subtype_fail:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.unit
-  =
-  fun env  ->
-    fun e  ->
-      fun t1  ->
-        fun t2  ->
-          let uu____12336 = FStar_TypeChecker_Env.get_range env in
-          let uu____12337 =
-            FStar_TypeChecker_Err.basic_type_error env (Some e) t2 t1 in
-          FStar_Errors.report uu____12336 uu____12337
-let sub_comp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.comp -> FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun env  ->
-    fun c1  ->
-      fun c2  ->
-        (let uu____12349 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel") in
-         if uu____12349
-         then
-           let uu____12350 = FStar_Syntax_Print.comp_to_string c1 in
-           let uu____12351 = FStar_Syntax_Print.comp_to_string c2 in
-           FStar_Util.print2 "sub_comp of %s and %s\n" uu____12350
-             uu____12351
-         else ());
-        (let rel =
-           if env.FStar_TypeChecker_Env.use_eq
-           then FStar_TypeChecker_Common.EQ
-           else FStar_TypeChecker_Common.SUB in
-         let prob =
-           let uu____12356 =
-             let uu____12359 = FStar_TypeChecker_Env.get_range env in
-             new_problem env c1 rel c2 None uu____12359 "sub_comp" in
-           FStar_All.pipe_left
-             (fun _0_76  -> FStar_TypeChecker_Common.CProb _0_76) uu____12356 in
-         let uu____12362 =
-           let uu____12364 = singleton env prob in
-           solve_and_commit env uu____12364 (fun uu____12365  -> None) in
-         FStar_All.pipe_left (with_guard env prob) uu____12362)
-let solve_universe_inequalities':
-  FStar_Unionfind.tx ->
-    FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.universe Prims.list*
-        (FStar_Syntax_Syntax.universe* FStar_Syntax_Syntax.universe)
-        Prims.list) -> Prims.unit
-  =
-  fun tx  ->
-    fun env  ->
-      fun uu____12384  ->
-        match uu____12384 with
-        | (variables,ineqs) ->
-            let fail u1 u2 =
-              FStar_Unionfind.rollback tx;
-              (let uu____12409 =
-                 let uu____12410 =
-                   let uu____12413 =
-                     let uu____12414 = FStar_Syntax_Print.univ_to_string u1 in
-                     let uu____12415 = FStar_Syntax_Print.univ_to_string u2 in
-                     FStar_Util.format2 "Universe %s and %s are incompatible"
-                       uu____12414 uu____12415 in
-                   let uu____12416 = FStar_TypeChecker_Env.get_range env in
-                   (uu____12413, uu____12416) in
-                 FStar_Errors.Error uu____12410 in
-               Prims.raise uu____12409) in
-            let equiv v1 v' =
-              let uu____12424 =
-                let uu____12427 = FStar_Syntax_Subst.compress_univ v1 in
-                let uu____12428 = FStar_Syntax_Subst.compress_univ v' in
-                (uu____12427, uu____12428) in
-              match uu____12424 with
-              | (FStar_Syntax_Syntax.U_unif v0,FStar_Syntax_Syntax.U_unif
-                 v0') -> FStar_Unionfind.equivalent v0 v0'
-              | uu____12436 -> false in
-            let sols =
-              FStar_All.pipe_right variables
-                (FStar_List.collect
-                   (fun v1  ->
-                      let uu____12450 = FStar_Syntax_Subst.compress_univ v1 in
-                      match uu____12450 with
-                      | FStar_Syntax_Syntax.U_unif uu____12454 ->
-                          let lower_bounds_of_v =
-                            FStar_All.pipe_right ineqs
-                              (FStar_List.collect
-                                 (fun uu____12465  ->
-                                    match uu____12465 with
-                                    | (u,v') ->
-                                        let uu____12471 = equiv v1 v' in
-                                        if uu____12471
-                                        then
-                                          let uu____12473 =
-                                            FStar_All.pipe_right variables
-                                              (FStar_Util.for_some (equiv u)) in
-                                          (if uu____12473 then [] else [u])
-                                        else [])) in
-                          let lb =
-                            FStar_TypeChecker_Normalize.normalize_universe
-                              env
-                              (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
-                          [(lb, v1)]
-                      | uu____12483 -> [])) in
-            let uu____12486 =
-              let wl =
-                let uu___177_12489 = empty_worklist env in
-                {
-                  attempting = (uu___177_12489.attempting);
-                  wl_deferred = (uu___177_12489.wl_deferred);
-                  ctr = (uu___177_12489.ctr);
-                  defer_ok = false;
-                  smt_ok = (uu___177_12489.smt_ok);
-                  tcenv = (uu___177_12489.tcenv)
-                } in
-              FStar_All.pipe_right sols
-                (FStar_List.map
-                   (fun uu____12496  ->
-                      match uu____12496 with
-                      | (lb,v1) ->
-                          let uu____12501 =
-                            solve_universe_eq (- (Prims.parse_int "1")) wl lb
-                              v1 in
-                          (match uu____12501 with
-                           | USolved wl1 -> ()
-                           | uu____12503 -> fail lb v1))) in
-            let rec check_ineq uu____12509 =
-              match uu____12509 with
-              | (u,v1) ->
-                  let u1 =
-                    FStar_TypeChecker_Normalize.normalize_universe env u in
-                  let v2 =
-                    FStar_TypeChecker_Normalize.normalize_universe env v1 in
-                  (match (u1, v2) with
-                   | (FStar_Syntax_Syntax.U_zero ,uu____12516) -> true
-                   | (FStar_Syntax_Syntax.U_succ
-                      u0,FStar_Syntax_Syntax.U_succ v0) ->
-                       check_ineq (u0, v0)
-                   | (FStar_Syntax_Syntax.U_name
-                      u0,FStar_Syntax_Syntax.U_name v0) ->
-                       FStar_Ident.ident_equals u0 v0
-                   | (FStar_Syntax_Syntax.U_unif
-                      u0,FStar_Syntax_Syntax.U_unif v0) ->
-                       FStar_Unionfind.equivalent u0 v0
-                   | (FStar_Syntax_Syntax.U_name _,FStar_Syntax_Syntax.U_succ
-                      v0)
-                     |(FStar_Syntax_Syntax.U_unif
-                       _,FStar_Syntax_Syntax.U_succ v0) ->
-                       check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_max us,uu____12532) ->
-                       FStar_All.pipe_right us
-                         (FStar_Util.for_all (fun u2  -> check_ineq (u2, v2)))
-                   | (uu____12536,FStar_Syntax_Syntax.U_max vs) ->
-                       FStar_All.pipe_right vs
-                         (FStar_Util.for_some
-                            (fun v3  -> check_ineq (u1, v3)))
-                   | uu____12541 -> false) in
-            let uu____12544 =
-              FStar_All.pipe_right ineqs
-                (FStar_Util.for_all
-                   (fun uu____12550  ->
-                      match uu____12550 with
-                      | (u,v1) ->
-                          let uu____12555 = check_ineq (u, v1) in
-                          if uu____12555
-                          then true
-                          else
-                            ((let uu____12558 =
-                                FStar_All.pipe_left
-                                  (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "GenUniverses") in
-                              if uu____12558
-                              then
-                                let uu____12559 =
-                                  FStar_Syntax_Print.univ_to_string u in
-                                let uu____12560 =
-                                  FStar_Syntax_Print.univ_to_string v1 in
-                                FStar_Util.print2 "%s </= %s" uu____12559
-                                  uu____12560
-                              else ());
-                             false))) in
-            if uu____12544
-            then ()
-            else
-              ((let uu____12564 =
-                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "GenUniverses") in
-                if uu____12564
-                then
-                  ((let uu____12566 = ineqs_to_string (variables, ineqs) in
-                    FStar_Util.print1
-                      "Partially solved inequality constraints are: %s\n"
-                      uu____12566);
-                   FStar_Unionfind.rollback tx;
-                   (let uu____12572 = ineqs_to_string (variables, ineqs) in
-                    FStar_Util.print1
-                      "Original solved inequality constraints are: %s\n"
-                      uu____12572))
-                else ());
-               (let uu____12578 =
-                  let uu____12579 =
-                    let uu____12582 = FStar_TypeChecker_Env.get_range env in
-                    ("Failed to solve universe inequalities for inductives",
-                      uu____12582) in
-                  FStar_Errors.Error uu____12579 in
-                Prims.raise uu____12578))
-let solve_universe_inequalities:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.universe Prims.list* (FStar_Syntax_Syntax.universe*
-      FStar_Syntax_Syntax.universe) Prims.list) -> Prims.unit
-  =
-  fun env  ->
-    fun ineqs  ->
-      let tx = FStar_Unionfind.new_transaction () in
-      solve_universe_inequalities' tx env ineqs; FStar_Unionfind.commit tx
-let rec solve_deferred_constraints:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun env  ->
-    fun g  ->
-      let fail uu____12615 =
-        match uu____12615 with
-        | (d,s) ->
-            let msg = explain env d s in
-            Prims.raise (FStar_Errors.Error (msg, (p_loc d))) in
-      let wl = wl_of_guard env g.FStar_TypeChecker_Env.deferred in
-      (let uu____12625 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck") in
-       if uu____12625
-       then
-         let uu____12626 = wl_to_string wl in
-         let uu____12627 =
-           FStar_Util.string_of_int
-             (FStar_List.length g.FStar_TypeChecker_Env.implicits) in
-         FStar_Util.print2
-           "Trying to solve carried problems: begin\n\t%s\nend\n and %s implicits\n"
-           uu____12626 uu____12627
-       else ());
-      (let g1 =
-         let uu____12639 = solve_and_commit env wl fail in
-         match uu____12639 with
-         | Some [] ->
-             let uu___178_12646 = g in
-             {
-               FStar_TypeChecker_Env.guard_f =
-                 (uu___178_12646.FStar_TypeChecker_Env.guard_f);
-               FStar_TypeChecker_Env.deferred = [];
-               FStar_TypeChecker_Env.univ_ineqs =
-                 (uu___178_12646.FStar_TypeChecker_Env.univ_ineqs);
-               FStar_TypeChecker_Env.implicits =
-                 (uu___178_12646.FStar_TypeChecker_Env.implicits)
-             }
-         | uu____12649 ->
-             failwith "impossible: Unexpected deferred constraints remain" in
-       solve_universe_inequalities env g1.FStar_TypeChecker_Env.univ_ineqs;
-       (let uu___179_12652 = g1 in
-        {
-          FStar_TypeChecker_Env.guard_f =
-            (uu___179_12652.FStar_TypeChecker_Env.guard_f);
-          FStar_TypeChecker_Env.deferred =
-            (uu___179_12652.FStar_TypeChecker_Env.deferred);
-          FStar_TypeChecker_Env.univ_ineqs = ([], []);
-          FStar_TypeChecker_Env.implicits =
-            (uu___179_12652.FStar_TypeChecker_Env.implicits)
-        }))
-let discharge_guard':
-  (Prims.unit -> Prims.string) Prims.option ->
-    FStar_TypeChecker_Env.env ->
-      FStar_TypeChecker_Env.guard_t ->
-        Prims.bool -> FStar_TypeChecker_Env.guard_t Prims.option
-  =
-  fun use_env_range_msg  ->
-    fun env  ->
-      fun g  ->
-        fun use_smt  ->
-          let g1 = solve_deferred_constraints env g in
-          let ret_g =
-            let uu___180_12678 = g1 in
-            {
-              FStar_TypeChecker_Env.guard_f =
-                FStar_TypeChecker_Common.Trivial;
-              FStar_TypeChecker_Env.deferred =
-                (uu___180_12678.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (uu___180_12678.FStar_TypeChecker_Env.univ_ineqs);
-              FStar_TypeChecker_Env.implicits =
-                (uu___180_12678.FStar_TypeChecker_Env.implicits)
-            } in
-          let uu____12679 =
-            let uu____12680 = FStar_TypeChecker_Env.should_verify env in
-            Prims.op_Negation uu____12680 in
-          if uu____12679
-          then Some ret_g
-          else
-            (match g1.FStar_TypeChecker_Env.guard_f with
-             | FStar_TypeChecker_Common.Trivial  -> Some ret_g
-             | FStar_TypeChecker_Common.NonTrivial vc ->
-                 ((let uu____12686 =
-                     FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       (FStar_Options.Other "Norm") in
-                   if uu____12686
-                   then
-                     let uu____12687 = FStar_TypeChecker_Env.get_range env in
-                     let uu____12688 =
-                       let uu____12689 = FStar_Syntax_Print.term_to_string vc in
-                       FStar_Util.format1 "Before normalization VC=\n%s\n"
-                         uu____12689 in
-                     FStar_Errors.diag uu____12687 uu____12688
-                   else ());
-                  (let vc1 =
-                     FStar_TypeChecker_Normalize.normalize
-                       [FStar_TypeChecker_Normalize.Eager_unfolding;
-                       FStar_TypeChecker_Normalize.Beta;
-                       FStar_TypeChecker_Normalize.Simplify] env vc in
-                   match check_trivial vc1 with
-                   | FStar_TypeChecker_Common.Trivial  -> Some ret_g
-                   | FStar_TypeChecker_Common.NonTrivial vc2 ->
-                       if Prims.op_Negation use_smt
-                       then None
-                       else
-                         ((let uu____12698 =
-                             FStar_All.pipe_left
-                               (FStar_TypeChecker_Env.debug env)
-                               (FStar_Options.Other "Rel") in
-                           if uu____12698
-                           then
-                             let uu____12699 =
-                               FStar_TypeChecker_Env.get_range env in
-                             let uu____12700 =
-                               let uu____12701 =
-                                 FStar_Syntax_Print.term_to_string vc2 in
-                               FStar_Util.format1 "Checking VC=\n%s\n"
-                                 uu____12701 in
-                             FStar_Errors.diag uu____12699 uu____12700
-                           else ());
-                          (let vcs =
-                             let uu____12707 = FStar_Options.use_tactics () in
-                             if uu____12707
-                             then
-                               (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
-                                 env vc2
-                             else [(env, vc2)] in
-                           FStar_All.pipe_right vcs
-                             (FStar_List.iter
-                                (fun uu____12721  ->
-                                   match uu____12721 with
-                                   | (env1,goal) ->
-                                       (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
-                                         use_env_range_msg env1 goal)));
-                          Some ret_g))))
-let discharge_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun env  ->
-    fun g  ->
-      let uu____12732 = discharge_guard' None env g true in
-      match uu____12732 with
-      | Some g1 -> g1
-      | None  ->
-          failwith
-            "Impossible, with use_smt = true, discharge_guard' should never have returned None"
-let resolve_implicits:
-  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t =
-  fun g  ->
-    let unresolved u =
-      let uu____12752 = FStar_Unionfind.find u in
-      match uu____12752 with
-      | FStar_Syntax_Syntax.Uvar  -> true
-      | uu____12761 -> false in
-    let rec until_fixpoint acc implicits =
-      let uu____12776 = acc in
-      match uu____12776 with
-      | (out,changed) ->
-          (match implicits with
-           | [] ->
-               if Prims.op_Negation changed
-               then out
-               else until_fixpoint ([], false) out
-           | hd1::tl1 ->
-               let uu____12822 = hd1 in
-               (match uu____12822 with
-                | (uu____12829,env,u,tm,k,r) ->
-                    let uu____12835 = unresolved u in
-                    if uu____12835
-                    then until_fixpoint ((hd1 :: out), changed) tl1
-                    else
-                      (let env1 =
-                         FStar_TypeChecker_Env.set_expected_typ env k in
-                       let tm1 =
-                         FStar_TypeChecker_Normalize.normalize
-                           [FStar_TypeChecker_Normalize.Beta] env1 tm in
-                       (let uu____12853 =
-                          FStar_All.pipe_left
-                            (FStar_TypeChecker_Env.debug env1)
-                            (FStar_Options.Other "RelCheck") in
-                        if uu____12853
-                        then
-                          let uu____12854 =
-                            FStar_Syntax_Print.uvar_to_string u in
-                          let uu____12858 =
-                            FStar_Syntax_Print.term_to_string tm1 in
-                          let uu____12859 =
-                            FStar_Syntax_Print.term_to_string k in
-                          FStar_Util.print3
-                            "Checking uvar %s resolved to %s at type %s\n"
-                            uu____12854 uu____12858 uu____12859
-                        else ());
-                       (let uu____12861 =
-                          env1.FStar_TypeChecker_Env.type_of
-                            (let uu___181_12865 = env1 in
-                             {
-                               FStar_TypeChecker_Env.solver =
-                                 (uu___181_12865.FStar_TypeChecker_Env.solver);
-                               FStar_TypeChecker_Env.range =
-                                 (uu___181_12865.FStar_TypeChecker_Env.range);
-                               FStar_TypeChecker_Env.curmodule =
-                                 (uu___181_12865.FStar_TypeChecker_Env.curmodule);
-                               FStar_TypeChecker_Env.gamma =
-                                 (uu___181_12865.FStar_TypeChecker_Env.gamma);
-                               FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___181_12865.FStar_TypeChecker_Env.gamma_cache);
-                               FStar_TypeChecker_Env.modules =
-                                 (uu___181_12865.FStar_TypeChecker_Env.modules);
-                               FStar_TypeChecker_Env.expected_typ =
-                                 (uu___181_12865.FStar_TypeChecker_Env.expected_typ);
-                               FStar_TypeChecker_Env.sigtab =
-                                 (uu___181_12865.FStar_TypeChecker_Env.sigtab);
-                               FStar_TypeChecker_Env.is_pattern =
-                                 (uu___181_12865.FStar_TypeChecker_Env.is_pattern);
-                               FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___181_12865.FStar_TypeChecker_Env.instantiate_imp);
-                               FStar_TypeChecker_Env.effects =
-                                 (uu___181_12865.FStar_TypeChecker_Env.effects);
-                               FStar_TypeChecker_Env.generalize =
-                                 (uu___181_12865.FStar_TypeChecker_Env.generalize);
-                               FStar_TypeChecker_Env.letrecs =
-                                 (uu___181_12865.FStar_TypeChecker_Env.letrecs);
-                               FStar_TypeChecker_Env.top_level =
-                                 (uu___181_12865.FStar_TypeChecker_Env.top_level);
-                               FStar_TypeChecker_Env.check_uvars =
-                                 (uu___181_12865.FStar_TypeChecker_Env.check_uvars);
-                               FStar_TypeChecker_Env.use_eq =
-                                 (uu___181_12865.FStar_TypeChecker_Env.use_eq);
-                               FStar_TypeChecker_Env.is_iface =
-                                 (uu___181_12865.FStar_TypeChecker_Env.is_iface);
-                               FStar_TypeChecker_Env.admit =
-                                 (uu___181_12865.FStar_TypeChecker_Env.admit);
-                               FStar_TypeChecker_Env.lax =
-                                 (uu___181_12865.FStar_TypeChecker_Env.lax);
-                               FStar_TypeChecker_Env.lax_universes =
-                                 (uu___181_12865.FStar_TypeChecker_Env.lax_universes);
-                               FStar_TypeChecker_Env.type_of =
-                                 (uu___181_12865.FStar_TypeChecker_Env.type_of);
-                               FStar_TypeChecker_Env.universe_of =
-                                 (uu___181_12865.FStar_TypeChecker_Env.universe_of);
-                               FStar_TypeChecker_Env.use_bv_sorts = true;
-                               FStar_TypeChecker_Env.qname_and_index =
-                                 (uu___181_12865.FStar_TypeChecker_Env.qname_and_index)
-                             }) tm1 in
-                        match uu____12861 with
-                        | (uu____12866,uu____12867,g1) ->
-                            let g2 =
-                              if env1.FStar_TypeChecker_Env.is_pattern
-                              then
-                                let uu___182_12870 = g1 in
-                                {
-                                  FStar_TypeChecker_Env.guard_f =
-                                    FStar_TypeChecker_Common.Trivial;
-                                  FStar_TypeChecker_Env.deferred =
-                                    (uu___182_12870.FStar_TypeChecker_Env.deferred);
-                                  FStar_TypeChecker_Env.univ_ineqs =
-                                    (uu___182_12870.FStar_TypeChecker_Env.univ_ineqs);
-                                  FStar_TypeChecker_Env.implicits =
-                                    (uu___182_12870.FStar_TypeChecker_Env.implicits)
-                                }
-                              else g1 in
-                            let g' =
-                              let uu____12873 =
-                                discharge_guard'
-                                  (Some
-                                     (fun uu____12877  ->
-                                        FStar_Syntax_Print.term_to_string tm1))
-                                  env1 g2 true in
-                              match uu____12873 with
-                              | Some g3 -> g3
-                              | None  ->
-                                  failwith
-                                    "Impossible, with use_smt = true, discharge_guard' should never have returned None" in
-                            until_fixpoint
-                              ((FStar_List.append
-                                  g'.FStar_TypeChecker_Env.implicits out),
-                                true) tl1)))) in
-    let uu___183_12892 = g in
-    let uu____12893 =
-      until_fixpoint ([], false) g.FStar_TypeChecker_Env.implicits in
-    {
-      FStar_TypeChecker_Env.guard_f =
-        (uu___183_12892.FStar_TypeChecker_Env.guard_f);
-      FStar_TypeChecker_Env.deferred =
-        (uu___183_12892.FStar_TypeChecker_Env.deferred);
-      FStar_TypeChecker_Env.univ_ineqs =
-        (uu___183_12892.FStar_TypeChecker_Env.univ_ineqs);
-      FStar_TypeChecker_Env.implicits = uu____12893
-    }
-let force_trivial_guard:
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.unit =
-  fun env  ->
-    fun g  ->
-      let g1 =
-        let uu____12921 = solve_deferred_constraints env g in
-        FStar_All.pipe_right uu____12921 resolve_implicits in
-      match g1.FStar_TypeChecker_Env.implicits with
-      | [] ->
-          let uu____12928 = discharge_guard env g1 in
-          FStar_All.pipe_left Prims.ignore uu____12928
-      | (reason,uu____12930,uu____12931,e,t,r)::uu____12935 ->
-          let uu____12949 =
-            let uu____12950 = FStar_Syntax_Print.term_to_string t in
-            let uu____12951 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format3
-              "Failed to resolve implicit argument of type '%s' introduced in %s because %s"
-              uu____12950 uu____12951 reason in
-          FStar_Errors.report r uu____12949
-let universe_inequality:
-  FStar_Syntax_Syntax.universe ->
-    FStar_Syntax_Syntax.universe -> FStar_TypeChecker_Env.guard_t
-  =
-  fun u1  ->
-    fun u2  ->
-      let uu___184_12958 = trivial_guard in
-      {
-        FStar_TypeChecker_Env.guard_f =
-          (uu___184_12958.FStar_TypeChecker_Env.guard_f);
-        FStar_TypeChecker_Env.deferred =
-          (uu___184_12958.FStar_TypeChecker_Env.deferred);
-        FStar_TypeChecker_Env.univ_ineqs = ([], [(u1, u2)]);
-        FStar_TypeChecker_Env.implicits =
-          (uu___184_12958.FStar_TypeChecker_Env.implicits)
-      }
-let teq_nosmt:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool
-  =
-  fun env  ->
-    fun t1  ->
-      fun t2  ->
-        let uu____12976 = try_teq false env t1 t2 in
-        match uu____12976 with
-        | None  -> false
-        | Some g ->
-            let uu____12979 = discharge_guard' None env g false in
-            (match uu____12979 with
-             | Some uu____12983 -> true
-             | None  -> false)
+| UDeferred of worklist
+| USolved of worklist
+| UFailed of Prims.string
+
+
+let uu___is_UDeferred : univ_eq_sol  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UDeferred (_0) -> begin
+true
+end
+| uu____5305 -> begin
+false
+end))
+
+
+let __proj__UDeferred__item___0 : univ_eq_sol  ->  worklist = (fun projectee -> (match (projectee) with
+| UDeferred (_0) -> begin
+_0
+end))
+
+
+let uu___is_USolved : univ_eq_sol  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| USolved (_0) -> begin
+true
+end
+| uu____5317 -> begin
+false
+end))
+
+
+let __proj__USolved__item___0 : univ_eq_sol  ->  worklist = (fun projectee -> (match (projectee) with
+| USolved (_0) -> begin
+_0
+end))
+
+
+let uu___is_UFailed : univ_eq_sol  ->  Prims.bool = (fun projectee -> (match (projectee) with
+| UFailed (_0) -> begin
+true
+end
+| uu____5329 -> begin
+false
+end))
+
+
+let __proj__UFailed__item___0 : univ_eq_sol  ->  Prims.string = (fun projectee -> (match (projectee) with
+| UFailed (_0) -> begin
+_0
+end))
+
+
+let rec really_solve_universe_eq : Prims.int  ->  worklist  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  univ_eq_sol = (fun pid_orig wl u1 u2 -> (
+
+let u11 = (FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u1)
+in (
+
+let u21 = (FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u2)
+in (
+
+let rec occurs_univ = (fun v1 u -> (match (u) with
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(FStar_All.pipe_right us (FStar_Util.for_some (fun u3 -> (
+
+let uu____5366 = (FStar_Syntax_Util.univ_kernel u3)
+in (match (uu____5366) with
+| (k, uu____5370) -> begin
+(match (k) with
+| FStar_Syntax_Syntax.U_unif (v2) -> begin
+(FStar_Unionfind.equivalent v1 v2)
+end
+| uu____5375 -> begin
+false
+end)
+end)))))
+end
+| uu____5376 -> begin
+(occurs_univ v1 (FStar_Syntax_Syntax.U_max ((u)::[])))
+end))
+in (
+
+let try_umax_components = (fun u12 u22 msg -> (match (((u12), (u22))) with
+| (FStar_Syntax_Syntax.U_max (us1), FStar_Syntax_Syntax.U_max (us2)) -> begin
+(match (((FStar_List.length us1) = (FStar_List.length us2))) with
+| true -> begin
+(
+
+let rec aux = (fun wl1 us11 us21 -> (match (((us11), (us21))) with
+| ((u13)::us12, (u23)::us22) -> begin
+(
+
+let uu____5419 = (really_solve_universe_eq pid_orig wl1 u13 u23)
+in (match (uu____5419) with
+| USolved (wl2) -> begin
+(aux wl2 us12 us22)
+end
+| failed -> begin
+failed
+end))
+end
+| uu____5422 -> begin
+USolved (wl1)
+end))
+in (aux wl us1 us2))
+end
+| uu____5427 -> begin
+(
+
+let uu____5428 = (
+
+let uu____5429 = (FStar_Syntax_Print.univ_to_string u12)
+in (
+
+let uu____5430 = (FStar_Syntax_Print.univ_to_string u22)
+in (FStar_Util.format2 "Unable to unify universes: %s and %s" uu____5429 uu____5430)))
+in UFailed (uu____5428))
+end)
+end
+| ((FStar_Syntax_Syntax.U_max (us), u')) | ((u', FStar_Syntax_Syntax.U_max (us))) -> begin
+(
+
+let rec aux = (fun wl1 us1 -> (match (us1) with
+| [] -> begin
+USolved (wl1)
+end
+| (u)::us2 -> begin
+(
+
+let uu____5447 = (really_solve_universe_eq pid_orig wl1 u u')
+in (match (uu____5447) with
+| USolved (wl2) -> begin
+(aux wl2 us2)
+end
+| failed -> begin
+failed
+end))
+end))
+in (aux wl us))
+end
+| uu____5450 -> begin
+(
+
+let uu____5453 = (
+
+let uu____5454 = (FStar_Syntax_Print.univ_to_string u12)
+in (
+
+let uu____5455 = (FStar_Syntax_Print.univ_to_string u22)
+in (FStar_Util.format3 "Unable to unify universes: %s and %s (%s)" uu____5454 uu____5455 msg)))
+in UFailed (uu____5453))
+end))
+in (match (((u11), (u21))) with
+| ((FStar_Syntax_Syntax.U_bvar (_), _)) | ((FStar_Syntax_Syntax.U_unknown, _)) | ((_, FStar_Syntax_Syntax.U_bvar (_))) | ((_, FStar_Syntax_Syntax.U_unknown)) -> begin
+(
+
+let uu____5462 = (
+
+let uu____5463 = (FStar_Syntax_Print.univ_to_string u11)
+in (
+
+let uu____5464 = (FStar_Syntax_Print.univ_to_string u21)
+in (FStar_Util.format2 "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s" uu____5463 uu____5464)))
+in (failwith uu____5462))
+end
+| (FStar_Syntax_Syntax.U_name (x), FStar_Syntax_Syntax.U_name (y)) -> begin
+(match ((x.FStar_Ident.idText = y.FStar_Ident.idText)) with
+| true -> begin
+USolved (wl)
+end
+| uu____5467 -> begin
+UFailed ("Incompatible universes")
+end)
+end
+| (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) -> begin
+USolved (wl)
+end
+| (FStar_Syntax_Syntax.U_succ (u12), FStar_Syntax_Syntax.U_succ (u22)) -> begin
+(really_solve_universe_eq pid_orig wl u12 u22)
+end
+| (FStar_Syntax_Syntax.U_unif (v1), FStar_Syntax_Syntax.U_unif (v2)) -> begin
+(
+
+let uu____5476 = (FStar_Unionfind.equivalent v1 v2)
+in (match (uu____5476) with
+| true -> begin
+USolved (wl)
+end
+| uu____5478 -> begin
+(
+
+let wl1 = (extend_solution pid_orig ((UNIV (((v1), (u21))))::[]) wl)
+in USolved (wl1))
+end))
+end
+| ((FStar_Syntax_Syntax.U_unif (v1), u)) | ((u, FStar_Syntax_Syntax.U_unif (v1))) -> begin
+(
+
+let u3 = (norm_univ wl u)
+in (
+
+let uu____5489 = (occurs_univ v1 u3)
+in (match (uu____5489) with
+| true -> begin
+(
+
+let uu____5490 = (
+
+let uu____5491 = (FStar_Syntax_Print.univ_to_string (FStar_Syntax_Syntax.U_unif (v1)))
+in (
+
+let uu____5492 = (FStar_Syntax_Print.univ_to_string u3)
+in (FStar_Util.format2 "Failed occurs check: %s occurs in %s" uu____5491 uu____5492)))
+in (try_umax_components u11 u21 uu____5490))
+end
+| uu____5493 -> begin
+(
+
+let uu____5494 = (extend_solution pid_orig ((UNIV (((v1), (u3))))::[]) wl)
+in USolved (uu____5494))
+end)))
+end
+| ((FStar_Syntax_Syntax.U_max (_), _)) | ((_, FStar_Syntax_Syntax.U_max (_))) -> begin
+(match (wl.defer_ok) with
+| true -> begin
+UDeferred (wl)
+end
+| uu____5501 -> begin
+(
+
+let u12 = (norm_univ wl u11)
+in (
+
+let u22 = (norm_univ wl u21)
+in (
+
+let uu____5504 = (FStar_Syntax_Util.eq_univs u12 u22)
+in (match (uu____5504) with
+| true -> begin
+USolved (wl)
+end
+| uu____5505 -> begin
+(try_umax_components u12 u22 "")
+end))))
+end)
+end
+| ((FStar_Syntax_Syntax.U_succ (_), FStar_Syntax_Syntax.U_zero)) | ((FStar_Syntax_Syntax.U_succ (_), FStar_Syntax_Syntax.U_name (_))) | ((FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_succ (_))) | ((FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_name (_))) | ((FStar_Syntax_Syntax.U_name (_), FStar_Syntax_Syntax.U_succ (_))) | ((FStar_Syntax_Syntax.U_name (_), FStar_Syntax_Syntax.U_zero)) -> begin
+UFailed ("Incompatible universes")
+end))))))
+
+
+let solve_universe_eq : Prims.int  ->  worklist  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  univ_eq_sol = (fun orig wl u1 u2 -> (match (wl.tcenv.FStar_TypeChecker_Env.lax_universes) with
+| true -> begin
+USolved (wl)
+end
+| uu____5526 -> begin
+(really_solve_universe_eq orig wl u1 u2)
+end))
+
+
+let match_num_binders = (fun bc1 bc2 -> (
+
+let uu____5575 = bc1
+in (match (uu____5575) with
+| (bs1, mk_cod1) -> begin
+(
+
+let uu____5600 = bc2
+in (match (uu____5600) with
+| (bs2, mk_cod2) -> begin
+(
+
+let curry = (fun n1 bs mk_cod -> (
+
+let uu____5647 = (FStar_Util.first_N n1 bs)
+in (match (uu____5647) with
+| (bs3, rest) -> begin
+(
+
+let uu____5661 = (mk_cod rest)
+in ((bs3), (uu____5661)))
+end)))
+in (
+
+let l1 = (FStar_List.length bs1)
+in (
+
+let l2 = (FStar_List.length bs2)
+in (match ((l1 = l2)) with
+| true -> begin
+(
+
+let uu____5679 = (
+
+let uu____5683 = (mk_cod1 [])
+in ((bs1), (uu____5683)))
+in (
+
+let uu____5685 = (
+
+let uu____5689 = (mk_cod2 [])
+in ((bs2), (uu____5689)))
+in ((uu____5679), (uu____5685))))
+end
+| uu____5697 -> begin
+(match ((l1 > l2)) with
+| true -> begin
+(
+
+let uu____5711 = (curry l2 bs1 mk_cod1)
+in (
+
+let uu____5718 = (
+
+let uu____5722 = (mk_cod2 [])
+in ((bs2), (uu____5722)))
+in ((uu____5711), (uu____5718))))
+end
+| uu____5730 -> begin
+(
+
+let uu____5731 = (
+
+let uu____5735 = (mk_cod1 [])
+in ((bs1), (uu____5735)))
+in (
+
+let uu____5737 = (curry l1 bs2 mk_cod2)
+in ((uu____5731), (uu____5737))))
+end)
+end))))
+end))
+end)))
+
+
+let rec solve : FStar_TypeChecker_Env.env  ->  worklist  ->  solution = (fun env probs -> ((
+
+let uu____5841 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____5841) with
+| true -> begin
+(
+
+let uu____5842 = (wl_to_string probs)
+in (FStar_Util.print1 "solve:\n\t%s\n" uu____5842))
+end
+| uu____5843 -> begin
+()
+end));
+(
+
+let uu____5844 = (next_prob probs)
+in (match (uu____5844) with
+| (Some (hd1), tl1, rank1) -> begin
+(
+
+let probs1 = (
+
+let uu___149_5857 = probs
+in {attempting = tl1; wl_deferred = uu___149_5857.wl_deferred; ctr = uu___149_5857.ctr; defer_ok = uu___149_5857.defer_ok; smt_ok = uu___149_5857.smt_ok; tcenv = uu___149_5857.tcenv})
+in (match (hd1) with
+| FStar_TypeChecker_Common.CProb (cp) -> begin
+(solve_c env (maybe_invert cp) probs1)
+end
+| FStar_TypeChecker_Common.TProb (tp) -> begin
+(match ((((not (probs1.defer_ok)) && (flex_refine_inner <= rank1)) && (rank1 <= flex_rigid))) with
+| true -> begin
+(
+
+let uu____5864 = (solve_flex_rigid_join env tp probs1)
+in (match (uu____5864) with
+| None -> begin
+(solve_t' env (maybe_invert tp) probs1)
+end
+| Some (wl) -> begin
+(solve env wl)
+end))
+end
+| uu____5867 -> begin
+(match ((((not (probs1.defer_ok)) && (rigid_flex <= rank1)) && (rank1 <= refine_flex))) with
+| true -> begin
+(
+
+let uu____5868 = (solve_rigid_flex_meet env tp probs1)
+in (match (uu____5868) with
+| None -> begin
+(solve_t' env (maybe_invert tp) probs1)
+end
+| Some (wl) -> begin
+(solve env wl)
+end))
+end
+| uu____5871 -> begin
+(solve_t' env (maybe_invert tp) probs1)
+end)
+end)
+end))
+end
+| (None, uu____5872, uu____5873) -> begin
+(match (probs.wl_deferred) with
+| [] -> begin
+Success ([])
+end
+| uu____5882 -> begin
+(
+
+let uu____5887 = (FStar_All.pipe_right probs.wl_deferred (FStar_List.partition (fun uu____5915 -> (match (uu____5915) with
+| (c, uu____5920, uu____5921) -> begin
+(c < probs.ctr)
+end))))
+in (match (uu____5887) with
+| (attempt1, rest) -> begin
+(match (attempt1) with
+| [] -> begin
+(
+
+let uu____5943 = (FStar_List.map (fun uu____5949 -> (match (uu____5949) with
+| (uu____5955, x, y) -> begin
+((x), (y))
+end)) probs.wl_deferred)
+in Success (uu____5943))
+end
+| uu____5958 -> begin
+(
+
+let uu____5963 = (
+
+let uu___150_5964 = probs
+in (
+
+let uu____5965 = (FStar_All.pipe_right attempt1 (FStar_List.map (fun uu____5974 -> (match (uu____5974) with
+| (uu____5978, uu____5979, y) -> begin
+y
+end))))
+in {attempting = uu____5965; wl_deferred = rest; ctr = uu___150_5964.ctr; defer_ok = uu___150_5964.defer_ok; smt_ok = uu___150_5964.smt_ok; tcenv = uu___150_5964.tcenv}))
+in (solve env uu____5963))
+end)
+end))
+end)
+end));
+))
+and solve_one_universe_eq : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  worklist  ->  solution = (fun env orig u1 u2 wl -> (
+
+let uu____5986 = (solve_universe_eq (p_pid orig) wl u1 u2)
+in (match (uu____5986) with
+| USolved (wl1) -> begin
+(
+
+let uu____5988 = (solve_prob orig None [] wl1)
+in (solve env uu____5988))
+end
+| UFailed (msg) -> begin
+(giveup env msg orig)
+end
+| UDeferred (wl1) -> begin
+(solve env (defer "" orig wl1))
+end)))
+and solve_maybe_uinsts : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  worklist  ->  univ_eq_sol = (fun env orig t1 t2 wl -> (
+
+let rec aux = (fun wl1 us1 us2 -> (match (((us1), (us2))) with
+| ([], []) -> begin
+USolved (wl1)
+end
+| ((u1)::us11, (u2)::us21) -> begin
+(
+
+let uu____6022 = (solve_universe_eq (p_pid orig) wl1 u1 u2)
+in (match (uu____6022) with
+| USolved (wl2) -> begin
+(aux wl2 us11 us21)
+end
+| failed_or_deferred -> begin
+failed_or_deferred
+end))
+end
+| uu____6025 -> begin
+UFailed ("Unequal number of universes")
+end))
+in (
+
+let t11 = (whnf env t1)
+in (
+
+let t21 = (whnf env t2)
+in (match (((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (f); FStar_Syntax_Syntax.tk = uu____6033; FStar_Syntax_Syntax.pos = uu____6034; FStar_Syntax_Syntax.vars = uu____6035}, us1), FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (g); FStar_Syntax_Syntax.tk = uu____6038; FStar_Syntax_Syntax.pos = uu____6039; FStar_Syntax_Syntax.vars = uu____6040}, us2)) -> begin
+(
+
+let b = (FStar_Syntax_Syntax.fv_eq f g)
+in (aux wl us1 us2))
+end
+| ((FStar_Syntax_Syntax.Tm_uinst (_), _)) | ((_, FStar_Syntax_Syntax.Tm_uinst (_))) -> begin
+(failwith "Impossible: expect head symbols to match")
+end
+| uu____6056 -> begin
+USolved (wl)
+end)))))
+and giveup_or_defer : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  worklist  ->  Prims.string  ->  solution = (fun env orig wl msg -> (match (wl.defer_ok) with
+| true -> begin
+((
+
+let uu____6064 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____6064) with
+| true -> begin
+(
+
+let uu____6065 = (prob_to_string env orig)
+in (FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n" uu____6065 msg))
+end
+| uu____6066 -> begin
+()
+end));
+(solve env (defer msg orig wl));
+)
+end
+| uu____6067 -> begin
+(giveup env msg orig)
+end))
+and solve_rigid_flex_meet : FStar_TypeChecker_Env.env  ->  tprob  ->  worklist  ->  worklist Prims.option = (fun env tp wl -> ((
+
+let uu____6073 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____6073) with
+| true -> begin
+(
+
+let uu____6074 = (FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid)
+in (FStar_Util.print1 "Trying to solve by meeting refinements:%s\n" uu____6074))
+end
+| uu____6075 -> begin
+()
+end));
+(
+
+let uu____6076 = (FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.rhs)
+in (match (uu____6076) with
+| (u, args) -> begin
+(
+
+let rec disjoin = (fun t1 t2 -> (
+
+let uu____6118 = (head_matches_delta env () t1 t2)
+in (match (uu____6118) with
+| (mr, ts) -> begin
+(match (mr) with
+| MisMatch (uu____6140) -> begin
+None
+end
+| FullMatch -> begin
+(match (ts) with
+| None -> begin
+Some (((t1), ([])))
+end
+| Some (t11, t21) -> begin
+Some (((t11), ([])))
+end)
+end
+| HeadMatch -> begin
+(
+
+let uu____6166 = (match (ts) with
+| Some (t11, t21) -> begin
+(
+
+let uu____6175 = (FStar_Syntax_Subst.compress t11)
+in (
+
+let uu____6176 = (FStar_Syntax_Subst.compress t21)
+in ((uu____6175), (uu____6176))))
+end
+| None -> begin
+(
+
+let uu____6179 = (FStar_Syntax_Subst.compress t1)
+in (
+
+let uu____6180 = (FStar_Syntax_Subst.compress t2)
+in ((uu____6179), (uu____6180))))
+end)
+in (match (uu____6166) with
+| (t11, t21) -> begin
+(
+
+let eq_prob = (fun t12 t22 -> (
+
+let uu____6202 = (new_problem env t12 FStar_TypeChecker_Common.EQ t22 None t12.FStar_Syntax_Syntax.pos "meeting refinements")
+in (FStar_All.pipe_left (fun _0_44 -> FStar_TypeChecker_Common.TProb (_0_44)) uu____6202)))
+in (match (((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_refine (x, phi1), FStar_Syntax_Syntax.Tm_refine (y, phi2)) -> begin
+(
+
+let uu____6225 = (
+
+let uu____6231 = (
+
+let uu____6234 = (
+
+let uu____6237 = (
+
+let uu____6238 = (
+
+let uu____6243 = (FStar_Syntax_Util.mk_disj phi1 phi2)
+in ((x), (uu____6243)))
+in FStar_Syntax_Syntax.Tm_refine (uu____6238))
+in (FStar_Syntax_Syntax.mk uu____6237))
+in (uu____6234 None t11.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____6256 = (
+
+let uu____6258 = (eq_prob x.FStar_Syntax_Syntax.sort y.FStar_Syntax_Syntax.sort)
+in (uu____6258)::[])
+in ((uu____6231), (uu____6256))))
+in Some (uu____6225))
+end
+| (uu____6267, FStar_Syntax_Syntax.Tm_refine (x, uu____6269)) -> begin
+(
+
+let uu____6274 = (
+
+let uu____6278 = (
+
+let uu____6280 = (eq_prob x.FStar_Syntax_Syntax.sort t11)
+in (uu____6280)::[])
+in ((t11), (uu____6278)))
+in Some (uu____6274))
+end
+| (FStar_Syntax_Syntax.Tm_refine (x, uu____6286), uu____6287) -> begin
+(
+
+let uu____6292 = (
+
+let uu____6296 = (
+
+let uu____6298 = (eq_prob x.FStar_Syntax_Syntax.sort t21)
+in (uu____6298)::[])
+in ((t21), (uu____6296)))
+in Some (uu____6292))
+end
+| uu____6303 -> begin
+(
+
+let uu____6306 = (FStar_Syntax_Util.head_and_args t11)
+in (match (uu____6306) with
+| (head1, uu____6321) -> begin
+(
+
+let uu____6336 = (
+
+let uu____6337 = (FStar_Syntax_Util.un_uinst head1)
+in uu____6337.FStar_Syntax_Syntax.n)
+in (match (uu____6336) with
+| FStar_Syntax_Syntax.Tm_fvar ({FStar_Syntax_Syntax.fv_name = uu____6344; FStar_Syntax_Syntax.fv_delta = FStar_Syntax_Syntax.Delta_defined_at_level (i); FStar_Syntax_Syntax.fv_qual = uu____6346}) -> begin
+(
+
+let prev = (match ((i > (Prims.parse_int "1"))) with
+| true -> begin
+FStar_Syntax_Syntax.Delta_defined_at_level ((i - (Prims.parse_int "1")))
+end
+| uu____6352 -> begin
+FStar_Syntax_Syntax.Delta_constant
+end)
+in (
+
+let t12 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.UnfoldUntil (prev))::[]) env t11)
+in (
+
+let t22 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.UnfoldUntil (prev))::[]) env t21)
+in (disjoin t12 t22))))
+end
+| uu____6355 -> begin
+None
+end))
+end))
+end))
+end))
+end)
+end)))
+in (
+
+let tt = u
+in (match (tt.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uvar (uv, uu____6364) -> begin
+(
+
+let uu____6377 = (FStar_All.pipe_right wl.attempting (FStar_List.partition (fun uu___124_6386 -> (match (uu___124_6386) with
+| FStar_TypeChecker_Common.TProb (tp1) -> begin
+(match (tp1.FStar_TypeChecker_Common.rank) with
+| Some (rank1) when (is_rigid_flex rank1) -> begin
+(
+
+let uu____6391 = (FStar_Syntax_Util.head_and_args tp1.FStar_TypeChecker_Common.rhs)
+in (match (uu____6391) with
+| (u', uu____6402) -> begin
+(
+
+let uu____6417 = (
+
+let uu____6418 = (whnf env u')
+in uu____6418.FStar_Syntax_Syntax.n)
+in (match (uu____6417) with
+| FStar_Syntax_Syntax.Tm_uvar (uv', uu____6422) -> begin
+(FStar_Unionfind.equivalent uv uv')
+end
+| uu____6438 -> begin
+false
+end))
+end))
+end
+| uu____6439 -> begin
+false
+end)
+end
+| uu____6441 -> begin
+false
+end))))
+in (match (uu____6377) with
+| (lower_bounds, rest) -> begin
+(
+
+let rec make_lower_bound = (fun uu____6462 tps -> (match (uu____6462) with
+| (bound, sub_probs) -> begin
+(match (tps) with
+| [] -> begin
+Some (((bound), (sub_probs)))
+end
+| (FStar_TypeChecker_Common.TProb (hd1))::tl1 -> begin
+(
+
+let uu____6489 = (
+
+let uu____6494 = (whnf env hd1.FStar_TypeChecker_Common.lhs)
+in (disjoin bound uu____6494))
+in (match (uu____6489) with
+| Some (bound1, sub1) -> begin
+(make_lower_bound ((bound1), ((FStar_List.append sub1 sub_probs))) tl1)
+end
+| None -> begin
+None
+end))
+end
+| uu____6513 -> begin
+None
+end)
+end))
+in (
+
+let uu____6518 = (
+
+let uu____6523 = (
+
+let uu____6527 = (whnf env tp.FStar_TypeChecker_Common.lhs)
+in ((uu____6527), ([])))
+in (make_lower_bound uu____6523 lower_bounds))
+in (match (uu____6518) with
+| None -> begin
+((
+
+let uu____6534 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____6534) with
+| true -> begin
+(FStar_Util.print_string "No lower bounds\n")
+end
+| uu____6535 -> begin
+()
+end));
+None;
+)
+end
+| Some (lhs_bound, sub_probs) -> begin
+(
+
+let eq_prob = (new_problem env lhs_bound FStar_TypeChecker_Common.EQ tp.FStar_TypeChecker_Common.rhs None tp.FStar_TypeChecker_Common.loc "meeting refinements")
+in ((
+
+let uu____6547 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____6547) with
+| true -> begin
+(
+
+let wl' = (
+
+let uu___151_6549 = wl
+in {attempting = (FStar_TypeChecker_Common.TProb (eq_prob))::sub_probs; wl_deferred = uu___151_6549.wl_deferred; ctr = uu___151_6549.ctr; defer_ok = uu___151_6549.defer_ok; smt_ok = uu___151_6549.smt_ok; tcenv = uu___151_6549.tcenv})
+in (
+
+let uu____6550 = (wl_to_string wl')
+in (FStar_Util.print1 "After meeting refinements: %s\n" uu____6550)))
+end
+| uu____6551 -> begin
+()
+end));
+(
+
+let uu____6552 = (solve_t env eq_prob (
+
+let uu___152_6553 = wl
+in {attempting = sub_probs; wl_deferred = uu___152_6553.wl_deferred; ctr = uu___152_6553.ctr; defer_ok = uu___152_6553.defer_ok; smt_ok = uu___152_6553.smt_ok; tcenv = uu___152_6553.tcenv}))
+in (match (uu____6552) with
+| Success (uu____6555) -> begin
+(
+
+let wl1 = (
+
+let uu___153_6557 = wl
+in {attempting = rest; wl_deferred = uu___153_6557.wl_deferred; ctr = uu___153_6557.ctr; defer_ok = uu___153_6557.defer_ok; smt_ok = uu___153_6557.smt_ok; tcenv = uu___153_6557.tcenv})
+in (
+
+let wl2 = (solve_prob' false (FStar_TypeChecker_Common.TProb (tp)) None [] wl1)
+in (
+
+let uu____6559 = (FStar_List.fold_left (fun wl3 p -> (solve_prob' true p None [] wl3)) wl2 lower_bounds)
+in Some (wl2))))
+end
+| uu____6562 -> begin
+None
+end));
+))
+end)))
+end))
+end
+| uu____6563 -> begin
+(failwith "Impossible: Not a rigid-flex")
+end)))
+end));
+))
+and solve_flex_rigid_join : FStar_TypeChecker_Env.env  ->  tprob  ->  worklist  ->  worklist Prims.option = (fun env tp wl -> ((
+
+let uu____6570 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____6570) with
+| true -> begin
+(
+
+let uu____6571 = (FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid)
+in (FStar_Util.print1 "Trying to solve by joining refinements:%s\n" uu____6571))
+end
+| uu____6572 -> begin
+()
+end));
+(
+
+let uu____6573 = (FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs)
+in (match (uu____6573) with
+| (u, args) -> begin
+(
+
+let uu____6600 = (((Prims.parse_int "0")), ((Prims.parse_int "1")), ((Prims.parse_int "2")), ((Prims.parse_int "3")), ((Prims.parse_int "4")))
+in (match (uu____6600) with
+| (ok, head_match1, partial_match, fallback, failed_match) -> begin
+(
+
+let max1 = (fun i j -> (match ((i < j)) with
+| true -> begin
+j
+end
+| uu____6619 -> begin
+i
+end))
+in (
+
+let base_types_match = (fun t1 t2 -> (
+
+let uu____6631 = (FStar_Syntax_Util.head_and_args t1)
+in (match (uu____6631) with
+| (h1, args1) -> begin
+(
+
+let uu____6659 = (FStar_Syntax_Util.head_and_args t2)
+in (match (uu____6659) with
+| (h2, uu____6672) -> begin
+(match (((h1.FStar_Syntax_Syntax.n), (h2.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_fvar (tc1), FStar_Syntax_Syntax.Tm_fvar (tc2)) -> begin
+(
+
+let uu____6691 = (FStar_Syntax_Syntax.fv_eq tc1 tc2)
+in (match (uu____6691) with
+| true -> begin
+(match (((FStar_List.length args1) = (Prims.parse_int "0"))) with
+| true -> begin
+Some ([])
+end
+| uu____6703 -> begin
+(
+
+let uu____6704 = (
+
+let uu____6706 = (
+
+let uu____6707 = (new_problem env t1 FStar_TypeChecker_Common.EQ t2 None t1.FStar_Syntax_Syntax.pos "joining refinements")
+in (FStar_All.pipe_left (fun _0_45 -> FStar_TypeChecker_Common.TProb (_0_45)) uu____6707))
+in (uu____6706)::[])
+in Some (uu____6704))
+end)
+end
+| uu____6713 -> begin
+None
+end))
+end
+| (FStar_Syntax_Syntax.Tm_name (a), FStar_Syntax_Syntax.Tm_name (b)) -> begin
+(match ((FStar_Syntax_Syntax.bv_eq a b)) with
+| true -> begin
+(match (((FStar_List.length args1) = (Prims.parse_int "0"))) with
+| true -> begin
+Some ([])
+end
+| uu____6728 -> begin
+(
+
+let uu____6729 = (
+
+let uu____6731 = (
+
+let uu____6732 = (new_problem env t1 FStar_TypeChecker_Common.EQ t2 None t1.FStar_Syntax_Syntax.pos "joining refinements")
+in (FStar_All.pipe_left (fun _0_46 -> FStar_TypeChecker_Common.TProb (_0_46)) uu____6732))
+in (uu____6731)::[])
+in Some (uu____6729))
+end)
+end
+| uu____6738 -> begin
+None
+end)
+end
+| uu____6740 -> begin
+None
+end)
+end))
+end)))
+in (
+
+let conjoin = (fun t1 t2 -> (match (((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.Tm_refine (x, phi1), FStar_Syntax_Syntax.Tm_refine (y, phi2)) -> begin
+(
+
+let m = (base_types_match x.FStar_Syntax_Syntax.sort y.FStar_Syntax_Syntax.sort)
+in (match (m) with
+| None -> begin
+None
+end
+| Some (m1) -> begin
+(
+
+let x1 = (FStar_Syntax_Syntax.freshen_bv x)
+in (
+
+let subst1 = (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x1))))::[]
+in (
+
+let phi11 = (FStar_Syntax_Subst.subst subst1 phi1)
+in (
+
+let phi21 = (FStar_Syntax_Subst.subst subst1 phi2)
+in (
+
+let uu____6806 = (
+
+let uu____6812 = (
+
+let uu____6815 = (FStar_Syntax_Util.mk_conj phi11 phi21)
+in (FStar_Syntax_Util.refine x1 uu____6815))
+in ((uu____6812), (m1)))
+in Some (uu____6806))))))
+end))
+end
+| (uu____6824, FStar_Syntax_Syntax.Tm_refine (y, uu____6826)) -> begin
+(
+
+let m = (base_types_match t1 y.FStar_Syntax_Syntax.sort)
+in (match (m) with
+| None -> begin
+None
+end
+| Some (m1) -> begin
+Some (((t2), (m1)))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_refine (x, uu____6858), uu____6859) -> begin
+(
+
+let m = (base_types_match x.FStar_Syntax_Syntax.sort t2)
+in (match (m) with
+| None -> begin
+None
+end
+| Some (m1) -> begin
+Some (((t1), (m1)))
+end))
+end
+| uu____6890 -> begin
+(
+
+let m = (base_types_match t1 t2)
+in (match (m) with
+| None -> begin
+None
+end
+| Some (m1) -> begin
+Some (((t1), (m1)))
+end))
+end))
+in (
+
+let tt = u
+in (match (tt.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_uvar (uv, uu____6924) -> begin
+(
+
+let uu____6937 = (FStar_All.pipe_right wl.attempting (FStar_List.partition (fun uu___125_6946 -> (match (uu___125_6946) with
+| FStar_TypeChecker_Common.TProb (tp1) -> begin
+(match (tp1.FStar_TypeChecker_Common.rank) with
+| Some (rank1) when (is_flex_rigid rank1) -> begin
+(
+
+let uu____6951 = (FStar_Syntax_Util.head_and_args tp1.FStar_TypeChecker_Common.lhs)
+in (match (uu____6951) with
+| (u', uu____6962) -> begin
+(
+
+let uu____6977 = (
+
+let uu____6978 = (whnf env u')
+in uu____6978.FStar_Syntax_Syntax.n)
+in (match (uu____6977) with
+| FStar_Syntax_Syntax.Tm_uvar (uv', uu____6982) -> begin
+(FStar_Unionfind.equivalent uv uv')
+end
+| uu____6998 -> begin
+false
+end))
+end))
+end
+| uu____6999 -> begin
+false
+end)
+end
+| uu____7001 -> begin
+false
+end))))
+in (match (uu____6937) with
+| (upper_bounds, rest) -> begin
+(
+
+let rec make_upper_bound = (fun uu____7026 tps -> (match (uu____7026) with
+| (bound, sub_probs) -> begin
+(match (tps) with
+| [] -> begin
+Some (((bound), (sub_probs)))
+end
+| (FStar_TypeChecker_Common.TProb (hd1))::tl1 -> begin
+(
+
+let uu____7067 = (
+
+let uu____7074 = (whnf env hd1.FStar_TypeChecker_Common.rhs)
+in (conjoin bound uu____7074))
+in (match (uu____7067) with
+| Some (bound1, sub1) -> begin
+(make_upper_bound ((bound1), ((FStar_List.append sub1 sub_probs))) tl1)
+end
+| None -> begin
+None
+end))
+end
+| uu____7109 -> begin
+None
+end)
+end))
+in (
+
+let uu____7116 = (
+
+let uu____7123 = (
+
+let uu____7129 = (whnf env tp.FStar_TypeChecker_Common.rhs)
+in ((uu____7129), ([])))
+in (make_upper_bound uu____7123 upper_bounds))
+in (match (uu____7116) with
+| None -> begin
+((
+
+let uu____7138 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____7138) with
+| true -> begin
+(FStar_Util.print_string "No upper bounds\n")
+end
+| uu____7139 -> begin
+()
+end));
+None;
+)
+end
+| Some (rhs_bound, sub_probs) -> begin
+(
+
+let eq_prob = (new_problem env tp.FStar_TypeChecker_Common.lhs FStar_TypeChecker_Common.EQ rhs_bound None tp.FStar_TypeChecker_Common.loc "joining refinements")
+in ((
+
+let uu____7157 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____7157) with
+| true -> begin
+(
+
+let wl' = (
+
+let uu___154_7159 = wl
+in {attempting = (FStar_TypeChecker_Common.TProb (eq_prob))::sub_probs; wl_deferred = uu___154_7159.wl_deferred; ctr = uu___154_7159.ctr; defer_ok = uu___154_7159.defer_ok; smt_ok = uu___154_7159.smt_ok; tcenv = uu___154_7159.tcenv})
+in (
+
+let uu____7160 = (wl_to_string wl')
+in (FStar_Util.print1 "After joining refinements: %s\n" uu____7160)))
+end
+| uu____7161 -> begin
+()
+end));
+(
+
+let uu____7162 = (solve_t env eq_prob (
+
+let uu___155_7163 = wl
+in {attempting = sub_probs; wl_deferred = uu___155_7163.wl_deferred; ctr = uu___155_7163.ctr; defer_ok = uu___155_7163.defer_ok; smt_ok = uu___155_7163.smt_ok; tcenv = uu___155_7163.tcenv}))
+in (match (uu____7162) with
+| Success (uu____7165) -> begin
+(
+
+let wl1 = (
+
+let uu___156_7167 = wl
+in {attempting = rest; wl_deferred = uu___156_7167.wl_deferred; ctr = uu___156_7167.ctr; defer_ok = uu___156_7167.defer_ok; smt_ok = uu___156_7167.smt_ok; tcenv = uu___156_7167.tcenv})
+in (
+
+let wl2 = (solve_prob' false (FStar_TypeChecker_Common.TProb (tp)) None [] wl1)
+in (
+
+let uu____7169 = (FStar_List.fold_left (fun wl3 p -> (solve_prob' true p None [] wl3)) wl2 upper_bounds)
+in Some (wl2))))
+end
+| uu____7172 -> begin
+None
+end));
+))
+end)))
+end))
+end
+| uu____7173 -> begin
+(failwith "Impossible: Not a flex-rigid")
+end)))))
+end))
+end));
+))
+and solve_binders : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders  ->  FStar_TypeChecker_Common.prob  ->  worklist  ->  (FStar_Syntax_Syntax.binders  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_TypeChecker_Common.prob)  ->  solution = (fun env bs1 bs2 orig wl rhs -> (
+
+let rec aux = (fun scope env1 subst1 xs ys -> (match (((xs), (ys))) with
+| ([], []) -> begin
+(
+
+let rhs_prob = (rhs (FStar_List.rev scope) env1 subst1)
+in ((
+
+let uu____7238 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Rel")))
+in (match (uu____7238) with
+| true -> begin
+(
+
+let uu____7239 = (prob_to_string env1 rhs_prob)
+in (FStar_Util.print1 "rhs_prob = %s\n" uu____7239))
+end
+| uu____7240 -> begin
+()
+end));
+(
+
+let formula = (FStar_All.pipe_right (p_guard rhs_prob) Prims.fst)
+in FStar_Util.Inl ((((rhs_prob)::[]), (formula))));
+))
+end
+| (((hd1, imp))::xs1, ((hd2, imp'))::ys1) when (imp = imp') -> begin
+(
+
+let hd11 = (
+
+let uu___157_7271 = hd1
+in (
+
+let uu____7272 = (FStar_Syntax_Subst.subst subst1 hd1.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___157_7271.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___157_7271.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____7272}))
+in (
+
+let hd21 = (
+
+let uu___158_7276 = hd2
+in (
+
+let uu____7277 = (FStar_Syntax_Subst.subst subst1 hd2.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___158_7276.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___158_7276.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____7277}))
+in (
+
+let prob = (
+
+let uu____7281 = (
+
+let uu____7284 = (FStar_All.pipe_left invert_rel (p_rel orig))
+in (mk_problem scope orig hd11.FStar_Syntax_Syntax.sort uu____7284 hd21.FStar_Syntax_Syntax.sort None "Formal parameter"))
+in (FStar_All.pipe_left (fun _0_47 -> FStar_TypeChecker_Common.TProb (_0_47)) uu____7281))
+in (
+
+let hd12 = (FStar_Syntax_Syntax.freshen_bv hd11)
+in (
+
+let subst2 = (
+
+let uu____7292 = (FStar_Syntax_Subst.shift_subst (Prims.parse_int "1") subst1)
+in (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (hd12))))::uu____7292)
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_bv env1 hd12)
+in (
+
+let uu____7295 = (aux ((((hd12), (imp)))::scope) env2 subst2 xs1 ys1)
+in (match (uu____7295) with
+| FStar_Util.Inl (sub_probs, phi) -> begin
+(
+
+let phi1 = (
+
+let uu____7313 = (FStar_All.pipe_right (p_guard prob) Prims.fst)
+in (
+
+let uu____7316 = (close_forall env2 ((((hd12), (imp)))::[]) phi)
+in (FStar_Syntax_Util.mk_conj uu____7313 uu____7316)))
+in ((
+
+let uu____7322 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("Rel")))
+in (match (uu____7322) with
+| true -> begin
+(
+
+let uu____7323 = (FStar_Syntax_Print.term_to_string phi1)
+in (
+
+let uu____7324 = (FStar_Syntax_Print.bv_to_string hd12)
+in (FStar_Util.print2 "Formula is %s\n\thd1=%s\n" uu____7323 uu____7324)))
+end
+| uu____7325 -> begin
+()
+end));
+FStar_Util.Inl ((((prob)::sub_probs), (phi1)));
+))
+end
+| fail -> begin
+fail
+end))))))))
+end
+| uu____7339 -> begin
+FStar_Util.Inr ("arity or argument-qualifier mismatch")
+end))
+in (
+
+let scope = (p_scope orig)
+in (
+
+let uu____7345 = (aux scope env [] bs1 bs2)
+in (match (uu____7345) with
+| FStar_Util.Inr (msg) -> begin
+(giveup env msg orig)
+end
+| FStar_Util.Inl (sub_probs, phi) -> begin
+(
+
+let wl1 = (solve_prob orig (Some (phi)) [] wl)
+in (solve env (attempt sub_probs wl1)))
+end)))))
+and solve_t : FStar_TypeChecker_Env.env  ->  tprob  ->  worklist  ->  solution = (fun env problem wl -> (
+
+let uu____7361 = (compress_tprob wl problem)
+in (solve_t' env uu____7361 wl)))
+and solve_t' : FStar_TypeChecker_Env.env  ->  tprob  ->  worklist  ->  solution = (fun env problem wl -> (
+
+let giveup_or_defer1 = (fun orig msg -> (giveup_or_defer env orig wl msg))
+in (
+
+let rigid_rigid_delta = (fun env1 orig wl1 head1 head2 t1 t2 -> (
+
+let uu____7394 = (head_matches_delta env1 wl1 t1 t2)
+in (match (uu____7394) with
+| (m, o) -> begin
+(match (((m), (o))) with
+| (MisMatch (uu____7411), uu____7412) -> begin
+(
+
+let may_relate = (fun head3 -> (
+
+let uu____7427 = (
+
+let uu____7428 = (FStar_Syntax_Util.un_uinst head3)
+in uu____7428.FStar_Syntax_Syntax.n)
+in (match (uu____7427) with
+| (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_match (_)) -> begin
+true
+end
+| FStar_Syntax_Syntax.Tm_fvar (tc) -> begin
+(tc.FStar_Syntax_Syntax.fv_delta = FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____7434 -> begin
+false
+end)))
+in (
+
+let uu____7435 = (((may_relate head1) || (may_relate head2)) && wl1.smt_ok)
+in (match (uu____7435) with
+| true -> begin
+(
+
+let guard = (match ((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ)) with
+| true -> begin
+(mk_eq2 env1 t1 t2)
+end
+| uu____7437 -> begin
+(
+
+let has_type_guard = (fun t11 t21 -> (match (problem.FStar_TypeChecker_Common.element) with
+| Some (t) -> begin
+(FStar_Syntax_Util.mk_has_type t11 t t21)
+end
+| None -> begin
+(
+
+let x = (FStar_Syntax_Syntax.new_bv None t11)
+in (
+
+let u_x = (env1.FStar_TypeChecker_Env.universe_of env1 t11)
+in (
+
+let uu____7452 = (
+
+let uu____7453 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_Syntax_Util.mk_has_type t11 uu____7453 t21))
+in (FStar_Syntax_Util.mk_forall u_x x uu____7452))))
+end))
+in (match ((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.SUB)) with
+| true -> begin
+(has_type_guard t1 t2)
+end
+| uu____7454 -> begin
+(has_type_guard t2 t1)
+end))
+end)
+in (
+
+let uu____7455 = (solve_prob orig (Some (guard)) [] wl1)
+in (solve env1 uu____7455)))
+end
+| uu____7456 -> begin
+(giveup env1 "head mismatch" orig)
+end)))
+end
+| (uu____7457, Some (t11, t21)) -> begin
+(solve_t env1 (
+
+let uu___159_7465 = problem
+in {FStar_TypeChecker_Common.pid = uu___159_7465.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = t11; FStar_TypeChecker_Common.relation = uu___159_7465.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = t21; FStar_TypeChecker_Common.element = uu___159_7465.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___159_7465.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___159_7465.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___159_7465.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___159_7465.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___159_7465.FStar_TypeChecker_Common.rank}) wl1)
+end
+| (uu____7466, None) -> begin
+((
+
+let uu____7473 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Rel")))
+in (match (uu____7473) with
+| true -> begin
+(
+
+let uu____7474 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____7475 = (FStar_Syntax_Print.tag_of_term t1)
+in (
+
+let uu____7476 = (FStar_Syntax_Print.term_to_string t2)
+in (
+
+let uu____7477 = (FStar_Syntax_Print.tag_of_term t2)
+in (FStar_Util.print4 "Head matches: %s (%s) and %s (%s)\n" uu____7474 uu____7475 uu____7476 uu____7477)))))
+end
+| uu____7478 -> begin
+()
+end));
+(
+
+let uu____7479 = (FStar_Syntax_Util.head_and_args t1)
+in (match (uu____7479) with
+| (head11, args1) -> begin
+(
+
+let uu____7505 = (FStar_Syntax_Util.head_and_args t2)
+in (match (uu____7505) with
+| (head21, args2) -> begin
+(
+
+let nargs = (FStar_List.length args1)
+in (match ((nargs <> (FStar_List.length args2))) with
+| true -> begin
+(
+
+let uu____7545 = (
+
+let uu____7546 = (FStar_Syntax_Print.term_to_string head11)
+in (
+
+let uu____7547 = (args_to_string args1)
+in (
+
+let uu____7548 = (FStar_Syntax_Print.term_to_string head21)
+in (
+
+let uu____7549 = (args_to_string args2)
+in (FStar_Util.format4 "unequal number of arguments: %s[%s] and %s[%s]" uu____7546 uu____7547 uu____7548 uu____7549)))))
+in (giveup env1 uu____7545 orig))
+end
+| uu____7550 -> begin
+(
+
+let uu____7551 = ((nargs = (Prims.parse_int "0")) || (
+
+let uu____7554 = (FStar_Syntax_Util.eq_args args1 args2)
+in (uu____7554 = FStar_Syntax_Util.Equal)))
+in (match (uu____7551) with
+| true -> begin
+(
+
+let uu____7555 = (solve_maybe_uinsts env1 orig head11 head21 wl1)
+in (match (uu____7555) with
+| USolved (wl2) -> begin
+(
+
+let uu____7557 = (solve_prob orig None [] wl2)
+in (solve env1 uu____7557))
+end
+| UFailed (msg) -> begin
+(giveup env1 msg orig)
+end
+| UDeferred (wl2) -> begin
+(solve env1 (defer "universe constraints" orig wl2))
+end))
+end
+| uu____7560 -> begin
+(
+
+let uu____7561 = (base_and_refinement env1 wl1 t1)
+in (match (uu____7561) with
+| (base1, refinement1) -> begin
+(
+
+let uu____7587 = (base_and_refinement env1 wl1 t2)
+in (match (uu____7587) with
+| (base2, refinement2) -> begin
+(match (((refinement1), (refinement2))) with
+| (None, None) -> begin
+(
+
+let uu____7641 = (solve_maybe_uinsts env1 orig head11 head21 wl1)
+in (match (uu____7641) with
+| UFailed (msg) -> begin
+(giveup env1 msg orig)
+end
+| UDeferred (wl2) -> begin
+(solve env1 (defer "universe constraints" orig wl2))
+end
+| USolved (wl2) -> begin
+(
+
+let subprobs = (FStar_List.map2 (fun uu____7651 uu____7652 -> (match (((uu____7651), (uu____7652))) with
+| ((a, uu____7662), (a', uu____7664)) -> begin
+(
+
+let uu____7669 = (mk_problem (p_scope orig) orig a FStar_TypeChecker_Common.EQ a' None "index")
+in (FStar_All.pipe_left (fun _0_48 -> FStar_TypeChecker_Common.TProb (_0_48)) uu____7669))
+end)) args1 args2)
+in (
+
+let formula = (
+
+let uu____7675 = (FStar_List.map (fun p -> (Prims.fst (p_guard p))) subprobs)
+in (FStar_Syntax_Util.mk_conj_l uu____7675))
+in (
+
+let wl3 = (solve_prob orig (Some (formula)) [] wl2)
+in (solve env1 (attempt subprobs wl3)))))
+end))
+end
+| uu____7679 -> begin
+(
+
+let lhs = (force_refinement ((base1), (refinement1)))
+in (
+
+let rhs = (force_refinement ((base2), (refinement2)))
+in (solve_t env1 (
+
+let uu___160_7712 = problem
+in {FStar_TypeChecker_Common.pid = uu___160_7712.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = lhs; FStar_TypeChecker_Common.relation = uu___160_7712.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = rhs; FStar_TypeChecker_Common.element = uu___160_7712.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___160_7712.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___160_7712.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___160_7712.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___160_7712.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___160_7712.FStar_TypeChecker_Common.rank}) wl1)))
+end)
+end))
+end))
+end))
+end))
+end))
+end));
+)
+end)
+end)))
+in (
+
+let imitate = (fun orig env1 wl1 p -> (
+
+let uu____7732 = p
+in (match (uu____7732) with
+| (((u, k), xs, c), ps, (h, uu____7743, qs)) -> begin
+(
+
+let xs1 = (sn_binders env1 xs)
+in (
+
+let r = (FStar_TypeChecker_Env.get_range env1)
+in (
+
+let uu____7792 = (imitation_sub_probs orig env1 xs1 ps qs)
+in (match (uu____7792) with
+| (sub_probs, gs_xs, formula) -> begin
+(
+
+let im = (
+
+let uu____7806 = (h gs_xs)
+in (
+
+let uu____7807 = (
+
+let uu____7814 = (FStar_All.pipe_right (FStar_Syntax_Util.lcomp_of_comp c) (fun _0_49 -> FStar_Util.Inl (_0_49)))
+in (FStar_All.pipe_right uu____7814 (fun _0_50 -> Some (_0_50))))
+in (FStar_Syntax_Util.abs xs1 uu____7806 uu____7807)))
+in ((
+
+let uu____7845 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Rel")))
+in (match (uu____7845) with
+| true -> begin
+(
+
+let uu____7846 = (FStar_Syntax_Print.binders_to_string ", " xs1)
+in (
+
+let uu____7847 = (FStar_Syntax_Print.comp_to_string c)
+in (
+
+let uu____7848 = (FStar_Syntax_Print.term_to_string im)
+in (
+
+let uu____7849 = (FStar_Syntax_Print.tag_of_term im)
+in (
+
+let uu____7850 = (
+
+let uu____7851 = (FStar_List.map (prob_to_string env1) sub_probs)
+in (FStar_All.pipe_right uu____7851 (FStar_String.concat ", ")))
+in (
+
+let uu____7854 = (FStar_TypeChecker_Normalize.term_to_string env1 formula)
+in (FStar_Util.print6 "Imitating  binders are {%s}, comp=%s\n\t%s (%s)\nsub_probs = %s\nformula=%s\n" uu____7846 uu____7847 uu____7848 uu____7849 uu____7850 uu____7854)))))))
+end
+| uu____7855 -> begin
+()
+end));
+(
+
+let wl2 = (solve_prob orig (Some (formula)) ((TERM (((((u), (k))), (im))))::[]) wl1)
+in (solve env1 (attempt sub_probs wl2)));
+))
+end))))
+end)))
+in (
+
+let imitate' = (fun orig env1 wl1 uu___126_7872 -> (match (uu___126_7872) with
+| None -> begin
+(giveup env1 "unable to compute subterms" orig)
+end
+| Some (p) -> begin
+(imitate orig env1 wl1 p)
+end))
+in (
+
+let project = (fun orig env1 wl1 i p -> (
+
+let uu____7901 = p
+in (match (uu____7901) with
+| ((u, xs, c), ps, (h, matches, qs)) -> begin
+(
+
+let r = (FStar_TypeChecker_Env.get_range env1)
+in (
+
+let uu____7959 = (FStar_List.nth ps i)
+in (match (uu____7959) with
+| (pi, uu____7962) -> begin
+(
+
+let uu____7967 = (FStar_List.nth xs i)
+in (match (uu____7967) with
+| (xi, uu____7974) -> begin
+(
+
+let rec gs = (fun k -> (
+
+let uu____7983 = (FStar_Syntax_Util.arrow_formals k)
+in (match (uu____7983) with
+| (bs, k1) -> begin
+(
+
+let rec aux = (fun subst1 bs1 -> (match (bs1) with
+| [] -> begin
+(([]), ([]))
+end
+| ((a, uu____8035))::tl1 -> begin
+(
+
+let k_a = (FStar_Syntax_Subst.subst subst1 a.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____8043 = (new_uvar r xs k_a)
+in (match (uu____8043) with
+| (gi_xs, gi) -> begin
+(
+
+let gi_xs1 = (FStar_TypeChecker_Normalize.eta_expand env1 gi_xs)
+in (
+
+let gi_ps = ((FStar_Syntax_Syntax.mk_Tm_app gi ps) (Some (k_a.FStar_Syntax_Syntax.n)) r)
+in (
+
+let subst2 = (FStar_Syntax_Syntax.NT (((a), (gi_xs1))))::subst1
+in (
+
+let uu____8062 = (aux subst2 tl1)
+in (match (uu____8062) with
+| (gi_xs', gi_ps') -> begin
+(
+
+let uu____8077 = (
+
+let uu____8079 = (FStar_Syntax_Syntax.as_arg gi_xs1)
+in (uu____8079)::gi_xs')
+in (
+
+let uu____8080 = (
+
+let uu____8082 = (FStar_Syntax_Syntax.as_arg gi_ps)
+in (uu____8082)::gi_ps')
+in ((uu____8077), (uu____8080))))
+end)))))
+end)))
+end))
+in (aux [] bs))
+end)))
+in (
+
+let uu____8085 = (
+
+let uu____8086 = (matches pi)
+in (FStar_All.pipe_left Prims.op_Negation uu____8086))
+in (match (uu____8085) with
+| true -> begin
+None
+end
+| uu____8088 -> begin
+(
+
+let uu____8089 = (gs xi.FStar_Syntax_Syntax.sort)
+in (match (uu____8089) with
+| (g_xs, uu____8096) -> begin
+(
+
+let xi1 = (FStar_Syntax_Syntax.bv_to_name xi)
+in (
+
+let proj = (
+
+let uu____8103 = ((FStar_Syntax_Syntax.mk_Tm_app xi1 g_xs) None r)
+in (
+
+let uu____8108 = (
+
+let uu____8115 = (FStar_All.pipe_right (FStar_Syntax_Util.lcomp_of_comp c) (fun _0_51 -> FStar_Util.Inl (_0_51)))
+in (FStar_All.pipe_right uu____8115 (fun _0_52 -> Some (_0_52))))
+in (FStar_Syntax_Util.abs xs uu____8103 uu____8108)))
+in (
+
+let sub1 = (
+
+let uu____8146 = (
+
+let uu____8149 = ((FStar_Syntax_Syntax.mk_Tm_app proj ps) None r)
+in (
+
+let uu____8156 = (
+
+let uu____8159 = (FStar_List.map (fun uu____8165 -> (match (uu____8165) with
+| (uu____8170, uu____8171, y) -> begin
+y
+end)) qs)
+in (FStar_All.pipe_left h uu____8159))
+in (mk_problem (p_scope orig) orig uu____8149 (p_rel orig) uu____8156 None "projection")))
+in (FStar_All.pipe_left (fun _0_53 -> FStar_TypeChecker_Common.TProb (_0_53)) uu____8146))
+in ((
+
+let uu____8181 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Rel")))
+in (match (uu____8181) with
+| true -> begin
+(
+
+let uu____8182 = (FStar_Syntax_Print.term_to_string proj)
+in (
+
+let uu____8183 = (prob_to_string env1 sub1)
+in (FStar_Util.print2 "Projecting %s\n\tsubprob=%s\n" uu____8182 uu____8183)))
+end
+| uu____8184 -> begin
+()
+end));
+(
+
+let wl2 = (
+
+let uu____8186 = (
+
+let uu____8188 = (FStar_All.pipe_left Prims.fst (p_guard sub1))
+in Some (uu____8188))
+in (solve_prob orig uu____8186 ((TERM (((u), (proj))))::[]) wl1))
+in (
+
+let uu____8193 = (solve env1 (attempt ((sub1)::[]) wl2))
+in (FStar_All.pipe_left (fun _0_54 -> Some (_0_54)) uu____8193)));
+))))
+end))
+end)))
+end))
+end)))
+end)))
+in (
+
+let solve_t_flex_rigid = (fun patterns_only orig lhs t2 wl1 -> (
+
+let uu____8217 = lhs
+in (match (uu____8217) with
+| ((t1, uv, k_uv, args_lhs), maybe_pat_vars) -> begin
+(
+
+let subterms = (fun ps -> (
+
+let uu____8240 = (FStar_Syntax_Util.arrow_formals_comp k_uv)
+in (match (uu____8240) with
+| (xs, c) -> begin
+(match (((FStar_List.length xs) = (FStar_List.length ps))) with
+| true -> begin
+(
+
+let uu____8262 = (
+
+let uu____8288 = (decompose env t2)
+in ((((((uv), (k_uv))), (xs), (c))), (ps), (uu____8288)))
+in Some (uu____8262))
+end
+| uu____8354 -> begin
+(
+
+let k_uv1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env k_uv)
+in (
+
+let rec elim = (fun k args -> (
+
+let uu____8371 = (
+
+let uu____8375 = (
+
+let uu____8376 = (FStar_Syntax_Subst.compress k)
+in uu____8376.FStar_Syntax_Syntax.n)
+in ((uu____8375), (args)))
+in (match (uu____8371) with
+| (uu____8383, []) -> begin
+(
+
+let uu____8385 = (
+
+let uu____8391 = (FStar_Syntax_Syntax.mk_Total k)
+in (([]), (uu____8391)))
+in Some (uu____8385))
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), _)) | ((FStar_Syntax_Syntax.Tm_app (_), _)) -> begin
+(
+
+let uu____8408 = (FStar_Syntax_Util.head_and_args k)
+in (match (uu____8408) with
+| (uv1, uv_args) -> begin
+(
+
+let uu____8437 = (
+
+let uu____8438 = (FStar_Syntax_Subst.compress uv1)
+in uu____8438.FStar_Syntax_Syntax.n)
+in (match (uu____8437) with
+| FStar_Syntax_Syntax.Tm_uvar (uvar, uu____8445) -> begin
+(
+
+let uu____8458 = (pat_vars env [] uv_args)
+in (match (uu____8458) with
+| None -> begin
+None
+end
+| Some (scope) -> begin
+(
+
+let xs1 = (FStar_All.pipe_right args (FStar_List.map (fun uu____8472 -> (
+
+let uu____8473 = (
+
+let uu____8474 = (
+
+let uu____8475 = (
+
+let uu____8478 = (
+
+let uu____8479 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____8479 Prims.fst))
+in (new_uvar k.FStar_Syntax_Syntax.pos scope uu____8478))
+in (Prims.fst uu____8475))
+in (FStar_Syntax_Syntax.new_bv (Some (k.FStar_Syntax_Syntax.pos)) uu____8474))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____8473)))))
+in (
+
+let c1 = (
+
+let uu____8485 = (
+
+let uu____8486 = (
+
+let uu____8489 = (
+
+let uu____8490 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____8490 Prims.fst))
+in (new_uvar k.FStar_Syntax_Syntax.pos scope uu____8489))
+in (Prims.fst uu____8486))
+in (FStar_Syntax_Syntax.mk_Total uu____8485))
+in (
+
+let k' = (FStar_Syntax_Util.arrow xs1 c1)
+in (
+
+let uv_sol = (
+
+let uu____8499 = (
+
+let uu____8506 = (
+
+let uu____8512 = (
+
+let uu____8513 = (
+
+let uu____8516 = (
+
+let uu____8517 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____8517 Prims.fst))
+in (FStar_Syntax_Syntax.mk_Total uu____8516))
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____8513))
+in FStar_Util.Inl (uu____8512))
+in Some (uu____8506))
+in (FStar_Syntax_Util.abs scope k' uu____8499))
+in ((FStar_Unionfind.change uvar (FStar_Syntax_Syntax.Fixed (uv_sol)));
+Some (((xs1), (c1)));
+)))))
+end))
+end
+| uu____8540 -> begin
+None
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_arrow (xs1, c1), uu____8545) -> begin
+(
+
+let n_args = (FStar_List.length args)
+in (
+
+let n_xs = (FStar_List.length xs1)
+in (match ((n_xs = n_args)) with
+| true -> begin
+(
+
+let uu____8571 = (FStar_Syntax_Subst.open_comp xs1 c1)
+in (FStar_All.pipe_right uu____8571 (fun _0_55 -> Some (_0_55))))
+end
+| uu____8581 -> begin
+(match ((n_xs < n_args)) with
+| true -> begin
+(
+
+let uu____8590 = (FStar_Util.first_N n_xs args)
+in (match (uu____8590) with
+| (args1, rest) -> begin
+(
+
+let uu____8606 = (FStar_Syntax_Subst.open_comp xs1 c1)
+in (match (uu____8606) with
+| (xs2, c2) -> begin
+(
+
+let uu____8614 = (elim (FStar_Syntax_Util.comp_result c2) rest)
+in (FStar_Util.bind_opt uu____8614 (fun uu____8625 -> (match (uu____8625) with
+| (xs', c3) -> begin
+Some ((((FStar_List.append xs2 xs')), (c3)))
+end))))
+end))
+end))
+end
+| uu____8646 -> begin
+(
+
+let uu____8647 = (FStar_Util.first_N n_args xs1)
+in (match (uu____8647) with
+| (xs2, rest) -> begin
+(
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((rest), (c1))))) None k.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____8693 = (
+
+let uu____8696 = (FStar_Syntax_Syntax.mk_Total t)
+in (FStar_Syntax_Subst.open_comp xs2 uu____8696))
+in (FStar_All.pipe_right uu____8693 (fun _0_56 -> Some (_0_56)))))
+end))
+end)
+end)))
+end
+| uu____8704 -> begin
+(
+
+let uu____8708 = (
+
+let uu____8709 = (FStar_Syntax_Print.uvar_to_string uv)
+in (
+
+let uu____8713 = (FStar_Syntax_Print.term_to_string k)
+in (
+
+let uu____8714 = (FStar_Syntax_Print.term_to_string k_uv1)
+in (FStar_Util.format3 "Impossible: ill-typed application %s : %s\n\t%s" uu____8709 uu____8713 uu____8714))))
+in (failwith uu____8708))
+end)))
+in (
+
+let uu____8718 = (elim k_uv1 ps)
+in (FStar_Util.bind_opt uu____8718 (fun uu____8746 -> (match (uu____8746) with
+| (xs1, c1) -> begin
+(
+
+let uu____8774 = (
+
+let uu____8797 = (decompose env t2)
+in ((((((uv), (k_uv1))), (xs1), (c1))), (ps), (uu____8797)))
+in Some (uu____8774))
+end))))))
+end)
+end)))
+in (
+
+let rec imitate_or_project = (fun n1 stopt i -> (match (((i >= n1) || (FStar_Option.isNone stopt))) with
+| true -> begin
+(giveup env "flex-rigid case failed all backtracking attempts" orig)
+end
+| uu____8866 -> begin
+(
+
+let st = (FStar_Option.get stopt)
+in (
+
+let tx = (FStar_Unionfind.new_transaction ())
+in (match ((i = (~- ((Prims.parse_int "1"))))) with
+| true -> begin
+(
+
+let uu____8869 = (imitate orig env wl1 st)
+in (match (uu____8869) with
+| Failed (uu____8874) -> begin
+((FStar_Unionfind.rollback tx);
+(imitate_or_project n1 stopt (i + (Prims.parse_int "1")));
+)
+end
+| sol -> begin
+sol
+end))
+end
+| uu____8879 -> begin
+(
+
+let uu____8880 = (project orig env wl1 i st)
+in (match (uu____8880) with
+| (None) | (Some (Failed (_))) -> begin
+((FStar_Unionfind.rollback tx);
+(imitate_or_project n1 stopt (i + (Prims.parse_int "1")));
+)
+end
+| Some (sol) -> begin
+sol
+end))
+end)))
+end))
+in (
+
+let check_head = (fun fvs1 t21 -> (
+
+let uu____8898 = (FStar_Syntax_Util.head_and_args t21)
+in (match (uu____8898) with
+| (hd1, uu____8909) -> begin
+(match (hd1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) -> begin
+true
+end
+| uu____8927 -> begin
+(
+
+let fvs_hd = (FStar_Syntax_Free.names hd1)
+in (
+
+let uu____8930 = (FStar_Util.set_is_subset_of fvs_hd fvs1)
+in (match (uu____8930) with
+| true -> begin
+true
+end
+| uu____8931 -> begin
+((
+
+let uu____8933 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____8933) with
+| true -> begin
+(
+
+let uu____8934 = (names_to_string fvs_hd)
+in (FStar_Util.print1 "Free variables are %s" uu____8934))
+end
+| uu____8935 -> begin
+()
+end));
+false;
+)
+end)))
+end)
+end)))
+in (
+
+let imitate_ok = (fun t21 -> (
+
+let fvs_hd = (
+
+let uu____8942 = (
+
+let uu____8945 = (FStar_Syntax_Util.head_and_args t21)
+in (FStar_All.pipe_right uu____8945 Prims.fst))
+in (FStar_All.pipe_right uu____8942 FStar_Syntax_Free.names))
+in (
+
+let uu____8976 = (FStar_Util.set_is_empty fvs_hd)
+in (match (uu____8976) with
+| true -> begin
+(~- ((Prims.parse_int "1")))
+end
+| uu____8977 -> begin
+(Prims.parse_int "0")
+end))))
+in (match (maybe_pat_vars) with
+| Some (vars) -> begin
+(
+
+let t11 = (sn env t1)
+in (
+
+let t21 = (sn env t2)
+in (
+
+let fvs1 = (FStar_Syntax_Free.names t11)
+in (
+
+let fvs2 = (FStar_Syntax_Free.names t21)
+in (
+
+let uu____8985 = (occurs_check env wl1 ((uv), (k_uv)) t21)
+in (match (uu____8985) with
+| (occurs_ok, msg) -> begin
+(match ((not (occurs_ok))) with
+| true -> begin
+(
+
+let uu____8993 = (
+
+let uu____8994 = (FStar_Option.get msg)
+in (Prims.strcat "occurs-check failed: " uu____8994))
+in (giveup_or_defer1 orig uu____8993))
+end
+| uu____8995 -> begin
+(
+
+let uu____8996 = (FStar_Util.set_is_subset_of fvs2 fvs1)
+in (match (uu____8996) with
+| true -> begin
+(
+
+let uu____8997 = (((not (patterns_only)) && (FStar_Syntax_Util.is_function_typ t21)) && ((p_rel orig) <> FStar_TypeChecker_Common.EQ))
+in (match (uu____8997) with
+| true -> begin
+(
+
+let uu____8998 = (subterms args_lhs)
+in (imitate' orig env wl1 uu____8998))
+end
+| uu____9000 -> begin
+((
+
+let uu____9002 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____9002) with
+| true -> begin
+(
+
+let uu____9003 = (FStar_Syntax_Print.term_to_string t11)
+in (
+
+let uu____9004 = (names_to_string fvs1)
+in (
+
+let uu____9005 = (names_to_string fvs2)
+in (FStar_Util.print3 "Pattern %s with fvars=%s succeeded fvar check: %s\n" uu____9003 uu____9004 uu____9005))))
+end
+| uu____9006 -> begin
+()
+end));
+(
+
+let sol = (match (vars) with
+| [] -> begin
+t21
+end
+| uu____9010 -> begin
+(
+
+let uu____9011 = (sn_binders env vars)
+in (u_abs k_uv uu____9011 t21))
+end)
+in (
+
+let wl2 = (solve_prob orig None ((TERM (((((uv), (k_uv))), (sol))))::[]) wl1)
+in (solve env wl2)));
+)
+end))
+end
+| uu____9018 -> begin
+(match ((((not (patterns_only)) && wl1.defer_ok) && ((p_rel orig) <> FStar_TypeChecker_Common.EQ))) with
+| true -> begin
+(solve env (defer "flex pattern/rigid: occurs or freevar check" orig wl1))
+end
+| uu____9019 -> begin
+(
+
+let uu____9020 = ((not (patterns_only)) && (check_head fvs1 t21))
+in (match (uu____9020) with
+| true -> begin
+((
+
+let uu____9022 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____9022) with
+| true -> begin
+(
+
+let uu____9023 = (FStar_Syntax_Print.term_to_string t11)
+in (
+
+let uu____9024 = (names_to_string fvs1)
+in (
+
+let uu____9025 = (names_to_string fvs2)
+in (FStar_Util.print3 "Pattern %s with fvars=%s failed fvar check: %s ... imitating\n" uu____9023 uu____9024 uu____9025))))
+end
+| uu____9026 -> begin
+()
+end));
+(
+
+let uu____9027 = (subterms args_lhs)
+in (imitate_or_project (FStar_List.length args_lhs) uu____9027 (~- ((Prims.parse_int "1")))));
+)
+end
+| uu____9036 -> begin
+(giveup env "free-variable check failed on a non-redex" orig)
+end))
+end)
+end))
+end)
+end))))))
+end
+| None when patterns_only -> begin
+(giveup env "not a pattern" orig)
+end
+| None -> begin
+(match (wl1.defer_ok) with
+| true -> begin
+(solve env (defer "not a pattern" orig wl1))
+end
+| uu____9037 -> begin
+(
+
+let uu____9038 = (
+
+let uu____9039 = (FStar_Syntax_Free.names t1)
+in (check_head uu____9039 t2))
+in (match (uu____9038) with
+| true -> begin
+(
+
+let im_ok = (imitate_ok t2)
+in ((
+
+let uu____9043 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____9043) with
+| true -> begin
+(
+
+let uu____9044 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print2 "Not a pattern (%s) ... %s\n" uu____9044 (match ((im_ok < (Prims.parse_int "0"))) with
+| true -> begin
+"imitating"
+end
+| uu____9045 -> begin
+"projecting"
+end)))
+end
+| uu____9046 -> begin
+()
+end));
+(
+
+let uu____9047 = (subterms args_lhs)
+in (imitate_or_project (FStar_List.length args_lhs) uu____9047 im_ok));
+))
+end
+| uu____9056 -> begin
+(giveup env "head-symbol is free" orig)
+end))
+end)
+end)))))
+end)))
+in (
+
+let flex_flex1 = (fun orig lhs rhs -> (match ((wl.defer_ok && ((p_rel orig) <> FStar_TypeChecker_Common.EQ))) with
+| true -> begin
+(solve env (defer "flex-flex deferred" orig wl))
+end
+| uu____9067 -> begin
+(
+
+let force_quasi_pattern = (fun xs_opt uu____9089 -> (match (uu____9089) with
+| (t, u, k, args) -> begin
+(
+
+let uu____9119 = (FStar_Syntax_Util.arrow_formals k)
+in (match (uu____9119) with
+| (all_formals, uu____9130) -> begin
+(
+
+let rec aux = (fun pat_args pattern_vars pattern_var_set formals args1 -> (match (((formals), (args1))) with
+| ([], []) -> begin
+(
+
+let pat_args1 = (FStar_All.pipe_right (FStar_List.rev pat_args) (FStar_List.map (fun uu____9222 -> (match (uu____9222) with
+| (x, imp) -> begin
+(
+
+let uu____9229 = (FStar_Syntax_Syntax.bv_to_name x)
+in ((uu____9229), (imp)))
+end))))
+in (
+
+let pattern_vars1 = (FStar_List.rev pattern_vars)
+in (
+
+let kk = (
+
+let uu____9237 = (FStar_Syntax_Util.type_u ())
+in (match (uu____9237) with
+| (t1, uu____9241) -> begin
+(
+
+let uu____9242 = (new_uvar t1.FStar_Syntax_Syntax.pos pattern_vars1 t1)
+in (Prims.fst uu____9242))
+end))
+in (
+
+let uu____9245 = (new_uvar t.FStar_Syntax_Syntax.pos pattern_vars1 kk)
+in (match (uu____9245) with
+| (t', tm_u1) -> begin
+(
+
+let uu____9252 = (destruct_flex_t t')
+in (match (uu____9252) with
+| (uu____9272, u1, k1, uu____9275) -> begin
+(
+
+let sol = (
+
+let uu____9303 = (
+
+let uu____9308 = (u_abs k all_formals t')
+in ((((u), (k))), (uu____9308)))
+in TERM (uu____9303))
+in (
+
+let t_app = ((FStar_Syntax_Syntax.mk_Tm_app tm_u1 pat_args1) None t.FStar_Syntax_Syntax.pos)
+in ((sol), (((t_app), (u1), (k1), (pat_args1))))))
+end))
+end)))))
+end
+| ((formal)::formals1, (hd1)::tl1) -> begin
+(
+
+let uu____9368 = (pat_var_opt env pat_args hd1)
+in (match (uu____9368) with
+| None -> begin
+(aux pat_args pattern_vars pattern_var_set formals1 tl1)
+end
+| Some (y) -> begin
+(
+
+let maybe_pat = (match (xs_opt) with
+| None -> begin
+true
+end
+| Some (xs) -> begin
+(FStar_All.pipe_right xs (FStar_Util.for_some (fun uu____9397 -> (match (uu____9397) with
+| (x, uu____9401) -> begin
+(FStar_Syntax_Syntax.bv_eq x (Prims.fst y))
+end))))
+end)
+in (match ((not (maybe_pat))) with
+| true -> begin
+(aux pat_args pattern_vars pattern_var_set formals1 tl1)
+end
+| uu____9404 -> begin
+(
+
+let fvs = (FStar_Syntax_Free.names (Prims.fst y).FStar_Syntax_Syntax.sort)
+in (
+
+let uu____9407 = (
+
+let uu____9408 = (FStar_Util.set_is_subset_of fvs pattern_var_set)
+in (not (uu____9408)))
+in (match (uu____9407) with
+| true -> begin
+(aux pat_args pattern_vars pattern_var_set formals1 tl1)
+end
+| uu____9411 -> begin
+(
+
+let uu____9412 = (FStar_Util.set_add (Prims.fst formal) pattern_var_set)
+in (aux ((y)::pat_args) ((formal)::pattern_vars) uu____9412 formals1 tl1))
+end)))
+end))
+end))
+end
+| uu____9418 -> begin
+(failwith "Impossible")
+end))
+in (
+
+let uu____9429 = (FStar_Syntax_Syntax.new_bv_set ())
+in (aux [] [] uu____9429 all_formals args)))
+end))
+end))
+in (
+
+let solve_both_pats = (fun wl1 uu____9477 uu____9478 r -> (match (((uu____9477), (uu____9478))) with
+| ((u1, k1, xs, args1), (u2, k2, ys, args2)) -> begin
+(
+
+let uu____9632 = ((FStar_Unionfind.equivalent u1 u2) && (binders_eq xs ys))
+in (match (uu____9632) with
+| true -> begin
+(
+
+let uu____9636 = (solve_prob orig None [] wl1)
+in (solve env uu____9636))
+end
+| uu____9637 -> begin
+(
+
+let xs1 = (sn_binders env xs)
+in (
+
+let ys1 = (sn_binders env ys)
+in (
+
+let zs = (intersect_vars xs1 ys1)
+in ((
+
+let uu____9651 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____9651) with
+| true -> begin
+(
+
+let uu____9652 = (FStar_Syntax_Print.binders_to_string ", " xs1)
+in (
+
+let uu____9653 = (FStar_Syntax_Print.binders_to_string ", " ys1)
+in (
+
+let uu____9654 = (FStar_Syntax_Print.binders_to_string ", " zs)
+in (
+
+let uu____9655 = (FStar_Syntax_Print.term_to_string k1)
+in (
+
+let uu____9656 = (FStar_Syntax_Print.term_to_string k2)
+in (FStar_Util.print5 "Flex-flex patterns: intersected %s and %s; got %s\n\tk1=%s\n\tk2=%s\n" uu____9652 uu____9653 uu____9654 uu____9655 uu____9656))))))
+end
+| uu____9657 -> begin
+()
+end));
+(
+
+let subst_k = (fun k xs2 args -> (
+
+let xs_len = (FStar_List.length xs2)
+in (
+
+let args_len = (FStar_List.length args)
+in (match ((xs_len = args_len)) with
+| true -> begin
+(
+
+let uu____9698 = (FStar_Syntax_Util.subst_of_list xs2 args)
+in (FStar_Syntax_Subst.subst uu____9698 k))
+end
+| uu____9700 -> begin
+(match ((args_len < xs_len)) with
+| true -> begin
+(
+
+let uu____9706 = (FStar_Util.first_N args_len xs2)
+in (match (uu____9706) with
+| (xs3, xs_rest) -> begin
+(
+
+let k3 = (
+
+let uu____9736 = (FStar_Syntax_Syntax.mk_GTotal k)
+in (FStar_Syntax_Util.arrow xs_rest uu____9736))
+in (
+
+let uu____9739 = (FStar_Syntax_Util.subst_of_list xs3 args)
+in (FStar_Syntax_Subst.subst uu____9739 k3)))
+end))
+end
+| uu____9741 -> begin
+(
+
+let uu____9742 = (
+
+let uu____9743 = (FStar_Syntax_Print.term_to_string k)
+in (
+
+let uu____9744 = (FStar_Syntax_Print.binders_to_string ", " xs2)
+in (
+
+let uu____9745 = (FStar_Syntax_Print.args_to_string args)
+in (FStar_Util.format3 "k=%s\nxs=%s\nargs=%s\nIll-formed substitutution" uu____9743 uu____9744 uu____9745))))
+in (failwith uu____9742))
+end)
+end))))
+in (
+
+let uu____9746 = (
+
+let uu____9752 = (
+
+let uu____9760 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env k1)
+in (FStar_Syntax_Util.arrow_formals uu____9760))
+in (match (uu____9752) with
+| (bs, k1') -> begin
+(
+
+let uu____9778 = (
+
+let uu____9786 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env k2)
+in (FStar_Syntax_Util.arrow_formals uu____9786))
+in (match (uu____9778) with
+| (cs, k2') -> begin
+(
+
+let k1'_xs = (subst_k k1' bs args1)
+in (
+
+let k2'_ys = (subst_k k2' cs args2)
+in (
+
+let sub_prob = (
+
+let uu____9807 = (mk_problem (p_scope orig) orig k1'_xs FStar_TypeChecker_Common.EQ k2'_ys None "flex-flex kinding")
+in (FStar_All.pipe_left (fun _0_57 -> FStar_TypeChecker_Common.TProb (_0_57)) uu____9807))
+in (
+
+let uu____9812 = (
+
+let uu____9815 = (
+
+let uu____9816 = (FStar_Syntax_Subst.compress k1')
+in uu____9816.FStar_Syntax_Syntax.n)
+in (
+
+let uu____9819 = (
+
+let uu____9820 = (FStar_Syntax_Subst.compress k2')
+in uu____9820.FStar_Syntax_Syntax.n)
+in ((uu____9815), (uu____9819))))
+in (match (uu____9812) with
+| (FStar_Syntax_Syntax.Tm_type (uu____9828), uu____9829) -> begin
+((k1'), ((sub_prob)::[]))
+end
+| (uu____9833, FStar_Syntax_Syntax.Tm_type (uu____9834)) -> begin
+((k2'), ((sub_prob)::[]))
+end
+| uu____9838 -> begin
+(
+
+let uu____9841 = (FStar_Syntax_Util.type_u ())
+in (match (uu____9841) with
+| (t, uu____9850) -> begin
+(
+
+let uu____9851 = (new_uvar r zs t)
+in (match (uu____9851) with
+| (k_zs, uu____9860) -> begin
+(
+
+let kprob = (
+
+let uu____9862 = (mk_problem (p_scope orig) orig k1'_xs FStar_TypeChecker_Common.EQ k_zs None "flex-flex kinding")
+in (FStar_All.pipe_left (fun _0_58 -> FStar_TypeChecker_Common.TProb (_0_58)) uu____9862))
+in ((k_zs), ((sub_prob)::(kprob)::[])))
+end))
+end))
+end)))))
+end))
+end))
+in (match (uu____9746) with
+| (k_u', sub_probs) -> begin
+(
+
+let uu____9876 = (
+
+let uu____9884 = (
+
+let uu____9885 = (new_uvar r zs k_u')
+in (FStar_All.pipe_left Prims.fst uu____9885))
+in (
+
+let uu____9890 = (
+
+let uu____9893 = (FStar_Syntax_Syntax.mk_Total k_u')
+in (FStar_Syntax_Util.arrow xs1 uu____9893))
+in (
+
+let uu____9896 = (
+
+let uu____9899 = (FStar_Syntax_Syntax.mk_Total k_u')
+in (FStar_Syntax_Util.arrow ys1 uu____9899))
+in ((uu____9884), (uu____9890), (uu____9896)))))
+in (match (uu____9876) with
+| (u_zs, knew1, knew2) -> begin
+(
+
+let sub1 = (u_abs knew1 xs1 u_zs)
+in (
+
+let uu____9918 = (occurs_check env wl1 ((u1), (k1)) sub1)
+in (match (uu____9918) with
+| (occurs_ok, msg) -> begin
+(match ((not (occurs_ok))) with
+| true -> begin
+(giveup_or_defer1 orig "flex-flex: failed occcurs check")
+end
+| uu____9930 -> begin
+(
+
+let sol1 = TERM (((((u1), (k1))), (sub1)))
+in (
+
+let uu____9942 = (FStar_Unionfind.equivalent u1 u2)
+in (match (uu____9942) with
+| true -> begin
+(
+
+let wl2 = (solve_prob orig None ((sol1)::[]) wl1)
+in (solve env wl2))
+end
+| uu____9947 -> begin
+(
+
+let sub2 = (u_abs knew2 ys1 u_zs)
+in (
+
+let uu____9949 = (occurs_check env wl1 ((u2), (k2)) sub2)
+in (match (uu____9949) with
+| (occurs_ok1, msg1) -> begin
+(match ((not (occurs_ok1))) with
+| true -> begin
+(giveup_or_defer1 orig "flex-flex: failed occurs check")
+end
+| uu____9961 -> begin
+(
+
+let sol2 = TERM (((((u2), (k2))), (sub2)))
+in (
+
+let wl2 = (solve_prob orig None ((sol1)::(sol2)::[]) wl1)
+in (solve env (attempt sub_probs wl2))))
+end)
+end)))
+end)))
+end)
+end)))
+end))
+end)));
+))))
+end))
+end))
+in (
+
+let solve_one_pat = (fun uu____10001 uu____10002 -> (match (((uu____10001), (uu____10002))) with
+| ((t1, u1, k1, xs), (t2, u2, k2, args2)) -> begin
+((
+
+let uu____10106 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____10106) with
+| true -> begin
+(
+
+let uu____10107 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____10108 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.print2 "Trying flex-flex one pattern (%s) with %s\n" uu____10107 uu____10108)))
+end
+| uu____10109 -> begin
+()
+end));
+(
+
+let uu____10110 = (FStar_Unionfind.equivalent u1 u2)
+in (match (uu____10110) with
+| true -> begin
+(
+
+let sub_probs = (FStar_List.map2 (fun uu____10120 uu____10121 -> (match (((uu____10120), (uu____10121))) with
+| ((a, uu____10131), (t21, uu____10133)) -> begin
+(
+
+let uu____10138 = (
+
+let uu____10141 = (FStar_Syntax_Syntax.bv_to_name a)
+in (mk_problem (p_scope orig) orig uu____10141 FStar_TypeChecker_Common.EQ t21 None "flex-flex index"))
+in (FStar_All.pipe_right uu____10138 (fun _0_59 -> FStar_TypeChecker_Common.TProb (_0_59))))
+end)) xs args2)
+in (
+
+let guard = (
+
+let uu____10145 = (FStar_List.map (fun p -> (FStar_All.pipe_right (p_guard p) Prims.fst)) sub_probs)
+in (FStar_Syntax_Util.mk_conj_l uu____10145))
+in (
+
+let wl1 = (solve_prob orig (Some (guard)) [] wl)
+in (solve env (attempt sub_probs wl1)))))
+end
+| uu____10151 -> begin
+(
+
+let t21 = (sn env t2)
+in (
+
+let rhs_vars = (FStar_Syntax_Free.names t21)
+in (
+
+let uu____10155 = (occurs_check env wl ((u1), (k1)) t21)
+in (match (uu____10155) with
+| (occurs_ok, uu____10164) -> begin
+(
+
+let lhs_vars = (FStar_Syntax_Free.names_of_binders xs)
+in (
+
+let uu____10169 = (occurs_ok && (FStar_Util.set_is_subset_of rhs_vars lhs_vars))
+in (match (uu____10169) with
+| true -> begin
+(
+
+let sol = (
+
+let uu____10171 = (
+
+let uu____10176 = (u_abs k1 xs t21)
+in ((((u1), (k1))), (uu____10176)))
+in TERM (uu____10171))
+in (
+
+let wl1 = (solve_prob orig None ((sol)::[]) wl)
+in (solve env wl1)))
+end
+| uu____10188 -> begin
+(
+
+let uu____10189 = (occurs_ok && (FStar_All.pipe_left Prims.op_Negation wl.defer_ok))
+in (match (uu____10189) with
+| true -> begin
+(
+
+let uu____10190 = (force_quasi_pattern (Some (xs)) ((t21), (u2), (k2), (args2)))
+in (match (uu____10190) with
+| (sol, (uu____10204, u21, k21, ys)) -> begin
+(
+
+let wl1 = (extend_solution (p_pid orig) ((sol)::[]) wl)
+in ((
+
+let uu____10214 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("QuasiPattern")))
+in (match (uu____10214) with
+| true -> begin
+(
+
+let uu____10215 = (uvi_to_string env sol)
+in (FStar_Util.print1 "flex-flex quasi pattern (2): %s\n" uu____10215))
+end
+| uu____10216 -> begin
+()
+end));
+(match (orig) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(solve_t env p wl1)
+end
+| uu____10220 -> begin
+(giveup env "impossible" orig)
+end);
+))
+end))
+end
+| uu____10221 -> begin
+(giveup_or_defer1 orig "flex-flex constraint")
+end))
+end)))
+end))))
+end));
+)
+end))
+in (
+
+let uu____10222 = lhs
+in (match (uu____10222) with
+| (t1, u1, k1, args1) -> begin
+(
+
+let uu____10227 = rhs
+in (match (uu____10227) with
+| (t2, u2, k2, args2) -> begin
+(
+
+let maybe_pat_vars1 = (pat_vars env [] args1)
+in (
+
+let maybe_pat_vars2 = (pat_vars env [] args2)
+in (
+
+let r = t2.FStar_Syntax_Syntax.pos
+in (match (((maybe_pat_vars1), (maybe_pat_vars2))) with
+| (Some (xs), Some (ys)) -> begin
+(solve_both_pats wl ((u1), (k1), (xs), (args1)) ((u2), (k2), (ys), (args2)) t2.FStar_Syntax_Syntax.pos)
+end
+| (Some (xs), None) -> begin
+(solve_one_pat ((t1), (u1), (k1), (xs)) rhs)
+end
+| (None, Some (ys)) -> begin
+(solve_one_pat ((t2), (u2), (k2), (ys)) lhs)
+end
+| uu____10253 -> begin
+(match (wl.defer_ok) with
+| true -> begin
+(giveup_or_defer1 orig "flex-flex: neither side is a pattern")
+end
+| uu____10258 -> begin
+(
+
+let uu____10259 = (force_quasi_pattern None ((t1), (u1), (k1), (args1)))
+in (match (uu____10259) with
+| (sol, uu____10266) -> begin
+(
+
+let wl1 = (extend_solution (p_pid orig) ((sol)::[]) wl)
+in ((
+
+let uu____10269 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("QuasiPattern")))
+in (match (uu____10269) with
+| true -> begin
+(
+
+let uu____10270 = (uvi_to_string env sol)
+in (FStar_Util.print1 "flex-flex quasi pattern (1): %s\n" uu____10270))
+end
+| uu____10271 -> begin
+()
+end));
+(match (orig) with
+| FStar_TypeChecker_Common.TProb (p) -> begin
+(solve_t env p wl1)
+end
+| uu____10275 -> begin
+(giveup env "impossible" orig)
+end);
+))
+end))
+end)
+end))))
+end))
+end)))))
+end))
+in (
+
+let orig = FStar_TypeChecker_Common.TProb (problem)
+in (
+
+let uu____10277 = (FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs problem.FStar_TypeChecker_Common.rhs)
+in (match (uu____10277) with
+| true -> begin
+(
+
+let uu____10278 = (solve_prob orig None [] wl)
+in (solve env uu____10278))
+end
+| uu____10279 -> begin
+(
+
+let t1 = problem.FStar_TypeChecker_Common.lhs
+in (
+
+let t2 = problem.FStar_TypeChecker_Common.rhs
+in (
+
+let uu____10282 = (FStar_Util.physical_equality t1 t2)
+in (match (uu____10282) with
+| true -> begin
+(
+
+let uu____10283 = (solve_prob orig None [] wl)
+in (solve env uu____10283))
+end
+| uu____10284 -> begin
+((
+
+let uu____10286 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("RelCheck")))
+in (match (uu____10286) with
+| true -> begin
+(
+
+let uu____10287 = (FStar_Util.string_of_int problem.FStar_TypeChecker_Common.pid)
+in (FStar_Util.print1 "Attempting %s\n" uu____10287))
+end
+| uu____10288 -> begin
+()
+end));
+(
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (match (((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))) with
+| ((FStar_Syntax_Syntax.Tm_bvar (_), _)) | ((_, FStar_Syntax_Syntax.Tm_bvar (_))) -> begin
+(failwith "Only locally nameless! We should never see a de Bruijn variable")
+end
+| (FStar_Syntax_Syntax.Tm_type (u1), FStar_Syntax_Syntax.Tm_type (u2)) -> begin
+(solve_one_universe_eq env orig u1 u2 wl)
+end
+| (FStar_Syntax_Syntax.Tm_arrow (bs1, c1), FStar_Syntax_Syntax.Tm_arrow (bs2, c2)) -> begin
+(
+
+let mk_c = (fun c uu___127_10333 -> (match (uu___127_10333) with
+| [] -> begin
+c
+end
+| bs -> begin
+(
+
+let uu____10347 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((bs), (c))))) None c.FStar_Syntax_Syntax.pos)
+in (FStar_Syntax_Syntax.mk_Total uu____10347))
+end))
+in (
+
+let uu____10361 = (match_num_binders ((bs1), ((mk_c c1))) ((bs2), ((mk_c c2))))
+in (match (uu____10361) with
+| ((bs11, c11), (bs21, c21)) -> begin
+(solve_binders env bs11 bs21 orig wl (fun scope env1 subst1 -> (
+
+let c12 = (FStar_Syntax_Subst.subst_comp subst1 c11)
+in (
+
+let c22 = (FStar_Syntax_Subst.subst_comp subst1 c21)
+in (
+
+let rel = (
+
+let uu____10447 = (FStar_Options.use_eq_at_higher_order ())
+in (match (uu____10447) with
+| true -> begin
+FStar_TypeChecker_Common.EQ
+end
+| uu____10448 -> begin
+problem.FStar_TypeChecker_Common.relation
+end))
+in (
+
+let uu____10449 = (mk_problem scope orig c12 rel c22 None "function co-domain")
+in (FStar_All.pipe_left (fun _0_60 -> FStar_TypeChecker_Common.CProb (_0_60)) uu____10449)))))))
+end)))
+end
+| (FStar_Syntax_Syntax.Tm_abs (bs1, tbody1, lopt1), FStar_Syntax_Syntax.Tm_abs (bs2, tbody2, lopt2)) -> begin
+(
+
+let mk_t = (fun t l uu___128_10526 -> (match (uu___128_10526) with
+| [] -> begin
+t
+end
+| bs -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_abs (((bs), (t), (l))))) None t.FStar_Syntax_Syntax.pos)
+end))
+in (
+
+let uu____10565 = (match_num_binders ((bs1), ((mk_t tbody1 lopt1))) ((bs2), ((mk_t tbody2 lopt2))))
+in (match (uu____10565) with
+| ((bs11, tbody11), (bs21, tbody21)) -> begin
+(solve_binders env bs11 bs21 orig wl (fun scope env1 subst1 -> (
+
+let uu____10648 = (
+
+let uu____10651 = (FStar_Syntax_Subst.subst subst1 tbody11)
+in (
+
+let uu____10652 = (FStar_Syntax_Subst.subst subst1 tbody21)
+in (mk_problem scope orig uu____10651 problem.FStar_TypeChecker_Common.relation uu____10652 None "lambda co-domain")))
+in (FStar_All.pipe_left (fun _0_61 -> FStar_TypeChecker_Common.TProb (_0_61)) uu____10648))))
+end)))
+end
+| ((FStar_Syntax_Syntax.Tm_abs (_), _)) | ((_, FStar_Syntax_Syntax.Tm_abs (_))) -> begin
+(
+
+let is_abs = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_abs (uu____10667) -> begin
+true
+end
+| uu____10682 -> begin
+false
+end))
+in (
+
+let maybe_eta = (fun t -> (match ((is_abs t)) with
+| true -> begin
+FStar_Util.Inl (t)
+end
+| uu____10701 -> begin
+(
+
+let t3 = (FStar_TypeChecker_Normalize.eta_expand wl.tcenv t)
+in (match ((is_abs t3)) with
+| true -> begin
+FStar_Util.Inl (t3)
+end
+| uu____10707 -> begin
+FStar_Util.Inr (t3)
+end))
+end))
+in (
+
+let uu____10710 = (
+
+let uu____10721 = (maybe_eta t1)
+in (
+
+let uu____10726 = (maybe_eta t2)
+in ((uu____10721), (uu____10726))))
+in (match (uu____10710) with
+| (FStar_Util.Inl (t11), FStar_Util.Inl (t21)) -> begin
+(solve_t env (
+
+let uu___161_10757 = problem
+in {FStar_TypeChecker_Common.pid = uu___161_10757.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = t11; FStar_TypeChecker_Common.relation = uu___161_10757.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = t21; FStar_TypeChecker_Common.element = uu___161_10757.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___161_10757.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___161_10757.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___161_10757.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___161_10757.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___161_10757.FStar_TypeChecker_Common.rank}) wl)
+end
+| ((FStar_Util.Inl (t_abs), FStar_Util.Inr (not_abs))) | ((FStar_Util.Inr (not_abs), FStar_Util.Inl (t_abs))) -> begin
+(
+
+let uu____10790 = ((is_flex not_abs) && ((p_rel orig) = FStar_TypeChecker_Common.EQ))
+in (match (uu____10790) with
+| true -> begin
+(
+
+let uu____10791 = (destruct_flex_pattern env not_abs)
+in (solve_t_flex_rigid true orig uu____10791 t_abs wl))
+end
+| uu____10795 -> begin
+(giveup env "head tag mismatch: RHS is an abstraction" orig)
+end))
+end
+| uu____10796 -> begin
+(failwith "Impossible: at least one side is an abstraction")
+end))))
+end
+| (FStar_Syntax_Syntax.Tm_refine (uu____10807), FStar_Syntax_Syntax.Tm_refine (uu____10808)) -> begin
+(
+
+let uu____10817 = (as_refinement env wl t1)
+in (match (uu____10817) with
+| (x1, phi1) -> begin
+(
+
+let uu____10822 = (as_refinement env wl t2)
+in (match (uu____10822) with
+| (x2, phi2) -> begin
+(
+
+let base_prob = (
+
+let uu____10828 = (mk_problem (p_scope orig) orig x1.FStar_Syntax_Syntax.sort problem.FStar_TypeChecker_Common.relation x2.FStar_Syntax_Syntax.sort problem.FStar_TypeChecker_Common.element "refinement base type")
+in (FStar_All.pipe_left (fun _0_62 -> FStar_TypeChecker_Common.TProb (_0_62)) uu____10828))
+in (
+
+let x11 = (FStar_Syntax_Syntax.freshen_bv x1)
+in (
+
+let subst1 = (FStar_Syntax_Syntax.DB ((((Prims.parse_int "0")), (x11))))::[]
+in (
+
+let phi11 = (FStar_Syntax_Subst.subst subst1 phi1)
+in (
+
+let phi21 = (FStar_Syntax_Subst.subst subst1 phi2)
+in (
+
+let env1 = (FStar_TypeChecker_Env.push_bv env x11)
+in (
+
+let mk_imp1 = (fun imp phi12 phi22 -> (
+
+let uu____10861 = (imp phi12 phi22)
+in (FStar_All.pipe_right uu____10861 (guard_on_element wl problem x11))))
+in (
+
+let fallback = (fun uu____10865 -> (
+
+let impl = (match ((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ)) with
+| true -> begin
+(mk_imp1 FStar_Syntax_Util.mk_iff phi11 phi21)
+end
+| uu____10867 -> begin
+(mk_imp1 FStar_Syntax_Util.mk_imp phi11 phi21)
+end)
+in (
+
+let guard = (
+
+let uu____10871 = (FStar_All.pipe_right (p_guard base_prob) Prims.fst)
+in (FStar_Syntax_Util.mk_conj uu____10871 impl))
+in (
+
+let wl1 = (solve_prob orig (Some (guard)) [] wl)
+in (solve env1 (attempt ((base_prob)::[]) wl1))))))
+in (match ((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ)) with
+| true -> begin
+(
+
+let ref_prob = (
+
+let uu____10878 = (
+
+let uu____10881 = (
+
+let uu____10882 = (FStar_Syntax_Syntax.mk_binder x11)
+in (uu____10882)::(p_scope orig))
+in (mk_problem uu____10881 orig phi11 FStar_TypeChecker_Common.EQ phi21 None "refinement formula"))
+in (FStar_All.pipe_left (fun _0_63 -> FStar_TypeChecker_Common.TProb (_0_63)) uu____10878))
+in (
+
+let uu____10885 = (solve env1 (
+
+let uu___162_10886 = wl
+in {attempting = (ref_prob)::[]; wl_deferred = []; ctr = uu___162_10886.ctr; defer_ok = false; smt_ok = uu___162_10886.smt_ok; tcenv = uu___162_10886.tcenv}))
+in (match (uu____10885) with
+| Failed (uu____10890) -> begin
+(fallback ())
+end
+| Success (uu____10893) -> begin
+(
+
+let guard = (
+
+let uu____10897 = (FStar_All.pipe_right (p_guard base_prob) Prims.fst)
+in (
+
+let uu____10900 = (
+
+let uu____10901 = (FStar_All.pipe_right (p_guard ref_prob) Prims.fst)
+in (FStar_All.pipe_right uu____10901 (guard_on_element wl problem x11)))
+in (FStar_Syntax_Util.mk_conj uu____10897 uu____10900)))
+in (
+
+let wl1 = (solve_prob orig (Some (guard)) [] wl)
+in (
+
+let wl2 = (
+
+let uu___163_10908 = wl1
+in {attempting = uu___163_10908.attempting; wl_deferred = uu___163_10908.wl_deferred; ctr = (wl1.ctr + (Prims.parse_int "1")); defer_ok = uu___163_10908.defer_ok; smt_ok = uu___163_10908.smt_ok; tcenv = uu___163_10908.tcenv})
+in (solve env1 (attempt ((base_prob)::[]) wl2)))))
+end)))
+end
+| uu____10909 -> begin
+(fallback ())
+end)))))))))
+end))
+end))
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), FStar_Syntax_Syntax.Tm_uvar (_))) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), FStar_Syntax_Syntax.Tm_uvar (_))) | ((FStar_Syntax_Syntax.Tm_uvar (_), FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))) -> begin
+(
+
+let uu____10962 = (destruct_flex_t t1)
+in (
+
+let uu____10963 = (destruct_flex_t t2)
+in (flex_flex1 orig uu____10962 uu____10963)))
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), _)) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), _)) when (problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ) -> begin
+(
+
+let uu____10979 = (destruct_flex_pattern env t1)
+in (solve_t_flex_rigid false orig uu____10979 t2 wl))
+end
+| ((_, FStar_Syntax_Syntax.Tm_uvar (_))) | ((_, FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))) when (problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ) -> begin
+(solve_t env (invert problem) wl)
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), FStar_Syntax_Syntax.Tm_type (_))) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), FStar_Syntax_Syntax.Tm_type (_))) | ((FStar_Syntax_Syntax.Tm_uvar (_), FStar_Syntax_Syntax.Tm_arrow (_))) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), FStar_Syntax_Syntax.Tm_arrow (_))) -> begin
+(solve_t' env (
+
+let uu___164_11028 = problem
+in {FStar_TypeChecker_Common.pid = uu___164_11028.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___164_11028.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ; FStar_TypeChecker_Common.rhs = uu___164_11028.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___164_11028.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___164_11028.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___164_11028.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___164_11028.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___164_11028.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___164_11028.FStar_TypeChecker_Common.rank}) wl)
+end
+| ((FStar_Syntax_Syntax.Tm_uvar (_), _)) | ((FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _), _)) -> begin
+(match (wl.defer_ok) with
+| true -> begin
+(solve env (defer "flex-rigid subtyping deferred" orig wl))
+end
+| uu____11044 -> begin
+(
+
+let new_rel = problem.FStar_TypeChecker_Common.relation
+in (
+
+let uu____11046 = (
+
+let uu____11047 = (is_top_level_prob orig)
+in (FStar_All.pipe_left Prims.op_Negation uu____11047))
+in (match (uu____11046) with
+| true -> begin
+(
+
+let uu____11048 = (FStar_All.pipe_left (fun _0_64 -> FStar_TypeChecker_Common.TProb (_0_64)) (
+
+let uu___165_11051 = problem
+in {FStar_TypeChecker_Common.pid = uu___165_11051.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___165_11051.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = new_rel; FStar_TypeChecker_Common.rhs = uu___165_11051.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___165_11051.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___165_11051.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___165_11051.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___165_11051.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___165_11051.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___165_11051.FStar_TypeChecker_Common.rank}))
+in (
+
+let uu____11052 = (destruct_flex_pattern env t1)
+in (solve_t_flex_rigid false uu____11048 uu____11052 t2 wl)))
+end
+| uu____11056 -> begin
+(
+
+let uu____11057 = (base_and_refinement env wl t2)
+in (match (uu____11057) with
+| (t_base, ref_opt) -> begin
+(match (ref_opt) with
+| None -> begin
+(
+
+let uu____11087 = (FStar_All.pipe_left (fun _0_65 -> FStar_TypeChecker_Common.TProb (_0_65)) (
+
+let uu___166_11090 = problem
+in {FStar_TypeChecker_Common.pid = uu___166_11090.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___166_11090.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = new_rel; FStar_TypeChecker_Common.rhs = uu___166_11090.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___166_11090.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___166_11090.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___166_11090.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___166_11090.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___166_11090.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___166_11090.FStar_TypeChecker_Common.rank}))
+in (
+
+let uu____11091 = (destruct_flex_pattern env t1)
+in (solve_t_flex_rigid false uu____11087 uu____11091 t_base wl)))
+end
+| Some (y, phi) -> begin
+(
+
+let y' = (
+
+let uu___167_11106 = y
+in {FStar_Syntax_Syntax.ppname = uu___167_11106.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___167_11106.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t1})
+in (
+
+let impl = (guard_on_element wl problem y' phi)
+in (
+
+let base_prob = (
+
+let uu____11109 = (mk_problem problem.FStar_TypeChecker_Common.scope orig t1 new_rel y.FStar_Syntax_Syntax.sort problem.FStar_TypeChecker_Common.element "flex-rigid: base type")
+in (FStar_All.pipe_left (fun _0_66 -> FStar_TypeChecker_Common.TProb (_0_66)) uu____11109))
+in (
+
+let guard = (
+
+let uu____11117 = (FStar_All.pipe_right (p_guard base_prob) Prims.fst)
+in (FStar_Syntax_Util.mk_conj uu____11117 impl))
+in (
+
+let wl1 = (solve_prob orig (Some (guard)) [] wl)
+in (solve env (attempt ((base_prob)::[]) wl1)))))))
+end)
+end))
+end)))
+end)
+end
+| ((_, FStar_Syntax_Syntax.Tm_uvar (_))) | ((_, FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _))) -> begin
+(match (wl.defer_ok) with
+| true -> begin
+(solve env (defer "rigid-flex subtyping deferred" orig wl))
+end
+| uu____11138 -> begin
+(
+
+let uu____11139 = (base_and_refinement env wl t1)
+in (match (uu____11139) with
+| (t_base, uu____11150) -> begin
+(solve_t env (
+
+let uu___168_11165 = problem
+in {FStar_TypeChecker_Common.pid = uu___168_11165.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = t_base; FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ; FStar_TypeChecker_Common.rhs = uu___168_11165.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___168_11165.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___168_11165.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___168_11165.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___168_11165.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___168_11165.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___168_11165.FStar_TypeChecker_Common.rank}) wl)
+end))
+end)
+end
+| (FStar_Syntax_Syntax.Tm_refine (uu____11168), uu____11169) -> begin
+(
+
+let t21 = (
+
+let uu____11177 = (base_and_refinement env wl t2)
+in (FStar_All.pipe_left force_refinement uu____11177))
+in (solve_t env (
+
+let uu___169_11190 = problem
+in {FStar_TypeChecker_Common.pid = uu___169_11190.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___169_11190.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___169_11190.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = t21; FStar_TypeChecker_Common.element = uu___169_11190.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___169_11190.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___169_11190.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___169_11190.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___169_11190.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___169_11190.FStar_TypeChecker_Common.rank}) wl))
+end
+| (uu____11191, FStar_Syntax_Syntax.Tm_refine (uu____11192)) -> begin
+(
+
+let t11 = (
+
+let uu____11200 = (base_and_refinement env wl t1)
+in (FStar_All.pipe_left force_refinement uu____11200))
+in (solve_t env (
+
+let uu___170_11213 = problem
+in {FStar_TypeChecker_Common.pid = uu___170_11213.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = t11; FStar_TypeChecker_Common.relation = uu___170_11213.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___170_11213.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___170_11213.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___170_11213.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___170_11213.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___170_11213.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___170_11213.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___170_11213.FStar_TypeChecker_Common.rank}) wl))
+end
+| ((FStar_Syntax_Syntax.Tm_match (_), _)) | ((FStar_Syntax_Syntax.Tm_uinst (_), _)) | ((FStar_Syntax_Syntax.Tm_name (_), _)) | ((FStar_Syntax_Syntax.Tm_constant (_), _)) | ((FStar_Syntax_Syntax.Tm_fvar (_), _)) | ((FStar_Syntax_Syntax.Tm_app (_), _)) | ((_, FStar_Syntax_Syntax.Tm_match (_))) | ((_, FStar_Syntax_Syntax.Tm_uinst (_))) | ((_, FStar_Syntax_Syntax.Tm_name (_))) | ((_, FStar_Syntax_Syntax.Tm_constant (_))) | ((_, FStar_Syntax_Syntax.Tm_fvar (_))) | ((_, FStar_Syntax_Syntax.Tm_app (_))) -> begin
+(
+
+let head1 = (
+
+let uu____11243 = (FStar_Syntax_Util.head_and_args t1)
+in (FStar_All.pipe_right uu____11243 Prims.fst))
+in (
+
+let head2 = (
+
+let uu____11274 = (FStar_Syntax_Util.head_and_args t2)
+in (FStar_All.pipe_right uu____11274 Prims.fst))
+in (
+
+let uu____11302 = ((((FStar_TypeChecker_Env.is_interpreted env head1) || (FStar_TypeChecker_Env.is_interpreted env head2)) && wl.smt_ok) && (problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ))
+in (match (uu____11302) with
+| true -> begin
+(
+
+let uv1 = (FStar_Syntax_Free.uvars t1)
+in (
+
+let uv2 = (FStar_Syntax_Free.uvars t2)
+in (
+
+let uu____11311 = ((FStar_Util.set_is_empty uv1) && (FStar_Util.set_is_empty uv2))
+in (match (uu____11311) with
+| true -> begin
+(
+
+let guard = (
+
+let uu____11318 = (
+
+let uu____11319 = (FStar_Syntax_Util.eq_tm t1 t2)
+in (uu____11319 = FStar_Syntax_Util.Equal))
+in (match (uu____11318) with
+| true -> begin
+None
+end
+| uu____11321 -> begin
+(
+
+let uu____11322 = (mk_eq2 env t1 t2)
+in (FStar_All.pipe_left (fun _0_67 -> Some (_0_67)) uu____11322))
+end))
+in (
+
+let uu____11324 = (solve_prob orig guard [] wl)
+in (solve env uu____11324)))
+end
+| uu____11325 -> begin
+(rigid_rigid_delta env orig wl head1 head2 t1 t2)
+end))))
+end
+| uu____11326 -> begin
+(rigid_rigid_delta env orig wl head1 head2 t1 t2)
+end))))
+end
+| (FStar_Syntax_Syntax.Tm_ascribed (t11, uu____11328, uu____11329), uu____11330) -> begin
+(solve_t' env (
+
+let uu___171_11359 = problem
+in {FStar_TypeChecker_Common.pid = uu___171_11359.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = t11; FStar_TypeChecker_Common.relation = uu___171_11359.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___171_11359.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___171_11359.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___171_11359.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___171_11359.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___171_11359.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___171_11359.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___171_11359.FStar_TypeChecker_Common.rank}) wl)
+end
+| (uu____11362, FStar_Syntax_Syntax.Tm_ascribed (t21, uu____11364, uu____11365)) -> begin
+(solve_t' env (
+
+let uu___172_11394 = problem
+in {FStar_TypeChecker_Common.pid = uu___172_11394.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___172_11394.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___172_11394.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = t21; FStar_TypeChecker_Common.element = uu___172_11394.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___172_11394.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___172_11394.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___172_11394.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___172_11394.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___172_11394.FStar_TypeChecker_Common.rank}) wl)
+end
+| ((FStar_Syntax_Syntax.Tm_let (_), _)) | ((FStar_Syntax_Syntax.Tm_meta (_), _)) | ((FStar_Syntax_Syntax.Tm_delayed (_), _)) | ((_, FStar_Syntax_Syntax.Tm_meta (_))) | ((_, FStar_Syntax_Syntax.Tm_delayed (_))) | ((_, FStar_Syntax_Syntax.Tm_let (_))) -> begin
+(
+
+let uu____11407 = (
+
+let uu____11408 = (FStar_Syntax_Print.tag_of_term t1)
+in (
+
+let uu____11409 = (FStar_Syntax_Print.tag_of_term t2)
+in (FStar_Util.format2 "Impossible: %s and %s" uu____11408 uu____11409)))
+in (failwith uu____11407))
+end
+| uu____11410 -> begin
+(giveup env "head tag mismatch" orig)
+end));
+)
+end))))
+end)))))))))))
+and solve_c : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.comp, Prims.unit) FStar_TypeChecker_Common.problem  ->  worklist  ->  solution = (fun env problem wl -> (
+
+let c1 = problem.FStar_TypeChecker_Common.lhs
+in (
+
+let c2 = problem.FStar_TypeChecker_Common.rhs
+in (
+
+let orig = FStar_TypeChecker_Common.CProb (problem)
+in (
+
+let sub_prob = (fun t1 rel t2 reason -> (mk_problem (p_scope orig) orig t1 rel t2 None reason))
+in (
+
+let solve_eq = (fun c1_comp c2_comp -> ((
+
+let uu____11442 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("EQ")))
+in (match (uu____11442) with
+| true -> begin
+(FStar_Util.print_string "solve_c is using an equality constraint\n")
+end
+| uu____11443 -> begin
+()
+end));
+(
+
+let sub_probs = (FStar_List.map2 (fun uu____11450 uu____11451 -> (match (((uu____11450), (uu____11451))) with
+| ((a1, uu____11461), (a2, uu____11463)) -> begin
+(
+
+let uu____11468 = (sub_prob a1 FStar_TypeChecker_Common.EQ a2 "effect arg")
+in (FStar_All.pipe_left (fun _0_68 -> FStar_TypeChecker_Common.TProb (_0_68)) uu____11468))
+end)) c1_comp.FStar_Syntax_Syntax.effect_args c2_comp.FStar_Syntax_Syntax.effect_args)
+in (
+
+let guard = (
+
+let uu____11474 = (FStar_List.map (fun p -> (FStar_All.pipe_right (p_guard p) Prims.fst)) sub_probs)
+in (FStar_Syntax_Util.mk_conj_l uu____11474))
+in (
+
+let wl1 = (solve_prob orig (Some (guard)) [] wl)
+in (solve env (attempt sub_probs wl1)))));
+))
+in (
+
+let solve_sub = (fun c11 edge c21 -> (
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let lift_c1 = (fun uu____11494 -> (
+
+let wp = (match (c11.FStar_Syntax_Syntax.effect_args) with
+| ((wp1, uu____11501))::[] -> begin
+wp1
+end
+| uu____11514 -> begin
+(
+
+let uu____11520 = (
+
+let uu____11521 = (FStar_Range.string_of_range (FStar_Ident.range_of_lid c11.FStar_Syntax_Syntax.effect_name))
+in (FStar_Util.format1 "Unexpected number of indices on a normalized effect (%s)" uu____11521))
+in (failwith uu____11520))
+end)
+in (
+
+let uu____11524 = (
+
+let uu____11530 = (
+
+let uu____11531 = (edge.FStar_TypeChecker_Env.mlift.FStar_TypeChecker_Env.mlift_wp c11.FStar_Syntax_Syntax.result_typ wp)
+in (FStar_Syntax_Syntax.as_arg uu____11531))
+in (uu____11530)::[])
+in {FStar_Syntax_Syntax.comp_univs = c11.FStar_Syntax_Syntax.comp_univs; FStar_Syntax_Syntax.effect_name = c21.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = c11.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu____11524; FStar_Syntax_Syntax.flags = c11.FStar_Syntax_Syntax.flags})))
+in (match ((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ)) with
+| true -> begin
+(
+
+let uu____11532 = (lift_c1 ())
+in (solve_eq uu____11532 c21))
+end
+| uu____11533 -> begin
+(
+
+let is_null_wp_2 = (FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags (FStar_Util.for_some (fun uu___129_11536 -> (match (uu___129_11536) with
+| (FStar_Syntax_Syntax.TOTAL) | (FStar_Syntax_Syntax.MLEFFECT) | (FStar_Syntax_Syntax.SOMETRIVIAL) -> begin
+true
+end
+| uu____11537 -> begin
+false
+end))))
+in (
+
+let uu____11538 = (match (((c11.FStar_Syntax_Syntax.effect_args), (c21.FStar_Syntax_Syntax.effect_args))) with
+| (((wp1, uu____11562))::uu____11563, ((wp2, uu____11565))::uu____11566) -> begin
+((wp1), (wp2))
+end
+| uu____11607 -> begin
+(
+
+let uu____11620 = (
+
+let uu____11621 = (FStar_Syntax_Print.lid_to_string c11.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____11622 = (FStar_Syntax_Print.lid_to_string c21.FStar_Syntax_Syntax.effect_name)
+in (FStar_Util.format2 "Got effects %s and %s, expected normalized effects" uu____11621 uu____11622)))
+in (failwith uu____11620))
+end)
+in (match (uu____11538) with
+| (wpc1, wpc2) -> begin
+(
+
+let uu____11639 = (FStar_Util.physical_equality wpc1 wpc2)
+in (match (uu____11639) with
+| true -> begin
+(
+
+let uu____11642 = (problem_using_guard orig c11.FStar_Syntax_Syntax.result_typ problem.FStar_TypeChecker_Common.relation c21.FStar_Syntax_Syntax.result_typ None "result type")
+in (solve_t env uu____11642 wl))
+end
+| uu____11645 -> begin
+(
+
+let c2_decl = (FStar_TypeChecker_Env.get_effect_decl env c21.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____11647 = (FStar_All.pipe_right c2_decl.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (match (uu____11647) with
+| true -> begin
+(
+
+let c1_repr = (
+
+let uu____11650 = (
+
+let uu____11651 = (
+
+let uu____11652 = (lift_c1 ())
+in (FStar_Syntax_Syntax.mk_Comp uu____11652))
+in (
+
+let uu____11653 = (env.FStar_TypeChecker_Env.universe_of env c11.FStar_Syntax_Syntax.result_typ)
+in (FStar_TypeChecker_Env.reify_comp env uu____11651 uu____11653)))
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.WHNF)::[]) env uu____11650))
+in (
+
+let c2_repr = (
+
+let uu____11655 = (
+
+let uu____11656 = (FStar_Syntax_Syntax.mk_Comp c21)
+in (
+
+let uu____11657 = (env.FStar_TypeChecker_Env.universe_of env c21.FStar_Syntax_Syntax.result_typ)
+in (FStar_TypeChecker_Env.reify_comp env uu____11656 uu____11657)))
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.WHNF)::[]) env uu____11655))
+in (
+
+let prob = (
+
+let uu____11659 = (
+
+let uu____11662 = (
+
+let uu____11663 = (FStar_Syntax_Print.term_to_string c1_repr)
+in (
+
+let uu____11664 = (FStar_Syntax_Print.term_to_string c2_repr)
+in (FStar_Util.format2 "sub effect repr: %s <: %s" uu____11663 uu____11664)))
+in (sub_prob c1_repr problem.FStar_TypeChecker_Common.relation c2_repr uu____11662))
+in FStar_TypeChecker_Common.TProb (uu____11659))
+in (
+
+let wl1 = (
+
+let uu____11666 = (
+
+let uu____11668 = (FStar_All.pipe_right (p_guard prob) Prims.fst)
+in Some (uu____11668))
+in (solve_prob orig uu____11666 [] wl))
+in (solve env (attempt ((prob)::[]) wl1))))))
+end
+| uu____11671 -> begin
+(
+
+let g = (match (env.FStar_TypeChecker_Env.lax) with
+| true -> begin
+FStar_Syntax_Util.t_true
+end
+| uu____11673 -> begin
+(match (is_null_wp_2) with
+| true -> begin
+((
+
+let uu____11675 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____11675) with
+| true -> begin
+(FStar_Util.print_string "Using trivial wp ... \n")
+end
+| uu____11676 -> begin
+()
+end));
+(
+
+let uu____11677 = (
+
+let uu____11680 = (
+
+let uu____11681 = (
+
+let uu____11691 = (
+
+let uu____11692 = (
+
+let uu____11693 = (env.FStar_TypeChecker_Env.universe_of env c11.FStar_Syntax_Syntax.result_typ)
+in (uu____11693)::[])
+in (FStar_TypeChecker_Env.inst_effect_fun_with uu____11692 env c2_decl c2_decl.FStar_Syntax_Syntax.trivial))
+in (
+
+let uu____11694 = (
+
+let uu____11696 = (FStar_Syntax_Syntax.as_arg c11.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____11697 = (
+
+let uu____11699 = (
+
+let uu____11700 = (edge.FStar_TypeChecker_Env.mlift.FStar_TypeChecker_Env.mlift_wp c11.FStar_Syntax_Syntax.result_typ wpc1)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____11700))
+in (uu____11699)::[])
+in (uu____11696)::uu____11697))
+in ((uu____11691), (uu____11694))))
+in FStar_Syntax_Syntax.Tm_app (uu____11681))
+in (FStar_Syntax_Syntax.mk uu____11680))
+in (uu____11677 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) r));
+)
+end
+| uu____11710 -> begin
+(
+
+let uu____11711 = (
+
+let uu____11714 = (
+
+let uu____11715 = (
+
+let uu____11725 = (
+
+let uu____11726 = (
+
+let uu____11727 = (env.FStar_TypeChecker_Env.universe_of env c21.FStar_Syntax_Syntax.result_typ)
+in (uu____11727)::[])
+in (FStar_TypeChecker_Env.inst_effect_fun_with uu____11726 env c2_decl c2_decl.FStar_Syntax_Syntax.stronger))
+in (
+
+let uu____11728 = (
+
+let uu____11730 = (FStar_Syntax_Syntax.as_arg c21.FStar_Syntax_Syntax.result_typ)
+in (
+
+let uu____11731 = (
+
+let uu____11733 = (FStar_Syntax_Syntax.as_arg wpc2)
+in (
+
+let uu____11734 = (
+
+let uu____11736 = (
+
+let uu____11737 = (edge.FStar_TypeChecker_Env.mlift.FStar_TypeChecker_Env.mlift_wp c11.FStar_Syntax_Syntax.result_typ wpc1)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____11737))
+in (uu____11736)::[])
+in (uu____11733)::uu____11734))
+in (uu____11730)::uu____11731))
+in ((uu____11725), (uu____11728))))
+in FStar_Syntax_Syntax.Tm_app (uu____11715))
+in (FStar_Syntax_Syntax.mk uu____11714))
+in (uu____11711 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) r))
+end)
+end)
+in (
+
+let base_prob = (
+
+let uu____11748 = (sub_prob c11.FStar_Syntax_Syntax.result_typ problem.FStar_TypeChecker_Common.relation c21.FStar_Syntax_Syntax.result_typ "result type")
+in (FStar_All.pipe_left (fun _0_69 -> FStar_TypeChecker_Common.TProb (_0_69)) uu____11748))
+in (
+
+let wl1 = (
+
+let uu____11754 = (
+
+let uu____11756 = (
+
+let uu____11759 = (FStar_All.pipe_right (p_guard base_prob) Prims.fst)
+in (FStar_Syntax_Util.mk_conj uu____11759 g))
+in (FStar_All.pipe_left (fun _0_70 -> Some (_0_70)) uu____11756))
+in (solve_prob orig uu____11754 [] wl))
+in (solve env (attempt ((base_prob)::[]) wl1)))))
+end)))
+end))
+end)))
+end))))
+in (
+
+let uu____11769 = (FStar_Util.physical_equality c1 c2)
+in (match (uu____11769) with
+| true -> begin
+(
+
+let uu____11770 = (solve_prob orig None [] wl)
+in (solve env uu____11770))
+end
+| uu____11771 -> begin
+((
+
+let uu____11773 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____11773) with
+| true -> begin
+(
+
+let uu____11774 = (FStar_Syntax_Print.comp_to_string c1)
+in (
+
+let uu____11775 = (FStar_Syntax_Print.comp_to_string c2)
+in (FStar_Util.print3 "solve_c %s %s %s\n" uu____11774 (rel_to_string problem.FStar_TypeChecker_Common.relation) uu____11775)))
+end
+| uu____11776 -> begin
+()
+end));
+(
+
+let uu____11777 = (
+
+let uu____11780 = (FStar_TypeChecker_Normalize.ghost_to_pure env c1)
+in (
+
+let uu____11781 = (FStar_TypeChecker_Normalize.ghost_to_pure env c2)
+in ((uu____11780), (uu____11781))))
+in (match (uu____11777) with
+| (c11, c21) -> begin
+(match (((c11.FStar_Syntax_Syntax.n), (c21.FStar_Syntax_Syntax.n))) with
+| (FStar_Syntax_Syntax.GTotal (t1, uu____11785), FStar_Syntax_Syntax.Total (t2, uu____11787)) when (FStar_Syntax_Util.non_informative t2) -> begin
+(
+
+let uu____11800 = (problem_using_guard orig t1 problem.FStar_TypeChecker_Common.relation t2 None "result type")
+in (solve_t env uu____11800 wl))
+end
+| (FStar_Syntax_Syntax.GTotal (uu____11803), FStar_Syntax_Syntax.Total (uu____11804)) -> begin
+(giveup env "incompatible monad ordering: GTot </: Tot" orig)
+end
+| ((FStar_Syntax_Syntax.Total (t1, _), FStar_Syntax_Syntax.Total (t2, _))) | ((FStar_Syntax_Syntax.GTotal (t1, _), FStar_Syntax_Syntax.GTotal (t2, _))) | ((FStar_Syntax_Syntax.Total (t1, _), FStar_Syntax_Syntax.GTotal (t2, _))) -> begin
+(
+
+let uu____11853 = (problem_using_guard orig t1 problem.FStar_TypeChecker_Common.relation t2 None "result type")
+in (solve_t env uu____11853 wl))
+end
+| ((FStar_Syntax_Syntax.GTotal (_), FStar_Syntax_Syntax.Comp (_))) | ((FStar_Syntax_Syntax.Total (_), FStar_Syntax_Syntax.Comp (_))) -> begin
+(
+
+let uu____11860 = (
+
+let uu___173_11863 = problem
+in (
+
+let uu____11866 = (
+
+let uu____11867 = (FStar_TypeChecker_Env.comp_to_comp_typ env c11)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp uu____11867))
+in {FStar_TypeChecker_Common.pid = uu___173_11863.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu____11866; FStar_TypeChecker_Common.relation = uu___173_11863.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu___173_11863.FStar_TypeChecker_Common.rhs; FStar_TypeChecker_Common.element = uu___173_11863.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___173_11863.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___173_11863.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___173_11863.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___173_11863.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___173_11863.FStar_TypeChecker_Common.rank}))
+in (solve_c env uu____11860 wl))
+end
+| ((FStar_Syntax_Syntax.Comp (_), FStar_Syntax_Syntax.GTotal (_))) | ((FStar_Syntax_Syntax.Comp (_), FStar_Syntax_Syntax.Total (_))) -> begin
+(
+
+let uu____11872 = (
+
+let uu___174_11875 = problem
+in (
+
+let uu____11878 = (
+
+let uu____11879 = (FStar_TypeChecker_Env.comp_to_comp_typ env c21)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp uu____11879))
+in {FStar_TypeChecker_Common.pid = uu___174_11875.FStar_TypeChecker_Common.pid; FStar_TypeChecker_Common.lhs = uu___174_11875.FStar_TypeChecker_Common.lhs; FStar_TypeChecker_Common.relation = uu___174_11875.FStar_TypeChecker_Common.relation; FStar_TypeChecker_Common.rhs = uu____11878; FStar_TypeChecker_Common.element = uu___174_11875.FStar_TypeChecker_Common.element; FStar_TypeChecker_Common.logical_guard = uu___174_11875.FStar_TypeChecker_Common.logical_guard; FStar_TypeChecker_Common.scope = uu___174_11875.FStar_TypeChecker_Common.scope; FStar_TypeChecker_Common.reason = uu___174_11875.FStar_TypeChecker_Common.reason; FStar_TypeChecker_Common.loc = uu___174_11875.FStar_TypeChecker_Common.loc; FStar_TypeChecker_Common.rank = uu___174_11875.FStar_TypeChecker_Common.rank}))
+in (solve_c env uu____11872 wl))
+end
+| (FStar_Syntax_Syntax.Comp (uu____11880), FStar_Syntax_Syntax.Comp (uu____11881)) -> begin
+(
+
+let uu____11882 = (((FStar_Syntax_Util.is_ml_comp c11) && (FStar_Syntax_Util.is_ml_comp c21)) || ((FStar_Syntax_Util.is_total_comp c11) && ((FStar_Syntax_Util.is_total_comp c21) || (FStar_Syntax_Util.is_ml_comp c21))))
+in (match (uu____11882) with
+| true -> begin
+(
+
+let uu____11883 = (problem_using_guard orig (FStar_Syntax_Util.comp_result c11) problem.FStar_TypeChecker_Common.relation (FStar_Syntax_Util.comp_result c21) None "result type")
+in (solve_t env uu____11883 wl))
+end
+| uu____11886 -> begin
+(
+
+let c1_comp = (FStar_TypeChecker_Env.comp_to_comp_typ env c11)
+in (
+
+let c2_comp = (FStar_TypeChecker_Env.comp_to_comp_typ env c21)
+in (match (((problem.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ) && (FStar_Ident.lid_equals c1_comp.FStar_Syntax_Syntax.effect_name c2_comp.FStar_Syntax_Syntax.effect_name))) with
+| true -> begin
+(solve_eq c1_comp c2_comp)
+end
+| uu____11889 -> begin
+(
+
+let c12 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c11)
+in (
+
+let c22 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c21)
+in ((
+
+let uu____11893 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____11893) with
+| true -> begin
+(FStar_Util.print2 "solve_c for %s and %s\n" c12.FStar_Syntax_Syntax.effect_name.FStar_Ident.str c22.FStar_Syntax_Syntax.effect_name.FStar_Ident.str)
+end
+| uu____11894 -> begin
+()
+end));
+(
+
+let uu____11895 = (FStar_TypeChecker_Env.monad_leq env c12.FStar_Syntax_Syntax.effect_name c22.FStar_Syntax_Syntax.effect_name)
+in (match (uu____11895) with
+| None -> begin
+(
+
+let uu____11897 = (((FStar_Syntax_Util.is_ghost_effect c12.FStar_Syntax_Syntax.effect_name) && (FStar_Syntax_Util.is_pure_effect c22.FStar_Syntax_Syntax.effect_name)) && (
+
+let uu____11898 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env c22.FStar_Syntax_Syntax.result_typ)
+in (FStar_Syntax_Util.non_informative uu____11898)))
+in (match (uu____11897) with
+| true -> begin
+(
+
+let edge = {FStar_TypeChecker_Env.msource = c12.FStar_Syntax_Syntax.effect_name; FStar_TypeChecker_Env.mtarget = c22.FStar_Syntax_Syntax.effect_name; FStar_TypeChecker_Env.mlift = FStar_TypeChecker_Env.identity_mlift}
+in (solve_sub c12 edge c22))
+end
+| uu____11900 -> begin
+(
+
+let uu____11901 = (
+
+let uu____11902 = (FStar_Syntax_Print.lid_to_string c12.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____11903 = (FStar_Syntax_Print.lid_to_string c22.FStar_Syntax_Syntax.effect_name)
+in (FStar_Util.format2 "incompatible monad ordering: %s </: %s" uu____11902 uu____11903)))
+in (giveup env uu____11901 orig))
+end))
+end
+| Some (edge) -> begin
+(solve_sub c12 edge c22)
+end));
+)))
+end)))
+end))
+end)
+end));
+)
+end)))))))))
+
+
+let print_pending_implicits : FStar_TypeChecker_Env.guard_t  ->  Prims.string = (fun g -> (
+
+let uu____11908 = (FStar_All.pipe_right g.FStar_TypeChecker_Env.implicits (FStar_List.map (fun uu____11928 -> (match (uu____11928) with
+| (uu____11939, uu____11940, u, uu____11942, uu____11943, uu____11944) -> begin
+(FStar_Syntax_Print.uvar_to_string u)
+end))))
+in (FStar_All.pipe_right uu____11908 (FStar_String.concat ", "))))
+
+
+let ineqs_to_string : (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.universe) Prims.list)  ->  Prims.string = (fun ineqs -> (
+
+let vars = (
+
+let uu____11973 = (FStar_All.pipe_right (Prims.fst ineqs) (FStar_List.map FStar_Syntax_Print.univ_to_string))
+in (FStar_All.pipe_right uu____11973 (FStar_String.concat ", ")))
+in (
+
+let ineqs1 = (
+
+let uu____11983 = (FStar_All.pipe_right (Prims.snd ineqs) (FStar_List.map (fun uu____11995 -> (match (uu____11995) with
+| (u1, u2) -> begin
+(
+
+let uu____12000 = (FStar_Syntax_Print.univ_to_string u1)
+in (
+
+let uu____12001 = (FStar_Syntax_Print.univ_to_string u2)
+in (FStar_Util.format2 "%s < %s" uu____12000 uu____12001)))
+end))))
+in (FStar_All.pipe_right uu____11983 (FStar_String.concat ", ")))
+in (FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1))))
+
+
+let guard_to_string : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  Prims.string = (fun env g -> (match (((g.FStar_TypeChecker_Env.guard_f), (g.FStar_TypeChecker_Env.deferred), (g.FStar_TypeChecker_Env.univ_ineqs))) with
+| (FStar_TypeChecker_Common.Trivial, [], (uu____12013, [])) -> begin
+"{}"
+end
+| uu____12026 -> begin
+(
+
+let form = (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+"trivial"
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu____12036 = (((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel"))) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Implicits")))) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme))
+in (match (uu____12036) with
+| true -> begin
+(FStar_TypeChecker_Normalize.term_to_string env f)
+end
+| uu____12037 -> begin
+"non-trivial"
+end))
+end)
+in (
+
+let carry = (
+
+let uu____12039 = (FStar_List.map (fun uu____12043 -> (match (uu____12043) with
+| (uu____12046, x) -> begin
+(prob_to_string env x)
+end)) g.FStar_TypeChecker_Env.deferred)
+in (FStar_All.pipe_right uu____12039 (FStar_String.concat ",\n")))
+in (
+
+let imps = (print_pending_implicits g)
+in (
+
+let uu____12050 = (ineqs_to_string g.FStar_TypeChecker_Env.univ_ineqs)
+in (FStar_Util.format4 "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n" form carry uu____12050 imps)))))
+end))
+
+
+let new_t_problem = (fun env lhs rel rhs elt loc -> (
+
+let reason = (
+
+let uu____12088 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("ExplainRel")))
+in (match (uu____12088) with
+| true -> begin
+(
+
+let uu____12089 = (FStar_TypeChecker_Normalize.term_to_string env lhs)
+in (
+
+let uu____12090 = (FStar_TypeChecker_Normalize.term_to_string env rhs)
+in (FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____12089 (rel_to_string rel) uu____12090)))
+end
+| uu____12091 -> begin
+"TOP"
+end))
+in (
+
+let p = (new_problem env lhs rel rhs elt loc reason)
+in p)))
+
+
+let new_t_prob : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_TypeChecker_Common.rel  ->  FStar_Syntax_Syntax.term  ->  (FStar_TypeChecker_Common.prob * FStar_Syntax_Syntax.bv) = (fun env t1 rel t2 -> (
+
+let x = (
+
+let uu____12110 = (
+
+let uu____12112 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_All.pipe_left (fun _0_71 -> Some (_0_71)) uu____12112))
+in (FStar_Syntax_Syntax.new_bv uu____12110 t1))
+in (
+
+let env1 = (FStar_TypeChecker_Env.push_bv env x)
+in (
+
+let p = (
+
+let uu____12118 = (
+
+let uu____12120 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_All.pipe_left (fun _0_72 -> Some (_0_72)) uu____12120))
+in (
+
+let uu____12122 = (FStar_TypeChecker_Env.get_range env1)
+in (new_t_problem env1 t1 rel t2 uu____12118 uu____12122)))
+in ((FStar_TypeChecker_Common.TProb (p)), (x))))))
+
+
+let solve_and_commit : FStar_TypeChecker_Env.env  ->  worklist  ->  ((FStar_TypeChecker_Common.prob * Prims.string)  ->  FStar_TypeChecker_Common.deferred Prims.option)  ->  FStar_TypeChecker_Common.deferred Prims.option = (fun env probs err -> (
+
+let probs1 = (
+
+let uu____12145 = (FStar_Options.eager_inference ())
+in (match (uu____12145) with
+| true -> begin
+(
+
+let uu___175_12146 = probs
+in {attempting = uu___175_12146.attempting; wl_deferred = uu___175_12146.wl_deferred; ctr = uu___175_12146.ctr; defer_ok = false; smt_ok = uu___175_12146.smt_ok; tcenv = uu___175_12146.tcenv})
+end
+| uu____12147 -> begin
+probs
+end))
+in (
+
+let tx = (FStar_Unionfind.new_transaction ())
+in (
+
+let sol = (solve env probs1)
+in (match (sol) with
+| Success (deferred) -> begin
+((FStar_Unionfind.commit tx);
+Some (deferred);
+)
+end
+| Failed (d, s) -> begin
+((FStar_Unionfind.rollback tx);
+(
+
+let uu____12157 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("ExplainRel")))
+in (match (uu____12157) with
+| true -> begin
+(
+
+let uu____12158 = (explain env d s)
+in (FStar_All.pipe_left FStar_Util.print_string uu____12158))
+end
+| uu____12159 -> begin
+()
+end));
+(err ((d), (s)));
+)
+end)))))
+
+
+let simplify_guard : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun env g -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+((
+
+let uu____12168 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Simplification")))
+in (match (uu____12168) with
+| true -> begin
+(
+
+let uu____12169 = (FStar_Syntax_Print.term_to_string f)
+in (FStar_Util.print1 "Simplifying guard %s\n" uu____12169))
+end
+| uu____12170 -> begin
+()
+end));
+(
+
+let f1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Simplify)::[]) env f)
+in ((
+
+let uu____12173 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Simplification")))
+in (match (uu____12173) with
+| true -> begin
+(
+
+let uu____12174 = (FStar_Syntax_Print.term_to_string f1)
+in (FStar_Util.print1 "Simplified guard to %s\n" uu____12174))
+end
+| uu____12175 -> begin
+()
+end));
+(
+
+let f2 = (
+
+let uu____12177 = (
+
+let uu____12178 = (FStar_Syntax_Util.unmeta f1)
+in uu____12178.FStar_Syntax_Syntax.n)
+in (match (uu____12177) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.true_lid) -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| uu____12182 -> begin
+FStar_TypeChecker_Common.NonTrivial (f1)
+end))
+in (
+
+let uu___176_12183 = g
+in {FStar_TypeChecker_Env.guard_f = f2; FStar_TypeChecker_Env.deferred = uu___176_12183.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___176_12183.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___176_12183.FStar_TypeChecker_Env.implicits}));
+));
+)
+end))
+
+
+let with_guard : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Common.prob  ->  FStar_TypeChecker_Common.deferred Prims.option  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun env prob dopt -> (match (dopt) with
+| None -> begin
+None
+end
+| Some (d) -> begin
+(
+
+let uu____12198 = (
+
+let uu____12199 = (
+
+let uu____12200 = (
+
+let uu____12201 = (FStar_All.pipe_right (p_guard prob) Prims.fst)
+in (FStar_All.pipe_right uu____12201 (fun _0_73 -> FStar_TypeChecker_Common.NonTrivial (_0_73))))
+in {FStar_TypeChecker_Env.guard_f = uu____12200; FStar_TypeChecker_Env.deferred = d; FStar_TypeChecker_Env.univ_ineqs = (([]), ([])); FStar_TypeChecker_Env.implicits = []})
+in (simplify_guard env uu____12199))
+in (FStar_All.pipe_left (fun _0_74 -> Some (_0_74)) uu____12198))
+end))
+
+
+let try_teq : Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun smt_ok env t1 t2 -> ((
+
+let uu____12228 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____12228) with
+| true -> begin
+(
+
+let uu____12229 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____12230 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.print2 "try_teq of %s and %s\n" uu____12229 uu____12230)))
+end
+| uu____12231 -> begin
+()
+end));
+(
+
+let prob = (
+
+let uu____12233 = (
+
+let uu____12236 = (FStar_TypeChecker_Env.get_range env)
+in (new_t_problem env t1 FStar_TypeChecker_Common.EQ t2 None uu____12236))
+in (FStar_All.pipe_left (fun _0_75 -> FStar_TypeChecker_Common.TProb (_0_75)) uu____12233))
+in (
+
+let g = (
+
+let uu____12241 = (
+
+let uu____12243 = (singleton' env prob smt_ok)
+in (solve_and_commit env uu____12243 (fun uu____12244 -> None)))
+in (FStar_All.pipe_left (with_guard env prob) uu____12241))
+in g));
+))
+
+
+let teq : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  FStar_TypeChecker_Env.guard_t = (fun env t1 t2 -> (
+
+let uu____12258 = (try_teq true env t1 t2)
+in (match (uu____12258) with
+| None -> begin
+(
+
+let uu____12260 = (
+
+let uu____12261 = (
+
+let uu____12264 = (FStar_TypeChecker_Err.basic_type_error env None t2 t1)
+in (
+
+let uu____12265 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____12264), (uu____12265))))
+in FStar_Errors.Error (uu____12261))
+in (Prims.raise uu____12260))
+end
+| Some (g) -> begin
+((
+
+let uu____12268 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____12268) with
+| true -> begin
+(
+
+let uu____12269 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____12270 = (FStar_Syntax_Print.term_to_string t2)
+in (
+
+let uu____12271 = (guard_to_string env g)
+in (FStar_Util.print3 "teq of %s and %s succeeded with guard %s\n" uu____12269 uu____12270 uu____12271))))
+end
+| uu____12272 -> begin
+()
+end));
+g;
+)
+end)))
+
+
+let try_subtype' : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  Prims.bool  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun env t1 t2 smt_ok -> ((
+
+let uu____12287 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____12287) with
+| true -> begin
+(
+
+let uu____12288 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let uu____12289 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (FStar_Util.print2 "try_subtype of %s and %s\n" uu____12288 uu____12289)))
+end
+| uu____12290 -> begin
+()
+end));
+(
+
+let uu____12291 = (new_t_prob env t1 FStar_TypeChecker_Common.SUB t2)
+in (match (uu____12291) with
+| (prob, x) -> begin
+(
+
+let g = (
+
+let uu____12299 = (
+
+let uu____12301 = (singleton' env prob smt_ok)
+in (solve_and_commit env uu____12301 (fun uu____12302 -> None)))
+in (FStar_All.pipe_left (with_guard env prob) uu____12299))
+in ((
+
+let uu____12308 = ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel"))) && (FStar_Util.is_some g))
+in (match (uu____12308) with
+| true -> begin
+(
+
+let uu____12309 = (FStar_TypeChecker_Normalize.term_to_string env t1)
+in (
+
+let uu____12310 = (FStar_TypeChecker_Normalize.term_to_string env t2)
+in (
+
+let uu____12311 = (
+
+let uu____12312 = (FStar_Util.must g)
+in (guard_to_string env uu____12312))
+in (FStar_Util.print3 "try_subtype succeeded: %s <: %s\n\tguard is %s\n" uu____12309 uu____12310 uu____12311))))
+end
+| uu____12313 -> begin
+()
+end));
+(abstract_guard x g);
+))
+end));
+))
+
+
+let try_subtype : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun env t1 t2 -> (try_subtype' env t1 t2 true))
+
+
+let subtype_fail : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit = (fun env e t1 t2 -> (
+
+let uu____12336 = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let uu____12337 = (FStar_TypeChecker_Err.basic_type_error env (Some (e)) t2 t1)
+in (FStar_Errors.report uu____12336 uu____12337))))
+
+
+let sub_comp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun env c1 c2 -> ((
+
+let uu____12349 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____12349) with
+| true -> begin
+(
+
+let uu____12350 = (FStar_Syntax_Print.comp_to_string c1)
+in (
+
+let uu____12351 = (FStar_Syntax_Print.comp_to_string c2)
+in (FStar_Util.print2 "sub_comp of %s and %s\n" uu____12350 uu____12351)))
+end
+| uu____12352 -> begin
+()
+end));
+(
+
+let rel = (match (env.FStar_TypeChecker_Env.use_eq) with
+| true -> begin
+FStar_TypeChecker_Common.EQ
+end
+| uu____12354 -> begin
+FStar_TypeChecker_Common.SUB
+end)
+in (
+
+let prob = (
+
+let uu____12356 = (
+
+let uu____12359 = (FStar_TypeChecker_Env.get_range env)
+in (new_problem env c1 rel c2 None uu____12359 "sub_comp"))
+in (FStar_All.pipe_left (fun _0_76 -> FStar_TypeChecker_Common.CProb (_0_76)) uu____12356))
+in (
+
+let uu____12362 = (
+
+let uu____12364 = (singleton env prob)
+in (solve_and_commit env uu____12364 (fun uu____12365 -> None)))
+in (FStar_All.pipe_left (with_guard env prob) uu____12362))));
+))
+
+
+let solve_universe_inequalities' : FStar_Unionfind.tx  ->  FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.universe) Prims.list)  ->  Prims.unit = (fun tx env uu____12384 -> (match (uu____12384) with
+| (variables, ineqs) -> begin
+(
+
+let fail = (fun u1 u2 -> ((FStar_Unionfind.rollback tx);
+(
+
+let uu____12409 = (
+
+let uu____12410 = (
+
+let uu____12413 = (
+
+let uu____12414 = (FStar_Syntax_Print.univ_to_string u1)
+in (
+
+let uu____12415 = (FStar_Syntax_Print.univ_to_string u2)
+in (FStar_Util.format2 "Universe %s and %s are incompatible" uu____12414 uu____12415)))
+in (
+
+let uu____12416 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____12413), (uu____12416))))
+in FStar_Errors.Error (uu____12410))
+in (Prims.raise uu____12409));
+))
+in (
+
+let equiv = (fun v1 v' -> (
+
+let uu____12424 = (
+
+let uu____12427 = (FStar_Syntax_Subst.compress_univ v1)
+in (
+
+let uu____12428 = (FStar_Syntax_Subst.compress_univ v')
+in ((uu____12427), (uu____12428))))
+in (match (uu____12424) with
+| (FStar_Syntax_Syntax.U_unif (v0), FStar_Syntax_Syntax.U_unif (v0')) -> begin
+(FStar_Unionfind.equivalent v0 v0')
+end
+| uu____12436 -> begin
+false
+end)))
+in (
+
+let sols = (FStar_All.pipe_right variables (FStar_List.collect (fun v1 -> (
+
+let uu____12450 = (FStar_Syntax_Subst.compress_univ v1)
+in (match (uu____12450) with
+| FStar_Syntax_Syntax.U_unif (uu____12454) -> begin
+(
+
+let lower_bounds_of_v = (FStar_All.pipe_right ineqs (FStar_List.collect (fun uu____12465 -> (match (uu____12465) with
+| (u, v') -> begin
+(
+
+let uu____12471 = (equiv v1 v')
+in (match (uu____12471) with
+| true -> begin
+(
+
+let uu____12473 = (FStar_All.pipe_right variables (FStar_Util.for_some (equiv u)))
+in (match (uu____12473) with
+| true -> begin
+[]
+end
+| uu____12476 -> begin
+(u)::[]
+end))
+end
+| uu____12477 -> begin
+[]
+end))
+end))))
+in (
+
+let lb = (FStar_TypeChecker_Normalize.normalize_universe env (FStar_Syntax_Syntax.U_max (lower_bounds_of_v)))
+in (((lb), (v1)))::[]))
+end
+| uu____12483 -> begin
+[]
+end)))))
+in (
+
+let uu____12486 = (
+
+let wl = (
+
+let uu___177_12489 = (empty_worklist env)
+in {attempting = uu___177_12489.attempting; wl_deferred = uu___177_12489.wl_deferred; ctr = uu___177_12489.ctr; defer_ok = false; smt_ok = uu___177_12489.smt_ok; tcenv = uu___177_12489.tcenv})
+in (FStar_All.pipe_right sols (FStar_List.map (fun uu____12496 -> (match (uu____12496) with
+| (lb, v1) -> begin
+(
+
+let uu____12501 = (solve_universe_eq (~- ((Prims.parse_int "1"))) wl lb v1)
+in (match (uu____12501) with
+| USolved (wl1) -> begin
+()
+end
+| uu____12503 -> begin
+(fail lb v1)
+end))
+end)))))
+in (
+
+let rec check_ineq = (fun uu____12509 -> (match (uu____12509) with
+| (u, v1) -> begin
+(
+
+let u1 = (FStar_TypeChecker_Normalize.normalize_universe env u)
+in (
+
+let v2 = (FStar_TypeChecker_Normalize.normalize_universe env v1)
+in (match (((u1), (v2))) with
+| (FStar_Syntax_Syntax.U_zero, uu____12516) -> begin
+true
+end
+| (FStar_Syntax_Syntax.U_succ (u0), FStar_Syntax_Syntax.U_succ (v0)) -> begin
+(check_ineq ((u0), (v0)))
+end
+| (FStar_Syntax_Syntax.U_name (u0), FStar_Syntax_Syntax.U_name (v0)) -> begin
+(FStar_Ident.ident_equals u0 v0)
+end
+| (FStar_Syntax_Syntax.U_unif (u0), FStar_Syntax_Syntax.U_unif (v0)) -> begin
+(FStar_Unionfind.equivalent u0 v0)
+end
+| ((FStar_Syntax_Syntax.U_name (_), FStar_Syntax_Syntax.U_succ (v0))) | ((FStar_Syntax_Syntax.U_unif (_), FStar_Syntax_Syntax.U_succ (v0))) -> begin
+(check_ineq ((u1), (v0)))
+end
+| (FStar_Syntax_Syntax.U_max (us), uu____12532) -> begin
+(FStar_All.pipe_right us (FStar_Util.for_all (fun u2 -> (check_ineq ((u2), (v2))))))
+end
+| (uu____12536, FStar_Syntax_Syntax.U_max (vs)) -> begin
+(FStar_All.pipe_right vs (FStar_Util.for_some (fun v3 -> (check_ineq ((u1), (v3))))))
+end
+| uu____12541 -> begin
+false
+end)))
+end))
+in (
+
+let uu____12544 = (FStar_All.pipe_right ineqs (FStar_Util.for_all (fun uu____12550 -> (match (uu____12550) with
+| (u, v1) -> begin
+(
+
+let uu____12555 = (check_ineq ((u), (v1)))
+in (match (uu____12555) with
+| true -> begin
+true
+end
+| uu____12556 -> begin
+((
+
+let uu____12558 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("GenUniverses")))
+in (match (uu____12558) with
+| true -> begin
+(
+
+let uu____12559 = (FStar_Syntax_Print.univ_to_string u)
+in (
+
+let uu____12560 = (FStar_Syntax_Print.univ_to_string v1)
+in (FStar_Util.print2 "%s </= %s" uu____12559 uu____12560)))
+end
+| uu____12561 -> begin
+()
+end));
+false;
+)
+end))
+end))))
+in (match (uu____12544) with
+| true -> begin
+()
+end
+| uu____12562 -> begin
+((
+
+let uu____12564 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("GenUniverses")))
+in (match (uu____12564) with
+| true -> begin
+((
+
+let uu____12566 = (ineqs_to_string ((variables), (ineqs)))
+in (FStar_Util.print1 "Partially solved inequality constraints are: %s\n" uu____12566));
+(FStar_Unionfind.rollback tx);
+(
+
+let uu____12572 = (ineqs_to_string ((variables), (ineqs)))
+in (FStar_Util.print1 "Original solved inequality constraints are: %s\n" uu____12572));
+)
+end
+| uu____12577 -> begin
+()
+end));
+(
+
+let uu____12578 = (
+
+let uu____12579 = (
+
+let uu____12582 = (FStar_TypeChecker_Env.get_range env)
+in (("Failed to solve universe inequalities for inductives"), (uu____12582)))
+in FStar_Errors.Error (uu____12579))
+in (Prims.raise uu____12578));
+)
+end)))))))
+end))
+
+
+let solve_universe_inequalities : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.universe) Prims.list)  ->  Prims.unit = (fun env ineqs -> (
+
+let tx = (FStar_Unionfind.new_transaction ())
+in ((solve_universe_inequalities' tx env ineqs);
+(FStar_Unionfind.commit tx);
+)))
+
+
+let rec solve_deferred_constraints : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun env g -> (
+
+let fail = (fun uu____12615 -> (match (uu____12615) with
+| (d, s) -> begin
+(
+
+let msg = (explain env d s)
+in (Prims.raise (FStar_Errors.Error (((msg), ((p_loc d)))))))
+end))
+in (
+
+let wl = (wl_of_guard env g.FStar_TypeChecker_Env.deferred)
+in ((
+
+let uu____12625 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____12625) with
+| true -> begin
+(
+
+let uu____12626 = (wl_to_string wl)
+in (
+
+let uu____12627 = (FStar_Util.string_of_int (FStar_List.length g.FStar_TypeChecker_Env.implicits))
+in (FStar_Util.print2 "Trying to solve carried problems: begin\n\t%s\nend\n and %s implicits\n" uu____12626 uu____12627)))
+end
+| uu____12637 -> begin
+()
+end));
+(
+
+let g1 = (
+
+let uu____12639 = (solve_and_commit env wl fail)
+in (match (uu____12639) with
+| Some ([]) -> begin
+(
+
+let uu___178_12646 = g
+in {FStar_TypeChecker_Env.guard_f = uu___178_12646.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = []; FStar_TypeChecker_Env.univ_ineqs = uu___178_12646.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___178_12646.FStar_TypeChecker_Env.implicits})
+end
+| uu____12649 -> begin
+(failwith "impossible: Unexpected deferred constraints remain")
+end))
+in ((solve_universe_inequalities env g1.FStar_TypeChecker_Env.univ_ineqs);
+(
+
+let uu___179_12652 = g1
+in {FStar_TypeChecker_Env.guard_f = uu___179_12652.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___179_12652.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = (([]), ([])); FStar_TypeChecker_Env.implicits = uu___179_12652.FStar_TypeChecker_Env.implicits});
+));
+))))
+
+
+let discharge_guard' : (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  Prims.bool  ->  FStar_TypeChecker_Env.guard_t Prims.option = (fun use_env_range_msg env g use_smt -> (
+
+let g1 = (solve_deferred_constraints env g)
+in (
+
+let ret_g = (
+
+let uu___180_12678 = g1
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___180_12678.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___180_12678.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___180_12678.FStar_TypeChecker_Env.implicits})
+in (
+
+let uu____12679 = (
+
+let uu____12680 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____12680)))
+in (match (uu____12679) with
+| true -> begin
+Some (ret_g)
+end
+| uu____12682 -> begin
+(match (g1.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+Some (ret_g)
+end
+| FStar_TypeChecker_Common.NonTrivial (vc) -> begin
+((
+
+let uu____12686 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Norm")))
+in (match (uu____12686) with
+| true -> begin
+(
+
+let uu____12687 = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let uu____12688 = (
+
+let uu____12689 = (FStar_Syntax_Print.term_to_string vc)
+in (FStar_Util.format1 "Before normalization VC=\n%s\n" uu____12689))
+in (FStar_Errors.diag uu____12687 uu____12688)))
+end
+| uu____12690 -> begin
+()
+end));
+(
+
+let vc1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Simplify)::[]) env vc)
+in (match ((check_trivial vc1)) with
+| FStar_TypeChecker_Common.Trivial -> begin
+Some (ret_g)
+end
+| FStar_TypeChecker_Common.NonTrivial (vc2) -> begin
+(match ((not (use_smt))) with
+| true -> begin
+None
+end
+| uu____12695 -> begin
+((
+
+let uu____12698 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Rel")))
+in (match (uu____12698) with
+| true -> begin
+(
+
+let uu____12699 = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let uu____12700 = (
+
+let uu____12701 = (FStar_Syntax_Print.term_to_string vc2)
+in (FStar_Util.format1 "Checking VC=\n%s\n" uu____12701))
+in (FStar_Errors.diag uu____12699 uu____12700)))
+end
+| uu____12702 -> begin
+()
+end));
+(
+
+let vcs = (
+
+let uu____12707 = (FStar_Options.use_tactics ())
+in (match (uu____12707) with
+| true -> begin
+(env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.preprocess env vc2)
+end
+| uu____12711 -> begin
+(((env), (vc2)))::[]
+end))
+in (FStar_All.pipe_right vcs (FStar_List.iter (fun uu____12721 -> (match (uu____12721) with
+| (env1, goal) -> begin
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.solve use_env_range_msg env1 goal)
+end)))));
+Some (ret_g);
+)
+end)
+end));
+)
+end)
+end)))))
+
+
+let discharge_guard : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun env g -> (
+
+let uu____12732 = (discharge_guard' None env g true)
+in (match (uu____12732) with
+| Some (g1) -> begin
+g1
+end
+| None -> begin
+(failwith "Impossible, with use_smt = true, discharge_guard\' should never have returned None")
+end)))
+
+
+let resolve_implicits : FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun g -> (
+
+let unresolved = (fun u -> (
+
+let uu____12752 = (FStar_Unionfind.find u)
+in (match (uu____12752) with
+| FStar_Syntax_Syntax.Uvar -> begin
+true
+end
+| uu____12761 -> begin
+false
+end)))
+in (
+
+let rec until_fixpoint = (fun acc implicits -> (
+
+let uu____12776 = acc
+in (match (uu____12776) with
+| (out, changed) -> begin
+(match (implicits) with
+| [] -> begin
+(match ((not (changed))) with
+| true -> begin
+out
+end
+| uu____12787 -> begin
+(until_fixpoint (([]), (false)) out)
+end)
+end
+| (hd1)::tl1 -> begin
+(
+
+let uu____12822 = hd1
+in (match (uu____12822) with
+| (uu____12829, env, u, tm, k, r) -> begin
+(
+
+let uu____12835 = (unresolved u)
+in (match (uu____12835) with
+| true -> begin
+(until_fixpoint (((hd1)::out), (changed)) tl1)
+end
+| uu____12849 -> begin
+(
+
+let env1 = (FStar_TypeChecker_Env.set_expected_typ env k)
+in (
+
+let tm1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env1 tm)
+in ((
+
+let uu____12853 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("RelCheck")))
+in (match (uu____12853) with
+| true -> begin
+(
+
+let uu____12854 = (FStar_Syntax_Print.uvar_to_string u)
+in (
+
+let uu____12858 = (FStar_Syntax_Print.term_to_string tm1)
+in (
+
+let uu____12859 = (FStar_Syntax_Print.term_to_string k)
+in (FStar_Util.print3 "Checking uvar %s resolved to %s at type %s\n" uu____12854 uu____12858 uu____12859))))
+end
+| uu____12860 -> begin
+()
+end));
+(
+
+let uu____12861 = (env1.FStar_TypeChecker_Env.type_of (
+
+let uu___181_12865 = env1
+in {FStar_TypeChecker_Env.solver = uu___181_12865.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___181_12865.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___181_12865.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___181_12865.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___181_12865.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___181_12865.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___181_12865.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___181_12865.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___181_12865.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___181_12865.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___181_12865.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___181_12865.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___181_12865.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___181_12865.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___181_12865.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___181_12865.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___181_12865.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___181_12865.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___181_12865.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___181_12865.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___181_12865.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___181_12865.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = true; FStar_TypeChecker_Env.qname_and_index = uu___181_12865.FStar_TypeChecker_Env.qname_and_index}) tm1)
+in (match (uu____12861) with
+| (uu____12866, uu____12867, g1) -> begin
+(
+
+let g2 = (match (env1.FStar_TypeChecker_Env.is_pattern) with
+| true -> begin
+(
+
+let uu___182_12870 = g1
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___182_12870.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___182_12870.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___182_12870.FStar_TypeChecker_Env.implicits})
+end
+| uu____12871 -> begin
+g1
+end)
+in (
+
+let g' = (
+
+let uu____12873 = (discharge_guard' (Some ((fun uu____12877 -> (FStar_Syntax_Print.term_to_string tm1)))) env1 g2 true)
+in (match (uu____12873) with
+| Some (g3) -> begin
+g3
+end
+| None -> begin
+(failwith "Impossible, with use_smt = true, discharge_guard\' should never have returned None")
+end))
+in (until_fixpoint (((FStar_List.append g'.FStar_TypeChecker_Env.implicits out)), (true)) tl1)))
+end));
+)))
+end))
+end))
+end)
+end)))
+in (
+
+let uu___183_12892 = g
+in (
+
+let uu____12893 = (until_fixpoint (([]), (false)) g.FStar_TypeChecker_Env.implicits)
+in {FStar_TypeChecker_Env.guard_f = uu___183_12892.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___183_12892.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___183_12892.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu____12893})))))
+
+
+let force_trivial_guard : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  Prims.unit = (fun env g -> (
+
+let g1 = (
+
+let uu____12921 = (solve_deferred_constraints env g)
+in (FStar_All.pipe_right uu____12921 resolve_implicits))
+in (match (g1.FStar_TypeChecker_Env.implicits) with
+| [] -> begin
+(
+
+let uu____12928 = (discharge_guard env g1)
+in (FStar_All.pipe_left Prims.ignore uu____12928))
+end
+| ((reason, uu____12930, uu____12931, e, t, r))::uu____12935 -> begin
+(
+
+let uu____12949 = (
+
+let uu____12950 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____12951 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format3 "Failed to resolve implicit argument of type \'%s\' introduced in %s because %s" uu____12950 uu____12951 reason)))
+in (FStar_Errors.report r uu____12949))
+end)))
+
+
+let universe_inequality : FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe  ->  FStar_TypeChecker_Env.guard_t = (fun u1 u2 -> (
+
+let uu___184_12958 = trivial_guard
+in {FStar_TypeChecker_Env.guard_f = uu___184_12958.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___184_12958.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = (([]), ((((u1), (u2)))::[])); FStar_TypeChecker_Env.implicits = uu___184_12958.FStar_TypeChecker_Env.implicits}))
+
+
+let teq_nosmt : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  Prims.bool = (fun env t1 t2 -> (
+
+let uu____12976 = (try_teq false env t1 t2)
+in (match (uu____12976) with
+| None -> begin
+false
+end
+| Some (g) -> begin
+(
+
+let uu____12979 = (discharge_guard' None env g false)
+in (match (uu____12979) with
+| Some (uu____12983) -> begin
+true
+end
+| None -> begin
+false
+end))
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -1,4248 +1,4109 @@
+
 open Prims
-let set_hint_correlator:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env
-  =
-  fun env  ->
-    fun se  ->
-      let uu____7 = FStar_Options.reuse_hint_for () in
-      match uu____7 with
-      | Some l ->
-          let lid =
-            let uu____11 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.lid_add_suffix uu____11 l in
-          let uu___88_12 = env in
-          {
-            FStar_TypeChecker_Env.solver =
-              (uu___88_12.FStar_TypeChecker_Env.solver);
-            FStar_TypeChecker_Env.range =
-              (uu___88_12.FStar_TypeChecker_Env.range);
-            FStar_TypeChecker_Env.curmodule =
-              (uu___88_12.FStar_TypeChecker_Env.curmodule);
-            FStar_TypeChecker_Env.gamma =
-              (uu___88_12.FStar_TypeChecker_Env.gamma);
-            FStar_TypeChecker_Env.gamma_cache =
-              (uu___88_12.FStar_TypeChecker_Env.gamma_cache);
-            FStar_TypeChecker_Env.modules =
-              (uu___88_12.FStar_TypeChecker_Env.modules);
-            FStar_TypeChecker_Env.expected_typ =
-              (uu___88_12.FStar_TypeChecker_Env.expected_typ);
-            FStar_TypeChecker_Env.sigtab =
-              (uu___88_12.FStar_TypeChecker_Env.sigtab);
-            FStar_TypeChecker_Env.is_pattern =
-              (uu___88_12.FStar_TypeChecker_Env.is_pattern);
-            FStar_TypeChecker_Env.instantiate_imp =
-              (uu___88_12.FStar_TypeChecker_Env.instantiate_imp);
-            FStar_TypeChecker_Env.effects =
-              (uu___88_12.FStar_TypeChecker_Env.effects);
-            FStar_TypeChecker_Env.generalize =
-              (uu___88_12.FStar_TypeChecker_Env.generalize);
-            FStar_TypeChecker_Env.letrecs =
-              (uu___88_12.FStar_TypeChecker_Env.letrecs);
-            FStar_TypeChecker_Env.top_level =
-              (uu___88_12.FStar_TypeChecker_Env.top_level);
-            FStar_TypeChecker_Env.check_uvars =
-              (uu___88_12.FStar_TypeChecker_Env.check_uvars);
-            FStar_TypeChecker_Env.use_eq =
-              (uu___88_12.FStar_TypeChecker_Env.use_eq);
-            FStar_TypeChecker_Env.is_iface =
-              (uu___88_12.FStar_TypeChecker_Env.is_iface);
-            FStar_TypeChecker_Env.admit =
-              (uu___88_12.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___88_12.FStar_TypeChecker_Env.lax);
-            FStar_TypeChecker_Env.lax_universes =
-              (uu___88_12.FStar_TypeChecker_Env.lax_universes);
-            FStar_TypeChecker_Env.type_of =
-              (uu___88_12.FStar_TypeChecker_Env.type_of);
-            FStar_TypeChecker_Env.universe_of =
-              (uu___88_12.FStar_TypeChecker_Env.universe_of);
-            FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___88_12.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qname_and_index =
-              (Some (lid, (Prims.parse_int "0")))
-          }
-      | None  ->
-          let lids = FStar_Syntax_Util.lids_of_sigelt se in
-          let lid =
-            match lids with
-            | [] ->
-                let uu____18 = FStar_TypeChecker_Env.current_module env in
-                let uu____19 =
-                  let uu____20 = FStar_Syntax_Syntax.next_id () in
-                  FStar_All.pipe_right uu____20 FStar_Util.string_of_int in
-                FStar_Ident.lid_add_suffix uu____18 uu____19
-            | l::uu____22 -> l in
-          let uu___89_24 = env in
-          {
-            FStar_TypeChecker_Env.solver =
-              (uu___89_24.FStar_TypeChecker_Env.solver);
-            FStar_TypeChecker_Env.range =
-              (uu___89_24.FStar_TypeChecker_Env.range);
-            FStar_TypeChecker_Env.curmodule =
-              (uu___89_24.FStar_TypeChecker_Env.curmodule);
-            FStar_TypeChecker_Env.gamma =
-              (uu___89_24.FStar_TypeChecker_Env.gamma);
-            FStar_TypeChecker_Env.gamma_cache =
-              (uu___89_24.FStar_TypeChecker_Env.gamma_cache);
-            FStar_TypeChecker_Env.modules =
-              (uu___89_24.FStar_TypeChecker_Env.modules);
-            FStar_TypeChecker_Env.expected_typ =
-              (uu___89_24.FStar_TypeChecker_Env.expected_typ);
-            FStar_TypeChecker_Env.sigtab =
-              (uu___89_24.FStar_TypeChecker_Env.sigtab);
-            FStar_TypeChecker_Env.is_pattern =
-              (uu___89_24.FStar_TypeChecker_Env.is_pattern);
-            FStar_TypeChecker_Env.instantiate_imp =
-              (uu___89_24.FStar_TypeChecker_Env.instantiate_imp);
-            FStar_TypeChecker_Env.effects =
-              (uu___89_24.FStar_TypeChecker_Env.effects);
-            FStar_TypeChecker_Env.generalize =
-              (uu___89_24.FStar_TypeChecker_Env.generalize);
-            FStar_TypeChecker_Env.letrecs =
-              (uu___89_24.FStar_TypeChecker_Env.letrecs);
-            FStar_TypeChecker_Env.top_level =
-              (uu___89_24.FStar_TypeChecker_Env.top_level);
-            FStar_TypeChecker_Env.check_uvars =
-              (uu___89_24.FStar_TypeChecker_Env.check_uvars);
-            FStar_TypeChecker_Env.use_eq =
-              (uu___89_24.FStar_TypeChecker_Env.use_eq);
-            FStar_TypeChecker_Env.is_iface =
-              (uu___89_24.FStar_TypeChecker_Env.is_iface);
-            FStar_TypeChecker_Env.admit =
-              (uu___89_24.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___89_24.FStar_TypeChecker_Env.lax);
-            FStar_TypeChecker_Env.lax_universes =
-              (uu___89_24.FStar_TypeChecker_Env.lax_universes);
-            FStar_TypeChecker_Env.type_of =
-              (uu___89_24.FStar_TypeChecker_Env.type_of);
-            FStar_TypeChecker_Env.universe_of =
-              (uu___89_24.FStar_TypeChecker_Env.universe_of);
-            FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___89_24.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qname_and_index =
-              (Some (lid, (Prims.parse_int "0")))
-          }
-let log: FStar_TypeChecker_Env.env -> Prims.bool =
-  fun env  ->
-    (FStar_Options.log_types ()) &&
-      (let uu____30 =
-         let uu____31 = FStar_TypeChecker_Env.current_module env in
-         FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____31 in
-       Prims.op_Negation uu____30)
-let tc_check_trivial_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      fun k  ->
-        let uu____41 =
-          FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term env t k in
-        match uu____41 with
-        | (t1,c,g) ->
-            (FStar_ST.write t1.FStar_Syntax_Syntax.tk
-               (Some ((c.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n));
-             FStar_TypeChecker_Rel.force_trivial_guard env g;
-             t1)
-let recheck_debug:
-  Prims.string ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun s  ->
-    fun env  ->
-      fun t  ->
-        (let uu____63 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-         if uu____63
-         then
-           let uu____64 = FStar_Syntax_Print.term_to_string t in
-           FStar_Util.print2
-             "Term has been %s-transformed to:\n%s\n----------\n" s uu____64
-         else ());
-        (let uu____66 = FStar_TypeChecker_TcTerm.tc_term env t in
-         match uu____66 with
-         | (t',uu____71,uu____72) ->
-             ((let uu____74 =
-                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-               if uu____74
-               then
-                 let uu____75 = FStar_Syntax_Print.term_to_string t' in
-                 FStar_Util.print1 "Re-checked; got:\n%s\n----------\n"
-                   uu____75
-               else ());
-              t))
-let check_and_gen:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.tscheme
-  =
-  fun env  ->
-    fun t  ->
-      fun k  ->
-        let uu____86 = tc_check_trivial_guard env t k in
-        FStar_TypeChecker_Util.generalize_universes env uu____86
-let check_nogen env t k =
-  let t1 = tc_check_trivial_guard env t k in
-  let uu____108 =
-    FStar_TypeChecker_Normalize.normalize [FStar_TypeChecker_Normalize.Beta]
-      env t1 in
-  ([], uu____108)
-let monad_signature:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term ->
-        (FStar_Syntax_Syntax.bv*
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax)
-  =
-  fun env  ->
-    fun m  ->
-      fun s  ->
-        let fail uu____130 =
-          let uu____131 =
-            let uu____132 =
-              let uu____135 =
-                FStar_TypeChecker_Err.unexpected_signature_for_monad env m s in
-              (uu____135, (FStar_Ident.range_of_lid m)) in
-            FStar_Errors.Error uu____132 in
-          Prims.raise uu____131 in
-        let s1 = FStar_Syntax_Subst.compress s in
-        match s1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-            let bs1 = FStar_Syntax_Subst.open_binders bs in
-            (match bs1 with
-             | (a,uu____163)::(wp,uu____165)::[] ->
-                 (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____174 -> fail ())
-        | uu____175 -> fail ()
-let rec tc_eff_decl:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.eff_decl
-  =
-  fun env0  ->
-    fun ed  ->
-      let uu____238 =
-        FStar_Syntax_Subst.open_term' ed.FStar_Syntax_Syntax.binders
-          ed.FStar_Syntax_Syntax.signature in
-      match uu____238 with
-      | (effect_params_un,signature_un,opening) ->
-          let uu____245 =
-            FStar_TypeChecker_TcTerm.tc_tparams env0 effect_params_un in
-          (match uu____245 with
-           | (effect_params,env,uu____251) ->
-               let uu____252 =
-                 FStar_TypeChecker_TcTerm.tc_trivial_guard env signature_un in
-               (match uu____252 with
-                | (signature,uu____256) ->
-                    let ed1 =
-                      let uu___90_258 = ed in
-                      {
-                        FStar_Syntax_Syntax.qualifiers =
-                          (uu___90_258.FStar_Syntax_Syntax.qualifiers);
-                        FStar_Syntax_Syntax.cattributes =
-                          (uu___90_258.FStar_Syntax_Syntax.cattributes);
-                        FStar_Syntax_Syntax.mname =
-                          (uu___90_258.FStar_Syntax_Syntax.mname);
-                        FStar_Syntax_Syntax.univs =
-                          (uu___90_258.FStar_Syntax_Syntax.univs);
-                        FStar_Syntax_Syntax.binders = effect_params;
-                        FStar_Syntax_Syntax.signature = signature;
-                        FStar_Syntax_Syntax.ret_wp =
-                          (uu___90_258.FStar_Syntax_Syntax.ret_wp);
-                        FStar_Syntax_Syntax.bind_wp =
-                          (uu___90_258.FStar_Syntax_Syntax.bind_wp);
-                        FStar_Syntax_Syntax.if_then_else =
-                          (uu___90_258.FStar_Syntax_Syntax.if_then_else);
-                        FStar_Syntax_Syntax.ite_wp =
-                          (uu___90_258.FStar_Syntax_Syntax.ite_wp);
-                        FStar_Syntax_Syntax.stronger =
-                          (uu___90_258.FStar_Syntax_Syntax.stronger);
-                        FStar_Syntax_Syntax.close_wp =
-                          (uu___90_258.FStar_Syntax_Syntax.close_wp);
-                        FStar_Syntax_Syntax.assert_p =
-                          (uu___90_258.FStar_Syntax_Syntax.assert_p);
-                        FStar_Syntax_Syntax.assume_p =
-                          (uu___90_258.FStar_Syntax_Syntax.assume_p);
-                        FStar_Syntax_Syntax.null_wp =
-                          (uu___90_258.FStar_Syntax_Syntax.null_wp);
-                        FStar_Syntax_Syntax.trivial =
-                          (uu___90_258.FStar_Syntax_Syntax.trivial);
-                        FStar_Syntax_Syntax.repr =
-                          (uu___90_258.FStar_Syntax_Syntax.repr);
-                        FStar_Syntax_Syntax.return_repr =
-                          (uu___90_258.FStar_Syntax_Syntax.return_repr);
-                        FStar_Syntax_Syntax.bind_repr =
-                          (uu___90_258.FStar_Syntax_Syntax.bind_repr);
-                        FStar_Syntax_Syntax.actions =
-                          (uu___90_258.FStar_Syntax_Syntax.actions)
-                      } in
-                    let ed2 =
-                      match effect_params with
-                      | [] -> ed1
-                      | uu____262 ->
-                          let op ts =
-                            let t1 =
-                              FStar_Syntax_Subst.subst opening (Prims.snd ts) in
-                            ([], t1) in
-                          let uu___91_280 = ed1 in
-                          let uu____281 = op ed1.FStar_Syntax_Syntax.ret_wp in
-                          let uu____282 = op ed1.FStar_Syntax_Syntax.bind_wp in
-                          let uu____283 =
-                            op ed1.FStar_Syntax_Syntax.if_then_else in
-                          let uu____284 = op ed1.FStar_Syntax_Syntax.ite_wp in
-                          let uu____285 = op ed1.FStar_Syntax_Syntax.stronger in
-                          let uu____286 = op ed1.FStar_Syntax_Syntax.close_wp in
-                          let uu____287 = op ed1.FStar_Syntax_Syntax.assert_p in
-                          let uu____288 = op ed1.FStar_Syntax_Syntax.assume_p in
-                          let uu____289 = op ed1.FStar_Syntax_Syntax.null_wp in
-                          let uu____290 = op ed1.FStar_Syntax_Syntax.trivial in
-                          let uu____291 =
-                            let uu____292 =
-                              op ([], (ed1.FStar_Syntax_Syntax.repr)) in
-                            Prims.snd uu____292 in
-                          let uu____298 =
-                            op ed1.FStar_Syntax_Syntax.return_repr in
-                          let uu____299 =
-                            op ed1.FStar_Syntax_Syntax.bind_repr in
-                          let uu____300 =
-                            FStar_List.map
-                              (fun a  ->
-                                 let uu___92_303 = a in
-                                 let uu____304 =
-                                   let uu____305 =
-                                     op
-                                       ([],
-                                         (a.FStar_Syntax_Syntax.action_defn)) in
-                                   Prims.snd uu____305 in
-                                 let uu____311 =
-                                   let uu____312 =
-                                     op
-                                       ([],
-                                         (a.FStar_Syntax_Syntax.action_typ)) in
-                                   Prims.snd uu____312 in
-                                 {
-                                   FStar_Syntax_Syntax.action_name =
-                                     (uu___92_303.FStar_Syntax_Syntax.action_name);
-                                   FStar_Syntax_Syntax.action_unqualified_name
-                                     =
-                                     (uu___92_303.FStar_Syntax_Syntax.action_unqualified_name);
-                                   FStar_Syntax_Syntax.action_univs =
-                                     (uu___92_303.FStar_Syntax_Syntax.action_univs);
-                                   FStar_Syntax_Syntax.action_defn =
-                                     uu____304;
-                                   FStar_Syntax_Syntax.action_typ = uu____311
-                                 }) ed1.FStar_Syntax_Syntax.actions in
-                          {
-                            FStar_Syntax_Syntax.qualifiers =
-                              (uu___91_280.FStar_Syntax_Syntax.qualifiers);
-                            FStar_Syntax_Syntax.cattributes =
-                              (uu___91_280.FStar_Syntax_Syntax.cattributes);
-                            FStar_Syntax_Syntax.mname =
-                              (uu___91_280.FStar_Syntax_Syntax.mname);
-                            FStar_Syntax_Syntax.univs =
-                              (uu___91_280.FStar_Syntax_Syntax.univs);
-                            FStar_Syntax_Syntax.binders =
-                              (uu___91_280.FStar_Syntax_Syntax.binders);
-                            FStar_Syntax_Syntax.signature =
-                              (uu___91_280.FStar_Syntax_Syntax.signature);
-                            FStar_Syntax_Syntax.ret_wp = uu____281;
-                            FStar_Syntax_Syntax.bind_wp = uu____282;
-                            FStar_Syntax_Syntax.if_then_else = uu____283;
-                            FStar_Syntax_Syntax.ite_wp = uu____284;
-                            FStar_Syntax_Syntax.stronger = uu____285;
-                            FStar_Syntax_Syntax.close_wp = uu____286;
-                            FStar_Syntax_Syntax.assert_p = uu____287;
-                            FStar_Syntax_Syntax.assume_p = uu____288;
-                            FStar_Syntax_Syntax.null_wp = uu____289;
-                            FStar_Syntax_Syntax.trivial = uu____290;
-                            FStar_Syntax_Syntax.repr = uu____291;
-                            FStar_Syntax_Syntax.return_repr = uu____298;
-                            FStar_Syntax_Syntax.bind_repr = uu____299;
-                            FStar_Syntax_Syntax.actions = uu____300
-                          } in
-                    let wp_with_fresh_result_type env1 mname signature1 =
-                      let fail t =
-                        let uu____340 =
-                          let uu____341 =
-                            let uu____344 =
-                              FStar_TypeChecker_Err.unexpected_signature_for_monad
-                                env1 mname t in
-                            (uu____344, (FStar_Ident.range_of_lid mname)) in
-                          FStar_Errors.Error uu____341 in
-                        Prims.raise uu____340 in
-                      let uu____349 =
-                        let uu____350 =
-                          FStar_Syntax_Subst.compress signature1 in
-                        uu____350.FStar_Syntax_Syntax.n in
-                      match uu____349 with
-                      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                          let bs1 = FStar_Syntax_Subst.open_binders bs in
-                          (match bs1 with
-                           | (a,uu____375)::(wp,uu____377)::[] ->
-                               (a, (wp.FStar_Syntax_Syntax.sort))
-                           | uu____386 -> fail signature1)
-                      | uu____387 -> fail signature1 in
-                    let uu____388 =
-                      wp_with_fresh_result_type env
-                        ed2.FStar_Syntax_Syntax.mname
-                        ed2.FStar_Syntax_Syntax.signature in
-                    (match uu____388 with
-                     | (a,wp_a) ->
-                         let fresh_effect_signature uu____406 =
-                           let uu____407 =
-                             FStar_TypeChecker_TcTerm.tc_trivial_guard env
-                               signature_un in
-                           match uu____407 with
-                           | (signature1,uu____415) ->
-                               wp_with_fresh_result_type env
-                                 ed2.FStar_Syntax_Syntax.mname signature1 in
-                         let env1 =
-                           let uu____417 =
-                             FStar_Syntax_Syntax.new_bv None
-                               ed2.FStar_Syntax_Syntax.signature in
-                           FStar_TypeChecker_Env.push_bv env uu____417 in
-                         ((let uu____419 =
-                             FStar_All.pipe_left
-                               (FStar_TypeChecker_Env.debug env0)
-                               (FStar_Options.Other "ED") in
-                           if uu____419
-                           then
-                             let uu____420 =
-                               FStar_Syntax_Print.lid_to_string
-                                 ed2.FStar_Syntax_Syntax.mname in
-                             let uu____421 =
-                               FStar_Syntax_Print.binders_to_string " "
-                                 ed2.FStar_Syntax_Syntax.binders in
-                             let uu____422 =
-                               FStar_Syntax_Print.term_to_string
-                                 ed2.FStar_Syntax_Syntax.signature in
-                             let uu____423 =
-                               let uu____424 =
-                                 FStar_Syntax_Syntax.bv_to_name a in
-                               FStar_Syntax_Print.term_to_string uu____424 in
-                             let uu____425 =
-                               FStar_Syntax_Print.term_to_string
-                                 a.FStar_Syntax_Syntax.sort in
-                             FStar_Util.print5
-                               "Checking effect signature: %s %s : %s\n(a is %s:%s)\n"
-                               uu____420 uu____421 uu____422 uu____423
-                               uu____425
-                           else ());
-                          (let check_and_gen' env2 uu____438 k =
-                             match uu____438 with
-                             | (uu____443,t) -> check_and_gen env2 t k in
-                           let return_wp =
-                             let expected_k =
-                               let uu____451 =
-                                 let uu____455 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____456 =
-                                   let uu____458 =
-                                     let uu____459 =
-                                       FStar_Syntax_Syntax.bv_to_name a in
-                                     FStar_Syntax_Syntax.null_binder
-                                       uu____459 in
-                                   [uu____458] in
-                                 uu____455 :: uu____456 in
-                               let uu____460 =
-                                 FStar_Syntax_Syntax.mk_GTotal wp_a in
-                               FStar_Syntax_Util.arrow uu____451 uu____460 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.ret_wp expected_k in
-                           let bind_wp =
-                             let uu____464 = fresh_effect_signature () in
-                             match uu____464 with
-                             | (b,wp_b) ->
-                                 let a_wp_b =
-                                   let uu____478 =
-                                     let uu____482 =
-                                       let uu____483 =
-                                         FStar_Syntax_Syntax.bv_to_name a in
-                                       FStar_Syntax_Syntax.null_binder
-                                         uu____483 in
-                                     [uu____482] in
-                                   let uu____484 =
-                                     FStar_Syntax_Syntax.mk_Total wp_b in
-                                   FStar_Syntax_Util.arrow uu____478
-                                     uu____484 in
-                                 let expected_k =
-                                   let uu____490 =
-                                     let uu____494 =
-                                       FStar_Syntax_Syntax.null_binder
-                                         FStar_TypeChecker_Common.t_range in
-                                     let uu____495 =
-                                       let uu____497 =
-                                         FStar_Syntax_Syntax.mk_binder a in
-                                       let uu____498 =
-                                         let uu____500 =
-                                           FStar_Syntax_Syntax.mk_binder b in
-                                         let uu____501 =
-                                           let uu____503 =
-                                             FStar_Syntax_Syntax.null_binder
-                                               wp_a in
-                                           let uu____504 =
-                                             let uu____506 =
-                                               FStar_Syntax_Syntax.null_binder
-                                                 a_wp_b in
-                                             [uu____506] in
-                                           uu____503 :: uu____504 in
-                                         uu____500 :: uu____501 in
-                                       uu____497 :: uu____498 in
-                                     uu____494 :: uu____495 in
-                                   let uu____507 =
-                                     FStar_Syntax_Syntax.mk_Total wp_b in
-                                   FStar_Syntax_Util.arrow uu____490
-                                     uu____507 in
-                                 check_and_gen' env1
-                                   ed2.FStar_Syntax_Syntax.bind_wp expected_k in
-                           let if_then_else1 =
-                             let p =
-                               let uu____512 =
-                                 let uu____513 = FStar_Syntax_Util.type_u () in
-                                 FStar_All.pipe_right uu____513 Prims.fst in
-                               FStar_Syntax_Syntax.new_bv
-                                 (Some
-                                    (FStar_Ident.range_of_lid
-                                       ed2.FStar_Syntax_Syntax.mname))
-                                 uu____512 in
-                             let expected_k =
-                               let uu____521 =
-                                 let uu____525 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____526 =
-                                   let uu____528 =
-                                     FStar_Syntax_Syntax.mk_binder p in
-                                   let uu____529 =
-                                     let uu____531 =
-                                       FStar_Syntax_Syntax.null_binder wp_a in
-                                     let uu____532 =
-                                       let uu____534 =
-                                         FStar_Syntax_Syntax.null_binder wp_a in
-                                       [uu____534] in
-                                     uu____531 :: uu____532 in
-                                   uu____528 :: uu____529 in
-                                 uu____525 :: uu____526 in
-                               let uu____535 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____521 uu____535 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.if_then_else
-                               expected_k in
-                           let ite_wp =
-                             let expected_k =
-                               let uu____542 =
-                                 let uu____546 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____547 =
-                                   let uu____549 =
-                                     FStar_Syntax_Syntax.null_binder wp_a in
-                                   [uu____549] in
-                                 uu____546 :: uu____547 in
-                               let uu____550 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____542 uu____550 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.ite_wp expected_k in
-                           let stronger =
-                             let uu____554 = FStar_Syntax_Util.type_u () in
-                             match uu____554 with
-                             | (t,uu____558) ->
-                                 let expected_k =
-                                   let uu____562 =
-                                     let uu____566 =
-                                       FStar_Syntax_Syntax.mk_binder a in
-                                     let uu____567 =
-                                       let uu____569 =
-                                         FStar_Syntax_Syntax.null_binder wp_a in
-                                       let uu____570 =
-                                         let uu____572 =
-                                           FStar_Syntax_Syntax.null_binder
-                                             wp_a in
-                                         [uu____572] in
-                                       uu____569 :: uu____570 in
-                                     uu____566 :: uu____567 in
-                                   let uu____573 =
-                                     FStar_Syntax_Syntax.mk_Total t in
-                                   FStar_Syntax_Util.arrow uu____562
-                                     uu____573 in
-                                 check_and_gen' env1
-                                   ed2.FStar_Syntax_Syntax.stronger
-                                   expected_k in
-                           let close_wp =
-                             let b =
-                               let uu____578 =
-                                 let uu____579 = FStar_Syntax_Util.type_u () in
-                                 FStar_All.pipe_right uu____579 Prims.fst in
-                               FStar_Syntax_Syntax.new_bv
-                                 (Some
-                                    (FStar_Ident.range_of_lid
-                                       ed2.FStar_Syntax_Syntax.mname))
-                                 uu____578 in
-                             let b_wp_a =
-                               let uu____587 =
-                                 let uu____591 =
-                                   let uu____592 =
-                                     FStar_Syntax_Syntax.bv_to_name b in
-                                   FStar_Syntax_Syntax.null_binder uu____592 in
-                                 [uu____591] in
-                               let uu____593 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____587 uu____593 in
-                             let expected_k =
-                               let uu____599 =
-                                 let uu____603 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____604 =
-                                   let uu____606 =
-                                     FStar_Syntax_Syntax.mk_binder b in
-                                   let uu____607 =
-                                     let uu____609 =
-                                       FStar_Syntax_Syntax.null_binder b_wp_a in
-                                     [uu____609] in
-                                   uu____606 :: uu____607 in
-                                 uu____603 :: uu____604 in
-                               let uu____610 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____599 uu____610 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.close_wp expected_k in
-                           let assert_p =
-                             let expected_k =
-                               let uu____617 =
-                                 let uu____621 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____622 =
-                                   let uu____624 =
-                                     let uu____625 =
-                                       let uu____626 =
-                                         FStar_Syntax_Util.type_u () in
-                                       FStar_All.pipe_right uu____626
-                                         Prims.fst in
-                                     FStar_Syntax_Syntax.null_binder
-                                       uu____625 in
-                                   let uu____631 =
-                                     let uu____633 =
-                                       FStar_Syntax_Syntax.null_binder wp_a in
-                                     [uu____633] in
-                                   uu____624 :: uu____631 in
-                                 uu____621 :: uu____622 in
-                               let uu____634 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____617 uu____634 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.assert_p expected_k in
-                           let assume_p =
-                             let expected_k =
-                               let uu____641 =
-                                 let uu____645 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 let uu____646 =
-                                   let uu____648 =
-                                     let uu____649 =
-                                       let uu____650 =
-                                         FStar_Syntax_Util.type_u () in
-                                       FStar_All.pipe_right uu____650
-                                         Prims.fst in
-                                     FStar_Syntax_Syntax.null_binder
-                                       uu____649 in
-                                   let uu____655 =
-                                     let uu____657 =
-                                       FStar_Syntax_Syntax.null_binder wp_a in
-                                     [uu____657] in
-                                   uu____648 :: uu____655 in
-                                 uu____645 :: uu____646 in
-                               let uu____658 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____641 uu____658 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.assume_p expected_k in
-                           let null_wp =
-                             let expected_k =
-                               let uu____665 =
-                                 let uu____669 =
-                                   FStar_Syntax_Syntax.mk_binder a in
-                                 [uu____669] in
-                               let uu____670 =
-                                 FStar_Syntax_Syntax.mk_Total wp_a in
-                               FStar_Syntax_Util.arrow uu____665 uu____670 in
-                             check_and_gen' env1
-                               ed2.FStar_Syntax_Syntax.null_wp expected_k in
-                           let trivial_wp =
-                             let uu____674 = FStar_Syntax_Util.type_u () in
-                             match uu____674 with
-                             | (t,uu____678) ->
-                                 let expected_k =
-                                   let uu____682 =
-                                     let uu____686 =
-                                       FStar_Syntax_Syntax.mk_binder a in
-                                     let uu____687 =
-                                       let uu____689 =
-                                         FStar_Syntax_Syntax.null_binder wp_a in
-                                       [uu____689] in
-                                     uu____686 :: uu____687 in
-                                   let uu____690 =
-                                     FStar_Syntax_Syntax.mk_GTotal t in
-                                   FStar_Syntax_Util.arrow uu____682
-                                     uu____690 in
-                                 check_and_gen' env1
-                                   ed2.FStar_Syntax_Syntax.trivial expected_k in
-                           let uu____693 =
-                             let uu____699 =
-                               let uu____700 =
-                                 FStar_Syntax_Subst.compress
-                                   ed2.FStar_Syntax_Syntax.repr in
-                               uu____700.FStar_Syntax_Syntax.n in
-                             match uu____699 with
-                             | FStar_Syntax_Syntax.Tm_unknown  ->
-                                 ((ed2.FStar_Syntax_Syntax.repr),
-                                   (ed2.FStar_Syntax_Syntax.bind_repr),
-                                   (ed2.FStar_Syntax_Syntax.return_repr),
-                                   (ed2.FStar_Syntax_Syntax.actions))
-                             | uu____709 ->
-                                 let repr =
-                                   let uu____711 =
-                                     FStar_Syntax_Util.type_u () in
-                                   match uu____711 with
-                                   | (t,uu____715) ->
-                                       let expected_k =
-                                         let uu____719 =
-                                           let uu____723 =
-                                             FStar_Syntax_Syntax.mk_binder a in
-                                           let uu____724 =
-                                             let uu____726 =
-                                               FStar_Syntax_Syntax.null_binder
-                                                 wp_a in
-                                             [uu____726] in
-                                           uu____723 :: uu____724 in
-                                         let uu____727 =
-                                           FStar_Syntax_Syntax.mk_GTotal t in
-                                         FStar_Syntax_Util.arrow uu____719
-                                           uu____727 in
-                                       tc_check_trivial_guard env1
-                                         ed2.FStar_Syntax_Syntax.repr
-                                         expected_k in
-                                 let mk_repr' t wp =
-                                   let repr1 =
-                                     FStar_TypeChecker_Normalize.normalize
-                                       [FStar_TypeChecker_Normalize.EraseUniverses;
-                                       FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                                       env1 repr in
-                                   let uu____740 =
-                                     let uu____743 =
-                                       let uu____744 =
-                                         let uu____754 =
-                                           let uu____756 =
-                                             FStar_Syntax_Syntax.as_arg t in
-                                           let uu____757 =
-                                             let uu____759 =
-                                               FStar_Syntax_Syntax.as_arg wp in
-                                             [uu____759] in
-                                           uu____756 :: uu____757 in
-                                         (repr1, uu____754) in
-                                       FStar_Syntax_Syntax.Tm_app uu____744 in
-                                     FStar_Syntax_Syntax.mk uu____743 in
-                                   uu____740 None FStar_Range.dummyRange in
-                                 let mk_repr a1 wp =
-                                   let uu____778 =
-                                     FStar_Syntax_Syntax.bv_to_name a1 in
-                                   mk_repr' uu____778 wp in
-                                 let destruct_repr t =
-                                   let uu____789 =
-                                     let uu____790 =
-                                       FStar_Syntax_Subst.compress t in
-                                     uu____790.FStar_Syntax_Syntax.n in
-                                   match uu____789 with
-                                   | FStar_Syntax_Syntax.Tm_app
-                                       (uu____799,(t1,uu____801)::(wp,uu____803)::[])
-                                       -> (t1, wp)
-                                   | uu____837 ->
-                                       failwith "Unexpected repr type" in
-                                 let bind_repr =
-                                   let r =
-                                     let uu____846 =
-                                       FStar_Syntax_Syntax.lid_as_fv
-                                         FStar_Syntax_Const.range_0
-                                         FStar_Syntax_Syntax.Delta_constant
-                                         None in
-                                     FStar_All.pipe_right uu____846
-                                       FStar_Syntax_Syntax.fv_to_tm in
-                                   let uu____847 = fresh_effect_signature () in
-                                   match uu____847 with
-                                   | (b,wp_b) ->
-                                       let a_wp_b =
-                                         let uu____861 =
-                                           let uu____865 =
-                                             let uu____866 =
-                                               FStar_Syntax_Syntax.bv_to_name
-                                                 a in
-                                             FStar_Syntax_Syntax.null_binder
-                                               uu____866 in
-                                           [uu____865] in
-                                         let uu____867 =
-                                           FStar_Syntax_Syntax.mk_Total wp_b in
-                                         FStar_Syntax_Util.arrow uu____861
-                                           uu____867 in
-                                       let wp_f =
-                                         FStar_Syntax_Syntax.gen_bv "wp_f"
-                                           None wp_a in
-                                       let wp_g =
-                                         FStar_Syntax_Syntax.gen_bv "wp_g"
-                                           None a_wp_b in
-                                       let x_a =
-                                         let uu____873 =
-                                           FStar_Syntax_Syntax.bv_to_name a in
-                                         FStar_Syntax_Syntax.gen_bv "x_a"
-                                           None uu____873 in
-                                       let wp_g_x =
-                                         let uu____877 =
-                                           let uu____878 =
-                                             FStar_Syntax_Syntax.bv_to_name
-                                               wp_g in
-                                           let uu____879 =
-                                             let uu____880 =
-                                               let uu____881 =
-                                                 FStar_Syntax_Syntax.bv_to_name
-                                                   x_a in
-                                               FStar_All.pipe_left
-                                                 FStar_Syntax_Syntax.as_arg
-                                                 uu____881 in
-                                             [uu____880] in
-                                           FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____878 uu____879 in
-                                         uu____877 None
-                                           FStar_Range.dummyRange in
-                                       let res =
-                                         let wp =
-                                           let uu____892 =
-                                             let uu____893 =
-                                               let uu____894 =
-                                                 FStar_TypeChecker_Env.inst_tscheme
-                                                   bind_wp in
-                                               FStar_All.pipe_right uu____894
-                                                 Prims.snd in
-                                             let uu____899 =
-                                               let uu____900 =
-                                                 let uu____902 =
-                                                   let uu____904 =
-                                                     FStar_Syntax_Syntax.bv_to_name
-                                                       a in
-                                                   let uu____905 =
-                                                     let uu____907 =
-                                                       FStar_Syntax_Syntax.bv_to_name
-                                                         b in
-                                                     let uu____908 =
-                                                       let uu____910 =
-                                                         FStar_Syntax_Syntax.bv_to_name
-                                                           wp_f in
-                                                       let uu____911 =
-                                                         let uu____913 =
-                                                           FStar_Syntax_Syntax.bv_to_name
-                                                             wp_g in
-                                                         [uu____913] in
-                                                       uu____910 :: uu____911 in
-                                                     uu____907 :: uu____908 in
-                                                   uu____904 :: uu____905 in
-                                                 r :: uu____902 in
-                                               FStar_List.map
-                                                 FStar_Syntax_Syntax.as_arg
-                                                 uu____900 in
-                                             FStar_Syntax_Syntax.mk_Tm_app
-                                               uu____893 uu____899 in
-                                           uu____892 None
-                                             FStar_Range.dummyRange in
-                                         mk_repr b wp in
-                                       let expected_k =
-                                         let uu____921 =
-                                           let uu____925 =
-                                             FStar_Syntax_Syntax.mk_binder a in
-                                           let uu____926 =
-                                             let uu____928 =
-                                               FStar_Syntax_Syntax.mk_binder
-                                                 b in
-                                             let uu____929 =
-                                               let uu____931 =
-                                                 FStar_Syntax_Syntax.mk_binder
-                                                   wp_f in
-                                               let uu____932 =
-                                                 let uu____934 =
-                                                   let uu____935 =
-                                                     let uu____936 =
-                                                       FStar_Syntax_Syntax.bv_to_name
-                                                         wp_f in
-                                                     mk_repr a uu____936 in
-                                                   FStar_Syntax_Syntax.null_binder
-                                                     uu____935 in
-                                                 let uu____937 =
-                                                   let uu____939 =
-                                                     FStar_Syntax_Syntax.mk_binder
-                                                       wp_g in
-                                                   let uu____940 =
-                                                     let uu____942 =
-                                                       let uu____943 =
-                                                         let uu____944 =
-                                                           let uu____948 =
-                                                             FStar_Syntax_Syntax.mk_binder
-                                                               x_a in
-                                                           [uu____948] in
-                                                         let uu____949 =
-                                                           let uu____952 =
-                                                             mk_repr b wp_g_x in
-                                                           FStar_All.pipe_left
-                                                             FStar_Syntax_Syntax.mk_Total
-                                                             uu____952 in
-                                                         FStar_Syntax_Util.arrow
-                                                           uu____944
-                                                           uu____949 in
-                                                       FStar_Syntax_Syntax.null_binder
-                                                         uu____943 in
-                                                     [uu____942] in
-                                                   uu____939 :: uu____940 in
-                                                 uu____934 :: uu____937 in
-                                               uu____931 :: uu____932 in
-                                             uu____928 :: uu____929 in
-                                           uu____925 :: uu____926 in
-                                         let uu____953 =
-                                           FStar_Syntax_Syntax.mk_Total res in
-                                         FStar_Syntax_Util.arrow uu____921
-                                           uu____953 in
-                                       let uu____956 =
-                                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                           env1 expected_k in
-                                       (match uu____956 with
-                                        | (expected_k1,uu____961,uu____962)
-                                            ->
-                                            let env2 =
-                                              FStar_TypeChecker_Env.set_range
-                                                env1
-                                                (Prims.snd
-                                                   ed2.FStar_Syntax_Syntax.bind_repr).FStar_Syntax_Syntax.pos in
-                                            let env3 =
-                                              let uu___93_966 = env2 in
-                                              {
-                                                FStar_TypeChecker_Env.solver
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.solver);
-                                                FStar_TypeChecker_Env.range =
-                                                  (uu___93_966.FStar_TypeChecker_Env.range);
-                                                FStar_TypeChecker_Env.curmodule
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.curmodule);
-                                                FStar_TypeChecker_Env.gamma =
-                                                  (uu___93_966.FStar_TypeChecker_Env.gamma);
-                                                FStar_TypeChecker_Env.gamma_cache
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.gamma_cache);
-                                                FStar_TypeChecker_Env.modules
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.modules);
-                                                FStar_TypeChecker_Env.expected_typ
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.expected_typ);
-                                                FStar_TypeChecker_Env.sigtab
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.sigtab);
-                                                FStar_TypeChecker_Env.is_pattern
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.is_pattern);
-                                                FStar_TypeChecker_Env.instantiate_imp
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.instantiate_imp);
-                                                FStar_TypeChecker_Env.effects
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.effects);
-                                                FStar_TypeChecker_Env.generalize
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.generalize);
-                                                FStar_TypeChecker_Env.letrecs
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.letrecs);
-                                                FStar_TypeChecker_Env.top_level
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.top_level);
-                                                FStar_TypeChecker_Env.check_uvars
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.check_uvars);
-                                                FStar_TypeChecker_Env.use_eq
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.use_eq);
-                                                FStar_TypeChecker_Env.is_iface
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.is_iface);
-                                                FStar_TypeChecker_Env.admit =
-                                                  (uu___93_966.FStar_TypeChecker_Env.admit);
-                                                FStar_TypeChecker_Env.lax =
-                                                  true;
-                                                FStar_TypeChecker_Env.lax_universes
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.lax_universes);
-                                                FStar_TypeChecker_Env.type_of
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.type_of);
-                                                FStar_TypeChecker_Env.universe_of
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.universe_of);
-                                                FStar_TypeChecker_Env.use_bv_sorts
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.use_bv_sorts);
-                                                FStar_TypeChecker_Env.qname_and_index
-                                                  =
-                                                  (uu___93_966.FStar_TypeChecker_Env.qname_and_index)
-                                              } in
-                                            let br =
-                                              check_and_gen' env3
-                                                ed2.FStar_Syntax_Syntax.bind_repr
-                                                expected_k1 in
-                                            br) in
-                                 let return_repr =
-                                   let x_a =
-                                     let uu____973 =
-                                       FStar_Syntax_Syntax.bv_to_name a in
-                                     FStar_Syntax_Syntax.gen_bv "x_a" None
-                                       uu____973 in
-                                   let res =
-                                     let wp =
-                                       let uu____980 =
-                                         let uu____981 =
-                                           let uu____982 =
-                                             FStar_TypeChecker_Env.inst_tscheme
-                                               return_wp in
-                                           FStar_All.pipe_right uu____982
-                                             Prims.snd in
-                                         let uu____987 =
-                                           let uu____988 =
-                                             let uu____990 =
-                                               FStar_Syntax_Syntax.bv_to_name
-                                                 a in
-                                             let uu____991 =
-                                               let uu____993 =
-                                                 FStar_Syntax_Syntax.bv_to_name
-                                                   x_a in
-                                               [uu____993] in
-                                             uu____990 :: uu____991 in
-                                           FStar_List.map
-                                             FStar_Syntax_Syntax.as_arg
-                                             uu____988 in
-                                         FStar_Syntax_Syntax.mk_Tm_app
-                                           uu____981 uu____987 in
-                                       uu____980 None FStar_Range.dummyRange in
-                                     mk_repr a wp in
-                                   let expected_k =
-                                     let uu____1001 =
-                                       let uu____1005 =
-                                         FStar_Syntax_Syntax.mk_binder a in
-                                       let uu____1006 =
-                                         let uu____1008 =
-                                           FStar_Syntax_Syntax.mk_binder x_a in
-                                         [uu____1008] in
-                                       uu____1005 :: uu____1006 in
-                                     let uu____1009 =
-                                       FStar_Syntax_Syntax.mk_Total res in
-                                     FStar_Syntax_Util.arrow uu____1001
-                                       uu____1009 in
-                                   let uu____1012 =
-                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                       env1 expected_k in
-                                   match uu____1012 with
-                                   | (expected_k1,uu____1020,uu____1021) ->
-                                       let env2 =
-                                         FStar_TypeChecker_Env.set_range env1
-                                           (Prims.snd
-                                              ed2.FStar_Syntax_Syntax.return_repr).FStar_Syntax_Syntax.pos in
-                                       let uu____1024 =
-                                         check_and_gen' env2
-                                           ed2.FStar_Syntax_Syntax.return_repr
-                                           expected_k1 in
-                                       (match uu____1024 with
-                                        | (univs1,repr1) ->
-                                            (match univs1 with
-                                             | [] -> ([], repr1)
-                                             | uu____1036 ->
-                                                 Prims.raise
-                                                   (FStar_Errors.Error
-                                                      ("Unexpected universe-polymorphic return for effect",
-                                                        (repr1.FStar_Syntax_Syntax.pos))))) in
-                                 let actions =
-                                   let check_action act =
-                                     let uu____1047 =
-                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                         env1
-                                         act.FStar_Syntax_Syntax.action_typ in
-                                     match uu____1047 with
-                                     | (act_typ,uu____1052,g_t) ->
-                                         let env' =
-                                           FStar_TypeChecker_Env.set_expected_typ
-                                             env1 act_typ in
-                                         ((let uu____1056 =
-                                             FStar_TypeChecker_Env.debug env1
-                                               (FStar_Options.Other "ED") in
-                                           if uu____1056
-                                           then
-                                             let uu____1057 =
-                                               FStar_Syntax_Print.term_to_string
-                                                 act.FStar_Syntax_Syntax.action_defn in
-                                             let uu____1058 =
-                                               FStar_Syntax_Print.term_to_string
-                                                 act_typ in
-                                             FStar_Util.print3
-                                               "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                               (FStar_Ident.text_of_lid
-                                                  act.FStar_Syntax_Syntax.action_name)
-                                               uu____1057 uu____1058
-                                           else ());
-                                          (let uu____1060 =
-                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                               env'
-                                               act.FStar_Syntax_Syntax.action_defn in
-                                           match uu____1060 with
-                                           | (act_defn,uu____1065,g_a) ->
-                                               let act_defn1 =
-                                                 FStar_TypeChecker_Normalize.normalize
-                                                   [FStar_TypeChecker_Normalize.UnfoldUntil
-                                                      FStar_Syntax_Syntax.Delta_constant]
-                                                   env1 act_defn in
-                                               let act_typ1 =
-                                                 FStar_TypeChecker_Normalize.normalize
-                                                   [FStar_TypeChecker_Normalize.UnfoldUntil
-                                                      FStar_Syntax_Syntax.Delta_constant;
-                                                   FStar_TypeChecker_Normalize.Eager_unfolding;
-                                                   FStar_TypeChecker_Normalize.Beta]
-                                                   env1 act_typ in
-                                               let uu____1069 =
-                                                 let act_typ2 =
-                                                   FStar_Syntax_Subst.compress
-                                                     act_typ1 in
-                                                 match act_typ2.FStar_Syntax_Syntax.n
-                                                 with
-                                                 | FStar_Syntax_Syntax.Tm_arrow
-                                                     (bs,c) ->
-                                                     let uu____1087 =
-                                                       FStar_Syntax_Subst.open_comp
-                                                         bs c in
-                                                     (match uu____1087 with
-                                                      | (bs1,uu____1093) ->
-                                                          let res =
-                                                            mk_repr'
-                                                              FStar_Syntax_Syntax.tun
-                                                              FStar_Syntax_Syntax.tun in
-                                                          let k =
-                                                            let uu____1100 =
-                                                              FStar_Syntax_Syntax.mk_Total
-                                                                res in
-                                                            FStar_Syntax_Util.arrow
-                                                              bs1 uu____1100 in
-                                                          let uu____1103 =
-                                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                              env1 k in
-                                                          (match uu____1103
-                                                           with
-                                                           | (k1,uu____1110,g)
-                                                               -> (k1, g)))
-                                                 | uu____1112 ->
-                                                     let uu____1113 =
-                                                       let uu____1114 =
-                                                         let uu____1117 =
-                                                           let uu____1118 =
-                                                             FStar_Syntax_Print.term_to_string
-                                                               act_typ2 in
-                                                           let uu____1119 =
-                                                             FStar_Syntax_Print.tag_of_term
-                                                               act_typ2 in
-                                                           FStar_Util.format2
-                                                             "Actions must have function types (not: %s, a.k.a. %s)"
-                                                             uu____1118
-                                                             uu____1119 in
-                                                         (uu____1117,
-                                                           (act_defn1.FStar_Syntax_Syntax.pos)) in
-                                                       FStar_Errors.Error
-                                                         uu____1114 in
-                                                     Prims.raise uu____1113 in
-                                               (match uu____1069 with
-                                                | (expected_k,g_k) ->
-                                                    let g =
-                                                      FStar_TypeChecker_Rel.teq
-                                                        env1 act_typ1
-                                                        expected_k in
-                                                    ((let uu____1126 =
-                                                        let uu____1127 =
-                                                          let uu____1128 =
-                                                            FStar_TypeChecker_Rel.conj_guard
-                                                              g_t g in
-                                                          FStar_TypeChecker_Rel.conj_guard
-                                                            g_k uu____1128 in
-                                                        FStar_TypeChecker_Rel.conj_guard
-                                                          g_a uu____1127 in
-                                                      FStar_TypeChecker_Rel.force_trivial_guard
-                                                        env1 uu____1126);
-                                                     (let act_typ2 =
-                                                        let uu____1132 =
-                                                          let uu____1133 =
-                                                            FStar_Syntax_Subst.compress
-                                                              expected_k in
-                                                          uu____1133.FStar_Syntax_Syntax.n in
-                                                        match uu____1132 with
-                                                        | FStar_Syntax_Syntax.Tm_arrow
-                                                            (bs,c) ->
-                                                            let uu____1150 =
-                                                              FStar_Syntax_Subst.open_comp
-                                                                bs c in
-                                                            (match uu____1150
-                                                             with
-                                                             | (bs1,c1) ->
-                                                                 let uu____1157
-                                                                   =
-                                                                   destruct_repr
-                                                                    (FStar_Syntax_Util.comp_result
-                                                                    c1) in
-                                                                 (match uu____1157
-                                                                  with
-                                                                  | (a1,wp)
-                                                                    ->
-                                                                    let c2 =
-                                                                    let uu____1177
-                                                                    =
-                                                                    let uu____1178
-                                                                    =
-                                                                    env1.FStar_TypeChecker_Env.universe_of
-                                                                    env1 a1 in
-                                                                    [uu____1178] in
-                                                                    let uu____1179
-                                                                    =
-                                                                    let uu____1185
-                                                                    =
-                                                                    FStar_Syntax_Syntax.as_arg
-                                                                    wp in
-                                                                    [uu____1185] in
-                                                                    {
-                                                                    FStar_Syntax_Syntax.comp_univs
-                                                                    =
-                                                                    uu____1177;
-                                                                    FStar_Syntax_Syntax.effect_name
-                                                                    =
-                                                                    (ed2.FStar_Syntax_Syntax.mname);
-                                                                    FStar_Syntax_Syntax.result_typ
-                                                                    = a1;
-                                                                    FStar_Syntax_Syntax.effect_args
-                                                                    =
-                                                                    uu____1179;
-                                                                    FStar_Syntax_Syntax.flags
-                                                                    = []
-                                                                    } in
-                                                                    let uu____1186
-                                                                    =
-                                                                    FStar_Syntax_Syntax.mk_Comp
-                                                                    c2 in
-                                                                    FStar_Syntax_Util.arrow
-                                                                    bs1
-                                                                    uu____1186))
-                                                        | uu____1189 ->
-                                                            failwith "" in
-                                                      let uu____1192 =
-                                                        FStar_TypeChecker_Util.generalize_universes
-                                                          env1 act_defn1 in
-                                                      match uu____1192 with
-                                                      | (univs1,act_defn2) ->
-                                                          let act_typ3 =
-                                                            FStar_TypeChecker_Normalize.normalize
-                                                              [FStar_TypeChecker_Normalize.Beta]
-                                                              env1 act_typ2 in
-                                                          let uu___94_1198 =
-                                                            act in
-                                                          {
-                                                            FStar_Syntax_Syntax.action_name
-                                                              =
-                                                              (uu___94_1198.FStar_Syntax_Syntax.action_name);
-                                                            FStar_Syntax_Syntax.action_unqualified_name
-                                                              =
-                                                              (uu___94_1198.FStar_Syntax_Syntax.action_unqualified_name);
-                                                            FStar_Syntax_Syntax.action_univs
-                                                              = univs1;
-                                                            FStar_Syntax_Syntax.action_defn
-                                                              = act_defn2;
-                                                            FStar_Syntax_Syntax.action_typ
-                                                              = act_typ3
-                                                          }))))) in
-                                   FStar_All.pipe_right
-                                     ed2.FStar_Syntax_Syntax.actions
-                                     (FStar_List.map check_action) in
-                                 (repr, bind_repr, return_repr, actions) in
-                           match uu____693 with
-                           | (repr,bind_repr,return_repr,actions) ->
-                               let t =
-                                 let uu____1214 =
-                                   FStar_Syntax_Syntax.mk_Total
-                                     ed2.FStar_Syntax_Syntax.signature in
-                                 FStar_Syntax_Util.arrow
-                                   ed2.FStar_Syntax_Syntax.binders uu____1214 in
-                               let uu____1217 =
-                                 FStar_TypeChecker_Util.generalize_universes
-                                   env0 t in
-                               (match uu____1217 with
-                                | (univs1,t1) ->
-                                    let signature1 =
-                                      let uu____1223 =
-                                        let uu____1226 =
-                                          let uu____1227 =
-                                            FStar_Syntax_Subst.compress t1 in
-                                          uu____1227.FStar_Syntax_Syntax.n in
-                                        (effect_params, uu____1226) in
-                                      match uu____1223 with
-                                      | ([],uu____1230) -> t1
-                                      | (uu____1236,FStar_Syntax_Syntax.Tm_arrow
-                                         (uu____1237,c)) ->
-                                          FStar_Syntax_Util.comp_result c
-                                      | uu____1249 -> failwith "Impossible" in
-                                    let close1 n1 ts =
-                                      let ts1 =
-                                        let uu____1260 =
-                                          FStar_Syntax_Subst.close_tscheme
-                                            effect_params ts in
-                                        FStar_Syntax_Subst.close_univ_vars_tscheme
-                                          univs1 uu____1260 in
-                                      let m =
-                                        FStar_List.length (Prims.fst ts1) in
-                                      (let uu____1265 =
-                                         ((n1 >= (Prims.parse_int "0")) &&
-                                            (let uu____1266 =
-                                               FStar_Syntax_Util.is_unknown
-                                                 (Prims.snd ts1) in
-                                             Prims.op_Negation uu____1266))
-                                           && (m <> n1) in
-                                       if uu____1265
-                                       then
-                                         let error =
-                                           if m < n1
-                                           then
-                                             "not universe-polymorphic enough"
-                                           else "too universe-polymorphic" in
-                                         let uu____1275 =
-                                           let uu____1276 =
-                                             FStar_Util.string_of_int n1 in
-                                           let uu____1277 =
-                                             FStar_Syntax_Print.tscheme_to_string
-                                               ts1 in
-                                           FStar_Util.format3
-                                             "The effect combinator is %s (n=%s) (%s)"
-                                             error uu____1276 uu____1277 in
-                                         failwith uu____1275
-                                       else ());
-                                      ts1 in
-                                    let close_action act =
-                                      let uu____1283 =
-                                        close1 (- (Prims.parse_int "1"))
-                                          ((act.FStar_Syntax_Syntax.action_univs),
-                                            (act.FStar_Syntax_Syntax.action_defn)) in
-                                      match uu____1283 with
-                                      | (univs2,defn) ->
-                                          let uu____1288 =
-                                            close1 (- (Prims.parse_int "1"))
-                                              ((act.FStar_Syntax_Syntax.action_univs),
-                                                (act.FStar_Syntax_Syntax.action_typ)) in
-                                          (match uu____1288 with
-                                           | (univs',typ) ->
-                                               let uu___95_1294 = act in
-                                               {
-                                                 FStar_Syntax_Syntax.action_name
-                                                   =
-                                                   (uu___95_1294.FStar_Syntax_Syntax.action_name);
-                                                 FStar_Syntax_Syntax.action_unqualified_name
-                                                   =
-                                                   (uu___95_1294.FStar_Syntax_Syntax.action_unqualified_name);
-                                                 FStar_Syntax_Syntax.action_univs
-                                                   = univs2;
-                                                 FStar_Syntax_Syntax.action_defn
-                                                   = defn;
-                                                 FStar_Syntax_Syntax.action_typ
-                                                   = typ
-                                               }) in
-                                    let nunivs = FStar_List.length univs1 in
-                                    let ed3 =
-                                      let uu___96_1299 = ed2 in
-                                      let uu____1300 =
-                                        close1 (Prims.parse_int "0")
-                                          return_wp in
-                                      let uu____1301 =
-                                        close1 (Prims.parse_int "1") bind_wp in
-                                      let uu____1302 =
-                                        close1 (Prims.parse_int "0")
-                                          if_then_else1 in
-                                      let uu____1303 =
-                                        close1 (Prims.parse_int "0") ite_wp in
-                                      let uu____1304 =
-                                        close1 (Prims.parse_int "0") stronger in
-                                      let uu____1305 =
-                                        close1 (Prims.parse_int "1") close_wp in
-                                      let uu____1306 =
-                                        close1 (Prims.parse_int "0") assert_p in
-                                      let uu____1307 =
-                                        close1 (Prims.parse_int "0") assume_p in
-                                      let uu____1308 =
-                                        close1 (Prims.parse_int "0") null_wp in
-                                      let uu____1309 =
-                                        close1 (Prims.parse_int "0")
-                                          trivial_wp in
-                                      let uu____1310 =
-                                        let uu____1311 =
-                                          close1 (Prims.parse_int "0")
-                                            ([], repr) in
-                                        Prims.snd uu____1311 in
-                                      let uu____1317 =
-                                        close1 (Prims.parse_int "0")
-                                          return_repr in
-                                      let uu____1318 =
-                                        close1 (Prims.parse_int "1")
-                                          bind_repr in
-                                      let uu____1319 =
-                                        FStar_List.map close_action actions in
-                                      {
-                                        FStar_Syntax_Syntax.qualifiers =
-                                          (uu___96_1299.FStar_Syntax_Syntax.qualifiers);
-                                        FStar_Syntax_Syntax.cattributes =
-                                          (uu___96_1299.FStar_Syntax_Syntax.cattributes);
-                                        FStar_Syntax_Syntax.mname =
-                                          (uu___96_1299.FStar_Syntax_Syntax.mname);
-                                        FStar_Syntax_Syntax.univs = univs1;
-                                        FStar_Syntax_Syntax.binders =
-                                          effect_params;
-                                        FStar_Syntax_Syntax.signature =
-                                          signature1;
-                                        FStar_Syntax_Syntax.ret_wp =
-                                          uu____1300;
-                                        FStar_Syntax_Syntax.bind_wp =
-                                          uu____1301;
-                                        FStar_Syntax_Syntax.if_then_else =
-                                          uu____1302;
-                                        FStar_Syntax_Syntax.ite_wp =
-                                          uu____1303;
-                                        FStar_Syntax_Syntax.stronger =
-                                          uu____1304;
-                                        FStar_Syntax_Syntax.close_wp =
-                                          uu____1305;
-                                        FStar_Syntax_Syntax.assert_p =
-                                          uu____1306;
-                                        FStar_Syntax_Syntax.assume_p =
-                                          uu____1307;
-                                        FStar_Syntax_Syntax.null_wp =
-                                          uu____1308;
-                                        FStar_Syntax_Syntax.trivial =
-                                          uu____1309;
-                                        FStar_Syntax_Syntax.repr = uu____1310;
-                                        FStar_Syntax_Syntax.return_repr =
-                                          uu____1317;
-                                        FStar_Syntax_Syntax.bind_repr =
-                                          uu____1318;
-                                        FStar_Syntax_Syntax.actions =
-                                          uu____1319
-                                      } in
-                                    ((let uu____1322 =
-                                        (FStar_TypeChecker_Env.debug env1
-                                           FStar_Options.Low)
-                                          ||
-                                          (FStar_All.pipe_left
-                                             (FStar_TypeChecker_Env.debug
-                                                env1)
-                                             (FStar_Options.Other "ED")) in
-                                      if uu____1322
-                                      then
-                                        let uu____1323 =
-                                          FStar_Syntax_Print.eff_decl_to_string
-                                            false ed3 in
-                                        FStar_Util.print_string uu____1323
-                                      else ());
-                                     ed3)))))))
-and cps_and_elaborate:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.eff_decl ->
-      (FStar_Syntax_Syntax.sigelt Prims.list* FStar_Syntax_Syntax.eff_decl*
-        FStar_Syntax_Syntax.sigelt Prims.option)
-  =
-  fun env  ->
-    fun ed  ->
-      let uu____1327 =
-        FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-          ed.FStar_Syntax_Syntax.signature in
-      match uu____1327 with
-      | (effect_binders_un,signature_un) ->
-          let uu____1337 =
-            FStar_TypeChecker_TcTerm.tc_tparams env effect_binders_un in
-          (match uu____1337 with
-           | (effect_binders,env1,uu____1348) ->
-               let uu____1349 =
-                 FStar_TypeChecker_TcTerm.tc_trivial_guard env1 signature_un in
-               (match uu____1349 with
-                | (signature,uu____1358) ->
-                    let effect_binders1 =
-                      FStar_List.map
-                        (fun uu____1367  ->
-                           match uu____1367 with
-                           | (bv,qual) ->
-                               let uu____1374 =
-                                 let uu___97_1375 = bv in
-                                 let uu____1376 =
-                                   FStar_TypeChecker_Normalize.normalize
-                                     [FStar_TypeChecker_Normalize.EraseUniverses]
-                                     env1 bv.FStar_Syntax_Syntax.sort in
-                                 {
-                                   FStar_Syntax_Syntax.ppname =
-                                     (uu___97_1375.FStar_Syntax_Syntax.ppname);
-                                   FStar_Syntax_Syntax.index =
-                                     (uu___97_1375.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort = uu____1376
-                                 } in
-                               (uu____1374, qual)) effect_binders in
-                    let uu____1379 =
-                      let uu____1384 =
-                        let uu____1385 =
-                          FStar_Syntax_Subst.compress signature_un in
-                        uu____1385.FStar_Syntax_Syntax.n in
-                      match uu____1384 with
-                      | FStar_Syntax_Syntax.Tm_arrow
-                          ((a,uu____1393)::[],effect_marker) ->
-                          (a, effect_marker)
-                      | uu____1408 ->
-                          failwith "bad shape for effect-for-free signature" in
-                    (match uu____1379 with
-                     | (a,effect_marker) ->
-                         let a1 =
-                           let uu____1425 = FStar_Syntax_Syntax.is_null_bv a in
-                           if uu____1425
-                           then
-                             let uu____1426 =
-                               let uu____1428 =
-                                 FStar_Syntax_Syntax.range_of_bv a in
-                               Some uu____1428 in
-                             FStar_Syntax_Syntax.gen_bv "a" uu____1426
-                               a.FStar_Syntax_Syntax.sort
-                           else a in
-                         let open_and_check t =
-                           let subst1 =
-                             FStar_Syntax_Subst.opening_of_binders
-                               effect_binders1 in
-                           let t1 = FStar_Syntax_Subst.subst subst1 t in
-                           let uu____1438 =
-                             FStar_TypeChecker_TcTerm.tc_term env1 t1 in
-                           match uu____1438 with
-                           | (t2,comp,uu____1446) -> (t2, comp) in
-                         let mk1 x =
-                           FStar_Syntax_Syntax.mk x None
-                             signature.FStar_Syntax_Syntax.pos in
-                         let uu____1457 =
-                           open_and_check ed.FStar_Syntax_Syntax.repr in
-                         (match uu____1457 with
-                          | (repr,_comp) ->
-                              ((let uu____1468 =
-                                  FStar_TypeChecker_Env.debug env1
-                                    (FStar_Options.Other "ED") in
-                                if uu____1468
-                                then
-                                  let uu____1469 =
-                                    FStar_Syntax_Print.term_to_string repr in
-                                  FStar_Util.print1 "Representation is: %s\n"
-                                    uu____1469
-                                else ());
-                               (let dmff_env =
-                                  FStar_TypeChecker_DMFF.empty env1
-                                    (FStar_TypeChecker_TcTerm.tc_constant
-                                       FStar_Range.dummyRange) in
-                                let wp_type =
-                                  FStar_TypeChecker_DMFF.star_type dmff_env
-                                    repr in
-                                let wp_type1 = recheck_debug "*" env1 wp_type in
-                                let wp_a =
-                                  let uu____1475 =
-                                    let uu____1476 =
-                                      let uu____1477 =
-                                        let uu____1487 =
-                                          let uu____1491 =
-                                            let uu____1494 =
-                                              FStar_Syntax_Syntax.bv_to_name
-                                                a1 in
-                                            let uu____1495 =
-                                              FStar_Syntax_Syntax.as_implicit
-                                                false in
-                                            (uu____1494, uu____1495) in
-                                          [uu____1491] in
-                                        (wp_type1, uu____1487) in
-                                      FStar_Syntax_Syntax.Tm_app uu____1477 in
-                                    mk1 uu____1476 in
-                                  FStar_TypeChecker_Normalize.normalize
-                                    [FStar_TypeChecker_Normalize.Beta] env1
-                                    uu____1475 in
-                                let effect_signature =
-                                  let binders =
-                                    let uu____1510 =
-                                      let uu____1513 =
-                                        FStar_Syntax_Syntax.as_implicit false in
-                                      (a1, uu____1513) in
-                                    let uu____1514 =
-                                      let uu____1518 =
-                                        let uu____1519 =
-                                          FStar_Syntax_Syntax.gen_bv
-                                            "dijkstra_wp" None wp_a in
-                                        FStar_All.pipe_right uu____1519
-                                          FStar_Syntax_Syntax.mk_binder in
-                                      [uu____1518] in
-                                    uu____1510 :: uu____1514 in
-                                  let binders1 =
-                                    FStar_Syntax_Subst.close_binders binders in
-                                  mk1
-                                    (FStar_Syntax_Syntax.Tm_arrow
-                                       (binders1, effect_marker)) in
-                                let effect_signature1 =
-                                  recheck_debug
-                                    "turned into the effect signature" env1
-                                    effect_signature in
-                                let sigelts = FStar_Util.mk_ref [] in
-                                let mk_lid name =
-                                  FStar_Ident.lid_of_path
-                                    (FStar_Ident.path_of_text
-                                       (Prims.strcat
-                                          (FStar_Ident.text_of_lid
-                                             ed.FStar_Syntax_Syntax.mname)
-                                          (Prims.strcat "_" name)))
-                                    FStar_Range.dummyRange in
-                                let elaborate_and_star dmff_env1 item =
-                                  let uu____1552 = item in
-                                  match uu____1552 with
-                                  | (u_item,item1) ->
-                                      let uu____1564 = open_and_check item1 in
-                                      (match uu____1564 with
-                                       | (item2,item_comp) ->
-                                           ((let uu____1574 =
-                                               let uu____1575 =
-                                                 FStar_Syntax_Util.is_total_lcomp
-                                                   item_comp in
-                                               Prims.op_Negation uu____1575 in
-                                             if uu____1574
-                                             then
-                                               let uu____1576 =
-                                                 let uu____1577 =
-                                                   let uu____1578 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       item2 in
-                                                   let uu____1579 =
-                                                     FStar_Syntax_Print.lcomp_to_string
-                                                       item_comp in
-                                                   FStar_Util.format2
-                                                     "Computation for [%s] is not total : %s !"
-                                                     uu____1578 uu____1579 in
-                                                 FStar_Errors.Err uu____1577 in
-                                               Prims.raise uu____1576
-                                             else ());
-                                            (let uu____1581 =
-                                               FStar_TypeChecker_DMFF.star_expr
-                                                 dmff_env1 item2 in
-                                             match uu____1581 with
-                                             | (item_t,item_wp,item_elab) ->
-                                                 let item_wp1 =
-                                                   recheck_debug "*" env1
-                                                     item_wp in
-                                                 let item_elab1 =
-                                                   recheck_debug "_" env1
-                                                     item_elab in
-                                                 (dmff_env1, item_t,
-                                                   item_wp1, item_elab1)))) in
-                                let uu____1594 =
-                                  elaborate_and_star dmff_env
-                                    ed.FStar_Syntax_Syntax.bind_repr in
-                                match uu____1594 with
-                                | (dmff_env1,uu____1605,bind_wp,bind_elab) ->
-                                    let uu____1608 =
-                                      elaborate_and_star dmff_env1
-                                        ed.FStar_Syntax_Syntax.return_repr in
-                                    (match uu____1608 with
-                                     | (dmff_env2,uu____1619,return_wp,return_elab)
-                                         ->
-                                         let lift_from_pure_wp =
-                                           let uu____1623 =
-                                             let uu____1624 =
-                                               FStar_Syntax_Subst.compress
-                                                 return_wp in
-                                             uu____1624.FStar_Syntax_Syntax.n in
-                                           match uu____1623 with
-                                           | FStar_Syntax_Syntax.Tm_abs
-                                               (b1::b2::bs,body,what) ->
-                                               let uu____1662 =
-                                                 let uu____1670 =
-                                                   let uu____1673 =
-                                                     FStar_Syntax_Util.abs bs
-                                                       body None in
-                                                   FStar_Syntax_Subst.open_term
-                                                     [b1; b2] uu____1673 in
-                                                 match uu____1670 with
-                                                 | (b11::b21::[],body1) ->
-                                                     (b11, b21, body1)
-                                                 | uu____1712 ->
-                                                     failwith
-                                                       "Impossible : open_term not preserving binders arity" in
-                                               (match uu____1662 with
-                                                | (b11,b21,body1) ->
-                                                    let env0 =
-                                                      let uu____1734 =
-                                                        FStar_TypeChecker_DMFF.get_env
-                                                          dmff_env2 in
-                                                      FStar_TypeChecker_Env.push_binders
-                                                        uu____1734 [b11; b21] in
-                                                    let wp_b1 =
-                                                      let raw_wp_b1 =
-                                                        let uu____1745 =
-                                                          let uu____1746 =
-                                                            let uu____1756 =
-                                                              let uu____1760
-                                                                =
-                                                                let uu____1763
-                                                                  =
-                                                                  FStar_Syntax_Syntax.bv_to_name
-                                                                    (
-                                                                    Prims.fst
-                                                                    b11) in
-                                                                let uu____1764
-                                                                  =
-                                                                  FStar_Syntax_Syntax.as_implicit
-                                                                    false in
-                                                                (uu____1763,
-                                                                  uu____1764) in
-                                                              [uu____1760] in
-                                                            (wp_type1,
-                                                              uu____1756) in
-                                                          FStar_Syntax_Syntax.Tm_app
-                                                            uu____1746 in
-                                                        mk1 uu____1745 in
-                                                      FStar_TypeChecker_Normalize.normalize
-                                                        [FStar_TypeChecker_Normalize.Beta]
-                                                        env0 raw_wp_b1 in
-                                                    let uu____1772 =
-                                                      let uu____1782 =
-                                                        let uu____1783 =
-                                                          FStar_Syntax_Util.unascribe
-                                                            wp_b1 in
-                                                        FStar_TypeChecker_Normalize.eta_expand_with_type
-                                                          body1 uu____1783 in
-                                                      FStar_All.pipe_left
-                                                        FStar_Syntax_Util.abs_formals
-                                                        uu____1782 in
-                                                    (match uu____1772 with
-                                                     | (bs1,body2,what') ->
-                                                         let fail uu____1811
-                                                           =
-                                                           let error_msg =
-                                                             let uu____1813 =
-                                                               FStar_Syntax_Print.term_to_string
-                                                                 body2 in
-                                                             let uu____1814 =
-                                                               match what'
-                                                               with
-                                                               | None  ->
-                                                                   "None"
-                                                               | Some
-                                                                   (FStar_Util.Inl
-                                                                   lc) ->
-                                                                   FStar_Syntax_Print.lcomp_to_string
-                                                                    lc
-                                                               | Some
-                                                                   (FStar_Util.Inr
-                                                                   (lid,uu____1830))
-                                                                   ->
-                                                                   FStar_Ident.text_of_lid
-                                                                    lid in
-                                                             FStar_Util.format2
-                                                               "The body of return_wp (%s) should be of type Type0 but is of type %s"
-                                                               uu____1813
-                                                               uu____1814 in
-                                                           failwith error_msg in
-                                                         ((match what' with
-                                                           | None  -> fail ()
-                                                           | Some
-                                                               (FStar_Util.Inl
-                                                               lc) ->
-                                                               let uu____1856
-                                                                 =
-                                                                 FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                                                   lc in
-                                                               if uu____1856
-                                                               then
-                                                                 let g_opt =
-                                                                   FStar_TypeChecker_Rel.try_teq
-                                                                    true env1
-                                                                    lc.FStar_Syntax_Syntax.res_typ
-                                                                    FStar_Syntax_Util.ktype0 in
-                                                                 (match g_opt
-                                                                  with
-                                                                  | Some g'
-                                                                    ->
-                                                                    FStar_TypeChecker_Rel.force_trivial_guard
-                                                                    env1 g'
-                                                                  | None  ->
-                                                                    fail ())
-                                                               else fail ()
-                                                           | Some
-                                                               (FStar_Util.Inr
-                                                               (lid,uu____1862))
-                                                               ->
-                                                               if
-                                                                 Prims.op_Negation
-                                                                   (FStar_Syntax_Util.is_pure_effect
-                                                                    lid)
-                                                               then fail ()
-                                                               else ());
-                                                          (let wp =
-                                                             let t2 =
-                                                               (Prims.fst b21).FStar_Syntax_Syntax.sort in
-                                                             let pure_wp_type
-                                                               =
-                                                               FStar_TypeChecker_DMFF.double_star
-                                                                 t2 in
-                                                             FStar_Syntax_Syntax.gen_bv
-                                                               "wp" None
-                                                               pure_wp_type in
-                                                           let body3 =
-                                                             let uu____1882 =
-                                                               let uu____1883
-                                                                 =
-                                                                 FStar_Syntax_Syntax.bv_to_name
-                                                                   wp in
-                                                               let uu____1884
-                                                                 =
-                                                                 let uu____1885
-                                                                   =
-                                                                   let uu____1889
-                                                                    =
-                                                                    FStar_Syntax_Util.abs
-                                                                    [b21]
-                                                                    body2
-                                                                    what' in
-                                                                   (uu____1889,
-                                                                    None) in
-                                                                 [uu____1885] in
-                                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                                 uu____1883
-                                                                 uu____1884 in
-                                                             uu____1882 None
-                                                               FStar_Range.dummyRange in
-                                                           let uu____1905 =
-                                                             let uu____1909 =
-                                                               let uu____1913
-                                                                 =
-                                                                 FStar_Syntax_Syntax.mk_binder
-                                                                   wp in
-                                                               [uu____1913] in
-                                                             b11 ::
-                                                               uu____1909 in
-                                                           let uu____1916 =
-                                                             FStar_Syntax_Util.abs
-                                                               bs1 body3 what in
-                                                           FStar_Syntax_Util.abs
-                                                             uu____1905
-                                                             uu____1916
-                                                             (Some
-                                                                (FStar_Util.Inr
-                                                                   (FStar_Syntax_Const.effect_GTot_lid,
-                                                                    [])))))))
-                                           | uu____1926 ->
-                                               failwith
-                                                 "unexpected shape for return" in
-                                         let return_wp1 =
-                                           let uu____1928 =
-                                             let uu____1929 =
-                                               FStar_Syntax_Subst.compress
-                                                 return_wp in
-                                             uu____1929.FStar_Syntax_Syntax.n in
-                                           match uu____1928 with
-                                           | FStar_Syntax_Syntax.Tm_abs
-                                               (b1::b2::bs,body,what) ->
-                                               let uu____1967 =
-                                                 FStar_Syntax_Util.abs bs
-                                                   body what in
-                                               FStar_Syntax_Util.abs 
-                                                 [b1; b2] uu____1967
-                                                 (Some
-                                                    (FStar_Util.Inr
-                                                       (FStar_Syntax_Const.effect_GTot_lid,
-                                                         [])))
-                                           | uu____1983 ->
-                                               failwith
-                                                 "unexpected shape for return" in
-                                         let bind_wp1 =
-                                           let uu____1985 =
-                                             let uu____1986 =
-                                               FStar_Syntax_Subst.compress
-                                                 bind_wp in
-                                             uu____1986.FStar_Syntax_Syntax.n in
-                                           match uu____1985 with
-                                           | FStar_Syntax_Syntax.Tm_abs
-                                               (binders,body,what) ->
-                                               let r =
-                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                   FStar_Syntax_Const.range_lid
-                                                   (FStar_Syntax_Syntax.Delta_defined_at_level
-                                                      (Prims.parse_int "1"))
-                                                   None in
-                                               let uu____2015 =
-                                                 let uu____2019 =
-                                                   let uu____2021 =
-                                                     let uu____2022 =
-                                                       mk1
-                                                         (FStar_Syntax_Syntax.Tm_fvar
-                                                            r) in
-                                                     FStar_Syntax_Syntax.null_binder
-                                                       uu____2022 in
-                                                   [uu____2021] in
-                                                 FStar_List.append uu____2019
-                                                   binders in
-                                               FStar_Syntax_Util.abs
-                                                 uu____2015 body what
-                                           | uu____2023 ->
-                                               failwith
-                                                 "unexpected shape for bind" in
-                                         let apply_close t =
-                                           if
-                                             (FStar_List.length
-                                                effect_binders1)
-                                               = (Prims.parse_int "0")
-                                           then t
-                                           else
-                                             (let uu____2041 =
-                                                let uu____2042 =
-                                                  let uu____2043 =
-                                                    let uu____2053 =
-                                                      let uu____2054 =
-                                                        FStar_Syntax_Util.args_of_binders
-                                                          effect_binders1 in
-                                                      Prims.snd uu____2054 in
-                                                    (t, uu____2053) in
-                                                  FStar_Syntax_Syntax.Tm_app
-                                                    uu____2043 in
-                                                mk1 uu____2042 in
-                                              FStar_Syntax_Subst.close
-                                                effect_binders1 uu____2041) in
-                                         let register name item =
-                                           let uu____2066 =
-                                             let uu____2069 = mk_lid name in
-                                             let uu____2070 =
-                                               FStar_Syntax_Util.abs
-                                                 effect_binders1 item None in
-                                             FStar_TypeChecker_Util.mk_toplevel_definition
-                                               env1 uu____2069 uu____2070 in
-                                           match uu____2066 with
-                                           | (sigelt,fv) ->
-                                               ((let uu____2079 =
-                                                   let uu____2081 =
-                                                     FStar_ST.read sigelts in
-                                                   sigelt :: uu____2081 in
-                                                 FStar_ST.write sigelts
-                                                   uu____2079);
-                                                fv) in
-                                         let lift_from_pure_wp1 =
-                                           register "lift_from_pure"
-                                             lift_from_pure_wp in
-                                         let return_wp2 =
-                                           register "return_wp" return_wp1 in
-                                         ((let uu____2092 =
-                                             let uu____2094 =
-                                               FStar_ST.read sigelts in
-                                             (FStar_Syntax_Syntax.Sig_pragma
-                                                ((FStar_Syntax_Syntax.SetOptions
-                                                    "--admit_smt_queries true"),
-                                                  FStar_Range.dummyRange))
-                                               :: uu____2094 in
-                                           FStar_ST.write sigelts uu____2092);
-                                          (let return_elab1 =
-                                             register "return_elab"
-                                               return_elab in
-                                           (let uu____2104 =
-                                              let uu____2106 =
-                                                FStar_ST.read sigelts in
-                                              (FStar_Syntax_Syntax.Sig_pragma
-                                                 ((FStar_Syntax_Syntax.SetOptions
-                                                     "--admit_smt_queries false"),
-                                                   FStar_Range.dummyRange))
-                                                :: uu____2106 in
-                                            FStar_ST.write sigelts uu____2104);
-                                           (let bind_wp2 =
-                                              register "bind_wp" bind_wp1 in
-                                            (let uu____2116 =
-                                               let uu____2118 =
-                                                 FStar_ST.read sigelts in
-                                               (FStar_Syntax_Syntax.Sig_pragma
-                                                  ((FStar_Syntax_Syntax.SetOptions
-                                                      "--admit_smt_queries true"),
-                                                    FStar_Range.dummyRange))
-                                                 :: uu____2118 in
-                                             FStar_ST.write sigelts
-                                               uu____2116);
-                                            (let bind_elab1 =
-                                               register "bind_elab" bind_elab in
-                                             (let uu____2128 =
-                                                let uu____2130 =
-                                                  FStar_ST.read sigelts in
-                                                (FStar_Syntax_Syntax.Sig_pragma
-                                                   ((FStar_Syntax_Syntax.SetOptions
-                                                       "--admit_smt_queries false"),
-                                                     FStar_Range.dummyRange))
-                                                  :: uu____2130 in
-                                              FStar_ST.write sigelts
-                                                uu____2128);
-                                             (let uu____2138 =
-                                                FStar_List.fold_left
-                                                  (fun uu____2145  ->
-                                                     fun action  ->
-                                                       match uu____2145 with
-                                                       | (dmff_env3,actions)
-                                                           ->
-                                                           let uu____2157 =
-                                                             elaborate_and_star
-                                                               dmff_env3
-                                                               ((action.FStar_Syntax_Syntax.action_univs),
-                                                                 (action.FStar_Syntax_Syntax.action_defn)) in
-                                                           (match uu____2157
-                                                            with
-                                                            | (dmff_env4,action_t,action_wp,action_elab)
-                                                                ->
-                                                                let name =
-                                                                  ((action.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText in
-                                                                let action_typ_with_wp
-                                                                  =
-                                                                  FStar_TypeChecker_DMFF.trans_F
-                                                                    dmff_env4
-                                                                    action_t
-                                                                    action_wp in
-                                                                let action_elab1
-                                                                  =
-                                                                  register
-                                                                    (
-                                                                    Prims.strcat
-                                                                    name
-                                                                    "_elab")
-                                                                    action_elab in
-                                                                let action_typ_with_wp1
-                                                                  =
-                                                                  register
-                                                                    (
-                                                                    Prims.strcat
-                                                                    name
-                                                                    "_complete_type")
-                                                                    action_typ_with_wp in
-                                                                let uu____2173
-                                                                  =
-                                                                  let uu____2175
-                                                                    =
-                                                                    let uu___98_2176
-                                                                    = action in
-                                                                    let uu____2177
-                                                                    =
-                                                                    apply_close
-                                                                    action_elab1 in
-                                                                    let uu____2178
-                                                                    =
-                                                                    apply_close
-                                                                    action_typ_with_wp1 in
-                                                                    {
-                                                                    FStar_Syntax_Syntax.action_name
-                                                                    =
-                                                                    (uu___98_2176.FStar_Syntax_Syntax.action_name);
-                                                                    FStar_Syntax_Syntax.action_unqualified_name
-                                                                    =
-                                                                    (uu___98_2176.FStar_Syntax_Syntax.action_unqualified_name);
-                                                                    FStar_Syntax_Syntax.action_univs
-                                                                    =
-                                                                    (uu___98_2176.FStar_Syntax_Syntax.action_univs);
-                                                                    FStar_Syntax_Syntax.action_defn
-                                                                    =
-                                                                    uu____2177;
-                                                                    FStar_Syntax_Syntax.action_typ
-                                                                    =
-                                                                    uu____2178
-                                                                    } in
-                                                                  uu____2175
-                                                                    ::
-                                                                    actions in
-                                                                (dmff_env4,
-                                                                  uu____2173)))
-                                                  (dmff_env2, [])
-                                                  ed.FStar_Syntax_Syntax.actions in
-                                              match uu____2138 with
-                                              | (dmff_env3,actions) ->
-                                                  let actions1 =
-                                                    FStar_List.rev actions in
-                                                  let repr1 =
-                                                    let wp =
-                                                      FStar_Syntax_Syntax.gen_bv
-                                                        "wp_a" None wp_a in
-                                                    let binders =
-                                                      let uu____2196 =
-                                                        FStar_Syntax_Syntax.mk_binder
-                                                          a1 in
-                                                      let uu____2197 =
-                                                        let uu____2199 =
-                                                          FStar_Syntax_Syntax.mk_binder
-                                                            wp in
-                                                        [uu____2199] in
-                                                      uu____2196 ::
-                                                        uu____2197 in
-                                                    let uu____2200 =
-                                                      let uu____2201 =
-                                                        let uu____2202 =
-                                                          let uu____2203 =
-                                                            let uu____2213 =
-                                                              let uu____2217
-                                                                =
-                                                                let uu____2220
-                                                                  =
-                                                                  FStar_Syntax_Syntax.bv_to_name
-                                                                    a1 in
-                                                                let uu____2221
-                                                                  =
-                                                                  FStar_Syntax_Syntax.as_implicit
-                                                                    false in
-                                                                (uu____2220,
-                                                                  uu____2221) in
-                                                              [uu____2217] in
-                                                            (repr,
-                                                              uu____2213) in
-                                                          FStar_Syntax_Syntax.Tm_app
-                                                            uu____2203 in
-                                                        mk1 uu____2202 in
-                                                      let uu____2229 =
-                                                        FStar_Syntax_Syntax.bv_to_name
-                                                          wp in
-                                                      FStar_TypeChecker_DMFF.trans_F
-                                                        dmff_env3 uu____2201
-                                                        uu____2229 in
-                                                    FStar_Syntax_Util.abs
-                                                      binders uu____2200 None in
-                                                  let repr2 =
-                                                    recheck_debug "FC" env1
-                                                      repr1 in
-                                                  let repr3 =
-                                                    register "repr" repr2 in
-                                                  let uu____2237 =
-                                                    let uu____2242 =
-                                                      let uu____2243 =
-                                                        let uu____2246 =
-                                                          FStar_Syntax_Subst.compress
-                                                            wp_type1 in
-                                                        FStar_All.pipe_left
-                                                          FStar_Syntax_Util.unascribe
-                                                          uu____2246 in
-                                                      uu____2243.FStar_Syntax_Syntax.n in
-                                                    match uu____2242 with
-                                                    | FStar_Syntax_Syntax.Tm_abs
-                                                        (type_param::effect_param,arrow1,uu____2254)
-                                                        ->
-                                                        let uu____2281 =
-                                                          let uu____2290 =
-                                                            FStar_Syntax_Subst.open_term
-                                                              (type_param ::
-                                                              effect_param)
-                                                              arrow1 in
-                                                          match uu____2290
-                                                          with
-                                                          | (b::bs,body) ->
-                                                              (b, bs, body)
-                                                          | uu____2321 ->
-                                                              failwith
-                                                                "Impossible : open_term nt preserving binders arity" in
-                                                        (match uu____2281
-                                                         with
-                                                         | (type_param1,effect_param1,arrow2)
-                                                             ->
-                                                             let uu____2349 =
-                                                               let uu____2350
-                                                                 =
-                                                                 let uu____2353
-                                                                   =
-                                                                   FStar_Syntax_Subst.compress
-                                                                    arrow2 in
-                                                                 FStar_All.pipe_left
-                                                                   FStar_Syntax_Util.unascribe
-                                                                   uu____2353 in
-                                                               uu____2350.FStar_Syntax_Syntax.n in
-                                                             (match uu____2349
-                                                              with
-                                                              | FStar_Syntax_Syntax.Tm_arrow
-                                                                  (wp_binders,c)
-                                                                  ->
-                                                                  let uu____2370
-                                                                    =
-                                                                    FStar_Syntax_Subst.open_comp
-                                                                    wp_binders
-                                                                    c in
-                                                                  (match uu____2370
-                                                                   with
-                                                                   | 
-                                                                   (wp_binders1,c1)
-                                                                    ->
-                                                                    let uu____2379
-                                                                    =
-                                                                    FStar_List.partition
-                                                                    (fun
-                                                                    uu____2390
-                                                                     ->
-                                                                    match uu____2390
-                                                                    with
-                                                                    | 
-                                                                    (bv,uu____2394)
-                                                                    ->
-                                                                    let uu____2395
-                                                                    =
-                                                                    let uu____2396
-                                                                    =
-                                                                    FStar_Syntax_Free.names
-                                                                    bv.FStar_Syntax_Syntax.sort in
-                                                                    FStar_All.pipe_right
-                                                                    uu____2396
-                                                                    (FStar_Util.set_mem
-                                                                    (Prims.fst
-                                                                    type_param1)) in
-                                                                    FStar_All.pipe_right
-                                                                    uu____2395
-                                                                    Prims.op_Negation)
-                                                                    wp_binders1 in
-                                                                    (match uu____2379
-                                                                    with
-                                                                    | 
-                                                                    (pre_args,post_args)
-                                                                    ->
-                                                                    let post
-                                                                    =
-                                                                    match post_args
-                                                                    with
-                                                                    | 
-                                                                    post::[]
-                                                                    -> post
-                                                                    | 
-                                                                    uu____2429
-                                                                    ->
-                                                                    let uu____2433
-                                                                    =
-                                                                    let uu____2434
-                                                                    =
-                                                                    FStar_Syntax_Print.term_to_string
-                                                                    arrow2 in
-                                                                    FStar_Util.format1
-                                                                    "Impossible: multiple post candidates %s"
-                                                                    uu____2434 in
-                                                                    failwith
-                                                                    uu____2433 in
-                                                                    let uu____2437
-                                                                    =
-                                                                    FStar_Syntax_Util.arrow
-                                                                    pre_args
-                                                                    c1 in
-                                                                    let uu____2440
-                                                                    =
-                                                                    FStar_Syntax_Util.abs
-                                                                    (type_param1
-                                                                    ::
-                                                                    effect_param1)
-                                                                    (Prims.fst
-                                                                    post).FStar_Syntax_Syntax.sort
-                                                                    None in
-                                                                    (uu____2437,
-                                                                    uu____2440)))
-                                                              | uu____2450 ->
-                                                                  let uu____2451
-                                                                    =
-                                                                    let uu____2452
-                                                                    =
-                                                                    FStar_Syntax_Print.term_to_string
-                                                                    arrow2 in
-                                                                    FStar_Util.format1
-                                                                    "Impossible: pre/post arrow %s"
-                                                                    uu____2452 in
-                                                                  failwith
-                                                                    uu____2451))
-                                                    | uu____2457 ->
-                                                        let uu____2458 =
-                                                          let uu____2459 =
-                                                            FStar_Syntax_Print.term_to_string
-                                                              wp_type1 in
-                                                          FStar_Util.format1
-                                                            "Impossible: pre/post abs %s"
-                                                            uu____2459 in
-                                                        failwith uu____2458 in
-                                                  (match uu____2237 with
-                                                   | (pre,post) ->
-                                                       ((let uu____2476 =
-                                                           register "pre" pre in
-                                                         ());
-                                                        (let uu____2478 =
-                                                           register "post"
-                                                             post in
-                                                         ());
-                                                        (let uu____2480 =
-                                                           register "wp"
-                                                             wp_type1 in
-                                                         ());
-                                                        (let ed1 =
-                                                           let uu___99_2482 =
-                                                             ed in
-                                                           let uu____2483 =
-                                                             FStar_Syntax_Subst.close_binders
-                                                               effect_binders1 in
-                                                           let uu____2484 =
-                                                             FStar_Syntax_Subst.close
-                                                               effect_binders1
-                                                               effect_signature1 in
-                                                           let uu____2485 =
-                                                             let uu____2486 =
-                                                               apply_close
-                                                                 return_wp2 in
-                                                             ([], uu____2486) in
-                                                           let uu____2492 =
-                                                             let uu____2493 =
-                                                               apply_close
-                                                                 bind_wp2 in
-                                                             ([], uu____2493) in
-                                                           let uu____2499 =
-                                                             apply_close
-                                                               repr3 in
-                                                           let uu____2500 =
-                                                             let uu____2501 =
-                                                               apply_close
-                                                                 return_elab1 in
-                                                             ([], uu____2501) in
-                                                           let uu____2507 =
-                                                             let uu____2508 =
-                                                               apply_close
-                                                                 bind_elab1 in
-                                                             ([], uu____2508) in
-                                                           {
-                                                             FStar_Syntax_Syntax.qualifiers
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.qualifiers);
-                                                             FStar_Syntax_Syntax.cattributes
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.cattributes);
-                                                             FStar_Syntax_Syntax.mname
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.mname);
-                                                             FStar_Syntax_Syntax.univs
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.univs);
-                                                             FStar_Syntax_Syntax.binders
-                                                               = uu____2483;
-                                                             FStar_Syntax_Syntax.signature
-                                                               = uu____2484;
-                                                             FStar_Syntax_Syntax.ret_wp
-                                                               = uu____2485;
-                                                             FStar_Syntax_Syntax.bind_wp
-                                                               = uu____2492;
-                                                             FStar_Syntax_Syntax.if_then_else
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.if_then_else);
-                                                             FStar_Syntax_Syntax.ite_wp
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.ite_wp);
-                                                             FStar_Syntax_Syntax.stronger
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.stronger);
-                                                             FStar_Syntax_Syntax.close_wp
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.close_wp);
-                                                             FStar_Syntax_Syntax.assert_p
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.assert_p);
-                                                             FStar_Syntax_Syntax.assume_p
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.assume_p);
-                                                             FStar_Syntax_Syntax.null_wp
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.null_wp);
-                                                             FStar_Syntax_Syntax.trivial
-                                                               =
-                                                               (uu___99_2482.FStar_Syntax_Syntax.trivial);
-                                                             FStar_Syntax_Syntax.repr
-                                                               = uu____2499;
-                                                             FStar_Syntax_Syntax.return_repr
-                                                               = uu____2500;
-                                                             FStar_Syntax_Syntax.bind_repr
-                                                               = uu____2507;
-                                                             FStar_Syntax_Syntax.actions
-                                                               = actions1
-                                                           } in
-                                                         let uu____2514 =
-                                                           FStar_TypeChecker_DMFF.gen_wps_for_free
-                                                             env1
-                                                             effect_binders1
-                                                             a1 wp_a ed1 in
-                                                         match uu____2514
-                                                         with
-                                                         | (sigelts',ed2) ->
-                                                             ((let uu____2525
-                                                                 =
-                                                                 FStar_TypeChecker_Env.debug
-                                                                   env1
-                                                                   (FStar_Options.Other
-                                                                    "ED") in
-                                                               if uu____2525
-                                                               then
-                                                                 let uu____2526
-                                                                   =
-                                                                   FStar_Syntax_Print.eff_decl_to_string
-                                                                    true ed2 in
-                                                                 FStar_Util.print_string
-                                                                   uu____2526
-                                                               else ());
-                                                              (let lift_from_pure_opt
-                                                                 =
-                                                                 if
-                                                                   (FStar_List.length
-                                                                    effect_binders1)
-                                                                    =
-                                                                    (Prims.parse_int
-                                                                    "0")
-                                                                 then
-                                                                   let lift_from_pure
-                                                                    =
-                                                                    let uu____2536
-                                                                    =
-                                                                    let uu____2538
-                                                                    =
-                                                                    let uu____2544
-                                                                    =
-                                                                    apply_close
-                                                                    lift_from_pure_wp1 in
-                                                                    ([],
-                                                                    uu____2544) in
-                                                                    Some
-                                                                    uu____2538 in
-                                                                    {
-                                                                    FStar_Syntax_Syntax.source
-                                                                    =
-                                                                    FStar_Syntax_Const.effect_PURE_lid;
-                                                                    FStar_Syntax_Syntax.target
-                                                                    =
-                                                                    (ed2.FStar_Syntax_Syntax.mname);
-                                                                    FStar_Syntax_Syntax.lift_wp
-                                                                    =
-                                                                    uu____2536;
-                                                                    FStar_Syntax_Syntax.lift
-                                                                    = None
-                                                                    } in
-                                                                   Some
-                                                                    (FStar_Syntax_Syntax.Sig_sub_effect
-                                                                    (lift_from_pure,
-                                                                    FStar_Range.dummyRange))
-                                                                 else None in
-                                                               let uu____2556
-                                                                 =
-                                                                 let uu____2558
-                                                                   =
-                                                                   let uu____2560
-                                                                    =
-                                                                    FStar_ST.read
-                                                                    sigelts in
-                                                                   FStar_List.rev
-                                                                    uu____2560 in
-                                                                 FStar_List.append
-                                                                   uu____2558
-                                                                   sigelts' in
-                                                               (uu____2556,
-                                                                 ed2,
-                                                                 lift_from_pure_opt))))))))))))))))))
-and tc_lex_t:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt
-  =
-  fun env  ->
-    fun ses  ->
-      fun quals  ->
-        fun lids  ->
-          match ses with
-          | (FStar_Syntax_Syntax.Sig_inductive_typ
-              (lex_t1,[],[],t,uu____2583,uu____2584,[],r))::(FStar_Syntax_Syntax.Sig_datacon
-              (lex_top1,[],_t_top,_lex_t_top,_0_28,[],uu____2589,r1))::(FStar_Syntax_Syntax.Sig_datacon
-              (lex_cons,[],_t_cons,_lex_t_cons,_0_29,[],uu____2594,r2))::[]
-              when
-              ((_0_28 = (Prims.parse_int "0")) &&
-                 (_0_29 = (Prims.parse_int "0")))
-                &&
-                (((FStar_Ident.lid_equals lex_t1 FStar_Syntax_Const.lex_t_lid)
-                    &&
-                    (FStar_Ident.lid_equals lex_top1
-                       FStar_Syntax_Const.lextop_lid))
-                   &&
-                   (FStar_Ident.lid_equals lex_cons
-                      FStar_Syntax_Const.lexcons_lid))
-              ->
-              let u = FStar_Syntax_Syntax.new_univ_name (Some r) in
-              let t1 =
-                FStar_Syntax_Syntax.mk
-                  (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_name u))
-                  None r in
-              let t2 = FStar_Syntax_Subst.close_univ_vars [u] t1 in
-              let tc =
-                FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lex_t1, [u], [], t2, [],
-                    [FStar_Syntax_Const.lextop_lid;
-                    FStar_Syntax_Const.lexcons_lid], [], r) in
-              let utop = FStar_Syntax_Syntax.new_univ_name (Some r1) in
-              let lex_top_t =
-                let uu____2638 =
-                  let uu____2641 =
-                    let uu____2642 =
-                      let uu____2647 =
-                        FStar_Syntax_Syntax.fvar
-                          (FStar_Ident.set_lid_range
-                             FStar_Syntax_Const.lex_t_lid r1)
-                          FStar_Syntax_Syntax.Delta_constant None in
-                      (uu____2647, [FStar_Syntax_Syntax.U_name utop]) in
-                    FStar_Syntax_Syntax.Tm_uinst uu____2642 in
-                  FStar_Syntax_Syntax.mk uu____2641 in
-                uu____2638 None r1 in
-              let lex_top_t1 =
-                FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t in
-              let dc_lextop =
-                FStar_Syntax_Syntax.Sig_datacon
-                  (lex_top1, [utop], lex_top_t1,
-                    FStar_Syntax_Const.lex_t_lid, (Prims.parse_int "0"), [],
-                    [], r1) in
-              let ucons1 = FStar_Syntax_Syntax.new_univ_name (Some r2) in
-              let ucons2 = FStar_Syntax_Syntax.new_univ_name (Some r2) in
-              let lex_cons_t =
-                let a =
-                  let uu____2668 =
-                    FStar_Syntax_Syntax.mk
-                      (FStar_Syntax_Syntax.Tm_type
-                         (FStar_Syntax_Syntax.U_name ucons1)) None r2 in
-                  FStar_Syntax_Syntax.new_bv (Some r2) uu____2668 in
-                let hd1 =
-                  let uu____2674 = FStar_Syntax_Syntax.bv_to_name a in
-                  FStar_Syntax_Syntax.new_bv (Some r2) uu____2674 in
-                let tl1 =
-                  let uu____2676 =
-                    let uu____2677 =
-                      let uu____2680 =
-                        let uu____2681 =
-                          let uu____2686 =
-                            FStar_Syntax_Syntax.fvar
-                              (FStar_Ident.set_lid_range
-                                 FStar_Syntax_Const.lex_t_lid r2)
-                              FStar_Syntax_Syntax.Delta_constant None in
-                          (uu____2686, [FStar_Syntax_Syntax.U_name ucons2]) in
-                        FStar_Syntax_Syntax.Tm_uinst uu____2681 in
-                      FStar_Syntax_Syntax.mk uu____2680 in
-                    uu____2677 None r2 in
-                  FStar_Syntax_Syntax.new_bv (Some r2) uu____2676 in
-                let res =
-                  let uu____2699 =
-                    let uu____2702 =
-                      let uu____2703 =
-                        let uu____2708 =
-                          FStar_Syntax_Syntax.fvar
-                            (FStar_Ident.set_lid_range
-                               FStar_Syntax_Const.lex_t_lid r2)
-                            FStar_Syntax_Syntax.Delta_constant None in
-                        (uu____2708,
-                          [FStar_Syntax_Syntax.U_max
-                             [FStar_Syntax_Syntax.U_name ucons1;
-                             FStar_Syntax_Syntax.U_name ucons2]]) in
-                      FStar_Syntax_Syntax.Tm_uinst uu____2703 in
-                    FStar_Syntax_Syntax.mk uu____2702 in
-                  uu____2699 None r2 in
-                let uu____2718 = FStar_Syntax_Syntax.mk_Total res in
-                FStar_Syntax_Util.arrow
-                  [(a, (Some FStar_Syntax_Syntax.imp_tag));
-                  (hd1, None);
-                  (tl1, None)] uu____2718 in
-              let lex_cons_t1 =
-                FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
-                  lex_cons_t in
-              let dc_lexcons =
-                FStar_Syntax_Syntax.Sig_datacon
-                  (lex_cons, [ucons1; ucons2], lex_cons_t1,
-                    FStar_Syntax_Const.lex_t_lid, (Prims.parse_int "0"), [],
-                    [], r2) in
-              let uu____2741 =
-                let uu____2749 = FStar_TypeChecker_Env.get_range env in
-                ([tc; dc_lextop; dc_lexcons], [], lids, uu____2749) in
-              FStar_Syntax_Syntax.Sig_bundle uu____2741
-          | uu____2753 ->
-              let uu____2755 =
-                let uu____2756 =
-                  FStar_Syntax_Print.sigelt_to_string
-                    (FStar_Syntax_Syntax.Sig_bundle
-                       (ses, [], lids, FStar_Range.dummyRange)) in
-                FStar_Util.format1 "Unexpected lex_t: %s\n" uu____2756 in
-              failwith uu____2755
-and tc_assume:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.formula ->
-        FStar_Syntax_Syntax.qualifier Prims.list ->
-          FStar_Range.range -> FStar_Syntax_Syntax.sigelt
-  =
-  fun env  ->
-    fun lid  ->
-      fun phi  ->
-        fun quals  ->
-          fun r  ->
-            let env1 = FStar_TypeChecker_Env.set_range env r in
-            let uu____2767 = FStar_Syntax_Util.type_u () in
-            match uu____2767 with
-            | (k,uu____2771) ->
-                let phi1 =
-                  let uu____2773 = tc_check_trivial_guard env1 phi k in
-                  FStar_All.pipe_right uu____2773
-                    (FStar_TypeChecker_Normalize.normalize
-                       [FStar_TypeChecker_Normalize.Beta;
-                       FStar_TypeChecker_Normalize.Eager_unfolding] env1) in
-                (FStar_TypeChecker_Util.check_uvars r phi1;
-                 FStar_Syntax_Syntax.Sig_assume (lid, phi1, quals, r))
-and tc_inductive:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Ident.lident Prims.list ->
-          (FStar_Syntax_Syntax.sigelt Prims.list* FStar_Syntax_Syntax.sigelt
-            Prims.list)
-  =
-  fun env  ->
-    fun ses  ->
-      fun quals  ->
-        fun lids  ->
-          let env0 = env in
-          let uu____2784 =
-            FStar_TypeChecker_TcInductive.check_inductive_well_typedness env
-              ses quals lids in
-          match uu____2784 with
-          | (sig_bndle,tcs,datas) ->
-              let data_ops_ses =
-                let uu____2803 =
-                  FStar_List.map
-                    (FStar_TypeChecker_Util.mk_data_operations quals env tcs)
-                    datas in
-                FStar_All.pipe_right uu____2803 FStar_List.flatten in
-              ((let uu____2811 =
-                  (FStar_Options.no_positivity ()) || (FStar_Options.lax ()) in
-                if uu____2811
-                then ()
-                else
-                  (let env1 =
-                     FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
-                   FStar_List.iter
-                     (fun ty  ->
-                        let b =
-                          FStar_TypeChecker_TcInductive.check_positivity ty
-                            env1 in
-                        if Prims.op_Negation b
-                        then
-                          let uu____2817 =
-                            match ty with
-                            | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (lid,uu____2823,uu____2824,uu____2825,uu____2826,uu____2827,uu____2828,r)
-                                -> (lid, r)
-                            | uu____2836 -> failwith "Impossible!" in
-                          match uu____2817 with
-                          | (lid,r) ->
-                              FStar_Errors.report r
-                                (Prims.strcat "Inductive type "
-                                   (Prims.strcat lid.FStar_Ident.str
-                                      " does not satisfy the positivity condition"))
-                        else ()) tcs));
-               (let skip_prims_type uu____2845 =
-                  let lid =
-                    let ty = FStar_List.hd tcs in
-                    match ty with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid,uu____2849,uu____2850,uu____2851,uu____2852,uu____2853,uu____2854,uu____2855)
-                        -> lid
-                    | uu____2862 -> failwith "Impossible" in
-                  let types_to_skip =
-                    ["c_False";
-                    "c_True";
-                    "equals";
-                    "h_equals";
-                    "c_and";
-                    "c_or"] in
-                  FStar_List.existsb
-                    (fun s  -> s = (lid.FStar_Ident.ident).FStar_Ident.idText)
-                    types_to_skip in
-                let is_noeq =
-                  FStar_List.existsb (fun q  -> q = FStar_Syntax_Syntax.Noeq)
-                    quals in
-                let uu____2868 =
-                  (((FStar_List.length tcs) = (Prims.parse_int "0")) ||
-                     ((FStar_Ident.lid_equals
-                         env.FStar_TypeChecker_Env.curmodule
-                         FStar_Syntax_Const.prims_lid)
-                        && (skip_prims_type ())))
-                    || is_noeq in
-                if uu____2868
-                then ([sig_bndle], data_ops_ses)
-                else
-                  (let is_unopteq =
-                     FStar_List.existsb
-                       (fun q  -> q = FStar_Syntax_Syntax.Unopteq) quals in
-                   let ses1 =
-                     if is_unopteq
-                     then
-                       FStar_TypeChecker_TcInductive.unoptimized_haseq_scheme
-                         sig_bndle tcs datas env0 tc_assume
-                     else
-                       FStar_TypeChecker_TcInductive.optimized_haseq_scheme
-                         sig_bndle tcs datas env0 tc_assume in
-                   let uu____2884 =
-                     let uu____2886 =
-                       let uu____2887 =
-                         let uu____2895 =
-                           FStar_TypeChecker_Env.get_range env0 in
-                         ((FStar_List.append tcs datas), quals, lids,
-                           uu____2895) in
-                       FStar_Syntax_Syntax.Sig_bundle uu____2887 in
-                     uu____2886 :: ses1 in
-                   (uu____2884, data_ops_ses))))
-and tc_decl:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt ->
-      (FStar_Syntax_Syntax.sigelt Prims.list* FStar_TypeChecker_Env.env*
-        FStar_Syntax_Syntax.sigelt Prims.list)
-  =
-  fun env  ->
-    fun se  ->
-      let env1 = set_hint_correlator env se in
-      FStar_TypeChecker_Util.check_sigelt_quals env1 se;
-      (match se with
-       | FStar_Syntax_Syntax.Sig_inductive_typ _
-         |FStar_Syntax_Syntax.Sig_datacon _ ->
-           failwith "Impossible bare data-constructor"
-       | FStar_Syntax_Syntax.Sig_bundle (ses,quals,lids,r) when
-           FStar_All.pipe_right lids
-             (FStar_Util.for_some
-                (FStar_Ident.lid_equals FStar_Syntax_Const.lex_t_lid))
-           ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let se1 = tc_lex_t env2 ses quals lids in
-           let uu____2935 = FStar_TypeChecker_Env.push_sigelt env2 se1 in
-           ([se1], uu____2935, [])
-       | FStar_Syntax_Syntax.Sig_bundle (ses,quals,lids,r) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let uu____2949 = tc_inductive env2 ses quals lids in
-           (match uu____2949 with
-            | (ses1,projectors_ses) ->
-                let env3 =
-                  FStar_List.fold_left
-                    (fun env'  ->
-                       fun se1  -> FStar_TypeChecker_Env.push_sigelt env' se1)
-                    env2 ses1 in
-                (ses1, env3, projectors_ses))
-       | FStar_Syntax_Syntax.Sig_pragma (p,r) ->
-           let set_options1 t s =
-             let uu____2979 = FStar_Options.set_options t s in
-             match uu____2979 with
-             | FStar_Getopt.Success  -> ()
-             | FStar_Getopt.Help  ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ("Failed to process pragma: use 'fstar --help' to see which options are available",
-                        r))
-             | FStar_Getopt.Error s1 ->
-                 Prims.raise
-                   (FStar_Errors.Error
-                      ((Prims.strcat "Failed to process pragma: " s1), r)) in
-           (match p with
-            | FStar_Syntax_Syntax.LightOff  ->
-                (if p = FStar_Syntax_Syntax.LightOff
-                 then FStar_Options.set_ml_ish ()
-                 else ();
-                 ([se], env1, []))
-            | FStar_Syntax_Syntax.SetOptions o ->
-                (set_options1 FStar_Options.Set o; ([se], env1, []))
-            | FStar_Syntax_Syntax.ResetOptions sopt ->
-                ((let uu____2997 =
-                    FStar_Options.restore_cmd_line_options false in
-                  FStar_All.pipe_right uu____2997 Prims.ignore);
-                 (match sopt with
-                  | None  -> ()
-                  | Some s -> set_options1 FStar_Options.Reset s);
-                 (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
-                   ();
-                 ([se], env1, [])))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free (ne,r) ->
-           let uu____3005 = cps_and_elaborate env1 ne in
-           (match uu____3005 with
-            | (ses,ne1,lift_from_pure_opt) ->
-                let effect_and_lift_ses =
-                  match lift_from_pure_opt with
-                  | Some lift ->
-                      [FStar_Syntax_Syntax.Sig_new_effect (ne1, r); lift]
-                  | None  -> [FStar_Syntax_Syntax.Sig_new_effect (ne1, r)] in
-                ([], env1, (FStar_List.append ses effect_and_lift_ses)))
-       | FStar_Syntax_Syntax.Sig_new_effect (ne,r) ->
-           let ne1 = tc_eff_decl env1 ne in
-           let se1 = FStar_Syntax_Syntax.Sig_new_effect (ne1, r) in
-           let env2 = FStar_TypeChecker_Env.push_sigelt env1 se1 in
-           let uu____3034 =
-             FStar_All.pipe_right ne1.FStar_Syntax_Syntax.actions
-               (FStar_List.fold_left
-                  (fun uu____3045  ->
-                     fun a  ->
-                       match uu____3045 with
-                       | (env3,ses) ->
-                           let se_let =
-                             FStar_Syntax_Util.action_as_lb
-                               ne1.FStar_Syntax_Syntax.mname a in
-                           let uu____3058 =
-                             FStar_TypeChecker_Env.push_sigelt env3 se_let in
-                           (uu____3058, (se_let :: ses))) (env2, [se1])) in
-           (match uu____3034 with | (env3,ses) -> ([se1], env3, []))
-       | FStar_Syntax_Syntax.Sig_sub_effect (sub1,r) ->
-           let ed_src =
-             FStar_TypeChecker_Env.get_effect_decl env1
-               sub1.FStar_Syntax_Syntax.source in
-           let ed_tgt =
-             FStar_TypeChecker_Env.get_effect_decl env1
-               sub1.FStar_Syntax_Syntax.target in
-           let uu____3076 =
-             let uu____3081 =
-               FStar_TypeChecker_Env.lookup_effect_lid env1
-                 sub1.FStar_Syntax_Syntax.source in
-             monad_signature env1 sub1.FStar_Syntax_Syntax.source uu____3081 in
-           (match uu____3076 with
-            | (a,wp_a_src) ->
-                let uu____3093 =
-                  let uu____3098 =
-                    FStar_TypeChecker_Env.lookup_effect_lid env1
-                      sub1.FStar_Syntax_Syntax.target in
-                  monad_signature env1 sub1.FStar_Syntax_Syntax.target
-                    uu____3098 in
-                (match uu____3093 with
-                 | (b,wp_b_tgt) ->
-                     let wp_a_tgt =
-                       let uu____3111 =
-                         let uu____3113 =
-                           let uu____3114 =
-                             let uu____3119 =
-                               FStar_Syntax_Syntax.bv_to_name a in
-                             (b, uu____3119) in
-                           FStar_Syntax_Syntax.NT uu____3114 in
-                         [uu____3113] in
-                       FStar_Syntax_Subst.subst uu____3111 wp_b_tgt in
-                     let expected_k =
-                       let uu____3123 =
-                         let uu____3127 = FStar_Syntax_Syntax.mk_binder a in
-                         let uu____3128 =
-                           let uu____3130 =
-                             FStar_Syntax_Syntax.null_binder wp_a_src in
-                           [uu____3130] in
-                         uu____3127 :: uu____3128 in
-                       let uu____3131 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
-                       FStar_Syntax_Util.arrow uu____3123 uu____3131 in
-                     let repr_type eff_name a1 wp =
-                       let no_reify l =
-                         let uu____3152 =
-                           let uu____3153 =
-                             let uu____3156 =
-                               FStar_Util.format1
-                                 "Effect %s cannot be reified"
-                                 l.FStar_Ident.str in
-                             let uu____3157 =
-                               FStar_TypeChecker_Env.get_range env1 in
-                             (uu____3156, uu____3157) in
-                           FStar_Errors.Error uu____3153 in
-                         Prims.raise uu____3152 in
-                       let uu____3160 =
-                         FStar_TypeChecker_Env.effect_decl_opt env1 eff_name in
-                       match uu____3160 with
-                       | None  -> no_reify eff_name
-                       | Some ed ->
-                           let repr =
-                             FStar_TypeChecker_Env.inst_effect_fun_with
-                               [FStar_Syntax_Syntax.U_unknown] env1 ed
-                               ([], (ed.FStar_Syntax_Syntax.repr)) in
-                           let uu____3167 =
-                             let uu____3168 =
-                               FStar_All.pipe_right
-                                 ed.FStar_Syntax_Syntax.qualifiers
-                                 (FStar_List.contains
-                                    FStar_Syntax_Syntax.Reifiable) in
-                             Prims.op_Negation uu____3168 in
-                           if uu____3167
-                           then no_reify eff_name
-                           else
-                             (let uu____3173 =
-                                FStar_TypeChecker_Env.get_range env1 in
-                              let uu____3174 =
-                                let uu____3177 =
-                                  let uu____3178 =
-                                    let uu____3188 =
-                                      let uu____3190 =
-                                        FStar_Syntax_Syntax.as_arg a1 in
-                                      let uu____3191 =
-                                        let uu____3193 =
-                                          FStar_Syntax_Syntax.as_arg wp in
-                                        [uu____3193] in
-                                      uu____3190 :: uu____3191 in
-                                    (repr, uu____3188) in
-                                  FStar_Syntax_Syntax.Tm_app uu____3178 in
-                                FStar_Syntax_Syntax.mk uu____3177 in
-                              uu____3174 None uu____3173) in
-                     let uu____3203 =
-                       match ((sub1.FStar_Syntax_Syntax.lift),
-                               (sub1.FStar_Syntax_Syntax.lift_wp))
-                       with
-                       | (None ,None ) -> failwith "Impossible"
-                       | (lift,Some (uu____3218,lift_wp)) ->
-                           let uu____3231 =
-                             check_and_gen env1 lift_wp expected_k in
-                           (lift, uu____3231)
-                       | (Some (what,lift),None ) ->
-                           ((let uu____3246 =
-                               FStar_TypeChecker_Env.debug env1
-                                 (FStar_Options.Other "ED") in
-                             if uu____3246
-                             then
-                               let uu____3247 =
-                                 FStar_Syntax_Print.term_to_string lift in
-                               FStar_Util.print1 "Lift for free : %s\n"
-                                 uu____3247
-                             else ());
-                            (let dmff_env =
-                               FStar_TypeChecker_DMFF.empty env1
-                                 (FStar_TypeChecker_TcTerm.tc_constant
-                                    FStar_Range.dummyRange) in
-                             let uu____3250 =
-                               FStar_TypeChecker_TcTerm.tc_term env1 lift in
-                             match uu____3250 with
-                             | (lift1,comp,uu____3259) ->
-                                 let uu____3260 =
-                                   FStar_TypeChecker_DMFF.star_expr dmff_env
-                                     lift1 in
-                                 (match uu____3260 with
-                                  | (uu____3267,lift_wp,lift_elab) ->
-                                      let uu____3270 =
-                                        recheck_debug "lift-wp" env1 lift_wp in
-                                      let uu____3271 =
-                                        recheck_debug "lift-elab" env1
-                                          lift_elab in
-                                      ((Some ([], lift_elab)), ([], lift_wp))))) in
-                     (match uu____3203 with
-                      | (lift,lift_wp) ->
-                          let lax1 = env1.FStar_TypeChecker_Env.lax in
-                          let env2 =
-                            let uu___100_3295 = env1 in
-                            {
-                              FStar_TypeChecker_Env.solver =
-                                (uu___100_3295.FStar_TypeChecker_Env.solver);
-                              FStar_TypeChecker_Env.range =
-                                (uu___100_3295.FStar_TypeChecker_Env.range);
-                              FStar_TypeChecker_Env.curmodule =
-                                (uu___100_3295.FStar_TypeChecker_Env.curmodule);
-                              FStar_TypeChecker_Env.gamma =
-                                (uu___100_3295.FStar_TypeChecker_Env.gamma);
-                              FStar_TypeChecker_Env.gamma_cache =
-                                (uu___100_3295.FStar_TypeChecker_Env.gamma_cache);
-                              FStar_TypeChecker_Env.modules =
-                                (uu___100_3295.FStar_TypeChecker_Env.modules);
-                              FStar_TypeChecker_Env.expected_typ =
-                                (uu___100_3295.FStar_TypeChecker_Env.expected_typ);
-                              FStar_TypeChecker_Env.sigtab =
-                                (uu___100_3295.FStar_TypeChecker_Env.sigtab);
-                              FStar_TypeChecker_Env.is_pattern =
-                                (uu___100_3295.FStar_TypeChecker_Env.is_pattern);
-                              FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___100_3295.FStar_TypeChecker_Env.instantiate_imp);
-                              FStar_TypeChecker_Env.effects =
-                                (uu___100_3295.FStar_TypeChecker_Env.effects);
-                              FStar_TypeChecker_Env.generalize =
-                                (uu___100_3295.FStar_TypeChecker_Env.generalize);
-                              FStar_TypeChecker_Env.letrecs =
-                                (uu___100_3295.FStar_TypeChecker_Env.letrecs);
-                              FStar_TypeChecker_Env.top_level =
-                                (uu___100_3295.FStar_TypeChecker_Env.top_level);
-                              FStar_TypeChecker_Env.check_uvars =
-                                (uu___100_3295.FStar_TypeChecker_Env.check_uvars);
-                              FStar_TypeChecker_Env.use_eq =
-                                (uu___100_3295.FStar_TypeChecker_Env.use_eq);
-                              FStar_TypeChecker_Env.is_iface =
-                                (uu___100_3295.FStar_TypeChecker_Env.is_iface);
-                              FStar_TypeChecker_Env.admit =
-                                (uu___100_3295.FStar_TypeChecker_Env.admit);
-                              FStar_TypeChecker_Env.lax = true;
-                              FStar_TypeChecker_Env.lax_universes =
-                                (uu___100_3295.FStar_TypeChecker_Env.lax_universes);
-                              FStar_TypeChecker_Env.type_of =
-                                (uu___100_3295.FStar_TypeChecker_Env.type_of);
-                              FStar_TypeChecker_Env.universe_of =
-                                (uu___100_3295.FStar_TypeChecker_Env.universe_of);
-                              FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___100_3295.FStar_TypeChecker_Env.use_bv_sorts);
-                              FStar_TypeChecker_Env.qname_and_index =
-                                (uu___100_3295.FStar_TypeChecker_Env.qname_and_index)
-                            } in
-                          let lift1 =
-                            match lift with
-                            | None  -> None
-                            | Some (uu____3299,lift1) ->
-                                let uu____3306 =
-                                  let uu____3311 =
-                                    FStar_TypeChecker_Env.lookup_effect_lid
-                                      env2 sub1.FStar_Syntax_Syntax.source in
-                                  monad_signature env2
-                                    sub1.FStar_Syntax_Syntax.source
-                                    uu____3311 in
-                                (match uu____3306 with
-                                 | (a1,wp_a_src1) ->
-                                     let wp_a =
-                                       FStar_Syntax_Syntax.new_bv None
-                                         wp_a_src1 in
-                                     let a_typ =
-                                       FStar_Syntax_Syntax.bv_to_name a1 in
-                                     let wp_a_typ =
-                                       FStar_Syntax_Syntax.bv_to_name wp_a in
-                                     let repr_f =
-                                       repr_type
-                                         sub1.FStar_Syntax_Syntax.source
-                                         a_typ wp_a_typ in
-                                     let repr_result =
-                                       let lift_wp1 =
-                                         FStar_TypeChecker_Normalize.normalize
-                                           [FStar_TypeChecker_Normalize.EraseUniverses;
-                                           FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                                           env2 (Prims.snd lift_wp) in
-                                       let lift_wp_a =
-                                         let uu____3333 =
-                                           FStar_TypeChecker_Env.get_range
-                                             env2 in
-                                         let uu____3334 =
-                                           let uu____3337 =
-                                             let uu____3338 =
-                                               let uu____3348 =
-                                                 let uu____3350 =
-                                                   FStar_Syntax_Syntax.as_arg
-                                                     a_typ in
-                                                 let uu____3351 =
-                                                   let uu____3353 =
-                                                     FStar_Syntax_Syntax.as_arg
-                                                       wp_a_typ in
-                                                   [uu____3353] in
-                                                 uu____3350 :: uu____3351 in
-                                               (lift_wp1, uu____3348) in
-                                             FStar_Syntax_Syntax.Tm_app
-                                               uu____3338 in
-                                           FStar_Syntax_Syntax.mk uu____3337 in
-                                         uu____3334 None uu____3333 in
-                                       repr_type
-                                         sub1.FStar_Syntax_Syntax.target
-                                         a_typ lift_wp_a in
-                                     let expected_k1 =
-                                       let uu____3366 =
-                                         let uu____3370 =
-                                           FStar_Syntax_Syntax.mk_binder a1 in
-                                         let uu____3371 =
-                                           let uu____3373 =
-                                             FStar_Syntax_Syntax.mk_binder
-                                               wp_a in
-                                           let uu____3374 =
-                                             let uu____3376 =
-                                               FStar_Syntax_Syntax.null_binder
-                                                 repr_f in
-                                             [uu____3376] in
-                                           uu____3373 :: uu____3374 in
-                                         uu____3370 :: uu____3371 in
-                                       let uu____3377 =
-                                         FStar_Syntax_Syntax.mk_Total
-                                           repr_result in
-                                       FStar_Syntax_Util.arrow uu____3366
-                                         uu____3377 in
-                                     let uu____3380 =
-                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                         env2 expected_k1 in
-                                     (match uu____3380 with
-                                      | (expected_k2,uu____3386,uu____3387)
-                                          ->
-                                          let lift2 =
-                                            check_and_gen env2 lift1
-                                              expected_k2 in
-                                          Some lift2)) in
-                          let env3 =
-                            let uu___101_3390 = env2 in
-                            {
-                              FStar_TypeChecker_Env.solver =
-                                (uu___101_3390.FStar_TypeChecker_Env.solver);
-                              FStar_TypeChecker_Env.range =
-                                (uu___101_3390.FStar_TypeChecker_Env.range);
-                              FStar_TypeChecker_Env.curmodule =
-                                (uu___101_3390.FStar_TypeChecker_Env.curmodule);
-                              FStar_TypeChecker_Env.gamma =
-                                (uu___101_3390.FStar_TypeChecker_Env.gamma);
-                              FStar_TypeChecker_Env.gamma_cache =
-                                (uu___101_3390.FStar_TypeChecker_Env.gamma_cache);
-                              FStar_TypeChecker_Env.modules =
-                                (uu___101_3390.FStar_TypeChecker_Env.modules);
-                              FStar_TypeChecker_Env.expected_typ =
-                                (uu___101_3390.FStar_TypeChecker_Env.expected_typ);
-                              FStar_TypeChecker_Env.sigtab =
-                                (uu___101_3390.FStar_TypeChecker_Env.sigtab);
-                              FStar_TypeChecker_Env.is_pattern =
-                                (uu___101_3390.FStar_TypeChecker_Env.is_pattern);
-                              FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___101_3390.FStar_TypeChecker_Env.instantiate_imp);
-                              FStar_TypeChecker_Env.effects =
-                                (uu___101_3390.FStar_TypeChecker_Env.effects);
-                              FStar_TypeChecker_Env.generalize =
-                                (uu___101_3390.FStar_TypeChecker_Env.generalize);
-                              FStar_TypeChecker_Env.letrecs =
-                                (uu___101_3390.FStar_TypeChecker_Env.letrecs);
-                              FStar_TypeChecker_Env.top_level =
-                                (uu___101_3390.FStar_TypeChecker_Env.top_level);
-                              FStar_TypeChecker_Env.check_uvars =
-                                (uu___101_3390.FStar_TypeChecker_Env.check_uvars);
-                              FStar_TypeChecker_Env.use_eq =
-                                (uu___101_3390.FStar_TypeChecker_Env.use_eq);
-                              FStar_TypeChecker_Env.is_iface =
-                                (uu___101_3390.FStar_TypeChecker_Env.is_iface);
-                              FStar_TypeChecker_Env.admit =
-                                (uu___101_3390.FStar_TypeChecker_Env.admit);
-                              FStar_TypeChecker_Env.lax = lax1;
-                              FStar_TypeChecker_Env.lax_universes =
-                                (uu___101_3390.FStar_TypeChecker_Env.lax_universes);
-                              FStar_TypeChecker_Env.type_of =
-                                (uu___101_3390.FStar_TypeChecker_Env.type_of);
-                              FStar_TypeChecker_Env.universe_of =
-                                (uu___101_3390.FStar_TypeChecker_Env.universe_of);
-                              FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___101_3390.FStar_TypeChecker_Env.use_bv_sorts);
-                              FStar_TypeChecker_Env.qname_and_index =
-                                (uu___101_3390.FStar_TypeChecker_Env.qname_and_index)
-                            } in
-                          let sub2 =
-                            let uu___102_3392 = sub1 in
-                            {
-                              FStar_Syntax_Syntax.source =
-                                (uu___102_3392.FStar_Syntax_Syntax.source);
-                              FStar_Syntax_Syntax.target =
-                                (uu___102_3392.FStar_Syntax_Syntax.target);
-                              FStar_Syntax_Syntax.lift_wp = (Some lift_wp);
-                              FStar_Syntax_Syntax.lift = lift1
-                            } in
-                          let se1 =
-                            FStar_Syntax_Syntax.Sig_sub_effect (sub2, r) in
-                          let env4 =
-                            FStar_TypeChecker_Env.push_sigelt env3 se1 in
-                          ([se1], env4, []))))
-       | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,tags,flags,r)
-           ->
-           let env0 = env1 in
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let uu____3411 = FStar_Syntax_Subst.open_comp tps c in
-           (match uu____3411 with
-            | (tps1,c1) ->
-                let uu____3421 =
-                  FStar_TypeChecker_TcTerm.tc_tparams env2 tps1 in
-                (match uu____3421 with
-                 | (tps2,env3,us) ->
-                     let uu____3433 =
-                       FStar_TypeChecker_TcTerm.tc_comp env3 c1 in
-                     (match uu____3433 with
-                      | (c2,u,g) ->
-                          (FStar_TypeChecker_Rel.force_trivial_guard env3 g;
-                           (let tps3 = FStar_Syntax_Subst.close_binders tps2 in
-                            let c3 = FStar_Syntax_Subst.close_comp tps3 c2 in
-                            let uu____3448 =
-                              let uu____3449 =
-                                FStar_Syntax_Syntax.mk
-                                  (FStar_Syntax_Syntax.Tm_arrow (tps3, c3))
-                                  None r in
-                              FStar_TypeChecker_Util.generalize_universes
-                                env0 uu____3449 in
-                            match uu____3448 with
-                            | (uvs1,t) ->
-                                let uu____3463 =
-                                  let uu____3471 =
-                                    let uu____3474 =
-                                      let uu____3475 =
-                                        FStar_Syntax_Subst.compress t in
-                                      uu____3475.FStar_Syntax_Syntax.n in
-                                    (tps3, uu____3474) in
-                                  match uu____3471 with
-                                  | ([],FStar_Syntax_Syntax.Tm_arrow
-                                     (uu____3485,c4)) -> ([], c4)
-                                  | (uu____3509,FStar_Syntax_Syntax.Tm_arrow
-                                     (tps4,c4)) -> (tps4, c4)
-                                  | uu____3527 -> failwith "Impossible" in
-                                (match uu____3463 with
-                                 | (tps4,c4) ->
-                                     (if
-                                        ((FStar_List.length uvs1) <>
-                                           (Prims.parse_int "1"))
-                                          &&
-                                          (Prims.op_Negation
-                                             (FStar_Ident.lid_equals lid
-                                                FStar_Syntax_Const.effect_Lemma_lid))
-                                      then
-                                        (let uu____3557 =
-                                           FStar_Syntax_Subst.open_univ_vars
-                                             uvs1 t in
-                                         match uu____3557 with
-                                         | (uu____3560,t1) ->
-                                             let uu____3562 =
-                                               let uu____3563 =
-                                                 let uu____3566 =
-                                                   let uu____3567 =
-                                                     FStar_Syntax_Print.lid_to_string
-                                                       lid in
-                                                   let uu____3568 =
-                                                     FStar_All.pipe_right
-                                                       (FStar_List.length
-                                                          uvs1)
-                                                       FStar_Util.string_of_int in
-                                                   let uu____3571 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       t1 in
-                                                   FStar_Util.format3
-                                                     "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                     uu____3567 uu____3568
-                                                     uu____3571 in
-                                                 (uu____3566, r) in
-                                               FStar_Errors.Error uu____3563 in
-                                             Prims.raise uu____3562)
-                                      else ();
-                                      (let se1 =
-                                         FStar_Syntax_Syntax.Sig_effect_abbrev
-                                           (lid, uvs1, tps4, c4, tags, flags,
-                                             r) in
-                                       let env4 =
-                                         FStar_TypeChecker_Env.push_sigelt
-                                           env0 se1 in
-                                       ([se1], env4, [])))))))))
-       | FStar_Syntax_Syntax.Sig_declare_typ (_,_,_,quals,_)
-         |FStar_Syntax_Syntax.Sig_let (_,_,_,quals,_) when
-           FStar_All.pipe_right quals
-             (FStar_Util.for_some
-                (fun uu___81_3601  ->
-                   match uu___81_3601 with
-                   | FStar_Syntax_Syntax.OnlyName  -> true
-                   | uu____3602 -> false))
-           -> ([], env1, [])
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t,quals,r) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let uu____3613 =
-             if uvs = []
-             then
-               let uu____3614 =
-                 let uu____3615 = FStar_Syntax_Util.type_u () in
-                 Prims.fst uu____3615 in
-               check_and_gen env2 t uu____3614
-             else
-               (let uu____3619 = FStar_Syntax_Subst.open_univ_vars uvs t in
-                match uu____3619 with
-                | (uvs1,t1) ->
-                    let t2 =
-                      let uu____3625 =
-                        let uu____3626 = FStar_Syntax_Util.type_u () in
-                        Prims.fst uu____3626 in
-                      tc_check_trivial_guard env2 t1 uu____3625 in
-                    let t3 =
-                      FStar_TypeChecker_Normalize.normalize
-                        [FStar_TypeChecker_Normalize.NoFullNorm;
-                        FStar_TypeChecker_Normalize.Beta] env2 t2 in
-                    let uu____3630 =
-                      FStar_Syntax_Subst.close_univ_vars uvs1 t3 in
-                    (uvs1, uu____3630)) in
-           (match uu____3613 with
-            | (uvs1,t1) ->
-                let se1 =
-                  FStar_Syntax_Syntax.Sig_declare_typ
-                    (lid, uvs1, t1, quals, r) in
-                let env3 = FStar_TypeChecker_Env.push_sigelt env2 se1 in
-                ([se1], env3, []))
-       | FStar_Syntax_Syntax.Sig_assume (lid,phi,quals,r) ->
-           let se1 = tc_assume env1 lid phi quals r in
-           let env2 = FStar_TypeChecker_Env.push_sigelt env1 se1 in
-           ([se1], env2, [])
-       | FStar_Syntax_Syntax.Sig_main (e,r) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let env3 =
-             FStar_TypeChecker_Env.set_expected_typ env2
-               FStar_TypeChecker_Common.t_unit in
-           let uu____3660 = FStar_TypeChecker_TcTerm.tc_term env3 e in
-           (match uu____3660 with
-            | (e1,c,g1) ->
-                let uu____3672 =
-                  let uu____3676 =
-                    let uu____3678 =
-                      FStar_Syntax_Util.ml_comp
-                        FStar_TypeChecker_Common.t_unit r in
-                    Some uu____3678 in
-                  let uu____3679 =
-                    let uu____3682 = c.FStar_Syntax_Syntax.comp () in
-                    (e1, uu____3682) in
-                  FStar_TypeChecker_TcTerm.check_expected_effect env3
-                    uu____3676 uu____3679 in
-                (match uu____3672 with
-                 | (e2,uu____3693,g) ->
-                     ((let uu____3696 = FStar_TypeChecker_Rel.conj_guard g1 g in
-                       FStar_TypeChecker_Rel.force_trivial_guard env3
-                         uu____3696);
-                      (let se1 = FStar_Syntax_Syntax.Sig_main (e2, r) in
-                       let env4 = FStar_TypeChecker_Env.push_sigelt env3 se1 in
-                       ([se1], env4, [])))))
-       | FStar_Syntax_Syntax.Sig_let (lbs,r,lids,quals,attrs) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r in
-           let check_quals_eq l qopt q =
-             match qopt with
-             | None  -> Some q
-             | Some q' ->
-                 let uu____3738 =
-                   ((FStar_List.length q) = (FStar_List.length q')) &&
-                     (FStar_List.forall2 FStar_Syntax_Util.qualifier_equal q
-                        q') in
-                 if uu____3738
-                 then Some q
-                 else
-                   (let uu____3747 =
-                      let uu____3748 =
-                        let uu____3751 =
-                          let uu____3752 = FStar_Syntax_Print.lid_to_string l in
-                          let uu____3753 =
-                            FStar_Syntax_Print.quals_to_string q in
-                          let uu____3754 =
-                            FStar_Syntax_Print.quals_to_string q' in
-                          FStar_Util.format3
-                            "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                            uu____3752 uu____3753 uu____3754 in
-                        (uu____3751, r) in
-                      FStar_Errors.Error uu____3748 in
-                    Prims.raise uu____3747) in
-           let uu____3757 =
-             FStar_All.pipe_right (Prims.snd lbs)
-               (FStar_List.fold_left
-                  (fun uu____3778  ->
-                     fun lb  ->
-                       match uu____3778 with
-                       | (gen1,lbs1,quals_opt) ->
-                           let lbname =
-                             FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                           let uu____3802 =
-                             let uu____3808 =
-                               FStar_TypeChecker_Env.try_lookup_val_decl env2
-                                 (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                             match uu____3808 with
-                             | None  ->
-                                 if lb.FStar_Syntax_Syntax.lbunivs <> []
-                                 then (false, lb, quals_opt)
-                                 else (gen1, lb, quals_opt)
-                             | Some ((uvs,tval),quals1) ->
-                                 let quals_opt1 =
-                                   check_quals_eq
-                                     (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                     quals_opt quals1 in
-                                 ((match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
-                                   with
-                                   | FStar_Syntax_Syntax.Tm_unknown  -> ()
-                                   | uu____3860 ->
-                                       FStar_Errors.warn r
-                                         "Annotation from val declaration overrides inline type annotation");
-                                  if
-                                    (lb.FStar_Syntax_Syntax.lbunivs <> []) &&
-                                      ((FStar_List.length
-                                          lb.FStar_Syntax_Syntax.lbunivs)
-                                         <> (FStar_List.length uvs))
-                                  then
-                                    Prims.raise
-                                      (FStar_Errors.Error
-                                         ("Inline universes are incoherent with annotation from val declaration",
-                                           r))
-                                  else ();
-                                  (let uu____3868 =
-                                     FStar_Syntax_Syntax.mk_lb
-                                       ((FStar_Util.Inr lbname), uvs,
-                                         FStar_Syntax_Const.effect_ALL_lid,
-                                         tval,
-                                         (lb.FStar_Syntax_Syntax.lbdef)) in
-                                   (false, uu____3868, quals_opt1))) in
-                           (match uu____3802 with
-                            | (gen2,lb1,quals_opt1) ->
-                                (gen2, (lb1 :: lbs1), quals_opt1)))
-                  (true, [], (if quals = [] then None else Some quals))) in
-           (match uu____3757 with
-            | (should_generalize,lbs',quals_opt) ->
-                let quals1 =
-                  match quals_opt with
-                  | None  -> [FStar_Syntax_Syntax.Visible_default]
-                  | Some q ->
-                      let uu____3922 =
-                        FStar_All.pipe_right q
-                          (FStar_Util.for_some
-                             (fun uu___82_3924  ->
-                                match uu___82_3924 with
-                                | FStar_Syntax_Syntax.Irreducible 
-                                  |FStar_Syntax_Syntax.Visible_default 
-                                   |FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
-                                    -> true
-                                | uu____3925 -> false)) in
-                      if uu____3922
-                      then q
-                      else FStar_Syntax_Syntax.Visible_default :: q in
-                let lbs'1 = FStar_List.rev lbs' in
-                let e =
-                  let uu____3933 =
-                    let uu____3936 =
-                      let uu____3937 =
-                        let uu____3945 =
-                          FStar_Syntax_Syntax.mk
-                            (FStar_Syntax_Syntax.Tm_constant
-                               FStar_Const.Const_unit) None r in
-                        (((Prims.fst lbs), lbs'1), uu____3945) in
-                      FStar_Syntax_Syntax.Tm_let uu____3937 in
-                    FStar_Syntax_Syntax.mk uu____3936 in
-                  uu____3933 None r in
-                let uu____3967 =
-                  let uu____3973 =
-                    FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                      (let uu___103_3977 = env2 in
-                       {
-                         FStar_TypeChecker_Env.solver =
-                           (uu___103_3977.FStar_TypeChecker_Env.solver);
-                         FStar_TypeChecker_Env.range =
-                           (uu___103_3977.FStar_TypeChecker_Env.range);
-                         FStar_TypeChecker_Env.curmodule =
-                           (uu___103_3977.FStar_TypeChecker_Env.curmodule);
-                         FStar_TypeChecker_Env.gamma =
-                           (uu___103_3977.FStar_TypeChecker_Env.gamma);
-                         FStar_TypeChecker_Env.gamma_cache =
-                           (uu___103_3977.FStar_TypeChecker_Env.gamma_cache);
-                         FStar_TypeChecker_Env.modules =
-                           (uu___103_3977.FStar_TypeChecker_Env.modules);
-                         FStar_TypeChecker_Env.expected_typ =
-                           (uu___103_3977.FStar_TypeChecker_Env.expected_typ);
-                         FStar_TypeChecker_Env.sigtab =
-                           (uu___103_3977.FStar_TypeChecker_Env.sigtab);
-                         FStar_TypeChecker_Env.is_pattern =
-                           (uu___103_3977.FStar_TypeChecker_Env.is_pattern);
-                         FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___103_3977.FStar_TypeChecker_Env.instantiate_imp);
-                         FStar_TypeChecker_Env.effects =
-                           (uu___103_3977.FStar_TypeChecker_Env.effects);
-                         FStar_TypeChecker_Env.generalize = should_generalize;
-                         FStar_TypeChecker_Env.letrecs =
-                           (uu___103_3977.FStar_TypeChecker_Env.letrecs);
-                         FStar_TypeChecker_Env.top_level = true;
-                         FStar_TypeChecker_Env.check_uvars =
-                           (uu___103_3977.FStar_TypeChecker_Env.check_uvars);
-                         FStar_TypeChecker_Env.use_eq =
-                           (uu___103_3977.FStar_TypeChecker_Env.use_eq);
-                         FStar_TypeChecker_Env.is_iface =
-                           (uu___103_3977.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (uu___103_3977.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax =
-                           (uu___103_3977.FStar_TypeChecker_Env.lax);
-                         FStar_TypeChecker_Env.lax_universes =
-                           (uu___103_3977.FStar_TypeChecker_Env.lax_universes);
-                         FStar_TypeChecker_Env.type_of =
-                           (uu___103_3977.FStar_TypeChecker_Env.type_of);
-                         FStar_TypeChecker_Env.universe_of =
-                           (uu___103_3977.FStar_TypeChecker_Env.universe_of);
-                         FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___103_3977.FStar_TypeChecker_Env.use_bv_sorts);
-                         FStar_TypeChecker_Env.qname_and_index =
-                           (uu___103_3977.FStar_TypeChecker_Env.qname_and_index)
-                       }) e in
-                  match uu____3973 with
-                  | ({
-                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_let
-                         (lbs1,e1);
-                       FStar_Syntax_Syntax.tk = uu____3985;
-                       FStar_Syntax_Syntax.pos = uu____3986;
-                       FStar_Syntax_Syntax.vars = uu____3987;_},uu____3988,g)
-                      when FStar_TypeChecker_Rel.is_trivial g ->
-                      let quals2 =
-                        match e1.FStar_Syntax_Syntax.n with
-                        | FStar_Syntax_Syntax.Tm_meta
-                            (uu____4007,FStar_Syntax_Syntax.Meta_desugared
-                             (FStar_Syntax_Syntax.Masked_effect ))
-                            -> FStar_Syntax_Syntax.HasMaskedEffect :: quals1
-                        | uu____4012 -> quals1 in
-                      let quals3 =
-                        FStar_List.choose
-                          (fun uu___83_4015  ->
-                             match uu___83_4015 with
-                             | FStar_Syntax_Syntax.Inline_for_extraction  ->
-                                 let uu____4017 =
-                                   let uu____4018 =
-                                     FStar_List.for_all
-                                       (fun lb  ->
-                                          let ok =
-                                            FStar_Syntax_Util.is_pure_or_ghost_function
-                                              lb.FStar_Syntax_Syntax.lbtyp in
-                                          if Prims.op_Negation ok
-                                          then
-                                            (let uu____4022 =
-                                               FStar_Syntax_Print.lbname_to_string
-                                                 lb.FStar_Syntax_Syntax.lbname in
-                                             FStar_Util.print1_warning
-                                               "Dropping inline_for_extraction from %s because it is not a pure function\n"
-                                               uu____4022)
-                                          else ();
-                                          ok) (Prims.snd lbs1) in
-                                   Prims.op_Negation uu____4018 in
-                                 if uu____4017
-                                 then None
-                                 else
-                                   Some
-                                     FStar_Syntax_Syntax.Inline_for_extraction
-                             | q -> Some q) quals2 in
-                      ((FStar_Syntax_Syntax.Sig_let
-                          (lbs1, r, lids, quals3, attrs)), lbs1)
-                  | uu____4037 -> failwith "impossible" in
-                (match uu____3967 with
-                 | (se1,lbs1) ->
-                     (FStar_All.pipe_right (Prims.snd lbs1)
-                        (FStar_List.iter
-                           (fun lb  ->
-                              let fv =
-                                FStar_Util.right
-                                  lb.FStar_Syntax_Syntax.lbname in
-                              let uu____4064 =
-                                FStar_Syntax_Syntax.range_of_fv fv in
-                              FStar_TypeChecker_Common.insert_identifier_info
-                                (FStar_Util.Inr fv)
-                                lb.FStar_Syntax_Syntax.lbtyp uu____4064));
-                      (let uu____4066 = log env2 in
-                       if uu____4066
-                       then
-                         let uu____4067 =
-                           let uu____4068 =
-                             FStar_All.pipe_right (Prims.snd lbs1)
-                               (FStar_List.map
-                                  (fun lb  ->
-                                     let should_log =
-                                       let uu____4075 =
-                                         let uu____4080 =
-                                           let uu____4081 =
-                                             let uu____4086 =
-                                               FStar_Util.right
-                                                 lb.FStar_Syntax_Syntax.lbname in
-                                             uu____4086.FStar_Syntax_Syntax.fv_name in
-                                           uu____4081.FStar_Syntax_Syntax.v in
-                                         FStar_TypeChecker_Env.try_lookup_val_decl
-                                           env2 uu____4080 in
-                                       match uu____4075 with
-                                       | None  -> true
-                                       | uu____4093 -> false in
-                                     if should_log
-                                     then
-                                       let uu____4098 =
-                                         FStar_Syntax_Print.lbname_to_string
-                                           lb.FStar_Syntax_Syntax.lbname in
-                                       let uu____4099 =
-                                         FStar_Syntax_Print.term_to_string
-                                           lb.FStar_Syntax_Syntax.lbtyp in
-                                       FStar_Util.format2 "let %s : %s"
-                                         uu____4098 uu____4099
-                                     else "")) in
-                           FStar_All.pipe_right uu____4068
-                             (FStar_String.concat "\n") in
-                         FStar_Util.print1 "%s\n" uu____4067
-                       else ());
-                      (let env3 = FStar_TypeChecker_Env.push_sigelt env2 se1 in
-                       ([se1], env3, []))))))
-let for_export:
-  FStar_Ident.lident Prims.list ->
-    FStar_Syntax_Syntax.sigelt ->
-      (FStar_Syntax_Syntax.sigelt Prims.list* FStar_Ident.lident Prims.list)
-  =
-  fun hidden  ->
-    fun se  ->
-      let is_abstract quals =
-        FStar_All.pipe_right quals
-          (FStar_Util.for_some
-             (fun uu___84_4129  ->
-                match uu___84_4129 with
-                | FStar_Syntax_Syntax.Abstract  -> true
-                | uu____4130 -> false)) in
-      let is_hidden_proj_or_disc q =
-        match q with
-        | FStar_Syntax_Syntax.Projector (l,_)
-          |FStar_Syntax_Syntax.Discriminator l ->
-            FStar_All.pipe_right hidden
-              (FStar_Util.for_some (FStar_Ident.lid_equals l))
-        | uu____4138 -> false in
-      match se with
-      | FStar_Syntax_Syntax.Sig_pragma uu____4143 -> ([], hidden)
-      | FStar_Syntax_Syntax.Sig_inductive_typ _
-        |FStar_Syntax_Syntax.Sig_datacon _ -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Sig_bundle (ses,quals,uu____4156,r) ->
-          let uu____4164 = is_abstract quals in
-          if uu____4164
-          then
-            let for_export_bundle se1 uu____4183 =
-              match uu____4183 with
-              | (out,hidden1) ->
-                  (match se1 with
-                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                       (l,us,bs,t,uu____4206,uu____4207,quals1,r1) ->
-                       let dec =
-                         let uu____4217 =
-                           let uu____4224 =
-                             let uu____4227 = FStar_Syntax_Syntax.mk_Total t in
-                             FStar_Syntax_Util.arrow bs uu____4227 in
-                           (l, us, uu____4224,
-                             (FStar_Syntax_Syntax.Assumption ::
-                             FStar_Syntax_Syntax.New :: quals1), r1) in
-                         FStar_Syntax_Syntax.Sig_declare_typ uu____4217 in
-                       ((dec :: out), hidden1)
-                   | FStar_Syntax_Syntax.Sig_datacon
-                       (l,us,t,uu____4238,uu____4239,uu____4240,uu____4241,r1)
-                       ->
-                       let dec =
-                         FStar_Syntax_Syntax.Sig_declare_typ
-                           (l, us, t, [FStar_Syntax_Syntax.Assumption], r1) in
-                       ((dec :: out), (l :: hidden1))
-                   | uu____4251 -> (out, hidden1)) in
-            FStar_List.fold_right for_export_bundle ses ([], hidden)
-          else ([se], hidden)
-      | FStar_Syntax_Syntax.Sig_assume
-          (uu____4263,uu____4264,quals,uu____4266) ->
-          let uu____4269 = is_abstract quals in
-          if uu____4269 then ([], hidden) else ([se], hidden)
-      | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t,quals,r) ->
-          let uu____4286 =
-            FStar_All.pipe_right quals
-              (FStar_Util.for_some is_hidden_proj_or_disc) in
-          if uu____4286
-          then
-            ([FStar_Syntax_Syntax.Sig_declare_typ
-                (l, us, t, [FStar_Syntax_Syntax.Assumption], r)], (l ::
-              hidden))
-          else
-            (let uu____4296 =
-               FStar_All.pipe_right quals
-                 (FStar_Util.for_some
-                    (fun uu___85_4298  ->
-                       match uu___85_4298 with
-                       | FStar_Syntax_Syntax.Assumption 
-                         |FStar_Syntax_Syntax.Projector _
-                          |FStar_Syntax_Syntax.Discriminator _ -> true
-                       | uu____4301 -> false)) in
-             if uu____4296 then ([se], hidden) else ([], hidden))
-      | FStar_Syntax_Syntax.Sig_main uu____4311 -> ([], hidden)
-      | FStar_Syntax_Syntax.Sig_new_effect _
-        |FStar_Syntax_Syntax.Sig_new_effect_for_free _
-         |FStar_Syntax_Syntax.Sig_sub_effect _
-          |FStar_Syntax_Syntax.Sig_effect_abbrev _ -> ([se], hidden)
-      | FStar_Syntax_Syntax.Sig_let
-          ((false ,lb::[]),uu____4323,uu____4324,quals,uu____4326) when
-          FStar_All.pipe_right quals
-            (FStar_Util.for_some is_hidden_proj_or_disc)
-          ->
-          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          let uu____4344 =
-            FStar_All.pipe_right hidden
-              (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)) in
-          if uu____4344
-          then ([], hidden)
-          else
-            (let dec =
-               FStar_Syntax_Syntax.Sig_declare_typ
-                 (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
-                   (lb.FStar_Syntax_Syntax.lbunivs),
-                   (lb.FStar_Syntax_Syntax.lbtyp),
-                   [FStar_Syntax_Syntax.Assumption],
-                   (FStar_Ident.range_of_lid lid)) in
-             ([dec], (lid :: hidden)))
-      | FStar_Syntax_Syntax.Sig_let (lbs,r,l,quals,uu____4368) ->
-          let uu____4375 = is_abstract quals in
-          if uu____4375
-          then
-            let uu____4380 =
-              FStar_All.pipe_right (Prims.snd lbs)
-                (FStar_List.map
-                   (fun lb  ->
-                      let uu____4386 =
-                        let uu____4393 =
-                          let uu____4394 =
-                            let uu____4399 =
-                              FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                            uu____4399.FStar_Syntax_Syntax.fv_name in
-                          uu____4394.FStar_Syntax_Syntax.v in
-                        (uu____4393, (lb.FStar_Syntax_Syntax.lbunivs),
-                          (lb.FStar_Syntax_Syntax.lbtyp),
-                          (FStar_Syntax_Syntax.Assumption :: quals), r) in
-                      FStar_Syntax_Syntax.Sig_declare_typ uu____4386)) in
-            (uu____4380, hidden)
-          else ([se], hidden)
-let tc_decls:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      (FStar_Syntax_Syntax.sigelt Prims.list* FStar_Syntax_Syntax.sigelt
-        Prims.list* FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun ses  ->
-      let rec process_one_decl uu____4447 se =
-        match uu____4447 with
-        | (ses1,exports,env1,hidden) ->
-            ((let uu____4477 =
-                FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-              if uu____4477
-              then
-                let uu____4478 = FStar_Syntax_Print.sigelt_to_string se in
-                FStar_Util.print1
-                  ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____4478
-              else ());
-             (let uu____4480 = tc_decl env1 se in
-              match uu____4480 with
-              | (ses',env2,ses_elaborated) ->
-                  ((let uu____4504 =
-                      (FStar_Options.log_types ()) ||
-                        (FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug env2)
-                           (FStar_Options.Other "LogTypes")) in
-                    if uu____4504
-                    then
-                      let uu____4505 =
-                        FStar_List.fold_left
-                          (fun s  ->
-                             fun se1  ->
-                               let uu____4508 =
-                                 let uu____4509 =
-                                   FStar_Syntax_Print.sigelt_to_string se1 in
-                                 Prims.strcat uu____4509 "\n" in
-                               Prims.strcat s uu____4508) "" ses' in
-                      FStar_Util.print1 "Checked: %s\n" uu____4505
-                    else ());
-                   FStar_List.iter
-                     (fun se1  ->
-                        (env2.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
-                          env2 se1) ses';
-                   (let uu____4513 =
-                      let accum_exports_hidden uu____4531 se1 =
-                        match uu____4531 with
-                        | (exports1,hidden1) ->
-                            let uu____4547 = for_export hidden1 se1 in
-                            (match uu____4547 with
-                             | (se_exported,hidden2) ->
-                                 ((FStar_List.rev_append se_exported exports1),
-                                   hidden2)) in
-                      FStar_List.fold_left accum_exports_hidden
-                        (exports, hidden) ses' in
-                    match uu____4513 with
-                    | (exports1,hidden1) ->
-                        (((FStar_List.rev_append ses' ses1), exports1, env2,
-                           hidden1), ses_elaborated))))) in
-      let uu____4597 =
-        FStar_Util.fold_flatten process_one_decl ([], [], env, []) ses in
-      match uu____4597 with
-      | (ses1,exports,env1,uu____4623) ->
-          ((FStar_List.rev_append ses1 []),
-            (FStar_List.rev_append exports []), env1)
-let tc_partial_modul:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      (FStar_Syntax_Syntax.modul* FStar_Syntax_Syntax.sigelt Prims.list*
-        FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun modul  ->
-      let verify =
-        FStar_Options.should_verify
-          (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
-      let action = if verify then "Verifying" else "Lax-checking" in
-      let label1 =
-        if modul.FStar_Syntax_Syntax.is_interface
-        then "interface"
-        else "implementation" in
-      (let uu____4648 = FStar_Options.debug_any () in
-       if uu____4648
-       then
-         FStar_Util.print3 "%s %s of %s\n" action label1
-           (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-       else ());
-      (let name =
-         FStar_Util.format2 "%s %s"
-           (if modul.FStar_Syntax_Syntax.is_interface
-            then "interface"
-            else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
-       let msg = Prims.strcat "Internals for " name in
-       let env1 =
-         let uu___104_4654 = env in
-         {
-           FStar_TypeChecker_Env.solver =
-             (uu___104_4654.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___104_4654.FStar_TypeChecker_Env.range);
-           FStar_TypeChecker_Env.curmodule =
-             (uu___104_4654.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___104_4654.FStar_TypeChecker_Env.gamma);
-           FStar_TypeChecker_Env.gamma_cache =
-             (uu___104_4654.FStar_TypeChecker_Env.gamma_cache);
-           FStar_TypeChecker_Env.modules =
-             (uu___104_4654.FStar_TypeChecker_Env.modules);
-           FStar_TypeChecker_Env.expected_typ =
-             (uu___104_4654.FStar_TypeChecker_Env.expected_typ);
-           FStar_TypeChecker_Env.sigtab =
-             (uu___104_4654.FStar_TypeChecker_Env.sigtab);
-           FStar_TypeChecker_Env.is_pattern =
-             (uu___104_4654.FStar_TypeChecker_Env.is_pattern);
-           FStar_TypeChecker_Env.instantiate_imp =
-             (uu___104_4654.FStar_TypeChecker_Env.instantiate_imp);
-           FStar_TypeChecker_Env.effects =
-             (uu___104_4654.FStar_TypeChecker_Env.effects);
-           FStar_TypeChecker_Env.generalize =
-             (uu___104_4654.FStar_TypeChecker_Env.generalize);
-           FStar_TypeChecker_Env.letrecs =
-             (uu___104_4654.FStar_TypeChecker_Env.letrecs);
-           FStar_TypeChecker_Env.top_level =
-             (uu___104_4654.FStar_TypeChecker_Env.top_level);
-           FStar_TypeChecker_Env.check_uvars =
-             (uu___104_4654.FStar_TypeChecker_Env.check_uvars);
-           FStar_TypeChecker_Env.use_eq =
-             (uu___104_4654.FStar_TypeChecker_Env.use_eq);
-           FStar_TypeChecker_Env.is_iface =
-             (modul.FStar_Syntax_Syntax.is_interface);
-           FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
-           FStar_TypeChecker_Env.lax =
-             (uu___104_4654.FStar_TypeChecker_Env.lax);
-           FStar_TypeChecker_Env.lax_universes =
-             (uu___104_4654.FStar_TypeChecker_Env.lax_universes);
-           FStar_TypeChecker_Env.type_of =
-             (uu___104_4654.FStar_TypeChecker_Env.type_of);
-           FStar_TypeChecker_Env.universe_of =
-             (uu___104_4654.FStar_TypeChecker_Env.universe_of);
-           FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___104_4654.FStar_TypeChecker_Env.use_bv_sorts);
-           FStar_TypeChecker_Env.qname_and_index =
-             (uu___104_4654.FStar_TypeChecker_Env.qname_and_index)
-         } in
-       (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push msg;
-       (let env2 =
-          FStar_TypeChecker_Env.set_current_module env1
-            modul.FStar_Syntax_Syntax.name in
-        let uu____4657 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
-        match uu____4657 with
-        | (ses,exports,env3) ->
-            ((let uu___105_4675 = modul in
-              {
-                FStar_Syntax_Syntax.name =
-                  (uu___105_4675.FStar_Syntax_Syntax.name);
-                FStar_Syntax_Syntax.declarations = ses;
-                FStar_Syntax_Syntax.exports =
-                  (uu___105_4675.FStar_Syntax_Syntax.exports);
-                FStar_Syntax_Syntax.is_interface =
-                  (uu___105_4675.FStar_Syntax_Syntax.is_interface)
-              }), exports, env3)))
-let tc_more_partial_modul:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      FStar_Syntax_Syntax.sigelt Prims.list ->
-        (FStar_Syntax_Syntax.modul* FStar_Syntax_Syntax.sigelt Prims.list*
-          FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun modul  ->
-      fun decls  ->
-        let uu____4691 = tc_decls env decls in
-        match uu____4691 with
-        | (ses,exports,env1) ->
-            let modul1 =
-              let uu___106_4709 = modul in
-              {
-                FStar_Syntax_Syntax.name =
-                  (uu___106_4709.FStar_Syntax_Syntax.name);
-                FStar_Syntax_Syntax.declarations =
-                  (FStar_List.append modul.FStar_Syntax_Syntax.declarations
-                     ses);
-                FStar_Syntax_Syntax.exports =
-                  (uu___106_4709.FStar_Syntax_Syntax.exports);
-                FStar_Syntax_Syntax.is_interface =
-                  (uu___106_4709.FStar_Syntax_Syntax.is_interface)
-              } in
-            (modul1, exports, env1)
-let check_exports:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit
-  =
-  fun env  ->
-    fun modul  ->
-      fun exports  ->
-        let env1 =
-          let uu___107_4723 = env in
-          {
-            FStar_TypeChecker_Env.solver =
-              (uu___107_4723.FStar_TypeChecker_Env.solver);
-            FStar_TypeChecker_Env.range =
-              (uu___107_4723.FStar_TypeChecker_Env.range);
-            FStar_TypeChecker_Env.curmodule =
-              (uu___107_4723.FStar_TypeChecker_Env.curmodule);
-            FStar_TypeChecker_Env.gamma =
-              (uu___107_4723.FStar_TypeChecker_Env.gamma);
-            FStar_TypeChecker_Env.gamma_cache =
-              (uu___107_4723.FStar_TypeChecker_Env.gamma_cache);
-            FStar_TypeChecker_Env.modules =
-              (uu___107_4723.FStar_TypeChecker_Env.modules);
-            FStar_TypeChecker_Env.expected_typ =
-              (uu___107_4723.FStar_TypeChecker_Env.expected_typ);
-            FStar_TypeChecker_Env.sigtab =
-              (uu___107_4723.FStar_TypeChecker_Env.sigtab);
-            FStar_TypeChecker_Env.is_pattern =
-              (uu___107_4723.FStar_TypeChecker_Env.is_pattern);
-            FStar_TypeChecker_Env.instantiate_imp =
-              (uu___107_4723.FStar_TypeChecker_Env.instantiate_imp);
-            FStar_TypeChecker_Env.effects =
-              (uu___107_4723.FStar_TypeChecker_Env.effects);
-            FStar_TypeChecker_Env.generalize =
-              (uu___107_4723.FStar_TypeChecker_Env.generalize);
-            FStar_TypeChecker_Env.letrecs =
-              (uu___107_4723.FStar_TypeChecker_Env.letrecs);
-            FStar_TypeChecker_Env.top_level = true;
-            FStar_TypeChecker_Env.check_uvars =
-              (uu___107_4723.FStar_TypeChecker_Env.check_uvars);
-            FStar_TypeChecker_Env.use_eq =
-              (uu___107_4723.FStar_TypeChecker_Env.use_eq);
-            FStar_TypeChecker_Env.is_iface =
-              (uu___107_4723.FStar_TypeChecker_Env.is_iface);
-            FStar_TypeChecker_Env.admit =
-              (uu___107_4723.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = true;
-            FStar_TypeChecker_Env.lax_universes = true;
-            FStar_TypeChecker_Env.type_of =
-              (uu___107_4723.FStar_TypeChecker_Env.type_of);
-            FStar_TypeChecker_Env.universe_of =
-              (uu___107_4723.FStar_TypeChecker_Env.universe_of);
-            FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___107_4723.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qname_and_index =
-              (uu___107_4723.FStar_TypeChecker_Env.qname_and_index)
-          } in
-        let check_term lid univs1 t =
-          let uu____4734 = FStar_Syntax_Subst.open_univ_vars univs1 t in
-          match uu____4734 with
-          | (univs2,t1) ->
-              ((let uu____4740 =
-                  let uu____4741 =
-                    let uu____4744 =
-                      FStar_TypeChecker_Env.set_current_module env1
-                        modul.FStar_Syntax_Syntax.name in
-                    FStar_TypeChecker_Env.debug uu____4744 in
-                  FStar_All.pipe_left uu____4741
-                    (FStar_Options.Other "Exports") in
-                if uu____4740
-                then
-                  let uu____4745 = FStar_Syntax_Print.lid_to_string lid in
-                  let uu____4746 =
-                    let uu____4747 =
-                      FStar_All.pipe_right univs2
-                        (FStar_List.map
-                           (fun x  ->
-                              FStar_Syntax_Print.univ_to_string
-                                (FStar_Syntax_Syntax.U_name x))) in
-                    FStar_All.pipe_right uu____4747
-                      (FStar_String.concat ", ") in
-                  let uu____4752 = FStar_Syntax_Print.term_to_string t1 in
-                  FStar_Util.print3 "Checking for export %s <%s> : %s\n"
-                    uu____4745 uu____4746 uu____4752
-                else ());
-               (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs2 in
-                let uu____4755 =
-                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1 in
-                FStar_All.pipe_right uu____4755 Prims.ignore)) in
-        let check_term1 lid univs1 t =
-          (let uu____4773 =
-             let uu____4774 =
-               FStar_Syntax_Print.lid_to_string
-                 modul.FStar_Syntax_Syntax.name in
-             let uu____4775 = FStar_Syntax_Print.lid_to_string lid in
-             FStar_Util.format2
-               "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____4774 uu____4775 in
-           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____4773);
-          check_term lid univs1 t;
-          FStar_Errors.message_prefix.FStar_Errors.clear_prefix () in
-        let rec check_sigelt uu___86_4780 =
-          match uu___86_4780 with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,quals,uu____4783,uu____4784)
-              ->
-              let uu____4791 =
-                let uu____4792 =
-                  FStar_All.pipe_right quals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
-                Prims.op_Negation uu____4792 in
-              if uu____4791
-              then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
-              else ()
-          | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,univs1,binders,typ,uu____4800,uu____4801,uu____4802,r) ->
-              let t =
-                let uu____4813 =
-                  let uu____4816 =
-                    let uu____4817 =
-                      let uu____4825 = FStar_Syntax_Syntax.mk_Total typ in
-                      (binders, uu____4825) in
-                    FStar_Syntax_Syntax.Tm_arrow uu____4817 in
-                  FStar_Syntax_Syntax.mk uu____4816 in
-                uu____4813 None r in
-              check_term1 l univs1 t
-          | FStar_Syntax_Syntax.Sig_datacon
-              (l,univs1,t,uu____4837,uu____4838,uu____4839,uu____4840,uu____4841)
-              -> check_term1 l univs1 t
-          | FStar_Syntax_Syntax.Sig_declare_typ (l,univs1,t,quals,uu____4850)
-              ->
-              let uu____4853 =
-                let uu____4854 =
-                  FStar_All.pipe_right quals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
-                Prims.op_Negation uu____4854 in
-              if uu____4853 then check_term1 l univs1 t else ()
-          | FStar_Syntax_Syntax.Sig_let
-              ((uu____4857,lbs),uu____4859,uu____4860,quals,uu____4862) ->
-              let uu____4874 =
-                let uu____4875 =
-                  FStar_All.pipe_right quals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
-                Prims.op_Negation uu____4875 in
-              if uu____4874
-              then
-                FStar_All.pipe_right lbs
-                  (FStar_List.iter
-                     (fun lb  ->
-                        let fv =
-                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                        check_term1
-                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                          lb.FStar_Syntax_Syntax.lbunivs
-                          lb.FStar_Syntax_Syntax.lbtyp))
-              else ()
-          | FStar_Syntax_Syntax.Sig_effect_abbrev
-              (l,univs1,binders,comp,quals,flags,r) ->
-              let uu____4896 =
-                let uu____4897 =
-                  FStar_All.pipe_right quals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
-                Prims.op_Negation uu____4897 in
-              if uu____4896
-              then
-                let arrow1 =
-                  (FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_arrow (binders, comp))) None r in
-                check_term1 l univs1 arrow1
-              else ()
-          | FStar_Syntax_Syntax.Sig_main _
-            |FStar_Syntax_Syntax.Sig_assume _
-             |FStar_Syntax_Syntax.Sig_new_effect _
-              |FStar_Syntax_Syntax.Sig_new_effect_for_free _
-               |FStar_Syntax_Syntax.Sig_sub_effect _
-                |FStar_Syntax_Syntax.Sig_pragma _
-              -> () in
-        if
-          FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
-            FStar_Syntax_Const.prims_lid
-        then ()
-        else FStar_List.iter check_sigelt exports
-let finish_partial_modul:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      FStar_Syntax_Syntax.sigelts ->
-        (FStar_Syntax_Syntax.modul* FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun modul  ->
-      fun exports  ->
-        let modul1 =
-          let uu___108_4930 = modul in
-          {
-            FStar_Syntax_Syntax.name =
-              (uu___108_4930.FStar_Syntax_Syntax.name);
-            FStar_Syntax_Syntax.declarations =
-              (uu___108_4930.FStar_Syntax_Syntax.declarations);
-            FStar_Syntax_Syntax.exports = exports;
-            FStar_Syntax_Syntax.is_interface =
-              (modul.FStar_Syntax_Syntax.is_interface)
-          } in
-        let env1 = FStar_TypeChecker_Env.finish_module env modul1 in
-        (let uu____4933 =
-           let uu____4934 = FStar_Options.lax () in
-           Prims.op_Negation uu____4934 in
-         if uu____4933 then check_exports env1 modul1 exports else ());
-        (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
-          (Prims.strcat "Ending modul "
-             (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str);
-        (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_modul
-          env1 modul1;
-        (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh ();
-        (let uu____4940 =
-           let uu____4941 = FStar_Options.interactive () in
-           Prims.op_Negation uu____4941 in
-         if uu____4940
-         then
-           let uu____4942 = FStar_Options.restore_cmd_line_options true in
-           FStar_All.pipe_right uu____4942 Prims.ignore
-         else ());
-        (modul1, env1)
-let tc_modul:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      (FStar_Syntax_Syntax.modul* FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun modul  ->
-      let uu____4952 = tc_partial_modul env modul in
-      match uu____4952 with
-      | (modul1,non_private_decls,env1) ->
-          finish_partial_modul env1 modul1 non_private_decls
-let check_module:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul ->
-      (FStar_Syntax_Syntax.modul* FStar_TypeChecker_Env.env)
-  =
-  fun env  ->
-    fun m  ->
-      (let uu____4973 = FStar_Options.debug_any () in
-       if uu____4973
-       then
-         let uu____4974 =
-           FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
-         FStar_Util.print2 "Checking %s: %s\n"
-           (if m.FStar_Syntax_Syntax.is_interface then "i'face" else "module")
-           uu____4974
-       else ());
-      (let env1 =
-         let uu___109_4978 = env in
-         let uu____4979 =
-           let uu____4980 =
-             FStar_Options.should_verify
-               (m.FStar_Syntax_Syntax.name).FStar_Ident.str in
-           Prims.op_Negation uu____4980 in
-         {
-           FStar_TypeChecker_Env.solver =
-             (uu___109_4978.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___109_4978.FStar_TypeChecker_Env.range);
-           FStar_TypeChecker_Env.curmodule =
-             (uu___109_4978.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___109_4978.FStar_TypeChecker_Env.gamma);
-           FStar_TypeChecker_Env.gamma_cache =
-             (uu___109_4978.FStar_TypeChecker_Env.gamma_cache);
-           FStar_TypeChecker_Env.modules =
-             (uu___109_4978.FStar_TypeChecker_Env.modules);
-           FStar_TypeChecker_Env.expected_typ =
-             (uu___109_4978.FStar_TypeChecker_Env.expected_typ);
-           FStar_TypeChecker_Env.sigtab =
-             (uu___109_4978.FStar_TypeChecker_Env.sigtab);
-           FStar_TypeChecker_Env.is_pattern =
-             (uu___109_4978.FStar_TypeChecker_Env.is_pattern);
-           FStar_TypeChecker_Env.instantiate_imp =
-             (uu___109_4978.FStar_TypeChecker_Env.instantiate_imp);
-           FStar_TypeChecker_Env.effects =
-             (uu___109_4978.FStar_TypeChecker_Env.effects);
-           FStar_TypeChecker_Env.generalize =
-             (uu___109_4978.FStar_TypeChecker_Env.generalize);
-           FStar_TypeChecker_Env.letrecs =
-             (uu___109_4978.FStar_TypeChecker_Env.letrecs);
-           FStar_TypeChecker_Env.top_level =
-             (uu___109_4978.FStar_TypeChecker_Env.top_level);
-           FStar_TypeChecker_Env.check_uvars =
-             (uu___109_4978.FStar_TypeChecker_Env.check_uvars);
-           FStar_TypeChecker_Env.use_eq =
-             (uu___109_4978.FStar_TypeChecker_Env.use_eq);
-           FStar_TypeChecker_Env.is_iface =
-             (uu___109_4978.FStar_TypeChecker_Env.is_iface);
-           FStar_TypeChecker_Env.admit =
-             (uu___109_4978.FStar_TypeChecker_Env.admit);
-           FStar_TypeChecker_Env.lax = uu____4979;
-           FStar_TypeChecker_Env.lax_universes =
-             (uu___109_4978.FStar_TypeChecker_Env.lax_universes);
-           FStar_TypeChecker_Env.type_of =
-             (uu___109_4978.FStar_TypeChecker_Env.type_of);
-           FStar_TypeChecker_Env.universe_of =
-             (uu___109_4978.FStar_TypeChecker_Env.universe_of);
-           FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___109_4978.FStar_TypeChecker_Env.use_bv_sorts);
-           FStar_TypeChecker_Env.qname_and_index =
-             (uu___109_4978.FStar_TypeChecker_Env.qname_and_index)
-         } in
-       let uu____4981 = tc_modul env1 m in
-       match uu____4981 with
-       | (m1,env2) ->
-           ((let uu____4989 =
-               FStar_Options.dump_module
-                 (m1.FStar_Syntax_Syntax.name).FStar_Ident.str in
-             if uu____4989
-             then
-               let uu____4990 = FStar_Syntax_Print.modul_to_string m1 in
-               FStar_Util.print1 "%s\n" uu____4990
-             else ());
-            (let uu____4993 =
-               (FStar_Options.dump_module
-                  (m1.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                 &&
-                 (FStar_Options.debug_at_level
-                    (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                    (FStar_Options.Other "Normalize")) in
-             if uu____4993
-             then
-               let normalize_toplevel_lets uu___87_4997 =
-                 match uu___87_4997 with
-                 | FStar_Syntax_Syntax.Sig_let ((b,lbs),r,ids,qs,attrs) ->
-                     let n1 =
-                       FStar_TypeChecker_Normalize.normalize
-                         [FStar_TypeChecker_Normalize.Beta;
-                         FStar_TypeChecker_Normalize.Eager_unfolding;
-                         FStar_TypeChecker_Normalize.Reify;
-                         FStar_TypeChecker_Normalize.Inlining;
-                         FStar_TypeChecker_Normalize.Primops;
-                         FStar_TypeChecker_Normalize.UnfoldUntil
-                           FStar_Syntax_Syntax.Delta_constant;
-                         FStar_TypeChecker_Normalize.AllowUnboundUniverses] in
-                     let update lb =
-                       let uu____5024 =
-                         FStar_Syntax_Subst.open_univ_vars
-                           lb.FStar_Syntax_Syntax.lbunivs
-                           lb.FStar_Syntax_Syntax.lbdef in
-                       match uu____5024 with
-                       | (univnames1,e) ->
-                           let uu___110_5029 = lb in
-                           let uu____5030 =
-                             let uu____5033 =
-                               FStar_TypeChecker_Env.push_univ_vars env2
-                                 univnames1 in
-                             n1 uu____5033 e in
-                           {
-                             FStar_Syntax_Syntax.lbname =
-                               (uu___110_5029.FStar_Syntax_Syntax.lbname);
-                             FStar_Syntax_Syntax.lbunivs =
-                               (uu___110_5029.FStar_Syntax_Syntax.lbunivs);
-                             FStar_Syntax_Syntax.lbtyp =
-                               (uu___110_5029.FStar_Syntax_Syntax.lbtyp);
-                             FStar_Syntax_Syntax.lbeff =
-                               (uu___110_5029.FStar_Syntax_Syntax.lbeff);
-                             FStar_Syntax_Syntax.lbdef = uu____5030
-                           } in
-                     let uu____5034 =
-                       let uu____5043 =
-                         let uu____5047 = FStar_List.map update lbs in
-                         (b, uu____5047) in
-                       (uu____5043, r, ids, qs, attrs) in
-                     FStar_Syntax_Syntax.Sig_let uu____5034
-                 | se -> se in
-               let normalized_module =
-                 let uu___111_5058 = m1 in
-                 let uu____5059 =
-                   FStar_List.map normalize_toplevel_lets
-                     m1.FStar_Syntax_Syntax.declarations in
-                 {
-                   FStar_Syntax_Syntax.name =
-                     (uu___111_5058.FStar_Syntax_Syntax.name);
-                   FStar_Syntax_Syntax.declarations = uu____5059;
-                   FStar_Syntax_Syntax.exports =
-                     (uu___111_5058.FStar_Syntax_Syntax.exports);
-                   FStar_Syntax_Syntax.is_interface =
-                     (uu___111_5058.FStar_Syntax_Syntax.is_interface)
-                 } in
-               let uu____5060 =
-                 FStar_Syntax_Print.modul_to_string normalized_module in
-               FStar_Util.print1 "%s\n" uu____5060
-             else ());
-            (m1, env2)))
+
+let set_hint_correlator : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt  ->  FStar_TypeChecker_Env.env = (fun env se -> (
+
+let uu____7 = (FStar_Options.reuse_hint_for ())
+in (match (uu____7) with
+| Some (l) -> begin
+(
+
+let lid = (
+
+let uu____11 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_add_suffix uu____11 l))
+in (
+
+let uu___84_12 = env
+in {FStar_TypeChecker_Env.solver = uu___84_12.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___84_12.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___84_12.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___84_12.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___84_12.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___84_12.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___84_12.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___84_12.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___84_12.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___84_12.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___84_12.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___84_12.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___84_12.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___84_12.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___84_12.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___84_12.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___84_12.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___84_12.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___84_12.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___84_12.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___84_12.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___84_12.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___84_12.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = Some (((lid), ((Prims.parse_int "0"))))}))
+end
+| None -> begin
+(
+
+let lids = (FStar_Syntax_Util.lids_of_sigelt se)
+in (
+
+let lid = (match (lids) with
+| [] -> begin
+(
+
+let uu____18 = (FStar_TypeChecker_Env.current_module env)
+in (
+
+let uu____19 = (
+
+let uu____20 = (FStar_Syntax_Syntax.next_id ())
+in (FStar_All.pipe_right uu____20 FStar_Util.string_of_int))
+in (FStar_Ident.lid_add_suffix uu____18 uu____19)))
+end
+| (l)::uu____22 -> begin
+l
+end)
+in (
+
+let uu___85_24 = env
+in {FStar_TypeChecker_Env.solver = uu___85_24.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___85_24.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___85_24.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___85_24.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___85_24.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___85_24.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___85_24.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___85_24.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___85_24.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___85_24.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___85_24.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___85_24.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___85_24.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___85_24.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___85_24.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___85_24.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___85_24.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___85_24.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___85_24.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___85_24.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___85_24.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___85_24.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___85_24.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = Some (((lid), ((Prims.parse_int "0"))))})))
+end)))
+
+
+let log : FStar_TypeChecker_Env.env  ->  Prims.bool = (fun env -> ((FStar_Options.log_types ()) && (
+
+let uu____30 = (
+
+let uu____31 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____31))
+in (not (uu____30)))))
+
+
+let tc_check_trivial_guard : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun env t k -> (
+
+let uu____41 = (FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term env t k)
+in (match (uu____41) with
+| (t1, c, g) -> begin
+((FStar_ST.write t1.FStar_Syntax_Syntax.tk (Some (c.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)));
+(FStar_TypeChecker_Rel.force_trivial_guard env g);
+t1;
+)
+end)))
+
+
+let recheck_debug : Prims.string  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun s env t -> ((
+
+let uu____63 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("ED")))
+in (match (uu____63) with
+| true -> begin
+(
+
+let uu____64 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print2 "Term has been %s-transformed to:\n%s\n----------\n" s uu____64))
+end
+| uu____65 -> begin
+()
+end));
+(
+
+let uu____66 = (FStar_TypeChecker_TcTerm.tc_term env t)
+in (match (uu____66) with
+| (t', uu____71, uu____72) -> begin
+((
+
+let uu____74 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("ED")))
+in (match (uu____74) with
+| true -> begin
+(
+
+let uu____75 = (FStar_Syntax_Print.term_to_string t')
+in (FStar_Util.print1 "Re-checked; got:\n%s\n----------\n" uu____75))
+end
+| uu____76 -> begin
+()
+end));
+t;
+)
+end));
+))
+
+
+let check_and_gen : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.tscheme = (fun env t k -> (
+
+let uu____86 = (tc_check_trivial_guard env t k)
+in (FStar_TypeChecker_Util.generalize_universes env uu____86)))
+
+
+let check_nogen = (fun env t k -> (
+
+let t1 = (tc_check_trivial_guard env t k)
+in (
+
+let uu____108 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env t1)
+in (([]), (uu____108)))))
+
+
+let monad_signature : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.bv * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax) = (fun env m s -> (
+
+let fail = (fun uu____130 -> (
+
+let uu____131 = (
+
+let uu____132 = (
+
+let uu____135 = (FStar_TypeChecker_Err.unexpected_signature_for_monad env m s)
+in ((uu____135), ((FStar_Ident.range_of_lid m))))
+in FStar_Errors.Error (uu____132))
+in (Prims.raise uu____131)))
+in (
+
+let s1 = (FStar_Syntax_Subst.compress s)
+in (match (s1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let bs1 = (FStar_Syntax_Subst.open_binders bs)
+in (match (bs1) with
+| ((a, uu____163))::((wp, uu____165))::[] -> begin
+((a), (wp.FStar_Syntax_Syntax.sort))
+end
+| uu____174 -> begin
+(fail ())
+end))
+end
+| uu____175 -> begin
+(fail ())
+end))))
+
+
+let rec tc_eff_decl : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.eff_decl  ->  FStar_Syntax_Syntax.eff_decl = (fun env0 ed -> (
+
+let uu____238 = (FStar_Syntax_Subst.open_term' ed.FStar_Syntax_Syntax.binders ed.FStar_Syntax_Syntax.signature)
+in (match (uu____238) with
+| (effect_params_un, signature_un, opening) -> begin
+(
+
+let uu____245 = (FStar_TypeChecker_TcTerm.tc_tparams env0 effect_params_un)
+in (match (uu____245) with
+| (effect_params, env, uu____251) -> begin
+(
+
+let uu____252 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env signature_un)
+in (match (uu____252) with
+| (signature, uu____256) -> begin
+(
+
+let ed1 = (
+
+let uu___86_258 = ed
+in {FStar_Syntax_Syntax.qualifiers = uu___86_258.FStar_Syntax_Syntax.qualifiers; FStar_Syntax_Syntax.cattributes = uu___86_258.FStar_Syntax_Syntax.cattributes; FStar_Syntax_Syntax.mname = uu___86_258.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.univs = uu___86_258.FStar_Syntax_Syntax.univs; FStar_Syntax_Syntax.binders = effect_params; FStar_Syntax_Syntax.signature = signature; FStar_Syntax_Syntax.ret_wp = uu___86_258.FStar_Syntax_Syntax.ret_wp; FStar_Syntax_Syntax.bind_wp = uu___86_258.FStar_Syntax_Syntax.bind_wp; FStar_Syntax_Syntax.if_then_else = uu___86_258.FStar_Syntax_Syntax.if_then_else; FStar_Syntax_Syntax.ite_wp = uu___86_258.FStar_Syntax_Syntax.ite_wp; FStar_Syntax_Syntax.stronger = uu___86_258.FStar_Syntax_Syntax.stronger; FStar_Syntax_Syntax.close_wp = uu___86_258.FStar_Syntax_Syntax.close_wp; FStar_Syntax_Syntax.assert_p = uu___86_258.FStar_Syntax_Syntax.assert_p; FStar_Syntax_Syntax.assume_p = uu___86_258.FStar_Syntax_Syntax.assume_p; FStar_Syntax_Syntax.null_wp = uu___86_258.FStar_Syntax_Syntax.null_wp; FStar_Syntax_Syntax.trivial = uu___86_258.FStar_Syntax_Syntax.trivial; FStar_Syntax_Syntax.repr = uu___86_258.FStar_Syntax_Syntax.repr; FStar_Syntax_Syntax.return_repr = uu___86_258.FStar_Syntax_Syntax.return_repr; FStar_Syntax_Syntax.bind_repr = uu___86_258.FStar_Syntax_Syntax.bind_repr; FStar_Syntax_Syntax.actions = uu___86_258.FStar_Syntax_Syntax.actions})
+in (
+
+let ed2 = (match (effect_params) with
+| [] -> begin
+ed1
+end
+| uu____262 -> begin
+(
+
+let op = (fun ts -> (
+
+let t1 = (FStar_Syntax_Subst.subst opening (Prims.snd ts))
+in (([]), (t1))))
+in (
+
+let uu___87_280 = ed1
+in (
+
+let uu____281 = (op ed1.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____282 = (op ed1.FStar_Syntax_Syntax.bind_wp)
+in (
+
+let uu____283 = (op ed1.FStar_Syntax_Syntax.if_then_else)
+in (
+
+let uu____284 = (op ed1.FStar_Syntax_Syntax.ite_wp)
+in (
+
+let uu____285 = (op ed1.FStar_Syntax_Syntax.stronger)
+in (
+
+let uu____286 = (op ed1.FStar_Syntax_Syntax.close_wp)
+in (
+
+let uu____287 = (op ed1.FStar_Syntax_Syntax.assert_p)
+in (
+
+let uu____288 = (op ed1.FStar_Syntax_Syntax.assume_p)
+in (
+
+let uu____289 = (op ed1.FStar_Syntax_Syntax.null_wp)
+in (
+
+let uu____290 = (op ed1.FStar_Syntax_Syntax.trivial)
+in (
+
+let uu____291 = (
+
+let uu____292 = (op (([]), (ed1.FStar_Syntax_Syntax.repr)))
+in (Prims.snd uu____292))
+in (
+
+let uu____298 = (op ed1.FStar_Syntax_Syntax.return_repr)
+in (
+
+let uu____299 = (op ed1.FStar_Syntax_Syntax.bind_repr)
+in (
+
+let uu____300 = (FStar_List.map (fun a -> (
+
+let uu___88_303 = a
+in (
+
+let uu____304 = (
+
+let uu____305 = (op (([]), (a.FStar_Syntax_Syntax.action_defn)))
+in (Prims.snd uu____305))
+in (
+
+let uu____311 = (
+
+let uu____312 = (op (([]), (a.FStar_Syntax_Syntax.action_typ)))
+in (Prims.snd uu____312))
+in {FStar_Syntax_Syntax.action_name = uu___88_303.FStar_Syntax_Syntax.action_name; FStar_Syntax_Syntax.action_unqualified_name = uu___88_303.FStar_Syntax_Syntax.action_unqualified_name; FStar_Syntax_Syntax.action_univs = uu___88_303.FStar_Syntax_Syntax.action_univs; FStar_Syntax_Syntax.action_defn = uu____304; FStar_Syntax_Syntax.action_typ = uu____311})))) ed1.FStar_Syntax_Syntax.actions)
+in {FStar_Syntax_Syntax.qualifiers = uu___87_280.FStar_Syntax_Syntax.qualifiers; FStar_Syntax_Syntax.cattributes = uu___87_280.FStar_Syntax_Syntax.cattributes; FStar_Syntax_Syntax.mname = uu___87_280.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.univs = uu___87_280.FStar_Syntax_Syntax.univs; FStar_Syntax_Syntax.binders = uu___87_280.FStar_Syntax_Syntax.binders; FStar_Syntax_Syntax.signature = uu___87_280.FStar_Syntax_Syntax.signature; FStar_Syntax_Syntax.ret_wp = uu____281; FStar_Syntax_Syntax.bind_wp = uu____282; FStar_Syntax_Syntax.if_then_else = uu____283; FStar_Syntax_Syntax.ite_wp = uu____284; FStar_Syntax_Syntax.stronger = uu____285; FStar_Syntax_Syntax.close_wp = uu____286; FStar_Syntax_Syntax.assert_p = uu____287; FStar_Syntax_Syntax.assume_p = uu____288; FStar_Syntax_Syntax.null_wp = uu____289; FStar_Syntax_Syntax.trivial = uu____290; FStar_Syntax_Syntax.repr = uu____291; FStar_Syntax_Syntax.return_repr = uu____298; FStar_Syntax_Syntax.bind_repr = uu____299; FStar_Syntax_Syntax.actions = uu____300}))))))))))))))))
+end)
+in (
+
+let wp_with_fresh_result_type = (fun env1 mname signature1 -> (
+
+let fail = (fun t -> (
+
+let uu____340 = (
+
+let uu____341 = (
+
+let uu____344 = (FStar_TypeChecker_Err.unexpected_signature_for_monad env1 mname t)
+in ((uu____344), ((FStar_Ident.range_of_lid mname))))
+in FStar_Errors.Error (uu____341))
+in (Prims.raise uu____340)))
+in (
+
+let uu____349 = (
+
+let uu____350 = (FStar_Syntax_Subst.compress signature1)
+in uu____350.FStar_Syntax_Syntax.n)
+in (match (uu____349) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let bs1 = (FStar_Syntax_Subst.open_binders bs)
+in (match (bs1) with
+| ((a, uu____375))::((wp, uu____377))::[] -> begin
+((a), (wp.FStar_Syntax_Syntax.sort))
+end
+| uu____386 -> begin
+(fail signature1)
+end))
+end
+| uu____387 -> begin
+(fail signature1)
+end))))
+in (
+
+let uu____388 = (wp_with_fresh_result_type env ed2.FStar_Syntax_Syntax.mname ed2.FStar_Syntax_Syntax.signature)
+in (match (uu____388) with
+| (a, wp_a) -> begin
+(
+
+let fresh_effect_signature = (fun uu____406 -> (
+
+let uu____407 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env signature_un)
+in (match (uu____407) with
+| (signature1, uu____415) -> begin
+(wp_with_fresh_result_type env ed2.FStar_Syntax_Syntax.mname signature1)
+end)))
+in (
+
+let env1 = (
+
+let uu____417 = (FStar_Syntax_Syntax.new_bv None ed2.FStar_Syntax_Syntax.signature)
+in (FStar_TypeChecker_Env.push_bv env uu____417))
+in ((
+
+let uu____419 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0) (FStar_Options.Other ("ED")))
+in (match (uu____419) with
+| true -> begin
+(
+
+let uu____420 = (FStar_Syntax_Print.lid_to_string ed2.FStar_Syntax_Syntax.mname)
+in (
+
+let uu____421 = (FStar_Syntax_Print.binders_to_string " " ed2.FStar_Syntax_Syntax.binders)
+in (
+
+let uu____422 = (FStar_Syntax_Print.term_to_string ed2.FStar_Syntax_Syntax.signature)
+in (
+
+let uu____423 = (
+
+let uu____424 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Print.term_to_string uu____424))
+in (
+
+let uu____425 = (FStar_Syntax_Print.term_to_string a.FStar_Syntax_Syntax.sort)
+in (FStar_Util.print5 "Checking effect signature: %s %s : %s\n(a is %s:%s)\n" uu____420 uu____421 uu____422 uu____423 uu____425))))))
+end
+| uu____426 -> begin
+()
+end));
+(
+
+let check_and_gen' = (fun env2 uu____438 k -> (match (uu____438) with
+| (uu____443, t) -> begin
+(check_and_gen env2 t k)
+end))
+in (
+
+let return_wp = (
+
+let expected_k = (
+
+let uu____451 = (
+
+let uu____455 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____456 = (
+
+let uu____458 = (
+
+let uu____459 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.null_binder uu____459))
+in (uu____458)::[])
+in (uu____455)::uu____456))
+in (
+
+let uu____460 = (FStar_Syntax_Syntax.mk_GTotal wp_a)
+in (FStar_Syntax_Util.arrow uu____451 uu____460)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.ret_wp expected_k))
+in (
+
+let bind_wp = (
+
+let uu____464 = (fresh_effect_signature ())
+in (match (uu____464) with
+| (b, wp_b) -> begin
+(
+
+let a_wp_b = (
+
+let uu____478 = (
+
+let uu____482 = (
+
+let uu____483 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.null_binder uu____483))
+in (uu____482)::[])
+in (
+
+let uu____484 = (FStar_Syntax_Syntax.mk_Total wp_b)
+in (FStar_Syntax_Util.arrow uu____478 uu____484)))
+in (
+
+let expected_k = (
+
+let uu____490 = (
+
+let uu____494 = (FStar_Syntax_Syntax.null_binder FStar_TypeChecker_Common.t_range)
+in (
+
+let uu____495 = (
+
+let uu____497 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____498 = (
+
+let uu____500 = (FStar_Syntax_Syntax.mk_binder b)
+in (
+
+let uu____501 = (
+
+let uu____503 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (
+
+let uu____504 = (
+
+let uu____506 = (FStar_Syntax_Syntax.null_binder a_wp_b)
+in (uu____506)::[])
+in (uu____503)::uu____504))
+in (uu____500)::uu____501))
+in (uu____497)::uu____498))
+in (uu____494)::uu____495))
+in (
+
+let uu____507 = (FStar_Syntax_Syntax.mk_Total wp_b)
+in (FStar_Syntax_Util.arrow uu____490 uu____507)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.bind_wp expected_k)))
+end))
+in (
+
+let if_then_else1 = (
+
+let p = (
+
+let uu____512 = (
+
+let uu____513 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____513 Prims.fst))
+in (FStar_Syntax_Syntax.new_bv (Some ((FStar_Ident.range_of_lid ed2.FStar_Syntax_Syntax.mname))) uu____512))
+in (
+
+let expected_k = (
+
+let uu____521 = (
+
+let uu____525 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____526 = (
+
+let uu____528 = (FStar_Syntax_Syntax.mk_binder p)
+in (
+
+let uu____529 = (
+
+let uu____531 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (
+
+let uu____532 = (
+
+let uu____534 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____534)::[])
+in (uu____531)::uu____532))
+in (uu____528)::uu____529))
+in (uu____525)::uu____526))
+in (
+
+let uu____535 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____521 uu____535)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.if_then_else expected_k)))
+in (
+
+let ite_wp = (
+
+let expected_k = (
+
+let uu____542 = (
+
+let uu____546 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____547 = (
+
+let uu____549 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____549)::[])
+in (uu____546)::uu____547))
+in (
+
+let uu____550 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____542 uu____550)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.ite_wp expected_k))
+in (
+
+let stronger = (
+
+let uu____554 = (FStar_Syntax_Util.type_u ())
+in (match (uu____554) with
+| (t, uu____558) -> begin
+(
+
+let expected_k = (
+
+let uu____562 = (
+
+let uu____566 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____567 = (
+
+let uu____569 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (
+
+let uu____570 = (
+
+let uu____572 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____572)::[])
+in (uu____569)::uu____570))
+in (uu____566)::uu____567))
+in (
+
+let uu____573 = (FStar_Syntax_Syntax.mk_Total t)
+in (FStar_Syntax_Util.arrow uu____562 uu____573)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.stronger expected_k))
+end))
+in (
+
+let close_wp = (
+
+let b = (
+
+let uu____578 = (
+
+let uu____579 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____579 Prims.fst))
+in (FStar_Syntax_Syntax.new_bv (Some ((FStar_Ident.range_of_lid ed2.FStar_Syntax_Syntax.mname))) uu____578))
+in (
+
+let b_wp_a = (
+
+let uu____587 = (
+
+let uu____591 = (
+
+let uu____592 = (FStar_Syntax_Syntax.bv_to_name b)
+in (FStar_Syntax_Syntax.null_binder uu____592))
+in (uu____591)::[])
+in (
+
+let uu____593 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____587 uu____593)))
+in (
+
+let expected_k = (
+
+let uu____599 = (
+
+let uu____603 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____604 = (
+
+let uu____606 = (FStar_Syntax_Syntax.mk_binder b)
+in (
+
+let uu____607 = (
+
+let uu____609 = (FStar_Syntax_Syntax.null_binder b_wp_a)
+in (uu____609)::[])
+in (uu____606)::uu____607))
+in (uu____603)::uu____604))
+in (
+
+let uu____610 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____599 uu____610)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.close_wp expected_k))))
+in (
+
+let assert_p = (
+
+let expected_k = (
+
+let uu____617 = (
+
+let uu____621 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____622 = (
+
+let uu____624 = (
+
+let uu____625 = (
+
+let uu____626 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____626 Prims.fst))
+in (FStar_Syntax_Syntax.null_binder uu____625))
+in (
+
+let uu____631 = (
+
+let uu____633 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____633)::[])
+in (uu____624)::uu____631))
+in (uu____621)::uu____622))
+in (
+
+let uu____634 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____617 uu____634)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.assert_p expected_k))
+in (
+
+let assume_p = (
+
+let expected_k = (
+
+let uu____641 = (
+
+let uu____645 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____646 = (
+
+let uu____648 = (
+
+let uu____649 = (
+
+let uu____650 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____650 Prims.fst))
+in (FStar_Syntax_Syntax.null_binder uu____649))
+in (
+
+let uu____655 = (
+
+let uu____657 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____657)::[])
+in (uu____648)::uu____655))
+in (uu____645)::uu____646))
+in (
+
+let uu____658 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____641 uu____658)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.assume_p expected_k))
+in (
+
+let null_wp = (
+
+let expected_k = (
+
+let uu____665 = (
+
+let uu____669 = (FStar_Syntax_Syntax.mk_binder a)
+in (uu____669)::[])
+in (
+
+let uu____670 = (FStar_Syntax_Syntax.mk_Total wp_a)
+in (FStar_Syntax_Util.arrow uu____665 uu____670)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.null_wp expected_k))
+in (
+
+let trivial_wp = (
+
+let uu____674 = (FStar_Syntax_Util.type_u ())
+in (match (uu____674) with
+| (t, uu____678) -> begin
+(
+
+let expected_k = (
+
+let uu____682 = (
+
+let uu____686 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____687 = (
+
+let uu____689 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____689)::[])
+in (uu____686)::uu____687))
+in (
+
+let uu____690 = (FStar_Syntax_Syntax.mk_GTotal t)
+in (FStar_Syntax_Util.arrow uu____682 uu____690)))
+in (check_and_gen' env1 ed2.FStar_Syntax_Syntax.trivial expected_k))
+end))
+in (
+
+let uu____693 = (
+
+let uu____699 = (
+
+let uu____700 = (FStar_Syntax_Subst.compress ed2.FStar_Syntax_Syntax.repr)
+in uu____700.FStar_Syntax_Syntax.n)
+in (match (uu____699) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+((ed2.FStar_Syntax_Syntax.repr), (ed2.FStar_Syntax_Syntax.bind_repr), (ed2.FStar_Syntax_Syntax.return_repr), (ed2.FStar_Syntax_Syntax.actions))
+end
+| uu____709 -> begin
+(
+
+let repr = (
+
+let uu____711 = (FStar_Syntax_Util.type_u ())
+in (match (uu____711) with
+| (t, uu____715) -> begin
+(
+
+let expected_k = (
+
+let uu____719 = (
+
+let uu____723 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____724 = (
+
+let uu____726 = (FStar_Syntax_Syntax.null_binder wp_a)
+in (uu____726)::[])
+in (uu____723)::uu____724))
+in (
+
+let uu____727 = (FStar_Syntax_Syntax.mk_GTotal t)
+in (FStar_Syntax_Util.arrow uu____719 uu____727)))
+in (tc_check_trivial_guard env1 ed2.FStar_Syntax_Syntax.repr expected_k))
+end))
+in (
+
+let mk_repr' = (fun t wp -> (
+
+let repr1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env1 repr)
+in (
+
+let uu____740 = (
+
+let uu____743 = (
+
+let uu____744 = (
+
+let uu____754 = (
+
+let uu____756 = (FStar_Syntax_Syntax.as_arg t)
+in (
+
+let uu____757 = (
+
+let uu____759 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____759)::[])
+in (uu____756)::uu____757))
+in ((repr1), (uu____754)))
+in FStar_Syntax_Syntax.Tm_app (uu____744))
+in (FStar_Syntax_Syntax.mk uu____743))
+in (uu____740 None FStar_Range.dummyRange))))
+in (
+
+let mk_repr = (fun a1 wp -> (
+
+let uu____778 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (mk_repr' uu____778 wp)))
+in (
+
+let destruct_repr = (fun t -> (
+
+let uu____789 = (
+
+let uu____790 = (FStar_Syntax_Subst.compress t)
+in uu____790.FStar_Syntax_Syntax.n)
+in (match (uu____789) with
+| FStar_Syntax_Syntax.Tm_app (uu____799, ((t1, uu____801))::((wp, uu____803))::[]) -> begin
+((t1), (wp))
+end
+| uu____837 -> begin
+(failwith "Unexpected repr type")
+end)))
+in (
+
+let bind_repr = (
+
+let r = (
+
+let uu____846 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.range_0 FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_All.pipe_right uu____846 FStar_Syntax_Syntax.fv_to_tm))
+in (
+
+let uu____847 = (fresh_effect_signature ())
+in (match (uu____847) with
+| (b, wp_b) -> begin
+(
+
+let a_wp_b = (
+
+let uu____861 = (
+
+let uu____865 = (
+
+let uu____866 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.null_binder uu____866))
+in (uu____865)::[])
+in (
+
+let uu____867 = (FStar_Syntax_Syntax.mk_Total wp_b)
+in (FStar_Syntax_Util.arrow uu____861 uu____867)))
+in (
+
+let wp_f = (FStar_Syntax_Syntax.gen_bv "wp_f" None wp_a)
+in (
+
+let wp_g = (FStar_Syntax_Syntax.gen_bv "wp_g" None a_wp_b)
+in (
+
+let x_a = (
+
+let uu____873 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.gen_bv "x_a" None uu____873))
+in (
+
+let wp_g_x = (
+
+let uu____877 = (
+
+let uu____878 = (FStar_Syntax_Syntax.bv_to_name wp_g)
+in (
+
+let uu____879 = (
+
+let uu____880 = (
+
+let uu____881 = (FStar_Syntax_Syntax.bv_to_name x_a)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____881))
+in (uu____880)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____878 uu____879)))
+in (uu____877 None FStar_Range.dummyRange))
+in (
+
+let res = (
+
+let wp = (
+
+let uu____892 = (
+
+let uu____893 = (
+
+let uu____894 = (FStar_TypeChecker_Env.inst_tscheme bind_wp)
+in (FStar_All.pipe_right uu____894 Prims.snd))
+in (
+
+let uu____899 = (
+
+let uu____900 = (
+
+let uu____902 = (
+
+let uu____904 = (FStar_Syntax_Syntax.bv_to_name a)
+in (
+
+let uu____905 = (
+
+let uu____907 = (FStar_Syntax_Syntax.bv_to_name b)
+in (
+
+let uu____908 = (
+
+let uu____910 = (FStar_Syntax_Syntax.bv_to_name wp_f)
+in (
+
+let uu____911 = (
+
+let uu____913 = (FStar_Syntax_Syntax.bv_to_name wp_g)
+in (uu____913)::[])
+in (uu____910)::uu____911))
+in (uu____907)::uu____908))
+in (uu____904)::uu____905))
+in (r)::uu____902)
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____900))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____893 uu____899)))
+in (uu____892 None FStar_Range.dummyRange))
+in (mk_repr b wp))
+in (
+
+let expected_k = (
+
+let uu____921 = (
+
+let uu____925 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____926 = (
+
+let uu____928 = (FStar_Syntax_Syntax.mk_binder b)
+in (
+
+let uu____929 = (
+
+let uu____931 = (FStar_Syntax_Syntax.mk_binder wp_f)
+in (
+
+let uu____932 = (
+
+let uu____934 = (
+
+let uu____935 = (
+
+let uu____936 = (FStar_Syntax_Syntax.bv_to_name wp_f)
+in (mk_repr a uu____936))
+in (FStar_Syntax_Syntax.null_binder uu____935))
+in (
+
+let uu____937 = (
+
+let uu____939 = (FStar_Syntax_Syntax.mk_binder wp_g)
+in (
+
+let uu____940 = (
+
+let uu____942 = (
+
+let uu____943 = (
+
+let uu____944 = (
+
+let uu____948 = (FStar_Syntax_Syntax.mk_binder x_a)
+in (uu____948)::[])
+in (
+
+let uu____949 = (
+
+let uu____952 = (mk_repr b wp_g_x)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu____952))
+in (FStar_Syntax_Util.arrow uu____944 uu____949)))
+in (FStar_Syntax_Syntax.null_binder uu____943))
+in (uu____942)::[])
+in (uu____939)::uu____940))
+in (uu____934)::uu____937))
+in (uu____931)::uu____932))
+in (uu____928)::uu____929))
+in (uu____925)::uu____926))
+in (
+
+let uu____953 = (FStar_Syntax_Syntax.mk_Total res)
+in (FStar_Syntax_Util.arrow uu____921 uu____953)))
+in (
+
+let uu____956 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1 expected_k)
+in (match (uu____956) with
+| (expected_k1, uu____961, uu____962) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 (Prims.snd ed2.FStar_Syntax_Syntax.bind_repr).FStar_Syntax_Syntax.pos)
+in (
+
+let env3 = (
+
+let uu___89_966 = env2
+in {FStar_TypeChecker_Env.solver = uu___89_966.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___89_966.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___89_966.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___89_966.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___89_966.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___89_966.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___89_966.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___89_966.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___89_966.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___89_966.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___89_966.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___89_966.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___89_966.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___89_966.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___89_966.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___89_966.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___89_966.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___89_966.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___89_966.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___89_966.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___89_966.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___89_966.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___89_966.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let br = (check_and_gen' env3 ed2.FStar_Syntax_Syntax.bind_repr expected_k1)
+in br)))
+end)))))))))
+end)))
+in (
+
+let return_repr = (
+
+let x_a = (
+
+let uu____973 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.gen_bv "x_a" None uu____973))
+in (
+
+let res = (
+
+let wp = (
+
+let uu____980 = (
+
+let uu____981 = (
+
+let uu____982 = (FStar_TypeChecker_Env.inst_tscheme return_wp)
+in (FStar_All.pipe_right uu____982 Prims.snd))
+in (
+
+let uu____987 = (
+
+let uu____988 = (
+
+let uu____990 = (FStar_Syntax_Syntax.bv_to_name a)
+in (
+
+let uu____991 = (
+
+let uu____993 = (FStar_Syntax_Syntax.bv_to_name x_a)
+in (uu____993)::[])
+in (uu____990)::uu____991))
+in (FStar_List.map FStar_Syntax_Syntax.as_arg uu____988))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____981 uu____987)))
+in (uu____980 None FStar_Range.dummyRange))
+in (mk_repr a wp))
+in (
+
+let expected_k = (
+
+let uu____1001 = (
+
+let uu____1005 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____1006 = (
+
+let uu____1008 = (FStar_Syntax_Syntax.mk_binder x_a)
+in (uu____1008)::[])
+in (uu____1005)::uu____1006))
+in (
+
+let uu____1009 = (FStar_Syntax_Syntax.mk_Total res)
+in (FStar_Syntax_Util.arrow uu____1001 uu____1009)))
+in (
+
+let uu____1012 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1 expected_k)
+in (match (uu____1012) with
+| (expected_k1, uu____1020, uu____1021) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 (Prims.snd ed2.FStar_Syntax_Syntax.return_repr).FStar_Syntax_Syntax.pos)
+in (
+
+let uu____1024 = (check_and_gen' env2 ed2.FStar_Syntax_Syntax.return_repr expected_k1)
+in (match (uu____1024) with
+| (univs1, repr1) -> begin
+(match (univs1) with
+| [] -> begin
+(([]), (repr1))
+end
+| uu____1036 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected universe-polymorphic return for effect"), (repr1.FStar_Syntax_Syntax.pos)))))
+end)
+end)))
+end)))))
+in (
+
+let actions = (
+
+let check_action = (fun act -> (
+
+let uu____1047 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1 act.FStar_Syntax_Syntax.action_typ)
+in (match (uu____1047) with
+| (act_typ, uu____1052, g_t) -> begin
+(
+
+let env' = (FStar_TypeChecker_Env.set_expected_typ env1 act_typ)
+in ((
+
+let uu____1056 = (FStar_TypeChecker_Env.debug env1 (FStar_Options.Other ("ED")))
+in (match (uu____1056) with
+| true -> begin
+(
+
+let uu____1057 = (FStar_Syntax_Print.term_to_string act.FStar_Syntax_Syntax.action_defn)
+in (
+
+let uu____1058 = (FStar_Syntax_Print.term_to_string act_typ)
+in (FStar_Util.print3 "Checking action %s:\n[definition]: %s\n[cps\'d type]: %s\n" (FStar_Ident.text_of_lid act.FStar_Syntax_Syntax.action_name) uu____1057 uu____1058)))
+end
+| uu____1059 -> begin
+()
+end));
+(
+
+let uu____1060 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env' act.FStar_Syntax_Syntax.action_defn)
+in (match (uu____1060) with
+| (act_defn, uu____1065, g_a) -> begin
+(
+
+let act_defn1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env1 act_defn)
+in (
+
+let act_typ1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Beta)::[]) env1 act_typ)
+in (
+
+let uu____1069 = (
+
+let act_typ2 = (FStar_Syntax_Subst.compress act_typ1)
+in (match (act_typ2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____1087 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____1087) with
+| (bs1, uu____1093) -> begin
+(
+
+let res = (mk_repr' FStar_Syntax_Syntax.tun FStar_Syntax_Syntax.tun)
+in (
+
+let k = (
+
+let uu____1100 = (FStar_Syntax_Syntax.mk_Total res)
+in (FStar_Syntax_Util.arrow bs1 uu____1100))
+in (
+
+let uu____1103 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1 k)
+in (match (uu____1103) with
+| (k1, uu____1110, g) -> begin
+((k1), (g))
+end))))
+end))
+end
+| uu____1112 -> begin
+(
+
+let uu____1113 = (
+
+let uu____1114 = (
+
+let uu____1117 = (
+
+let uu____1118 = (FStar_Syntax_Print.term_to_string act_typ2)
+in (
+
+let uu____1119 = (FStar_Syntax_Print.tag_of_term act_typ2)
+in (FStar_Util.format2 "Actions must have function types (not: %s, a.k.a. %s)" uu____1118 uu____1119)))
+in ((uu____1117), (act_defn1.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____1114))
+in (Prims.raise uu____1113))
+end))
+in (match (uu____1069) with
+| (expected_k, g_k) -> begin
+(
+
+let g = (FStar_TypeChecker_Rel.teq env1 act_typ1 expected_k)
+in ((
+
+let uu____1126 = (
+
+let uu____1127 = (
+
+let uu____1128 = (FStar_TypeChecker_Rel.conj_guard g_t g)
+in (FStar_TypeChecker_Rel.conj_guard g_k uu____1128))
+in (FStar_TypeChecker_Rel.conj_guard g_a uu____1127))
+in (FStar_TypeChecker_Rel.force_trivial_guard env1 uu____1126));
+(
+
+let act_typ2 = (
+
+let uu____1132 = (
+
+let uu____1133 = (FStar_Syntax_Subst.compress expected_k)
+in uu____1133.FStar_Syntax_Syntax.n)
+in (match (uu____1132) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____1150 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____1150) with
+| (bs1, c1) -> begin
+(
+
+let uu____1157 = (destruct_repr (FStar_Syntax_Util.comp_result c1))
+in (match (uu____1157) with
+| (a1, wp) -> begin
+(
+
+let c2 = (
+
+let uu____1177 = (
+
+let uu____1178 = (env1.FStar_TypeChecker_Env.universe_of env1 a1)
+in (uu____1178)::[])
+in (
+
+let uu____1179 = (
+
+let uu____1185 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____1185)::[])
+in {FStar_Syntax_Syntax.comp_univs = uu____1177; FStar_Syntax_Syntax.effect_name = ed2.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.result_typ = a1; FStar_Syntax_Syntax.effect_args = uu____1179; FStar_Syntax_Syntax.flags = []}))
+in (
+
+let uu____1186 = (FStar_Syntax_Syntax.mk_Comp c2)
+in (FStar_Syntax_Util.arrow bs1 uu____1186)))
+end))
+end))
+end
+| uu____1189 -> begin
+(failwith "")
+end))
+in (
+
+let uu____1192 = (FStar_TypeChecker_Util.generalize_universes env1 act_defn1)
+in (match (uu____1192) with
+| (univs1, act_defn2) -> begin
+(
+
+let act_typ3 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env1 act_typ2)
+in (
+
+let uu___90_1198 = act
+in {FStar_Syntax_Syntax.action_name = uu___90_1198.FStar_Syntax_Syntax.action_name; FStar_Syntax_Syntax.action_unqualified_name = uu___90_1198.FStar_Syntax_Syntax.action_unqualified_name; FStar_Syntax_Syntax.action_univs = univs1; FStar_Syntax_Syntax.action_defn = act_defn2; FStar_Syntax_Syntax.action_typ = act_typ3}))
+end)));
+))
+end))))
+end));
+))
+end)))
+in (FStar_All.pipe_right ed2.FStar_Syntax_Syntax.actions (FStar_List.map check_action)))
+in ((repr), (bind_repr), (return_repr), (actions)))))))))
+end))
+in (match (uu____693) with
+| (repr, bind_repr, return_repr, actions) -> begin
+(
+
+let t = (
+
+let uu____1214 = (FStar_Syntax_Syntax.mk_Total ed2.FStar_Syntax_Syntax.signature)
+in (FStar_Syntax_Util.arrow ed2.FStar_Syntax_Syntax.binders uu____1214))
+in (
+
+let uu____1217 = (FStar_TypeChecker_Util.generalize_universes env0 t)
+in (match (uu____1217) with
+| (univs1, t1) -> begin
+(
+
+let signature1 = (
+
+let uu____1223 = (
+
+let uu____1226 = (
+
+let uu____1227 = (FStar_Syntax_Subst.compress t1)
+in uu____1227.FStar_Syntax_Syntax.n)
+in ((effect_params), (uu____1226)))
+in (match (uu____1223) with
+| ([], uu____1230) -> begin
+t1
+end
+| (uu____1236, FStar_Syntax_Syntax.Tm_arrow (uu____1237, c)) -> begin
+(FStar_Syntax_Util.comp_result c)
+end
+| uu____1249 -> begin
+(failwith "Impossible")
+end))
+in (
+
+let close1 = (fun n1 ts -> (
+
+let ts1 = (
+
+let uu____1260 = (FStar_Syntax_Subst.close_tscheme effect_params ts)
+in (FStar_Syntax_Subst.close_univ_vars_tscheme univs1 uu____1260))
+in (
+
+let m = (FStar_List.length (Prims.fst ts1))
+in ((
+
+let uu____1265 = (((n1 >= (Prims.parse_int "0")) && (
+
+let uu____1266 = (FStar_Syntax_Util.is_unknown (Prims.snd ts1))
+in (not (uu____1266)))) && (m <> n1))
+in (match (uu____1265) with
+| true -> begin
+(
+
+let error = (match ((m < n1)) with
+| true -> begin
+"not universe-polymorphic enough"
+end
+| uu____1274 -> begin
+"too universe-polymorphic"
+end)
+in (
+
+let uu____1275 = (
+
+let uu____1276 = (FStar_Util.string_of_int n1)
+in (
+
+let uu____1277 = (FStar_Syntax_Print.tscheme_to_string ts1)
+in (FStar_Util.format3 "The effect combinator is %s (n=%s) (%s)" error uu____1276 uu____1277)))
+in (failwith uu____1275)))
+end
+| uu____1278 -> begin
+()
+end));
+ts1;
+))))
+in (
+
+let close_action = (fun act -> (
+
+let uu____1283 = (close1 (~- ((Prims.parse_int "1"))) ((act.FStar_Syntax_Syntax.action_univs), (act.FStar_Syntax_Syntax.action_defn)))
+in (match (uu____1283) with
+| (univs2, defn) -> begin
+(
+
+let uu____1288 = (close1 (~- ((Prims.parse_int "1"))) ((act.FStar_Syntax_Syntax.action_univs), (act.FStar_Syntax_Syntax.action_typ)))
+in (match (uu____1288) with
+| (univs', typ) -> begin
+(
+
+let uu___91_1294 = act
+in {FStar_Syntax_Syntax.action_name = uu___91_1294.FStar_Syntax_Syntax.action_name; FStar_Syntax_Syntax.action_unqualified_name = uu___91_1294.FStar_Syntax_Syntax.action_unqualified_name; FStar_Syntax_Syntax.action_univs = univs2; FStar_Syntax_Syntax.action_defn = defn; FStar_Syntax_Syntax.action_typ = typ})
+end))
+end)))
+in (
+
+let nunivs = (FStar_List.length univs1)
+in (
+
+let ed3 = (
+
+let uu___92_1299 = ed2
+in (
+
+let uu____1300 = (close1 (Prims.parse_int "0") return_wp)
+in (
+
+let uu____1301 = (close1 (Prims.parse_int "1") bind_wp)
+in (
+
+let uu____1302 = (close1 (Prims.parse_int "0") if_then_else1)
+in (
+
+let uu____1303 = (close1 (Prims.parse_int "0") ite_wp)
+in (
+
+let uu____1304 = (close1 (Prims.parse_int "0") stronger)
+in (
+
+let uu____1305 = (close1 (Prims.parse_int "1") close_wp)
+in (
+
+let uu____1306 = (close1 (Prims.parse_int "0") assert_p)
+in (
+
+let uu____1307 = (close1 (Prims.parse_int "0") assume_p)
+in (
+
+let uu____1308 = (close1 (Prims.parse_int "0") null_wp)
+in (
+
+let uu____1309 = (close1 (Prims.parse_int "0") trivial_wp)
+in (
+
+let uu____1310 = (
+
+let uu____1311 = (close1 (Prims.parse_int "0") (([]), (repr)))
+in (Prims.snd uu____1311))
+in (
+
+let uu____1317 = (close1 (Prims.parse_int "0") return_repr)
+in (
+
+let uu____1318 = (close1 (Prims.parse_int "1") bind_repr)
+in (
+
+let uu____1319 = (FStar_List.map close_action actions)
+in {FStar_Syntax_Syntax.qualifiers = uu___92_1299.FStar_Syntax_Syntax.qualifiers; FStar_Syntax_Syntax.cattributes = uu___92_1299.FStar_Syntax_Syntax.cattributes; FStar_Syntax_Syntax.mname = uu___92_1299.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.univs = univs1; FStar_Syntax_Syntax.binders = effect_params; FStar_Syntax_Syntax.signature = signature1; FStar_Syntax_Syntax.ret_wp = uu____1300; FStar_Syntax_Syntax.bind_wp = uu____1301; FStar_Syntax_Syntax.if_then_else = uu____1302; FStar_Syntax_Syntax.ite_wp = uu____1303; FStar_Syntax_Syntax.stronger = uu____1304; FStar_Syntax_Syntax.close_wp = uu____1305; FStar_Syntax_Syntax.assert_p = uu____1306; FStar_Syntax_Syntax.assume_p = uu____1307; FStar_Syntax_Syntax.null_wp = uu____1308; FStar_Syntax_Syntax.trivial = uu____1309; FStar_Syntax_Syntax.repr = uu____1310; FStar_Syntax_Syntax.return_repr = uu____1317; FStar_Syntax_Syntax.bind_repr = uu____1318; FStar_Syntax_Syntax.actions = uu____1319})))))))))))))))
+in ((
+
+let uu____1322 = ((FStar_TypeChecker_Env.debug env1 FStar_Options.Low) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("ED"))))
+in (match (uu____1322) with
+| true -> begin
+(
+
+let uu____1323 = (FStar_Syntax_Print.eff_decl_to_string false ed3)
+in (FStar_Util.print_string uu____1323))
+end
+| uu____1324 -> begin
+()
+end));
+ed3;
+))))))
+end)))
+end)))))))))))));
+)))
+end)))))
+end))
+end))
+end)))
+and cps_and_elaborate : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.eff_decl  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Syntax_Syntax.eff_decl * FStar_Syntax_Syntax.sigelt Prims.option) = (fun env ed -> (
+
+let uu____1327 = (FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders ed.FStar_Syntax_Syntax.signature)
+in (match (uu____1327) with
+| (effect_binders_un, signature_un) -> begin
+(
+
+let uu____1337 = (FStar_TypeChecker_TcTerm.tc_tparams env effect_binders_un)
+in (match (uu____1337) with
+| (effect_binders, env1, uu____1348) -> begin
+(
+
+let uu____1349 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env1 signature_un)
+in (match (uu____1349) with
+| (signature, uu____1358) -> begin
+(
+
+let effect_binders1 = (FStar_List.map (fun uu____1367 -> (match (uu____1367) with
+| (bv, qual) -> begin
+(
+
+let uu____1374 = (
+
+let uu___93_1375 = bv
+in (
+
+let uu____1376 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.EraseUniverses)::[]) env1 bv.FStar_Syntax_Syntax.sort)
+in {FStar_Syntax_Syntax.ppname = uu___93_1375.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___93_1375.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____1376}))
+in ((uu____1374), (qual)))
+end)) effect_binders)
+in (
+
+let uu____1379 = (
+
+let uu____1384 = (
+
+let uu____1385 = (FStar_Syntax_Subst.compress signature_un)
+in uu____1385.FStar_Syntax_Syntax.n)
+in (match (uu____1384) with
+| FStar_Syntax_Syntax.Tm_arrow (((a, uu____1393))::[], effect_marker) -> begin
+((a), (effect_marker))
+end
+| uu____1408 -> begin
+(failwith "bad shape for effect-for-free signature")
+end))
+in (match (uu____1379) with
+| (a, effect_marker) -> begin
+(
+
+let a1 = (
+
+let uu____1425 = (FStar_Syntax_Syntax.is_null_bv a)
+in (match (uu____1425) with
+| true -> begin
+(
+
+let uu____1426 = (
+
+let uu____1428 = (FStar_Syntax_Syntax.range_of_bv a)
+in Some (uu____1428))
+in (FStar_Syntax_Syntax.gen_bv "a" uu____1426 a.FStar_Syntax_Syntax.sort))
+end
+| uu____1429 -> begin
+a
+end))
+in (
+
+let open_and_check = (fun t -> (
+
+let subst1 = (FStar_Syntax_Subst.opening_of_binders effect_binders1)
+in (
+
+let t1 = (FStar_Syntax_Subst.subst subst1 t)
+in (
+
+let uu____1438 = (FStar_TypeChecker_TcTerm.tc_term env1 t1)
+in (match (uu____1438) with
+| (t2, comp, uu____1446) -> begin
+((t2), (comp))
+end)))))
+in (
+
+let mk1 = (fun x -> (FStar_Syntax_Syntax.mk x None signature.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____1457 = (open_and_check ed.FStar_Syntax_Syntax.repr)
+in (match (uu____1457) with
+| (repr, _comp) -> begin
+((
+
+let uu____1468 = (FStar_TypeChecker_Env.debug env1 (FStar_Options.Other ("ED")))
+in (match (uu____1468) with
+| true -> begin
+(
+
+let uu____1469 = (FStar_Syntax_Print.term_to_string repr)
+in (FStar_Util.print1 "Representation is: %s\n" uu____1469))
+end
+| uu____1470 -> begin
+()
+end));
+(
+
+let dmff_env = (FStar_TypeChecker_DMFF.empty env1 (FStar_TypeChecker_TcTerm.tc_constant FStar_Range.dummyRange))
+in (
+
+let wp_type = (FStar_TypeChecker_DMFF.star_type dmff_env repr)
+in (
+
+let wp_type1 = (recheck_debug "*" env1 wp_type)
+in (
+
+let wp_a = (
+
+let uu____1475 = (
+
+let uu____1476 = (
+
+let uu____1477 = (
+
+let uu____1487 = (
+
+let uu____1491 = (
+
+let uu____1494 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (
+
+let uu____1495 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____1494), (uu____1495))))
+in (uu____1491)::[])
+in ((wp_type1), (uu____1487)))
+in FStar_Syntax_Syntax.Tm_app (uu____1477))
+in (mk1 uu____1476))
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env1 uu____1475))
+in (
+
+let effect_signature = (
+
+let binders = (
+
+let uu____1510 = (
+
+let uu____1513 = (FStar_Syntax_Syntax.as_implicit false)
+in ((a1), (uu____1513)))
+in (
+
+let uu____1514 = (
+
+let uu____1518 = (
+
+let uu____1519 = (FStar_Syntax_Syntax.gen_bv "dijkstra_wp" None wp_a)
+in (FStar_All.pipe_right uu____1519 FStar_Syntax_Syntax.mk_binder))
+in (uu____1518)::[])
+in (uu____1510)::uu____1514))
+in (
+
+let binders1 = (FStar_Syntax_Subst.close_binders binders)
+in (mk1 (FStar_Syntax_Syntax.Tm_arrow (((binders1), (effect_marker)))))))
+in (
+
+let effect_signature1 = (recheck_debug "turned into the effect signature" env1 effect_signature)
+in (
+
+let sigelts = (FStar_Util.mk_ref [])
+in (
+
+let mk_lid = (fun name -> (FStar_Ident.lid_of_path (FStar_Ident.path_of_text (Prims.strcat (FStar_Ident.text_of_lid ed.FStar_Syntax_Syntax.mname) (Prims.strcat "_" name))) FStar_Range.dummyRange))
+in (
+
+let elaborate_and_star = (fun dmff_env1 item -> (
+
+let uu____1552 = item
+in (match (uu____1552) with
+| (u_item, item1) -> begin
+(
+
+let uu____1564 = (open_and_check item1)
+in (match (uu____1564) with
+| (item2, item_comp) -> begin
+((
+
+let uu____1574 = (
+
+let uu____1575 = (FStar_Syntax_Util.is_total_lcomp item_comp)
+in (not (uu____1575)))
+in (match (uu____1574) with
+| true -> begin
+(
+
+let uu____1576 = (
+
+let uu____1577 = (
+
+let uu____1578 = (FStar_Syntax_Print.term_to_string item2)
+in (
+
+let uu____1579 = (FStar_Syntax_Print.lcomp_to_string item_comp)
+in (FStar_Util.format2 "Computation for [%s] is not total : %s !" uu____1578 uu____1579)))
+in FStar_Errors.Err (uu____1577))
+in (Prims.raise uu____1576))
+end
+| uu____1580 -> begin
+()
+end));
+(
+
+let uu____1581 = (FStar_TypeChecker_DMFF.star_expr dmff_env1 item2)
+in (match (uu____1581) with
+| (item_t, item_wp, item_elab) -> begin
+(
+
+let item_wp1 = (recheck_debug "*" env1 item_wp)
+in (
+
+let item_elab1 = (recheck_debug "_" env1 item_elab)
+in ((dmff_env1), (item_t), (item_wp1), (item_elab1))))
+end));
+)
+end))
+end)))
+in (
+
+let uu____1594 = (elaborate_and_star dmff_env ed.FStar_Syntax_Syntax.bind_repr)
+in (match (uu____1594) with
+| (dmff_env1, uu____1605, bind_wp, bind_elab) -> begin
+(
+
+let uu____1608 = (elaborate_and_star dmff_env1 ed.FStar_Syntax_Syntax.return_repr)
+in (match (uu____1608) with
+| (dmff_env2, uu____1619, return_wp, return_elab) -> begin
+(
+
+let lift_from_pure_wp = (
+
+let uu____1623 = (
+
+let uu____1624 = (FStar_Syntax_Subst.compress return_wp)
+in uu____1624.FStar_Syntax_Syntax.n)
+in (match (uu____1623) with
+| FStar_Syntax_Syntax.Tm_abs ((b1)::(b2)::bs, body, what) -> begin
+(
+
+let uu____1662 = (
+
+let uu____1670 = (
+
+let uu____1673 = (FStar_Syntax_Util.abs bs body None)
+in (FStar_Syntax_Subst.open_term ((b1)::(b2)::[]) uu____1673))
+in (match (uu____1670) with
+| ((b11)::(b21)::[], body1) -> begin
+((b11), (b21), (body1))
+end
+| uu____1712 -> begin
+(failwith "Impossible : open_term not preserving binders arity")
+end))
+in (match (uu____1662) with
+| (b11, b21, body1) -> begin
+(
+
+let env0 = (
+
+let uu____1734 = (FStar_TypeChecker_DMFF.get_env dmff_env2)
+in (FStar_TypeChecker_Env.push_binders uu____1734 ((b11)::(b21)::[])))
+in (
+
+let wp_b1 = (
+
+let raw_wp_b1 = (
+
+let uu____1745 = (
+
+let uu____1746 = (
+
+let uu____1756 = (
+
+let uu____1760 = (
+
+let uu____1763 = (FStar_Syntax_Syntax.bv_to_name (Prims.fst b11))
+in (
+
+let uu____1764 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____1763), (uu____1764))))
+in (uu____1760)::[])
+in ((wp_type1), (uu____1756)))
+in FStar_Syntax_Syntax.Tm_app (uu____1746))
+in (mk1 uu____1745))
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env0 raw_wp_b1))
+in (
+
+let uu____1772 = (
+
+let uu____1782 = (
+
+let uu____1783 = (FStar_Syntax_Util.unascribe wp_b1)
+in (FStar_TypeChecker_Normalize.eta_expand_with_type body1 uu____1783))
+in (FStar_All.pipe_left FStar_Syntax_Util.abs_formals uu____1782))
+in (match (uu____1772) with
+| (bs1, body2, what') -> begin
+(
+
+let fail = (fun uu____1811 -> (
+
+let error_msg = (
+
+let uu____1813 = (FStar_Syntax_Print.term_to_string body2)
+in (
+
+let uu____1814 = (match (what') with
+| None -> begin
+"None"
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+(FStar_Syntax_Print.lcomp_to_string lc)
+end
+| Some (FStar_Util.Inr (lid, uu____1830)) -> begin
+(FStar_Ident.text_of_lid lid)
+end)
+in (FStar_Util.format2 "The body of return_wp (%s) should be of type Type0 but is of type %s" uu____1813 uu____1814)))
+in (failwith error_msg)))
+in ((match (what') with
+| None -> begin
+(fail ())
+end
+| Some (FStar_Util.Inl (lc)) -> begin
+(
+
+let uu____1856 = (FStar_Syntax_Util.is_pure_or_ghost_lcomp lc)
+in (match (uu____1856) with
+| true -> begin
+(
+
+let g_opt = (FStar_TypeChecker_Rel.try_teq true env1 lc.FStar_Syntax_Syntax.res_typ FStar_Syntax_Util.ktype0)
+in (match (g_opt) with
+| Some (g') -> begin
+(FStar_TypeChecker_Rel.force_trivial_guard env1 g')
+end
+| None -> begin
+(fail ())
+end))
+end
+| uu____1860 -> begin
+(fail ())
+end))
+end
+| Some (FStar_Util.Inr (lid, uu____1862)) -> begin
+(match ((not ((FStar_Syntax_Util.is_pure_effect lid)))) with
+| true -> begin
+(fail ())
+end
+| uu____1873 -> begin
+()
+end)
+end);
+(
+
+let wp = (
+
+let t2 = (Prims.fst b21).FStar_Syntax_Syntax.sort
+in (
+
+let pure_wp_type = (FStar_TypeChecker_DMFF.double_star t2)
+in (FStar_Syntax_Syntax.gen_bv "wp" None pure_wp_type)))
+in (
+
+let body3 = (
+
+let uu____1882 = (
+
+let uu____1883 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (
+
+let uu____1884 = (
+
+let uu____1885 = (
+
+let uu____1889 = (FStar_Syntax_Util.abs ((b21)::[]) body2 what')
+in ((uu____1889), (None)))
+in (uu____1885)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____1883 uu____1884)))
+in (uu____1882 None FStar_Range.dummyRange))
+in (
+
+let uu____1905 = (
+
+let uu____1909 = (
+
+let uu____1913 = (FStar_Syntax_Syntax.mk_binder wp)
+in (uu____1913)::[])
+in (b11)::uu____1909)
+in (
+
+let uu____1916 = (FStar_Syntax_Util.abs bs1 body3 what)
+in (FStar_Syntax_Util.abs uu____1905 uu____1916 (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_GTot_lid), ([]))))))))));
+))
+end))))
+end))
+end
+| uu____1926 -> begin
+(failwith "unexpected shape for return")
+end))
+in (
+
+let return_wp1 = (
+
+let uu____1928 = (
+
+let uu____1929 = (FStar_Syntax_Subst.compress return_wp)
+in uu____1929.FStar_Syntax_Syntax.n)
+in (match (uu____1928) with
+| FStar_Syntax_Syntax.Tm_abs ((b1)::(b2)::bs, body, what) -> begin
+(
+
+let uu____1967 = (FStar_Syntax_Util.abs bs body what)
+in (FStar_Syntax_Util.abs ((b1)::(b2)::[]) uu____1967 (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_GTot_lid), ([])))))))
+end
+| uu____1983 -> begin
+(failwith "unexpected shape for return")
+end))
+in (
+
+let bind_wp1 = (
+
+let uu____1985 = (
+
+let uu____1986 = (FStar_Syntax_Subst.compress bind_wp)
+in uu____1986.FStar_Syntax_Syntax.n)
+in (match (uu____1985) with
+| FStar_Syntax_Syntax.Tm_abs (binders, body, what) -> begin
+(
+
+let r = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.range_lid (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in (
+
+let uu____2015 = (
+
+let uu____2019 = (
+
+let uu____2021 = (
+
+let uu____2022 = (mk1 (FStar_Syntax_Syntax.Tm_fvar (r)))
+in (FStar_Syntax_Syntax.null_binder uu____2022))
+in (uu____2021)::[])
+in (FStar_List.append uu____2019 binders))
+in (FStar_Syntax_Util.abs uu____2015 body what)))
+end
+| uu____2023 -> begin
+(failwith "unexpected shape for bind")
+end))
+in (
+
+let apply_close = (fun t -> (match (((FStar_List.length effect_binders1) = (Prims.parse_int "0"))) with
+| true -> begin
+t
+end
+| uu____2040 -> begin
+(
+
+let uu____2041 = (
+
+let uu____2042 = (
+
+let uu____2043 = (
+
+let uu____2053 = (
+
+let uu____2054 = (FStar_Syntax_Util.args_of_binders effect_binders1)
+in (Prims.snd uu____2054))
+in ((t), (uu____2053)))
+in FStar_Syntax_Syntax.Tm_app (uu____2043))
+in (mk1 uu____2042))
+in (FStar_Syntax_Subst.close effect_binders1 uu____2041))
+end))
+in (
+
+let register = (fun name item -> (
+
+let uu____2066 = (
+
+let uu____2069 = (mk_lid name)
+in (
+
+let uu____2070 = (FStar_Syntax_Util.abs effect_binders1 item None)
+in (FStar_TypeChecker_Util.mk_toplevel_definition env1 uu____2069 uu____2070)))
+in (match (uu____2066) with
+| (sigelt, fv) -> begin
+((
+
+let uu____2079 = (
+
+let uu____2081 = (FStar_ST.read sigelts)
+in (sigelt)::uu____2081)
+in (FStar_ST.write sigelts uu____2079));
+fv;
+)
+end)))
+in (
+
+let lift_from_pure_wp1 = (register "lift_from_pure" lift_from_pure_wp)
+in (
+
+let return_wp2 = (register "return_wp" return_wp1)
+in ((
+
+let uu____2092 = (
+
+let uu____2094 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.SetOptions ("--admit_smt_queries true"))))
+in (
+
+let uu____2095 = (FStar_ST.read sigelts)
+in (uu____2094)::uu____2095))
+in (FStar_ST.write sigelts uu____2092));
+(
+
+let return_elab1 = (register "return_elab" return_elab)
+in ((
+
+let uu____2105 = (
+
+let uu____2107 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.SetOptions ("--admit_smt_queries false"))))
+in (
+
+let uu____2108 = (FStar_ST.read sigelts)
+in (uu____2107)::uu____2108))
+in (FStar_ST.write sigelts uu____2105));
+(
+
+let bind_wp2 = (register "bind_wp" bind_wp1)
+in ((
+
+let uu____2118 = (
+
+let uu____2120 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.SetOptions ("--admit_smt_queries true"))))
+in (
+
+let uu____2121 = (FStar_ST.read sigelts)
+in (uu____2120)::uu____2121))
+in (FStar_ST.write sigelts uu____2118));
+(
+
+let bind_elab1 = (register "bind_elab" bind_elab)
+in ((
+
+let uu____2131 = (
+
+let uu____2133 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.SetOptions ("--admit_smt_queries false"))))
+in (
+
+let uu____2134 = (FStar_ST.read sigelts)
+in (uu____2133)::uu____2134))
+in (FStar_ST.write sigelts uu____2131));
+(
+
+let uu____2142 = (FStar_List.fold_left (fun uu____2149 action -> (match (uu____2149) with
+| (dmff_env3, actions) -> begin
+(
+
+let uu____2161 = (elaborate_and_star dmff_env3 ((action.FStar_Syntax_Syntax.action_univs), (action.FStar_Syntax_Syntax.action_defn)))
+in (match (uu____2161) with
+| (dmff_env4, action_t, action_wp, action_elab) -> begin
+(
+
+let name = action.FStar_Syntax_Syntax.action_name.FStar_Ident.ident.FStar_Ident.idText
+in (
+
+let action_typ_with_wp = (FStar_TypeChecker_DMFF.trans_F dmff_env4 action_t action_wp)
+in (
+
+let action_elab1 = (register (Prims.strcat name "_elab") action_elab)
+in (
+
+let action_typ_with_wp1 = (register (Prims.strcat name "_complete_type") action_typ_with_wp)
+in (
+
+let uu____2177 = (
+
+let uu____2179 = (
+
+let uu___94_2180 = action
+in (
+
+let uu____2181 = (apply_close action_elab1)
+in (
+
+let uu____2182 = (apply_close action_typ_with_wp1)
+in {FStar_Syntax_Syntax.action_name = uu___94_2180.FStar_Syntax_Syntax.action_name; FStar_Syntax_Syntax.action_unqualified_name = uu___94_2180.FStar_Syntax_Syntax.action_unqualified_name; FStar_Syntax_Syntax.action_univs = uu___94_2180.FStar_Syntax_Syntax.action_univs; FStar_Syntax_Syntax.action_defn = uu____2181; FStar_Syntax_Syntax.action_typ = uu____2182})))
+in (uu____2179)::actions)
+in ((dmff_env4), (uu____2177)))))))
+end))
+end)) ((dmff_env2), ([])) ed.FStar_Syntax_Syntax.actions)
+in (match (uu____2142) with
+| (dmff_env3, actions) -> begin
+(
+
+let actions1 = (FStar_List.rev actions)
+in (
+
+let repr1 = (
+
+let wp = (FStar_Syntax_Syntax.gen_bv "wp_a" None wp_a)
+in (
+
+let binders = (
+
+let uu____2200 = (FStar_Syntax_Syntax.mk_binder a1)
+in (
+
+let uu____2201 = (
+
+let uu____2203 = (FStar_Syntax_Syntax.mk_binder wp)
+in (uu____2203)::[])
+in (uu____2200)::uu____2201))
+in (
+
+let uu____2204 = (
+
+let uu____2205 = (
+
+let uu____2206 = (
+
+let uu____2207 = (
+
+let uu____2217 = (
+
+let uu____2221 = (
+
+let uu____2224 = (FStar_Syntax_Syntax.bv_to_name a1)
+in (
+
+let uu____2225 = (FStar_Syntax_Syntax.as_implicit false)
+in ((uu____2224), (uu____2225))))
+in (uu____2221)::[])
+in ((repr), (uu____2217)))
+in FStar_Syntax_Syntax.Tm_app (uu____2207))
+in (mk1 uu____2206))
+in (
+
+let uu____2233 = (FStar_Syntax_Syntax.bv_to_name wp)
+in (FStar_TypeChecker_DMFF.trans_F dmff_env3 uu____2205 uu____2233)))
+in (FStar_Syntax_Util.abs binders uu____2204 None))))
+in (
+
+let repr2 = (recheck_debug "FC" env1 repr1)
+in (
+
+let repr3 = (register "repr" repr2)
+in (
+
+let uu____2241 = (
+
+let uu____2246 = (
+
+let uu____2247 = (
+
+let uu____2250 = (FStar_Syntax_Subst.compress wp_type1)
+in (FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____2250))
+in uu____2247.FStar_Syntax_Syntax.n)
+in (match (uu____2246) with
+| FStar_Syntax_Syntax.Tm_abs ((type_param)::effect_param, arrow1, uu____2258) -> begin
+(
+
+let uu____2285 = (
+
+let uu____2294 = (FStar_Syntax_Subst.open_term ((type_param)::effect_param) arrow1)
+in (match (uu____2294) with
+| ((b)::bs, body) -> begin
+((b), (bs), (body))
+end
+| uu____2325 -> begin
+(failwith "Impossible : open_term nt preserving binders arity")
+end))
+in (match (uu____2285) with
+| (type_param1, effect_param1, arrow2) -> begin
+(
+
+let uu____2353 = (
+
+let uu____2354 = (
+
+let uu____2357 = (FStar_Syntax_Subst.compress arrow2)
+in (FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____2357))
+in uu____2354.FStar_Syntax_Syntax.n)
+in (match (uu____2353) with
+| FStar_Syntax_Syntax.Tm_arrow (wp_binders, c) -> begin
+(
+
+let uu____2374 = (FStar_Syntax_Subst.open_comp wp_binders c)
+in (match (uu____2374) with
+| (wp_binders1, c1) -> begin
+(
+
+let uu____2383 = (FStar_List.partition (fun uu____2394 -> (match (uu____2394) with
+| (bv, uu____2398) -> begin
+(
+
+let uu____2399 = (
+
+let uu____2400 = (FStar_Syntax_Free.names bv.FStar_Syntax_Syntax.sort)
+in (FStar_All.pipe_right uu____2400 (FStar_Util.set_mem (Prims.fst type_param1))))
+in (FStar_All.pipe_right uu____2399 Prims.op_Negation))
+end)) wp_binders1)
+in (match (uu____2383) with
+| (pre_args, post_args) -> begin
+(
+
+let post = (match (post_args) with
+| (post)::[] -> begin
+post
+end
+| uu____2433 -> begin
+(
+
+let uu____2437 = (
+
+let uu____2438 = (FStar_Syntax_Print.term_to_string arrow2)
+in (FStar_Util.format1 "Impossible: multiple post candidates %s" uu____2438))
+in (failwith uu____2437))
+end)
+in (
+
+let uu____2441 = (FStar_Syntax_Util.arrow pre_args c1)
+in (
+
+let uu____2444 = (FStar_Syntax_Util.abs ((type_param1)::effect_param1) (Prims.fst post).FStar_Syntax_Syntax.sort None)
+in ((uu____2441), (uu____2444)))))
+end))
+end))
+end
+| uu____2454 -> begin
+(
+
+let uu____2455 = (
+
+let uu____2456 = (FStar_Syntax_Print.term_to_string arrow2)
+in (FStar_Util.format1 "Impossible: pre/post arrow %s" uu____2456))
+in (failwith uu____2455))
+end))
+end))
+end
+| uu____2461 -> begin
+(
+
+let uu____2462 = (
+
+let uu____2463 = (FStar_Syntax_Print.term_to_string wp_type1)
+in (FStar_Util.format1 "Impossible: pre/post abs %s" uu____2463))
+in (failwith uu____2462))
+end))
+in (match (uu____2241) with
+| (pre, post) -> begin
+((
+
+let uu____2480 = (register "pre" pre)
+in ());
+(
+
+let uu____2482 = (register "post" post)
+in ());
+(
+
+let uu____2484 = (register "wp" wp_type1)
+in ());
+(
+
+let ed1 = (
+
+let uu___95_2486 = ed
+in (
+
+let uu____2487 = (FStar_Syntax_Subst.close_binders effect_binders1)
+in (
+
+let uu____2488 = (FStar_Syntax_Subst.close effect_binders1 effect_signature1)
+in (
+
+let uu____2489 = (
+
+let uu____2490 = (apply_close return_wp2)
+in (([]), (uu____2490)))
+in (
+
+let uu____2496 = (
+
+let uu____2497 = (apply_close bind_wp2)
+in (([]), (uu____2497)))
+in (
+
+let uu____2503 = (apply_close repr3)
+in (
+
+let uu____2504 = (
+
+let uu____2505 = (apply_close return_elab1)
+in (([]), (uu____2505)))
+in (
+
+let uu____2511 = (
+
+let uu____2512 = (apply_close bind_elab1)
+in (([]), (uu____2512)))
+in {FStar_Syntax_Syntax.qualifiers = uu___95_2486.FStar_Syntax_Syntax.qualifiers; FStar_Syntax_Syntax.cattributes = uu___95_2486.FStar_Syntax_Syntax.cattributes; FStar_Syntax_Syntax.mname = uu___95_2486.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.univs = uu___95_2486.FStar_Syntax_Syntax.univs; FStar_Syntax_Syntax.binders = uu____2487; FStar_Syntax_Syntax.signature = uu____2488; FStar_Syntax_Syntax.ret_wp = uu____2489; FStar_Syntax_Syntax.bind_wp = uu____2496; FStar_Syntax_Syntax.if_then_else = uu___95_2486.FStar_Syntax_Syntax.if_then_else; FStar_Syntax_Syntax.ite_wp = uu___95_2486.FStar_Syntax_Syntax.ite_wp; FStar_Syntax_Syntax.stronger = uu___95_2486.FStar_Syntax_Syntax.stronger; FStar_Syntax_Syntax.close_wp = uu___95_2486.FStar_Syntax_Syntax.close_wp; FStar_Syntax_Syntax.assert_p = uu___95_2486.FStar_Syntax_Syntax.assert_p; FStar_Syntax_Syntax.assume_p = uu___95_2486.FStar_Syntax_Syntax.assume_p; FStar_Syntax_Syntax.null_wp = uu___95_2486.FStar_Syntax_Syntax.null_wp; FStar_Syntax_Syntax.trivial = uu___95_2486.FStar_Syntax_Syntax.trivial; FStar_Syntax_Syntax.repr = uu____2503; FStar_Syntax_Syntax.return_repr = uu____2504; FStar_Syntax_Syntax.bind_repr = uu____2511; FStar_Syntax_Syntax.actions = actions1}))))))))
+in (
+
+let uu____2518 = (FStar_TypeChecker_DMFF.gen_wps_for_free env1 effect_binders1 a1 wp_a ed1)
+in (match (uu____2518) with
+| (sigelts', ed2) -> begin
+((
+
+let uu____2529 = (FStar_TypeChecker_Env.debug env1 (FStar_Options.Other ("ED")))
+in (match (uu____2529) with
+| true -> begin
+(
+
+let uu____2530 = (FStar_Syntax_Print.eff_decl_to_string true ed2)
+in (FStar_Util.print_string uu____2530))
+end
+| uu____2531 -> begin
+()
+end));
+(
+
+let lift_from_pure_opt = (match (((FStar_List.length effect_binders1) = (Prims.parse_int "0"))) with
+| true -> begin
+(
+
+let lift_from_pure = (
+
+let uu____2540 = (
+
+let uu____2542 = (
+
+let uu____2548 = (apply_close lift_from_pure_wp1)
+in (([]), (uu____2548)))
+in Some (uu____2542))
+in {FStar_Syntax_Syntax.source = FStar_Syntax_Const.effect_PURE_lid; FStar_Syntax_Syntax.target = ed2.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.lift_wp = uu____2540; FStar_Syntax_Syntax.lift = None})
+in (
+
+let uu____2559 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_sub_effect (lift_from_pure)))
+in Some (uu____2559)))
+end
+| uu____2560 -> begin
+None
+end)
+in (
+
+let uu____2561 = (
+
+let uu____2563 = (
+
+let uu____2565 = (FStar_ST.read sigelts)
+in (FStar_List.rev uu____2565))
+in (FStar_List.append uu____2563 sigelts'))
+in ((uu____2561), (ed2), (lift_from_pure_opt))));
+)
+end)));
+)
+end))))))
+end));
+));
+));
+));
+))))))))
+end))
+end)))))))))));
+)
+end)))))
+end)))
+end))
+end))
+end)))
+and tc_lex_t : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Ident.lident Prims.list  ->  FStar_Syntax_Syntax.sigelt = (fun env ses quals lids -> (match (ses) with
+| ({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (lex_t1, [], [], t, uu____2588, uu____2589, []); FStar_Syntax_Syntax.sigdoc = d; FStar_Syntax_Syntax.sigrng = r})::({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (lex_top1, [], _t_top, _lex_t_top, _0_28, [], uu____2595); FStar_Syntax_Syntax.sigdoc = d1; FStar_Syntax_Syntax.sigrng = r1})::({FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (lex_cons, [], _t_cons, _lex_t_cons, _0_29, [], uu____2601); FStar_Syntax_Syntax.sigdoc = d2; FStar_Syntax_Syntax.sigrng = r2})::[] when (((_0_28 = (Prims.parse_int "0")) && (_0_29 = (Prims.parse_int "0"))) && (((FStar_Ident.lid_equals lex_t1 FStar_Syntax_Const.lex_t_lid) && (FStar_Ident.lid_equals lex_top1 FStar_Syntax_Const.lextop_lid)) && (FStar_Ident.lid_equals lex_cons FStar_Syntax_Const.lexcons_lid))) -> begin
+(
+
+let u = (FStar_Syntax_Syntax.new_univ_name (Some (r)))
+in (
+
+let t1 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_name (u))) None r)
+in (
+
+let t2 = (FStar_Syntax_Subst.close_univ_vars ((u)::[]) t1)
+in (
+
+let tc = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((lex_t1), ((u)::[]), ([]), (t2), ([]), ((FStar_Syntax_Const.lextop_lid)::(FStar_Syntax_Const.lexcons_lid)::[]), ([]))); FStar_Syntax_Syntax.sigdoc = d; FStar_Syntax_Syntax.sigrng = r}
+in (
+
+let utop = (FStar_Syntax_Syntax.new_univ_name (Some (r1)))
+in (
+
+let lex_top_t = (
+
+let uu____2649 = (
+
+let uu____2652 = (
+
+let uu____2653 = (
+
+let uu____2658 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.lex_t_lid r1) FStar_Syntax_Syntax.Delta_constant None)
+in ((uu____2658), ((FStar_Syntax_Syntax.U_name (utop))::[])))
+in FStar_Syntax_Syntax.Tm_uinst (uu____2653))
+in (FStar_Syntax_Syntax.mk uu____2652))
+in (uu____2649 None r1))
+in (
+
+let lex_top_t1 = (FStar_Syntax_Subst.close_univ_vars ((utop)::[]) lex_top_t)
+in (
+
+let dc_lextop = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (((lex_top1), ((utop)::[]), (lex_top_t1), (FStar_Syntax_Const.lex_t_lid), ((Prims.parse_int "0")), ([]), ([]))); FStar_Syntax_Syntax.sigdoc = d1; FStar_Syntax_Syntax.sigrng = r1}
+in (
+
+let ucons1 = (FStar_Syntax_Syntax.new_univ_name (Some (r2)))
+in (
+
+let ucons2 = (FStar_Syntax_Syntax.new_univ_name (Some (r2)))
+in (
+
+let lex_cons_t = (
+
+let a = (
+
+let uu____2679 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_name (ucons1))) None r2)
+in (FStar_Syntax_Syntax.new_bv (Some (r2)) uu____2679))
+in (
+
+let hd1 = (
+
+let uu____2685 = (FStar_Syntax_Syntax.bv_to_name a)
+in (FStar_Syntax_Syntax.new_bv (Some (r2)) uu____2685))
+in (
+
+let tl1 = (
+
+let uu____2687 = (
+
+let uu____2688 = (
+
+let uu____2691 = (
+
+let uu____2692 = (
+
+let uu____2697 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.lex_t_lid r2) FStar_Syntax_Syntax.Delta_constant None)
+in ((uu____2697), ((FStar_Syntax_Syntax.U_name (ucons2))::[])))
+in FStar_Syntax_Syntax.Tm_uinst (uu____2692))
+in (FStar_Syntax_Syntax.mk uu____2691))
+in (uu____2688 None r2))
+in (FStar_Syntax_Syntax.new_bv (Some (r2)) uu____2687))
+in (
+
+let res = (
+
+let uu____2710 = (
+
+let uu____2713 = (
+
+let uu____2714 = (
+
+let uu____2719 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.lex_t_lid r2) FStar_Syntax_Syntax.Delta_constant None)
+in ((uu____2719), ((FStar_Syntax_Syntax.U_max ((FStar_Syntax_Syntax.U_name (ucons1))::(FStar_Syntax_Syntax.U_name (ucons2))::[]))::[])))
+in FStar_Syntax_Syntax.Tm_uinst (uu____2714))
+in (FStar_Syntax_Syntax.mk uu____2713))
+in (uu____2710 None r2))
+in (
+
+let uu____2729 = (FStar_Syntax_Syntax.mk_Total res)
+in (FStar_Syntax_Util.arrow ((((a), (Some (FStar_Syntax_Syntax.imp_tag))))::(((hd1), (None)))::(((tl1), (None)))::[]) uu____2729))))))
+in (
+
+let lex_cons_t1 = (FStar_Syntax_Subst.close_univ_vars ((ucons1)::(ucons2)::[]) lex_cons_t)
+in (
+
+let dc_lexcons = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (((lex_cons), ((ucons1)::(ucons2)::[]), (lex_cons_t1), (FStar_Syntax_Const.lex_t_lid), ((Prims.parse_int "0")), ([]), ([]))); FStar_Syntax_Syntax.sigdoc = d2; FStar_Syntax_Syntax.sigrng = r2}
+in (
+
+let uu____2752 = (FStar_TypeChecker_Env.get_range env)
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle ((((tc)::(dc_lextop)::(dc_lexcons)::[]), ([]), (lids))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = uu____2752}))))))))))))))
+end
+| uu____2756 -> begin
+(
+
+let uu____2758 = (
+
+let uu____2759 = (
+
+let uu____2760 = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_bundle (((ses), ([]), (lids)))))
+in (FStar_Syntax_Print.sigelt_to_string uu____2760))
+in (FStar_Util.format1 "Unexpected lex_t: %s\n" uu____2759))
+in (failwith uu____2758))
+end))
+and tc_assume : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.formula  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.sigelt = (fun env lid phi quals r -> (
+
+let env1 = (FStar_TypeChecker_Env.set_range env r)
+in (
+
+let uu____2771 = (FStar_Syntax_Util.type_u ())
+in (match (uu____2771) with
+| (k, uu____2775) -> begin
+(
+
+let phi1 = (
+
+let uu____2777 = (tc_check_trivial_guard env1 phi k)
+in (FStar_All.pipe_right uu____2777 (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::[]) env1)))
+in ((FStar_TypeChecker_Util.check_uvars r phi1);
+{FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_assume (((lid), (phi1), (quals))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = r};
+))
+end))))
+and tc_inductive : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Ident.lident Prims.list  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env ses quals lids -> (
+
+let env0 = env
+in (
+
+let uu____2788 = (FStar_TypeChecker_TcInductive.check_inductive_well_typedness env ses quals lids)
+in (match (uu____2788) with
+| (sig_bndle, tcs, datas) -> begin
+(
+
+let data_ops_ses = (
+
+let uu____2807 = (FStar_List.map (FStar_TypeChecker_Util.mk_data_operations quals env tcs) datas)
+in (FStar_All.pipe_right uu____2807 FStar_List.flatten))
+in ((
+
+let uu____2815 = ((FStar_Options.no_positivity ()) || (FStar_Options.lax ()))
+in (match (uu____2815) with
+| true -> begin
+()
+end
+| uu____2816 -> begin
+(
+
+let env1 = (FStar_TypeChecker_Env.push_sigelt env0 sig_bndle)
+in (FStar_List.iter (fun ty -> (
+
+let b = (FStar_TypeChecker_TcInductive.check_positivity ty env1)
+in (match ((not (b))) with
+| true -> begin
+(
+
+let uu____2821 = (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, uu____2827, uu____2828, uu____2829, uu____2830, uu____2831, uu____2832) -> begin
+((lid), (ty.FStar_Syntax_Syntax.sigrng))
+end
+| uu____2839 -> begin
+(failwith "Impossible!")
+end)
+in (match (uu____2821) with
+| (lid, r) -> begin
+(FStar_Errors.report r (Prims.strcat "Inductive type " (Prims.strcat lid.FStar_Ident.str " does not satisfy the positivity condition")))
+end))
+end
+| uu____2844 -> begin
+()
+end))) tcs))
+end));
+(
+
+let skip_prims_type = (fun uu____2848 -> (
+
+let lid = (
+
+let ty = (FStar_List.hd tcs)
+in (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, uu____2852, uu____2853, uu____2854, uu____2855, uu____2856, uu____2857) -> begin
+lid
+end
+| uu____2864 -> begin
+(failwith "Impossible")
+end))
+in (
+
+let types_to_skip = ("c_False")::("c_True")::("equals")::("h_equals")::("c_and")::("c_or")::[]
+in (FStar_List.existsb (fun s -> (s = lid.FStar_Ident.ident.FStar_Ident.idText)) types_to_skip))))
+in (
+
+let is_noeq = (FStar_List.existsb (fun q -> (q = FStar_Syntax_Syntax.Noeq)) quals)
+in (
+
+let uu____2870 = ((((FStar_List.length tcs) = (Prims.parse_int "0")) || ((FStar_Ident.lid_equals env.FStar_TypeChecker_Env.curmodule FStar_Syntax_Const.prims_lid) && (skip_prims_type ()))) || is_noeq)
+in (match (uu____2870) with
+| true -> begin
+(((sig_bndle)::[]), (data_ops_ses))
+end
+| uu____2879 -> begin
+(
+
+let is_unopteq = (FStar_List.existsb (fun q -> (q = FStar_Syntax_Syntax.Unopteq)) quals)
+in (
+
+let ses1 = (match (is_unopteq) with
+| true -> begin
+(FStar_TypeChecker_TcInductive.unoptimized_haseq_scheme sig_bndle tcs datas env0 tc_assume)
+end
+| uu____2885 -> begin
+(FStar_TypeChecker_TcInductive.optimized_haseq_scheme sig_bndle tcs datas env0 tc_assume)
+end)
+in (
+
+let uu____2886 = (
+
+let uu____2888 = (
+
+let uu____2889 = (FStar_TypeChecker_Env.get_range env0)
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle ((((FStar_List.append tcs datas)), (quals), (lids))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = uu____2889})
+in (uu____2888)::ses1)
+in ((uu____2886), (data_ops_ses)))))
+end))));
+))
+end))))
+and tc_decl : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_TypeChecker_Env.env * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env se -> (
+
+let env1 = (set_hint_correlator env se)
+in ((FStar_TypeChecker_Util.check_sigelt_quals env1 se);
+(
+
+let r = se.FStar_Syntax_Syntax.sigrng
+in (match (se.FStar_Syntax_Syntax.sigel) with
+| (FStar_Syntax_Syntax.Sig_inductive_typ (_)) | (FStar_Syntax_Syntax.Sig_datacon (_)) -> begin
+(failwith "Impossible bare data-constructor")
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, lids) when (FStar_All.pipe_right lids (FStar_Util.for_some (FStar_Ident.lid_equals FStar_Syntax_Const.lex_t_lid))) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let se1 = (tc_lex_t env2 ses quals lids)
+in (
+
+let uu____2929 = (FStar_TypeChecker_Env.push_sigelt env2 se1)
+in (((se1)::[]), (uu____2929), ([])))))
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, lids) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let uu____2942 = (tc_inductive env2 ses quals lids)
+in (match (uu____2942) with
+| (ses1, projectors_ses) -> begin
+(
+
+let env3 = (FStar_List.fold_left (fun env' se1 -> (FStar_TypeChecker_Env.push_sigelt env' se1)) env2 ses1)
+in ((ses1), (env3), (projectors_ses)))
+end)))
+end
+| FStar_Syntax_Syntax.Sig_pragma (p) -> begin
+(
+
+let set_options1 = (fun t s -> (
+
+let uu____2971 = (FStar_Options.set_options t s)
+in (match (uu____2971) with
+| FStar_Getopt.Success -> begin
+()
+end
+| FStar_Getopt.Help -> begin
+(Prims.raise (FStar_Errors.Error ((("Failed to process pragma: use \'fstar --help\' to see which options are available"), (r)))))
+end
+| FStar_Getopt.Error (s1) -> begin
+(Prims.raise (FStar_Errors.Error ((((Prims.strcat "Failed to process pragma: " s1)), (r)))))
+end)))
+in (match (p) with
+| FStar_Syntax_Syntax.LightOff -> begin
+((match ((p = FStar_Syntax_Syntax.LightOff)) with
+| true -> begin
+(FStar_Options.set_ml_ish ())
+end
+| uu____2979 -> begin
+()
+end);
+(((se)::[]), (env1), ([]));
+)
+end
+| FStar_Syntax_Syntax.SetOptions (o) -> begin
+((set_options1 FStar_Options.Set o);
+(((se)::[]), (env1), ([]));
+)
+end
+| FStar_Syntax_Syntax.ResetOptions (sopt) -> begin
+((
+
+let uu____2989 = (FStar_Options.restore_cmd_line_options false)
+in (FStar_All.pipe_right uu____2989 Prims.ignore));
+(match (sopt) with
+| None -> begin
+()
+end
+| Some (s) -> begin
+(set_options1 FStar_Options.Reset s)
+end);
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.refresh ());
+(((se)::[]), (env1), ([]));
+)
+end))
+end
+| FStar_Syntax_Syntax.Sig_new_effect_for_free (ne) -> begin
+(
+
+let uu____2996 = (cps_and_elaborate env1 ne)
+in (match (uu____2996) with
+| (ses, ne1, lift_from_pure_opt) -> begin
+(
+
+let effect_and_lift_ses = (match (lift_from_pure_opt) with
+| Some (lift) -> begin
+((
+
+let uu___96_3018 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne1); FStar_Syntax_Syntax.sigdoc = uu___96_3018.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___96_3018.FStar_Syntax_Syntax.sigrng}))::(lift)::[]
+end
+| None -> begin
+((
+
+let uu___97_3019 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne1); FStar_Syntax_Syntax.sigdoc = uu___97_3019.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___97_3019.FStar_Syntax_Syntax.sigrng}))::[]
+end)
+in (([]), (env1), ((FStar_List.append ses effect_and_lift_ses))))
+end))
+end
+| FStar_Syntax_Syntax.Sig_new_effect (ne) -> begin
+(
+
+let ne1 = (tc_eff_decl env1 ne)
+in (
+
+let se1 = (
+
+let uu___98_3025 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect (ne1); FStar_Syntax_Syntax.sigdoc = uu___98_3025.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___98_3025.FStar_Syntax_Syntax.sigrng})
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_sigelt env1 se1)
+in (
+
+let uu____3027 = (FStar_All.pipe_right ne1.FStar_Syntax_Syntax.actions (FStar_List.fold_left (fun uu____3038 a -> (match (uu____3038) with
+| (env3, ses) -> begin
+(
+
+let se_let = (FStar_Syntax_Util.action_as_lb ne1.FStar_Syntax_Syntax.mname a)
+in (
+
+let uu____3051 = (FStar_TypeChecker_Env.push_sigelt env3 se_let)
+in ((uu____3051), ((se_let)::ses))))
+end)) ((env2), ((se1)::[]))))
+in (match (uu____3027) with
+| (env3, ses) -> begin
+(((se1)::[]), (env3), ([]))
+end)))))
+end
+| FStar_Syntax_Syntax.Sig_sub_effect (sub1) -> begin
+(
+
+let ed_src = (FStar_TypeChecker_Env.get_effect_decl env1 sub1.FStar_Syntax_Syntax.source)
+in (
+
+let ed_tgt = (FStar_TypeChecker_Env.get_effect_decl env1 sub1.FStar_Syntax_Syntax.target)
+in (
+
+let uu____3068 = (
+
+let uu____3073 = (FStar_TypeChecker_Env.lookup_effect_lid env1 sub1.FStar_Syntax_Syntax.source)
+in (monad_signature env1 sub1.FStar_Syntax_Syntax.source uu____3073))
+in (match (uu____3068) with
+| (a, wp_a_src) -> begin
+(
+
+let uu____3085 = (
+
+let uu____3090 = (FStar_TypeChecker_Env.lookup_effect_lid env1 sub1.FStar_Syntax_Syntax.target)
+in (monad_signature env1 sub1.FStar_Syntax_Syntax.target uu____3090))
+in (match (uu____3085) with
+| (b, wp_b_tgt) -> begin
+(
+
+let wp_a_tgt = (
+
+let uu____3103 = (
+
+let uu____3105 = (
+
+let uu____3106 = (
+
+let uu____3111 = (FStar_Syntax_Syntax.bv_to_name a)
+in ((b), (uu____3111)))
+in FStar_Syntax_Syntax.NT (uu____3106))
+in (uu____3105)::[])
+in (FStar_Syntax_Subst.subst uu____3103 wp_b_tgt))
+in (
+
+let expected_k = (
+
+let uu____3115 = (
+
+let uu____3119 = (FStar_Syntax_Syntax.mk_binder a)
+in (
+
+let uu____3120 = (
+
+let uu____3122 = (FStar_Syntax_Syntax.null_binder wp_a_src)
+in (uu____3122)::[])
+in (uu____3119)::uu____3120))
+in (
+
+let uu____3123 = (FStar_Syntax_Syntax.mk_Total wp_a_tgt)
+in (FStar_Syntax_Util.arrow uu____3115 uu____3123)))
+in (
+
+let repr_type = (fun eff_name a1 wp -> (
+
+let no_reify = (fun l -> (
+
+let uu____3144 = (
+
+let uu____3145 = (
+
+let uu____3148 = (FStar_Util.format1 "Effect %s cannot be reified" l.FStar_Ident.str)
+in (
+
+let uu____3149 = (FStar_TypeChecker_Env.get_range env1)
+in ((uu____3148), (uu____3149))))
+in FStar_Errors.Error (uu____3145))
+in (Prims.raise uu____3144)))
+in (
+
+let uu____3152 = (FStar_TypeChecker_Env.effect_decl_opt env1 eff_name)
+in (match (uu____3152) with
+| None -> begin
+(no_reify eff_name)
+end
+| Some (ed) -> begin
+(
+
+let repr = (FStar_TypeChecker_Env.inst_effect_fun_with ((FStar_Syntax_Syntax.U_unknown)::[]) env1 ed (([]), (ed.FStar_Syntax_Syntax.repr)))
+in (
+
+let uu____3159 = (
+
+let uu____3160 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+in (not (uu____3160)))
+in (match (uu____3159) with
+| true -> begin
+(no_reify eff_name)
+end
+| uu____3164 -> begin
+(
+
+let uu____3165 = (FStar_TypeChecker_Env.get_range env1)
+in (
+
+let uu____3166 = (
+
+let uu____3169 = (
+
+let uu____3170 = (
+
+let uu____3180 = (
+
+let uu____3182 = (FStar_Syntax_Syntax.as_arg a1)
+in (
+
+let uu____3183 = (
+
+let uu____3185 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____3185)::[])
+in (uu____3182)::uu____3183))
+in ((repr), (uu____3180)))
+in FStar_Syntax_Syntax.Tm_app (uu____3170))
+in (FStar_Syntax_Syntax.mk uu____3169))
+in (uu____3166 None uu____3165)))
+end)))
+end))))
+in (
+
+let uu____3195 = (match (((sub1.FStar_Syntax_Syntax.lift), (sub1.FStar_Syntax_Syntax.lift_wp))) with
+| (None, None) -> begin
+(failwith "Impossible")
+end
+| (lift, Some (uu____3210, lift_wp)) -> begin
+(
+
+let uu____3223 = (check_and_gen env1 lift_wp expected_k)
+in ((lift), (uu____3223)))
+end
+| (Some (what, lift), None) -> begin
+((
+
+let uu____3238 = (FStar_TypeChecker_Env.debug env1 (FStar_Options.Other ("ED")))
+in (match (uu____3238) with
+| true -> begin
+(
+
+let uu____3239 = (FStar_Syntax_Print.term_to_string lift)
+in (FStar_Util.print1 "Lift for free : %s\n" uu____3239))
+end
+| uu____3240 -> begin
+()
+end));
+(
+
+let dmff_env = (FStar_TypeChecker_DMFF.empty env1 (FStar_TypeChecker_TcTerm.tc_constant FStar_Range.dummyRange))
+in (
+
+let uu____3242 = (FStar_TypeChecker_TcTerm.tc_term env1 lift)
+in (match (uu____3242) with
+| (lift1, comp, uu____3251) -> begin
+(
+
+let uu____3252 = (FStar_TypeChecker_DMFF.star_expr dmff_env lift1)
+in (match (uu____3252) with
+| (uu____3259, lift_wp, lift_elab) -> begin
+(
+
+let uu____3262 = (recheck_debug "lift-wp" env1 lift_wp)
+in (
+
+let uu____3263 = (recheck_debug "lift-elab" env1 lift_elab)
+in ((Some ((([]), (lift_elab)))), ((([]), (lift_wp))))))
+end))
+end)));
+)
+end)
+in (match (uu____3195) with
+| (lift, lift_wp) -> begin
+(
+
+let lax1 = env1.FStar_TypeChecker_Env.lax
+in (
+
+let env2 = (
+
+let uu___99_3287 = env1
+in {FStar_TypeChecker_Env.solver = uu___99_3287.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___99_3287.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___99_3287.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___99_3287.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___99_3287.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___99_3287.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___99_3287.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___99_3287.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___99_3287.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___99_3287.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___99_3287.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___99_3287.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___99_3287.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___99_3287.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___99_3287.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___99_3287.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___99_3287.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___99_3287.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___99_3287.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___99_3287.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___99_3287.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___99_3287.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___99_3287.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let lift1 = (match (lift) with
+| None -> begin
+None
+end
+| Some (uu____3291, lift1) -> begin
+(
+
+let uu____3298 = (
+
+let uu____3303 = (FStar_TypeChecker_Env.lookup_effect_lid env2 sub1.FStar_Syntax_Syntax.source)
+in (monad_signature env2 sub1.FStar_Syntax_Syntax.source uu____3303))
+in (match (uu____3298) with
+| (a1, wp_a_src1) -> begin
+(
+
+let wp_a = (FStar_Syntax_Syntax.new_bv None wp_a_src1)
+in (
+
+let a_typ = (FStar_Syntax_Syntax.bv_to_name a1)
+in (
+
+let wp_a_typ = (FStar_Syntax_Syntax.bv_to_name wp_a)
+in (
+
+let repr_f = (repr_type sub1.FStar_Syntax_Syntax.source a_typ wp_a_typ)
+in (
+
+let repr_result = (
+
+let lift_wp1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.EraseUniverses)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env2 (Prims.snd lift_wp))
+in (
+
+let lift_wp_a = (
+
+let uu____3325 = (FStar_TypeChecker_Env.get_range env2)
+in (
+
+let uu____3326 = (
+
+let uu____3329 = (
+
+let uu____3330 = (
+
+let uu____3340 = (
+
+let uu____3342 = (FStar_Syntax_Syntax.as_arg a_typ)
+in (
+
+let uu____3343 = (
+
+let uu____3345 = (FStar_Syntax_Syntax.as_arg wp_a_typ)
+in (uu____3345)::[])
+in (uu____3342)::uu____3343))
+in ((lift_wp1), (uu____3340)))
+in FStar_Syntax_Syntax.Tm_app (uu____3330))
+in (FStar_Syntax_Syntax.mk uu____3329))
+in (uu____3326 None uu____3325)))
+in (repr_type sub1.FStar_Syntax_Syntax.target a_typ lift_wp_a)))
+in (
+
+let expected_k1 = (
+
+let uu____3358 = (
+
+let uu____3362 = (FStar_Syntax_Syntax.mk_binder a1)
+in (
+
+let uu____3363 = (
+
+let uu____3365 = (FStar_Syntax_Syntax.mk_binder wp_a)
+in (
+
+let uu____3366 = (
+
+let uu____3368 = (FStar_Syntax_Syntax.null_binder repr_f)
+in (uu____3368)::[])
+in (uu____3365)::uu____3366))
+in (uu____3362)::uu____3363))
+in (
+
+let uu____3369 = (FStar_Syntax_Syntax.mk_Total repr_result)
+in (FStar_Syntax_Util.arrow uu____3358 uu____3369)))
+in (
+
+let uu____3372 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env2 expected_k1)
+in (match (uu____3372) with
+| (expected_k2, uu____3378, uu____3379) -> begin
+(
+
+let lift2 = (check_and_gen env2 lift1 expected_k2)
+in Some (lift2))
+end))))))))
+end))
+end)
+in (
+
+let env3 = (
+
+let uu___100_3382 = env2
+in {FStar_TypeChecker_Env.solver = uu___100_3382.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___100_3382.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___100_3382.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___100_3382.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___100_3382.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___100_3382.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___100_3382.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___100_3382.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___100_3382.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___100_3382.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___100_3382.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___100_3382.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___100_3382.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___100_3382.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___100_3382.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___100_3382.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___100_3382.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___100_3382.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = lax1; FStar_TypeChecker_Env.lax_universes = uu___100_3382.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___100_3382.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___100_3382.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___100_3382.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___100_3382.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let sub2 = (
+
+let uu___101_3384 = sub1
+in {FStar_Syntax_Syntax.source = uu___101_3384.FStar_Syntax_Syntax.source; FStar_Syntax_Syntax.target = uu___101_3384.FStar_Syntax_Syntax.target; FStar_Syntax_Syntax.lift_wp = Some (lift_wp); FStar_Syntax_Syntax.lift = lift1})
+in (
+
+let se1 = (
+
+let uu___102_3386 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_sub_effect (sub2); FStar_Syntax_Syntax.sigdoc = uu___102_3386.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___102_3386.FStar_Syntax_Syntax.sigrng})
+in (
+
+let env4 = (FStar_TypeChecker_Env.push_sigelt env3 se1)
+in (((se1)::[]), (env4), ([])))))))))
+end)))))
+end))
+end))))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uvs, tps, c, tags, flags) -> begin
+(
+
+let env0 = env1
+in (
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let uu____3403 = (FStar_Syntax_Subst.open_comp tps c)
+in (match (uu____3403) with
+| (tps1, c1) -> begin
+(
+
+let uu____3413 = (FStar_TypeChecker_TcTerm.tc_tparams env2 tps1)
+in (match (uu____3413) with
+| (tps2, env3, us) -> begin
+(
+
+let uu____3425 = (FStar_TypeChecker_TcTerm.tc_comp env3 c1)
+in (match (uu____3425) with
+| (c2, u, g) -> begin
+((FStar_TypeChecker_Rel.force_trivial_guard env3 g);
+(
+
+let tps3 = (FStar_Syntax_Subst.close_binders tps2)
+in (
+
+let c3 = (FStar_Syntax_Subst.close_comp tps3 c2)
+in (
+
+let uu____3440 = (
+
+let uu____3441 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((tps3), (c3)))) None r)
+in (FStar_TypeChecker_Util.generalize_universes env0 uu____3441))
+in (match (uu____3440) with
+| (uvs1, t) -> begin
+(
+
+let uu____3455 = (
+
+let uu____3463 = (
+
+let uu____3466 = (
+
+let uu____3467 = (FStar_Syntax_Subst.compress t)
+in uu____3467.FStar_Syntax_Syntax.n)
+in ((tps3), (uu____3466)))
+in (match (uu____3463) with
+| ([], FStar_Syntax_Syntax.Tm_arrow (uu____3477, c4)) -> begin
+(([]), (c4))
+end
+| (uu____3501, FStar_Syntax_Syntax.Tm_arrow (tps4, c4)) -> begin
+((tps4), (c4))
+end
+| uu____3519 -> begin
+(failwith "Impossible")
+end))
+in (match (uu____3455) with
+| (tps4, c4) -> begin
+((match ((((FStar_List.length uvs1) <> (Prims.parse_int "1")) && (not ((FStar_Ident.lid_equals lid FStar_Syntax_Const.effect_Lemma_lid))))) with
+| true -> begin
+(
+
+let uu____3549 = (FStar_Syntax_Subst.open_univ_vars uvs1 t)
+in (match (uu____3549) with
+| (uu____3552, t1) -> begin
+(
+
+let uu____3554 = (
+
+let uu____3555 = (
+
+let uu____3558 = (
+
+let uu____3559 = (FStar_Syntax_Print.lid_to_string lid)
+in (
+
+let uu____3560 = (FStar_All.pipe_right (FStar_List.length uvs1) FStar_Util.string_of_int)
+in (
+
+let uu____3563 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.format3 "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)" uu____3559 uu____3560 uu____3563))))
+in ((uu____3558), (r)))
+in FStar_Errors.Error (uu____3555))
+in (Prims.raise uu____3554))
+end))
+end
+| uu____3564 -> begin
+()
+end);
+(
+
+let se1 = (
+
+let uu___103_3566 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_effect_abbrev (((lid), (uvs1), (tps4), (c4), (tags), (flags))); FStar_Syntax_Syntax.sigdoc = uu___103_3566.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___103_3566.FStar_Syntax_Syntax.sigrng})
+in (
+
+let env4 = (FStar_TypeChecker_Env.push_sigelt env0 se1)
+in (((se1)::[]), (env4), ([]))));
+)
+end))
+end))));
+)
+end))
+end))
+end))))
+end
+| (FStar_Syntax_Syntax.Sig_declare_typ (_, _, _, quals)) | (FStar_Syntax_Syntax.Sig_let (_, _, quals, _)) when (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___79_3592 -> (match (uu___79_3592) with
+| FStar_Syntax_Syntax.OnlyName -> begin
+true
+end
+| uu____3593 -> begin
+false
+end)))) -> begin
+(([]), (env1), ([]))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t, quals) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let uu____3603 = (match ((uvs = [])) with
+| true -> begin
+(
+
+let uu____3604 = (
+
+let uu____3605 = (FStar_Syntax_Util.type_u ())
+in (Prims.fst uu____3605))
+in (check_and_gen env2 t uu____3604))
+end
+| uu____3608 -> begin
+(
+
+let uu____3609 = (FStar_Syntax_Subst.open_univ_vars uvs t)
+in (match (uu____3609) with
+| (uvs1, t1) -> begin
+(
+
+let t2 = (
+
+let uu____3615 = (
+
+let uu____3616 = (FStar_Syntax_Util.type_u ())
+in (Prims.fst uu____3616))
+in (tc_check_trivial_guard env2 t1 uu____3615))
+in (
+
+let t3 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.NoFullNorm)::(FStar_TypeChecker_Normalize.Beta)::[]) env2 t2)
+in (
+
+let uu____3620 = (FStar_Syntax_Subst.close_univ_vars uvs1 t3)
+in ((uvs1), (uu____3620)))))
+end))
+end)
+in (match (uu____3603) with
+| (uvs1, t1) -> begin
+(
+
+let se1 = (
+
+let uu___104_3631 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((lid), (uvs1), (t1), (quals))); FStar_Syntax_Syntax.sigdoc = uu___104_3631.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___104_3631.FStar_Syntax_Syntax.sigrng})
+in (
+
+let env3 = (FStar_TypeChecker_Env.push_sigelt env2 se1)
+in (((se1)::[]), (env3), ([]))))
+end)))
+end
+| FStar_Syntax_Syntax.Sig_assume (lid, phi, quals) -> begin
+(
+
+let se1 = (tc_assume env1 lid phi quals r)
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_sigelt env1 se1)
+in (((se1)::[]), (env2), ([]))))
+end
+| FStar_Syntax_Syntax.Sig_main (e) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let env3 = (FStar_TypeChecker_Env.set_expected_typ env2 FStar_TypeChecker_Common.t_unit)
+in (
+
+let uu____3649 = (FStar_TypeChecker_TcTerm.tc_term env3 e)
+in (match (uu____3649) with
+| (e1, c, g1) -> begin
+(
+
+let uu____3661 = (
+
+let uu____3665 = (
+
+let uu____3667 = (FStar_Syntax_Util.ml_comp FStar_TypeChecker_Common.t_unit r)
+in Some (uu____3667))
+in (
+
+let uu____3668 = (
+
+let uu____3671 = (c.FStar_Syntax_Syntax.comp ())
+in ((e1), (uu____3671)))
+in (FStar_TypeChecker_TcTerm.check_expected_effect env3 uu____3665 uu____3668)))
+in (match (uu____3661) with
+| (e2, uu____3682, g) -> begin
+((
+
+let uu____3685 = (FStar_TypeChecker_Rel.conj_guard g1 g)
+in (FStar_TypeChecker_Rel.force_trivial_guard env3 uu____3685));
+(
+
+let se1 = (
+
+let uu___105_3687 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_main (e2); FStar_Syntax_Syntax.sigdoc = uu___105_3687.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___105_3687.FStar_Syntax_Syntax.sigrng})
+in (
+
+let env4 = (FStar_TypeChecker_Env.push_sigelt env3 se1)
+in (((se1)::[]), (env4), ([]))));
+)
+end))
+end))))
+end
+| FStar_Syntax_Syntax.Sig_let (lbs, lids, quals, attrs) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.set_range env1 r)
+in (
+
+let check_quals_eq = (fun l qopt q -> (match (qopt) with
+| None -> begin
+Some (q)
+end
+| Some (q') -> begin
+(
+
+let uu____3727 = (((FStar_List.length q) = (FStar_List.length q')) && (FStar_List.forall2 FStar_Syntax_Util.qualifier_equal q q'))
+in (match (uu____3727) with
+| true -> begin
+Some (q)
+end
+| uu____3735 -> begin
+(
+
+let uu____3736 = (
+
+let uu____3737 = (
+
+let uu____3740 = (
+
+let uu____3741 = (FStar_Syntax_Print.lid_to_string l)
+in (
+
+let uu____3742 = (FStar_Syntax_Print.quals_to_string q)
+in (
+
+let uu____3743 = (FStar_Syntax_Print.quals_to_string q')
+in (FStar_Util.format3 "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}" uu____3741 uu____3742 uu____3743))))
+in ((uu____3740), (r)))
+in FStar_Errors.Error (uu____3737))
+in (Prims.raise uu____3736))
+end))
+end))
+in (
+
+let uu____3746 = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.fold_left (fun uu____3767 lb -> (match (uu____3767) with
+| (gen1, lbs1, quals_opt) -> begin
+(
+
+let lbname = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____3791 = (
+
+let uu____3797 = (FStar_TypeChecker_Env.try_lookup_val_decl env2 lbname.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____3797) with
+| None -> begin
+(match ((lb.FStar_Syntax_Syntax.lbunivs <> [])) with
+| true -> begin
+((false), (lb), (quals_opt))
+end
+| uu____3822 -> begin
+((gen1), (lb), (quals_opt))
+end)
+end
+| Some ((uvs, tval), quals1) -> begin
+(
+
+let quals_opt1 = (check_quals_eq lbname.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v quals_opt quals1)
+in ((match (lb.FStar_Syntax_Syntax.lbtyp.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+()
+end
+| uu____3849 -> begin
+(FStar_Errors.warn r "Annotation from val declaration overrides inline type annotation")
+end);
+(match (((lb.FStar_Syntax_Syntax.lbunivs <> []) && ((FStar_List.length lb.FStar_Syntax_Syntax.lbunivs) <> (FStar_List.length uvs)))) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Inline universes are incoherent with annotation from val declaration"), (r)))))
+end
+| uu____3856 -> begin
+()
+end);
+(
+
+let uu____3857 = (FStar_Syntax_Syntax.mk_lb ((FStar_Util.Inr (lbname)), (uvs), (FStar_Syntax_Const.effect_ALL_lid), (tval), (lb.FStar_Syntax_Syntax.lbdef)))
+in ((false), (uu____3857), (quals_opt1)));
+))
+end))
+in (match (uu____3791) with
+| (gen2, lb1, quals_opt1) -> begin
+((gen2), ((lb1)::lbs1), (quals_opt1))
+end)))
+end)) ((true), ([]), ((match ((quals = [])) with
+| true -> begin
+None
+end
+| uu____3888 -> begin
+Some (quals)
+end)))))
+in (match (uu____3746) with
+| (should_generalize, lbs', quals_opt) -> begin
+(
+
+let quals1 = (match (quals_opt) with
+| None -> begin
+(FStar_Syntax_Syntax.Visible_default)::[]
+end
+| Some (q) -> begin
+(
+
+let uu____3911 = (FStar_All.pipe_right q (FStar_Util.for_some (fun uu___80_3913 -> (match (uu___80_3913) with
+| (FStar_Syntax_Syntax.Irreducible) | (FStar_Syntax_Syntax.Visible_default) | (FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen) -> begin
+true
+end
+| uu____3914 -> begin
+false
+end))))
+in (match (uu____3911) with
+| true -> begin
+q
+end
+| uu____3916 -> begin
+(FStar_Syntax_Syntax.Visible_default)::q
+end))
+end)
+in (
+
+let lbs'1 = (FStar_List.rev lbs')
+in (
+
+let e = (
+
+let uu____3922 = (
+
+let uu____3925 = (
+
+let uu____3926 = (
+
+let uu____3934 = (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit)) None r)
+in (((((Prims.fst lbs)), (lbs'1))), (uu____3934)))
+in FStar_Syntax_Syntax.Tm_let (uu____3926))
+in (FStar_Syntax_Syntax.mk uu____3925))
+in (uu____3922 None r))
+in (
+
+let uu____3956 = (
+
+let uu____3962 = (FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term (
+
+let uu___106_3966 = env2
+in {FStar_TypeChecker_Env.solver = uu___106_3966.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___106_3966.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___106_3966.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___106_3966.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___106_3966.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___106_3966.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___106_3966.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___106_3966.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___106_3966.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___106_3966.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___106_3966.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = should_generalize; FStar_TypeChecker_Env.letrecs = uu___106_3966.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = true; FStar_TypeChecker_Env.check_uvars = uu___106_3966.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___106_3966.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___106_3966.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___106_3966.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___106_3966.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___106_3966.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___106_3966.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___106_3966.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___106_3966.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___106_3966.FStar_TypeChecker_Env.qname_and_index}) e)
+in (match (uu____3962) with
+| ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_let (lbs1, e1); FStar_Syntax_Syntax.tk = uu____3974; FStar_Syntax_Syntax.pos = uu____3975; FStar_Syntax_Syntax.vars = uu____3976}, uu____3977, g) when (FStar_TypeChecker_Rel.is_trivial g) -> begin
+(
+
+let quals2 = (match (e1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_meta (uu____3996, FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Masked_effect)) -> begin
+(FStar_Syntax_Syntax.HasMaskedEffect)::quals1
+end
+| uu____4001 -> begin
+quals1
+end)
+in (
+
+let quals3 = (FStar_List.choose (fun uu___81_4004 -> (match (uu___81_4004) with
+| FStar_Syntax_Syntax.Inline_for_extraction -> begin
+(
+
+let uu____4006 = (
+
+let uu____4007 = (FStar_List.for_all (fun lb -> (
+
+let ok = (FStar_Syntax_Util.is_pure_or_ghost_function lb.FStar_Syntax_Syntax.lbtyp)
+in ((match ((not (ok))) with
+| true -> begin
+(
+
+let uu____4011 = (FStar_Syntax_Print.lbname_to_string lb.FStar_Syntax_Syntax.lbname)
+in (FStar_Util.print1_warning "Dropping inline_for_extraction from %s because it is not a pure function\n" uu____4011))
+end
+| uu____4012 -> begin
+()
+end);
+ok;
+))) (Prims.snd lbs1))
+in (not (uu____4007)))
+in (match (uu____4006) with
+| true -> begin
+None
+end
+| uu____4015 -> begin
+Some (FStar_Syntax_Syntax.Inline_for_extraction)
+end))
+end
+| q -> begin
+Some (q)
+end)) quals2)
+in (((
+
+let uu___107_4020 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let (((lbs1), (lids), (quals3), (attrs))); FStar_Syntax_Syntax.sigdoc = uu___107_4020.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___107_4020.FStar_Syntax_Syntax.sigrng})), (lbs1))))
+end
+| uu____4027 -> begin
+(failwith "impossible")
+end))
+in (match (uu____3956) with
+| (se1, lbs1) -> begin
+((FStar_All.pipe_right (Prims.snd lbs1) (FStar_List.iter (fun lb -> (
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____4054 = (FStar_Syntax_Syntax.range_of_fv fv)
+in (FStar_TypeChecker_Common.insert_identifier_info (FStar_Util.Inr (fv)) lb.FStar_Syntax_Syntax.lbtyp uu____4054))))));
+(
+
+let uu____4056 = (log env2)
+in (match (uu____4056) with
+| true -> begin
+(
+
+let uu____4057 = (
+
+let uu____4058 = (FStar_All.pipe_right (Prims.snd lbs1) (FStar_List.map (fun lb -> (
+
+let should_log = (
+
+let uu____4065 = (
+
+let uu____4070 = (
+
+let uu____4071 = (
+
+let uu____4076 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in uu____4076.FStar_Syntax_Syntax.fv_name)
+in uu____4071.FStar_Syntax_Syntax.v)
+in (FStar_TypeChecker_Env.try_lookup_val_decl env2 uu____4070))
+in (match (uu____4065) with
+| None -> begin
+true
+end
+| uu____4083 -> begin
+false
+end))
+in (match (should_log) with
+| true -> begin
+(
+
+let uu____4088 = (FStar_Syntax_Print.lbname_to_string lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____4089 = (FStar_Syntax_Print.term_to_string lb.FStar_Syntax_Syntax.lbtyp)
+in (FStar_Util.format2 "let %s : %s" uu____4088 uu____4089)))
+end
+| uu____4090 -> begin
+""
+end)))))
+in (FStar_All.pipe_right uu____4058 (FStar_String.concat "\n")))
+in (FStar_Util.print1 "%s\n" uu____4057))
+end
+| uu____4092 -> begin
+()
+end));
+(
+
+let env3 = (FStar_TypeChecker_Env.push_sigelt env2 se1)
+in (((se1)::[]), (env3), ([])));
+)
+end)))))
+end))))
+end));
+)))
+
+
+let for_export : FStar_Ident.lident Prims.list  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Ident.lident Prims.list) = (fun hidden se -> (
+
+let is_abstract = (fun quals -> (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___82_4119 -> (match (uu___82_4119) with
+| FStar_Syntax_Syntax.Abstract -> begin
+true
+end
+| uu____4120 -> begin
+false
+end)))))
+in (
+
+let is_hidden_proj_or_disc = (fun q -> (match (q) with
+| (FStar_Syntax_Syntax.Projector (l, _)) | (FStar_Syntax_Syntax.Discriminator (l)) -> begin
+(FStar_All.pipe_right hidden (FStar_Util.for_some (FStar_Ident.lid_equals l)))
+end
+| uu____4128 -> begin
+false
+end))
+in (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_pragma (uu____4133) -> begin
+(([]), (hidden))
+end
+| (FStar_Syntax_Syntax.Sig_inductive_typ (_)) | (FStar_Syntax_Syntax.Sig_datacon (_)) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, uu____4144) -> begin
+(
+
+let uu____4151 = (is_abstract quals)
+in (match (uu____4151) with
+| true -> begin
+(
+
+let for_export_bundle = (fun se1 uu____4170 -> (match (uu____4170) with
+| (out, hidden1) -> begin
+(match (se1.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (l, us, bs, t, uu____4193, uu____4194, quals1) -> begin
+(
+
+let dec = (
+
+let uu___108_4203 = se1
+in (
+
+let uu____4204 = (
+
+let uu____4205 = (
+
+let uu____4211 = (
+
+let uu____4214 = (FStar_Syntax_Syntax.mk_Total t)
+in (FStar_Syntax_Util.arrow bs uu____4214))
+in ((l), (us), (uu____4211), ((FStar_Syntax_Syntax.Assumption)::(FStar_Syntax_Syntax.New)::quals1)))
+in FStar_Syntax_Syntax.Sig_declare_typ (uu____4205))
+in {FStar_Syntax_Syntax.sigel = uu____4204; FStar_Syntax_Syntax.sigdoc = uu___108_4203.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___108_4203.FStar_Syntax_Syntax.sigrng}))
+in (((dec)::out), (hidden1)))
+end
+| FStar_Syntax_Syntax.Sig_datacon (l, us, t, uu____4225, uu____4226, uu____4227, uu____4228) -> begin
+(
+
+let dec = (
+
+let uu___109_4234 = se1
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), (us), (t), ((FStar_Syntax_Syntax.Assumption)::[]))); FStar_Syntax_Syntax.sigdoc = uu___109_4234.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___109_4234.FStar_Syntax_Syntax.sigrng})
+in (((dec)::out), ((l)::hidden1)))
+end
+| uu____4238 -> begin
+((out), (hidden1))
+end)
+end))
+in (FStar_List.fold_right for_export_bundle ses (([]), (hidden))))
+end
+| uu____4247 -> begin
+(((se)::[]), (hidden))
+end))
+end
+| FStar_Syntax_Syntax.Sig_assume (uu____4250, uu____4251, quals) -> begin
+(
+
+let uu____4255 = (is_abstract quals)
+in (match (uu____4255) with
+| true -> begin
+(([]), (hidden))
+end
+| uu____4262 -> begin
+(((se)::[]), (hidden))
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (l, us, t, quals) -> begin
+(
+
+let uu____4271 = (FStar_All.pipe_right quals (FStar_Util.for_some is_hidden_proj_or_disc))
+in (match (uu____4271) with
+| true -> begin
+((((
+
+let uu___110_4279 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((l), (us), (t), ((FStar_Syntax_Syntax.Assumption)::[]))); FStar_Syntax_Syntax.sigdoc = uu___110_4279.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___110_4279.FStar_Syntax_Syntax.sigrng}))::[]), ((l)::hidden))
+end
+| uu____4281 -> begin
+(
+
+let uu____4282 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___83_4284 -> (match (uu___83_4284) with
+| (FStar_Syntax_Syntax.Assumption) | (FStar_Syntax_Syntax.Projector (_)) | (FStar_Syntax_Syntax.Discriminator (_)) -> begin
+true
+end
+| uu____4287 -> begin
+false
+end))))
+in (match (uu____4282) with
+| true -> begin
+(((se)::[]), (hidden))
+end
+| uu____4294 -> begin
+(([]), (hidden))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Sig_main (uu____4297) -> begin
+(([]), (hidden))
+end
+| (FStar_Syntax_Syntax.Sig_new_effect (_)) | (FStar_Syntax_Syntax.Sig_new_effect_for_free (_)) | (FStar_Syntax_Syntax.Sig_sub_effect (_)) | (FStar_Syntax_Syntax.Sig_effect_abbrev (_)) -> begin
+(((se)::[]), (hidden))
+end
+| FStar_Syntax_Syntax.Sig_let ((false, (lb)::[]), uu____4307, quals, uu____4309) when (FStar_All.pipe_right quals (FStar_Util.for_some is_hidden_proj_or_disc)) -> begin
+(
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let lid = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____4327 = (FStar_All.pipe_right hidden (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)))
+in (match (uu____4327) with
+| true -> begin
+(([]), (hidden))
+end
+| uu____4335 -> begin
+(
+
+let dec = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v), (lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp), ((FStar_Syntax_Syntax.Assumption)::[]))); FStar_Syntax_Syntax.sigdoc = se.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid lid)}
+in (((dec)::[]), ((lid)::hidden)))
+end))))
+end
+| FStar_Syntax_Syntax.Sig_let (lbs, l, quals, uu____4350) -> begin
+(
+
+let uu____4357 = (is_abstract quals)
+in (match (uu____4357) with
+| true -> begin
+(
+
+let uu____4362 = (FStar_All.pipe_right (Prims.snd lbs) (FStar_List.map (fun lb -> (
+
+let uu___111_4368 = se
+in (
+
+let uu____4369 = (
+
+let uu____4370 = (
+
+let uu____4376 = (
+
+let uu____4377 = (
+
+let uu____4382 = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in uu____4382.FStar_Syntax_Syntax.fv_name)
+in uu____4377.FStar_Syntax_Syntax.v)
+in ((uu____4376), (lb.FStar_Syntax_Syntax.lbunivs), (lb.FStar_Syntax_Syntax.lbtyp), ((FStar_Syntax_Syntax.Assumption)::quals)))
+in FStar_Syntax_Syntax.Sig_declare_typ (uu____4370))
+in {FStar_Syntax_Syntax.sigel = uu____4369; FStar_Syntax_Syntax.sigdoc = uu___111_4368.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___111_4368.FStar_Syntax_Syntax.sigrng})))))
+in ((uu____4362), (hidden)))
+end
+| uu____4392 -> begin
+(((se)::[]), (hidden))
+end))
+end))))
+
+
+let tc_decls : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Syntax_Syntax.sigelt Prims.list * FStar_TypeChecker_Env.env) = (fun env ses -> (
+
+let rec process_one_decl = (fun uu____4430 se -> (match (uu____4430) with
+| (ses1, exports, env1, hidden) -> begin
+((
+
+let uu____4460 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____4460) with
+| true -> begin
+(
+
+let uu____4461 = (FStar_Syntax_Print.sigelt_to_string se)
+in (FStar_Util.print1 ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____4461))
+end
+| uu____4462 -> begin
+()
+end));
+(
+
+let uu____4463 = (tc_decl env1 se)
+in (match (uu____4463) with
+| (ses', env2, ses_elaborated) -> begin
+((
+
+let uu____4487 = ((FStar_Options.log_types ()) || (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("LogTypes"))))
+in (match (uu____4487) with
+| true -> begin
+(
+
+let uu____4488 = (FStar_List.fold_left (fun s se1 -> (
+
+let uu____4491 = (
+
+let uu____4492 = (FStar_Syntax_Print.sigelt_to_string se1)
+in (Prims.strcat uu____4492 "\n"))
+in (Prims.strcat s uu____4491))) "" ses')
+in (FStar_Util.print1 "Checked: %s\n" uu____4488))
+end
+| uu____4493 -> begin
+()
+end));
+(FStar_List.iter (fun se1 -> (env2.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.encode_sig env2 se1)) ses');
+(
+
+let uu____4496 = (
+
+let accum_exports_hidden = (fun uu____4514 se1 -> (match (uu____4514) with
+| (exports1, hidden1) -> begin
+(
+
+let uu____4530 = (for_export hidden1 se1)
+in (match (uu____4530) with
+| (se_exported, hidden2) -> begin
+(((FStar_List.rev_append se_exported exports1)), (hidden2))
+end))
+end))
+in (FStar_List.fold_left accum_exports_hidden ((exports), (hidden)) ses'))
+in (match (uu____4496) with
+| (exports1, hidden1) -> begin
+(((((FStar_List.rev_append ses' ses1)), (exports1), (env2), (hidden1))), (ses_elaborated))
+end));
+)
+end));
+)
+end))
+in (
+
+let uu____4580 = (FStar_Util.fold_flatten process_one_decl (([]), ([]), (env), ([])) ses)
+in (match (uu____4580) with
+| (ses1, exports, env1, uu____4606) -> begin
+(((FStar_List.rev_append ses1 [])), ((FStar_List.rev_append exports [])), (env1))
+end))))
+
+
+let tc_partial_modul : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  (FStar_Syntax_Syntax.modul * FStar_Syntax_Syntax.sigelt Prims.list * FStar_TypeChecker_Env.env) = (fun env modul -> (
+
+let verify = (FStar_Options.should_verify modul.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in (
+
+let action = (match (verify) with
+| true -> begin
+"Verifying"
+end
+| uu____4627 -> begin
+"Lax-checking"
+end)
+in (
+
+let label1 = (match (modul.FStar_Syntax_Syntax.is_interface) with
+| true -> begin
+"interface"
+end
+| uu____4629 -> begin
+"implementation"
+end)
+in ((
+
+let uu____4631 = (FStar_Options.debug_any ())
+in (match (uu____4631) with
+| true -> begin
+(FStar_Util.print3 "%s %s of %s\n" action label1 modul.FStar_Syntax_Syntax.name.FStar_Ident.str)
+end
+| uu____4632 -> begin
+()
+end));
+(
+
+let name = (FStar_Util.format2 "%s %s" (match (modul.FStar_Syntax_Syntax.is_interface) with
+| true -> begin
+"interface"
+end
+| uu____4634 -> begin
+"module"
+end) modul.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in (
+
+let msg = (Prims.strcat "Internals for " name)
+in (
+
+let env1 = (
+
+let uu___112_4637 = env
+in {FStar_TypeChecker_Env.solver = uu___112_4637.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___112_4637.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___112_4637.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___112_4637.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___112_4637.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___112_4637.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___112_4637.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___112_4637.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___112_4637.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___112_4637.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___112_4637.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___112_4637.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___112_4637.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___112_4637.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___112_4637.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___112_4637.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = modul.FStar_Syntax_Syntax.is_interface; FStar_TypeChecker_Env.admit = (not (verify)); FStar_TypeChecker_Env.lax = uu___112_4637.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___112_4637.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___112_4637.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___112_4637.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___112_4637.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___112_4637.FStar_TypeChecker_Env.qname_and_index})
+in ((env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.push msg);
+(
+
+let env2 = (FStar_TypeChecker_Env.set_current_module env1 modul.FStar_Syntax_Syntax.name)
+in (
+
+let uu____4640 = (tc_decls env2 modul.FStar_Syntax_Syntax.declarations)
+in (match (uu____4640) with
+| (ses, exports, env3) -> begin
+(((
+
+let uu___113_4658 = modul
+in {FStar_Syntax_Syntax.name = uu___113_4658.FStar_Syntax_Syntax.name; FStar_Syntax_Syntax.declarations = ses; FStar_Syntax_Syntax.exports = uu___113_4658.FStar_Syntax_Syntax.exports; FStar_Syntax_Syntax.is_interface = uu___113_4658.FStar_Syntax_Syntax.is_interface})), (exports), (env3))
+end)));
+))));
+)))))
+
+
+let tc_more_partial_modul : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  (FStar_Syntax_Syntax.modul * FStar_Syntax_Syntax.sigelt Prims.list * FStar_TypeChecker_Env.env) = (fun env modul decls -> (
+
+let uu____4674 = (tc_decls env decls)
+in (match (uu____4674) with
+| (ses, exports, env1) -> begin
+(
+
+let modul1 = (
+
+let uu___114_4692 = modul
+in {FStar_Syntax_Syntax.name = uu___114_4692.FStar_Syntax_Syntax.name; FStar_Syntax_Syntax.declarations = (FStar_List.append modul.FStar_Syntax_Syntax.declarations ses); FStar_Syntax_Syntax.exports = uu___114_4692.FStar_Syntax_Syntax.exports; FStar_Syntax_Syntax.is_interface = uu___114_4692.FStar_Syntax_Syntax.is_interface})
+in ((modul1), (exports), (env1)))
+end)))
+
+
+let check_exports : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  Prims.unit = (fun env modul exports -> (
+
+let env1 = (
+
+let uu___115_4706 = env
+in {FStar_TypeChecker_Env.solver = uu___115_4706.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___115_4706.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___115_4706.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___115_4706.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___115_4706.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___115_4706.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___115_4706.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___115_4706.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___115_4706.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___115_4706.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___115_4706.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___115_4706.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___115_4706.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = true; FStar_TypeChecker_Env.check_uvars = uu___115_4706.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___115_4706.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___115_4706.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___115_4706.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = true; FStar_TypeChecker_Env.type_of = uu___115_4706.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___115_4706.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___115_4706.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___115_4706.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let check_term = (fun lid univs1 t -> (
+
+let uu____4717 = (FStar_Syntax_Subst.open_univ_vars univs1 t)
+in (match (uu____4717) with
+| (univs2, t1) -> begin
+((
+
+let uu____4723 = (
+
+let uu____4724 = (
+
+let uu____4727 = (FStar_TypeChecker_Env.set_current_module env1 modul.FStar_Syntax_Syntax.name)
+in (FStar_TypeChecker_Env.debug uu____4727))
+in (FStar_All.pipe_left uu____4724 (FStar_Options.Other ("Exports"))))
+in (match (uu____4723) with
+| true -> begin
+(
+
+let uu____4728 = (FStar_Syntax_Print.lid_to_string lid)
+in (
+
+let uu____4729 = (
+
+let uu____4730 = (FStar_All.pipe_right univs2 (FStar_List.map (fun x -> (FStar_Syntax_Print.univ_to_string (FStar_Syntax_Syntax.U_name (x))))))
+in (FStar_All.pipe_right uu____4730 (FStar_String.concat ", ")))
+in (
+
+let uu____4735 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print3 "Checking for export %s <%s> : %s\n" uu____4728 uu____4729 uu____4735))))
+end
+| uu____4736 -> begin
+()
+end));
+(
+
+let env2 = (FStar_TypeChecker_Env.push_univ_vars env1 univs2)
+in (
+
+let uu____4738 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1)
+in (FStar_All.pipe_right uu____4738 Prims.ignore)));
+)
+end)))
+in (
+
+let check_term1 = (fun lid univs1 t -> ((
+
+let uu____4756 = (
+
+let uu____4757 = (FStar_Syntax_Print.lid_to_string modul.FStar_Syntax_Syntax.name)
+in (
+
+let uu____4758 = (FStar_Syntax_Print.lid_to_string lid)
+in (FStar_Util.format2 "Interface of %s violates its abstraction (add a \'private\' qualifier to \'%s\'?)" uu____4757 uu____4758)))
+in (FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____4756));
+(check_term lid univs1 t);
+(FStar_Errors.message_prefix.FStar_Errors.clear_prefix ());
+))
+in (
+
+let rec check_sigelt = (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_bundle (ses, quals, uu____4766) -> begin
+(
+
+let uu____4773 = (
+
+let uu____4774 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Private))
+in (not (uu____4774)))
+in (match (uu____4773) with
+| true -> begin
+(FStar_All.pipe_right ses (FStar_List.iter check_sigelt))
+end
+| uu____4777 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_inductive_typ (l, univs1, binders, typ, uu____4782, uu____4783, uu____4784) -> begin
+(
+
+let t = (
+
+let uu____4794 = (
+
+let uu____4797 = (
+
+let uu____4798 = (
+
+let uu____4806 = (FStar_Syntax_Syntax.mk_Total typ)
+in ((binders), (uu____4806)))
+in FStar_Syntax_Syntax.Tm_arrow (uu____4798))
+in (FStar_Syntax_Syntax.mk uu____4797))
+in (uu____4794 None se.FStar_Syntax_Syntax.sigrng))
+in (check_term1 l univs1 t))
+end
+| FStar_Syntax_Syntax.Sig_datacon (l, univs1, t, uu____4818, uu____4819, uu____4820, uu____4821) -> begin
+(check_term1 l univs1 t)
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (l, univs1, t, quals) -> begin
+(
+
+let uu____4832 = (
+
+let uu____4833 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Private))
+in (not (uu____4833)))
+in (match (uu____4832) with
+| true -> begin
+(check_term1 l univs1 t)
+end
+| uu____4835 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_let ((uu____4836, lbs), uu____4838, quals, uu____4840) -> begin
+(
+
+let uu____4852 = (
+
+let uu____4853 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Private))
+in (not (uu____4853)))
+in (match (uu____4852) with
+| true -> begin
+(FStar_All.pipe_right lbs (FStar_List.iter (fun lb -> (
+
+let fv = (FStar_Util.right lb.FStar_Syntax_Syntax.lbname)
+in (check_term1 fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v lb.FStar_Syntax_Syntax.lbunivs lb.FStar_Syntax_Syntax.lbtyp)))))
+end
+| uu____4862 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (l, univs1, binders, comp, quals, flags) -> begin
+(
+
+let uu____4873 = (
+
+let uu____4874 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Private))
+in (not (uu____4874)))
+in (match (uu____4873) with
+| true -> begin
+(
+
+let arrow1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((binders), (comp))))) None se.FStar_Syntax_Syntax.sigrng)
+in (check_term1 l univs1 arrow1))
+end
+| uu____4887 -> begin
+()
+end))
+end
+| (FStar_Syntax_Syntax.Sig_main (_)) | (FStar_Syntax_Syntax.Sig_assume (_)) | (FStar_Syntax_Syntax.Sig_new_effect (_)) | (FStar_Syntax_Syntax.Sig_new_effect_for_free (_)) | (FStar_Syntax_Syntax.Sig_sub_effect (_)) | (FStar_Syntax_Syntax.Sig_pragma (_)) -> begin
+()
+end))
+in (match ((FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name FStar_Syntax_Const.prims_lid)) with
+| true -> begin
+()
+end
+| uu____4894 -> begin
+(FStar_List.iter check_sigelt exports)
+end))))))
+
+
+let finish_partial_modul : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  FStar_Syntax_Syntax.sigelts  ->  (FStar_Syntax_Syntax.modul * FStar_TypeChecker_Env.env) = (fun env modul exports -> (
+
+let modul1 = (
+
+let uu___116_4907 = modul
+in {FStar_Syntax_Syntax.name = uu___116_4907.FStar_Syntax_Syntax.name; FStar_Syntax_Syntax.declarations = uu___116_4907.FStar_Syntax_Syntax.declarations; FStar_Syntax_Syntax.exports = exports; FStar_Syntax_Syntax.is_interface = modul.FStar_Syntax_Syntax.is_interface})
+in (
+
+let env1 = (FStar_TypeChecker_Env.finish_module env modul1)
+in ((
+
+let uu____4910 = (
+
+let uu____4911 = (FStar_Options.lax ())
+in (not (uu____4911)))
+in (match (uu____4910) with
+| true -> begin
+(check_exports env1 modul1 exports)
+end
+| uu____4912 -> begin
+()
+end));
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.pop (Prims.strcat "Ending modul " modul1.FStar_Syntax_Syntax.name.FStar_Ident.str));
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.encode_modul env1 modul1);
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.refresh ());
+(
+
+let uu____4917 = (
+
+let uu____4918 = (FStar_Options.interactive ())
+in (not (uu____4918)))
+in (match (uu____4917) with
+| true -> begin
+(
+
+let uu____4919 = (FStar_Options.restore_cmd_line_options true)
+in (FStar_All.pipe_right uu____4919 Prims.ignore))
+end
+| uu____4920 -> begin
+()
+end));
+((modul1), (env1));
+))))
+
+
+let tc_modul : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  (FStar_Syntax_Syntax.modul * FStar_TypeChecker_Env.env) = (fun env modul -> (
+
+let uu____4929 = (tc_partial_modul env modul)
+in (match (uu____4929) with
+| (modul1, non_private_decls, env1) -> begin
+(finish_partial_modul env1 modul1 non_private_decls)
+end)))
+
+
+let check_module : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.modul  ->  (FStar_Syntax_Syntax.modul * FStar_TypeChecker_Env.env) = (fun env m -> ((
+
+let uu____4950 = (FStar_Options.debug_any ())
+in (match (uu____4950) with
+| true -> begin
+(
+
+let uu____4951 = (FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name)
+in (FStar_Util.print2 "Checking %s: %s\n" (match (m.FStar_Syntax_Syntax.is_interface) with
+| true -> begin
+"i\'face"
+end
+| uu____4952 -> begin
+"module"
+end) uu____4951))
+end
+| uu____4953 -> begin
+()
+end));
+(
+
+let env1 = (
+
+let uu___117_4955 = env
+in (
+
+let uu____4956 = (
+
+let uu____4957 = (FStar_Options.should_verify m.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in (not (uu____4957)))
+in {FStar_TypeChecker_Env.solver = uu___117_4955.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___117_4955.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___117_4955.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___117_4955.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___117_4955.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___117_4955.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___117_4955.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___117_4955.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___117_4955.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___117_4955.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___117_4955.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___117_4955.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___117_4955.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___117_4955.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___117_4955.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___117_4955.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___117_4955.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___117_4955.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu____4956; FStar_TypeChecker_Env.lax_universes = uu___117_4955.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___117_4955.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___117_4955.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___117_4955.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___117_4955.FStar_TypeChecker_Env.qname_and_index}))
+in (
+
+let uu____4958 = (tc_modul env1 m)
+in (match (uu____4958) with
+| (m1, env2) -> begin
+((
+
+let uu____4966 = (FStar_Options.dump_module m1.FStar_Syntax_Syntax.name.FStar_Ident.str)
+in (match (uu____4966) with
+| true -> begin
+(
+
+let uu____4967 = (FStar_Syntax_Print.modul_to_string m1)
+in (FStar_Util.print1 "%s\n" uu____4967))
+end
+| uu____4968 -> begin
+()
+end));
+(
+
+let uu____4970 = ((FStar_Options.dump_module m1.FStar_Syntax_Syntax.name.FStar_Ident.str) && (FStar_Options.debug_at_level m1.FStar_Syntax_Syntax.name.FStar_Ident.str (FStar_Options.Other ("Normalize"))))
+in (match (uu____4970) with
+| true -> begin
+(
+
+let normalize_toplevel_lets = (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((b, lbs), ids, qs, attrs) -> begin
+(
+
+let n1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Reify)::(FStar_TypeChecker_Normalize.Inlining)::(FStar_TypeChecker_Normalize.Primops)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]))
+in (
+
+let update = (fun lb -> (
+
+let uu____5000 = (FStar_Syntax_Subst.open_univ_vars lb.FStar_Syntax_Syntax.lbunivs lb.FStar_Syntax_Syntax.lbdef)
+in (match (uu____5000) with
+| (univnames1, e) -> begin
+(
+
+let uu___118_5005 = lb
+in (
+
+let uu____5006 = (
+
+let uu____5009 = (FStar_TypeChecker_Env.push_univ_vars env2 univnames1)
+in (n1 uu____5009 e))
+in {FStar_Syntax_Syntax.lbname = uu___118_5005.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = uu___118_5005.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___118_5005.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___118_5005.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu____5006}))
+end)))
+in (
+
+let uu___119_5010 = se
+in (
+
+let uu____5011 = (
+
+let uu____5012 = (
+
+let uu____5020 = (
+
+let uu____5024 = (FStar_List.map update lbs)
+in ((b), (uu____5024)))
+in ((uu____5020), (ids), (qs), (attrs)))
+in FStar_Syntax_Syntax.Sig_let (uu____5012))
+in {FStar_Syntax_Syntax.sigel = uu____5011; FStar_Syntax_Syntax.sigdoc = uu___119_5010.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___119_5010.FStar_Syntax_Syntax.sigrng}))))
+end
+| uu____5033 -> begin
+se
+end))
+in (
+
+let normalized_module = (
+
+let uu___120_5035 = m1
+in (
+
+let uu____5036 = (FStar_List.map normalize_toplevel_lets m1.FStar_Syntax_Syntax.declarations)
+in {FStar_Syntax_Syntax.name = uu___120_5035.FStar_Syntax_Syntax.name; FStar_Syntax_Syntax.declarations = uu____5036; FStar_Syntax_Syntax.exports = uu___120_5035.FStar_Syntax_Syntax.exports; FStar_Syntax_Syntax.is_interface = uu___120_5035.FStar_Syntax_Syntax.is_interface}))
+in (
+
+let uu____5037 = (FStar_Syntax_Print.modul_to_string normalized_module)
+in (FStar_Util.print1 "%s\n" uu____5037))))
+end
+| uu____5038 -> begin
+()
+end));
+((m1), (env2));
+)
+end)));
+))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -1,1804 +1,2002 @@
+
 open Prims
-let tc_tycon:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.sigelt ->
-      (FStar_TypeChecker_Env.env_t* FStar_Syntax_Syntax.sigelt*
-        FStar_Syntax_Syntax.universe* FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun s  ->
-      match s with
-      | FStar_Syntax_Syntax.Sig_inductive_typ
-          (tc,uvs,tps,k,mutuals,data,quals,r) ->
-          let uu____34 = FStar_Syntax_Subst.open_term tps k in
-          (match uu____34 with
-           | (tps1,k1) ->
-               let uu____43 = FStar_TypeChecker_TcTerm.tc_binders env tps1 in
-               (match uu____43 with
-                | (tps2,env_tps,guard_params,us) ->
-                    let uu____56 = FStar_Syntax_Util.arrow_formals k1 in
-                    (match uu____56 with
-                     | (indices,t) ->
-                         let uu____80 =
-                           FStar_TypeChecker_TcTerm.tc_binders env_tps
-                             indices in
-                         (match uu____80 with
-                          | (indices1,env',guard_indices,us') ->
-                              let uu____93 =
-                                let uu____96 =
-                                  FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                    env' t in
-                                match uu____96 with
-                                | (t1,uu____103,g) ->
-                                    let uu____105 =
-                                      let uu____106 =
-                                        let uu____107 =
-                                          FStar_TypeChecker_Rel.conj_guard
-                                            guard_indices g in
-                                        FStar_TypeChecker_Rel.conj_guard
-                                          guard_params uu____107 in
-                                      FStar_TypeChecker_Rel.discharge_guard
-                                        env' uu____106 in
-                                    (t1, uu____105) in
-                              (match uu____93 with
-                               | (t1,guard) ->
-                                   let k2 =
-                                     let uu____117 =
-                                       FStar_Syntax_Syntax.mk_Total t1 in
-                                     FStar_Syntax_Util.arrow indices1
-                                       uu____117 in
-                                   let uu____120 =
-                                     FStar_Syntax_Util.type_u () in
-                                   (match uu____120 with
-                                    | (t_type,u) ->
-                                        ((let uu____130 =
-                                            FStar_TypeChecker_Rel.teq env' t1
-                                              t_type in
-                                          FStar_TypeChecker_Rel.force_trivial_guard
-                                            env' uu____130);
-                                         (let t_tc =
-                                            let uu____134 =
-                                              FStar_Syntax_Syntax.mk_Total t1 in
-                                            FStar_Syntax_Util.arrow
-                                              (FStar_List.append tps2
-                                                 indices1) uu____134 in
-                                          let tps3 =
-                                            FStar_Syntax_Subst.close_binders
-                                              tps2 in
-                                          let k3 =
-                                            FStar_Syntax_Subst.close tps3 k2 in
-                                          let fv_tc =
-                                            FStar_Syntax_Syntax.lid_as_fv tc
-                                              FStar_Syntax_Syntax.Delta_constant
-                                              None in
-                                          let uu____142 =
-                                            FStar_TypeChecker_Env.push_let_binding
-                                              env (FStar_Util.Inr fv_tc)
-                                              ([], t_tc) in
-                                          (uu____142,
-                                            (FStar_Syntax_Syntax.Sig_inductive_typ
-                                               (tc, [], tps3, k3, mutuals,
-                                                 data, quals, r)), u, guard)))))))))
-      | uu____150 -> failwith "impossible"
-let tc_data:
-  FStar_TypeChecker_Env.env_t ->
-    (FStar_Syntax_Syntax.sigelt* FStar_Syntax_Syntax.universe) Prims.list ->
-      FStar_Syntax_Syntax.sigelt ->
-        (FStar_Syntax_Syntax.sigelt* FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun tcs  ->
-      fun uu___79_175  ->
-        match uu___79_175 with
-        | FStar_Syntax_Syntax.Sig_datacon
-            (c,_uvs,t,tc_lid,ntps,quals,_mutual_tcs,r) ->
-            let uu____191 =
-              let tps_u_opt =
-                FStar_Util.find_map tcs
-                  (fun uu____205  ->
-                     match uu____205 with
-                     | (se,u_tc) ->
-                         let uu____214 =
-                           let uu____215 =
-                             let uu____216 =
-                               FStar_Syntax_Util.lid_of_sigelt se in
-                             FStar_Util.must uu____216 in
-                           FStar_Ident.lid_equals tc_lid uu____215 in
-                         if uu____214
-                         then
-                           (match se with
-                            | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (uu____226,uu____227,tps,uu____229,uu____230,uu____231,uu____232,uu____233)
-                                ->
-                                let tps1 =
-                                  FStar_All.pipe_right tps
-                                    (FStar_List.map
-                                       (fun uu____254  ->
-                                          match uu____254 with
-                                          | (x,uu____261) ->
-                                              (x,
-                                                (Some
-                                                   FStar_Syntax_Syntax.imp_tag)))) in
-                                let tps2 =
-                                  FStar_Syntax_Subst.open_binders tps1 in
-                                let uu____264 =
-                                  let uu____268 =
-                                    FStar_TypeChecker_Env.push_binders env
-                                      tps2 in
-                                  (uu____268, tps2, u_tc) in
-                                Some uu____264
-                            | uu____272 -> failwith "Impossible")
-                         else None) in
-              match tps_u_opt with
-              | Some x -> x
-              | None  ->
-                  if FStar_Ident.lid_equals tc_lid FStar_Syntax_Const.exn_lid
-                  then (env, [], FStar_Syntax_Syntax.U_zero)
-                  else
-                    Prims.raise
-                      (FStar_Errors.Error ("Unexpected data constructor", r)) in
-            (match uu____191 with
-             | (env1,tps,u_tc) ->
-                 let uu____311 =
-                   let uu____319 =
-                     let uu____320 = FStar_Syntax_Subst.compress t in
-                     uu____320.FStar_Syntax_Syntax.n in
-                   match uu____319 with
-                   | FStar_Syntax_Syntax.Tm_arrow (bs,res) ->
-                       let uu____342 = FStar_Util.first_N ntps bs in
-                       (match uu____342 with
-                        | (uu____360,bs') ->
-                            let t1 =
-                              (FStar_Syntax_Syntax.mk
-                                 (FStar_Syntax_Syntax.Tm_arrow (bs', res)))
-                                None t.FStar_Syntax_Syntax.pos in
-                            let subst1 =
-                              FStar_All.pipe_right tps
-                                (FStar_List.mapi
-                                   (fun i  ->
-                                      fun uu____396  ->
-                                        match uu____396 with
-                                        | (x,uu____400) ->
-                                            FStar_Syntax_Syntax.DB
-                                              ((ntps -
-                                                  ((Prims.parse_int "1") + i)),
-                                                x))) in
-                            let uu____401 =
-                              FStar_Syntax_Subst.subst subst1 t1 in
-                            FStar_Syntax_Util.arrow_formals uu____401)
-                   | uu____402 -> ([], t) in
-                 (match uu____311 with
-                  | (arguments,result) ->
-                      ((let uu____423 =
-                          FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-                        if uu____423
-                        then
-                          let uu____424 = FStar_Syntax_Print.lid_to_string c in
-                          let uu____425 =
-                            FStar_Syntax_Print.binders_to_string "->"
-                              arguments in
-                          let uu____426 =
-                            FStar_Syntax_Print.term_to_string result in
-                          FStar_Util.print3
-                            "Checking datacon  %s : %s -> %s \n" uu____424
-                            uu____425 uu____426
-                        else ());
-                       (let uu____428 =
-                          FStar_TypeChecker_TcTerm.tc_tparams env1 arguments in
-                        match uu____428 with
-                        | (arguments1,env',us) ->
-                            let uu____437 =
-                              FStar_TypeChecker_TcTerm.tc_trivial_guard env'
-                                result in
-                            (match uu____437 with
-                             | (result1,res_lcomp) ->
-                                 ((let uu____445 =
-                                     let uu____446 =
-                                       FStar_Syntax_Subst.compress
-                                         res_lcomp.FStar_Syntax_Syntax.res_typ in
-                                     uu____446.FStar_Syntax_Syntax.n in
-                                   match uu____445 with
-                                   | FStar_Syntax_Syntax.Tm_type uu____449 ->
-                                       ()
-                                   | ty ->
-                                       let uu____451 =
-                                         let uu____452 =
-                                           let uu____455 =
-                                             let uu____456 =
-                                               FStar_Syntax_Print.term_to_string
-                                                 result1 in
-                                             let uu____457 =
-                                               FStar_Syntax_Print.term_to_string
-                                                 res_lcomp.FStar_Syntax_Syntax.res_typ in
-                                             FStar_Util.format2
-                                               "The type of %s is %s, but since this is the result type of a constructor its type should be Type"
-                                               uu____456 uu____457 in
-                                           (uu____455, r) in
-                                         FStar_Errors.Error uu____452 in
-                                       Prims.raise uu____451);
-                                  (let uu____458 =
-                                     FStar_Syntax_Util.head_and_args result1 in
-                                   match uu____458 with
-                                   | (head1,uu____471) ->
-                                       ((let uu____487 =
-                                           let uu____488 =
-                                             FStar_Syntax_Subst.compress
-                                               head1 in
-                                           uu____488.FStar_Syntax_Syntax.n in
-                                         match uu____487 with
-                                         | FStar_Syntax_Syntax.Tm_fvar fv
-                                             when
-                                             FStar_Syntax_Syntax.fv_eq_lid fv
-                                               tc_lid
-                                             -> ()
-                                         | uu____492 ->
-                                             let uu____493 =
-                                               let uu____494 =
-                                                 let uu____497 =
-                                                   let uu____498 =
-                                                     FStar_Syntax_Print.lid_to_string
-                                                       tc_lid in
-                                                   let uu____499 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       head1 in
-                                                   FStar_Util.format2
-                                                     "Expected a constructor of type %s; got %s"
-                                                     uu____498 uu____499 in
-                                                 (uu____497, r) in
-                                               FStar_Errors.Error uu____494 in
-                                             Prims.raise uu____493);
-                                        (let g =
-                                           FStar_List.fold_left2
-                                             (fun g  ->
-                                                fun uu____504  ->
-                                                  fun u_x  ->
-                                                    match uu____504 with
-                                                    | (x,uu____509) ->
-                                                        let uu____510 =
-                                                          FStar_TypeChecker_Rel.universe_inequality
-                                                            u_x u_tc in
-                                                        FStar_TypeChecker_Rel.conj_guard
-                                                          g uu____510)
-                                             FStar_TypeChecker_Rel.trivial_guard
-                                             arguments1 us in
-                                         let t1 =
-                                           let uu____514 =
-                                             let uu____518 =
-                                               FStar_All.pipe_right tps
-                                                 (FStar_List.map
-                                                    (fun uu____532  ->
-                                                       match uu____532 with
-                                                       | (x,uu____539) ->
-                                                           (x,
-                                                             (Some
-                                                                (FStar_Syntax_Syntax.Implicit
-                                                                   true))))) in
-                                             FStar_List.append uu____518
-                                               arguments1 in
-                                           let uu____544 =
-                                             FStar_Syntax_Syntax.mk_Total
-                                               result1 in
-                                           FStar_Syntax_Util.arrow uu____514
-                                             uu____544 in
-                                         ((FStar_Syntax_Syntax.Sig_datacon
-                                             (c, [], t1, tc_lid, ntps, quals,
-                                               [], r)), g))))))))))
-        | uu____552 -> failwith "impossible"
-let generalize_and_inst_within:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_TypeChecker_Env.guard_t ->
-      (FStar_Syntax_Syntax.sigelt* FStar_Syntax_Syntax.universe) Prims.list
-        ->
-        FStar_Syntax_Syntax.sigelt Prims.list ->
-          (FStar_Syntax_Syntax.sigelt Prims.list* FStar_Syntax_Syntax.sigelt
-            Prims.list)
-  =
-  fun env  ->
-    fun g  ->
-      fun tcs  ->
-        fun datas  ->
-          let tc_universe_vars = FStar_List.map Prims.snd tcs in
-          let g1 =
-            let uu___85_588 = g in
-            {
-              FStar_TypeChecker_Env.guard_f =
-                (uu___85_588.FStar_TypeChecker_Env.guard_f);
-              FStar_TypeChecker_Env.deferred =
-                (uu___85_588.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (tc_universe_vars,
-                  (Prims.snd g.FStar_TypeChecker_Env.univ_ineqs));
-              FStar_TypeChecker_Env.implicits =
-                (uu___85_588.FStar_TypeChecker_Env.implicits)
-            } in
-          (let uu____594 =
-             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "GenUniverses") in
-           if uu____594
-           then
-             let uu____595 = FStar_TypeChecker_Rel.guard_to_string env g1 in
-             FStar_Util.print1 "@@@@@@Guard before generalization: %s\n"
-               uu____595
-           else ());
-          FStar_TypeChecker_Rel.force_trivial_guard env g1;
-          (let binders =
-             FStar_All.pipe_right tcs
-               (FStar_List.map
-                  (fun uu____606  ->
-                     match uu____606 with
-                     | (se,uu____610) ->
-                         (match se with
-                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                              (uu____611,uu____612,tps,k,uu____615,uu____616,uu____617,uu____618)
-                              ->
-                              let uu____625 =
-                                let uu____626 =
-                                  FStar_Syntax_Syntax.mk_Total k in
-                                FStar_All.pipe_left
-                                  (FStar_Syntax_Util.arrow tps) uu____626 in
-                              FStar_Syntax_Syntax.null_binder uu____625
-                          | uu____633 -> failwith "Impossible"))) in
-           let binders' =
-             FStar_All.pipe_right datas
-               (FStar_List.map
-                  (fun uu___80_638  ->
-                     match uu___80_638 with
-                     | FStar_Syntax_Syntax.Sig_datacon
-                         (uu____639,uu____640,t,uu____642,uu____643,uu____644,uu____645,uu____646)
-                         -> FStar_Syntax_Syntax.null_binder t
-                     | uu____651 -> failwith "Impossible")) in
-           let t =
-             let uu____655 =
-               FStar_Syntax_Syntax.mk_Total FStar_TypeChecker_Common.t_unit in
-             FStar_Syntax_Util.arrow (FStar_List.append binders binders')
-               uu____655 in
-           (let uu____659 =
-              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "GenUniverses") in
-            if uu____659
-            then
-              let uu____660 =
-                FStar_TypeChecker_Normalize.term_to_string env t in
-              FStar_Util.print1
-                "@@@@@@Trying to generalize universes in %s\n" uu____660
-            else ());
-           (let uu____662 = FStar_TypeChecker_Util.generalize_universes env t in
-            match uu____662 with
-            | (uvs,t1) ->
-                ((let uu____672 =
-                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                      (FStar_Options.Other "GenUniverses") in
-                  if uu____672
-                  then
-                    let uu____673 =
-                      let uu____674 =
-                        FStar_All.pipe_right uvs
-                          (FStar_List.map (fun u  -> u.FStar_Ident.idText)) in
-                      FStar_All.pipe_right uu____674
-                        (FStar_String.concat ", ") in
-                    let uu____680 = FStar_Syntax_Print.term_to_string t1 in
-                    FStar_Util.print2 "@@@@@@Generalized to (%s, %s)\n"
-                      uu____673 uu____680
-                  else ());
-                 (let uu____682 = FStar_Syntax_Subst.open_univ_vars uvs t1 in
-                  match uu____682 with
-                  | (uvs1,t2) ->
-                      let uu____691 = FStar_Syntax_Util.arrow_formals t2 in
-                      (match uu____691 with
-                       | (args,uu____704) ->
-                           let uu____715 =
-                             FStar_Util.first_N (FStar_List.length binders)
-                               args in
-                           (match uu____715 with
-                            | (tc_types,data_types) ->
-                                let tcs1 =
-                                  FStar_List.map2
-                                    (fun uu____752  ->
-                                       fun uu____753  ->
-                                         match (uu____752, uu____753) with
-                                         | ((x,uu____763),(se,uu____765)) ->
-                                             (match se with
-                                              | FStar_Syntax_Syntax.Sig_inductive_typ
-                                                  (tc,uu____771,tps,uu____773,mutuals,datas1,quals,r)
-                                                  ->
-                                                  let ty =
-                                                    FStar_Syntax_Subst.close_univ_vars
-                                                      uvs1
-                                                      x.FStar_Syntax_Syntax.sort in
-                                                  let uu____785 =
-                                                    let uu____793 =
-                                                      let uu____794 =
-                                                        FStar_Syntax_Subst.compress
-                                                          ty in
-                                                      uu____794.FStar_Syntax_Syntax.n in
-                                                    match uu____793 with
-                                                    | FStar_Syntax_Syntax.Tm_arrow
-                                                        (binders1,c) ->
-                                                        let uu____816 =
-                                                          FStar_Util.first_N
-                                                            (FStar_List.length
-                                                               tps) binders1 in
-                                                        (match uu____816 with
-                                                         | (tps1,rest) ->
-                                                             let t3 =
-                                                               match rest
-                                                               with
-                                                               | [] ->
-                                                                   FStar_Syntax_Util.comp_result
-                                                                    c
-                                                               | uu____859 ->
-                                                                   let uu____863
-                                                                    =
-                                                                    FStar_ST.read
-                                                                    (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.tk in
-                                                                   (FStar_Syntax_Syntax.mk
-                                                                    (FStar_Syntax_Syntax.Tm_arrow
-                                                                    (rest, c)))
-                                                                    uu____863
-                                                                    (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
-                                                             (tps1, t3))
-                                                    | uu____886 -> ([], ty) in
-                                                  (match uu____785 with
-                                                   | (tps1,t3) ->
-                                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                                         (tc, uvs1, tps1, t3,
-                                                           mutuals, datas1,
-                                                           quals, r))
-                                              | uu____912 ->
-                                                  failwith "Impossible"))
-                                    tc_types tcs in
-                                let datas1 =
-                                  match uvs1 with
-                                  | [] -> datas
-                                  | uu____916 ->
-                                      let uvs_universes =
-                                        FStar_All.pipe_right uvs1
-                                          (FStar_List.map
-                                             (fun _0_28  ->
-                                                FStar_Syntax_Syntax.U_name
-                                                  _0_28)) in
-                                      let tc_insts =
-                                        FStar_All.pipe_right tcs1
-                                          (FStar_List.map
-                                             (fun uu___81_933  ->
-                                                match uu___81_933 with
-                                                | FStar_Syntax_Syntax.Sig_inductive_typ
-                                                    (tc,uu____938,uu____939,uu____940,uu____941,uu____942,uu____943,uu____944)
-                                                    -> (tc, uvs_universes)
-                                                | uu____952 ->
-                                                    failwith "Impossible")) in
-                                      FStar_List.map2
-                                        (fun uu____958  ->
-                                           fun d  ->
-                                             match uu____958 with
-                                             | (t3,uu____963) ->
-                                                 (match d with
-                                                  | FStar_Syntax_Syntax.Sig_datacon
-                                                      (l,uu____965,uu____966,tc,ntps,quals,mutuals,r)
-                                                      ->
-                                                      let ty =
-                                                        let uu____977 =
-                                                          FStar_Syntax_InstFV.instantiate
-                                                            tc_insts
-                                                            t3.FStar_Syntax_Syntax.sort in
-                                                        FStar_All.pipe_right
-                                                          uu____977
-                                                          (FStar_Syntax_Subst.close_univ_vars
-                                                             uvs1) in
-                                                      FStar_Syntax_Syntax.Sig_datacon
-                                                        (l, uvs1, ty, tc,
-                                                          ntps, quals,
-                                                          mutuals, r)
-                                                  | uu____980 ->
-                                                      failwith "Impossible"))
-                                        data_types datas in
-                                (tcs1, datas1)))))))
-let debug_log: FStar_TypeChecker_Env.env_t -> Prims.string -> Prims.unit =
-  fun env  ->
-    fun s  ->
-      let uu____989 =
-        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-          (FStar_Options.Other "Positivity") in
-      if uu____989
-      then
-        FStar_Util.print_string
-          (Prims.strcat "Positivity::" (Prims.strcat s "\n"))
-      else ()
-let ty_occurs_in:
-  FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool =
-  fun ty_lid  ->
-    fun t  ->
-      let uu____997 = FStar_Syntax_Free.fvars t in
-      FStar_Util.set_mem ty_lid uu____997
-let try_get_fv:
-  FStar_Syntax_Syntax.term ->
-    (FStar_Syntax_Syntax.fv* FStar_Syntax_Syntax.universes)
-  =
-  fun t  ->
-    let uu____1006 =
-      let uu____1007 = FStar_Syntax_Subst.compress t in
-      uu____1007.FStar_Syntax_Syntax.n in
-    match uu____1006 with
-    | FStar_Syntax_Syntax.Tm_fvar fv -> (fv, [])
-    | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-        (match t1.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_fvar fv -> (fv, us)
-         | uu____1023 ->
-             failwith "Node is a Tm_uinst, but Tm_uinst is not an fvar")
-    | uu____1026 -> failwith "Node is not an fvar or a Tm_uinst"
+
+let tc_tycon : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_TypeChecker_Env.env_t * FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe * FStar_TypeChecker_Env.guard_t) = (fun env s -> (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (tc, uvs, tps, k, mutuals, data, quals) -> begin
+(
+
+let uu____33 = (FStar_Syntax_Subst.open_term tps k)
+in (match (uu____33) with
+| (tps1, k1) -> begin
+(
+
+let uu____42 = (FStar_TypeChecker_TcTerm.tc_binders env tps1)
+in (match (uu____42) with
+| (tps2, env_tps, guard_params, us) -> begin
+(
+
+let uu____55 = (FStar_Syntax_Util.arrow_formals k1)
+in (match (uu____55) with
+| (indices, t) -> begin
+(
+
+let uu____79 = (FStar_TypeChecker_TcTerm.tc_binders env_tps indices)
+in (match (uu____79) with
+| (indices1, env', guard_indices, us') -> begin
+(
+
+let uu____92 = (
+
+let uu____95 = (FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env' t)
+in (match (uu____95) with
+| (t1, uu____102, g) -> begin
+(
+
+let uu____104 = (
+
+let uu____105 = (
+
+let uu____106 = (FStar_TypeChecker_Rel.conj_guard guard_indices g)
+in (FStar_TypeChecker_Rel.conj_guard guard_params uu____106))
+in (FStar_TypeChecker_Rel.discharge_guard env' uu____105))
+in ((t1), (uu____104)))
+end))
+in (match (uu____92) with
+| (t1, guard) -> begin
+(
+
+let k2 = (
+
+let uu____116 = (FStar_Syntax_Syntax.mk_Total t1)
+in (FStar_Syntax_Util.arrow indices1 uu____116))
+in (
+
+let uu____119 = (FStar_Syntax_Util.type_u ())
+in (match (uu____119) with
+| (t_type, u) -> begin
+((
+
+let uu____129 = (FStar_TypeChecker_Rel.teq env' t1 t_type)
+in (FStar_TypeChecker_Rel.force_trivial_guard env' uu____129));
+(
+
+let t_tc = (
+
+let uu____133 = (FStar_Syntax_Syntax.mk_Total t1)
+in (FStar_Syntax_Util.arrow (FStar_List.append tps2 indices1) uu____133))
+in (
+
+let tps3 = (FStar_Syntax_Subst.close_binders tps2)
+in (
+
+let k3 = (FStar_Syntax_Subst.close tps3 k2)
+in (
+
+let fv_tc = (FStar_Syntax_Syntax.lid_as_fv tc FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____141 = (FStar_TypeChecker_Env.push_let_binding env (FStar_Util.Inr (fv_tc)) (([]), (t_tc)))
+in ((uu____141), ((
+
+let uu___81_145 = s
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((tc), ([]), (tps3), (k3), (mutuals), (data), (quals))); FStar_Syntax_Syntax.sigdoc = uu___81_145.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___81_145.FStar_Syntax_Syntax.sigrng})), (u), (guard)))))));
+)
+end)))
+end))
+end))
+end))
+end))
+end))
+end
+| uu____150 -> begin
+(failwith "impossible")
+end))
+
+
+let tc_data : FStar_TypeChecker_Env.env_t  ->  (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe) Prims.list  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_Syntax_Syntax.sigelt * FStar_TypeChecker_Env.guard_t) = (fun env tcs se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (c, _uvs, t, tc_lid, ntps, quals, _mutual_tcs) -> begin
+(
+
+let uu____190 = (
+
+let tps_u_opt = (FStar_Util.find_map tcs (fun uu____204 -> (match (uu____204) with
+| (se1, u_tc) -> begin
+(
+
+let uu____213 = (
+
+let uu____214 = (
+
+let uu____215 = (FStar_Syntax_Util.lid_of_sigelt se1)
+in (FStar_Util.must uu____215))
+in (FStar_Ident.lid_equals tc_lid uu____214))
+in (match (uu____213) with
+| true -> begin
+(match (se1.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____225, uu____226, tps, uu____228, uu____229, uu____230, uu____231) -> begin
+(
+
+let tps1 = (FStar_All.pipe_right tps (FStar_List.map (fun uu____252 -> (match (uu____252) with
+| (x, uu____259) -> begin
+((x), (Some (FStar_Syntax_Syntax.imp_tag)))
+end))))
+in (
+
+let tps2 = (FStar_Syntax_Subst.open_binders tps1)
+in (
+
+let uu____262 = (
+
+let uu____266 = (FStar_TypeChecker_Env.push_binders env tps2)
+in ((uu____266), (tps2), (u_tc)))
+in Some (uu____262))))
+end
+| uu____270 -> begin
+(failwith "Impossible")
+end)
+end
+| uu____275 -> begin
+None
+end))
+end)))
+in (match (tps_u_opt) with
+| Some (x) -> begin
+x
+end
+| None -> begin
+(match ((FStar_Ident.lid_equals tc_lid FStar_Syntax_Const.exn_lid)) with
+| true -> begin
+((env), ([]), (FStar_Syntax_Syntax.U_zero))
+end
+| uu____300 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected data constructor"), (se.FStar_Syntax_Syntax.sigrng)))))
+end)
+end))
+in (match (uu____190) with
+| (env1, tps, u_tc) -> begin
+(
+
+let uu____309 = (
+
+let uu____317 = (
+
+let uu____318 = (FStar_Syntax_Subst.compress t)
+in uu____318.FStar_Syntax_Syntax.n)
+in (match (uu____317) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, res) -> begin
+(
+
+let uu____340 = (FStar_Util.first_N ntps bs)
+in (match (uu____340) with
+| (uu____358, bs') -> begin
+(
+
+let t1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((bs'), (res))))) None t.FStar_Syntax_Syntax.pos)
+in (
+
+let subst1 = (FStar_All.pipe_right tps (FStar_List.mapi (fun i uu____394 -> (match (uu____394) with
+| (x, uu____398) -> begin
+FStar_Syntax_Syntax.DB ((((ntps - ((Prims.parse_int "1") + i))), (x)))
+end))))
+in (
+
+let uu____399 = (FStar_Syntax_Subst.subst subst1 t1)
+in (FStar_Syntax_Util.arrow_formals uu____399))))
+end))
+end
+| uu____400 -> begin
+(([]), (t))
+end))
+in (match (uu____309) with
+| (arguments, result) -> begin
+((
+
+let uu____421 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____421) with
+| true -> begin
+(
+
+let uu____422 = (FStar_Syntax_Print.lid_to_string c)
+in (
+
+let uu____423 = (FStar_Syntax_Print.binders_to_string "->" arguments)
+in (
+
+let uu____424 = (FStar_Syntax_Print.term_to_string result)
+in (FStar_Util.print3 "Checking datacon  %s : %s -> %s \n" uu____422 uu____423 uu____424))))
+end
+| uu____425 -> begin
+()
+end));
+(
+
+let uu____426 = (FStar_TypeChecker_TcTerm.tc_tparams env1 arguments)
+in (match (uu____426) with
+| (arguments1, env', us) -> begin
+(
+
+let uu____435 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env' result)
+in (match (uu____435) with
+| (result1, res_lcomp) -> begin
+((
+
+let uu____443 = (
+
+let uu____444 = (FStar_Syntax_Subst.compress res_lcomp.FStar_Syntax_Syntax.res_typ)
+in uu____444.FStar_Syntax_Syntax.n)
+in (match (uu____443) with
+| FStar_Syntax_Syntax.Tm_type (uu____447) -> begin
+()
+end
+| ty -> begin
+(
+
+let uu____449 = (
+
+let uu____450 = (
+
+let uu____453 = (
+
+let uu____454 = (FStar_Syntax_Print.term_to_string result1)
+in (
+
+let uu____455 = (FStar_Syntax_Print.term_to_string res_lcomp.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.format2 "The type of %s is %s, but since this is the result type of a constructor its type should be Type" uu____454 uu____455)))
+in ((uu____453), (se.FStar_Syntax_Syntax.sigrng)))
+in FStar_Errors.Error (uu____450))
+in (Prims.raise uu____449))
+end));
+(
+
+let uu____456 = (FStar_Syntax_Util.head_and_args result1)
+in (match (uu____456) with
+| (head1, uu____469) -> begin
+((
+
+let uu____485 = (
+
+let uu____486 = (FStar_Syntax_Subst.compress head1)
+in uu____486.FStar_Syntax_Syntax.n)
+in (match (uu____485) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv tc_lid) -> begin
+()
+end
+| uu____490 -> begin
+(
+
+let uu____491 = (
+
+let uu____492 = (
+
+let uu____495 = (
+
+let uu____496 = (FStar_Syntax_Print.lid_to_string tc_lid)
+in (
+
+let uu____497 = (FStar_Syntax_Print.term_to_string head1)
+in (FStar_Util.format2 "Expected a constructor of type %s; got %s" uu____496 uu____497)))
+in ((uu____495), (se.FStar_Syntax_Syntax.sigrng)))
+in FStar_Errors.Error (uu____492))
+in (Prims.raise uu____491))
+end));
+(
+
+let g = (FStar_List.fold_left2 (fun g uu____502 u_x -> (match (uu____502) with
+| (x, uu____507) -> begin
+(
+
+let uu____508 = (FStar_TypeChecker_Rel.universe_inequality u_x u_tc)
+in (FStar_TypeChecker_Rel.conj_guard g uu____508))
+end)) FStar_TypeChecker_Rel.trivial_guard arguments1 us)
+in (
+
+let t1 = (
+
+let uu____512 = (
+
+let uu____516 = (FStar_All.pipe_right tps (FStar_List.map (fun uu____530 -> (match (uu____530) with
+| (x, uu____537) -> begin
+((x), (Some (FStar_Syntax_Syntax.Implicit (true))))
+end))))
+in (FStar_List.append uu____516 arguments1))
+in (
+
+let uu____542 = (FStar_Syntax_Syntax.mk_Total result1)
+in (FStar_Syntax_Util.arrow uu____512 uu____542)))
+in (((
+
+let uu___82_545 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (((c), ([]), (t1), (tc_lid), (ntps), (quals), ([]))); FStar_Syntax_Syntax.sigdoc = uu___82_545.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___82_545.FStar_Syntax_Syntax.sigrng})), (g))));
+)
+end));
+)
+end))
+end));
+)
+end))
+end))
+end
+| uu____551 -> begin
+(failwith "impossible")
+end))
+
+
+let generalize_and_inst_within : FStar_TypeChecker_Env.env_t  ->  FStar_TypeChecker_Env.guard_t  ->  (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe) Prims.list  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env g tcs datas -> (
+
+let tc_universe_vars = (FStar_List.map Prims.snd tcs)
+in (
+
+let g1 = (
+
+let uu___83_587 = g
+in {FStar_TypeChecker_Env.guard_f = uu___83_587.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___83_587.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = ((tc_universe_vars), ((Prims.snd g.FStar_TypeChecker_Env.univ_ineqs))); FStar_TypeChecker_Env.implicits = uu___83_587.FStar_TypeChecker_Env.implicits})
+in ((
+
+let uu____593 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("GenUniverses")))
+in (match (uu____593) with
+| true -> begin
+(
+
+let uu____594 = (FStar_TypeChecker_Rel.guard_to_string env g1)
+in (FStar_Util.print1 "@@@@@@Guard before generalization: %s\n" uu____594))
+end
+| uu____595 -> begin
+()
+end));
+(FStar_TypeChecker_Rel.force_trivial_guard env g1);
+(
+
+let binders = (FStar_All.pipe_right tcs (FStar_List.map (fun uu____605 -> (match (uu____605) with
+| (se, uu____609) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____610, uu____611, tps, k, uu____614, uu____615, uu____616) -> begin
+(
+
+let uu____623 = (
+
+let uu____624 = (FStar_Syntax_Syntax.mk_Total k)
+in (FStar_All.pipe_left (FStar_Syntax_Util.arrow tps) uu____624))
+in (FStar_Syntax_Syntax.null_binder uu____623))
+end
+| uu____631 -> begin
+(failwith "Impossible")
+end)
+end))))
+in (
+
+let binders' = (FStar_All.pipe_right datas (FStar_List.map (fun se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (uu____637, uu____638, t, uu____640, uu____641, uu____642, uu____643) -> begin
+(FStar_Syntax_Syntax.null_binder t)
+end
+| uu____648 -> begin
+(failwith "Impossible")
+end))))
+in (
+
+let t = (
+
+let uu____652 = (FStar_Syntax_Syntax.mk_Total FStar_TypeChecker_Common.t_unit)
+in (FStar_Syntax_Util.arrow (FStar_List.append binders binders') uu____652))
+in ((
+
+let uu____656 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("GenUniverses")))
+in (match (uu____656) with
+| true -> begin
+(
+
+let uu____657 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (FStar_Util.print1 "@@@@@@Trying to generalize universes in %s\n" uu____657))
+end
+| uu____658 -> begin
+()
+end));
+(
+
+let uu____659 = (FStar_TypeChecker_Util.generalize_universes env t)
+in (match (uu____659) with
+| (uvs, t1) -> begin
+((
+
+let uu____669 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("GenUniverses")))
+in (match (uu____669) with
+| true -> begin
+(
+
+let uu____670 = (
+
+let uu____671 = (FStar_All.pipe_right uvs (FStar_List.map (fun u -> u.FStar_Ident.idText)))
+in (FStar_All.pipe_right uu____671 (FStar_String.concat ", ")))
+in (
+
+let uu____677 = (FStar_Syntax_Print.term_to_string t1)
+in (FStar_Util.print2 "@@@@@@Generalized to (%s, %s)\n" uu____670 uu____677)))
+end
+| uu____678 -> begin
+()
+end));
+(
+
+let uu____679 = (FStar_Syntax_Subst.open_univ_vars uvs t1)
+in (match (uu____679) with
+| (uvs1, t2) -> begin
+(
+
+let uu____688 = (FStar_Syntax_Util.arrow_formals t2)
+in (match (uu____688) with
+| (args, uu____701) -> begin
+(
+
+let uu____712 = (FStar_Util.first_N (FStar_List.length binders) args)
+in (match (uu____712) with
+| (tc_types, data_types) -> begin
+(
+
+let tcs1 = (FStar_List.map2 (fun uu____749 uu____750 -> (match (((uu____749), (uu____750))) with
+| ((x, uu____760), (se, uu____762)) -> begin
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (tc, uu____768, tps, uu____770, mutuals, datas1, quals) -> begin
+(
+
+let ty = (FStar_Syntax_Subst.close_univ_vars uvs1 x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____781 = (
+
+let uu____789 = (
+
+let uu____790 = (FStar_Syntax_Subst.compress ty)
+in uu____790.FStar_Syntax_Syntax.n)
+in (match (uu____789) with
+| FStar_Syntax_Syntax.Tm_arrow (binders1, c) -> begin
+(
+
+let uu____812 = (FStar_Util.first_N (FStar_List.length tps) binders1)
+in (match (uu____812) with
+| (tps1, rest) -> begin
+(
+
+let t3 = (match (rest) with
+| [] -> begin
+(FStar_Syntax_Util.comp_result c)
+end
+| uu____855 -> begin
+(
+
+let uu____859 = (FStar_ST.read x.FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.tk)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow (((rest), (c))))) uu____859 x.FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.pos))
+end)
+in ((tps1), (t3)))
+end))
+end
+| uu____882 -> begin
+(([]), (ty))
+end))
+in (match (uu____781) with
+| (tps1, t3) -> begin
+(
+
+let uu___84_900 = se
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (((tc), (uvs1), (tps1), (t3), (mutuals), (datas1), (quals))); FStar_Syntax_Syntax.sigdoc = uu___84_900.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___84_900.FStar_Syntax_Syntax.sigrng})
+end)))
+end
+| uu____909 -> begin
+(failwith "Impossible")
+end)
+end)) tc_types tcs)
+in (
+
+let datas1 = (match (uvs1) with
+| [] -> begin
+datas
+end
+| uu____913 -> begin
+(
+
+let uvs_universes = (FStar_All.pipe_right uvs1 (FStar_List.map (fun _0_28 -> FStar_Syntax_Syntax.U_name (_0_28))))
+in (
+
+let tc_insts = (FStar_All.pipe_right tcs1 (FStar_List.map (fun uu___77_930 -> (match (uu___77_930) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (tc, uu____935, uu____936, uu____937, uu____938, uu____939, uu____940); FStar_Syntax_Syntax.sigdoc = uu____941; FStar_Syntax_Syntax.sigrng = uu____942} -> begin
+((tc), (uvs_universes))
+end
+| uu____951 -> begin
+(failwith "Impossible")
+end))))
+in (FStar_List.map2 (fun uu____957 d -> (match (uu____957) with
+| (t3, uu____962) -> begin
+(match (d.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (l, uu____964, uu____965, tc, ntps, quals, mutuals) -> begin
+(
+
+let ty = (
+
+let uu____975 = (FStar_Syntax_InstFV.instantiate tc_insts t3.FStar_Syntax_Syntax.sort)
+in (FStar_All.pipe_right uu____975 (FStar_Syntax_Subst.close_univ_vars uvs1)))
+in (
+
+let uu___85_976 = d
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (((l), (uvs1), (ty), (tc), (ntps), (quals), (mutuals))); FStar_Syntax_Syntax.sigdoc = uu___85_976.FStar_Syntax_Syntax.sigdoc; FStar_Syntax_Syntax.sigrng = uu___85_976.FStar_Syntax_Syntax.sigrng}))
+end
+| uu____979 -> begin
+(failwith "Impossible")
+end)
+end)) data_types datas)))
+end)
+in ((tcs1), (datas1))))
+end))
+end))
+end));
+)
+end));
+))));
+))))
+
+
+let debug_log : FStar_TypeChecker_Env.env_t  ->  Prims.string  ->  Prims.unit = (fun env s -> (
+
+let uu____988 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Positivity")))
+in (match (uu____988) with
+| true -> begin
+(FStar_Util.print_string (Prims.strcat "Positivity::" (Prims.strcat s "\n")))
+end
+| uu____989 -> begin
+()
+end)))
+
+
+let ty_occurs_in : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  Prims.bool = (fun ty_lid t -> (
+
+let uu____996 = (FStar_Syntax_Free.fvars t)
+in (FStar_Util.set_mem ty_lid uu____996)))
+
+
+let try_get_fv : FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universes) = (fun t -> (
+
+let uu____1005 = (
+
+let uu____1006 = (FStar_Syntax_Subst.compress t)
+in uu____1006.FStar_Syntax_Syntax.n)
+in (match (uu____1005) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+((fv), ([]))
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, us) -> begin
+(match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+((fv), (us))
+end
+| uu____1022 -> begin
+(failwith "Node is a Tm_uinst, but Tm_uinst is not an fvar")
+end)
+end
+| uu____1025 -> begin
+(failwith "Node is not an fvar or a Tm_uinst")
+end)))
+
+
 type unfolded_memo_elt =
-  (FStar_Ident.lident* FStar_Syntax_Syntax.args) Prims.list
-type unfolded_memo_t = unfolded_memo_elt FStar_ST.ref
-let already_unfolded:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.args ->
-      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
-  =
-  fun ilid  ->
-    fun arrghs  ->
-      fun unfolded  ->
-        fun env  ->
-          let uu____1045 = FStar_ST.read unfolded in
-          FStar_List.existsML
-            (fun uu____1057  ->
-               match uu____1057 with
-               | (lid,l) ->
-                   (FStar_Ident.lid_equals lid ilid) &&
-                     (let args =
-                        let uu____1077 =
-                          FStar_List.splitAt (FStar_List.length l) arrghs in
-                        Prims.fst uu____1077 in
-                      FStar_List.fold_left2
-                        (fun b  ->
-                           fun a  ->
-                             fun a'  ->
-                               b &&
-                                 (FStar_TypeChecker_Rel.teq_nosmt env
-                                    (Prims.fst a) (Prims.fst a'))) true args
-                        l)) uu____1045
-let rec ty_strictly_positive_in_type:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.term ->
-      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
-  =
-  fun ty_lid  ->
-    fun btype  ->
-      fun unfolded  ->
-        fun env  ->
-          (let uu____1172 =
-             let uu____1173 = FStar_Syntax_Print.term_to_string btype in
-             Prims.strcat "Checking strict positivity in type: " uu____1173 in
-           debug_log env uu____1172);
-          (let btype1 =
-             FStar_TypeChecker_Normalize.normalize
-               [FStar_TypeChecker_Normalize.Beta;
-               FStar_TypeChecker_Normalize.Eager_unfolding;
-               FStar_TypeChecker_Normalize.UnfoldUntil
-                 FStar_Syntax_Syntax.Delta_constant;
-               FStar_TypeChecker_Normalize.Iota;
-               FStar_TypeChecker_Normalize.Zeta;
-               FStar_TypeChecker_Normalize.AllowUnboundUniverses] env btype in
-           (let uu____1176 =
-              let uu____1177 = FStar_Syntax_Print.term_to_string btype1 in
-              Prims.strcat
-                "Checking strict positivity in type, after normalization: "
-                uu____1177 in
-            debug_log env uu____1176);
-           (let uu____1178 = ty_occurs_in ty_lid btype1 in
-            Prims.op_Negation uu____1178) ||
-             ((debug_log env "ty does occur in this type, pressing ahead";
-               (let uu____1180 =
-                  let uu____1181 = FStar_Syntax_Subst.compress btype1 in
-                  uu____1181.FStar_Syntax_Syntax.n in
-                match uu____1180 with
-                | FStar_Syntax_Syntax.Tm_app (t,args) ->
-                    let uu____1200 = try_get_fv t in
-                    (match uu____1200 with
-                     | (fv,us) ->
-                         if
-                           FStar_Ident.lid_equals
-                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                             ty_lid
-                         then
-                           (debug_log env
-                              "Checking strict positivity in the Tm_app node where head lid is ty itself, checking that ty does not occur in the arguments";
-                            FStar_List.for_all
-                              (fun uu____1212  ->
-                                 match uu____1212 with
-                                 | (t1,uu____1216) ->
-                                     let uu____1217 = ty_occurs_in ty_lid t1 in
-                                     Prims.op_Negation uu____1217) args)
-                         else
-                           (debug_log env
-                              "Checking strict positivity in the Tm_app node, head lid is not ty, so checking nested positivity";
-                            ty_nested_positive_in_inductive ty_lid
-                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                              us args unfolded env))
-                | FStar_Syntax_Syntax.Tm_arrow (sbs,c) ->
-                    (debug_log env "Checking strict positivity in Tm_arrow";
-                     (let uu____1237 =
-                        let uu____1238 =
-                          FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                        Prims.op_Negation uu____1238 in
-                      if uu____1237
-                      then
-                        (debug_log env
-                           "Checking strict positivity , the arrow is impure, so return true";
-                         true)
-                      else
-                        (debug_log env
-                           "Checking struict positivity, Pure arrow, checking that ty does not occur in the binders, and that it is strictly positive in the return type";
-                         (FStar_List.for_all
-                            (fun uu____1244  ->
-                               match uu____1244 with
-                               | (b,uu____1248) ->
-                                   let uu____1249 =
-                                     ty_occurs_in ty_lid
-                                       b.FStar_Syntax_Syntax.sort in
-                                   Prims.op_Negation uu____1249) sbs)
-                           &&
-                           ((let uu____1250 =
-                               FStar_Syntax_Subst.open_term sbs
-                                 (FStar_Syntax_Util.comp_result c) in
-                             match uu____1250 with
-                             | (uu____1253,return_type) ->
-                                 let uu____1255 =
-                                   FStar_TypeChecker_Env.push_binders env sbs in
-                                 ty_strictly_positive_in_type ty_lid
-                                   return_type unfolded uu____1255)))))
-                | FStar_Syntax_Syntax.Tm_fvar uu____1256 ->
-                    (debug_log env
-                       "Checking strict positivity in an fvar, return true";
-                     true)
-                | FStar_Syntax_Syntax.Tm_type uu____1258 ->
-                    (debug_log env
-                       "Checking strict positivity in an Tm_type, return true";
-                     true)
-                | FStar_Syntax_Syntax.Tm_uinst (t,uu____1261) ->
-                    (debug_log env
-                       "Checking strict positivity in an Tm_uinst, recur on the term inside (mostly it should be the same inductive)";
-                     ty_strictly_positive_in_type ty_lid t unfolded env)
-                | FStar_Syntax_Syntax.Tm_refine (bv,uu____1268) ->
-                    (debug_log env
-                       "Checking strict positivity in an Tm_refine, recur in the bv sort)";
-                     ty_strictly_positive_in_type ty_lid
-                       bv.FStar_Syntax_Syntax.sort unfolded env)
-                | FStar_Syntax_Syntax.Tm_match (uu____1274,branches) ->
-                    (debug_log env
-                       "Checking strict positivity in an Tm_match, recur in the branches)";
-                     FStar_List.for_all
-                       (fun uu____1309  ->
-                          match uu____1309 with
-                          | (p,uu____1317,t) ->
-                              let bs =
-                                let uu____1327 =
-                                  FStar_Syntax_Syntax.pat_bvs p in
-                                FStar_List.map FStar_Syntax_Syntax.mk_binder
-                                  uu____1327 in
-                              let uu____1329 =
-                                FStar_Syntax_Subst.open_term bs t in
-                              (match uu____1329 with
-                               | (bs1,t1) ->
-                                   let uu____1334 =
-                                     FStar_TypeChecker_Env.push_binders env
-                                       bs1 in
-                                   ty_strictly_positive_in_type ty_lid t1
-                                     unfolded uu____1334)) branches)
-                | FStar_Syntax_Syntax.Tm_ascribed (t,uu____1336,uu____1337)
-                    ->
-                    (debug_log env
-                       "Checking strict positivity in an Tm_ascribed, recur)";
-                     ty_strictly_positive_in_type ty_lid t unfolded env)
-                | uu____1367 ->
-                    ((let uu____1369 =
-                        let uu____1370 =
-                          let uu____1371 =
-                            FStar_Syntax_Print.tag_of_term btype1 in
-                          let uu____1372 =
-                            let uu____1373 =
-                              FStar_Syntax_Print.term_to_string btype1 in
-                            Prims.strcat " and term: " uu____1373 in
-                          Prims.strcat uu____1371 uu____1372 in
-                        Prims.strcat
-                          "Checking strict positivity, unexpected tag: "
-                          uu____1370 in
-                      debug_log env uu____1369);
-                     false)))))
-and ty_nested_positive_in_inductive:
-  FStar_Ident.lident ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.universes ->
-        FStar_Syntax_Syntax.args ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
-  =
-  fun ty_lid  ->
-    fun ilid  ->
-      fun us  ->
-        fun args  ->
-          fun unfolded  ->
-            fun env  ->
-              (let uu____1381 =
-                 let uu____1382 =
-                   let uu____1383 =
-                     let uu____1384 = FStar_Syntax_Print.args_to_string args in
-                     Prims.strcat " applied to arguments: " uu____1384 in
-                   Prims.strcat ilid.FStar_Ident.str uu____1383 in
-                 Prims.strcat "Checking nested positivity in the inductive "
-                   uu____1382 in
-               debug_log env uu____1381);
-              (let uu____1385 =
-                 FStar_TypeChecker_Env.datacons_of_typ env ilid in
-               match uu____1385 with
-               | (b,idatas) ->
-                   if Prims.op_Negation b
-                   then
-                     (debug_log env
-                        "Checking nested positivity, not an inductive, return false";
-                      false)
-                   else
-                     (let uu____1395 =
-                        already_unfolded ilid args unfolded env in
-                      if uu____1395
-                      then
-                        (debug_log env
-                           "Checking nested positivity, we have already unfolded this inductive with these args";
-                         true)
-                      else
-                        (let num_ibs =
-                           FStar_TypeChecker_Env.num_inductive_ty_params env
-                             ilid in
-                         (let uu____1400 =
-                            let uu____1401 =
-                              let uu____1402 =
-                                FStar_Util.string_of_int num_ibs in
-                              Prims.strcat uu____1402
-                                ", also adding to the memo table" in
-                            Prims.strcat
-                              "Checking nested positivity, number of type parameters is "
-                              uu____1401 in
-                          debug_log env uu____1400);
-                         (let uu____1404 =
-                            let uu____1405 = FStar_ST.read unfolded in
-                            let uu____1409 =
-                              let uu____1413 =
-                                let uu____1421 =
-                                  let uu____1427 =
-                                    FStar_List.splitAt num_ibs args in
-                                  Prims.fst uu____1427 in
-                                (ilid, uu____1421) in
-                              [uu____1413] in
-                            FStar_List.append uu____1405 uu____1409 in
-                          FStar_ST.write unfolded uu____1404);
-                         FStar_List.for_all
-                           (fun d  ->
-                              ty_nested_positive_in_dlid ty_lid d ilid us
-                                args num_ibs unfolded env) idatas)))
-and ty_nested_positive_in_dlid:
-  FStar_Ident.lident ->
-    FStar_Ident.lident ->
-      FStar_Ident.lident ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            Prims.int ->
-              unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
-  =
-  fun ty_lid  ->
-    fun dlid  ->
-      fun ilid  ->
-        fun us  ->
-          fun args  ->
-            fun num_ibs  ->
-              fun unfolded  ->
-                fun env  ->
-                  debug_log env
-                    (Prims.strcat
-                       "Checking nested positivity in data constructor "
-                       (Prims.strcat dlid.FStar_Ident.str
-                          (Prims.strcat " of the inductive "
-                             ilid.FStar_Ident.str)));
-                  (let uu____1485 =
-                     FStar_TypeChecker_Env.lookup_datacon env dlid in
-                   match uu____1485 with
-                   | (univ_unif_vars,dt) ->
-                       (FStar_List.iter2
-                          (fun u'  ->
-                             fun u  ->
-                               match u' with
-                               | FStar_Syntax_Syntax.U_unif u'' ->
-                                   FStar_Unionfind.change u'' (Some u)
-                               | uu____1497 ->
-                                   failwith
-                                     "Impossible! Expected universe unification variables")
-                          univ_unif_vars us;
-                        (let dt1 =
-                           FStar_TypeChecker_Normalize.normalize
-                             [FStar_TypeChecker_Normalize.Beta;
-                             FStar_TypeChecker_Normalize.Eager_unfolding;
-                             FStar_TypeChecker_Normalize.UnfoldUntil
-                               FStar_Syntax_Syntax.Delta_constant;
-                             FStar_TypeChecker_Normalize.Iota;
-                             FStar_TypeChecker_Normalize.Zeta;
-                             FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                             env dt in
-                         (let uu____1500 =
-                            let uu____1501 =
-                              FStar_Syntax_Print.term_to_string dt1 in
-                            Prims.strcat
-                              "Checking nested positivity in the data constructor type: "
-                              uu____1501 in
-                          debug_log env uu____1500);
-                         (let uu____1502 =
-                            let uu____1503 = FStar_Syntax_Subst.compress dt1 in
-                            uu____1503.FStar_Syntax_Syntax.n in
-                          match uu____1502 with
-                          | FStar_Syntax_Syntax.Tm_arrow (dbs,c) ->
-                              (debug_log env
-                                 "Checked nested positivity in Tm_arrow data constructor type";
-                               (let uu____1519 =
-                                  FStar_List.splitAt num_ibs dbs in
-                                match uu____1519 with
-                                | (ibs,dbs1) ->
-                                    let ibs1 =
-                                      FStar_Syntax_Subst.open_binders ibs in
-                                    let dbs2 =
-                                      let uu____1546 =
-                                        FStar_Syntax_Subst.opening_of_binders
-                                          ibs1 in
-                                      FStar_Syntax_Subst.subst_binders
-                                        uu____1546 dbs1 in
-                                    let c1 =
-                                      let uu____1549 =
-                                        FStar_Syntax_Subst.opening_of_binders
-                                          ibs1 in
-                                      FStar_Syntax_Subst.subst_comp
-                                        uu____1549 c in
-                                    let uu____1551 =
-                                      FStar_List.splitAt num_ibs args in
-                                    (match uu____1551 with
-                                     | (args1,uu____1569) ->
-                                         let subst1 =
-                                           FStar_List.fold_left2
-                                             (fun subst1  ->
-                                                fun ib  ->
-                                                  fun arg  ->
-                                                    FStar_List.append subst1
-                                                      [FStar_Syntax_Syntax.NT
-                                                         ((Prims.fst ib),
-                                                           (Prims.fst arg))])
-                                             [] ibs1 args1 in
-                                         let dbs3 =
-                                           FStar_Syntax_Subst.subst_binders
-                                             subst1 dbs2 in
-                                         let c2 =
-                                           let uu____1615 =
-                                             FStar_Syntax_Subst.shift_subst
-                                               (FStar_List.length dbs3)
-                                               subst1 in
-                                           FStar_Syntax_Subst.subst_comp
-                                             uu____1615 c1 in
-                                         ((let uu____1623 =
-                                             let uu____1624 =
-                                               let uu____1625 =
-                                                 FStar_Syntax_Print.binders_to_string
-                                                   "; " dbs3 in
-                                               let uu____1626 =
-                                                 let uu____1627 =
-                                                   FStar_Syntax_Print.comp_to_string
-                                                     c2 in
-                                                 Prims.strcat ", and c: "
-                                                   uu____1627 in
-                                               Prims.strcat uu____1625
-                                                 uu____1626 in
-                                             Prims.strcat
-                                               "Checking nested positivity in the unfolded data constructor binders as: "
-                                               uu____1624 in
-                                           debug_log env uu____1623);
-                                          ty_nested_positive_in_type ty_lid
-                                            (FStar_Syntax_Syntax.Tm_arrow
-                                               (dbs3, c2)) ilid num_ibs
-                                            unfolded env))))
-                          | uu____1628 ->
-                              (debug_log env
-                                 "Checking nested positivity in the data constructor type that is not an arrow";
-                               (let uu____1630 =
-                                  let uu____1631 =
-                                    FStar_Syntax_Subst.compress dt1 in
-                                  uu____1631.FStar_Syntax_Syntax.n in
-                                ty_nested_positive_in_type ty_lid uu____1630
-                                  ilid num_ibs unfolded env))))))
-and ty_nested_positive_in_type:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.term' ->
-      FStar_Ident.lident ->
-        Prims.int ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
-  =
-  fun ty_lid  ->
-    fun t  ->
-      fun ilid  ->
-        fun num_ibs  ->
-          fun unfolded  ->
-            fun env  ->
-              match t with
-              | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-                  (debug_log env
-                     "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself";
-                   (let uu____1657 = try_get_fv t1 in
-                    match uu____1657 with
-                    | (fv,uu____1661) ->
-                        if
-                          FStar_Ident.lid_equals
-                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                            ilid
-                        then true
-                        else
-                          failwith "Impossible, expected the type to be ilid"))
-              | FStar_Syntax_Syntax.Tm_arrow (sbs,c) ->
-                  ((let uu____1680 =
-                      let uu____1681 =
-                        FStar_Syntax_Print.binders_to_string "; " sbs in
-                      Prims.strcat
-                        "Checking nested positivity in an Tm_arrow node, with binders as: "
-                        uu____1681 in
-                    debug_log env uu____1680);
-                   (let uu____1682 =
-                      FStar_List.fold_left
-                        (fun uu____1689  ->
-                           fun b  ->
-                             match uu____1689 with
-                             | (r,env1) ->
-                                 if Prims.op_Negation r
-                                 then (r, env1)
-                                 else
-                                   (let uu____1702 =
-                                      ty_strictly_positive_in_type ty_lid
-                                        (Prims.fst b).FStar_Syntax_Syntax.sort
-                                        unfolded env1 in
-                                    let uu____1703 =
-                                      FStar_TypeChecker_Env.push_binders env1
-                                        [b] in
-                                    (uu____1702, uu____1703))) (true, env)
-                        sbs in
-                    match uu____1682 with | (b,uu____1709) -> b))
-              | uu____1710 ->
-                  failwith "Nested positive check, unhandled case"
-let ty_positive_in_datacon:
-  FStar_Ident.lident ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.binders ->
-        FStar_Syntax_Syntax.universes ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env -> Prims.bool
-  =
-  fun ty_lid  ->
-    fun dlid  ->
-      fun ty_bs  ->
-        fun us  ->
-          fun unfolded  ->
-            fun env  ->
-              let uu____1729 = FStar_TypeChecker_Env.lookup_datacon env dlid in
-              match uu____1729 with
-              | (univ_unif_vars,dt) ->
-                  (FStar_List.iter2
-                     (fun u'  ->
-                        fun u  ->
-                          match u' with
-                          | FStar_Syntax_Syntax.U_unif u'' ->
-                              FStar_Unionfind.change u'' (Some u)
-                          | uu____1741 ->
-                              failwith
-                                "Impossible! Expected universe unification variables")
-                     univ_unif_vars us;
-                   (let uu____1743 =
-                      let uu____1744 = FStar_Syntax_Print.term_to_string dt in
-                      Prims.strcat "Checking data constructor type: "
-                        uu____1744 in
-                    debug_log env uu____1743);
-                   (let uu____1745 =
-                      let uu____1746 = FStar_Syntax_Subst.compress dt in
-                      uu____1746.FStar_Syntax_Syntax.n in
-                    match uu____1745 with
-                    | FStar_Syntax_Syntax.Tm_fvar uu____1749 ->
-                        (debug_log env
-                           "Data constructor type is simply an fvar, returning true";
-                         true)
-                    | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____1752) ->
-                        let dbs1 =
-                          let uu____1767 =
-                            FStar_List.splitAt (FStar_List.length ty_bs) dbs in
-                          Prims.snd uu____1767 in
-                        let dbs2 =
-                          let uu____1789 =
-                            FStar_Syntax_Subst.opening_of_binders ty_bs in
-                          FStar_Syntax_Subst.subst_binders uu____1789 dbs1 in
-                        let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
-                        ((let uu____1793 =
-                            let uu____1794 =
-                              let uu____1795 =
-                                FStar_Util.string_of_int
-                                  (FStar_List.length dbs3) in
-                              Prims.strcat uu____1795 " binders" in
-                            Prims.strcat
-                              "Data constructor type is an arrow type, so checking strict positivity in "
-                              uu____1794 in
-                          debug_log env uu____1793);
-                         (let uu____1801 =
-                            FStar_List.fold_left
-                              (fun uu____1808  ->
-                                 fun b  ->
-                                   match uu____1808 with
-                                   | (r,env1) ->
-                                       if Prims.op_Negation r
-                                       then (r, env1)
-                                       else
-                                         (let uu____1821 =
-                                            ty_strictly_positive_in_type
-                                              ty_lid
-                                              (Prims.fst b).FStar_Syntax_Syntax.sort
-                                              unfolded env1 in
-                                          let uu____1822 =
-                                            FStar_TypeChecker_Env.push_binders
-                                              env1 [b] in
-                                          (uu____1821, uu____1822)))
-                              (true, env) dbs3 in
-                          match uu____1801 with | (b,uu____1828) -> b))
-                    | FStar_Syntax_Syntax.Tm_app (uu____1829,uu____1830) ->
-                        (debug_log env
-                           "Data constructor type is a Tm_app, so returning true";
-                         true)
-                    | uu____1846 ->
-                        failwith
-                          "Unexpected data constructor type when checking positivity"))
-let check_positivity:
-  FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env_t -> Prims.bool =
-  fun ty  ->
-    fun env  ->
-      let unfolded_inductives = FStar_Util.mk_ref [] in
-      let uu____1864 =
-        match ty with
-        | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,us,bs,uu____1874,uu____1875,uu____1876,uu____1877,uu____1878)
-            -> (lid, us, bs)
-        | uu____1885 -> failwith "Impossible!" in
-      match uu____1864 with
-      | (ty_lid,ty_us,ty_bs) ->
-          let uu____1892 = FStar_Syntax_Subst.univ_var_opening ty_us in
-          (match uu____1892 with
-           | (ty_usubst,ty_us1) ->
-               let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
-               let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
-               let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
-               let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
-               let uu____1907 =
-                 let uu____1909 =
-                   FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
-                 Prims.snd uu____1909 in
-               FStar_List.for_all
-                 (fun d  ->
-                    let uu____1915 =
-                      FStar_List.map (fun s  -> FStar_Syntax_Syntax.U_name s)
-                        ty_us1 in
-                    ty_positive_in_datacon ty_lid d ty_bs2 uu____1915
-                      unfolded_inductives env2) uu____1907)
-let datacon_typ: FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term =
-  fun data  ->
-    match data with
-    | FStar_Syntax_Syntax.Sig_datacon
-        (uu____1922,uu____1923,t,uu____1925,uu____1926,uu____1927,uu____1928,uu____1929)
-        -> t
-    | uu____1934 -> failwith "Impossible!"
-let optimized_haseq_soundness_for_data:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.sigelt ->
-      FStar_Syntax_Syntax.subst_elt Prims.list ->
-        FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.term
-  =
-  fun ty_lid  ->
-    fun data  ->
-      fun usubst  ->
-        fun bs  ->
-          let dt = datacon_typ data in
-          let dt1 = FStar_Syntax_Subst.subst usubst dt in
-          let uu____1951 =
-            let uu____1952 = FStar_Syntax_Subst.compress dt1 in
-            uu____1952.FStar_Syntax_Syntax.n in
-          match uu____1951 with
-          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____1956) ->
-              let dbs1 =
-                let uu____1971 =
-                  FStar_List.splitAt (FStar_List.length bs) dbs in
-                Prims.snd uu____1971 in
-              let dbs2 =
-                let uu____1993 = FStar_Syntax_Subst.opening_of_binders bs in
-                FStar_Syntax_Subst.subst_binders uu____1993 dbs1 in
-              let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
-              let cond =
-                FStar_List.fold_left
-                  (fun t  ->
-                     fun b  ->
-                       let haseq_b =
-                         let uu____2002 =
-                           let uu____2003 =
-                             let uu____2004 =
-                               FStar_Syntax_Syntax.as_arg
-                                 (Prims.fst b).FStar_Syntax_Syntax.sort in
-                             [uu____2004] in
-                           FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____2003 in
-                         uu____2002 None FStar_Range.dummyRange in
-                       let sort_range =
-                         ((Prims.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
-                       let haseq_b1 =
-                         let uu____2011 =
-                           FStar_Util.format1
-                             "Failed to prove that the type '%s' supports decidable equality because of this argument; add the 'noeq' qualifier"
-                             ty_lid.FStar_Ident.str in
-                         FStar_TypeChecker_Util.label uu____2011 sort_range
-                           haseq_b in
-                       FStar_Syntax_Util.mk_conj t haseq_b1)
-                  FStar_Syntax_Util.t_true dbs3 in
-              FStar_List.fold_right
-                (fun b  ->
-                   fun t  ->
-                     let uu____2016 =
-                       let uu____2017 =
-                         let uu____2018 =
-                           let uu____2019 =
-                             let uu____2020 = FStar_Syntax_Subst.close [b] t in
-                             FStar_Syntax_Util.abs [((Prims.fst b), None)]
-                               uu____2020 None in
-                           FStar_Syntax_Syntax.as_arg uu____2019 in
-                         [uu____2018] in
-                       FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.tforall uu____2017 in
-                     uu____2016 None FStar_Range.dummyRange) dbs3 cond
-          | uu____2037 -> FStar_Syntax_Util.t_true
-let optimized_haseq_ty all_datas_in_the_bundle usubst us acc ty =
-  let uu____2096 =
-    match ty with
-    | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,uu____2108,bs,t,uu____2111,d_lids,uu____2113,uu____2114) ->
-        (lid, bs, t, d_lids)
-    | uu____2122 -> failwith "Impossible!" in
-  match uu____2096 with
-  | (lid,bs,t,d_lids) ->
-      let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
-      let t1 =
-        let uu____2147 =
-          FStar_Syntax_Subst.shift_subst (FStar_List.length bs1) usubst in
-        FStar_Syntax_Subst.subst uu____2147 t in
-      let uu____2154 = FStar_Syntax_Subst.open_term bs1 t1 in
-      (match uu____2154 with
-       | (bs2,t2) ->
-           let ibs =
-             let uu____2174 =
-               let uu____2175 = FStar_Syntax_Subst.compress t2 in
-               uu____2175.FStar_Syntax_Syntax.n in
-             match uu____2174 with
-             | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____2182) -> ibs
-             | uu____2193 -> [] in
-           let ibs1 = FStar_Syntax_Subst.open_binders ibs in
-           let ind =
-             let uu____2198 =
-               FStar_Syntax_Syntax.fvar lid
-                 FStar_Syntax_Syntax.Delta_constant None in
-             let uu____2199 =
-               FStar_List.map (fun u  -> FStar_Syntax_Syntax.U_name u) us in
-             FStar_Syntax_Syntax.mk_Tm_uinst uu____2198 uu____2199 in
-           let ind1 =
-             let uu____2204 =
-               let uu____2205 =
-                 FStar_List.map
-                   (fun uu____2210  ->
-                      match uu____2210 with
-                      | (bv,aq) ->
-                          let uu____2217 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (uu____2217, aq)) bs2 in
-               FStar_Syntax_Syntax.mk_Tm_app ind uu____2205 in
-             uu____2204 None FStar_Range.dummyRange in
-           let ind2 =
-             let uu____2225 =
-               let uu____2226 =
-                 FStar_List.map
-                   (fun uu____2231  ->
-                      match uu____2231 with
-                      | (bv,aq) ->
-                          let uu____2238 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (uu____2238, aq)) ibs1 in
-               FStar_Syntax_Syntax.mk_Tm_app ind1 uu____2226 in
-             uu____2225 None FStar_Range.dummyRange in
-           let haseq_ind =
-             let uu____2246 =
-               let uu____2247 =
-                 let uu____2248 = FStar_Syntax_Syntax.as_arg ind2 in
-                 [uu____2248] in
-               FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq
-                 uu____2247 in
-             uu____2246 None FStar_Range.dummyRange in
-           let bs' =
-             FStar_List.filter
-               (fun b  ->
-                  let uu____2262 = acc in
-                  match uu____2262 with
-                  | (uu____2270,en,uu____2272,uu____2273) ->
-                      let opt =
-                        let uu____2282 =
-                          let uu____2283 = FStar_Syntax_Util.type_u () in
-                          Prims.fst uu____2283 in
-                        FStar_TypeChecker_Rel.try_subtype' en
-                          (Prims.fst b).FStar_Syntax_Syntax.sort uu____2282
-                          false in
-                      (match opt with
-                       | None  -> false
-                       | Some uu____2286 -> true)) bs2 in
-           let haseq_bs =
-             FStar_List.fold_left
-               (fun t3  ->
-                  fun b  ->
-                    let uu____2290 =
-                      let uu____2291 =
-                        let uu____2292 =
-                          let uu____2293 =
-                            let uu____2294 =
-                              FStar_Syntax_Syntax.bv_to_name (Prims.fst b) in
-                            FStar_Syntax_Syntax.as_arg uu____2294 in
-                          [uu____2293] in
-                        FStar_Syntax_Syntax.mk_Tm_app
-                          FStar_Syntax_Util.t_haseq uu____2292 in
-                      uu____2291 None FStar_Range.dummyRange in
-                    FStar_Syntax_Util.mk_conj t3 uu____2290)
-               FStar_Syntax_Util.t_true bs' in
-           let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind in
-           let fml1 =
-             let uu___86_2303 = fml in
-             let uu____2304 =
-               let uu____2305 =
-                 let uu____2310 =
-                   let uu____2311 =
-                     let uu____2318 =
-                       let uu____2320 = FStar_Syntax_Syntax.as_arg haseq_ind in
-                       [uu____2320] in
-                     [uu____2318] in
-                   FStar_Syntax_Syntax.Meta_pattern uu____2311 in
-                 (fml, uu____2310) in
-               FStar_Syntax_Syntax.Tm_meta uu____2305 in
-             {
-               FStar_Syntax_Syntax.n = uu____2304;
-               FStar_Syntax_Syntax.tk = (uu___86_2303.FStar_Syntax_Syntax.tk);
-               FStar_Syntax_Syntax.pos =
-                 (uu___86_2303.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___86_2303.FStar_Syntax_Syntax.vars)
-             } in
-           let fml2 =
-             FStar_List.fold_right
-               (fun b  ->
-                  fun t3  ->
-                    let uu____2332 =
-                      let uu____2333 =
-                        let uu____2334 =
-                          let uu____2335 =
-                            let uu____2336 = FStar_Syntax_Subst.close [b] t3 in
-                            FStar_Syntax_Util.abs [((Prims.fst b), None)]
-                              uu____2336 None in
-                          FStar_Syntax_Syntax.as_arg uu____2335 in
-                        [uu____2334] in
-                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
-                        uu____2333 in
-                    uu____2332 None FStar_Range.dummyRange) ibs1 fml1 in
-           let fml3 =
-             FStar_List.fold_right
-               (fun b  ->
-                  fun t3  ->
-                    let uu____2358 =
-                      let uu____2359 =
-                        let uu____2360 =
-                          let uu____2361 =
-                            let uu____2362 = FStar_Syntax_Subst.close [b] t3 in
-                            FStar_Syntax_Util.abs [((Prims.fst b), None)]
-                              uu____2362 None in
-                          FStar_Syntax_Syntax.as_arg uu____2361 in
-                        [uu____2360] in
-                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
-                        uu____2359 in
-                    uu____2358 None FStar_Range.dummyRange) bs2 fml2 in
-           let guard = FStar_Syntax_Util.mk_conj haseq_bs fml3 in
-           let uu____2382 = acc in
-           (match uu____2382 with
-            | (l_axioms,env,guard',cond') ->
-                let env1 = FStar_TypeChecker_Env.push_binders env bs2 in
-                let env2 = FStar_TypeChecker_Env.push_binders env1 ibs1 in
-                let t_datas =
-                  FStar_List.filter
-                    (fun s  ->
-                       match s with
-                       | FStar_Syntax_Syntax.Sig_datacon
-                           (uu____2416,uu____2417,uu____2418,t_lid,uu____2420,uu____2421,uu____2422,uu____2423)
-                           -> t_lid = lid
-                       | uu____2428 -> failwith "Impossible")
-                    all_datas_in_the_bundle in
-                let cond =
-                  FStar_List.fold_left
-                    (fun acc1  ->
-                       fun d  ->
-                         let uu____2432 =
-                           optimized_haseq_soundness_for_data lid d usubst
-                             bs2 in
-                         FStar_Syntax_Util.mk_conj acc1 uu____2432)
-                    FStar_Syntax_Util.t_true t_datas in
-                let axiom_lid =
-                  FStar_Ident.lid_of_ids
-                    (FStar_List.append lid.FStar_Ident.ns
-                       [FStar_Ident.id_of_text
-                          (Prims.strcat
-                             (lid.FStar_Ident.ident).FStar_Ident.idText
-                             "_haseq")]) in
-                let uu____2434 = FStar_Syntax_Util.mk_conj guard' guard in
-                let uu____2437 = FStar_Syntax_Util.mk_conj cond' cond in
-                ((FStar_List.append l_axioms [(axiom_lid, fml3)]), env2,
-                  uu____2434, uu____2437)))
-let optimized_haseq_scheme:
-  FStar_Syntax_Syntax.sigelt ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      FStar_Syntax_Syntax.sigelt Prims.list ->
-        FStar_TypeChecker_Env.env_t ->
-          (FStar_TypeChecker_Env.env_t ->
-             FStar_Ident.lident ->
-               FStar_Syntax_Syntax.formula ->
-                 FStar_Syntax_Syntax.qualifier Prims.list ->
-                   FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
-            -> FStar_Syntax_Syntax.sigelt Prims.list
-  =
-  fun sig_bndle  ->
-    fun tcs  ->
-      fun datas  ->
-        fun env0  ->
-          fun tc_assume  ->
-            let us =
-              let ty = FStar_List.hd tcs in
-              match ty with
-              | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (uu____2503,us,uu____2505,uu____2506,uu____2507,uu____2508,uu____2509,uu____2510)
-                  -> us
-              | uu____2517 -> failwith "Impossible!" in
-            let uu____2518 = FStar_Syntax_Subst.univ_var_opening us in
-            match uu____2518 with
-            | (usubst,us1) ->
-                let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
-                ((env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
-                   "haseq";
-                 (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
-                   env sig_bndle;
-                 (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
-                  let uu____2534 =
-                    FStar_List.fold_left
-                      (optimized_haseq_ty datas usubst us1)
-                      ([], env1, FStar_Syntax_Util.t_true,
-                        FStar_Syntax_Util.t_true) tcs in
-                  match uu____2534 with
-                  | (axioms,env2,guard,cond) ->
-                      let phi = FStar_Syntax_Util.mk_imp guard cond in
-                      let uu____2566 =
-                        FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi in
-                      (match uu____2566 with
-                       | (phi1,uu____2571) ->
-                           ((let uu____2573 =
-                               FStar_TypeChecker_Env.should_verify env2 in
-                             if uu____2573
-                             then
-                               let uu____2574 =
-                                 FStar_TypeChecker_Rel.guard_of_guard_formula
-                                   (FStar_TypeChecker_Common.NonTrivial phi1) in
-                               FStar_TypeChecker_Rel.force_trivial_guard env2
-                                 uu____2574
-                             else ());
-                            (let ses =
-                               FStar_List.fold_left
-                                 (fun l  ->
-                                    fun uu____2582  ->
-                                      match uu____2582 with
-                                      | (lid,fml) ->
-                                          let se =
-                                            tc_assume env2 lid fml []
-                                              FStar_Range.dummyRange in
-                                          FStar_List.append l [se]) [] axioms in
-                             (env2.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
-                               "haseq";
-                             ses)))))
-let unoptimized_haseq_data:
-  FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Ident.lident Prims.list ->
-          FStar_Syntax_Syntax.term ->
-            FStar_Syntax_Syntax.sigelt ->
-              (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-                FStar_Syntax_Syntax.syntax
-  =
-  fun usubst  ->
-    fun bs  ->
-      fun haseq_ind  ->
-        fun mutuals  ->
-          fun acc  ->
-            fun data  ->
-              let rec is_mutual t =
-                let uu____2625 =
-                  let uu____2626 = FStar_Syntax_Subst.compress t in
-                  uu____2626.FStar_Syntax_Syntax.n in
-                match uu____2625 with
-                | FStar_Syntax_Syntax.Tm_fvar fv ->
-                    FStar_List.existsb
-                      (fun lid  ->
-                         FStar_Ident.lid_equals lid
-                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                      mutuals
-                | FStar_Syntax_Syntax.Tm_uinst (t',uu____2636) ->
-                    is_mutual t'
-                | FStar_Syntax_Syntax.Tm_refine (bv,t') ->
-                    is_mutual bv.FStar_Syntax_Syntax.sort
-                | FStar_Syntax_Syntax.Tm_app (t',args) ->
-                    let uu____2663 = is_mutual t' in
-                    if uu____2663
-                    then true
-                    else
-                      (let uu____2665 = FStar_List.map Prims.fst args in
-                       exists_mutual uu____2665)
-                | FStar_Syntax_Syntax.Tm_meta (t',uu____2678) -> is_mutual t'
-                | uu____2683 -> false
-              and exists_mutual uu___82_2684 =
-                match uu___82_2684 with
-                | [] -> false
-                | hd1::tl1 -> (is_mutual hd1) || (exists_mutual tl1) in
-              let dt = datacon_typ data in
-              let dt1 = FStar_Syntax_Subst.subst usubst dt in
-              let uu____2701 =
-                let uu____2702 = FStar_Syntax_Subst.compress dt1 in
-                uu____2702.FStar_Syntax_Syntax.n in
-              match uu____2701 with
-              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____2708) ->
-                  let dbs1 =
-                    let uu____2723 =
-                      FStar_List.splitAt (FStar_List.length bs) dbs in
-                    Prims.snd uu____2723 in
-                  let dbs2 =
-                    let uu____2745 = FStar_Syntax_Subst.opening_of_binders bs in
-                    FStar_Syntax_Subst.subst_binders uu____2745 dbs1 in
-                  let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
-                  let cond =
-                    FStar_List.fold_left
-                      (fun t  ->
-                         fun b  ->
-                           let sort = (Prims.fst b).FStar_Syntax_Syntax.sort in
-                           let haseq_sort =
-                             let uu____2757 =
-                               let uu____2758 =
-                                 let uu____2759 =
-                                   FStar_Syntax_Syntax.as_arg
-                                     (Prims.fst b).FStar_Syntax_Syntax.sort in
-                                 [uu____2759] in
-                               FStar_Syntax_Syntax.mk_Tm_app
-                                 FStar_Syntax_Util.t_haseq uu____2758 in
-                             uu____2757 None FStar_Range.dummyRange in
-                           let haseq_sort1 =
-                             let uu____2765 = is_mutual sort in
-                             if uu____2765
-                             then
-                               FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
-                             else haseq_sort in
-                           FStar_Syntax_Util.mk_conj t haseq_sort1)
-                      FStar_Syntax_Util.t_true dbs3 in
-                  let cond1 =
-                    FStar_List.fold_right
-                      (fun b  ->
-                         fun t  ->
-                           let uu____2772 =
-                             let uu____2773 =
-                               let uu____2774 =
-                                 let uu____2775 =
-                                   let uu____2776 =
-                                     FStar_Syntax_Subst.close [b] t in
-                                   FStar_Syntax_Util.abs
-                                     [((Prims.fst b), None)] uu____2776 None in
-                                 FStar_Syntax_Syntax.as_arg uu____2775 in
-                               [uu____2774] in
-                             FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.tforall uu____2773 in
-                           uu____2772 None FStar_Range.dummyRange) dbs3 cond in
-                  FStar_Syntax_Util.mk_conj acc cond1
-              | uu____2793 -> acc
-let unoptimized_haseq_ty all_datas_in_the_bundle mutuals usubst us acc ty =
-  let uu____2836 =
-    match ty with
-    | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,uu____2848,bs,t,uu____2851,d_lids,uu____2853,uu____2854) ->
-        (lid, bs, t, d_lids)
-    | uu____2862 -> failwith "Impossible!" in
-  match uu____2836 with
-  | (lid,bs,t,d_lids) ->
-      let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
-      let t1 =
-        let uu____2878 =
-          FStar_Syntax_Subst.shift_subst (FStar_List.length bs1) usubst in
-        FStar_Syntax_Subst.subst uu____2878 t in
-      let uu____2885 = FStar_Syntax_Subst.open_term bs1 t1 in
-      (match uu____2885 with
-       | (bs2,t2) ->
-           let ibs =
-             let uu____2896 =
-               let uu____2897 = FStar_Syntax_Subst.compress t2 in
-               uu____2897.FStar_Syntax_Syntax.n in
-             match uu____2896 with
-             | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____2904) -> ibs
-             | uu____2915 -> [] in
-           let ibs1 = FStar_Syntax_Subst.open_binders ibs in
-           let ind =
-             let uu____2920 =
-               FStar_Syntax_Syntax.fvar lid
-                 FStar_Syntax_Syntax.Delta_constant None in
-             let uu____2921 =
-               FStar_List.map (fun u  -> FStar_Syntax_Syntax.U_name u) us in
-             FStar_Syntax_Syntax.mk_Tm_uinst uu____2920 uu____2921 in
-           let ind1 =
-             let uu____2926 =
-               let uu____2927 =
-                 FStar_List.map
-                   (fun uu____2932  ->
-                      match uu____2932 with
-                      | (bv,aq) ->
-                          let uu____2939 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (uu____2939, aq)) bs2 in
-               FStar_Syntax_Syntax.mk_Tm_app ind uu____2927 in
-             uu____2926 None FStar_Range.dummyRange in
-           let ind2 =
-             let uu____2947 =
-               let uu____2948 =
-                 FStar_List.map
-                   (fun uu____2953  ->
-                      match uu____2953 with
-                      | (bv,aq) ->
-                          let uu____2960 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (uu____2960, aq)) ibs1 in
-               FStar_Syntax_Syntax.mk_Tm_app ind1 uu____2948 in
-             uu____2947 None FStar_Range.dummyRange in
-           let haseq_ind =
-             let uu____2968 =
-               let uu____2969 =
-                 let uu____2970 = FStar_Syntax_Syntax.as_arg ind2 in
-                 [uu____2970] in
-               FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq
-                 uu____2969 in
-             uu____2968 None FStar_Range.dummyRange in
-           let t_datas =
-             FStar_List.filter
-               (fun s  ->
-                  match s with
-                  | FStar_Syntax_Syntax.Sig_datacon
-                      (uu____2978,uu____2979,uu____2980,t_lid,uu____2982,uu____2983,uu____2984,uu____2985)
-                      -> t_lid = lid
-                  | uu____2990 -> failwith "Impossible")
-               all_datas_in_the_bundle in
-           let data_cond =
-             FStar_List.fold_left
-               (unoptimized_haseq_data usubst bs2 haseq_ind mutuals)
-               FStar_Syntax_Util.t_true t_datas in
-           let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind in
-           let fml1 =
-             let uu___87_2996 = fml in
-             let uu____2997 =
-               let uu____2998 =
-                 let uu____3003 =
-                   let uu____3004 =
-                     let uu____3011 =
-                       let uu____3013 = FStar_Syntax_Syntax.as_arg haseq_ind in
-                       [uu____3013] in
-                     [uu____3011] in
-                   FStar_Syntax_Syntax.Meta_pattern uu____3004 in
-                 (fml, uu____3003) in
-               FStar_Syntax_Syntax.Tm_meta uu____2998 in
-             {
-               FStar_Syntax_Syntax.n = uu____2997;
-               FStar_Syntax_Syntax.tk = (uu___87_2996.FStar_Syntax_Syntax.tk);
-               FStar_Syntax_Syntax.pos =
-                 (uu___87_2996.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___87_2996.FStar_Syntax_Syntax.vars)
-             } in
-           let fml2 =
-             FStar_List.fold_right
-               (fun b  ->
-                  fun t3  ->
-                    let uu____3025 =
-                      let uu____3026 =
-                        let uu____3027 =
-                          let uu____3028 =
-                            let uu____3029 = FStar_Syntax_Subst.close [b] t3 in
-                            FStar_Syntax_Util.abs [((Prims.fst b), None)]
-                              uu____3029 None in
-                          FStar_Syntax_Syntax.as_arg uu____3028 in
-                        [uu____3027] in
-                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
-                        uu____3026 in
-                    uu____3025 None FStar_Range.dummyRange) ibs1 fml1 in
-           let fml3 =
-             FStar_List.fold_right
-               (fun b  ->
-                  fun t3  ->
-                    let uu____3051 =
-                      let uu____3052 =
-                        let uu____3053 =
-                          let uu____3054 =
-                            let uu____3055 = FStar_Syntax_Subst.close [b] t3 in
-                            FStar_Syntax_Util.abs [((Prims.fst b), None)]
-                              uu____3055 None in
-                          FStar_Syntax_Syntax.as_arg uu____3054 in
-                        [uu____3053] in
-                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
-                        uu____3052 in
-                    uu____3051 None FStar_Range.dummyRange) bs2 fml2 in
-           FStar_Syntax_Util.mk_conj acc fml3)
-let unoptimized_haseq_scheme:
-  FStar_Syntax_Syntax.sigelt ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      FStar_Syntax_Syntax.sigelt Prims.list ->
-        FStar_TypeChecker_Env.env_t ->
-          (FStar_TypeChecker_Env.env_t ->
-             FStar_Ident.lident ->
-               FStar_Syntax_Syntax.formula ->
-                 FStar_Syntax_Syntax.qualifier Prims.list ->
-                   FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
-            -> FStar_Syntax_Syntax.sigelt Prims.list
-  =
-  fun sig_bndle  ->
-    fun tcs  ->
-      fun datas  ->
-        fun env0  ->
-          fun tc_assume  ->
-            let mutuals =
-              FStar_List.map
-                (fun ty  ->
-                   match ty with
-                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                       (lid,uu____3124,uu____3125,uu____3126,uu____3127,uu____3128,uu____3129,uu____3130)
-                       -> lid
-                   | uu____3137 -> failwith "Impossible!") tcs in
-            let uu____3138 =
-              let ty = FStar_List.hd tcs in
-              match ty with
-              | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid,us,uu____3146,uu____3147,uu____3148,uu____3149,uu____3150,uu____3151)
-                  -> (lid, us)
-              | uu____3158 -> failwith "Impossible!" in
-            match uu____3138 with
-            | (lid,us) ->
-                let uu____3164 = FStar_Syntax_Subst.univ_var_opening us in
-                (match uu____3164 with
-                 | (usubst,us1) ->
-                     let fml =
-                       FStar_List.fold_left
-                         (unoptimized_haseq_ty datas mutuals usubst us1)
-                         FStar_Syntax_Util.t_true tcs in
-                     let env =
-                       FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
-                     ((env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
-                        "haseq";
-                      (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
-                        env sig_bndle;
-                      (let env1 =
-                         FStar_TypeChecker_Env.push_univ_vars env us1 in
-                       let se =
-                         let uu____3182 =
-                           FStar_Ident.lid_of_ids
-                             (FStar_List.append lid.FStar_Ident.ns
-                                [FStar_Ident.id_of_text
-                                   (Prims.strcat
-                                      (lid.FStar_Ident.ident).FStar_Ident.idText
-                                      "_haseq")]) in
-                         tc_assume env1 uu____3182 fml []
-                           FStar_Range.dummyRange in
-                       (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
-                         "haseq";
-                       [se])))
-let check_inductive_well_typedness:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.sigelt Prims.list ->
-      FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Ident.lident Prims.list ->
-          (FStar_Syntax_Syntax.sigelt* FStar_Syntax_Syntax.sigelt Prims.list*
-            FStar_Syntax_Syntax.sigelt Prims.list)
-  =
-  fun env  ->
-    fun ses  ->
-      fun quals  ->
-        fun lids  ->
-          let uu____3212 =
-            FStar_All.pipe_right ses
-              (FStar_List.partition
-                 (fun uu___83_3222  ->
-                    match uu___83_3222 with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ uu____3223 ->
-                        true
-                    | uu____3235 -> false)) in
-          match uu____3212 with
-          | (tys,datas) ->
-              ((let uu____3248 =
-                  FStar_All.pipe_right datas
-                    (FStar_Util.for_some
-                       (fun uu___84_3250  ->
-                          match uu___84_3250 with
-                          | FStar_Syntax_Syntax.Sig_datacon uu____3251 ->
-                              false
-                          | uu____3262 -> true)) in
-                if uu____3248
-                then
-                  let uu____3263 =
-                    let uu____3264 =
-                      let uu____3267 = FStar_TypeChecker_Env.get_range env in
-                      ("Mutually defined type contains a non-inductive element",
-                        uu____3267) in
-                    FStar_Errors.Error uu____3264 in
-                  Prims.raise uu____3263
-                else ());
-               (let env0 = env in
-                let uu____3270 =
-                  FStar_List.fold_right
-                    (fun tc  ->
-                       fun uu____3284  ->
-                         match uu____3284 with
-                         | (env1,all_tcs,g) ->
-                             let uu____3306 = tc_tycon env1 tc in
-                             (match uu____3306 with
-                              | (env2,tc1,tc_u,guard) ->
-                                  let g' =
-                                    FStar_TypeChecker_Rel.universe_inequality
-                                      FStar_Syntax_Syntax.U_zero tc_u in
-                                  ((let uu____3323 =
-                                      FStar_TypeChecker_Env.debug env2
-                                        FStar_Options.Low in
-                                    if uu____3323
-                                    then
-                                      let uu____3324 =
-                                        FStar_Syntax_Print.sigelt_to_string
-                                          tc1 in
-                                      FStar_Util.print1
-                                        "Checked inductive: %s\n" uu____3324
-                                    else ());
-                                   (let uu____3326 =
-                                      let uu____3327 =
-                                        FStar_TypeChecker_Rel.conj_guard
-                                          guard g' in
-                                      FStar_TypeChecker_Rel.conj_guard g
-                                        uu____3327 in
-                                    (env2, ((tc1, tc_u) :: all_tcs),
-                                      uu____3326))))) tys
-                    (env, [], FStar_TypeChecker_Rel.trivial_guard) in
-                match uu____3270 with
-                | (env1,tcs,g) ->
-                    let uu____3352 =
-                      FStar_List.fold_right
-                        (fun se  ->
-                           fun uu____3360  ->
-                             match uu____3360 with
-                             | (datas1,g1) ->
-                                 let uu____3371 =
-                                   let uu____3374 = tc_data env1 tcs in
-                                   uu____3374 se in
-                                 (match uu____3371 with
-                                  | (data,g') ->
-                                      let uu____3384 =
-                                        FStar_TypeChecker_Rel.conj_guard g1
-                                          g' in
-                                      ((data :: datas1), uu____3384))) datas
-                        ([], g) in
-                    (match uu____3352 with
-                     | (datas1,g1) ->
-                         let uu____3396 =
-                           generalize_and_inst_within env0 g1 tcs datas1 in
-                         (match uu____3396 with
-                          | (tcs1,datas2) ->
-                              let sig_bndle =
-                                let uu____3413 =
-                                  let uu____3421 =
-                                    FStar_TypeChecker_Env.get_range env0 in
-                                  ((FStar_List.append tcs1 datas2), quals,
-                                    lids, uu____3421) in
-                                FStar_Syntax_Syntax.Sig_bundle uu____3413 in
-                              (sig_bndle, tcs1, datas2)))))
+(FStar_Ident.lident * FStar_Syntax_Syntax.args) Prims.list
+
+
+type unfolded_memo_t =
+unfolded_memo_elt FStar_ST.ref
+
+
+let already_unfolded : FStar_Ident.lident  ->  FStar_Syntax_Syntax.args  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env_t  ->  Prims.bool = (fun ilid arrghs unfolded env -> (
+
+let uu____1044 = (FStar_ST.read unfolded)
+in (FStar_List.existsML (fun uu____1056 -> (match (uu____1056) with
+| (lid, l) -> begin
+((FStar_Ident.lid_equals lid ilid) && (
+
+let args = (
+
+let uu____1076 = (FStar_List.splitAt (FStar_List.length l) arrghs)
+in (Prims.fst uu____1076))
+in (FStar_List.fold_left2 (fun b a a' -> (b && (FStar_TypeChecker_Rel.teq_nosmt env (Prims.fst a) (Prims.fst a')))) true args l)))
+end)) uu____1044)))
+
+
+let rec ty_strictly_positive_in_type : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env_t  ->  Prims.bool = (fun ty_lid btype unfolded env -> ((
+
+let uu____1171 = (
+
+let uu____1172 = (FStar_Syntax_Print.term_to_string btype)
+in (Prims.strcat "Checking strict positivity in type: " uu____1172))
+in (debug_log env uu____1171));
+(
+
+let btype1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env btype)
+in ((
+
+let uu____1175 = (
+
+let uu____1176 = (FStar_Syntax_Print.term_to_string btype1)
+in (Prims.strcat "Checking strict positivity in type, after normalization: " uu____1176))
+in (debug_log env uu____1175));
+((
+
+let uu____1177 = (ty_occurs_in ty_lid btype1)
+in (not (uu____1177))) || ((debug_log env "ty does occur in this type, pressing ahead");
+(
+
+let uu____1179 = (
+
+let uu____1180 = (FStar_Syntax_Subst.compress btype1)
+in uu____1180.FStar_Syntax_Syntax.n)
+in (match (uu____1179) with
+| FStar_Syntax_Syntax.Tm_app (t, args) -> begin
+(
+
+let uu____1199 = (try_get_fv t)
+in (match (uu____1199) with
+| (fv, us) -> begin
+(match ((FStar_Ident.lid_equals fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v ty_lid)) with
+| true -> begin
+((debug_log env "Checking strict positivity in the Tm_app node where head lid is ty itself, checking that ty does not occur in the arguments");
+(FStar_List.for_all (fun uu____1211 -> (match (uu____1211) with
+| (t1, uu____1215) -> begin
+(
+
+let uu____1216 = (ty_occurs_in ty_lid t1)
+in (not (uu____1216)))
+end)) args);
+)
+end
+| uu____1217 -> begin
+((debug_log env "Checking strict positivity in the Tm_app node, head lid is not ty, so checking nested positivity");
+(ty_nested_positive_in_inductive ty_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v us args unfolded env);
+)
+end)
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (sbs, c) -> begin
+((debug_log env "Checking strict positivity in Tm_arrow");
+(
+
+let uu____1236 = (
+
+let uu____1237 = (FStar_Syntax_Util.is_pure_or_ghost_comp c)
+in (not (uu____1237)))
+in (match (uu____1236) with
+| true -> begin
+((debug_log env "Checking strict positivity , the arrow is impure, so return true");
+true;
+)
+end
+| uu____1239 -> begin
+((debug_log env "Checking struict positivity, Pure arrow, checking that ty does not occur in the binders, and that it is strictly positive in the return type");
+((FStar_List.for_all (fun uu____1243 -> (match (uu____1243) with
+| (b, uu____1247) -> begin
+(
+
+let uu____1248 = (ty_occurs_in ty_lid b.FStar_Syntax_Syntax.sort)
+in (not (uu____1248)))
+end)) sbs) && (
+
+let uu____1249 = (FStar_Syntax_Subst.open_term sbs (FStar_Syntax_Util.comp_result c))
+in (match (uu____1249) with
+| (uu____1252, return_type) -> begin
+(
+
+let uu____1254 = (FStar_TypeChecker_Env.push_binders env sbs)
+in (ty_strictly_positive_in_type ty_lid return_type unfolded uu____1254))
+end)));
+)
+end));
+)
+end
+| FStar_Syntax_Syntax.Tm_fvar (uu____1255) -> begin
+((debug_log env "Checking strict positivity in an fvar, return true");
+true;
+)
+end
+| FStar_Syntax_Syntax.Tm_type (uu____1257) -> begin
+((debug_log env "Checking strict positivity in an Tm_type, return true");
+true;
+)
+end
+| FStar_Syntax_Syntax.Tm_uinst (t, uu____1260) -> begin
+((debug_log env "Checking strict positivity in an Tm_uinst, recur on the term inside (mostly it should be the same inductive)");
+(ty_strictly_positive_in_type ty_lid t unfolded env);
+)
+end
+| FStar_Syntax_Syntax.Tm_refine (bv, uu____1267) -> begin
+((debug_log env "Checking strict positivity in an Tm_refine, recur in the bv sort)");
+(ty_strictly_positive_in_type ty_lid bv.FStar_Syntax_Syntax.sort unfolded env);
+)
+end
+| FStar_Syntax_Syntax.Tm_match (uu____1273, branches) -> begin
+((debug_log env "Checking strict positivity in an Tm_match, recur in the branches)");
+(FStar_List.for_all (fun uu____1308 -> (match (uu____1308) with
+| (p, uu____1316, t) -> begin
+(
+
+let bs = (
+
+let uu____1326 = (FStar_Syntax_Syntax.pat_bvs p)
+in (FStar_List.map FStar_Syntax_Syntax.mk_binder uu____1326))
+in (
+
+let uu____1328 = (FStar_Syntax_Subst.open_term bs t)
+in (match (uu____1328) with
+| (bs1, t1) -> begin
+(
+
+let uu____1333 = (FStar_TypeChecker_Env.push_binders env bs1)
+in (ty_strictly_positive_in_type ty_lid t1 unfolded uu____1333))
+end)))
+end)) branches);
+)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (t, uu____1335, uu____1336) -> begin
+((debug_log env "Checking strict positivity in an Tm_ascribed, recur)");
+(ty_strictly_positive_in_type ty_lid t unfolded env);
+)
+end
+| uu____1366 -> begin
+((
+
+let uu____1368 = (
+
+let uu____1369 = (
+
+let uu____1370 = (FStar_Syntax_Print.tag_of_term btype1)
+in (
+
+let uu____1371 = (
+
+let uu____1372 = (FStar_Syntax_Print.term_to_string btype1)
+in (Prims.strcat " and term: " uu____1372))
+in (Prims.strcat uu____1370 uu____1371)))
+in (Prims.strcat "Checking strict positivity, unexpected tag: " uu____1369))
+in (debug_log env uu____1368));
+false;
+)
+end));
+));
+));
+))
+and ty_nested_positive_in_inductive : FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.universes  ->  FStar_Syntax_Syntax.args  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env_t  ->  Prims.bool = (fun ty_lid ilid us args unfolded env -> ((
+
+let uu____1380 = (
+
+let uu____1381 = (
+
+let uu____1382 = (
+
+let uu____1383 = (FStar_Syntax_Print.args_to_string args)
+in (Prims.strcat " applied to arguments: " uu____1383))
+in (Prims.strcat ilid.FStar_Ident.str uu____1382))
+in (Prims.strcat "Checking nested positivity in the inductive " uu____1381))
+in (debug_log env uu____1380));
+(
+
+let uu____1384 = (FStar_TypeChecker_Env.datacons_of_typ env ilid)
+in (match (uu____1384) with
+| (b, idatas) -> begin
+(match ((not (b))) with
+| true -> begin
+((debug_log env "Checking nested positivity, not an inductive, return false");
+false;
+)
+end
+| uu____1393 -> begin
+(
+
+let uu____1394 = (already_unfolded ilid args unfolded env)
+in (match (uu____1394) with
+| true -> begin
+((debug_log env "Checking nested positivity, we have already unfolded this inductive with these args");
+true;
+)
+end
+| uu____1396 -> begin
+(
+
+let num_ibs = (FStar_TypeChecker_Env.num_inductive_ty_params env ilid)
+in ((
+
+let uu____1399 = (
+
+let uu____1400 = (
+
+let uu____1401 = (FStar_Util.string_of_int num_ibs)
+in (Prims.strcat uu____1401 ", also adding to the memo table"))
+in (Prims.strcat "Checking nested positivity, number of type parameters is " uu____1400))
+in (debug_log env uu____1399));
+(
+
+let uu____1403 = (
+
+let uu____1404 = (FStar_ST.read unfolded)
+in (
+
+let uu____1408 = (
+
+let uu____1412 = (
+
+let uu____1420 = (
+
+let uu____1426 = (FStar_List.splitAt num_ibs args)
+in (Prims.fst uu____1426))
+in ((ilid), (uu____1420)))
+in (uu____1412)::[])
+in (FStar_List.append uu____1404 uu____1408)))
+in (FStar_ST.write unfolded uu____1403));
+(FStar_List.for_all (fun d -> (ty_nested_positive_in_dlid ty_lid d ilid us args num_ibs unfolded env)) idatas);
+))
+end))
+end)
+end));
+))
+and ty_nested_positive_in_dlid : FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.universes  ->  FStar_Syntax_Syntax.args  ->  Prims.int  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env_t  ->  Prims.bool = (fun ty_lid dlid ilid us args num_ibs unfolded env -> ((debug_log env (Prims.strcat "Checking nested positivity in data constructor " (Prims.strcat dlid.FStar_Ident.str (Prims.strcat " of the inductive " ilid.FStar_Ident.str))));
+(
+
+let uu____1484 = (FStar_TypeChecker_Env.lookup_datacon env dlid)
+in (match (uu____1484) with
+| (univ_unif_vars, dt) -> begin
+((FStar_List.iter2 (fun u' u -> (match (u') with
+| FStar_Syntax_Syntax.U_unif (u'') -> begin
+(FStar_Unionfind.change u'' (Some (u)))
+end
+| uu____1496 -> begin
+(failwith "Impossible! Expected universe unification variables")
+end)) univ_unif_vars us);
+(
+
+let dt1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Iota)::(FStar_TypeChecker_Normalize.Zeta)::(FStar_TypeChecker_Normalize.AllowUnboundUniverses)::[]) env dt)
+in ((
+
+let uu____1499 = (
+
+let uu____1500 = (FStar_Syntax_Print.term_to_string dt1)
+in (Prims.strcat "Checking nested positivity in the data constructor type: " uu____1500))
+in (debug_log env uu____1499));
+(
+
+let uu____1501 = (
+
+let uu____1502 = (FStar_Syntax_Subst.compress dt1)
+in uu____1502.FStar_Syntax_Syntax.n)
+in (match (uu____1501) with
+| FStar_Syntax_Syntax.Tm_arrow (dbs, c) -> begin
+((debug_log env "Checked nested positivity in Tm_arrow data constructor type");
+(
+
+let uu____1518 = (FStar_List.splitAt num_ibs dbs)
+in (match (uu____1518) with
+| (ibs, dbs1) -> begin
+(
+
+let ibs1 = (FStar_Syntax_Subst.open_binders ibs)
+in (
+
+let dbs2 = (
+
+let uu____1545 = (FStar_Syntax_Subst.opening_of_binders ibs1)
+in (FStar_Syntax_Subst.subst_binders uu____1545 dbs1))
+in (
+
+let c1 = (
+
+let uu____1548 = (FStar_Syntax_Subst.opening_of_binders ibs1)
+in (FStar_Syntax_Subst.subst_comp uu____1548 c))
+in (
+
+let uu____1550 = (FStar_List.splitAt num_ibs args)
+in (match (uu____1550) with
+| (args1, uu____1568) -> begin
+(
+
+let subst1 = (FStar_List.fold_left2 (fun subst1 ib arg -> (FStar_List.append subst1 ((FStar_Syntax_Syntax.NT ((((Prims.fst ib)), ((Prims.fst arg)))))::[]))) [] ibs1 args1)
+in (
+
+let dbs3 = (FStar_Syntax_Subst.subst_binders subst1 dbs2)
+in (
+
+let c2 = (
+
+let uu____1614 = (FStar_Syntax_Subst.shift_subst (FStar_List.length dbs3) subst1)
+in (FStar_Syntax_Subst.subst_comp uu____1614 c1))
+in ((
+
+let uu____1622 = (
+
+let uu____1623 = (
+
+let uu____1624 = (FStar_Syntax_Print.binders_to_string "; " dbs3)
+in (
+
+let uu____1625 = (
+
+let uu____1626 = (FStar_Syntax_Print.comp_to_string c2)
+in (Prims.strcat ", and c: " uu____1626))
+in (Prims.strcat uu____1624 uu____1625)))
+in (Prims.strcat "Checking nested positivity in the unfolded data constructor binders as: " uu____1623))
+in (debug_log env uu____1622));
+(ty_nested_positive_in_type ty_lid (FStar_Syntax_Syntax.Tm_arrow (((dbs3), (c2)))) ilid num_ibs unfolded env);
+))))
+end)))))
+end));
+)
+end
+| uu____1627 -> begin
+((debug_log env "Checking nested positivity in the data constructor type that is not an arrow");
+(
+
+let uu____1629 = (
+
+let uu____1630 = (FStar_Syntax_Subst.compress dt1)
+in uu____1630.FStar_Syntax_Syntax.n)
+in (ty_nested_positive_in_type ty_lid uu____1629 ilid num_ibs unfolded env));
+)
+end));
+));
+)
+end));
+))
+and ty_nested_positive_in_type : FStar_Ident.lident  ->  FStar_Syntax_Syntax.term'  ->  FStar_Ident.lident  ->  Prims.int  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env_t  ->  Prims.bool = (fun ty_lid t ilid num_ibs unfolded env -> (match (t) with
+| FStar_Syntax_Syntax.Tm_app (t1, args) -> begin
+((debug_log env "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself");
+(
+
+let uu____1656 = (try_get_fv t1)
+in (match (uu____1656) with
+| (fv, uu____1660) -> begin
+(match ((FStar_Ident.lid_equals fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v ilid)) with
+| true -> begin
+true
+end
+| uu____1665 -> begin
+(failwith "Impossible, expected the type to be ilid")
+end)
+end));
+)
+end
+| FStar_Syntax_Syntax.Tm_arrow (sbs, c) -> begin
+((
+
+let uu____1679 = (
+
+let uu____1680 = (FStar_Syntax_Print.binders_to_string "; " sbs)
+in (Prims.strcat "Checking nested positivity in an Tm_arrow node, with binders as: " uu____1680))
+in (debug_log env uu____1679));
+(
+
+let uu____1681 = (FStar_List.fold_left (fun uu____1688 b -> (match (uu____1688) with
+| (r, env1) -> begin
+(match ((not (r))) with
+| true -> begin
+((r), (env1))
+end
+| uu____1700 -> begin
+(
+
+let uu____1701 = (ty_strictly_positive_in_type ty_lid (Prims.fst b).FStar_Syntax_Syntax.sort unfolded env1)
+in (
+
+let uu____1702 = (FStar_TypeChecker_Env.push_binders env1 ((b)::[]))
+in ((uu____1701), (uu____1702))))
+end)
+end)) ((true), (env)) sbs)
+in (match (uu____1681) with
+| (b, uu____1708) -> begin
+b
+end));
+)
+end
+| uu____1709 -> begin
+(failwith "Nested positive check, unhandled case")
+end))
+
+
+let ty_positive_in_datacon : FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.universes  ->  unfolded_memo_t  ->  FStar_TypeChecker_Env.env  ->  Prims.bool = (fun ty_lid dlid ty_bs us unfolded env -> (
+
+let uu____1728 = (FStar_TypeChecker_Env.lookup_datacon env dlid)
+in (match (uu____1728) with
+| (univ_unif_vars, dt) -> begin
+((FStar_List.iter2 (fun u' u -> (match (u') with
+| FStar_Syntax_Syntax.U_unif (u'') -> begin
+(FStar_Unionfind.change u'' (Some (u)))
+end
+| uu____1740 -> begin
+(failwith "Impossible! Expected universe unification variables")
+end)) univ_unif_vars us);
+(
+
+let uu____1742 = (
+
+let uu____1743 = (FStar_Syntax_Print.term_to_string dt)
+in (Prims.strcat "Checking data constructor type: " uu____1743))
+in (debug_log env uu____1742));
+(
+
+let uu____1744 = (
+
+let uu____1745 = (FStar_Syntax_Subst.compress dt)
+in uu____1745.FStar_Syntax_Syntax.n)
+in (match (uu____1744) with
+| FStar_Syntax_Syntax.Tm_fvar (uu____1748) -> begin
+((debug_log env "Data constructor type is simply an fvar, returning true");
+true;
+)
+end
+| FStar_Syntax_Syntax.Tm_arrow (dbs, uu____1751) -> begin
+(
+
+let dbs1 = (
+
+let uu____1766 = (FStar_List.splitAt (FStar_List.length ty_bs) dbs)
+in (Prims.snd uu____1766))
+in (
+
+let dbs2 = (
+
+let uu____1788 = (FStar_Syntax_Subst.opening_of_binders ty_bs)
+in (FStar_Syntax_Subst.subst_binders uu____1788 dbs1))
+in (
+
+let dbs3 = (FStar_Syntax_Subst.open_binders dbs2)
+in ((
+
+let uu____1792 = (
+
+let uu____1793 = (
+
+let uu____1794 = (FStar_Util.string_of_int (FStar_List.length dbs3))
+in (Prims.strcat uu____1794 " binders"))
+in (Prims.strcat "Data constructor type is an arrow type, so checking strict positivity in " uu____1793))
+in (debug_log env uu____1792));
+(
+
+let uu____1800 = (FStar_List.fold_left (fun uu____1807 b -> (match (uu____1807) with
+| (r, env1) -> begin
+(match ((not (r))) with
+| true -> begin
+((r), (env1))
+end
+| uu____1819 -> begin
+(
+
+let uu____1820 = (ty_strictly_positive_in_type ty_lid (Prims.fst b).FStar_Syntax_Syntax.sort unfolded env1)
+in (
+
+let uu____1821 = (FStar_TypeChecker_Env.push_binders env1 ((b)::[]))
+in ((uu____1820), (uu____1821))))
+end)
+end)) ((true), (env)) dbs3)
+in (match (uu____1800) with
+| (b, uu____1827) -> begin
+b
+end));
+))))
+end
+| FStar_Syntax_Syntax.Tm_app (uu____1828, uu____1829) -> begin
+((debug_log env "Data constructor type is a Tm_app, so returning true");
+true;
+)
+end
+| uu____1845 -> begin
+(failwith "Unexpected data constructor type when checking positivity")
+end));
+)
+end)))
+
+
+let check_positivity : FStar_Syntax_Syntax.sigelt  ->  FStar_TypeChecker_Env.env  ->  Prims.bool = (fun ty env -> (
+
+let unfolded_inductives = (FStar_Util.mk_ref [])
+in (
+
+let uu____1863 = (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, us, bs, uu____1873, uu____1874, uu____1875, uu____1876) -> begin
+((lid), (us), (bs))
+end
+| uu____1883 -> begin
+(failwith "Impossible!")
+end)
+in (match (uu____1863) with
+| (ty_lid, ty_us, ty_bs) -> begin
+(
+
+let uu____1890 = (FStar_Syntax_Subst.univ_var_opening ty_us)
+in (match (uu____1890) with
+| (ty_usubst, ty_us1) -> begin
+(
+
+let env1 = (FStar_TypeChecker_Env.push_univ_vars env ty_us1)
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_binders env1 ty_bs)
+in (
+
+let ty_bs1 = (FStar_Syntax_Subst.subst_binders ty_usubst ty_bs)
+in (
+
+let ty_bs2 = (FStar_Syntax_Subst.open_binders ty_bs1)
+in (
+
+let uu____1905 = (
+
+let uu____1907 = (FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid)
+in (Prims.snd uu____1907))
+in (FStar_List.for_all (fun d -> (
+
+let uu____1913 = (FStar_List.map (fun s -> FStar_Syntax_Syntax.U_name (s)) ty_us1)
+in (ty_positive_in_datacon ty_lid d ty_bs2 uu____1913 unfolded_inductives env2))) uu____1905))))))
+end))
+end))))
+
+
+let datacon_typ : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.term = (fun data -> (match (data.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (uu____1920, uu____1921, t, uu____1923, uu____1924, uu____1925, uu____1926) -> begin
+t
+end
+| uu____1931 -> begin
+(failwith "Impossible!")
+end))
+
+
+let optimized_haseq_soundness_for_data : FStar_Ident.lident  ->  FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term = (fun ty_lid data usubst bs -> (
+
+let dt = (datacon_typ data)
+in (
+
+let dt1 = (FStar_Syntax_Subst.subst usubst dt)
+in (
+
+let uu____1948 = (
+
+let uu____1949 = (FStar_Syntax_Subst.compress dt1)
+in uu____1949.FStar_Syntax_Syntax.n)
+in (match (uu____1948) with
+| FStar_Syntax_Syntax.Tm_arrow (dbs, uu____1953) -> begin
+(
+
+let dbs1 = (
+
+let uu____1968 = (FStar_List.splitAt (FStar_List.length bs) dbs)
+in (Prims.snd uu____1968))
+in (
+
+let dbs2 = (
+
+let uu____1990 = (FStar_Syntax_Subst.opening_of_binders bs)
+in (FStar_Syntax_Subst.subst_binders uu____1990 dbs1))
+in (
+
+let dbs3 = (FStar_Syntax_Subst.open_binders dbs2)
+in (
+
+let cond = (FStar_List.fold_left (fun t b -> (
+
+let haseq_b = (
+
+let uu____1999 = (
+
+let uu____2000 = (
+
+let uu____2001 = (FStar_Syntax_Syntax.as_arg (Prims.fst b).FStar_Syntax_Syntax.sort)
+in (uu____2001)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq uu____2000))
+in (uu____1999 None FStar_Range.dummyRange))
+in (
+
+let sort_range = (Prims.fst b).FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.pos
+in (
+
+let haseq_b1 = (
+
+let uu____2008 = (FStar_Util.format1 "Failed to prove that the type \'%s\' supports decidable equality because of this argument; add the \'noeq\' qualifier" ty_lid.FStar_Ident.str)
+in (FStar_TypeChecker_Util.label uu____2008 sort_range haseq_b))
+in (FStar_Syntax_Util.mk_conj t haseq_b1))))) FStar_Syntax_Util.t_true dbs3)
+in (FStar_List.fold_right (fun b t -> (
+
+let uu____2013 = (
+
+let uu____2014 = (
+
+let uu____2015 = (
+
+let uu____2016 = (
+
+let uu____2017 = (FStar_Syntax_Subst.close ((b)::[]) t)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____2017 None))
+in (FStar_Syntax_Syntax.as_arg uu____2016))
+in (uu____2015)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____2014))
+in (uu____2013 None FStar_Range.dummyRange))) dbs3 cond)))))
+end
+| uu____2034 -> begin
+FStar_Syntax_Util.t_true
+end)))))
+
+
+let optimized_haseq_ty = (fun all_datas_in_the_bundle usubst us acc ty -> (
+
+let uu____2093 = (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, uu____2105, bs, t, uu____2108, d_lids, uu____2110) -> begin
+((lid), (bs), (t), (d_lids))
+end
+| uu____2118 -> begin
+(failwith "Impossible!")
+end)
+in (match (uu____2093) with
+| (lid, bs, t, d_lids) -> begin
+(
+
+let bs1 = (FStar_Syntax_Subst.subst_binders usubst bs)
+in (
+
+let t1 = (
+
+let uu____2143 = (FStar_Syntax_Subst.shift_subst (FStar_List.length bs1) usubst)
+in (FStar_Syntax_Subst.subst uu____2143 t))
+in (
+
+let uu____2150 = (FStar_Syntax_Subst.open_term bs1 t1)
+in (match (uu____2150) with
+| (bs2, t2) -> begin
+(
+
+let ibs = (
+
+let uu____2170 = (
+
+let uu____2171 = (FStar_Syntax_Subst.compress t2)
+in uu____2171.FStar_Syntax_Syntax.n)
+in (match (uu____2170) with
+| FStar_Syntax_Syntax.Tm_arrow (ibs, uu____2178) -> begin
+ibs
+end
+| uu____2189 -> begin
+[]
+end))
+in (
+
+let ibs1 = (FStar_Syntax_Subst.open_binders ibs)
+in (
+
+let ind = (
+
+let uu____2194 = (FStar_Syntax_Syntax.fvar lid FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____2195 = (FStar_List.map (fun u -> FStar_Syntax_Syntax.U_name (u)) us)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____2194 uu____2195)))
+in (
+
+let ind1 = (
+
+let uu____2200 = (
+
+let uu____2201 = (FStar_List.map (fun uu____2206 -> (match (uu____2206) with
+| (bv, aq) -> begin
+(
+
+let uu____2213 = (FStar_Syntax_Syntax.bv_to_name bv)
+in ((uu____2213), (aq)))
+end)) bs2)
+in (FStar_Syntax_Syntax.mk_Tm_app ind uu____2201))
+in (uu____2200 None FStar_Range.dummyRange))
+in (
+
+let ind2 = (
+
+let uu____2221 = (
+
+let uu____2222 = (FStar_List.map (fun uu____2227 -> (match (uu____2227) with
+| (bv, aq) -> begin
+(
+
+let uu____2234 = (FStar_Syntax_Syntax.bv_to_name bv)
+in ((uu____2234), (aq)))
+end)) ibs1)
+in (FStar_Syntax_Syntax.mk_Tm_app ind1 uu____2222))
+in (uu____2221 None FStar_Range.dummyRange))
+in (
+
+let haseq_ind = (
+
+let uu____2242 = (
+
+let uu____2243 = (
+
+let uu____2244 = (FStar_Syntax_Syntax.as_arg ind2)
+in (uu____2244)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq uu____2243))
+in (uu____2242 None FStar_Range.dummyRange))
+in (
+
+let bs' = (FStar_List.filter (fun b -> (
+
+let uu____2258 = acc
+in (match (uu____2258) with
+| (uu____2266, en, uu____2268, uu____2269) -> begin
+(
+
+let opt = (
+
+let uu____2278 = (
+
+let uu____2279 = (FStar_Syntax_Util.type_u ())
+in (Prims.fst uu____2279))
+in (FStar_TypeChecker_Rel.try_subtype' en (Prims.fst b).FStar_Syntax_Syntax.sort uu____2278 false))
+in (match (opt) with
+| None -> begin
+false
+end
+| Some (uu____2282) -> begin
+true
+end))
+end))) bs2)
+in (
+
+let haseq_bs = (FStar_List.fold_left (fun t3 b -> (
+
+let uu____2286 = (
+
+let uu____2287 = (
+
+let uu____2288 = (
+
+let uu____2289 = (
+
+let uu____2290 = (FStar_Syntax_Syntax.bv_to_name (Prims.fst b))
+in (FStar_Syntax_Syntax.as_arg uu____2290))
+in (uu____2289)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq uu____2288))
+in (uu____2287 None FStar_Range.dummyRange))
+in (FStar_Syntax_Util.mk_conj t3 uu____2286))) FStar_Syntax_Util.t_true bs')
+in (
+
+let fml = (FStar_Syntax_Util.mk_imp haseq_bs haseq_ind)
+in (
+
+let fml1 = (
+
+let uu___86_2299 = fml
+in (
+
+let uu____2300 = (
+
+let uu____2301 = (
+
+let uu____2306 = (
+
+let uu____2307 = (
+
+let uu____2314 = (
+
+let uu____2316 = (FStar_Syntax_Syntax.as_arg haseq_ind)
+in (uu____2316)::[])
+in (uu____2314)::[])
+in FStar_Syntax_Syntax.Meta_pattern (uu____2307))
+in ((fml), (uu____2306)))
+in FStar_Syntax_Syntax.Tm_meta (uu____2301))
+in {FStar_Syntax_Syntax.n = uu____2300; FStar_Syntax_Syntax.tk = uu___86_2299.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___86_2299.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___86_2299.FStar_Syntax_Syntax.vars}))
+in (
+
+let fml2 = (FStar_List.fold_right (fun b t3 -> (
+
+let uu____2328 = (
+
+let uu____2329 = (
+
+let uu____2330 = (
+
+let uu____2331 = (
+
+let uu____2332 = (FStar_Syntax_Subst.close ((b)::[]) t3)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____2332 None))
+in (FStar_Syntax_Syntax.as_arg uu____2331))
+in (uu____2330)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____2329))
+in (uu____2328 None FStar_Range.dummyRange))) ibs1 fml1)
+in (
+
+let fml3 = (FStar_List.fold_right (fun b t3 -> (
+
+let uu____2354 = (
+
+let uu____2355 = (
+
+let uu____2356 = (
+
+let uu____2357 = (
+
+let uu____2358 = (FStar_Syntax_Subst.close ((b)::[]) t3)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____2358 None))
+in (FStar_Syntax_Syntax.as_arg uu____2357))
+in (uu____2356)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____2355))
+in (uu____2354 None FStar_Range.dummyRange))) bs2 fml2)
+in (
+
+let guard = (FStar_Syntax_Util.mk_conj haseq_bs fml3)
+in (
+
+let uu____2378 = acc
+in (match (uu____2378) with
+| (l_axioms, env, guard', cond') -> begin
+(
+
+let env1 = (FStar_TypeChecker_Env.push_binders env bs2)
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_binders env1 ibs1)
+in (
+
+let t_datas = (FStar_List.filter (fun s -> (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (uu____2412, uu____2413, uu____2414, t_lid, uu____2416, uu____2417, uu____2418) -> begin
+(t_lid = lid)
+end
+| uu____2423 -> begin
+(failwith "Impossible")
+end)) all_datas_in_the_bundle)
+in (
+
+let cond = (FStar_List.fold_left (fun acc1 d -> (
+
+let uu____2427 = (optimized_haseq_soundness_for_data lid d usubst bs2)
+in (FStar_Syntax_Util.mk_conj acc1 uu____2427))) FStar_Syntax_Util.t_true t_datas)
+in (
+
+let axiom_lid = (FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns (((FStar_Ident.id_of_text (Prims.strcat lid.FStar_Ident.ident.FStar_Ident.idText "_haseq")))::[])))
+in (
+
+let uu____2429 = (FStar_Syntax_Util.mk_conj guard' guard)
+in (
+
+let uu____2432 = (FStar_Syntax_Util.mk_conj cond' cond)
+in (((FStar_List.append l_axioms ((((axiom_lid), (fml3)))::[]))), (env2), (uu____2429), (uu____2432)))))))))
+end)))))))))))))))
+end))))
+end)))
+
+
+let optimized_haseq_scheme : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_TypeChecker_Env.env_t  ->  (FStar_TypeChecker_Env.env_t  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.formula  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.sigelt)  ->  FStar_Syntax_Syntax.sigelt Prims.list = (fun sig_bndle tcs datas env0 tc_assume -> (
+
+let us = (
+
+let ty = (FStar_List.hd tcs)
+in (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____2498, us, uu____2500, uu____2501, uu____2502, uu____2503, uu____2504) -> begin
+us
+end
+| uu____2511 -> begin
+(failwith "Impossible!")
+end))
+in (
+
+let uu____2512 = (FStar_Syntax_Subst.univ_var_opening us)
+in (match (uu____2512) with
+| (usubst, us1) -> begin
+(
+
+let env = (FStar_TypeChecker_Env.push_sigelt env0 sig_bndle)
+in ((env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.push "haseq");
+(env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.encode_sig env sig_bndle);
+(
+
+let env1 = (FStar_TypeChecker_Env.push_univ_vars env us1)
+in (
+
+let uu____2528 = (FStar_List.fold_left (optimized_haseq_ty datas usubst us1) (([]), (env1), (FStar_Syntax_Util.t_true), (FStar_Syntax_Util.t_true)) tcs)
+in (match (uu____2528) with
+| (axioms, env2, guard, cond) -> begin
+(
+
+let phi = (FStar_Syntax_Util.mk_imp guard cond)
+in (
+
+let uu____2560 = (FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi)
+in (match (uu____2560) with
+| (phi1, uu____2565) -> begin
+((
+
+let uu____2567 = (FStar_TypeChecker_Env.should_verify env2)
+in (match (uu____2567) with
+| true -> begin
+(
+
+let uu____2568 = (FStar_TypeChecker_Rel.guard_of_guard_formula (FStar_TypeChecker_Common.NonTrivial (phi1)))
+in (FStar_TypeChecker_Rel.force_trivial_guard env2 uu____2568))
+end
+| uu____2569 -> begin
+()
+end));
+(
+
+let ses = (FStar_List.fold_left (fun l uu____2576 -> (match (uu____2576) with
+| (lid, fml) -> begin
+(
+
+let se = (tc_assume env2 lid fml [] FStar_Range.dummyRange)
+in (FStar_List.append l ((se)::[])))
+end)) [] axioms)
+in ((env2.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.pop "haseq");
+ses;
+));
+)
+end)))
+end)));
+))
+end))))
+
+
+let unoptimized_haseq_data : FStar_Syntax_Syntax.subst_elt Prims.list  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term  ->  FStar_Ident.lident Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.sigelt  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun usubst bs haseq_ind mutuals acc data -> (
+
+let rec is_mutual = (fun t -> (
+
+let uu____2619 = (
+
+let uu____2620 = (FStar_Syntax_Subst.compress t)
+in uu____2620.FStar_Syntax_Syntax.n)
+in (match (uu____2619) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_List.existsb (fun lid -> (FStar_Ident.lid_equals lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)) mutuals)
+end
+| FStar_Syntax_Syntax.Tm_uinst (t', uu____2630) -> begin
+(is_mutual t')
+end
+| FStar_Syntax_Syntax.Tm_refine (bv, t') -> begin
+(is_mutual bv.FStar_Syntax_Syntax.sort)
+end
+| FStar_Syntax_Syntax.Tm_app (t', args) -> begin
+(
+
+let uu____2657 = (is_mutual t')
+in (match (uu____2657) with
+| true -> begin
+true
+end
+| uu____2658 -> begin
+(
+
+let uu____2659 = (FStar_List.map Prims.fst args)
+in (exists_mutual uu____2659))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (t', uu____2672) -> begin
+(is_mutual t')
+end
+| uu____2677 -> begin
+false
+end)))
+and exists_mutual = (fun uu___78_2678 -> (match (uu___78_2678) with
+| [] -> begin
+false
+end
+| (hd1)::tl1 -> begin
+((is_mutual hd1) || (exists_mutual tl1))
+end))
+in (
+
+let dt = (datacon_typ data)
+in (
+
+let dt1 = (FStar_Syntax_Subst.subst usubst dt)
+in (
+
+let uu____2695 = (
+
+let uu____2696 = (FStar_Syntax_Subst.compress dt1)
+in uu____2696.FStar_Syntax_Syntax.n)
+in (match (uu____2695) with
+| FStar_Syntax_Syntax.Tm_arrow (dbs, uu____2702) -> begin
+(
+
+let dbs1 = (
+
+let uu____2717 = (FStar_List.splitAt (FStar_List.length bs) dbs)
+in (Prims.snd uu____2717))
+in (
+
+let dbs2 = (
+
+let uu____2739 = (FStar_Syntax_Subst.opening_of_binders bs)
+in (FStar_Syntax_Subst.subst_binders uu____2739 dbs1))
+in (
+
+let dbs3 = (FStar_Syntax_Subst.open_binders dbs2)
+in (
+
+let cond = (FStar_List.fold_left (fun t b -> (
+
+let sort = (Prims.fst b).FStar_Syntax_Syntax.sort
+in (
+
+let haseq_sort = (
+
+let uu____2751 = (
+
+let uu____2752 = (
+
+let uu____2753 = (FStar_Syntax_Syntax.as_arg (Prims.fst b).FStar_Syntax_Syntax.sort)
+in (uu____2753)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq uu____2752))
+in (uu____2751 None FStar_Range.dummyRange))
+in (
+
+let haseq_sort1 = (
+
+let uu____2759 = (is_mutual sort)
+in (match (uu____2759) with
+| true -> begin
+(FStar_Syntax_Util.mk_imp haseq_ind haseq_sort)
+end
+| uu____2760 -> begin
+haseq_sort
+end))
+in (FStar_Syntax_Util.mk_conj t haseq_sort1))))) FStar_Syntax_Util.t_true dbs3)
+in (
+
+let cond1 = (FStar_List.fold_right (fun b t -> (
+
+let uu____2766 = (
+
+let uu____2767 = (
+
+let uu____2768 = (
+
+let uu____2769 = (
+
+let uu____2770 = (FStar_Syntax_Subst.close ((b)::[]) t)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____2770 None))
+in (FStar_Syntax_Syntax.as_arg uu____2769))
+in (uu____2768)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____2767))
+in (uu____2766 None FStar_Range.dummyRange))) dbs3 cond)
+in (FStar_Syntax_Util.mk_conj acc cond1))))))
+end
+| uu____2787 -> begin
+acc
+end))))))
+
+
+let unoptimized_haseq_ty = (fun all_datas_in_the_bundle mutuals usubst us acc ty -> (
+
+let uu____2830 = (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, uu____2842, bs, t, uu____2845, d_lids, uu____2847) -> begin
+((lid), (bs), (t), (d_lids))
+end
+| uu____2855 -> begin
+(failwith "Impossible!")
+end)
+in (match (uu____2830) with
+| (lid, bs, t, d_lids) -> begin
+(
+
+let bs1 = (FStar_Syntax_Subst.subst_binders usubst bs)
+in (
+
+let t1 = (
+
+let uu____2871 = (FStar_Syntax_Subst.shift_subst (FStar_List.length bs1) usubst)
+in (FStar_Syntax_Subst.subst uu____2871 t))
+in (
+
+let uu____2878 = (FStar_Syntax_Subst.open_term bs1 t1)
+in (match (uu____2878) with
+| (bs2, t2) -> begin
+(
+
+let ibs = (
+
+let uu____2889 = (
+
+let uu____2890 = (FStar_Syntax_Subst.compress t2)
+in uu____2890.FStar_Syntax_Syntax.n)
+in (match (uu____2889) with
+| FStar_Syntax_Syntax.Tm_arrow (ibs, uu____2897) -> begin
+ibs
+end
+| uu____2908 -> begin
+[]
+end))
+in (
+
+let ibs1 = (FStar_Syntax_Subst.open_binders ibs)
+in (
+
+let ind = (
+
+let uu____2913 = (FStar_Syntax_Syntax.fvar lid FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let uu____2914 = (FStar_List.map (fun u -> FStar_Syntax_Syntax.U_name (u)) us)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____2913 uu____2914)))
+in (
+
+let ind1 = (
+
+let uu____2919 = (
+
+let uu____2920 = (FStar_List.map (fun uu____2925 -> (match (uu____2925) with
+| (bv, aq) -> begin
+(
+
+let uu____2932 = (FStar_Syntax_Syntax.bv_to_name bv)
+in ((uu____2932), (aq)))
+end)) bs2)
+in (FStar_Syntax_Syntax.mk_Tm_app ind uu____2920))
+in (uu____2919 None FStar_Range.dummyRange))
+in (
+
+let ind2 = (
+
+let uu____2940 = (
+
+let uu____2941 = (FStar_List.map (fun uu____2946 -> (match (uu____2946) with
+| (bv, aq) -> begin
+(
+
+let uu____2953 = (FStar_Syntax_Syntax.bv_to_name bv)
+in ((uu____2953), (aq)))
+end)) ibs1)
+in (FStar_Syntax_Syntax.mk_Tm_app ind1 uu____2941))
+in (uu____2940 None FStar_Range.dummyRange))
+in (
+
+let haseq_ind = (
+
+let uu____2961 = (
+
+let uu____2962 = (
+
+let uu____2963 = (FStar_Syntax_Syntax.as_arg ind2)
+in (uu____2963)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq uu____2962))
+in (uu____2961 None FStar_Range.dummyRange))
+in (
+
+let t_datas = (FStar_List.filter (fun s -> (match (s.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (uu____2971, uu____2972, uu____2973, t_lid, uu____2975, uu____2976, uu____2977) -> begin
+(t_lid = lid)
+end
+| uu____2982 -> begin
+(failwith "Impossible")
+end)) all_datas_in_the_bundle)
+in (
+
+let data_cond = (FStar_List.fold_left (unoptimized_haseq_data usubst bs2 haseq_ind mutuals) FStar_Syntax_Util.t_true t_datas)
+in (
+
+let fml = (FStar_Syntax_Util.mk_imp data_cond haseq_ind)
+in (
+
+let fml1 = (
+
+let uu___87_2988 = fml
+in (
+
+let uu____2989 = (
+
+let uu____2990 = (
+
+let uu____2995 = (
+
+let uu____2996 = (
+
+let uu____3003 = (
+
+let uu____3005 = (FStar_Syntax_Syntax.as_arg haseq_ind)
+in (uu____3005)::[])
+in (uu____3003)::[])
+in FStar_Syntax_Syntax.Meta_pattern (uu____2996))
+in ((fml), (uu____2995)))
+in FStar_Syntax_Syntax.Tm_meta (uu____2990))
+in {FStar_Syntax_Syntax.n = uu____2989; FStar_Syntax_Syntax.tk = uu___87_2988.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___87_2988.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___87_2988.FStar_Syntax_Syntax.vars}))
+in (
+
+let fml2 = (FStar_List.fold_right (fun b t3 -> (
+
+let uu____3017 = (
+
+let uu____3018 = (
+
+let uu____3019 = (
+
+let uu____3020 = (
+
+let uu____3021 = (FStar_Syntax_Subst.close ((b)::[]) t3)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____3021 None))
+in (FStar_Syntax_Syntax.as_arg uu____3020))
+in (uu____3019)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____3018))
+in (uu____3017 None FStar_Range.dummyRange))) ibs1 fml1)
+in (
+
+let fml3 = (FStar_List.fold_right (fun b t3 -> (
+
+let uu____3043 = (
+
+let uu____3044 = (
+
+let uu____3045 = (
+
+let uu____3046 = (
+
+let uu____3047 = (FStar_Syntax_Subst.close ((b)::[]) t3)
+in (FStar_Syntax_Util.abs (((((Prims.fst b)), (None)))::[]) uu____3047 None))
+in (FStar_Syntax_Syntax.as_arg uu____3046))
+in (uu____3045)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall uu____3044))
+in (uu____3043 None FStar_Range.dummyRange))) bs2 fml2)
+in (FStar_Syntax_Util.mk_conj acc fml3)))))))))))))
+end))))
+end)))
+
+
+let unoptimized_haseq_scheme : FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_TypeChecker_Env.env_t  ->  (FStar_TypeChecker_Env.env_t  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.formula  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.sigelt)  ->  FStar_Syntax_Syntax.sigelt Prims.list = (fun sig_bndle tcs datas env0 tc_assume -> (
+
+let mutuals = (FStar_List.map (fun ty -> (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, uu____3116, uu____3117, uu____3118, uu____3119, uu____3120, uu____3121) -> begin
+lid
+end
+| uu____3128 -> begin
+(failwith "Impossible!")
+end)) tcs)
+in (
+
+let uu____3129 = (
+
+let ty = (FStar_List.hd tcs)
+in (match (ty.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (lid, us, uu____3137, uu____3138, uu____3139, uu____3140, uu____3141) -> begin
+((lid), (us))
+end
+| uu____3148 -> begin
+(failwith "Impossible!")
+end))
+in (match (uu____3129) with
+| (lid, us) -> begin
+(
+
+let uu____3154 = (FStar_Syntax_Subst.univ_var_opening us)
+in (match (uu____3154) with
+| (usubst, us1) -> begin
+(
+
+let fml = (FStar_List.fold_left (unoptimized_haseq_ty datas mutuals usubst us1) FStar_Syntax_Util.t_true tcs)
+in (
+
+let env = (FStar_TypeChecker_Env.push_sigelt env0 sig_bndle)
+in ((env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.push "haseq");
+(env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.encode_sig env sig_bndle);
+(
+
+let env1 = (FStar_TypeChecker_Env.push_univ_vars env us1)
+in (
+
+let se = (
+
+let uu____3172 = (FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns (((FStar_Ident.id_of_text (Prims.strcat lid.FStar_Ident.ident.FStar_Ident.idText "_haseq")))::[])))
+in (tc_assume env1 uu____3172 fml [] FStar_Range.dummyRange))
+in ((env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.pop "haseq");
+(se)::[];
+)));
+)))
+end))
+end))))
+
+
+let check_inductive_well_typedness : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Ident.lident Prims.list  ->  (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.sigelt Prims.list * FStar_Syntax_Syntax.sigelt Prims.list) = (fun env ses quals lids -> (
+
+let uu____3202 = (FStar_All.pipe_right ses (FStar_List.partition (fun uu___79_3212 -> (match (uu___79_3212) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_inductive_typ (uu____3213); FStar_Syntax_Syntax.sigdoc = uu____3214; FStar_Syntax_Syntax.sigrng = uu____3215} -> begin
+true
+end
+| uu____3227 -> begin
+false
+end))))
+in (match (uu____3202) with
+| (tys, datas) -> begin
+((
+
+let uu____3240 = (FStar_All.pipe_right datas (FStar_Util.for_some (fun uu___80_3242 -> (match (uu___80_3242) with
+| {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon (uu____3243); FStar_Syntax_Syntax.sigdoc = uu____3244; FStar_Syntax_Syntax.sigrng = uu____3245} -> begin
+false
+end
+| uu____3256 -> begin
+true
+end))))
+in (match (uu____3240) with
+| true -> begin
+(
+
+let uu____3257 = (
+
+let uu____3258 = (
+
+let uu____3261 = (FStar_TypeChecker_Env.get_range env)
+in (("Mutually defined type contains a non-inductive element"), (uu____3261)))
+in FStar_Errors.Error (uu____3258))
+in (Prims.raise uu____3257))
+end
+| uu____3262 -> begin
+()
+end));
+(
+
+let env0 = env
+in (
+
+let uu____3264 = (FStar_List.fold_right (fun tc uu____3278 -> (match (uu____3278) with
+| (env1, all_tcs, g) -> begin
+(
+
+let uu____3300 = (tc_tycon env1 tc)
+in (match (uu____3300) with
+| (env2, tc1, tc_u, guard) -> begin
+(
+
+let g' = (FStar_TypeChecker_Rel.universe_inequality FStar_Syntax_Syntax.U_zero tc_u)
+in ((
+
+let uu____3317 = (FStar_TypeChecker_Env.debug env2 FStar_Options.Low)
+in (match (uu____3317) with
+| true -> begin
+(
+
+let uu____3318 = (FStar_Syntax_Print.sigelt_to_string tc1)
+in (FStar_Util.print1 "Checked inductive: %s\n" uu____3318))
+end
+| uu____3319 -> begin
+()
+end));
+(
+
+let uu____3320 = (
+
+let uu____3321 = (FStar_TypeChecker_Rel.conj_guard guard g')
+in (FStar_TypeChecker_Rel.conj_guard g uu____3321))
+in ((env2), ((((tc1), (tc_u)))::all_tcs), (uu____3320)));
+))
+end))
+end)) tys ((env), ([]), (FStar_TypeChecker_Rel.trivial_guard)))
+in (match (uu____3264) with
+| (env1, tcs, g) -> begin
+(
+
+let uu____3346 = (FStar_List.fold_right (fun se uu____3354 -> (match (uu____3354) with
+| (datas1, g1) -> begin
+(
+
+let uu____3365 = (
+
+let uu____3368 = (tc_data env1 tcs)
+in (uu____3368 se))
+in (match (uu____3365) with
+| (data, g') -> begin
+(
+
+let uu____3378 = (FStar_TypeChecker_Rel.conj_guard g1 g')
+in (((data)::datas1), (uu____3378)))
+end))
+end)) datas (([]), (g)))
+in (match (uu____3346) with
+| (datas1, g1) -> begin
+(
+
+let uu____3390 = (generalize_and_inst_within env0 g1 tcs datas1)
+in (match (uu____3390) with
+| (tcs1, datas2) -> begin
+(
+
+let sig_bndle = (
+
+let uu____3407 = (FStar_TypeChecker_Env.get_range env0)
+in {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_bundle ((((FStar_List.append tcs1 datas2)), (quals), (lids))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = uu____3407})
+in ((sig_bndle), (tcs1), (datas2)))
+end))
+end))
+end)));
+)
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1,6169 +1,6034 @@
+
 open Prims
-let instantiate_both: FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env
-  =
-  fun env  ->
-    let uu___86_4 = env in
-    {
-      FStar_TypeChecker_Env.solver = (uu___86_4.FStar_TypeChecker_Env.solver);
-      FStar_TypeChecker_Env.range = (uu___86_4.FStar_TypeChecker_Env.range);
-      FStar_TypeChecker_Env.curmodule =
-        (uu___86_4.FStar_TypeChecker_Env.curmodule);
-      FStar_TypeChecker_Env.gamma = (uu___86_4.FStar_TypeChecker_Env.gamma);
-      FStar_TypeChecker_Env.gamma_cache =
-        (uu___86_4.FStar_TypeChecker_Env.gamma_cache);
-      FStar_TypeChecker_Env.modules =
-        (uu___86_4.FStar_TypeChecker_Env.modules);
-      FStar_TypeChecker_Env.expected_typ =
-        (uu___86_4.FStar_TypeChecker_Env.expected_typ);
-      FStar_TypeChecker_Env.sigtab = (uu___86_4.FStar_TypeChecker_Env.sigtab);
-      FStar_TypeChecker_Env.is_pattern =
-        (uu___86_4.FStar_TypeChecker_Env.is_pattern);
-      FStar_TypeChecker_Env.instantiate_imp = true;
-      FStar_TypeChecker_Env.effects =
-        (uu___86_4.FStar_TypeChecker_Env.effects);
-      FStar_TypeChecker_Env.generalize =
-        (uu___86_4.FStar_TypeChecker_Env.generalize);
-      FStar_TypeChecker_Env.letrecs =
-        (uu___86_4.FStar_TypeChecker_Env.letrecs);
-      FStar_TypeChecker_Env.top_level =
-        (uu___86_4.FStar_TypeChecker_Env.top_level);
-      FStar_TypeChecker_Env.check_uvars =
-        (uu___86_4.FStar_TypeChecker_Env.check_uvars);
-      FStar_TypeChecker_Env.use_eq = (uu___86_4.FStar_TypeChecker_Env.use_eq);
-      FStar_TypeChecker_Env.is_iface =
-        (uu___86_4.FStar_TypeChecker_Env.is_iface);
-      FStar_TypeChecker_Env.admit = (uu___86_4.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (uu___86_4.FStar_TypeChecker_Env.lax);
-      FStar_TypeChecker_Env.lax_universes =
-        (uu___86_4.FStar_TypeChecker_Env.lax_universes);
-      FStar_TypeChecker_Env.type_of =
-        (uu___86_4.FStar_TypeChecker_Env.type_of);
-      FStar_TypeChecker_Env.universe_of =
-        (uu___86_4.FStar_TypeChecker_Env.universe_of);
-      FStar_TypeChecker_Env.use_bv_sorts =
-        (uu___86_4.FStar_TypeChecker_Env.use_bv_sorts);
-      FStar_TypeChecker_Env.qname_and_index =
-        (uu___86_4.FStar_TypeChecker_Env.qname_and_index)
-    }
-let no_inst: FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env =
-  fun env  ->
-    let uu___87_8 = env in
-    {
-      FStar_TypeChecker_Env.solver = (uu___87_8.FStar_TypeChecker_Env.solver);
-      FStar_TypeChecker_Env.range = (uu___87_8.FStar_TypeChecker_Env.range);
-      FStar_TypeChecker_Env.curmodule =
-        (uu___87_8.FStar_TypeChecker_Env.curmodule);
-      FStar_TypeChecker_Env.gamma = (uu___87_8.FStar_TypeChecker_Env.gamma);
-      FStar_TypeChecker_Env.gamma_cache =
-        (uu___87_8.FStar_TypeChecker_Env.gamma_cache);
-      FStar_TypeChecker_Env.modules =
-        (uu___87_8.FStar_TypeChecker_Env.modules);
-      FStar_TypeChecker_Env.expected_typ =
-        (uu___87_8.FStar_TypeChecker_Env.expected_typ);
-      FStar_TypeChecker_Env.sigtab = (uu___87_8.FStar_TypeChecker_Env.sigtab);
-      FStar_TypeChecker_Env.is_pattern =
-        (uu___87_8.FStar_TypeChecker_Env.is_pattern);
-      FStar_TypeChecker_Env.instantiate_imp = false;
-      FStar_TypeChecker_Env.effects =
-        (uu___87_8.FStar_TypeChecker_Env.effects);
-      FStar_TypeChecker_Env.generalize =
-        (uu___87_8.FStar_TypeChecker_Env.generalize);
-      FStar_TypeChecker_Env.letrecs =
-        (uu___87_8.FStar_TypeChecker_Env.letrecs);
-      FStar_TypeChecker_Env.top_level =
-        (uu___87_8.FStar_TypeChecker_Env.top_level);
-      FStar_TypeChecker_Env.check_uvars =
-        (uu___87_8.FStar_TypeChecker_Env.check_uvars);
-      FStar_TypeChecker_Env.use_eq = (uu___87_8.FStar_TypeChecker_Env.use_eq);
-      FStar_TypeChecker_Env.is_iface =
-        (uu___87_8.FStar_TypeChecker_Env.is_iface);
-      FStar_TypeChecker_Env.admit = (uu___87_8.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (uu___87_8.FStar_TypeChecker_Env.lax);
-      FStar_TypeChecker_Env.lax_universes =
-        (uu___87_8.FStar_TypeChecker_Env.lax_universes);
-      FStar_TypeChecker_Env.type_of =
-        (uu___87_8.FStar_TypeChecker_Env.type_of);
-      FStar_TypeChecker_Env.universe_of =
-        (uu___87_8.FStar_TypeChecker_Env.universe_of);
-      FStar_TypeChecker_Env.use_bv_sorts =
-        (uu___87_8.FStar_TypeChecker_Env.use_bv_sorts);
-      FStar_TypeChecker_Env.qname_and_index =
-        (uu___87_8.FStar_TypeChecker_Env.qname_and_index)
-    }
-let mk_lex_list:
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax Prims.list ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax
-  =
-  fun vs  ->
-    FStar_List.fold_right
-      (fun v1  ->
-         fun tl1  ->
-           let r =
-             if tl1.FStar_Syntax_Syntax.pos = FStar_Range.dummyRange
-             then v1.FStar_Syntax_Syntax.pos
-             else
-               FStar_Range.union_ranges v1.FStar_Syntax_Syntax.pos
-                 tl1.FStar_Syntax_Syntax.pos in
-           let uu____34 =
-             let uu____35 =
-               let uu____36 = FStar_Syntax_Syntax.as_arg v1 in
-               let uu____37 =
-                 let uu____39 = FStar_Syntax_Syntax.as_arg tl1 in [uu____39] in
-               uu____36 :: uu____37 in
-             FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair
-               uu____35 in
-           uu____34 (Some (FStar_Syntax_Util.lex_t.FStar_Syntax_Syntax.n)) r)
-      vs FStar_Syntax_Util.lex_top
-let is_eq: FStar_Syntax_Syntax.arg_qualifier Prims.option -> Prims.bool =
-  fun uu___80_47  ->
-    match uu___80_47 with
-    | Some (FStar_Syntax_Syntax.Equality ) -> true
-    | uu____49 -> false
-let steps env =
-  [FStar_TypeChecker_Normalize.Beta;
-  FStar_TypeChecker_Normalize.Eager_unfolding]
-let unfold_whnf:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  ->
-      FStar_TypeChecker_Normalize.normalize
-        [FStar_TypeChecker_Normalize.WHNF;
-        FStar_TypeChecker_Normalize.UnfoldUntil
-          FStar_Syntax_Syntax.Delta_constant;
-        FStar_TypeChecker_Normalize.Beta] env t
-let norm:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun t  -> FStar_TypeChecker_Normalize.normalize (steps env) env t
-let norm_c:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
-  =
-  fun env  ->
-    fun c  -> FStar_TypeChecker_Normalize.normalize_comp (steps env) env c
-let check_no_escape:
-  FStar_Syntax_Syntax.term Prims.option ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.bv Prims.list ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-  =
-  fun head_opt  ->
-    fun env  ->
-      fun fvs  ->
-        fun kt  ->
-          let rec aux try_norm t =
-            match fvs with
-            | [] -> t
-            | uu____100 ->
-                let t1 = if try_norm then norm env t else t in
-                let fvs' = FStar_Syntax_Free.names t1 in
-                let uu____106 =
-                  FStar_List.tryFind (fun x  -> FStar_Util.set_mem x fvs')
-                    fvs in
-                (match uu____106 with
-                 | None  -> t1
-                 | Some x ->
-                     if Prims.op_Negation try_norm
-                     then aux true t1
-                     else
-                       (let fail uu____114 =
-                          let msg =
-                            match head_opt with
-                            | None  ->
-                                let uu____116 =
-                                  FStar_Syntax_Print.bv_to_string x in
-                                FStar_Util.format1
-                                  "Bound variables '%s' escapes; add a type annotation"
-                                  uu____116
-                            | Some head1 ->
-                                let uu____118 =
-                                  FStar_Syntax_Print.bv_to_string x in
-                                let uu____119 =
-                                  FStar_TypeChecker_Normalize.term_to_string
-                                    env head1 in
-                                FStar_Util.format2
-                                  "Bound variables '%s' in the type of '%s' escape because of impure applications; add explicit let-bindings"
-                                  uu____118 uu____119 in
-                          let uu____120 =
-                            let uu____121 =
-                              let uu____124 =
-                                FStar_TypeChecker_Env.get_range env in
-                              (msg, uu____124) in
-                            FStar_Errors.Error uu____121 in
-                          Prims.raise uu____120 in
-                        let s =
-                          let uu____126 =
-                            let uu____127 = FStar_Syntax_Util.type_u () in
-                            FStar_All.pipe_left Prims.fst uu____127 in
-                          FStar_TypeChecker_Util.new_uvar env uu____126 in
-                        let uu____132 =
-                          FStar_TypeChecker_Rel.try_teq true env t1 s in
-                        match uu____132 with
-                        | Some g ->
-                            (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                             s)
-                        | uu____136 -> fail ())) in
-          aux false kt
-let push_binding env b = FStar_TypeChecker_Env.push_bv env (Prims.fst b)
-let maybe_extend_subst:
-  FStar_Syntax_Syntax.subst_t ->
-    FStar_Syntax_Syntax.binder ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.subst_t
-  =
-  fun s  ->
-    fun b  ->
-      fun v1  ->
-        let uu____167 = FStar_Syntax_Syntax.is_null_binder b in
-        if uu____167
-        then s
-        else (FStar_Syntax_Syntax.NT ((Prims.fst b), v1)) :: s
-let set_lcomp_result:
-  FStar_Syntax_Syntax.lcomp ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.lcomp
-  =
-  fun lc  ->
-    fun t  ->
-      let uu___88_181 = lc in
-      {
-        FStar_Syntax_Syntax.eff_name =
-          (uu___88_181.FStar_Syntax_Syntax.eff_name);
-        FStar_Syntax_Syntax.res_typ = t;
-        FStar_Syntax_Syntax.cflags = (uu___88_181.FStar_Syntax_Syntax.cflags);
-        FStar_Syntax_Syntax.comp =
-          (fun uu____182  ->
-             let uu____183 = lc.FStar_Syntax_Syntax.comp () in
-             FStar_Syntax_Util.set_result_typ uu____183 t)
-      }
-let memo_tk:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun e  ->
-    fun t  ->
-      FStar_ST.write e.FStar_Syntax_Syntax.tk
-        (Some (t.FStar_Syntax_Syntax.n));
-      e
-let value_check_expected_typ:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp) FStar_Util.either
-        ->
-        FStar_TypeChecker_Env.guard_t ->
-          (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-            FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun tlc  ->
-        fun guard  ->
-          let should_return t =
-            let uu____222 =
-              let uu____223 = FStar_Syntax_Subst.compress t in
-              uu____223.FStar_Syntax_Syntax.n in
-            match uu____222 with
-            | FStar_Syntax_Syntax.Tm_arrow (uu____226,c) ->
-                let uu____238 =
-                  FStar_TypeChecker_Util.is_pure_or_ghost_effect env
-                    (FStar_Syntax_Util.comp_effect_name c) in
-                if uu____238
-                then
-                  let t1 =
-                    FStar_All.pipe_left FStar_Syntax_Util.unrefine
-                      (FStar_Syntax_Util.comp_result c) in
-                  let uu____240 =
-                    let uu____241 = FStar_Syntax_Subst.compress t1 in
-                    uu____241.FStar_Syntax_Syntax.n in
-                  (match uu____240 with
-                   | FStar_Syntax_Syntax.Tm_fvar fv when
-                       FStar_Syntax_Syntax.fv_eq_lid fv
-                         FStar_Syntax_Const.unit_lid
-                       -> false
-                   | FStar_Syntax_Syntax.Tm_constant uu____245 -> false
-                   | uu____246 -> true)
-                else false
-            | uu____248 -> true in
-          let lc =
-            match tlc with
-            | FStar_Util.Inl t ->
-                let uu____251 =
-                  let uu____254 =
-                    (let uu____255 = should_return t in
-                     Prims.op_Negation uu____255) ||
-                      (let uu____256 =
-                         FStar_TypeChecker_Env.should_verify env in
-                       Prims.op_Negation uu____256) in
-                  if uu____254
-                  then FStar_Syntax_Syntax.mk_Total t
-                  else FStar_TypeChecker_Util.return_value env t e in
-                FStar_Syntax_Util.lcomp_of_comp uu____251
-            | FStar_Util.Inr lc -> lc in
-          let t = lc.FStar_Syntax_Syntax.res_typ in
-          let uu____264 =
-            let uu____268 = FStar_TypeChecker_Env.expected_typ env in
-            match uu____268 with
-            | None  -> let uu____273 = memo_tk e t in (uu____273, lc, guard)
-            | Some t' ->
-                ((let uu____276 =
-                    FStar_TypeChecker_Env.debug env FStar_Options.High in
-                  if uu____276
-                  then
-                    let uu____277 = FStar_Syntax_Print.term_to_string t in
-                    let uu____278 = FStar_Syntax_Print.term_to_string t' in
-                    FStar_Util.print2
-                      "Computed return type %s; expected type %s\n" uu____277
-                      uu____278
-                  else ());
-                 (let uu____280 =
-                    FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc
-                      t' in
-                  match uu____280 with
-                  | (e1,lc1) ->
-                      let t1 = lc1.FStar_Syntax_Syntax.res_typ in
-                      let uu____291 =
-                        FStar_TypeChecker_Util.check_and_ascribe env e1 t1 t' in
-                      (match uu____291 with
-                       | (e2,g) ->
-                           ((let uu____300 =
-                               FStar_TypeChecker_Env.debug env
-                                 FStar_Options.High in
-                             if uu____300
-                             then
-                               let uu____301 =
-                                 FStar_Syntax_Print.term_to_string t1 in
-                               let uu____302 =
-                                 FStar_Syntax_Print.term_to_string t' in
-                               let uu____303 =
-                                 FStar_TypeChecker_Rel.guard_to_string env g in
-                               let uu____304 =
-                                 FStar_TypeChecker_Rel.guard_to_string env
-                                   guard in
-                               FStar_Util.print4
-                                 "check_and_ascribe: type is %s<:%s \tguard is %s, %s\n"
-                                 uu____301 uu____302 uu____303 uu____304
-                             else ());
-                            (let msg =
-                               let uu____310 =
-                                 FStar_TypeChecker_Rel.is_trivial g in
-                               if uu____310
-                               then None
-                               else
-                                 FStar_All.pipe_left
-                                   (fun _0_28  -> Some _0_28)
-                                   (FStar_TypeChecker_Err.subtyping_failed
-                                      env t1 t') in
-                             let g1 =
-                               FStar_TypeChecker_Rel.conj_guard g guard in
-                             let uu____325 =
-                               FStar_TypeChecker_Util.strengthen_precondition
-                                 msg env e2 lc1 g1 in
-                             match uu____325 with
-                             | (lc2,g2) ->
-                                 let uu____333 = memo_tk e2 t' in
-                                 (uu____333, (set_lcomp_result lc2 t'), g2)))))) in
-          match uu____264 with
-          | (e1,lc1,g) ->
-              ((let uu____341 =
-                  FStar_TypeChecker_Env.debug env FStar_Options.Low in
-                if uu____341
-                then
-                  let uu____342 = FStar_Syntax_Print.lcomp_to_string lc1 in
-                  FStar_Util.print1 "Return comp type is %s\n" uu____342
-                else ());
-               (e1, lc1, g))
-let comp_check_expected_typ:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-          FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun lc  ->
-        let uu____359 = FStar_TypeChecker_Env.expected_typ env in
-        match uu____359 with
-        | None  -> (e, lc, FStar_TypeChecker_Rel.trivial_guard)
-        | Some t ->
-            let uu____365 =
-              FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc t in
-            (match uu____365 with
-             | (e1,lc1) ->
-                 FStar_TypeChecker_Util.weaken_result_typ env e1 lc1 t)
-let check_expected_effect:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp Prims.option ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.comp) ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.comp*
-          FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun copt  ->
-      fun uu____387  ->
-        match uu____387 with
-        | (e,c) ->
-            let expected_c_opt =
-              match copt with
-              | Some uu____402 -> copt
-              | None  ->
-                  let uu____403 =
-                    ((FStar_Options.ml_ish ()) &&
-                       (FStar_Ident.lid_equals
-                          FStar_Syntax_Const.effect_ALL_lid
-                          (FStar_Syntax_Util.comp_effect_name c)))
-                      ||
-                      (((FStar_Options.ml_ish ()) &&
-                          env.FStar_TypeChecker_Env.lax)
-                         &&
-                         (let uu____404 =
-                            FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                          Prims.op_Negation uu____404)) in
-                  if uu____403
-                  then
-                    let uu____406 =
-                      FStar_Syntax_Util.ml_comp
-                        (FStar_Syntax_Util.comp_result c)
-                        e.FStar_Syntax_Syntax.pos in
-                    Some uu____406
-                  else
-                    (let uu____408 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                     if uu____408
-                     then None
-                     else
-                       (let uu____411 = FStar_Syntax_Util.is_pure_comp c in
-                        if uu____411
-                        then
-                          let uu____413 =
-                            FStar_Syntax_Syntax.mk_Total
-                              (FStar_Syntax_Util.comp_result c) in
-                          Some uu____413
-                        else
-                          (let uu____415 =
-                             FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                           if uu____415
-                           then
-                             let uu____417 =
-                               FStar_Syntax_Syntax.mk_GTotal
-                                 (FStar_Syntax_Util.comp_result c) in
-                             Some uu____417
-                           else None))) in
-            (match expected_c_opt with
-             | None  ->
-                 let uu____422 = norm_c env c in
-                 (e, uu____422, FStar_TypeChecker_Rel.trivial_guard)
-             | Some expected_c ->
-                 ((let uu____425 =
-                     FStar_TypeChecker_Env.debug env FStar_Options.Low in
-                   if uu____425
-                   then
-                     let uu____426 = FStar_Syntax_Print.term_to_string e in
-                     let uu____427 = FStar_Syntax_Print.comp_to_string c in
-                     let uu____428 =
-                       FStar_Syntax_Print.comp_to_string expected_c in
-                     FStar_Util.print3
-                       "\n\n(%s) About to check\n\t%s\nagainst expected effect\n\t%s\n"
-                       uu____426 uu____427 uu____428
-                   else ());
-                  (let c1 = norm_c env c in
-                   (let uu____432 =
-                      FStar_TypeChecker_Env.debug env FStar_Options.Low in
-                    if uu____432
-                    then
-                      let uu____433 = FStar_Syntax_Print.term_to_string e in
-                      let uu____434 = FStar_Syntax_Print.comp_to_string c1 in
-                      let uu____435 =
-                        FStar_Syntax_Print.comp_to_string expected_c in
-                      FStar_Util.print3
-                        "\n\nAfter normalization (%s) About to check\n\t%s\nagainst expected effect\n\t%s\n"
-                        uu____433 uu____434 uu____435
-                    else ());
-                   (let uu____437 =
-                      FStar_TypeChecker_Util.check_comp env e c1 expected_c in
-                    match uu____437 with
-                    | (e1,uu____445,g) ->
-                        let g1 =
-                          let uu____448 = FStar_TypeChecker_Env.get_range env in
-                          FStar_TypeChecker_Util.label_guard uu____448
-                            "could not prove post-condition" g in
-                        ((let uu____450 =
-                            FStar_TypeChecker_Env.debug env FStar_Options.Low in
-                          if uu____450
-                          then
-                            let uu____451 =
-                              FStar_Range.string_of_range
-                                e1.FStar_Syntax_Syntax.pos in
-                            let uu____452 =
-                              FStar_TypeChecker_Rel.guard_to_string env g1 in
-                            FStar_Util.print2
-                              "(%s) DONE check_expected_effect; guard is: %s\n"
-                              uu____451 uu____452
-                          else ());
-                         (let e2 =
-                            FStar_TypeChecker_Util.maybe_lift env e1
-                              (FStar_Syntax_Util.comp_effect_name c1)
-                              (FStar_Syntax_Util.comp_effect_name expected_c)
-                              (FStar_Syntax_Util.comp_result c1) in
-                          (e2, expected_c, g1)))))))
-let no_logical_guard env uu____474 =
-  match uu____474 with
-  | (te,kt,f) ->
-      let uu____481 = FStar_TypeChecker_Rel.guard_form f in
-      (match uu____481 with
-       | FStar_TypeChecker_Common.Trivial  -> (te, kt, f)
-       | FStar_TypeChecker_Common.NonTrivial f1 ->
-           let uu____486 =
-             let uu____487 =
-               let uu____490 =
-                 FStar_TypeChecker_Err.unexpected_non_trivial_precondition_on_term
-                   env f1 in
-               let uu____491 = FStar_TypeChecker_Env.get_range env in
-               (uu____490, uu____491) in
-             FStar_Errors.Error uu____487 in
-           Prims.raise uu____486)
-let print_expected_ty: FStar_TypeChecker_Env.env -> Prims.unit =
-  fun env  ->
-    let uu____498 = FStar_TypeChecker_Env.expected_typ env in
-    match uu____498 with
-    | None  -> FStar_Util.print_string "Expected type is None"
-    | Some t ->
-        let uu____501 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.print1 "Expected type is %s" uu____501
-let check_smt_pat env t bs c =
-  let uu____536 = FStar_Syntax_Util.is_smt_lemma t in
-  if uu____536
-  then
-    match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Comp
-        { FStar_Syntax_Syntax.comp_univs = uu____537;
-          FStar_Syntax_Syntax.effect_name = uu____538;
-          FStar_Syntax_Syntax.result_typ = uu____539;
-          FStar_Syntax_Syntax.effect_args = _pre::_post::(pats,uu____543)::[];
-          FStar_Syntax_Syntax.flags = uu____544;_}
-        ->
-        let pat_vars =
-          let uu____578 =
-            FStar_TypeChecker_Normalize.normalize
-              [FStar_TypeChecker_Normalize.Beta] env pats in
-          FStar_Syntax_Free.names uu____578 in
-        let uu____579 =
-          FStar_All.pipe_right bs
-            (FStar_Util.find_opt
-               (fun uu____591  ->
-                  match uu____591 with
-                  | (b,uu____595) ->
-                      let uu____596 = FStar_Util.set_mem b pat_vars in
-                      Prims.op_Negation uu____596)) in
-        (match uu____579 with
-         | None  -> ()
-         | Some (x,uu____600) ->
-             let uu____603 =
-               let uu____604 = FStar_Syntax_Print.bv_to_string x in
-               FStar_Util.format1
-                 "Pattern misses at least one bound variable: %s" uu____604 in
-             FStar_Errors.warn t.FStar_Syntax_Syntax.pos uu____603)
-    | uu____605 -> failwith "Impossible"
-  else ()
-let guard_letrecs:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax ->
-        (FStar_Syntax_Syntax.lbname* FStar_Syntax_Syntax.typ) Prims.list
-  =
-  fun env  ->
-    fun actuals  ->
-      fun expected_c  ->
-        let uu____626 =
-          let uu____627 = FStar_TypeChecker_Env.should_verify env in
-          Prims.op_Negation uu____627 in
-        if uu____626
-        then env.FStar_TypeChecker_Env.letrecs
-        else
-          (match env.FStar_TypeChecker_Env.letrecs with
-           | [] -> []
-           | letrecs ->
-               let r = FStar_TypeChecker_Env.get_range env in
-               let env1 =
-                 let uu___89_645 = env in
-                 {
-                   FStar_TypeChecker_Env.solver =
-                     (uu___89_645.FStar_TypeChecker_Env.solver);
-                   FStar_TypeChecker_Env.range =
-                     (uu___89_645.FStar_TypeChecker_Env.range);
-                   FStar_TypeChecker_Env.curmodule =
-                     (uu___89_645.FStar_TypeChecker_Env.curmodule);
-                   FStar_TypeChecker_Env.gamma =
-                     (uu___89_645.FStar_TypeChecker_Env.gamma);
-                   FStar_TypeChecker_Env.gamma_cache =
-                     (uu___89_645.FStar_TypeChecker_Env.gamma_cache);
-                   FStar_TypeChecker_Env.modules =
-                     (uu___89_645.FStar_TypeChecker_Env.modules);
-                   FStar_TypeChecker_Env.expected_typ =
-                     (uu___89_645.FStar_TypeChecker_Env.expected_typ);
-                   FStar_TypeChecker_Env.sigtab =
-                     (uu___89_645.FStar_TypeChecker_Env.sigtab);
-                   FStar_TypeChecker_Env.is_pattern =
-                     (uu___89_645.FStar_TypeChecker_Env.is_pattern);
-                   FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___89_645.FStar_TypeChecker_Env.instantiate_imp);
-                   FStar_TypeChecker_Env.effects =
-                     (uu___89_645.FStar_TypeChecker_Env.effects);
-                   FStar_TypeChecker_Env.generalize =
-                     (uu___89_645.FStar_TypeChecker_Env.generalize);
-                   FStar_TypeChecker_Env.letrecs = [];
-                   FStar_TypeChecker_Env.top_level =
-                     (uu___89_645.FStar_TypeChecker_Env.top_level);
-                   FStar_TypeChecker_Env.check_uvars =
-                     (uu___89_645.FStar_TypeChecker_Env.check_uvars);
-                   FStar_TypeChecker_Env.use_eq =
-                     (uu___89_645.FStar_TypeChecker_Env.use_eq);
-                   FStar_TypeChecker_Env.is_iface =
-                     (uu___89_645.FStar_TypeChecker_Env.is_iface);
-                   FStar_TypeChecker_Env.admit =
-                     (uu___89_645.FStar_TypeChecker_Env.admit);
-                   FStar_TypeChecker_Env.lax =
-                     (uu___89_645.FStar_TypeChecker_Env.lax);
-                   FStar_TypeChecker_Env.lax_universes =
-                     (uu___89_645.FStar_TypeChecker_Env.lax_universes);
-                   FStar_TypeChecker_Env.type_of =
-                     (uu___89_645.FStar_TypeChecker_Env.type_of);
-                   FStar_TypeChecker_Env.universe_of =
-                     (uu___89_645.FStar_TypeChecker_Env.universe_of);
-                   FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___89_645.FStar_TypeChecker_Env.use_bv_sorts);
-                   FStar_TypeChecker_Env.qname_and_index =
-                     (uu___89_645.FStar_TypeChecker_Env.qname_and_index)
-                 } in
-               let precedes =
-                 FStar_TypeChecker_Util.fvar_const env1
-                   FStar_Syntax_Const.precedes_lid in
-               let decreases_clause bs c =
-                 let filter_types_and_functions bs1 =
-                   FStar_All.pipe_right bs1
-                     (FStar_List.collect
-                        (fun uu____668  ->
-                           match uu____668 with
-                           | (b,uu____673) ->
-                               let t =
-                                 let uu____675 =
-                                   FStar_Syntax_Util.unrefine
-                                     b.FStar_Syntax_Syntax.sort in
-                                 unfold_whnf env1 uu____675 in
-                               (match t.FStar_Syntax_Syntax.n with
-                                | FStar_Syntax_Syntax.Tm_type _
-                                  |FStar_Syntax_Syntax.Tm_arrow _ -> []
-                                | uu____679 ->
-                                    let uu____680 =
-                                      FStar_Syntax_Syntax.bv_to_name b in
-                                    [uu____680]))) in
-                 let as_lex_list dec =
-                   let uu____685 = FStar_Syntax_Util.head_and_args dec in
-                   match uu____685 with
-                   | (head1,uu____696) ->
-                       (match head1.FStar_Syntax_Syntax.n with
-                        | FStar_Syntax_Syntax.Tm_fvar fv when
-                            FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Syntax_Const.lexcons_lid
-                            -> dec
-                        | uu____712 -> mk_lex_list [dec]) in
-                 let cflags = FStar_Syntax_Util.comp_flags c in
-                 let uu____715 =
-                   FStar_All.pipe_right cflags
-                     (FStar_List.tryFind
-                        (fun uu___81_719  ->
-                           match uu___81_719 with
-                           | FStar_Syntax_Syntax.DECREASES uu____720 -> true
-                           | uu____723 -> false)) in
-                 match uu____715 with
-                 | Some (FStar_Syntax_Syntax.DECREASES dec) ->
-                     as_lex_list dec
-                 | uu____727 ->
-                     let xs =
-                       FStar_All.pipe_right bs filter_types_and_functions in
-                     (match xs with
-                      | x::[] -> x
-                      | uu____733 -> mk_lex_list xs) in
-               let previous_dec = decreases_clause actuals expected_c in
-               let guard_one_letrec uu____745 =
-                 match uu____745 with
-                 | (l,t) ->
-                     let uu____754 =
-                       let uu____755 = FStar_Syntax_Subst.compress t in
-                       uu____755.FStar_Syntax_Syntax.n in
-                     (match uu____754 with
-                      | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
-                          let formals1 =
-                            FStar_All.pipe_right formals
-                              (FStar_List.map
-                                 (fun uu____788  ->
-                                    match uu____788 with
-                                    | (x,imp) ->
-                                        let uu____795 =
-                                          FStar_Syntax_Syntax.is_null_bv x in
-                                        if uu____795
-                                        then
-                                          let uu____798 =
-                                            let uu____799 =
-                                              let uu____801 =
-                                                FStar_Syntax_Syntax.range_of_bv
-                                                  x in
-                                              Some uu____801 in
-                                            FStar_Syntax_Syntax.new_bv
-                                              uu____799
-                                              x.FStar_Syntax_Syntax.sort in
-                                          (uu____798, imp)
-                                        else (x, imp))) in
-                          let uu____803 =
-                            FStar_Syntax_Subst.open_comp formals1 c in
-                          (match uu____803 with
-                           | (formals2,c1) ->
-                               let dec = decreases_clause formals2 c1 in
-                               let precedes1 =
-                                 let uu____816 =
-                                   let uu____817 =
-                                     let uu____818 =
-                                       FStar_Syntax_Syntax.as_arg dec in
-                                     let uu____819 =
-                                       let uu____821 =
-                                         FStar_Syntax_Syntax.as_arg
-                                           previous_dec in
-                                       [uu____821] in
-                                     uu____818 :: uu____819 in
-                                   FStar_Syntax_Syntax.mk_Tm_app precedes
-                                     uu____817 in
-                                 uu____816 None r in
-                               let uu____826 = FStar_Util.prefix formals2 in
-                               (match uu____826 with
-                                | (bs,(last1,imp)) ->
-                                    let last2 =
-                                      let uu___90_852 = last1 in
-                                      let uu____853 =
-                                        FStar_Syntax_Util.refine last1
-                                          precedes1 in
-                                      {
-                                        FStar_Syntax_Syntax.ppname =
-                                          (uu___90_852.FStar_Syntax_Syntax.ppname);
-                                        FStar_Syntax_Syntax.index =
-                                          (uu___90_852.FStar_Syntax_Syntax.index);
-                                        FStar_Syntax_Syntax.sort = uu____853
-                                      } in
-                                    let refined_formals =
-                                      FStar_List.append bs [(last2, imp)] in
-                                    let t' =
-                                      FStar_Syntax_Util.arrow refined_formals
-                                        c1 in
-                                    ((let uu____870 =
-                                        FStar_TypeChecker_Env.debug env1
-                                          FStar_Options.Low in
-                                      if uu____870
-                                      then
-                                        let uu____871 =
-                                          FStar_Syntax_Print.lbname_to_string
-                                            l in
-                                        let uu____872 =
-                                          FStar_Syntax_Print.term_to_string t in
-                                        let uu____873 =
-                                          FStar_Syntax_Print.term_to_string
-                                            t' in
-                                        FStar_Util.print3
-                                          "Refined let rec %s\n\tfrom type %s\n\tto type %s\n"
-                                          uu____871 uu____872 uu____873
-                                      else ());
-                                     (l, t'))))
-                      | uu____877 ->
-                          Prims.raise
-                            (FStar_Errors.Error
-                               ("Annotated type of 'let rec' must be an arrow",
-                                 (t.FStar_Syntax_Syntax.pos)))) in
-               FStar_All.pipe_right letrecs (FStar_List.map guard_one_letrec))
-let rec tc_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      tc_maybe_toplevel_term
-        (let uu___91_1149 = env in
-         {
-           FStar_TypeChecker_Env.solver =
-             (uu___91_1149.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___91_1149.FStar_TypeChecker_Env.range);
-           FStar_TypeChecker_Env.curmodule =
-             (uu___91_1149.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___91_1149.FStar_TypeChecker_Env.gamma);
-           FStar_TypeChecker_Env.gamma_cache =
-             (uu___91_1149.FStar_TypeChecker_Env.gamma_cache);
-           FStar_TypeChecker_Env.modules =
-             (uu___91_1149.FStar_TypeChecker_Env.modules);
-           FStar_TypeChecker_Env.expected_typ =
-             (uu___91_1149.FStar_TypeChecker_Env.expected_typ);
-           FStar_TypeChecker_Env.sigtab =
-             (uu___91_1149.FStar_TypeChecker_Env.sigtab);
-           FStar_TypeChecker_Env.is_pattern =
-             (uu___91_1149.FStar_TypeChecker_Env.is_pattern);
-           FStar_TypeChecker_Env.instantiate_imp =
-             (uu___91_1149.FStar_TypeChecker_Env.instantiate_imp);
-           FStar_TypeChecker_Env.effects =
-             (uu___91_1149.FStar_TypeChecker_Env.effects);
-           FStar_TypeChecker_Env.generalize =
-             (uu___91_1149.FStar_TypeChecker_Env.generalize);
-           FStar_TypeChecker_Env.letrecs =
-             (uu___91_1149.FStar_TypeChecker_Env.letrecs);
-           FStar_TypeChecker_Env.top_level = false;
-           FStar_TypeChecker_Env.check_uvars =
-             (uu___91_1149.FStar_TypeChecker_Env.check_uvars);
-           FStar_TypeChecker_Env.use_eq =
-             (uu___91_1149.FStar_TypeChecker_Env.use_eq);
-           FStar_TypeChecker_Env.is_iface =
-             (uu___91_1149.FStar_TypeChecker_Env.is_iface);
-           FStar_TypeChecker_Env.admit =
-             (uu___91_1149.FStar_TypeChecker_Env.admit);
-           FStar_TypeChecker_Env.lax =
-             (uu___91_1149.FStar_TypeChecker_Env.lax);
-           FStar_TypeChecker_Env.lax_universes =
-             (uu___91_1149.FStar_TypeChecker_Env.lax_universes);
-           FStar_TypeChecker_Env.type_of =
-             (uu___91_1149.FStar_TypeChecker_Env.type_of);
-           FStar_TypeChecker_Env.universe_of =
-             (uu___91_1149.FStar_TypeChecker_Env.universe_of);
-           FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___91_1149.FStar_TypeChecker_Env.use_bv_sorts);
-           FStar_TypeChecker_Env.qname_and_index =
-             (uu___91_1149.FStar_TypeChecker_Env.qname_and_index)
-         }) e
-and tc_maybe_toplevel_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      let env1 =
-        if e.FStar_Syntax_Syntax.pos = FStar_Range.dummyRange
-        then env
-        else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
-      (let uu____1158 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-       if uu____1158
-       then
-         let uu____1159 =
-           let uu____1160 = FStar_TypeChecker_Env.get_range env1 in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____1160 in
-         let uu____1161 = FStar_Syntax_Print.tag_of_term e in
-         FStar_Util.print2 "%s (%s)\n" uu____1159 uu____1161
-       else ());
-      (let top = FStar_Syntax_Subst.compress e in
-       match top.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____1167 -> failwith "Impossible"
-       | FStar_Syntax_Syntax.Tm_uinst _
-         |FStar_Syntax_Syntax.Tm_uvar _
-          |FStar_Syntax_Syntax.Tm_bvar _
-           |FStar_Syntax_Syntax.Tm_name _
-            |FStar_Syntax_Syntax.Tm_fvar _
-             |FStar_Syntax_Syntax.Tm_constant _
-              |FStar_Syntax_Syntax.Tm_abs _
-               |FStar_Syntax_Syntax.Tm_arrow _
-                |FStar_Syntax_Syntax.Tm_refine _
-                 |FStar_Syntax_Syntax.Tm_type _
-                  |FStar_Syntax_Syntax.Tm_unknown 
-           -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_desugared
-            (FStar_Syntax_Syntax.Meta_smt_pat ))
-           ->
-           let uu____1206 = tc_tot_or_gtot_term env1 e1 in
-           (match uu____1206 with
-            | (e2,c,g) ->
-                let g1 =
-                  let uu___92_1217 = g in
-                  {
-                    FStar_TypeChecker_Env.guard_f =
-                      FStar_TypeChecker_Common.Trivial;
-                    FStar_TypeChecker_Env.deferred =
-                      (uu___92_1217.FStar_TypeChecker_Env.deferred);
-                    FStar_TypeChecker_Env.univ_ineqs =
-                      (uu___92_1217.FStar_TypeChecker_Env.univ_ineqs);
-                    FStar_TypeChecker_Env.implicits =
-                      (uu___92_1217.FStar_TypeChecker_Env.implicits)
-                  } in
-                (e2, c, g1))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_pattern pats) ->
-           let uu____1230 = FStar_Syntax_Util.type_u () in
-           (match uu____1230 with
-            | (t,u) ->
-                let uu____1238 = tc_check_tot_or_gtot_term env1 e1 t in
-                (match uu____1238 with
-                 | (e2,c,g) ->
-                     let uu____1248 =
-                       let uu____1257 =
-                         FStar_TypeChecker_Env.clear_expected_typ env1 in
-                       match uu____1257 with
-                       | (env2,uu____1270) -> tc_pats env2 pats in
-                     (match uu____1248 with
-                      | (pats1,g') ->
-                          let g'1 =
-                            let uu___93_1291 = g' in
-                            {
-                              FStar_TypeChecker_Env.guard_f =
-                                FStar_TypeChecker_Common.Trivial;
-                              FStar_TypeChecker_Env.deferred =
-                                (uu___93_1291.FStar_TypeChecker_Env.deferred);
-                              FStar_TypeChecker_Env.univ_ineqs =
-                                (uu___93_1291.FStar_TypeChecker_Env.univ_ineqs);
-                              FStar_TypeChecker_Env.implicits =
-                                (uu___93_1291.FStar_TypeChecker_Env.implicits)
-                            } in
-                          let uu____1292 =
-                            (FStar_Syntax_Syntax.mk
-                               (FStar_Syntax_Syntax.Tm_meta
-                                  (e2,
-                                    (FStar_Syntax_Syntax.Meta_pattern pats1))))
-                              (Some (t.FStar_Syntax_Syntax.n))
-                              top.FStar_Syntax_Syntax.pos in
-                          let uu____1303 =
-                            FStar_TypeChecker_Rel.conj_guard g g'1 in
-                          (uu____1292, c, uu____1303))))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_desugared
-            (FStar_Syntax_Syntax.Sequence ))
-           ->
-           let uu____1311 =
-             let uu____1312 = FStar_Syntax_Subst.compress e1 in
-             uu____1312.FStar_Syntax_Syntax.n in
-           (match uu____1311 with
-            | FStar_Syntax_Syntax.Tm_let
-                ((uu____1318,{ FStar_Syntax_Syntax.lbname = x;
-                               FStar_Syntax_Syntax.lbunivs = uu____1320;
-                               FStar_Syntax_Syntax.lbtyp = uu____1321;
-                               FStar_Syntax_Syntax.lbeff = uu____1322;
-                               FStar_Syntax_Syntax.lbdef = e11;_}::[]),e2)
-                ->
-                let uu____1340 =
-                  let uu____1344 =
-                    FStar_TypeChecker_Env.set_expected_typ env1
-                      FStar_TypeChecker_Common.t_unit in
-                  tc_term uu____1344 e11 in
-                (match uu____1340 with
-                 | (e12,c1,g1) ->
-                     let uu____1351 = tc_term env1 e2 in
-                     (match uu____1351 with
-                      | (e21,c2,g2) ->
-                          let c =
-                            FStar_TypeChecker_Util.bind
-                              e12.FStar_Syntax_Syntax.pos env1 (Some e12) c1
-                              (None, c2) in
-                          let e13 =
-                            FStar_TypeChecker_Util.maybe_lift env1 e12
-                              c1.FStar_Syntax_Syntax.eff_name
-                              c.FStar_Syntax_Syntax.eff_name
-                              c1.FStar_Syntax_Syntax.res_typ in
-                          let e22 =
-                            FStar_TypeChecker_Util.maybe_lift env1 e21
-                              c2.FStar_Syntax_Syntax.eff_name
-                              c.FStar_Syntax_Syntax.eff_name
-                              c2.FStar_Syntax_Syntax.res_typ in
-                          let e3 =
-                            let uu____1368 =
-                              let uu____1371 =
-                                let uu____1372 =
-                                  let uu____1380 =
-                                    let uu____1384 =
-                                      let uu____1386 =
-                                        FStar_Syntax_Syntax.mk_lb
-                                          (x, [],
-                                            (c1.FStar_Syntax_Syntax.eff_name),
-                                            FStar_TypeChecker_Common.t_unit,
-                                            e13) in
-                                      [uu____1386] in
-                                    (false, uu____1384) in
-                                  (uu____1380, e22) in
-                                FStar_Syntax_Syntax.Tm_let uu____1372 in
-                              FStar_Syntax_Syntax.mk uu____1371 in
-                            uu____1368
-                              (Some
-                                 ((c.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                              e1.FStar_Syntax_Syntax.pos in
-                          let e4 =
-                            FStar_TypeChecker_Util.maybe_monadic env1 e3
-                              c.FStar_Syntax_Syntax.eff_name
-                              c.FStar_Syntax_Syntax.res_typ in
-                          let e5 =
-                            (FStar_Syntax_Syntax.mk
-                               (FStar_Syntax_Syntax.Tm_meta
-                                  (e4,
-                                    (FStar_Syntax_Syntax.Meta_desugared
-                                       FStar_Syntax_Syntax.Sequence))))
-                              (Some
-                                 ((c.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                              top.FStar_Syntax_Syntax.pos in
-                          let uu____1416 =
-                            FStar_TypeChecker_Rel.conj_guard g1 g2 in
-                          (e5, c, uu____1416)))
-            | uu____1419 ->
-                let uu____1420 = tc_term env1 e1 in
-                (match uu____1420 with
-                 | (e2,c,g) ->
-                     let e3 =
-                       (FStar_Syntax_Syntax.mk
-                          (FStar_Syntax_Syntax.Tm_meta
-                             (e2,
-                               (FStar_Syntax_Syntax.Meta_desugared
-                                  FStar_Syntax_Syntax.Sequence))))
-                         (Some
-                            ((c.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                         top.FStar_Syntax_Syntax.pos in
-                     (e3, c, g)))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_monadic uu____1444) ->
-           tc_term env1 e1
-       | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
-           let uu____1459 = tc_term env1 e1 in
-           (match uu____1459 with
-            | (e2,c,g) ->
-                let e3 =
-                  (FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_meta (e2, m)))
-                    (Some
-                       ((c.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                    top.FStar_Syntax_Syntax.pos in
-                (e3, c, g))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inr expected_c,topt),uu____1485) ->
-           let uu____1521 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-           (match uu____1521 with
-            | (env0,uu____1529) ->
-                let uu____1532 = tc_comp env0 expected_c in
-                (match uu____1532 with
-                 | (expected_c1,uu____1540,g) ->
-                     let t_res = FStar_Syntax_Util.comp_result expected_c1 in
-                     let uu____1545 =
-                       let uu____1549 =
-                         FStar_TypeChecker_Env.set_expected_typ env0 t_res in
-                       tc_term uu____1549 e1 in
-                     (match uu____1545 with
-                      | (e2,c',g') ->
-                          let uu____1556 =
-                            let uu____1560 =
-                              let uu____1563 = c'.FStar_Syntax_Syntax.comp () in
-                              (e2, uu____1563) in
-                            check_expected_effect env0 (Some expected_c1)
-                              uu____1560 in
-                          (match uu____1556 with
-                           | (e3,expected_c2,g'') ->
-                               let e4 =
-                                 (FStar_Syntax_Syntax.mk
-                                    (FStar_Syntax_Syntax.Tm_ascribed
-                                       (e3, ((FStar_Util.Inl t_res), None),
-                                         (Some
-                                            (FStar_Syntax_Util.comp_effect_name
-                                               expected_c2)))))
-                                   (Some (t_res.FStar_Syntax_Syntax.n))
-                                   top.FStar_Syntax_Syntax.pos in
-                               let lc =
-                                 FStar_Syntax_Util.lcomp_of_comp expected_c2 in
-                               let f =
-                                 let uu____1614 =
-                                   FStar_TypeChecker_Rel.conj_guard g' g'' in
-                                 FStar_TypeChecker_Rel.conj_guard g
-                                   uu____1614 in
-                               let topt1 = tc_tactic_opt env0 topt in
-                               let f1 =
-                                 match topt1 with
-                                 | None  -> f
-                                 | Some tactic ->
-                                     FStar_TypeChecker_Rel.map_guard f
-                                       (FStar_TypeChecker_Common.mk_by_tactic
-                                          tactic) in
-                               let uu____1619 =
-                                 comp_check_expected_typ env1 e4 lc in
-                               (match uu____1619 with
-                                | (e5,c,f2) ->
-                                    let uu____1629 =
-                                      FStar_TypeChecker_Rel.conj_guard f1 f2 in
-                                    (e5, c, uu____1629))))))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inl t,topt),uu____1633) ->
-           let uu____1669 = FStar_Syntax_Util.type_u () in
-           (match uu____1669 with
-            | (k,u) ->
-                let uu____1677 = tc_check_tot_or_gtot_term env1 t k in
-                (match uu____1677 with
-                 | (t1,uu____1685,f) ->
-                     let uu____1687 =
-                       let uu____1691 =
-                         FStar_TypeChecker_Env.set_expected_typ env1 t1 in
-                       tc_term uu____1691 e1 in
-                     (match uu____1687 with
-                      | (e2,c,g) ->
-                          let uu____1698 =
-                            let uu____1701 =
-                              FStar_TypeChecker_Env.set_range env1
-                                t1.FStar_Syntax_Syntax.pos in
-                            FStar_TypeChecker_Util.strengthen_precondition
-                              (Some
-                                 (fun uu____1704  ->
-                                    FStar_TypeChecker_Err.ill_kinded_type))
-                              uu____1701 e2 c f in
-                          (match uu____1698 with
-                           | (c1,f1) ->
-                               let uu____1710 =
-                                 let uu____1714 =
-                                   (FStar_Syntax_Syntax.mk
-                                      (FStar_Syntax_Syntax.Tm_ascribed
-                                         (e2, ((FStar_Util.Inl t1), None),
-                                           (Some
-                                              (c1.FStar_Syntax_Syntax.eff_name)))))
-                                     (Some (t1.FStar_Syntax_Syntax.n))
-                                     top.FStar_Syntax_Syntax.pos in
-                                 comp_check_expected_typ env1 uu____1714 c1 in
-                               (match uu____1710 with
-                                | (e3,c2,f2) ->
-                                    let uu____1750 =
-                                      let uu____1751 =
-                                        FStar_TypeChecker_Rel.conj_guard g f2 in
-                                      FStar_TypeChecker_Rel.conj_guard f1
-                                        uu____1751 in
-                                    (e3, c2, uu____1750))))))
-       | FStar_Syntax_Syntax.Tm_app
-         ({
-            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-              (FStar_Const.Const_reify );
-            FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-            FStar_Syntax_Syntax.vars = _;_},a::hd1::rest)
-         |FStar_Syntax_Syntax.Tm_app
-         ({
-            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-              (FStar_Const.Const_reflect _);
-            FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-            FStar_Syntax_Syntax.vars = _;_},a::hd1::rest)
-           ->
-           let rest1 = hd1 :: rest in
-           let uu____1828 = FStar_Syntax_Util.head_and_args top in
-           (match uu____1828 with
-            | (unary_op,uu____1842) ->
-                let head1 =
-                  let uu____1860 =
-                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
-                      (Prims.fst a).FStar_Syntax_Syntax.pos in
-                  (FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))) None
-                    uu____1860 in
-                let t =
-                  (FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (head1, rest1))) None
-                    top.FStar_Syntax_Syntax.pos in
-                tc_term env1 t)
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.tk = uu____1904;
-              FStar_Syntax_Syntax.pos = uu____1905;
-              FStar_Syntax_Syntax.vars = uu____1906;_},(e1,aqual)::[])
-           ->
-           (if FStar_Option.isSome aqual
-            then
-              FStar_Errors.warn e1.FStar_Syntax_Syntax.pos
-                "Qualifier on argument to reify is irrelevant and will be ignored"
-            else ();
-            (let uu____1932 =
-               let uu____1936 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               match uu____1936 with | (env0,uu____1944) -> tc_term env0 e1 in
-             match uu____1932 with
-             | (e2,c,g) ->
-                 let uu____1953 = FStar_Syntax_Util.head_and_args top in
-                 (match uu____1953 with
-                  | (reify_op,uu____1967) ->
-                      let u_c =
-                        let uu____1983 =
-                          tc_term env1 c.FStar_Syntax_Syntax.res_typ in
-                        match uu____1983 with
-                        | (uu____1987,c',uu____1989) ->
-                            let uu____1990 =
-                              let uu____1991 =
-                                FStar_Syntax_Subst.compress
-                                  c'.FStar_Syntax_Syntax.res_typ in
-                              uu____1991.FStar_Syntax_Syntax.n in
-                            (match uu____1990 with
-                             | FStar_Syntax_Syntax.Tm_type u -> u
-                             | uu____1995 ->
-                                 let uu____1996 = FStar_Syntax_Util.type_u () in
-                                 (match uu____1996 with
-                                  | (t,u) ->
-                                      let g_opt =
-                                        FStar_TypeChecker_Rel.try_teq true
-                                          env1 c'.FStar_Syntax_Syntax.res_typ
-                                          t in
-                                      ((match g_opt with
-                                        | Some g' ->
-                                            FStar_TypeChecker_Rel.force_trivial_guard
-                                              env1 g'
-                                        | None  ->
-                                            let uu____2005 =
-                                              let uu____2006 =
-                                                FStar_Syntax_Print.lcomp_to_string
-                                                  c' in
-                                              let uu____2007 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  c.FStar_Syntax_Syntax.res_typ in
-                                              let uu____2008 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  c'.FStar_Syntax_Syntax.res_typ in
-                                              FStar_Util.format3
-                                                "Unexpected result type of computation. The computation type %s of the term %s should have type Type n for some level n but has type %s"
-                                                uu____2006 uu____2007
-                                                uu____2008 in
-                                            failwith uu____2005);
-                                       u))) in
-                      let repr =
-                        let uu____2010 = c.FStar_Syntax_Syntax.comp () in
-                        FStar_TypeChecker_Env.reify_comp env1 uu____2010 u_c in
-                      let e3 =
-                        (FStar_Syntax_Syntax.mk
-                           (FStar_Syntax_Syntax.Tm_app
-                              (reify_op, [(e2, aqual)])))
-                          (Some (repr.FStar_Syntax_Syntax.n))
-                          top.FStar_Syntax_Syntax.pos in
-                      let c1 =
-                        let uu____2032 = FStar_Syntax_Syntax.mk_Total repr in
-                        FStar_All.pipe_right uu____2032
-                          FStar_Syntax_Util.lcomp_of_comp in
-                      let uu____2033 = comp_check_expected_typ env1 e3 c1 in
-                      (match uu____2033 with
-                       | (e4,c2,g') ->
-                           let uu____2043 =
-                             FStar_TypeChecker_Rel.conj_guard g g' in
-                           (e4, c2, uu____2043)))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.tk = uu____2045;
-              FStar_Syntax_Syntax.pos = uu____2046;
-              FStar_Syntax_Syntax.vars = uu____2047;_},(e1,aqual)::[])
-           ->
-           (if FStar_Option.isSome aqual
-            then
-              FStar_Errors.warn e1.FStar_Syntax_Syntax.pos
-                "Qualifier on argument to reflect is irrelevant and will be ignored"
-            else ();
-            (let no_reflect uu____2079 =
-               let uu____2080 =
-                 let uu____2081 =
-                   let uu____2084 =
-                     FStar_Util.format1 "Effect %s cannot be reified"
-                       l.FStar_Ident.str in
-                   (uu____2084, (e1.FStar_Syntax_Syntax.pos)) in
-                 FStar_Errors.Error uu____2081 in
-               Prims.raise uu____2080 in
-             let uu____2088 = FStar_Syntax_Util.head_and_args top in
-             match uu____2088 with
-             | (reflect_op,uu____2102) ->
-                 let uu____2117 =
-                   FStar_TypeChecker_Env.effect_decl_opt env1 l in
-                 (match uu____2117 with
-                  | None  -> no_reflect ()
-                  | Some ed ->
-                      let uu____2123 =
-                        let uu____2124 =
-                          FStar_All.pipe_right
-                            ed.FStar_Syntax_Syntax.qualifiers
-                            FStar_Syntax_Syntax.contains_reflectable in
-                        Prims.op_Negation uu____2124 in
-                      if uu____2123
-                      then no_reflect ()
-                      else
-                        (let uu____2130 =
-                           FStar_TypeChecker_Env.clear_expected_typ env1 in
-                         match uu____2130 with
-                         | (env_no_ex,topt) ->
-                             let uu____2141 =
-                               let u = FStar_TypeChecker_Env.new_u_univ () in
-                               let repr =
-                                 FStar_TypeChecker_Env.inst_effect_fun_with
-                                   [u] env1 ed
-                                   ([], (ed.FStar_Syntax_Syntax.repr)) in
-                               let t =
-                                 let uu____2156 =
-                                   let uu____2159 =
-                                     let uu____2160 =
-                                       let uu____2170 =
-                                         let uu____2172 =
-                                           FStar_Syntax_Syntax.as_arg
-                                             FStar_Syntax_Syntax.tun in
-                                         let uu____2173 =
-                                           let uu____2175 =
-                                             FStar_Syntax_Syntax.as_arg
-                                               FStar_Syntax_Syntax.tun in
-                                           [uu____2175] in
-                                         uu____2172 :: uu____2173 in
-                                       (repr, uu____2170) in
-                                     FStar_Syntax_Syntax.Tm_app uu____2160 in
-                                   FStar_Syntax_Syntax.mk uu____2159 in
-                                 uu____2156 None top.FStar_Syntax_Syntax.pos in
-                               let uu____2185 =
-                                 let uu____2189 =
-                                   let uu____2190 =
-                                     FStar_TypeChecker_Env.clear_expected_typ
-                                       env1 in
-                                   FStar_All.pipe_right uu____2190 Prims.fst in
-                                 tc_tot_or_gtot_term uu____2189 t in
-                               match uu____2185 with
-                               | (t1,uu____2207,g) ->
-                                   let uu____2209 =
-                                     let uu____2210 =
-                                       FStar_Syntax_Subst.compress t1 in
-                                     uu____2210.FStar_Syntax_Syntax.n in
-                                   (match uu____2209 with
-                                    | FStar_Syntax_Syntax.Tm_app
-                                        (uu____2221,(res,uu____2223)::
-                                         (wp,uu____2225)::[])
-                                        -> (t1, res, wp, g)
-                                    | uu____2259 -> failwith "Impossible") in
-                             (match uu____2141 with
-                              | (expected_repr_typ,res_typ,wp,g0) ->
-                                  let uu____2283 =
-                                    let uu____2286 =
-                                      tc_tot_or_gtot_term env_no_ex e1 in
-                                    match uu____2286 with
-                                    | (e2,c,g) ->
-                                        ((let uu____2296 =
-                                            let uu____2297 =
-                                              FStar_Syntax_Util.is_total_lcomp
-                                                c in
-                                            FStar_All.pipe_left
-                                              Prims.op_Negation uu____2297 in
-                                          if uu____2296
-                                          then
-                                            FStar_TypeChecker_Err.add_errors
-                                              env1
-                                              [("Expected Tot, got a GTot computation",
-                                                 (e2.FStar_Syntax_Syntax.pos))]
-                                          else ());
-                                         (let uu____2303 =
-                                            FStar_TypeChecker_Rel.try_teq
-                                              true env_no_ex
-                                              c.FStar_Syntax_Syntax.res_typ
-                                              expected_repr_typ in
-                                          match uu____2303 with
-                                          | None  ->
-                                              ((let uu____2308 =
-                                                  let uu____2312 =
-                                                    let uu____2315 =
-                                                      let uu____2316 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          ed.FStar_Syntax_Syntax.repr in
-                                                      let uu____2317 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          c.FStar_Syntax_Syntax.res_typ in
-                                                      FStar_Util.format2
-                                                        "Expected an instance of %s; got %s"
-                                                        uu____2316 uu____2317 in
-                                                    (uu____2315,
-                                                      (e2.FStar_Syntax_Syntax.pos)) in
-                                                  [uu____2312] in
-                                                FStar_TypeChecker_Err.add_errors
-                                                  env1 uu____2308);
-                                               (let uu____2322 =
-                                                  FStar_TypeChecker_Rel.conj_guard
-                                                    g g0 in
-                                                (e2, uu____2322)))
-                                          | Some g' ->
-                                              let uu____2324 =
-                                                let uu____2325 =
-                                                  FStar_TypeChecker_Rel.conj_guard
-                                                    g g0 in
-                                                FStar_TypeChecker_Rel.conj_guard
-                                                  g' uu____2325 in
-                                              (e2, uu____2324))) in
-                                  (match uu____2283 with
-                                   | (e2,g) ->
-                                       let c =
-                                         let uu____2332 =
-                                           let uu____2333 =
-                                             let uu____2334 =
-                                               let uu____2335 =
-                                                 env1.FStar_TypeChecker_Env.universe_of
-                                                   env1 res_typ in
-                                               [uu____2335] in
-                                             let uu____2336 =
-                                               let uu____2342 =
-                                                 FStar_Syntax_Syntax.as_arg
-                                                   wp in
-                                               [uu____2342] in
-                                             {
-                                               FStar_Syntax_Syntax.comp_univs
-                                                 = uu____2334;
-                                               FStar_Syntax_Syntax.effect_name
-                                                 =
-                                                 (ed.FStar_Syntax_Syntax.mname);
-                                               FStar_Syntax_Syntax.result_typ
-                                                 = res_typ;
-                                               FStar_Syntax_Syntax.effect_args
-                                                 = uu____2336;
-                                               FStar_Syntax_Syntax.flags = []
-                                             } in
-                                           FStar_Syntax_Syntax.mk_Comp
-                                             uu____2333 in
-                                         FStar_All.pipe_right uu____2332
-                                           FStar_Syntax_Util.lcomp_of_comp in
-                                       let e3 =
-                                         (FStar_Syntax_Syntax.mk
-                                            (FStar_Syntax_Syntax.Tm_app
-                                               (reflect_op, [(e2, aqual)])))
-                                           (Some
-                                              (res_typ.FStar_Syntax_Syntax.n))
-                                           top.FStar_Syntax_Syntax.pos in
-                                       let uu____2363 =
-                                         comp_check_expected_typ env1 e3 c in
-                                       (match uu____2363 with
-                                        | (e4,c1,g') ->
-                                            let uu____2373 =
-                                              FStar_TypeChecker_Rel.conj_guard
-                                                g' g in
-                                            (e4, c1, uu____2373))))))))
-       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-           let env0 = env1 in
-           let env2 =
-             let uu____2392 =
-               let uu____2393 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_All.pipe_right uu____2393 Prims.fst in
-             FStar_All.pipe_right uu____2392 instantiate_both in
-           ((let uu____2402 =
-               FStar_TypeChecker_Env.debug env2 FStar_Options.High in
-             if uu____2402
-             then
-               let uu____2403 =
-                 FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
-               let uu____2404 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.print2 "(%s) Checking app %s\n" uu____2403
-                 uu____2404
-             else ());
-            (let uu____2406 = tc_term (no_inst env2) head1 in
-             match uu____2406 with
-             | (head2,chead,g_head) ->
-                 let uu____2416 =
-                   let uu____2420 =
-                     (Prims.op_Negation env2.FStar_TypeChecker_Env.lax) &&
-                       (FStar_TypeChecker_Util.short_circuit_head head2) in
-                   if uu____2420
-                   then
-                     let uu____2424 = FStar_TypeChecker_Env.expected_typ env0 in
-                     check_short_circuit_args env2 head2 chead g_head args
-                       uu____2424
-                   else
-                     (let uu____2427 =
-                        FStar_TypeChecker_Env.expected_typ env0 in
-                      check_application_args env2 head2 chead g_head args
-                        uu____2427) in
-                 (match uu____2416 with
-                  | (e1,c,g) ->
-                      ((let uu____2436 =
-                          FStar_TypeChecker_Env.debug env2
-                            FStar_Options.Extreme in
-                        if uu____2436
-                        then
-                          let uu____2437 =
-                            FStar_TypeChecker_Rel.print_pending_implicits g in
-                          FStar_Util.print1
-                            "Introduced {%s} implicits in application\n"
-                            uu____2437
-                        else ());
-                       (let c1 =
-                          let uu____2440 =
-                            ((FStar_TypeChecker_Env.should_verify env2) &&
-                               (let uu____2441 =
-                                  FStar_Syntax_Util.is_lcomp_partial_return c in
-                                Prims.op_Negation uu____2441))
-                              && (FStar_Syntax_Util.is_pure_or_ghost_lcomp c) in
-                          if uu____2440
-                          then
-                            FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                              env2 e1 c
-                          else c in
-                        let uu____2443 = comp_check_expected_typ env0 e1 c1 in
-                        match uu____2443 with
-                        | (e2,c2,g') ->
-                            let gimp =
-                              let uu____2454 =
-                                let uu____2455 =
-                                  FStar_Syntax_Subst.compress head2 in
-                                uu____2455.FStar_Syntax_Syntax.n in
-                              match uu____2454 with
-                              | FStar_Syntax_Syntax.Tm_uvar (u,uu____2459) ->
-                                  let imp =
-                                    ("head of application is a uvar", env0,
-                                      u, e2,
-                                      (c2.FStar_Syntax_Syntax.res_typ),
-                                      (head2.FStar_Syntax_Syntax.pos)) in
-                                  let uu___94_2491 =
-                                    FStar_TypeChecker_Rel.trivial_guard in
-                                  {
-                                    FStar_TypeChecker_Env.guard_f =
-                                      (uu___94_2491.FStar_TypeChecker_Env.guard_f);
-                                    FStar_TypeChecker_Env.deferred =
-                                      (uu___94_2491.FStar_TypeChecker_Env.deferred);
-                                    FStar_TypeChecker_Env.univ_ineqs =
-                                      (uu___94_2491.FStar_TypeChecker_Env.univ_ineqs);
-                                    FStar_TypeChecker_Env.implicits = [imp]
-                                  }
-                              | uu____2516 ->
-                                  FStar_TypeChecker_Rel.trivial_guard in
-                            let gres =
-                              let uu____2518 =
-                                FStar_TypeChecker_Rel.conj_guard g' gimp in
-                              FStar_TypeChecker_Rel.conj_guard g uu____2518 in
-                            ((let uu____2520 =
-                                FStar_TypeChecker_Env.debug env2
-                                  FStar_Options.Extreme in
-                              if uu____2520
-                              then
-                                let uu____2521 =
-                                  FStar_Syntax_Print.term_to_string e2 in
-                                let uu____2522 =
-                                  FStar_TypeChecker_Rel.guard_to_string env2
-                                    gres in
-                                FStar_Util.print2
-                                  "Guard from application node %s is %s\n"
-                                  uu____2521 uu____2522
-                              else ());
-                             (e2, c2, gres)))))))
-       | FStar_Syntax_Syntax.Tm_match (e1,eqns) ->
-           let uu____2552 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-           (match uu____2552 with
-            | (env11,topt) ->
-                let env12 = instantiate_both env11 in
-                let uu____2564 = tc_term env12 e1 in
-                (match uu____2564 with
-                 | (e11,c1,g1) ->
-                     let uu____2574 =
-                       match topt with
-                       | Some t -> (env1, t)
-                       | None  ->
-                           let uu____2580 = FStar_Syntax_Util.type_u () in
-                           (match uu____2580 with
-                            | (k,uu____2586) ->
-                                let res_t =
-                                  FStar_TypeChecker_Util.new_uvar env1 k in
-                                let uu____2588 =
-                                  FStar_TypeChecker_Env.set_expected_typ env1
-                                    res_t in
-                                (uu____2588, res_t)) in
-                     (match uu____2574 with
-                      | (env_branches,res_t) ->
-                          ((let uu____2595 =
-                              FStar_TypeChecker_Env.debug env1
-                                FStar_Options.Extreme in
-                            if uu____2595
-                            then
-                              let uu____2596 =
-                                FStar_Syntax_Print.term_to_string res_t in
-                              FStar_Util.print1
-                                "Tm_match: expected type of branches is %s\n"
-                                uu____2596
-                            else ());
-                           (let guard_x =
-                              FStar_Syntax_Syntax.new_bv
-                                (Some (e11.FStar_Syntax_Syntax.pos))
-                                c1.FStar_Syntax_Syntax.res_typ in
-                            let t_eqns =
-                              FStar_All.pipe_right eqns
-                                (FStar_List.map (tc_eqn guard_x env_branches)) in
-                            let uu____2647 =
-                              let uu____2650 =
-                                FStar_List.fold_right
-                                  (fun uu____2669  ->
-                                     fun uu____2670  ->
-                                       match (uu____2669, uu____2670) with
-                                       | ((uu____2702,f,c,g),(caccum,gaccum))
-                                           ->
-                                           let uu____2735 =
-                                             FStar_TypeChecker_Rel.conj_guard
-                                               g gaccum in
-                                           (((f, c) :: caccum), uu____2735))
-                                  t_eqns
-                                  ([], FStar_TypeChecker_Rel.trivial_guard) in
-                              match uu____2650 with
-                              | (cases,g) ->
-                                  let uu____2756 =
-                                    FStar_TypeChecker_Util.bind_cases env1
-                                      res_t cases in
-                                  (uu____2756, g) in
-                            match uu____2647 with
-                            | (c_branches,g_branches) ->
-                                let cres =
-                                  FStar_TypeChecker_Util.bind
-                                    e11.FStar_Syntax_Syntax.pos env1
-                                    (Some e11) c1
-                                    ((Some guard_x), c_branches) in
-                                let e2 =
-                                  let mk_match scrutinee =
-                                    let branches =
-                                      FStar_All.pipe_right t_eqns
-                                        (FStar_List.map
-                                           (fun uu____2809  ->
-                                              match uu____2809 with
-                                              | ((pat,wopt,br),uu____2825,lc,uu____2827)
-                                                  ->
-                                                  let uu____2834 =
-                                                    FStar_TypeChecker_Util.maybe_lift
-                                                      env1 br
-                                                      lc.FStar_Syntax_Syntax.eff_name
-                                                      cres.FStar_Syntax_Syntax.eff_name
-                                                      lc.FStar_Syntax_Syntax.res_typ in
-                                                  (pat, wopt, uu____2834))) in
-                                    let e2 =
-                                      (FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_match
-                                            (scrutinee, branches)))
-                                        (Some
-                                           ((cres.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                        top.FStar_Syntax_Syntax.pos in
-                                    let e3 =
-                                      FStar_TypeChecker_Util.maybe_monadic
-                                        env1 e2
-                                        cres.FStar_Syntax_Syntax.eff_name
-                                        cres.FStar_Syntax_Syntax.res_typ in
-                                    (FStar_Syntax_Syntax.mk
-                                       (FStar_Syntax_Syntax.Tm_ascribed
-                                          (e3,
-                                            ((FStar_Util.Inl
-                                                (cres.FStar_Syntax_Syntax.res_typ)),
-                                              None),
-                                            (Some
-                                               (cres.FStar_Syntax_Syntax.eff_name)))))
-                                      None e3.FStar_Syntax_Syntax.pos in
-                                  let uu____2890 =
-                                    FStar_TypeChecker_Util.is_pure_or_ghost_effect
-                                      env1 c1.FStar_Syntax_Syntax.eff_name in
-                                  if uu____2890
-                                  then mk_match e11
-                                  else
-                                    (let e_match =
-                                       let uu____2897 =
-                                         FStar_Syntax_Syntax.bv_to_name
-                                           guard_x in
-                                       mk_match uu____2897 in
-                                     let lb =
-                                       let uu____2901 =
-                                         FStar_TypeChecker_Env.norm_eff_name
-                                           env1
-                                           c1.FStar_Syntax_Syntax.eff_name in
-                                       {
-                                         FStar_Syntax_Syntax.lbname =
-                                           (FStar_Util.Inl guard_x);
-                                         FStar_Syntax_Syntax.lbunivs = [];
-                                         FStar_Syntax_Syntax.lbtyp =
-                                           (c1.FStar_Syntax_Syntax.res_typ);
-                                         FStar_Syntax_Syntax.lbeff =
-                                           uu____2901;
-                                         FStar_Syntax_Syntax.lbdef = e11
-                                       } in
-                                     let e2 =
-                                       let uu____2905 =
-                                         let uu____2908 =
-                                           let uu____2909 =
-                                             let uu____2917 =
-                                               let uu____2918 =
-                                                 let uu____2919 =
-                                                   FStar_Syntax_Syntax.mk_binder
-                                                     guard_x in
-                                                 [uu____2919] in
-                                               FStar_Syntax_Subst.close
-                                                 uu____2918 e_match in
-                                             ((false, [lb]), uu____2917) in
-                                           FStar_Syntax_Syntax.Tm_let
-                                             uu____2909 in
-                                         FStar_Syntax_Syntax.mk uu____2908 in
-                                       uu____2905
-                                         (Some
-                                            ((cres.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                         top.FStar_Syntax_Syntax.pos in
-                                     FStar_TypeChecker_Util.maybe_monadic
-                                       env1 e2
-                                       cres.FStar_Syntax_Syntax.eff_name
-                                       cres.FStar_Syntax_Syntax.res_typ) in
-                                ((let uu____2933 =
-                                    FStar_TypeChecker_Env.debug env1
-                                      FStar_Options.Extreme in
-                                  if uu____2933
-                                  then
-                                    let uu____2934 =
-                                      FStar_Range.string_of_range
-                                        top.FStar_Syntax_Syntax.pos in
-                                    let uu____2935 =
-                                      let uu____2936 =
-                                        cres.FStar_Syntax_Syntax.comp () in
-                                      FStar_All.pipe_left
-                                        FStar_Syntax_Print.comp_to_string
-                                        uu____2936 in
-                                    FStar_Util.print2 "(%s) comp type = %s\n"
-                                      uu____2934 uu____2935
-                                  else ());
-                                 (let uu____2938 =
-                                    FStar_TypeChecker_Rel.conj_guard g1
-                                      g_branches in
-                                  (e2, cres, uu____2938))))))))
-       | FStar_Syntax_Syntax.Tm_let
-           ((false
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____2941;
-                FStar_Syntax_Syntax.lbunivs = uu____2942;
-                FStar_Syntax_Syntax.lbtyp = uu____2943;
-                FStar_Syntax_Syntax.lbeff = uu____2944;
-                FStar_Syntax_Syntax.lbdef = uu____2945;_}::[]),uu____2946)
-           ->
-           ((let uu____2961 =
-               FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-             if uu____2961
-             then
-               let uu____2962 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.print1 "%s\n" uu____2962
-             else ());
-            check_top_level_let env1 top)
-       | FStar_Syntax_Syntax.Tm_let ((false ,uu____2964),uu____2965) ->
-           check_inner_let env1 top
-       | FStar_Syntax_Syntax.Tm_let
-           ((true
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____2975;
-                FStar_Syntax_Syntax.lbunivs = uu____2976;
-                FStar_Syntax_Syntax.lbtyp = uu____2977;
-                FStar_Syntax_Syntax.lbeff = uu____2978;
-                FStar_Syntax_Syntax.lbdef = uu____2979;_}::uu____2980),uu____2981)
-           ->
-           ((let uu____2997 =
-               FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-             if uu____2997
-             then
-               let uu____2998 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.print1 "%s\n" uu____2998
-             else ());
-            check_top_level_let_rec env1 top)
-       | FStar_Syntax_Syntax.Tm_let ((true ,uu____3000),uu____3001) ->
-           check_inner_let_rec env1 top)
-and tc_tactic_opt:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax Prims.option ->
-      FStar_Syntax_Syntax.term Prims.option
-  =
-  fun env  ->
-    fun topt  ->
-      match topt with
-      | None  -> None
-      | Some tactic ->
-          let uu____3024 =
-            tc_check_tot_or_gtot_term env tactic
-              FStar_TypeChecker_Common.t_tactic_unit in
-          (match uu____3024 with
-           | (tactic1,uu____3030,uu____3031) -> Some tactic1)
-and tc_value:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      let check_instantiated_fvar env1 v1 dc e1 t =
-        let uu____3066 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
-        match uu____3066 with
-        | (e2,t1,implicits) ->
-            let tc =
-              let uu____3079 = FStar_TypeChecker_Env.should_verify env1 in
-              if uu____3079
-              then FStar_Util.Inl t1
-              else
-                (let uu____3083 =
-                   let uu____3084 = FStar_Syntax_Syntax.mk_Total t1 in
-                   FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                     uu____3084 in
-                 FStar_Util.Inr uu____3083) in
-            let is_data_ctor uu___82_3093 =
-              match uu___82_3093 with
-              | Some (FStar_Syntax_Syntax.Data_ctor )|Some
-                (FStar_Syntax_Syntax.Record_ctor _) -> true
-              | uu____3096 -> false in
-            let uu____3098 =
-              (is_data_ctor dc) &&
-                (let uu____3099 =
-                   FStar_TypeChecker_Env.is_datacon env1
-                     v1.FStar_Syntax_Syntax.v in
-                 Prims.op_Negation uu____3099) in
-            if uu____3098
-            then
-              let uu____3105 =
-                let uu____3106 =
-                  let uu____3109 =
-                    FStar_Util.format1 "Expected a data constructor; got %s"
-                      (v1.FStar_Syntax_Syntax.v).FStar_Ident.str in
-                  let uu____3112 = FStar_TypeChecker_Env.get_range env1 in
-                  (uu____3109, uu____3112) in
-                FStar_Errors.Error uu____3106 in
-              Prims.raise uu____3105
-            else value_check_expected_typ env1 e2 tc implicits in
-      let env1 =
-        FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
-      let top = FStar_Syntax_Subst.compress e in
-      match top.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____3123 =
-            let uu____3124 = FStar_Syntax_Print.term_to_string top in
-            FStar_Util.format1
-              "Impossible: Violation of locally nameless convention: %s"
-              uu____3124 in
-          failwith uu____3123
-      | FStar_Syntax_Syntax.Tm_uvar (u,t1) ->
-          let g =
-            let uu____3143 =
-              let uu____3144 = FStar_Syntax_Subst.compress t1 in
-              uu____3144.FStar_Syntax_Syntax.n in
-            match uu____3143 with
-            | FStar_Syntax_Syntax.Tm_arrow uu____3147 ->
-                FStar_TypeChecker_Rel.trivial_guard
-            | uu____3155 ->
-                let imp =
-                  ("uvar in term", env1, u, top, t1,
-                    (top.FStar_Syntax_Syntax.pos)) in
-                let uu___95_3175 = FStar_TypeChecker_Rel.trivial_guard in
-                {
-                  FStar_TypeChecker_Env.guard_f =
-                    (uu___95_3175.FStar_TypeChecker_Env.guard_f);
-                  FStar_TypeChecker_Env.deferred =
-                    (uu___95_3175.FStar_TypeChecker_Env.deferred);
-                  FStar_TypeChecker_Env.univ_ineqs =
-                    (uu___95_3175.FStar_TypeChecker_Env.univ_ineqs);
-                  FStar_TypeChecker_Env.implicits = [imp]
-                } in
-          value_check_expected_typ env1 e (FStar_Util.Inl t1) g
-      | FStar_Syntax_Syntax.Tm_unknown  ->
-          let r = FStar_TypeChecker_Env.get_range env1 in
-          let uu____3203 =
-            let uu____3210 = FStar_TypeChecker_Env.expected_typ env1 in
-            match uu____3210 with
-            | None  ->
-                let uu____3218 = FStar_Syntax_Util.type_u () in
-                (match uu____3218 with
-                 | (k,u) ->
-                     FStar_TypeChecker_Util.new_implicit_var
-                       "type of user-provided implicit term" r env1 k)
-            | Some t -> (t, [], FStar_TypeChecker_Rel.trivial_guard) in
-          (match uu____3203 with
-           | (t,uu____3239,g0) ->
-               let uu____3247 =
-                 FStar_TypeChecker_Util.new_implicit_var
-                   "user-provided implicit term" r env1 t in
-               (match uu____3247 with
-                | (e1,uu____3258,g1) ->
-                    let uu____3266 =
-                      let uu____3267 = FStar_Syntax_Syntax.mk_Total t in
-                      FStar_All.pipe_right uu____3267
-                        FStar_Syntax_Util.lcomp_of_comp in
-                    let uu____3268 = FStar_TypeChecker_Rel.conj_guard g0 g1 in
-                    (e1, uu____3266, uu____3268)))
-      | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____3270 =
-            if env1.FStar_TypeChecker_Env.use_bv_sorts
-            then
-              let uu____3279 = FStar_Syntax_Syntax.range_of_bv x in
-              ((x.FStar_Syntax_Syntax.sort), uu____3279)
-            else FStar_TypeChecker_Env.lookup_bv env1 x in
-          (match uu____3270 with
-           | (t,rng) ->
-               let x1 =
-                 FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___96_3293 = x in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___96_3293.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index =
-                        (uu___96_3293.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = t
-                    }) rng in
-               (FStar_TypeChecker_Common.insert_bv x1 t;
-                (let e1 = FStar_Syntax_Syntax.bv_to_name x1 in
-                 let uu____3296 =
-                   FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
-                 match uu____3296 with
-                 | (e2,t1,implicits) ->
-                     let tc =
-                       let uu____3309 =
-                         FStar_TypeChecker_Env.should_verify env1 in
-                       if uu____3309
-                       then FStar_Util.Inl t1
-                       else
-                         (let uu____3313 =
-                            let uu____3314 = FStar_Syntax_Syntax.mk_Total t1 in
-                            FStar_All.pipe_left
-                              FStar_Syntax_Util.lcomp_of_comp uu____3314 in
-                          FStar_Util.Inr uu____3313) in
-                     value_check_expected_typ env1 e2 tc implicits)))
-      | FStar_Syntax_Syntax.Tm_uinst
-          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.tk = uu____3320;
-             FStar_Syntax_Syntax.pos = uu____3321;
-             FStar_Syntax_Syntax.vars = uu____3322;_},us)
-          ->
-          let us1 = FStar_List.map (tc_universe env1) us in
-          let uu____3330 =
-            FStar_TypeChecker_Env.lookup_lid env1
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____3330 with
-           | ((us',t),range) ->
-               (if (FStar_List.length us1) <> (FStar_List.length us')
-                then
-                  (let uu____3352 =
-                     let uu____3353 =
-                       let uu____3356 = FStar_TypeChecker_Env.get_range env1 in
-                       ("Unexpected number of universe instantiations",
-                         uu____3356) in
-                     FStar_Errors.Error uu____3353 in
-                   Prims.raise uu____3352)
-                else
-                  FStar_List.iter2
-                    (fun u'  ->
-                       fun u  ->
-                         match u' with
-                         | FStar_Syntax_Syntax.U_unif u'' ->
-                             FStar_Unionfind.change u'' (Some u)
-                         | uu____3364 -> failwith "Impossible") us' us1;
-                (let fv' =
-                   let uu___97_3366 = fv in
-                   {
-                     FStar_Syntax_Syntax.fv_name =
-                       (let uu___98_3367 = fv.FStar_Syntax_Syntax.fv_name in
-                        {
-                          FStar_Syntax_Syntax.v =
-                            (uu___98_3367.FStar_Syntax_Syntax.v);
-                          FStar_Syntax_Syntax.ty = t;
-                          FStar_Syntax_Syntax.p =
-                            (uu___98_3367.FStar_Syntax_Syntax.p)
-                        });
-                     FStar_Syntax_Syntax.fv_delta =
-                       (uu___97_3366.FStar_Syntax_Syntax.fv_delta);
-                     FStar_Syntax_Syntax.fv_qual =
-                       (uu___97_3366.FStar_Syntax_Syntax.fv_qual)
-                   } in
-                 let fv'1 = FStar_Syntax_Syntax.set_range_of_fv fv' range in
-                 FStar_TypeChecker_Common.insert_fv fv'1 t;
-                 (let e1 =
-                    let uu____3383 =
-                      (FStar_Syntax_Syntax.mk
-                         (FStar_Syntax_Syntax.Tm_fvar fv'1))
-                        (Some (t.FStar_Syntax_Syntax.n))
-                        e.FStar_Syntax_Syntax.pos in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____3383 us1 in
-                  check_instantiated_fvar env1
-                    fv'1.FStar_Syntax_Syntax.fv_name
-                    fv'1.FStar_Syntax_Syntax.fv_qual e1 t))))
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____3395 =
-            FStar_TypeChecker_Env.lookup_lid env1
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____3395 with
-           | ((us,t),range) ->
-               ((let uu____3413 =
-                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                     (FStar_Options.Other "Range") in
-                 if uu____3413
-                 then
-                   let uu____3414 =
-                     let uu____3415 = FStar_Syntax_Syntax.lid_of_fv fv in
-                     FStar_Syntax_Print.lid_to_string uu____3415 in
-                   let uu____3416 =
-                     FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                   let uu____3417 = FStar_Range.string_of_range range in
-                   let uu____3418 = FStar_Range.string_of_use_range range in
-                   let uu____3419 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print5
-                     "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got type %s"
-                     uu____3414 uu____3416 uu____3417 uu____3418 uu____3419
-                 else ());
-                (let fv' =
-                   let uu___99_3422 = fv in
-                   {
-                     FStar_Syntax_Syntax.fv_name =
-                       (let uu___100_3423 = fv.FStar_Syntax_Syntax.fv_name in
-                        {
-                          FStar_Syntax_Syntax.v =
-                            (uu___100_3423.FStar_Syntax_Syntax.v);
-                          FStar_Syntax_Syntax.ty = t;
-                          FStar_Syntax_Syntax.p =
-                            (uu___100_3423.FStar_Syntax_Syntax.p)
-                        });
-                     FStar_Syntax_Syntax.fv_delta =
-                       (uu___99_3422.FStar_Syntax_Syntax.fv_delta);
-                     FStar_Syntax_Syntax.fv_qual =
-                       (uu___99_3422.FStar_Syntax_Syntax.fv_qual)
-                   } in
-                 let fv'1 = FStar_Syntax_Syntax.set_range_of_fv fv' range in
-                 FStar_TypeChecker_Common.insert_fv fv'1 t;
-                 (let e1 =
-                    let uu____3439 =
-                      (FStar_Syntax_Syntax.mk
-                         (FStar_Syntax_Syntax.Tm_fvar fv'1))
-                        (Some (t.FStar_Syntax_Syntax.n))
-                        e.FStar_Syntax_Syntax.pos in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____3439 us in
-                  check_instantiated_fvar env1
-                    fv'1.FStar_Syntax_Syntax.fv_name
-                    fv'1.FStar_Syntax_Syntax.fv_qual e1 t))))
-      | FStar_Syntax_Syntax.Tm_constant c ->
-          let t = tc_constant top.FStar_Syntax_Syntax.pos c in
-          let e1 =
-            (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c))
-              (Some (t.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos in
-          value_check_expected_typ env1 e1 (FStar_Util.Inl t)
-            FStar_TypeChecker_Rel.trivial_guard
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____3475 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____3475 with
-           | (bs1,c1) ->
-               let env0 = env1 in
-               let uu____3484 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____3484 with
-                | (env2,uu____3492) ->
-                    let uu____3495 = tc_binders env2 bs1 in
-                    (match uu____3495 with
-                     | (bs2,env3,g,us) ->
-                         let uu____3507 = tc_comp env3 c1 in
-                         (match uu____3507 with
-                          | (c2,uc,f) ->
-                              let e1 =
-                                let uu___101_3520 =
-                                  FStar_Syntax_Util.arrow bs2 c2 in
-                                {
-                                  FStar_Syntax_Syntax.n =
-                                    (uu___101_3520.FStar_Syntax_Syntax.n);
-                                  FStar_Syntax_Syntax.tk =
-                                    (uu___101_3520.FStar_Syntax_Syntax.tk);
-                                  FStar_Syntax_Syntax.pos =
-                                    (top.FStar_Syntax_Syntax.pos);
-                                  FStar_Syntax_Syntax.vars =
-                                    (uu___101_3520.FStar_Syntax_Syntax.vars)
-                                } in
-                              (check_smt_pat env3 e1 bs2 c2;
-                               (let u = FStar_Syntax_Syntax.U_max (uc :: us) in
-                                let t =
-                                  (FStar_Syntax_Syntax.mk
-                                     (FStar_Syntax_Syntax.Tm_type u)) None
-                                    top.FStar_Syntax_Syntax.pos in
-                                let g1 =
-                                  let uu____3541 =
-                                    FStar_TypeChecker_Rel.close_guard_univs
-                                      us bs2 f in
-                                  FStar_TypeChecker_Rel.conj_guard g
-                                    uu____3541 in
-                                value_check_expected_typ env0 e1
-                                  (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_type u ->
-          let u1 = tc_universe env1 u in
-          let t =
-            (FStar_Syntax_Syntax.mk
-               (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u1)))
-              None top.FStar_Syntax_Syntax.pos in
-          let e1 =
-            (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1))
-              (Some (t.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos in
-          value_check_expected_typ env1 e1 (FStar_Util.Inl t)
-            FStar_TypeChecker_Rel.trivial_guard
-      | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let uu____3576 =
-            let uu____3579 =
-              let uu____3580 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____3580] in
-            FStar_Syntax_Subst.open_term uu____3579 phi in
-          (match uu____3576 with
-           | (x1,phi1) ->
-               let env0 = env1 in
-               let uu____3587 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____3587 with
-                | (env2,uu____3595) ->
-                    let uu____3598 =
-                      let uu____3605 = FStar_List.hd x1 in
-                      tc_binder env2 uu____3605 in
-                    (match uu____3598 with
-                     | (x2,env3,f1,u) ->
-                         ((let uu____3622 =
-                             FStar_TypeChecker_Env.debug env3
-                               FStar_Options.High in
-                           if uu____3622
-                           then
-                             let uu____3623 =
-                               FStar_Range.string_of_range
-                                 top.FStar_Syntax_Syntax.pos in
-                             let uu____3624 =
-                               FStar_Syntax_Print.term_to_string phi1 in
-                             let uu____3625 =
-                               FStar_Syntax_Print.bv_to_string (Prims.fst x2) in
-                             FStar_Util.print3
-                               "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____3623 uu____3624 uu____3625
-                           else ());
-                          (let uu____3627 = FStar_Syntax_Util.type_u () in
-                           match uu____3627 with
-                           | (t_phi,uu____3634) ->
-                               let uu____3635 =
-                                 tc_check_tot_or_gtot_term env3 phi1 t_phi in
-                               (match uu____3635 with
-                                | (phi2,uu____3643,f2) ->
-                                    let e1 =
-                                      let uu___102_3648 =
-                                        FStar_Syntax_Util.refine
-                                          (Prims.fst x2) phi2 in
-                                      {
-                                        FStar_Syntax_Syntax.n =
-                                          (uu___102_3648.FStar_Syntax_Syntax.n);
-                                        FStar_Syntax_Syntax.tk =
-                                          (uu___102_3648.FStar_Syntax_Syntax.tk);
-                                        FStar_Syntax_Syntax.pos =
-                                          (top.FStar_Syntax_Syntax.pos);
-                                        FStar_Syntax_Syntax.vars =
-                                          (uu___102_3648.FStar_Syntax_Syntax.vars)
-                                      } in
-                                    let t =
-                                      (FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_type u))
-                                        None top.FStar_Syntax_Syntax.pos in
-                                    let g =
-                                      let uu____3667 =
-                                        FStar_TypeChecker_Rel.close_guard_univs
-                                          [u] [x2] f2 in
-                                      FStar_TypeChecker_Rel.conj_guard f1
-                                        uu____3667 in
-                                    value_check_expected_typ env0 e1
-                                      (FStar_Util.Inl t) g))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____3676) ->
-          let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs in
-          ((let uu____3701 =
-              FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-            if uu____3701
-            then
-              let uu____3702 =
-                FStar_Syntax_Print.term_to_string
-                  (let uu___103_3703 = top in
-                   {
-                     FStar_Syntax_Syntax.n =
-                       (FStar_Syntax_Syntax.Tm_abs (bs1, body, None));
-                     FStar_Syntax_Syntax.tk =
-                       (uu___103_3703.FStar_Syntax_Syntax.tk);
-                     FStar_Syntax_Syntax.pos =
-                       (uu___103_3703.FStar_Syntax_Syntax.pos);
-                     FStar_Syntax_Syntax.vars =
-                       (uu___103_3703.FStar_Syntax_Syntax.vars)
-                   }) in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____3702
-            else ());
-           (let uu____3722 = FStar_Syntax_Subst.open_term bs1 body in
-            match uu____3722 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
-      | uu____3730 ->
-          let uu____3731 =
-            let uu____3732 = FStar_Syntax_Print.term_to_string top in
-            let uu____3733 = FStar_Syntax_Print.tag_of_term top in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____3732
-              uu____3733 in
-          failwith uu____3731
-and tc_constant:
-  FStar_Range.range -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ =
-  fun r  ->
-    fun c  ->
-      match c with
-      | FStar_Const.Const_unit  -> FStar_TypeChecker_Common.t_unit
-      | FStar_Const.Const_bool uu____3739 -> FStar_TypeChecker_Common.t_bool
-      | FStar_Const.Const_int (uu____3740,None ) ->
-          FStar_TypeChecker_Common.t_int
-      | FStar_Const.Const_int (uu____3746,Some uu____3747) ->
-          failwith "machine integers should be desugared"
-      | FStar_Const.Const_string uu____3755 ->
-          FStar_TypeChecker_Common.t_string
-      | FStar_Const.Const_float uu____3759 ->
-          FStar_TypeChecker_Common.t_float
-      | FStar_Const.Const_char uu____3760 -> FStar_TypeChecker_Common.t_char
-      | FStar_Const.Const_effect  -> FStar_Syntax_Util.ktype0
-      | FStar_Const.Const_range uu____3761 ->
-          FStar_TypeChecker_Common.t_range
-      | uu____3762 ->
-          Prims.raise (FStar_Errors.Error ("Unsupported constant", r))
-and tc_comp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.comp* FStar_Syntax_Syntax.universe*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun c  ->
-      let c0 = c in
-      match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t,uu____3773) ->
-          let uu____3780 = FStar_Syntax_Util.type_u () in
-          (match uu____3780 with
-           | (k,u) ->
-               let uu____3788 = tc_check_tot_or_gtot_term env t k in
-               (match uu____3788 with
-                | (t1,uu____3796,g) ->
-                    let uu____3798 =
-                      FStar_Syntax_Syntax.mk_Total' t1 (Some u) in
-                    (uu____3798, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t,uu____3800) ->
-          let uu____3807 = FStar_Syntax_Util.type_u () in
-          (match uu____3807 with
-           | (k,u) ->
-               let uu____3815 = tc_check_tot_or_gtot_term env t k in
-               (match uu____3815 with
-                | (t1,uu____3823,g) ->
-                    let uu____3825 =
-                      FStar_Syntax_Syntax.mk_GTotal' t1 (Some u) in
-                    (uu____3825, u, g)))
-      | FStar_Syntax_Syntax.Comp c1 ->
-          let head1 =
-            FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
-              FStar_Syntax_Syntax.Delta_constant None in
-          let head2 =
-            match c1.FStar_Syntax_Syntax.comp_univs with
-            | [] -> head1
-            | us ->
-                (FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_uinst (head1, us))) None
-                  c0.FStar_Syntax_Syntax.pos in
-          let tc =
-            let uu____3841 =
-              let uu____3842 =
-                let uu____3843 =
-                  FStar_Syntax_Syntax.as_arg
-                    c1.FStar_Syntax_Syntax.result_typ in
-                uu____3843 :: (c1.FStar_Syntax_Syntax.effect_args) in
-              FStar_Syntax_Syntax.mk_Tm_app head2 uu____3842 in
-            uu____3841 None
-              (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-          let uu____3848 =
-            tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff in
-          (match uu____3848 with
-           | (tc1,uu____3856,f) ->
-               let uu____3858 = FStar_Syntax_Util.head_and_args tc1 in
-               (match uu____3858 with
-                | (head3,args) ->
-                    let comp_univs =
-                      let uu____3888 =
-                        let uu____3889 = FStar_Syntax_Subst.compress head3 in
-                        uu____3889.FStar_Syntax_Syntax.n in
-                      match uu____3888 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____3892,us) -> us
-                      | uu____3898 -> [] in
-                    let uu____3899 = FStar_Syntax_Util.head_and_args tc1 in
-                    (match uu____3899 with
-                     | (uu____3912,args1) ->
-                         let uu____3928 =
-                           let uu____3940 = FStar_List.hd args1 in
-                           let uu____3949 = FStar_List.tl args1 in
-                           (uu____3940, uu____3949) in
-                         (match uu____3928 with
-                          | (res,args2) ->
-                              let uu____3991 =
-                                let uu____3996 =
-                                  FStar_All.pipe_right
-                                    c1.FStar_Syntax_Syntax.flags
-                                    (FStar_List.map
-                                       (fun uu___83_4006  ->
-                                          match uu___83_4006 with
-                                          | FStar_Syntax_Syntax.DECREASES e
-                                              ->
-                                              let uu____4012 =
-                                                FStar_TypeChecker_Env.clear_expected_typ
-                                                  env in
-                                              (match uu____4012 with
-                                               | (env1,uu____4019) ->
-                                                   let uu____4022 =
-                                                     tc_tot_or_gtot_term env1
-                                                       e in
-                                                   (match uu____4022 with
-                                                    | (e1,uu____4029,g) ->
-                                                        ((FStar_Syntax_Syntax.DECREASES
-                                                            e1), g)))
-                                          | f1 ->
-                                              (f1,
-                                                FStar_TypeChecker_Rel.trivial_guard))) in
-                                FStar_All.pipe_right uu____3996
-                                  FStar_List.unzip in
-                              (match uu____3991 with
-                               | (flags,guards) ->
-                                   let u =
-                                     env.FStar_TypeChecker_Env.universe_of
-                                       env (Prims.fst res) in
-                                   let c2 =
-                                     FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___104_4052 = c1 in
-                                        {
-                                          FStar_Syntax_Syntax.comp_univs =
-                                            comp_univs;
-                                          FStar_Syntax_Syntax.effect_name =
-                                            (uu___104_4052.FStar_Syntax_Syntax.effect_name);
-                                          FStar_Syntax_Syntax.result_typ =
-                                            (Prims.fst res);
-                                          FStar_Syntax_Syntax.effect_args =
-                                            args2;
-                                          FStar_Syntax_Syntax.flags =
-                                            (uu___104_4052.FStar_Syntax_Syntax.flags)
-                                        }) in
-                                   let u_c =
-                                     let uu____4056 =
-                                       FStar_TypeChecker_Env.effect_repr env
-                                         c2 u in
-                                     match uu____4056 with
-                                     | None  -> u
-                                     | Some tm ->
-                                         env.FStar_TypeChecker_Env.universe_of
-                                           env tm in
-                                   let uu____4059 =
-                                     FStar_List.fold_left
-                                       FStar_TypeChecker_Rel.conj_guard f
-                                       guards in
-                                   (c2, u_c, uu____4059))))))
-and tc_universe:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
-  =
-  fun env  ->
-    fun u  ->
-      let rec aux u1 =
-        let u2 = FStar_Syntax_Subst.compress_univ u1 in
-        match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____4067 ->
-            failwith "Impossible: locally nameless"
-        | FStar_Syntax_Syntax.U_unknown  -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif _|FStar_Syntax_Syntax.U_zero  -> u2
-        | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____4070 = aux u3 in FStar_Syntax_Syntax.U_succ uu____4070
-        | FStar_Syntax_Syntax.U_max us ->
-            let uu____4073 = FStar_List.map aux us in
-            FStar_Syntax_Syntax.U_max uu____4073
-        | FStar_Syntax_Syntax.U_name x -> u2 in
-      if env.FStar_TypeChecker_Env.lax_universes
-      then FStar_Syntax_Syntax.U_zero
-      else
-        (match u with
-         | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____4077 = FStar_Syntax_Util.type_u () in
-             FStar_All.pipe_right uu____4077 Prims.snd
-         | uu____4082 -> aux u)
-and tc_abs:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.binders ->
-        FStar_Syntax_Syntax.term ->
-          (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-            FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun top  ->
-      fun bs  ->
-        fun body  ->
-          let fail msg t =
-            let uu____4103 =
-              let uu____4104 =
-                let uu____4107 =
-                  FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
-                    env msg t top in
-                (uu____4107, (top.FStar_Syntax_Syntax.pos)) in
-              FStar_Errors.Error uu____4104 in
-            Prims.raise uu____4103 in
-          let check_binders env1 bs1 bs_expected =
-            let rec aux uu____4161 bs2 bs_expected1 =
-              match uu____4161 with
-              | (env2,out,g,subst1) ->
-                  (match (bs2, bs_expected1) with
-                   | ([],[]) -> (env2, (FStar_List.rev out), None, g, subst1)
-                   | ((hd1,imp)::bs3,(hd_expected,imp')::bs_expected2) ->
-                       ((match (imp, imp') with
-                         | (None ,Some (FStar_Syntax_Syntax.Implicit _))
-                           |(Some (FStar_Syntax_Syntax.Implicit _),None ) ->
-                             let uu____4258 =
-                               let uu____4259 =
-                                 let uu____4262 =
-                                   let uu____4263 =
-                                     FStar_Syntax_Print.bv_to_string hd1 in
-                                   FStar_Util.format1
-                                     "Inconsistent implicit argument annotation on argument %s"
-                                     uu____4263 in
-                                 let uu____4264 =
-                                   FStar_Syntax_Syntax.range_of_bv hd1 in
-                                 (uu____4262, uu____4264) in
-                               FStar_Errors.Error uu____4259 in
-                             Prims.raise uu____4258
-                         | uu____4265 -> ());
-                        (let expected_t =
-                           FStar_Syntax_Subst.subst subst1
-                             hd_expected.FStar_Syntax_Syntax.sort in
-                         let uu____4269 =
-                           let uu____4272 =
-                             let uu____4273 =
-                               FStar_Syntax_Util.unmeta
-                                 hd1.FStar_Syntax_Syntax.sort in
-                             uu____4273.FStar_Syntax_Syntax.n in
-                           match uu____4272 with
-                           | FStar_Syntax_Syntax.Tm_unknown  ->
-                               (expected_t, g)
-                           | uu____4278 ->
-                               ((let uu____4280 =
-                                   FStar_TypeChecker_Env.debug env2
-                                     FStar_Options.High in
-                                 if uu____4280
-                                 then
-                                   let uu____4281 =
-                                     FStar_Syntax_Print.bv_to_string hd1 in
-                                   FStar_Util.print1 "Checking binder %s\n"
-                                     uu____4281
-                                 else ());
-                                (let uu____4283 =
-                                   tc_tot_or_gtot_term env2
-                                     hd1.FStar_Syntax_Syntax.sort in
-                                 match uu____4283 with
-                                 | (t,uu____4290,g1) ->
-                                     let g2 =
-                                       let uu____4293 =
-                                         FStar_TypeChecker_Env.get_range env2 in
-                                       let uu____4294 =
-                                         FStar_TypeChecker_Rel.teq env2 t
-                                           expected_t in
-                                       FStar_TypeChecker_Util.label_guard
-                                         uu____4293
-                                         "Type annotation on parameter incompatible with the expected type"
-                                         uu____4294 in
-                                     let g3 =
-                                       let uu____4296 =
-                                         FStar_TypeChecker_Rel.conj_guard g1
-                                           g2 in
-                                       FStar_TypeChecker_Rel.conj_guard g
-                                         uu____4296 in
-                                     (t, g3))) in
-                         match uu____4269 with
-                         | (t,g1) ->
-                             let hd2 =
-                               let uu___105_4312 = hd1 in
-                               {
-                                 FStar_Syntax_Syntax.ppname =
-                                   (uu___105_4312.FStar_Syntax_Syntax.ppname);
-                                 FStar_Syntax_Syntax.index =
-                                   (uu___105_4312.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = t
-                               } in
-                             let b = (hd2, imp) in
-                             let b_expected = (hd_expected, imp') in
-                             let env3 = push_binding env2 b in
-                             let subst2 =
-                               let uu____4321 =
-                                 FStar_Syntax_Syntax.bv_to_name hd2 in
-                               maybe_extend_subst subst1 b_expected
-                                 uu____4321 in
-                             aux (env3, (b :: out), g1, subst2) bs3
-                               bs_expected2))
-                   | (rest,[]) ->
-                       (env2, (FStar_List.rev out),
-                         (Some (FStar_Util.Inl rest)), g, subst1)
-                   | ([],rest) ->
-                       (env2, (FStar_List.rev out),
-                         (Some (FStar_Util.Inr rest)), g, subst1)) in
-            aux (env1, [], FStar_TypeChecker_Rel.trivial_guard, []) bs1
-              bs_expected in
-          let rec expected_function_typ1 env1 t0 body1 =
-            match t0 with
-            | None  ->
-                ((match env1.FStar_TypeChecker_Env.letrecs with
-                  | [] -> ()
-                  | uu____4423 ->
-                      failwith
-                        "Impossible: Can't have a let rec annotation but no expected type");
-                 (let uu____4427 = tc_binders env1 bs in
-                  match uu____4427 with
-                  | (bs1,envbody,g,uu____4448) ->
-                      let uu____4449 =
-                        let uu____4456 =
-                          let uu____4457 = FStar_Syntax_Subst.compress body1 in
-                          uu____4457.FStar_Syntax_Syntax.n in
-                        match uu____4456 with
-                        | FStar_Syntax_Syntax.Tm_ascribed
-                            (e,(FStar_Util.Inr c,tacopt),uu____4469) ->
-                            let uu____4505 = tc_comp envbody c in
-                            (match uu____4505 with
-                             | (c1,uu____4516,g') ->
-                                 let uu____4518 =
-                                   tc_tactic_opt envbody tacopt in
-                                 let uu____4520 =
-                                   FStar_TypeChecker_Rel.conj_guard g g' in
-                                 ((Some c1), uu____4518, body1, uu____4520))
-                        | uu____4523 -> (None, None, body1, g) in
-                      (match uu____4449 with
-                       | (copt,tacopt,body2,g1) ->
-                           (None, bs1, [], copt, tacopt, envbody, body2, g1))))
-            | Some t ->
-                let t1 = FStar_Syntax_Subst.compress t in
-                let rec as_function_typ norm1 t2 =
-                  let uu____4582 =
-                    let uu____4583 = FStar_Syntax_Subst.compress t2 in
-                    uu____4583.FStar_Syntax_Syntax.n in
-                  match uu____4582 with
-                  | FStar_Syntax_Syntax.Tm_uvar _|FStar_Syntax_Syntax.Tm_app
-                    ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                       FStar_Syntax_Syntax.tk = _;
-                       FStar_Syntax_Syntax.pos = _;
-                       FStar_Syntax_Syntax.vars = _;_},_)
-                      ->
-                      ((match env1.FStar_TypeChecker_Env.letrecs with
-                        | [] -> ()
-                        | uu____4616 -> failwith "Impossible");
-                       (let uu____4620 = tc_binders env1 bs in
-                        match uu____4620 with
-                        | (bs1,envbody,g,uu____4642) ->
-                            let uu____4643 =
-                              FStar_TypeChecker_Env.clear_expected_typ
-                                envbody in
-                            (match uu____4643 with
-                             | (envbody1,uu____4662) ->
-                                 ((Some (t2, true)), bs1, [], None, None,
-                                   envbody1, body1, g))))
-                  | FStar_Syntax_Syntax.Tm_refine (b,uu____4674) ->
-                      let uu____4679 =
-                        as_function_typ norm1 b.FStar_Syntax_Syntax.sort in
-                      (match uu____4679 with
-                       | (uu____4708,bs1,bs',copt,tacopt,env2,body2,g) ->
-                           ((Some (t2, false)), bs1, bs', copt, tacopt, env2,
-                             body2, g))
-                  | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
-                      let uu____4748 =
-                        FStar_Syntax_Subst.open_comp bs_expected c_expected in
-                      (match uu____4748 with
-                       | (bs_expected1,c_expected1) ->
-                           let check_actuals_against_formals env2 bs1
-                             bs_expected2 =
-                             let rec handle_more uu____4811 c_expected2 =
-                               match uu____4811 with
-                               | (env3,bs2,more,guard,subst1) ->
-                                   (match more with
-                                    | None  ->
-                                        let uu____4872 =
-                                          FStar_Syntax_Subst.subst_comp
-                                            subst1 c_expected2 in
-                                        (env3, bs2, guard, uu____4872)
-                                    | Some (FStar_Util.Inr more_bs_expected)
-                                        ->
-                                        let c =
-                                          let uu____4889 =
-                                            FStar_Syntax_Util.arrow
-                                              more_bs_expected c_expected2 in
-                                          FStar_Syntax_Syntax.mk_Total
-                                            uu____4889 in
-                                        let uu____4890 =
-                                          FStar_Syntax_Subst.subst_comp
-                                            subst1 c in
-                                        (env3, bs2, guard, uu____4890)
-                                    | Some (FStar_Util.Inl more_bs) ->
-                                        let c =
-                                          FStar_Syntax_Subst.subst_comp
-                                            subst1 c_expected2 in
-                                        if FStar_Syntax_Util.is_named_tot c
-                                        then
-                                          let t3 =
-                                            unfold_whnf env3
-                                              (FStar_Syntax_Util.comp_result
-                                                 c) in
-                                          (match t3.FStar_Syntax_Syntax.n
-                                           with
-                                           | FStar_Syntax_Syntax.Tm_arrow
-                                               (bs_expected3,c_expected3) ->
-                                               let uu____4931 =
-                                                 check_binders env3 more_bs
-                                                   bs_expected3 in
-                                               (match uu____4931 with
-                                                | (env4,bs',more1,guard',subst2)
-                                                    ->
-                                                    let uu____4958 =
-                                                      let uu____4974 =
-                                                        FStar_TypeChecker_Rel.conj_guard
-                                                          guard guard' in
-                                                      (env4,
-                                                        (FStar_List.append
-                                                           bs2 bs'), more1,
-                                                        uu____4974, subst2) in
-                                                    handle_more uu____4958
-                                                      c_expected3)
-                                           | uu____4983 ->
-                                               let uu____4984 =
-                                                 let uu____4985 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     t3 in
-                                                 FStar_Util.format1
-                                                   "More arguments than annotated type (%s)"
-                                                   uu____4985 in
-                                               fail uu____4984 t3)
-                                        else
-                                          fail
-                                            "Function definition takes more arguments than expected from its annotated type"
-                                            t2) in
-                             let uu____5001 =
-                               check_binders env2 bs1 bs_expected2 in
-                             handle_more uu____5001 c_expected1 in
-                           let mk_letrec_env envbody bs1 c =
-                             let letrecs = guard_letrecs envbody bs1 c in
-                             let envbody1 =
-                               let uu___106_5039 = envbody in
-                               {
-                                 FStar_TypeChecker_Env.solver =
-                                   (uu___106_5039.FStar_TypeChecker_Env.solver);
-                                 FStar_TypeChecker_Env.range =
-                                   (uu___106_5039.FStar_TypeChecker_Env.range);
-                                 FStar_TypeChecker_Env.curmodule =
-                                   (uu___106_5039.FStar_TypeChecker_Env.curmodule);
-                                 FStar_TypeChecker_Env.gamma =
-                                   (uu___106_5039.FStar_TypeChecker_Env.gamma);
-                                 FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___106_5039.FStar_TypeChecker_Env.gamma_cache);
-                                 FStar_TypeChecker_Env.modules =
-                                   (uu___106_5039.FStar_TypeChecker_Env.modules);
-                                 FStar_TypeChecker_Env.expected_typ =
-                                   (uu___106_5039.FStar_TypeChecker_Env.expected_typ);
-                                 FStar_TypeChecker_Env.sigtab =
-                                   (uu___106_5039.FStar_TypeChecker_Env.sigtab);
-                                 FStar_TypeChecker_Env.is_pattern =
-                                   (uu___106_5039.FStar_TypeChecker_Env.is_pattern);
-                                 FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___106_5039.FStar_TypeChecker_Env.instantiate_imp);
-                                 FStar_TypeChecker_Env.effects =
-                                   (uu___106_5039.FStar_TypeChecker_Env.effects);
-                                 FStar_TypeChecker_Env.generalize =
-                                   (uu___106_5039.FStar_TypeChecker_Env.generalize);
-                                 FStar_TypeChecker_Env.letrecs = [];
-                                 FStar_TypeChecker_Env.top_level =
-                                   (uu___106_5039.FStar_TypeChecker_Env.top_level);
-                                 FStar_TypeChecker_Env.check_uvars =
-                                   (uu___106_5039.FStar_TypeChecker_Env.check_uvars);
-                                 FStar_TypeChecker_Env.use_eq =
-                                   (uu___106_5039.FStar_TypeChecker_Env.use_eq);
-                                 FStar_TypeChecker_Env.is_iface =
-                                   (uu___106_5039.FStar_TypeChecker_Env.is_iface);
-                                 FStar_TypeChecker_Env.admit =
-                                   (uu___106_5039.FStar_TypeChecker_Env.admit);
-                                 FStar_TypeChecker_Env.lax =
-                                   (uu___106_5039.FStar_TypeChecker_Env.lax);
-                                 FStar_TypeChecker_Env.lax_universes =
-                                   (uu___106_5039.FStar_TypeChecker_Env.lax_universes);
-                                 FStar_TypeChecker_Env.type_of =
-                                   (uu___106_5039.FStar_TypeChecker_Env.type_of);
-                                 FStar_TypeChecker_Env.universe_of =
-                                   (uu___106_5039.FStar_TypeChecker_Env.universe_of);
-                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___106_5039.FStar_TypeChecker_Env.use_bv_sorts);
-                                 FStar_TypeChecker_Env.qname_and_index =
-                                   (uu___106_5039.FStar_TypeChecker_Env.qname_and_index)
-                               } in
-                             FStar_All.pipe_right letrecs
-                               (FStar_List.fold_left
-                                  (fun uu____5053  ->
-                                     fun uu____5054  ->
-                                       match (uu____5053, uu____5054) with
-                                       | ((env2,letrec_binders),(l,t3)) ->
-                                           let uu____5079 =
-                                             let uu____5083 =
-                                               let uu____5084 =
-                                                 FStar_TypeChecker_Env.clear_expected_typ
-                                                   env2 in
-                                               FStar_All.pipe_right
-                                                 uu____5084 Prims.fst in
-                                             tc_term uu____5083 t3 in
-                                           (match uu____5079 with
-                                            | (t4,uu____5096,uu____5097) ->
-                                                let env3 =
-                                                  FStar_TypeChecker_Env.push_let_binding
-                                                    env2 l ([], t4) in
-                                                let lb =
-                                                  match l with
-                                                  | FStar_Util.Inl x ->
-                                                      let uu____5104 =
-                                                        FStar_Syntax_Syntax.mk_binder
-                                                          (let uu___107_5105
-                                                             = x in
-                                                           {
-                                                             FStar_Syntax_Syntax.ppname
-                                                               =
-                                                               (uu___107_5105.FStar_Syntax_Syntax.ppname);
-                                                             FStar_Syntax_Syntax.index
-                                                               =
-                                                               (uu___107_5105.FStar_Syntax_Syntax.index);
-                                                             FStar_Syntax_Syntax.sort
-                                                               = t4
-                                                           }) in
-                                                      uu____5104 ::
-                                                        letrec_binders
-                                                  | uu____5106 ->
-                                                      letrec_binders in
-                                                (env3, lb))) (envbody1, [])) in
-                           let uu____5109 =
-                             check_actuals_against_formals env1 bs
-                               bs_expected1 in
-                           (match uu____5109 with
-                            | (envbody,bs1,g,c) ->
-                                let uu____5141 =
-                                  let uu____5145 =
-                                    FStar_TypeChecker_Env.should_verify env1 in
-                                  if uu____5145
-                                  then mk_letrec_env envbody bs1 c
-                                  else (envbody, []) in
-                                (match uu____5141 with
-                                 | (envbody1,letrecs) ->
-                                     let envbody2 =
-                                       FStar_TypeChecker_Env.set_expected_typ
-                                         envbody1
-                                         (FStar_Syntax_Util.comp_result c) in
-                                     ((Some (t2, false)), bs1, letrecs,
-                                       (Some c), None, envbody2, body1, g))))
-                  | uu____5181 ->
-                      if Prims.op_Negation norm1
-                      then
-                        let uu____5196 = unfold_whnf env1 t2 in
-                        as_function_typ true uu____5196
-                      else
-                        (let uu____5198 =
-                           expected_function_typ1 env1 None body1 in
-                         match uu____5198 with
-                         | (uu____5226,bs1,uu____5228,c_opt,tacopt,envbody,body2,g)
-                             ->
-                             ((Some (t2, false)), bs1, [], c_opt, tacopt,
-                               envbody, body2, g)) in
-                as_function_typ false t1 in
-          let use_eq = env.FStar_TypeChecker_Env.use_eq in
-          let uu____5253 = FStar_TypeChecker_Env.clear_expected_typ env in
-          match uu____5253 with
-          | (env1,topt) ->
-              ((let uu____5265 =
-                  FStar_TypeChecker_Env.debug env1 FStar_Options.High in
-                if uu____5265
-                then
-                  let uu____5266 =
-                    match topt with
-                    | None  -> "None"
-                    | Some t -> FStar_Syntax_Print.term_to_string t in
-                  FStar_Util.print2
-                    "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____5266
-                    (if env1.FStar_TypeChecker_Env.top_level
-                     then "true"
-                     else "false")
-                else ());
-               (let uu____5270 = expected_function_typ1 env1 topt body in
-                match uu____5270 with
-                | (tfun_opt,bs1,letrec_binders,c_opt,tacopt,envbody,body1,g)
-                    ->
-                    let uu____5305 =
-                      tc_term
-                        (let uu___108_5309 = envbody in
-                         {
-                           FStar_TypeChecker_Env.solver =
-                             (uu___108_5309.FStar_TypeChecker_Env.solver);
-                           FStar_TypeChecker_Env.range =
-                             (uu___108_5309.FStar_TypeChecker_Env.range);
-                           FStar_TypeChecker_Env.curmodule =
-                             (uu___108_5309.FStar_TypeChecker_Env.curmodule);
-                           FStar_TypeChecker_Env.gamma =
-                             (uu___108_5309.FStar_TypeChecker_Env.gamma);
-                           FStar_TypeChecker_Env.gamma_cache =
-                             (uu___108_5309.FStar_TypeChecker_Env.gamma_cache);
-                           FStar_TypeChecker_Env.modules =
-                             (uu___108_5309.FStar_TypeChecker_Env.modules);
-                           FStar_TypeChecker_Env.expected_typ =
-                             (uu___108_5309.FStar_TypeChecker_Env.expected_typ);
-                           FStar_TypeChecker_Env.sigtab =
-                             (uu___108_5309.FStar_TypeChecker_Env.sigtab);
-                           FStar_TypeChecker_Env.is_pattern =
-                             (uu___108_5309.FStar_TypeChecker_Env.is_pattern);
-                           FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___108_5309.FStar_TypeChecker_Env.instantiate_imp);
-                           FStar_TypeChecker_Env.effects =
-                             (uu___108_5309.FStar_TypeChecker_Env.effects);
-                           FStar_TypeChecker_Env.generalize =
-                             (uu___108_5309.FStar_TypeChecker_Env.generalize);
-                           FStar_TypeChecker_Env.letrecs =
-                             (uu___108_5309.FStar_TypeChecker_Env.letrecs);
-                           FStar_TypeChecker_Env.top_level = false;
-                           FStar_TypeChecker_Env.check_uvars =
-                             (uu___108_5309.FStar_TypeChecker_Env.check_uvars);
-                           FStar_TypeChecker_Env.use_eq = use_eq;
-                           FStar_TypeChecker_Env.is_iface =
-                             (uu___108_5309.FStar_TypeChecker_Env.is_iface);
-                           FStar_TypeChecker_Env.admit =
-                             (uu___108_5309.FStar_TypeChecker_Env.admit);
-                           FStar_TypeChecker_Env.lax =
-                             (uu___108_5309.FStar_TypeChecker_Env.lax);
-                           FStar_TypeChecker_Env.lax_universes =
-                             (uu___108_5309.FStar_TypeChecker_Env.lax_universes);
-                           FStar_TypeChecker_Env.type_of =
-                             (uu___108_5309.FStar_TypeChecker_Env.type_of);
-                           FStar_TypeChecker_Env.universe_of =
-                             (uu___108_5309.FStar_TypeChecker_Env.universe_of);
-                           FStar_TypeChecker_Env.use_bv_sorts =
-                             (uu___108_5309.FStar_TypeChecker_Env.use_bv_sorts);
-                           FStar_TypeChecker_Env.qname_and_index =
-                             (uu___108_5309.FStar_TypeChecker_Env.qname_and_index)
-                         }) body1 in
-                    (match uu____5305 with
-                     | (body2,cbody,guard_body) ->
-                         let guard_body1 =
-                           FStar_TypeChecker_Rel.solve_deferred_constraints
-                             envbody guard_body in
-                         ((let uu____5318 =
-                             FStar_All.pipe_left
-                               (FStar_TypeChecker_Env.debug env1)
-                               (FStar_Options.Other "Implicits") in
-                           if uu____5318
-                           then
-                             let uu____5319 =
-                               FStar_All.pipe_left FStar_Util.string_of_int
-                                 (FStar_List.length
-                                    guard_body1.FStar_TypeChecker_Env.implicits) in
-                             let uu____5328 =
-                               let uu____5329 =
-                                 cbody.FStar_Syntax_Syntax.comp () in
-                               FStar_All.pipe_left
-                                 FStar_Syntax_Print.comp_to_string uu____5329 in
-                             FStar_Util.print2
-                               "Introduced %s implicits in body of abstraction\nAfter solving constraints, cbody is %s\n"
-                               uu____5319 uu____5328
-                           else ());
-                          (let uu____5331 =
-                             let uu____5335 =
-                               let uu____5338 =
-                                 cbody.FStar_Syntax_Syntax.comp () in
-                               (body2, uu____5338) in
-                             check_expected_effect
-                               (let uu___109_5343 = envbody in
-                                {
-                                  FStar_TypeChecker_Env.solver =
-                                    (uu___109_5343.FStar_TypeChecker_Env.solver);
-                                  FStar_TypeChecker_Env.range =
-                                    (uu___109_5343.FStar_TypeChecker_Env.range);
-                                  FStar_TypeChecker_Env.curmodule =
-                                    (uu___109_5343.FStar_TypeChecker_Env.curmodule);
-                                  FStar_TypeChecker_Env.gamma =
-                                    (uu___109_5343.FStar_TypeChecker_Env.gamma);
-                                  FStar_TypeChecker_Env.gamma_cache =
-                                    (uu___109_5343.FStar_TypeChecker_Env.gamma_cache);
-                                  FStar_TypeChecker_Env.modules =
-                                    (uu___109_5343.FStar_TypeChecker_Env.modules);
-                                  FStar_TypeChecker_Env.expected_typ =
-                                    (uu___109_5343.FStar_TypeChecker_Env.expected_typ);
-                                  FStar_TypeChecker_Env.sigtab =
-                                    (uu___109_5343.FStar_TypeChecker_Env.sigtab);
-                                  FStar_TypeChecker_Env.is_pattern =
-                                    (uu___109_5343.FStar_TypeChecker_Env.is_pattern);
-                                  FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___109_5343.FStar_TypeChecker_Env.instantiate_imp);
-                                  FStar_TypeChecker_Env.effects =
-                                    (uu___109_5343.FStar_TypeChecker_Env.effects);
-                                  FStar_TypeChecker_Env.generalize =
-                                    (uu___109_5343.FStar_TypeChecker_Env.generalize);
-                                  FStar_TypeChecker_Env.letrecs =
-                                    (uu___109_5343.FStar_TypeChecker_Env.letrecs);
-                                  FStar_TypeChecker_Env.top_level =
-                                    (uu___109_5343.FStar_TypeChecker_Env.top_level);
-                                  FStar_TypeChecker_Env.check_uvars =
-                                    (uu___109_5343.FStar_TypeChecker_Env.check_uvars);
-                                  FStar_TypeChecker_Env.use_eq = use_eq;
-                                  FStar_TypeChecker_Env.is_iface =
-                                    (uu___109_5343.FStar_TypeChecker_Env.is_iface);
-                                  FStar_TypeChecker_Env.admit =
-                                    (uu___109_5343.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax =
-                                    (uu___109_5343.FStar_TypeChecker_Env.lax);
-                                  FStar_TypeChecker_Env.lax_universes =
-                                    (uu___109_5343.FStar_TypeChecker_Env.lax_universes);
-                                  FStar_TypeChecker_Env.type_of =
-                                    (uu___109_5343.FStar_TypeChecker_Env.type_of);
-                                  FStar_TypeChecker_Env.universe_of =
-                                    (uu___109_5343.FStar_TypeChecker_Env.universe_of);
-                                  FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___109_5343.FStar_TypeChecker_Env.use_bv_sorts);
-                                  FStar_TypeChecker_Env.qname_and_index =
-                                    (uu___109_5343.FStar_TypeChecker_Env.qname_and_index)
-                                }) c_opt uu____5335 in
-                           match uu____5331 with
-                           | (body3,cbody1,guard) ->
-                               let guard1 =
-                                 FStar_TypeChecker_Rel.conj_guard guard_body1
-                                   guard in
-                               let guard2 =
-                                 let uu____5352 =
-                                   env1.FStar_TypeChecker_Env.top_level ||
-                                     (let uu____5353 =
-                                        FStar_TypeChecker_Env.should_verify
-                                          env1 in
-                                      Prims.op_Negation uu____5353) in
-                                 if uu____5352
-                                 then
-                                   let uu____5354 =
-                                     FStar_TypeChecker_Rel.conj_guard g
-                                       guard1 in
-                                   FStar_TypeChecker_Rel.discharge_guard
-                                     envbody uu____5354
-                                 else
-                                   (let guard2 =
-                                      let uu____5357 =
-                                        FStar_TypeChecker_Rel.conj_guard g
-                                          guard1 in
-                                      FStar_TypeChecker_Rel.close_guard env1
-                                        (FStar_List.append bs1 letrec_binders)
-                                        uu____5357 in
-                                    guard2) in
-                               let tfun_computed =
-                                 FStar_Syntax_Util.arrow bs1 cbody1 in
-                               let e =
-                                 let uu____5364 =
-                                   let uu____5371 =
-                                     let uu____5377 =
-                                       FStar_All.pipe_right
-                                         (FStar_Util.dflt cbody1 c_opt)
-                                         FStar_Syntax_Util.lcomp_of_comp in
-                                     FStar_All.pipe_right uu____5377
-                                       (fun _0_29  -> FStar_Util.Inl _0_29) in
-                                   Some uu____5371 in
-                                 FStar_Syntax_Util.abs bs1 body3 uu____5364 in
-                               let uu____5391 =
-                                 match tfun_opt with
-                                 | Some (t,use_teq) ->
-                                     let t1 = FStar_Syntax_Subst.compress t in
-                                     (match t1.FStar_Syntax_Syntax.n with
-                                      | FStar_Syntax_Syntax.Tm_arrow
-                                          uu____5406 -> (e, t1, guard2)
-                                      | uu____5414 ->
-                                          let uu____5415 =
-                                            if use_teq
-                                            then
-                                              let uu____5420 =
-                                                FStar_TypeChecker_Rel.teq
-                                                  env1 t1 tfun_computed in
-                                              (e, uu____5420)
-                                            else
-                                              FStar_TypeChecker_Util.check_and_ascribe
-                                                env1 e tfun_computed t1 in
-                                          (match uu____5415 with
-                                           | (e1,guard') ->
-                                               let uu____5427 =
-                                                 FStar_TypeChecker_Rel.conj_guard
-                                                   guard2 guard' in
-                                               (e1, t1, uu____5427)))
-                                 | None  -> (e, tfun_computed, guard2) in
-                               (match uu____5391 with
-                                | (e1,tfun,guard3) ->
-                                    let c =
-                                      if env1.FStar_TypeChecker_Env.top_level
-                                      then FStar_Syntax_Syntax.mk_Total tfun
-                                      else
-                                        FStar_TypeChecker_Util.return_value
-                                          env1 tfun e1 in
-                                    let uu____5440 =
-                                      FStar_TypeChecker_Util.strengthen_precondition
-                                        None env1 e1
-                                        (FStar_Syntax_Util.lcomp_of_comp c)
-                                        guard3 in
-                                    (match uu____5440 with
-                                     | (c1,g1) -> (e1, c1, g1))))))))
-and check_application_args:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp ->
-        FStar_TypeChecker_Env.guard_t ->
-          ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-            ->
-            FStar_Syntax_Syntax.typ Prims.option ->
-              ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-                FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.lcomp*
-                FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun head1  ->
-      fun chead  ->
-        fun ghead  ->
-          fun args  ->
-            fun expected_topt  ->
-              let n_args = FStar_List.length args in
-              let r = FStar_TypeChecker_Env.get_range env in
-              let thead = chead.FStar_Syntax_Syntax.res_typ in
-              (let uu____5476 =
-                 FStar_TypeChecker_Env.debug env FStar_Options.High in
-               if uu____5476
-               then
-                 let uu____5477 =
-                   FStar_Range.string_of_range head1.FStar_Syntax_Syntax.pos in
-                 let uu____5478 = FStar_Syntax_Print.term_to_string thead in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____5477
-                   uu____5478
-               else ());
-              (let monadic_application uu____5520 subst1 arg_comps_rev
-                 arg_rets guard fvs bs =
-                 match uu____5520 with
-                 | (head2,chead1,ghead1,cres) ->
-                     let rt =
-                       check_no_escape (Some head2) env fvs
-                         cres.FStar_Syntax_Syntax.res_typ in
-                     let cres1 =
-                       let uu___110_5561 = cres in
-                       {
-                         FStar_Syntax_Syntax.eff_name =
-                           (uu___110_5561.FStar_Syntax_Syntax.eff_name);
-                         FStar_Syntax_Syntax.res_typ = rt;
-                         FStar_Syntax_Syntax.cflags =
-                           (uu___110_5561.FStar_Syntax_Syntax.cflags);
-                         FStar_Syntax_Syntax.comp =
-                           (uu___110_5561.FStar_Syntax_Syntax.comp)
-                       } in
-                     let uu____5562 =
-                       match bs with
-                       | [] ->
-                           let cres2 =
-                             FStar_TypeChecker_Util.subst_lcomp subst1 cres1 in
-                           let g =
-                             FStar_TypeChecker_Rel.conj_guard ghead1 guard in
-                           let refine_with_equality =
-                             (FStar_Syntax_Util.is_pure_or_ghost_lcomp cres2)
-                               &&
-                               (FStar_All.pipe_right arg_comps_rev
-                                  (FStar_Util.for_some
-                                     (fun uu___84_5589  ->
-                                        match uu___84_5589 with
-                                        | (uu____5598,uu____5599,FStar_Util.Inl
-                                           uu____5600) -> false
-                                        | (uu____5611,uu____5612,FStar_Util.Inr
-                                           c) ->
-                                            let uu____5622 =
-                                              FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                                c in
-                                            Prims.op_Negation uu____5622))) in
-                           let cres3 =
-                             if refine_with_equality
-                             then
-                               let uu____5624 =
-                                 (FStar_Syntax_Syntax.mk_Tm_app head2
-                                    (FStar_List.rev arg_rets))
-                                   (Some
-                                      ((cres2.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                   r in
-                               FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                                 env uu____5624 cres2
-                             else
-                               ((let uu____5635 =
-                                   FStar_TypeChecker_Env.debug env
-                                     FStar_Options.Low in
-                                 if uu____5635
-                                 then
-                                   let uu____5636 =
-                                     FStar_Syntax_Print.term_to_string head2 in
-                                   let uu____5637 =
-                                     FStar_Syntax_Print.lcomp_to_string cres2 in
-                                   let uu____5638 =
-                                     FStar_TypeChecker_Rel.guard_to_string
-                                       env g in
-                                   FStar_Util.print3
-                                     "Not refining result: f=%s; cres=%s; guard=%s\n"
-                                     uu____5636 uu____5637 uu____5638
-                                 else ());
-                                cres2) in
-                           (cres3, g)
-                       | uu____5640 ->
-                           let g =
-                             let uu____5645 =
-                               FStar_TypeChecker_Rel.conj_guard ghead1 guard in
-                             FStar_All.pipe_right uu____5645
-                               (FStar_TypeChecker_Rel.solve_deferred_constraints
-                                  env) in
-                           let uu____5646 =
-                             let uu____5647 =
-                               let uu____5650 =
-                                 let uu____5651 =
-                                   let uu____5652 =
-                                     cres1.FStar_Syntax_Syntax.comp () in
-                                   FStar_Syntax_Util.arrow bs uu____5652 in
-                                 FStar_All.pipe_left
-                                   (FStar_Syntax_Subst.subst subst1)
-                                   uu____5651 in
-                               FStar_Syntax_Syntax.mk_Total uu____5650 in
-                             FStar_All.pipe_left
-                               FStar_Syntax_Util.lcomp_of_comp uu____5647 in
-                           (uu____5646, g) in
-                     (match uu____5562 with
-                      | (cres2,guard1) ->
-                          ((let uu____5663 =
-                              FStar_TypeChecker_Env.debug env
-                                FStar_Options.Low in
-                            if uu____5663
-                            then
-                              let uu____5664 =
-                                FStar_Syntax_Print.lcomp_to_string cres2 in
-                              FStar_Util.print1
-                                "\t Type of result cres is %s\n" uu____5664
-                            else ());
-                           (let comp =
-                              FStar_List.fold_left
-                                (fun out_c  ->
-                                   fun uu____5680  ->
-                                     match uu____5680 with
-                                     | ((e,q),x,c) ->
-                                         (match c with
-                                          | FStar_Util.Inl (eff_name,arg_typ)
-                                              -> out_c
-                                          | FStar_Util.Inr c1 ->
-                                              FStar_TypeChecker_Util.bind
-                                                e.FStar_Syntax_Syntax.pos env
-                                                None c1 (x, out_c))) cres2
-                                arg_comps_rev in
-                            let comp1 =
-                              FStar_TypeChecker_Util.bind
-                                head2.FStar_Syntax_Syntax.pos env None chead1
-                                (None, comp) in
-                            let shortcuts_evaluation_order =
-                              let uu____5726 =
-                                let uu____5727 =
-                                  FStar_Syntax_Subst.compress head2 in
-                                uu____5727.FStar_Syntax_Syntax.n in
-                              match uu____5726 with
-                              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                  (FStar_Syntax_Syntax.fv_eq_lid fv
-                                     FStar_Syntax_Const.op_And)
-                                    ||
-                                    (FStar_Syntax_Syntax.fv_eq_lid fv
-                                       FStar_Syntax_Const.op_Or)
-                              | uu____5731 -> false in
-                            let app =
-                              if shortcuts_evaluation_order
-                              then
-                                let args1 =
-                                  FStar_List.fold_left
-                                    (fun args1  ->
-                                       fun uu____5745  ->
-                                         match uu____5745 with
-                                         | (arg,uu____5757,uu____5758) -> arg
-                                             :: args1) [] arg_comps_rev in
-                                let app =
-                                  (FStar_Syntax_Syntax.mk_Tm_app head2 args1)
-                                    (Some
-                                       ((comp1.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                    r in
-                                let app1 =
-                                  FStar_TypeChecker_Util.maybe_lift env app
-                                    cres2.FStar_Syntax_Syntax.eff_name
-                                    comp1.FStar_Syntax_Syntax.eff_name
-                                    comp1.FStar_Syntax_Syntax.res_typ in
-                                FStar_TypeChecker_Util.maybe_monadic env app1
-                                  comp1.FStar_Syntax_Syntax.eff_name
-                                  comp1.FStar_Syntax_Syntax.res_typ
-                              else
-                                (let uu____5778 =
-                                   let map_fun uu____5817 =
-                                     match uu____5817 with
-                                     | ((e,q),uu____5841,c0) ->
-                                         (match c0 with
-                                          | FStar_Util.Inl uu____5866 ->
-                                              (None, (e, q))
-                                          | FStar_Util.Inr c when
-                                              FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                                c
-                                              -> (None, (e, q))
-                                          | FStar_Util.Inr c ->
-                                              let x =
-                                                FStar_Syntax_Syntax.new_bv
-                                                  None
-                                                  c.FStar_Syntax_Syntax.res_typ in
-                                              let e1 =
-                                                FStar_TypeChecker_Util.maybe_lift
-                                                  env e
-                                                  c.FStar_Syntax_Syntax.eff_name
-                                                  comp1.FStar_Syntax_Syntax.eff_name
-                                                  c.FStar_Syntax_Syntax.res_typ in
-                                              let uu____5909 =
-                                                let uu____5912 =
-                                                  FStar_Syntax_Syntax.bv_to_name
-                                                    x in
-                                                (uu____5912, q) in
-                                              ((Some
-                                                  (x,
-                                                    (c.FStar_Syntax_Syntax.eff_name),
-                                                    (c.FStar_Syntax_Syntax.res_typ),
-                                                    e1)), uu____5909)) in
-                                   let uu____5930 =
-                                     let uu____5944 =
-                                       let uu____5957 =
-                                         let uu____5969 =
-                                           let uu____5978 =
-                                             FStar_Syntax_Syntax.as_arg head2 in
-                                           (uu____5978, None,
-                                             (FStar_Util.Inr chead1)) in
-                                         uu____5969 :: arg_comps_rev in
-                                       FStar_List.map map_fun uu____5957 in
-                                     FStar_All.pipe_left FStar_List.split
-                                       uu____5944 in
-                                   match uu____5930 with
-                                   | (lifted_args,reverse_args) ->
-                                       let uu____6087 =
-                                         let uu____6088 =
-                                           FStar_List.hd reverse_args in
-                                         Prims.fst uu____6088 in
-                                       let uu____6093 =
-                                         let uu____6097 =
-                                           FStar_List.tl reverse_args in
-                                         FStar_List.rev uu____6097 in
-                                       (lifted_args, uu____6087, uu____6093) in
-                                 match uu____5778 with
-                                 | (lifted_args,head3,args1) ->
-                                     let app =
-                                       (FStar_Syntax_Syntax.mk_Tm_app head3
-                                          args1)
-                                         (Some
-                                            ((comp1.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                         r in
-                                     let app1 =
-                                       FStar_TypeChecker_Util.maybe_lift env
-                                         app
-                                         cres2.FStar_Syntax_Syntax.eff_name
-                                         comp1.FStar_Syntax_Syntax.eff_name
-                                         comp1.FStar_Syntax_Syntax.res_typ in
-                                     let app2 =
-                                       FStar_TypeChecker_Util.maybe_monadic
-                                         env app1
-                                         comp1.FStar_Syntax_Syntax.eff_name
-                                         comp1.FStar_Syntax_Syntax.res_typ in
-                                     let bind_lifted_args e uu___85_6165 =
-                                       match uu___85_6165 with
-                                       | None  -> e
-                                       | Some (x,m,t,e1) ->
-                                           let lb =
-                                             FStar_Syntax_Util.mk_letbinding
-                                               (FStar_Util.Inl x) [] t m e1 in
-                                           let letbinding =
-                                             let uu____6207 =
-                                               let uu____6210 =
-                                                 let uu____6211 =
-                                                   let uu____6219 =
-                                                     let uu____6220 =
-                                                       let uu____6221 =
-                                                         FStar_Syntax_Syntax.mk_binder
-                                                           x in
-                                                       [uu____6221] in
-                                                     FStar_Syntax_Subst.close
-                                                       uu____6220 e in
-                                                   ((false, [lb]),
-                                                     uu____6219) in
-                                                 FStar_Syntax_Syntax.Tm_let
-                                                   uu____6211 in
-                                               FStar_Syntax_Syntax.mk
-                                                 uu____6210 in
-                                             uu____6207 None
-                                               e.FStar_Syntax_Syntax.pos in
-                                           (FStar_Syntax_Syntax.mk
-                                              (FStar_Syntax_Syntax.Tm_meta
-                                                 (letbinding,
-                                                   (FStar_Syntax_Syntax.Meta_monadic
-                                                      (m,
-                                                        (comp1.FStar_Syntax_Syntax.res_typ))))))
-                                             None e.FStar_Syntax_Syntax.pos in
-                                     FStar_List.fold_left bind_lifted_args
-                                       app2 lifted_args) in
-                            let uu____6255 =
-                              FStar_TypeChecker_Util.strengthen_precondition
-                                None env app comp1 guard1 in
-                            match uu____6255 with
-                            | (comp2,g) -> (app, comp2, g)))) in
-               let rec tc_args head_info uu____6313 bs args1 =
-                 match uu____6313 with
-                 | (subst1,outargs,arg_rets,g,fvs) ->
-                     (match (bs, args1) with
-                      | ((x,Some (FStar_Syntax_Syntax.Implicit uu____6408))::rest,
-                         (uu____6410,None )::uu____6411) ->
-                          let t =
-                            FStar_Syntax_Subst.subst subst1
-                              x.FStar_Syntax_Syntax.sort in
-                          let t1 = check_no_escape (Some head1) env fvs t in
-                          let uu____6448 =
-                            FStar_TypeChecker_Util.new_implicit_var
-                              "Instantiating implicit argument in application"
-                              head1.FStar_Syntax_Syntax.pos env t1 in
-                          (match uu____6448 with
-                           | (varg,uu____6459,implicits) ->
-                               let subst2 =
-                                 (FStar_Syntax_Syntax.NT (x, varg)) :: subst1 in
-                               let arg =
-                                 let uu____6472 =
-                                   FStar_Syntax_Syntax.as_implicit true in
-                                 (varg, uu____6472) in
-                               let uu____6473 =
-                                 let uu____6495 =
-                                   FStar_TypeChecker_Rel.conj_guard implicits
-                                     g in
-                                 (subst2,
-                                   ((arg, None,
-                                      (FStar_Util.Inl
-                                         (FStar_Syntax_Const.effect_Tot_lid,
-                                           t1))) :: outargs), (arg ::
-                                   arg_rets), uu____6495, fvs) in
-                               tc_args head_info uu____6473 rest args1)
-                      | ((x,aqual)::rest,(e,aq)::rest') ->
-                          ((match (aqual, aq) with
-                            | (Some (FStar_Syntax_Syntax.Implicit _),Some
-                               (FStar_Syntax_Syntax.Implicit _))
-                              |(None ,None )
-                               |(Some (FStar_Syntax_Syntax.Equality ),None )
-                                -> ()
-                            | uu____6586 ->
-                                Prims.raise
-                                  (FStar_Errors.Error
-                                     ("Inconsistent implicit qualifier",
-                                       (e.FStar_Syntax_Syntax.pos))));
-                           (let targ =
-                              FStar_Syntax_Subst.subst subst1
-                                x.FStar_Syntax_Syntax.sort in
-                            let x1 =
-                              let uu___111_6593 = x in
-                              {
-                                FStar_Syntax_Syntax.ppname =
-                                  (uu___111_6593.FStar_Syntax_Syntax.ppname);
-                                FStar_Syntax_Syntax.index =
-                                  (uu___111_6593.FStar_Syntax_Syntax.index);
-                                FStar_Syntax_Syntax.sort = targ
-                              } in
-                            (let uu____6595 =
-                               FStar_TypeChecker_Env.debug env
-                                 FStar_Options.Extreme in
-                             if uu____6595
-                             then
-                               let uu____6596 =
-                                 FStar_Syntax_Print.term_to_string targ in
-                               FStar_Util.print1
-                                 "\tType of arg (after subst) = %s\n"
-                                 uu____6596
-                             else ());
-                            (let targ1 =
-                               check_no_escape (Some head1) env fvs targ in
-                             let env1 =
-                               FStar_TypeChecker_Env.set_expected_typ env
-                                 targ1 in
-                             let env2 =
-                               let uu___112_6601 = env1 in
-                               {
-                                 FStar_TypeChecker_Env.solver =
-                                   (uu___112_6601.FStar_TypeChecker_Env.solver);
-                                 FStar_TypeChecker_Env.range =
-                                   (uu___112_6601.FStar_TypeChecker_Env.range);
-                                 FStar_TypeChecker_Env.curmodule =
-                                   (uu___112_6601.FStar_TypeChecker_Env.curmodule);
-                                 FStar_TypeChecker_Env.gamma =
-                                   (uu___112_6601.FStar_TypeChecker_Env.gamma);
-                                 FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___112_6601.FStar_TypeChecker_Env.gamma_cache);
-                                 FStar_TypeChecker_Env.modules =
-                                   (uu___112_6601.FStar_TypeChecker_Env.modules);
-                                 FStar_TypeChecker_Env.expected_typ =
-                                   (uu___112_6601.FStar_TypeChecker_Env.expected_typ);
-                                 FStar_TypeChecker_Env.sigtab =
-                                   (uu___112_6601.FStar_TypeChecker_Env.sigtab);
-                                 FStar_TypeChecker_Env.is_pattern =
-                                   (uu___112_6601.FStar_TypeChecker_Env.is_pattern);
-                                 FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___112_6601.FStar_TypeChecker_Env.instantiate_imp);
-                                 FStar_TypeChecker_Env.effects =
-                                   (uu___112_6601.FStar_TypeChecker_Env.effects);
-                                 FStar_TypeChecker_Env.generalize =
-                                   (uu___112_6601.FStar_TypeChecker_Env.generalize);
-                                 FStar_TypeChecker_Env.letrecs =
-                                   (uu___112_6601.FStar_TypeChecker_Env.letrecs);
-                                 FStar_TypeChecker_Env.top_level =
-                                   (uu___112_6601.FStar_TypeChecker_Env.top_level);
-                                 FStar_TypeChecker_Env.check_uvars =
-                                   (uu___112_6601.FStar_TypeChecker_Env.check_uvars);
-                                 FStar_TypeChecker_Env.use_eq = (is_eq aqual);
-                                 FStar_TypeChecker_Env.is_iface =
-                                   (uu___112_6601.FStar_TypeChecker_Env.is_iface);
-                                 FStar_TypeChecker_Env.admit =
-                                   (uu___112_6601.FStar_TypeChecker_Env.admit);
-                                 FStar_TypeChecker_Env.lax =
-                                   (uu___112_6601.FStar_TypeChecker_Env.lax);
-                                 FStar_TypeChecker_Env.lax_universes =
-                                   (uu___112_6601.FStar_TypeChecker_Env.lax_universes);
-                                 FStar_TypeChecker_Env.type_of =
-                                   (uu___112_6601.FStar_TypeChecker_Env.type_of);
-                                 FStar_TypeChecker_Env.universe_of =
-                                   (uu___112_6601.FStar_TypeChecker_Env.universe_of);
-                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___112_6601.FStar_TypeChecker_Env.use_bv_sorts);
-                                 FStar_TypeChecker_Env.qname_and_index =
-                                   (uu___112_6601.FStar_TypeChecker_Env.qname_and_index)
-                               } in
-                             (let uu____6603 =
-                                FStar_TypeChecker_Env.debug env2
-                                  FStar_Options.High in
-                              if uu____6603
-                              then
-                                let uu____6604 =
-                                  FStar_Syntax_Print.tag_of_term e in
-                                let uu____6605 =
-                                  FStar_Syntax_Print.term_to_string e in
-                                let uu____6606 =
-                                  FStar_Syntax_Print.term_to_string targ1 in
-                                FStar_Util.print3
-                                  "Checking arg (%s) %s at type %s\n"
-                                  uu____6604 uu____6605 uu____6606
-                              else ());
-                             (let uu____6608 = tc_term env2 e in
-                              match uu____6608 with
-                              | (e1,c,g_e) ->
-                                  let g1 =
-                                    FStar_TypeChecker_Rel.conj_guard g g_e in
-                                  let arg = (e1, aq) in
-                                  let uu____6624 =
-                                    FStar_Syntax_Util.is_tot_or_gtot_lcomp c in
-                                  if uu____6624
-                                  then
-                                    let subst2 =
-                                      let uu____6629 = FStar_List.hd bs in
-                                      maybe_extend_subst subst1 uu____6629 e1 in
-                                    tc_args head_info
-                                      (subst2,
-                                        ((arg, None,
-                                           (FStar_Util.Inl
-                                              ((c.FStar_Syntax_Syntax.eff_name),
-                                                (c.FStar_Syntax_Syntax.res_typ))))
-                                        :: outargs), (arg :: arg_rets), g1,
-                                        fvs) rest rest'
-                                  else
-                                    (let uu____6685 =
-                                       FStar_TypeChecker_Util.is_pure_or_ghost_effect
-                                         env2 c.FStar_Syntax_Syntax.eff_name in
-                                     if uu____6685
-                                     then
-                                       let subst2 =
-                                         let uu____6690 = FStar_List.hd bs in
-                                         maybe_extend_subst subst1 uu____6690
-                                           e1 in
-                                       tc_args head_info
-                                         (subst2,
-                                           ((arg, (Some x1),
-                                              (FStar_Util.Inr c)) ::
-                                           outargs), (arg :: arg_rets), g1,
-                                           fvs) rest rest'
-                                     else
-                                       (let uu____6736 =
-                                          let uu____6737 = FStar_List.hd bs in
-                                          FStar_Syntax_Syntax.is_null_binder
-                                            uu____6737 in
-                                        if uu____6736
-                                        then
-                                          let newx =
-                                            FStar_Syntax_Syntax.new_bv
-                                              (Some
-                                                 (e1.FStar_Syntax_Syntax.pos))
-                                              c.FStar_Syntax_Syntax.res_typ in
-                                          let arg' =
-                                            let uu____6746 =
-                                              FStar_Syntax_Syntax.bv_to_name
-                                                newx in
-                                            FStar_All.pipe_left
-                                              FStar_Syntax_Syntax.as_arg
-                                              uu____6746 in
-                                          tc_args head_info
-                                            (subst1,
-                                              ((arg, (Some newx),
-                                                 (FStar_Util.Inr c)) ::
-                                              outargs), (arg' :: arg_rets),
-                                              g1, fvs) rest rest'
-                                        else
-                                          (let uu____6784 =
-                                             let uu____6806 =
-                                               let uu____6808 =
-                                                 let uu____6809 =
-                                                   FStar_Syntax_Syntax.bv_to_name
-                                                     x1 in
-                                                 FStar_Syntax_Syntax.as_arg
-                                                   uu____6809 in
-                                               uu____6808 :: arg_rets in
-                                             (subst1,
-                                               ((arg, (Some x1),
-                                                  (FStar_Util.Inr c)) ::
-                                               outargs), uu____6806, g1, (x1
-                                               :: fvs)) in
-                                           tc_args head_info uu____6784 rest
-                                             rest')))))))
-                      | (uu____6846,[]) ->
-                          monadic_application head_info subst1 outargs
-                            arg_rets g fvs bs
-                      | ([],arg::uu____6867) ->
-                          let uu____6897 =
-                            monadic_application head_info subst1 outargs
-                              arg_rets g fvs [] in
-                          (match uu____6897 with
-                           | (head2,chead1,ghead1) ->
-                               let rec aux norm1 tres =
-                                 let tres1 =
-                                   let uu____6920 =
-                                     FStar_Syntax_Subst.compress tres in
-                                   FStar_All.pipe_right uu____6920
-                                     FStar_Syntax_Util.unrefine in
-                                 match tres1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow (bs1,cres')
-                                     ->
-                                     let uu____6936 =
-                                       FStar_Syntax_Subst.open_comp bs1 cres' in
-                                     (match uu____6936 with
-                                      | (bs2,cres'1) ->
-                                          let head_info1 =
-                                            (head2, chead1, ghead1,
-                                              (FStar_Syntax_Util.lcomp_of_comp
-                                                 cres'1)) in
-                                          ((let uu____6950 =
-                                              FStar_TypeChecker_Env.debug env
-                                                FStar_Options.Low in
-                                            if uu____6950
-                                            then
-                                              let uu____6951 =
-                                                FStar_Range.string_of_range
-                                                  tres1.FStar_Syntax_Syntax.pos in
-                                              FStar_Util.print1
-                                                "%s: Warning: Potentially redundant explicit currying of a function type \n"
-                                                uu____6951
-                                            else ());
-                                           tc_args head_info1
-                                             ([], [], [],
-                                               FStar_TypeChecker_Rel.trivial_guard,
-                                               []) bs2 args1))
-                                 | uu____6981 when Prims.op_Negation norm1 ->
-                                     let uu____6982 = unfold_whnf env tres1 in
-                                     aux true uu____6982
-                                 | uu____6983 ->
-                                     let uu____6984 =
-                                       let uu____6985 =
-                                         let uu____6988 =
-                                           let uu____6989 =
-                                             FStar_TypeChecker_Normalize.term_to_string
-                                               env thead in
-                                           let uu____6990 =
-                                             FStar_Util.string_of_int n_args in
-                                           FStar_Util.format2
-                                             "Too many arguments to function of type %s; got %s arguments"
-                                             uu____6989 uu____6990 in
-                                         let uu____6994 =
-                                           FStar_Syntax_Syntax.argpos arg in
-                                         (uu____6988, uu____6994) in
-                                       FStar_Errors.Error uu____6985 in
-                                     Prims.raise uu____6984 in
-                               aux false chead1.FStar_Syntax_Syntax.res_typ)) in
-               let rec check_function_app norm1 tf =
-                 let uu____7010 =
-                   let uu____7011 = FStar_Syntax_Util.unrefine tf in
-                   uu____7011.FStar_Syntax_Syntax.n in
-                 match uu____7010 with
-                 | FStar_Syntax_Syntax.Tm_uvar _|FStar_Syntax_Syntax.Tm_app
-                   ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar _;
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_)
-                     ->
-                     let rec tc_args1 env1 args1 =
-                       match args1 with
-                       | [] -> ([], [], FStar_TypeChecker_Rel.trivial_guard)
-                       | (e,imp)::tl1 ->
-                           let uu____7087 = tc_term env1 e in
-                           (match uu____7087 with
-                            | (e1,c,g_e) ->
-                                let uu____7100 = tc_args1 env1 tl1 in
-                                (match uu____7100 with
-                                 | (args2,comps,g_rest) ->
-                                     let uu____7122 =
-                                       FStar_TypeChecker_Rel.conj_guard g_e
-                                         g_rest in
-                                     (((e1, imp) :: args2),
-                                       (((e1.FStar_Syntax_Syntax.pos), c) ::
-                                       comps), uu____7122))) in
-                     let uu____7133 = tc_args1 env args in
-                     (match uu____7133 with
-                      | (args1,comps,g_args) ->
-                          let bs =
-                            let uu____7155 =
-                              FStar_All.pipe_right comps
-                                (FStar_List.map
-                                   (fun uu____7175  ->
-                                      match uu____7175 with
-                                      | (uu____7183,c) ->
-                                          ((c.FStar_Syntax_Syntax.res_typ),
-                                            None))) in
-                            FStar_Syntax_Util.null_binders_of_tks uu____7155 in
-                          let ml_or_tot t r1 =
-                            let uu____7199 = FStar_Options.ml_ish () in
-                            if uu____7199
-                            then FStar_Syntax_Util.ml_comp t r1
-                            else FStar_Syntax_Syntax.mk_Total t in
-                          let cres =
-                            let uu____7202 =
-                              let uu____7205 =
-                                let uu____7206 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____7206 Prims.fst in
-                              FStar_TypeChecker_Util.new_uvar env uu____7205 in
-                            ml_or_tot uu____7202 r in
-                          let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                          ((let uu____7215 =
-                              FStar_All.pipe_left
-                                (FStar_TypeChecker_Env.debug env)
-                                FStar_Options.Extreme in
-                            if uu____7215
-                            then
-                              let uu____7216 =
-                                FStar_Syntax_Print.term_to_string head1 in
-                              let uu____7217 =
-                                FStar_Syntax_Print.term_to_string tf in
-                              let uu____7218 =
-                                FStar_Syntax_Print.term_to_string bs_cres in
-                              FStar_Util.print3
-                                "Forcing the type of %s from %s to %s\n"
-                                uu____7216 uu____7217 uu____7218
-                            else ());
-                           (let uu____7221 =
-                              FStar_TypeChecker_Rel.teq env tf bs_cres in
-                            FStar_All.pipe_left
-                              (FStar_TypeChecker_Rel.force_trivial_guard env)
-                              uu____7221);
-                           (let comp =
-                              let uu____7223 =
-                                FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp cres in
-                              FStar_List.fold_right
-                                (fun uu____7228  ->
-                                   fun out  ->
-                                     match uu____7228 with
-                                     | (r1,c) ->
-                                         FStar_TypeChecker_Util.bind r1 env
-                                           None c (None, out))
-                                (((head1.FStar_Syntax_Syntax.pos), chead) ::
-                                comps) uu____7223 in
-                            let uu____7237 =
-                              (FStar_Syntax_Syntax.mk_Tm_app head1 args1)
-                                (Some
-                                   ((comp.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                                r in
-                            let uu____7244 =
-                              FStar_TypeChecker_Rel.conj_guard ghead g_args in
-                            (uu____7237, comp, uu____7244))))
-                 | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____7259 = FStar_Syntax_Subst.open_comp bs c in
-                     (match uu____7259 with
-                      | (bs1,c1) ->
-                          let head_info =
-                            (head1, chead, ghead,
-                              (FStar_Syntax_Util.lcomp_of_comp c1)) in
-                          tc_args head_info
-                            ([], [], [], FStar_TypeChecker_Rel.trivial_guard,
-                              []) bs1 args)
-                 | uu____7302 ->
-                     if Prims.op_Negation norm1
-                     then
-                       let uu____7308 = unfold_whnf env tf in
-                       check_function_app true uu____7308
-                     else
-                       (let uu____7310 =
-                          let uu____7311 =
-                            let uu____7314 =
-                              FStar_TypeChecker_Err.expected_function_typ env
-                                tf in
-                            (uu____7314, (head1.FStar_Syntax_Syntax.pos)) in
-                          FStar_Errors.Error uu____7311 in
-                        Prims.raise uu____7310) in
-               let uu____7320 =
-                 let uu____7321 = FStar_Syntax_Util.unrefine thead in
-                 FStar_TypeChecker_Normalize.normalize
-                   [FStar_TypeChecker_Normalize.Beta;
-                   FStar_TypeChecker_Normalize.WHNF] env uu____7321 in
-               check_function_app false uu____7320)
-and check_short_circuit_args:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp ->
-        FStar_TypeChecker_Env.guard_t ->
-          ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-            FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-            ->
-            FStar_Syntax_Syntax.typ Prims.option ->
-              (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-                FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun head1  ->
-      fun chead  ->
-        fun g_head  ->
-          fun args  ->
-            fun expected_topt  ->
-              let r = FStar_TypeChecker_Env.get_range env in
-              let tf =
-                FStar_Syntax_Subst.compress chead.FStar_Syntax_Syntax.res_typ in
-              match tf.FStar_Syntax_Syntax.n with
-              | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                  (FStar_Syntax_Util.is_total_comp c) &&
-                    ((FStar_List.length bs) = (FStar_List.length args))
-                  ->
-                  let res_t = FStar_Syntax_Util.comp_result c in
-                  let uu____7367 =
-                    FStar_List.fold_left2
-                      (fun uu____7380  ->
-                         fun uu____7381  ->
-                           fun uu____7382  ->
-                             match (uu____7380, uu____7381, uu____7382) with
-                             | ((seen,guard,ghost),(e,aq),(b,aq')) ->
-                                 (if aq <> aq'
-                                  then
-                                    Prims.raise
-                                      (FStar_Errors.Error
-                                         ("Inconsistent implicit qualifiers",
-                                           (e.FStar_Syntax_Syntax.pos)))
-                                  else ();
-                                  (let uu____7426 =
-                                     tc_check_tot_or_gtot_term env e
-                                       b.FStar_Syntax_Syntax.sort in
-                                   match uu____7426 with
-                                   | (e1,c1,g) ->
-                                       let short =
-                                         FStar_TypeChecker_Util.short_circuit
-                                           head1 seen in
-                                       let g1 =
-                                         let uu____7438 =
-                                           FStar_TypeChecker_Rel.guard_of_guard_formula
-                                             short in
-                                         FStar_TypeChecker_Rel.imp_guard
-                                           uu____7438 g in
-                                       let ghost1 =
-                                         ghost ||
-                                           ((let uu____7440 =
-                                               FStar_Syntax_Util.is_total_lcomp
-                                                 c1 in
-                                             Prims.op_Negation uu____7440) &&
-                                              (let uu____7441 =
-                                                 FStar_TypeChecker_Util.is_pure_effect
-                                                   env
-                                                   c1.FStar_Syntax_Syntax.eff_name in
-                                               Prims.op_Negation uu____7441)) in
-                                       let uu____7442 =
-                                         let uu____7448 =
-                                           let uu____7454 =
-                                             FStar_Syntax_Syntax.as_arg e1 in
-                                           [uu____7454] in
-                                         FStar_List.append seen uu____7448 in
-                                       let uu____7459 =
-                                         FStar_TypeChecker_Rel.conj_guard
-                                           guard g1 in
-                                       (uu____7442, uu____7459, ghost1))))
-                      ([], g_head, false) args bs in
-                  (match uu____7367 with
-                   | (args1,guard,ghost) ->
-                       let e =
-                         (FStar_Syntax_Syntax.mk_Tm_app head1 args1)
-                           (Some (res_t.FStar_Syntax_Syntax.n)) r in
-                       let c1 =
-                         if ghost
-                         then
-                           let uu____7488 =
-                             FStar_Syntax_Syntax.mk_GTotal res_t in
-                           FStar_All.pipe_right uu____7488
-                             FStar_Syntax_Util.lcomp_of_comp
-                         else FStar_Syntax_Util.lcomp_of_comp c in
-                       let uu____7490 =
-                         FStar_TypeChecker_Util.strengthen_precondition None
-                           env e c1 guard in
-                       (match uu____7490 with | (c2,g) -> (e, c2, g)))
-              | uu____7502 ->
-                  check_application_args env head1 chead g_head args
-                    expected_topt
-and tc_eqn:
-  FStar_Syntax_Syntax.bv ->
-    FStar_TypeChecker_Env.env ->
-      ((FStar_Syntax_Syntax.pat',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.withinfo_t*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax Prims.option*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax) ->
-        ((FStar_Syntax_Syntax.pat* FStar_Syntax_Syntax.term Prims.option*
-          FStar_Syntax_Syntax.term)* FStar_Syntax_Syntax.term*
-          FStar_Syntax_Syntax.lcomp* FStar_TypeChecker_Env.guard_t)
-  =
-  fun scrutinee  ->
-    fun env  ->
-      fun branch1  ->
-        let uu____7524 = FStar_Syntax_Subst.open_branch branch1 in
-        match uu____7524 with
-        | (pattern,when_clause,branch_exp) ->
-            let uu____7550 = branch1 in
-            (match uu____7550 with
-             | (cpat,uu____7570,cbr) ->
-                 let tc_pat allow_implicits pat_t p0 =
-                   let uu____7612 =
-                     FStar_TypeChecker_Util.pat_as_exps allow_implicits env
-                       p0 in
-                   match uu____7612 with
-                   | (pat_bvs1,exps,p) ->
-                       ((let uu____7634 =
-                           FStar_TypeChecker_Env.debug env FStar_Options.High in
-                         if uu____7634
-                         then
-                           let uu____7635 =
-                             FStar_Syntax_Print.pat_to_string p0 in
-                           let uu____7636 =
-                             FStar_Syntax_Print.pat_to_string p in
-                           FStar_Util.print2 "Pattern %s elaborated to %s\n"
-                             uu____7635 uu____7636
-                         else ());
-                        (let pat_env =
-                           FStar_List.fold_left FStar_TypeChecker_Env.push_bv
-                             env pat_bvs1 in
-                         let uu____7639 =
-                           FStar_TypeChecker_Env.clear_expected_typ pat_env in
-                         match uu____7639 with
-                         | (env1,uu____7652) ->
-                             let env11 =
-                               let uu___113_7656 = env1 in
-                               {
-                                 FStar_TypeChecker_Env.solver =
-                                   (uu___113_7656.FStar_TypeChecker_Env.solver);
-                                 FStar_TypeChecker_Env.range =
-                                   (uu___113_7656.FStar_TypeChecker_Env.range);
-                                 FStar_TypeChecker_Env.curmodule =
-                                   (uu___113_7656.FStar_TypeChecker_Env.curmodule);
-                                 FStar_TypeChecker_Env.gamma =
-                                   (uu___113_7656.FStar_TypeChecker_Env.gamma);
-                                 FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___113_7656.FStar_TypeChecker_Env.gamma_cache);
-                                 FStar_TypeChecker_Env.modules =
-                                   (uu___113_7656.FStar_TypeChecker_Env.modules);
-                                 FStar_TypeChecker_Env.expected_typ =
-                                   (uu___113_7656.FStar_TypeChecker_Env.expected_typ);
-                                 FStar_TypeChecker_Env.sigtab =
-                                   (uu___113_7656.FStar_TypeChecker_Env.sigtab);
-                                 FStar_TypeChecker_Env.is_pattern = true;
-                                 FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___113_7656.FStar_TypeChecker_Env.instantiate_imp);
-                                 FStar_TypeChecker_Env.effects =
-                                   (uu___113_7656.FStar_TypeChecker_Env.effects);
-                                 FStar_TypeChecker_Env.generalize =
-                                   (uu___113_7656.FStar_TypeChecker_Env.generalize);
-                                 FStar_TypeChecker_Env.letrecs =
-                                   (uu___113_7656.FStar_TypeChecker_Env.letrecs);
-                                 FStar_TypeChecker_Env.top_level =
-                                   (uu___113_7656.FStar_TypeChecker_Env.top_level);
-                                 FStar_TypeChecker_Env.check_uvars =
-                                   (uu___113_7656.FStar_TypeChecker_Env.check_uvars);
-                                 FStar_TypeChecker_Env.use_eq =
-                                   (uu___113_7656.FStar_TypeChecker_Env.use_eq);
-                                 FStar_TypeChecker_Env.is_iface =
-                                   (uu___113_7656.FStar_TypeChecker_Env.is_iface);
-                                 FStar_TypeChecker_Env.admit =
-                                   (uu___113_7656.FStar_TypeChecker_Env.admit);
-                                 FStar_TypeChecker_Env.lax =
-                                   (uu___113_7656.FStar_TypeChecker_Env.lax);
-                                 FStar_TypeChecker_Env.lax_universes =
-                                   (uu___113_7656.FStar_TypeChecker_Env.lax_universes);
-                                 FStar_TypeChecker_Env.type_of =
-                                   (uu___113_7656.FStar_TypeChecker_Env.type_of);
-                                 FStar_TypeChecker_Env.universe_of =
-                                   (uu___113_7656.FStar_TypeChecker_Env.universe_of);
-                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___113_7656.FStar_TypeChecker_Env.use_bv_sorts);
-                                 FStar_TypeChecker_Env.qname_and_index =
-                                   (uu___113_7656.FStar_TypeChecker_Env.qname_and_index)
-                               } in
-                             let expected_pat_t =
-                               FStar_TypeChecker_Rel.unrefine env pat_t in
-                             let uu____7658 =
-                               let uu____7663 =
-                                 FStar_All.pipe_right exps
-                                   (FStar_List.map
-                                      (fun e  ->
-                                         (let uu____7675 =
-                                            FStar_TypeChecker_Env.debug env
-                                              FStar_Options.High in
-                                          if uu____7675
-                                          then
-                                            let uu____7676 =
-                                              FStar_Syntax_Print.term_to_string
-                                                e in
-                                            let uu____7677 =
-                                              FStar_Syntax_Print.term_to_string
-                                                pat_t in
-                                            FStar_Util.print2
-                                              "Checking pattern expression %s against expected type %s\n"
-                                              uu____7676 uu____7677
-                                          else ());
-                                         (let uu____7679 = tc_term env11 e in
-                                          match uu____7679 with
-                                          | (e1,lc,g) ->
-                                              ((let uu____7689 =
-                                                  FStar_TypeChecker_Env.debug
-                                                    env FStar_Options.High in
-                                                if uu____7689
-                                                then
-                                                  let uu____7690 =
-                                                    FStar_TypeChecker_Normalize.term_to_string
-                                                      env e1 in
-                                                  let uu____7691 =
-                                                    FStar_TypeChecker_Normalize.term_to_string
-                                                      env
-                                                      lc.FStar_Syntax_Syntax.res_typ in
-                                                  FStar_Util.print2
-                                                    "Pre-checked pattern expression %s at type %s\n"
-                                                    uu____7690 uu____7691
-                                                else ());
-                                               (let g' =
-                                                  FStar_TypeChecker_Rel.teq
-                                                    env
-                                                    lc.FStar_Syntax_Syntax.res_typ
-                                                    expected_pat_t in
-                                                let g1 =
-                                                  FStar_TypeChecker_Rel.conj_guard
-                                                    g g' in
-                                                let uu____7695 =
-                                                  let uu____7696 =
-                                                    FStar_TypeChecker_Rel.discharge_guard
-                                                      env
-                                                      (let uu___114_7697 = g1 in
-                                                       {
-                                                         FStar_TypeChecker_Env.guard_f
-                                                           =
-                                                           FStar_TypeChecker_Common.Trivial;
-                                                         FStar_TypeChecker_Env.deferred
-                                                           =
-                                                           (uu___114_7697.FStar_TypeChecker_Env.deferred);
-                                                         FStar_TypeChecker_Env.univ_ineqs
-                                                           =
-                                                           (uu___114_7697.FStar_TypeChecker_Env.univ_ineqs);
-                                                         FStar_TypeChecker_Env.implicits
-                                                           =
-                                                           (uu___114_7697.FStar_TypeChecker_Env.implicits)
-                                                       }) in
-                                                  FStar_All.pipe_right
-                                                    uu____7696
-                                                    FStar_TypeChecker_Rel.resolve_implicits in
-                                                let e' =
-                                                  FStar_TypeChecker_Normalize.normalize
-                                                    [FStar_TypeChecker_Normalize.Beta]
-                                                    env e1 in
-                                                let uvars_to_string uvs =
-                                                  let uu____7711 =
-                                                    let uu____7713 =
-                                                      FStar_All.pipe_right
-                                                        uvs
-                                                        FStar_Util.set_elements in
-                                                    FStar_All.pipe_right
-                                                      uu____7713
-                                                      (FStar_List.map
-                                                         (fun uu____7737  ->
-                                                            match uu____7737
-                                                            with
-                                                            | (u,uu____7742)
-                                                                ->
-                                                                FStar_Syntax_Print.uvar_to_string
-                                                                  u)) in
-                                                  FStar_All.pipe_right
-                                                    uu____7711
-                                                    (FStar_String.concat ", ") in
-                                                let uvs1 =
-                                                  FStar_Syntax_Free.uvars e' in
-                                                let uvs2 =
-                                                  FStar_Syntax_Free.uvars
-                                                    expected_pat_t in
-                                                (let uu____7755 =
-                                                   let uu____7756 =
-                                                     FStar_Util.set_is_subset_of
-                                                       uvs1 uvs2 in
-                                                   FStar_All.pipe_left
-                                                     Prims.op_Negation
-                                                     uu____7756 in
-                                                 if uu____7755
-                                                 then
-                                                   let unresolved =
-                                                     let uu____7763 =
-                                                       FStar_Util.set_difference
-                                                         uvs1 uvs2 in
-                                                     FStar_All.pipe_right
-                                                       uu____7763
-                                                       FStar_Util.set_elements in
-                                                   let uu____7777 =
-                                                     let uu____7778 =
-                                                       let uu____7781 =
-                                                         let uu____7782 =
-                                                           FStar_TypeChecker_Normalize.term_to_string
-                                                             env e' in
-                                                         let uu____7783 =
-                                                           FStar_TypeChecker_Normalize.term_to_string
-                                                             env
-                                                             expected_pat_t in
-                                                         let uu____7784 =
-                                                           let uu____7785 =
-                                                             FStar_All.pipe_right
-                                                               unresolved
-                                                               (FStar_List.map
-                                                                  (fun
-                                                                    uu____7797
-                                                                     ->
-                                                                    match uu____7797
-                                                                    with
-                                                                    | 
-                                                                    (u,uu____7805)
-                                                                    ->
-                                                                    FStar_Syntax_Print.uvar_to_string
-                                                                    u)) in
-                                                           FStar_All.pipe_right
-                                                             uu____7785
-                                                             (FStar_String.concat
-                                                                ", ") in
-                                                         FStar_Util.format3
-                                                           "Implicit pattern variables in %s could not be resolved against expected type %s;Variables {%s} were unresolved; please bind them explicitly"
-                                                           uu____7782
-                                                           uu____7783
-                                                           uu____7784 in
-                                                       (uu____7781,
-                                                         (p.FStar_Syntax_Syntax.p)) in
-                                                     FStar_Errors.Error
-                                                       uu____7778 in
-                                                   Prims.raise uu____7777
-                                                 else ());
-                                                (let uu____7820 =
-                                                   FStar_TypeChecker_Env.debug
-                                                     env FStar_Options.High in
-                                                 if uu____7820
-                                                 then
-                                                   let uu____7821 =
-                                                     FStar_TypeChecker_Normalize.term_to_string
-                                                       env e1 in
-                                                   FStar_Util.print1
-                                                     "Done checking pattern expression %s\n"
-                                                     uu____7821
-                                                 else ());
-                                                (e1, e')))))) in
-                               FStar_All.pipe_right uu____7663
-                                 FStar_List.unzip in
-                             (match uu____7658 with
-                              | (exps1,norm_exps) ->
-                                  let p1 =
-                                    FStar_TypeChecker_Util.decorate_pattern
-                                      env p exps1 in
-                                  (p1, pat_bvs1, pat_env, exps1, norm_exps)))) in
-                 let pat_t = scrutinee.FStar_Syntax_Syntax.sort in
-                 let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee in
-                 let uu____7852 =
-                   let uu____7856 =
-                     FStar_TypeChecker_Env.push_bv env scrutinee in
-                   FStar_All.pipe_right uu____7856
-                     FStar_TypeChecker_Env.clear_expected_typ in
-                 (match uu____7852 with
-                  | (scrutinee_env,uu____7869) ->
-                      let uu____7872 = tc_pat true pat_t pattern in
-                      (match uu____7872 with
-                       | (pattern1,pat_bvs1,pat_env,disj_exps,norm_disj_exps)
-                           ->
-                           let uu____7900 =
-                             match when_clause with
-                             | None  ->
-                                 (None, FStar_TypeChecker_Rel.trivial_guard)
-                             | Some e ->
-                                 let uu____7915 =
-                                   FStar_TypeChecker_Env.should_verify env in
-                                 if uu____7915
-                                 then
-                                   Prims.raise
-                                     (FStar_Errors.Error
-                                        ("When clauses are not yet supported in --verify mode; they will be some day",
-                                          (e.FStar_Syntax_Syntax.pos)))
-                                 else
-                                   (let uu____7923 =
-                                      let uu____7927 =
-                                        FStar_TypeChecker_Env.set_expected_typ
-                                          pat_env
-                                          FStar_TypeChecker_Common.t_bool in
-                                      tc_term uu____7927 e in
-                                    match uu____7923 with
-                                    | (e1,c,g) -> ((Some e1), g)) in
-                           (match uu____7900 with
-                            | (when_clause1,g_when) ->
-                                let uu____7947 = tc_term pat_env branch_exp in
-                                (match uu____7947 with
-                                 | (branch_exp1,c,g_branch) ->
-                                     let when_condition =
-                                       match when_clause1 with
-                                       | None  -> None
-                                       | Some w ->
-                                           let uu____7966 =
-                                             FStar_Syntax_Util.mk_eq2
-                                               FStar_Syntax_Syntax.U_zero
-                                               FStar_Syntax_Util.t_bool w
-                                               FStar_Syntax_Const.exp_true_bool in
-                                           FStar_All.pipe_left
-                                             (fun _0_30  -> Some _0_30)
-                                             uu____7966 in
-                                     let uu____7968 =
-                                       let eqs =
-                                         let uu____7974 =
-                                           let uu____7975 =
-                                             FStar_TypeChecker_Env.should_verify
-                                               env in
-                                           Prims.op_Negation uu____7975 in
-                                         if uu____7974
-                                         then None
-                                         else
-                                           FStar_All.pipe_right disj_exps
-                                             (FStar_List.fold_left
-                                                (fun fopt  ->
-                                                   fun e  ->
-                                                     let e1 =
-                                                       FStar_Syntax_Subst.compress
-                                                         e in
-                                                     match e1.FStar_Syntax_Syntax.n
-                                                     with
-                                                     | FStar_Syntax_Syntax.Tm_uvar
-                                                       _
-                                                       |FStar_Syntax_Syntax.Tm_constant
-                                                        _
-                                                        |FStar_Syntax_Syntax.Tm_fvar
-                                                        _ -> fopt
-                                                     | uu____7989 ->
-                                                         let clause =
-                                                           let uu____7991 =
-                                                             env.FStar_TypeChecker_Env.universe_of
-                                                               env pat_t in
-                                                           FStar_Syntax_Util.mk_eq2
-                                                             uu____7991 pat_t
-                                                             scrutinee_tm e1 in
-                                                         (match fopt with
-                                                          | None  ->
-                                                              Some clause
-                                                          | Some f ->
-                                                              let uu____7994
-                                                                =
-                                                                FStar_Syntax_Util.mk_disj
-                                                                  clause f in
-                                                              FStar_All.pipe_left
-                                                                (fun _0_31 
-                                                                   ->
-                                                                   Some _0_31)
-                                                                uu____7994))
-                                                None) in
-                                       let uu____8004 =
-                                         FStar_TypeChecker_Util.strengthen_precondition
-                                           None env branch_exp1 c g_branch in
-                                       match uu____8004 with
-                                       | (c1,g_branch1) ->
-                                           let uu____8014 =
-                                             match (eqs, when_condition) with
-                                             | uu____8021 when
-                                                 let uu____8026 =
-                                                   FStar_TypeChecker_Env.should_verify
-                                                     env in
-                                                 Prims.op_Negation uu____8026
-                                                 -> (c1, g_when)
-                                             | (None ,None ) -> (c1, g_when)
-                                             | (Some f,None ) ->
-                                                 let gf =
-                                                   FStar_TypeChecker_Common.NonTrivial
-                                                     f in
-                                                 let g =
-                                                   FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                     gf in
-                                                 let uu____8034 =
-                                                   FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 gf in
-                                                 let uu____8035 =
-                                                   FStar_TypeChecker_Rel.imp_guard
-                                                     g g_when in
-                                                 (uu____8034, uu____8035)
-                                             | (Some f,Some w) ->
-                                                 let g_f =
-                                                   FStar_TypeChecker_Common.NonTrivial
-                                                     f in
-                                                 let g_fw =
-                                                   let uu____8042 =
-                                                     FStar_Syntax_Util.mk_conj
-                                                       f w in
-                                                   FStar_TypeChecker_Common.NonTrivial
-                                                     uu____8042 in
-                                                 let uu____8043 =
-                                                   FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 g_fw in
-                                                 let uu____8044 =
-                                                   let uu____8045 =
-                                                     FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                       g_f in
-                                                   FStar_TypeChecker_Rel.imp_guard
-                                                     uu____8045 g_when in
-                                                 (uu____8043, uu____8044)
-                                             | (None ,Some w) ->
-                                                 let g_w =
-                                                   FStar_TypeChecker_Common.NonTrivial
-                                                     w in
-                                                 let g =
-                                                   FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                     g_w in
-                                                 let uu____8051 =
-                                                   FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 g_w in
-                                                 (uu____8051, g_when) in
-                                           (match uu____8014 with
-                                            | (c_weak,g_when_weak) ->
-                                                let binders =
-                                                  FStar_List.map
-                                                    FStar_Syntax_Syntax.mk_binder
-                                                    pat_bvs1 in
-                                                let uu____8059 =
-                                                  FStar_TypeChecker_Util.close_comp
-                                                    env pat_bvs1 c_weak in
-                                                let uu____8060 =
-                                                  FStar_TypeChecker_Rel.close_guard
-                                                    env binders g_when_weak in
-                                                (uu____8059, uu____8060,
-                                                  g_branch1)) in
-                                     (match uu____7968 with
-                                      | (c1,g_when1,g_branch1) ->
-                                          let branch_guard =
-                                            let uu____8073 =
-                                              let uu____8074 =
-                                                FStar_TypeChecker_Env.should_verify
-                                                  env in
-                                              Prims.op_Negation uu____8074 in
-                                            if uu____8073
-                                            then FStar_Syntax_Util.t_true
-                                            else
-                                              (let rec build_branch_guard
-                                                 scrutinee_tm1 pat_exp =
-                                                 let discriminate
-                                                   scrutinee_tm2 f =
-                                                   let uu____8105 =
-                                                     let uu____8106 =
-                                                       let uu____8107 =
-                                                         let uu____8109 =
-                                                           let uu____8113 =
-                                                             FStar_TypeChecker_Env.typ_of_datacon
-                                                               env
-                                                               f.FStar_Syntax_Syntax.v in
-                                                           FStar_TypeChecker_Env.datacons_of_typ
-                                                             env uu____8113 in
-                                                         Prims.snd uu____8109 in
-                                                       FStar_List.length
-                                                         uu____8107 in
-                                                     uu____8106 >
-                                                       (Prims.parse_int "1") in
-                                                   if uu____8105
-                                                   then
-                                                     let discriminator =
-                                                       FStar_Syntax_Util.mk_discriminator
-                                                         f.FStar_Syntax_Syntax.v in
-                                                     let uu____8122 =
-                                                       FStar_TypeChecker_Env.try_lookup_lid
-                                                         env discriminator in
-                                                     match uu____8122 with
-                                                     | None  -> []
-                                                     | uu____8133 ->
-                                                         let disc =
-                                                           FStar_Syntax_Syntax.fvar
-                                                             discriminator
-                                                             FStar_Syntax_Syntax.Delta_equational
-                                                             None in
-                                                         let disc1 =
-                                                           let uu____8143 =
-                                                             let uu____8144 =
-                                                               let uu____8145
-                                                                 =
-                                                                 FStar_Syntax_Syntax.as_arg
-                                                                   scrutinee_tm2 in
-                                                               [uu____8145] in
-                                                             FStar_Syntax_Syntax.mk_Tm_app
-                                                               disc
-                                                               uu____8144 in
-                                                           uu____8143 None
-                                                             scrutinee_tm2.FStar_Syntax_Syntax.pos in
-                                                         let uu____8150 =
-                                                           FStar_Syntax_Util.mk_eq2
-                                                             FStar_Syntax_Syntax.U_zero
-                                                             FStar_Syntax_Util.t_bool
-                                                             disc1
-                                                             FStar_Syntax_Const.exp_true_bool in
-                                                         [uu____8150]
-                                                   else [] in
-                                                 let fail uu____8158 =
-                                                   let uu____8159 =
-                                                     let uu____8160 =
-                                                       FStar_Range.string_of_range
-                                                         pat_exp.FStar_Syntax_Syntax.pos in
-                                                     let uu____8161 =
-                                                       FStar_Syntax_Print.term_to_string
-                                                         pat_exp in
-                                                     let uu____8162 =
-                                                       FStar_Syntax_Print.tag_of_term
-                                                         pat_exp in
-                                                     FStar_Util.format3
-                                                       "tc_eqn: Impossible (%s) %s (%s)"
-                                                       uu____8160 uu____8161
-                                                       uu____8162 in
-                                                   failwith uu____8159 in
-                                                 let rec head_constructor t =
-                                                   match t.FStar_Syntax_Syntax.n
-                                                   with
-                                                   | FStar_Syntax_Syntax.Tm_fvar
-                                                       fv ->
-                                                       fv.FStar_Syntax_Syntax.fv_name
-                                                   | FStar_Syntax_Syntax.Tm_uinst
-                                                       (t1,uu____8183) ->
-                                                       head_constructor t1
-                                                   | uu____8189 -> fail () in
-                                                 let pat_exp1 =
-                                                   let uu____8192 =
-                                                     FStar_Syntax_Subst.compress
-                                                       pat_exp in
-                                                   FStar_All.pipe_right
-                                                     uu____8192
-                                                     FStar_Syntax_Util.unmeta in
-                                                 match pat_exp1.FStar_Syntax_Syntax.n
-                                                 with
-                                                 | FStar_Syntax_Syntax.Tm_uvar
-                                                   _
-                                                   |FStar_Syntax_Syntax.Tm_app
-                                                    ({
-                                                       FStar_Syntax_Syntax.n
-                                                         =
-                                                         FStar_Syntax_Syntax.Tm_uvar
-                                                         _;
-                                                       FStar_Syntax_Syntax.tk
-                                                         = _;
-                                                       FStar_Syntax_Syntax.pos
-                                                         = _;
-                                                       FStar_Syntax_Syntax.vars
-                                                         = _;_},_)
-                                                    |FStar_Syntax_Syntax.Tm_name
-                                                     _
-                                                     |FStar_Syntax_Syntax.Tm_constant
-                                                     (FStar_Const.Const_unit
-                                                     ) -> []
-                                                 | FStar_Syntax_Syntax.Tm_constant
-                                                     c2 ->
-                                                     let uu____8209 =
-                                                       let uu____8210 =
-                                                         tc_constant
-                                                           pat_exp1.FStar_Syntax_Syntax.pos
-                                                           c2 in
-                                                       FStar_Syntax_Util.mk_eq2
-                                                         FStar_Syntax_Syntax.U_zero
-                                                         uu____8210
-                                                         scrutinee_tm1
-                                                         pat_exp1 in
-                                                     [uu____8209]
-                                                 | FStar_Syntax_Syntax.Tm_uinst
-                                                   _
-                                                   |FStar_Syntax_Syntax.Tm_fvar
-                                                   _ ->
-                                                     let f =
-                                                       head_constructor
-                                                         pat_exp1 in
-                                                     let uu____8218 =
-                                                       let uu____8219 =
-                                                         FStar_TypeChecker_Env.is_datacon
-                                                           env
-                                                           f.FStar_Syntax_Syntax.v in
-                                                       Prims.op_Negation
-                                                         uu____8219 in
-                                                     if uu____8218
-                                                     then []
-                                                     else
-                                                       (let uu____8226 =
-                                                          head_constructor
-                                                            pat_exp1 in
-                                                        discriminate
-                                                          scrutinee_tm1
-                                                          uu____8226)
-                                                 | FStar_Syntax_Syntax.Tm_app
-                                                     (head1,args) ->
-                                                     let f =
-                                                       head_constructor head1 in
-                                                     let uu____8253 =
-                                                       let uu____8254 =
-                                                         FStar_TypeChecker_Env.is_datacon
-                                                           env
-                                                           f.FStar_Syntax_Syntax.v in
-                                                       Prims.op_Negation
-                                                         uu____8254 in
-                                                     if uu____8253
-                                                     then []
-                                                     else
-                                                       (let sub_term_guards =
-                                                          let uu____8263 =
-                                                            FStar_All.pipe_right
-                                                              args
-                                                              (FStar_List.mapi
-                                                                 (fun i  ->
-                                                                    fun
-                                                                    uu____8279
-                                                                     ->
-                                                                    match uu____8279
-                                                                    with
-                                                                    | 
-                                                                    (ei,uu____8286)
-                                                                    ->
-                                                                    let projector
-                                                                    =
-                                                                    FStar_TypeChecker_Env.lookup_projector
-                                                                    env
-                                                                    f.FStar_Syntax_Syntax.v
-                                                                    i in
-                                                                    let uu____8296
-                                                                    =
-                                                                    FStar_TypeChecker_Env.try_lookup_lid
-                                                                    env
-                                                                    projector in
-                                                                    (match uu____8296
-                                                                    with
-                                                                    | 
-                                                                    None  ->
-                                                                    []
-                                                                    | 
-                                                                    uu____8307
-                                                                    ->
-                                                                    let sub_term
-                                                                    =
-                                                                    let uu____8316
-                                                                    =
-                                                                    let uu____8317
-                                                                    =
-                                                                    FStar_Syntax_Syntax.fvar
-                                                                    (FStar_Ident.set_lid_range
-                                                                    projector
-                                                                    f.FStar_Syntax_Syntax.p)
-                                                                    FStar_Syntax_Syntax.Delta_equational
-                                                                    None in
-                                                                    let uu____8322
-                                                                    =
-                                                                    let uu____8323
-                                                                    =
-                                                                    FStar_Syntax_Syntax.as_arg
-                                                                    scrutinee_tm1 in
-                                                                    [uu____8323] in
-                                                                    FStar_Syntax_Syntax.mk_Tm_app
-                                                                    uu____8317
-                                                                    uu____8322 in
-                                                                    uu____8316
-                                                                    None
-                                                                    f.FStar_Syntax_Syntax.p in
-                                                                    build_branch_guard
-                                                                    sub_term
-                                                                    ei))) in
-                                                          FStar_All.pipe_right
-                                                            uu____8263
-                                                            FStar_List.flatten in
-                                                        let uu____8335 =
-                                                          discriminate
-                                                            scrutinee_tm1 f in
-                                                        FStar_List.append
-                                                          uu____8335
-                                                          sub_term_guards)
-                                                 | uu____8339 -> [] in
-                                               let build_and_check_branch_guard
-                                                 scrutinee_tm1 pat =
-                                                 let uu____8351 =
-                                                   let uu____8352 =
-                                                     FStar_TypeChecker_Env.should_verify
-                                                       env in
-                                                   Prims.op_Negation
-                                                     uu____8352 in
-                                                 if uu____8351
-                                                 then
-                                                   FStar_TypeChecker_Util.fvar_const
-                                                     env
-                                                     FStar_Syntax_Const.true_lid
-                                                 else
-                                                   (let t =
-                                                      let uu____8355 =
-                                                        build_branch_guard
-                                                          scrutinee_tm1 pat in
-                                                      FStar_All.pipe_left
-                                                        FStar_Syntax_Util.mk_conj_l
-                                                        uu____8355 in
-                                                    let uu____8358 =
-                                                      FStar_Syntax_Util.type_u
-                                                        () in
-                                                    match uu____8358 with
-                                                    | (k,uu____8362) ->
-                                                        let uu____8363 =
-                                                          tc_check_tot_or_gtot_term
-                                                            scrutinee_env t k in
-                                                        (match uu____8363
-                                                         with
-                                                         | (t1,uu____8368,uu____8369)
-                                                             -> t1)) in
-                                               let branch_guard =
-                                                 let uu____8371 =
-                                                   FStar_All.pipe_right
-                                                     norm_disj_exps
-                                                     (FStar_List.map
-                                                        (build_and_check_branch_guard
-                                                           scrutinee_tm)) in
-                                                 FStar_All.pipe_right
-                                                   uu____8371
-                                                   FStar_Syntax_Util.mk_disj_l in
-                                               let branch_guard1 =
-                                                 match when_condition with
-                                                 | None  -> branch_guard
-                                                 | Some w ->
-                                                     FStar_Syntax_Util.mk_conj
-                                                       branch_guard w in
-                                               branch_guard1) in
-                                          let guard =
-                                            FStar_TypeChecker_Rel.conj_guard
-                                              g_when1 g_branch1 in
-                                          ((let uu____8382 =
-                                              FStar_TypeChecker_Env.debug env
-                                                FStar_Options.High in
-                                            if uu____8382
-                                            then
-                                              let uu____8383 =
-                                                FStar_TypeChecker_Rel.guard_to_string
-                                                  env guard in
-                                              FStar_All.pipe_left
-                                                (FStar_Util.print1
-                                                   "Carrying guard from match: %s\n")
-                                                uu____8383
-                                            else ());
-                                           (let uu____8385 =
-                                              FStar_Syntax_Subst.close_branch
-                                                (pattern1, when_clause1,
-                                                  branch_exp1) in
-                                            (uu____8385, branch_guard, c1,
-                                              guard)))))))))
-and check_top_level_let:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      let env1 = instantiate_both env in
-      match e.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____8403 = check_let_bound_def true env1 lb in
-          (match uu____8403 with
-           | (e1,univ_vars1,c1,g1,annotated) ->
-               let uu____8417 =
-                 if
-                   annotated &&
-                     (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
-                 then (g1, e1, univ_vars1, c1)
-                 else
-                   (let g11 =
-                      let uu____8428 =
-                        FStar_TypeChecker_Rel.solve_deferred_constraints env1
-                          g1 in
-                      FStar_All.pipe_right uu____8428
-                        FStar_TypeChecker_Rel.resolve_implicits in
-                    let uu____8430 =
-                      let uu____8435 =
-                        let uu____8441 =
-                          let uu____8446 =
-                            let uu____8454 = c1.FStar_Syntax_Syntax.comp () in
-                            ((lb.FStar_Syntax_Syntax.lbname), e1, uu____8454) in
-                          [uu____8446] in
-                        FStar_TypeChecker_Util.generalize env1 uu____8441 in
-                      FStar_List.hd uu____8435 in
-                    match uu____8430 with
-                    | (uu____8483,univs1,e11,c11) ->
-                        (g11, e11, univs1,
-                          (FStar_Syntax_Util.lcomp_of_comp c11))) in
-               (match uu____8417 with
-                | (g11,e11,univ_vars2,c11) ->
-                    let uu____8494 =
-                      let uu____8499 =
-                        FStar_TypeChecker_Env.should_verify env1 in
-                      if uu____8499
-                      then
-                        let uu____8504 =
-                          FStar_TypeChecker_Util.check_top_level env1 g11 c11 in
-                        match uu____8504 with
-                        | (ok,c12) ->
-                            (if ok
-                             then (e2, c12)
-                             else
-                               ((let uu____8521 =
-                                   FStar_Options.warn_top_level_effects () in
-                                 if uu____8521
-                                 then
-                                   let uu____8522 =
-                                     FStar_TypeChecker_Env.get_range env1 in
-                                   FStar_Errors.warn uu____8522
-                                     FStar_TypeChecker_Err.top_level_effect
-                                 else ());
-                                (let uu____8524 =
-                                   (FStar_Syntax_Syntax.mk
-                                      (FStar_Syntax_Syntax.Tm_meta
-                                         (e2,
-                                           (FStar_Syntax_Syntax.Meta_desugared
-                                              FStar_Syntax_Syntax.Masked_effect))))
-                                     None e2.FStar_Syntax_Syntax.pos in
-                                 (uu____8524, c12))))
-                      else
-                        (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let c =
-                            let uu____8542 = c11.FStar_Syntax_Syntax.comp () in
-                            FStar_All.pipe_right uu____8542
-                              (FStar_TypeChecker_Normalize.normalize_comp
-                                 [FStar_TypeChecker_Normalize.Beta] env1) in
-                          let e21 =
-                            let uu____8550 = FStar_Syntax_Util.is_pure_comp c in
-                            if uu____8550
-                            then e2
-                            else
-                              (FStar_Syntax_Syntax.mk
-                                 (FStar_Syntax_Syntax.Tm_meta
-                                    (e2,
-                                      (FStar_Syntax_Syntax.Meta_desugared
-                                         FStar_Syntax_Syntax.Masked_effect))))
-                                None e2.FStar_Syntax_Syntax.pos in
-                          (e21, c))) in
-                    (match uu____8494 with
-                     | (e21,c12) ->
-                         let cres =
-                           FStar_TypeChecker_Env.null_wp_for_eff env1
-                             (FStar_Syntax_Util.comp_effect_name c12)
-                             FStar_Syntax_Syntax.U_zero
-                             FStar_TypeChecker_Common.t_unit in
-                         (FStar_ST.write e21.FStar_Syntax_Syntax.tk
-                            (Some
-                               (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n));
-                          (let lb1 =
-                             FStar_Syntax_Util.close_univs_and_mk_letbinding
-                               None lb.FStar_Syntax_Syntax.lbname univ_vars2
-                               (FStar_Syntax_Util.comp_result c12)
-                               (FStar_Syntax_Util.comp_effect_name c12) e11 in
-                           let uu____8582 =
-                             (FStar_Syntax_Syntax.mk
-                                (FStar_Syntax_Syntax.Tm_let
-                                   ((false, [lb1]), e21)))
-                               (Some
-                                  (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n))
-                               e.FStar_Syntax_Syntax.pos in
-                           (uu____8582,
-                             (FStar_Syntax_Util.lcomp_of_comp cres),
-                             FStar_TypeChecker_Rel.trivial_guard))))))
-      | uu____8601 -> failwith "Impossible"
-and check_inner_let:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      let env1 = instantiate_both env in
-      match e.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let env2 =
-            let uu___115_8622 = env1 in
-            {
-              FStar_TypeChecker_Env.solver =
-                (uu___115_8622.FStar_TypeChecker_Env.solver);
-              FStar_TypeChecker_Env.range =
-                (uu___115_8622.FStar_TypeChecker_Env.range);
-              FStar_TypeChecker_Env.curmodule =
-                (uu___115_8622.FStar_TypeChecker_Env.curmodule);
-              FStar_TypeChecker_Env.gamma =
-                (uu___115_8622.FStar_TypeChecker_Env.gamma);
-              FStar_TypeChecker_Env.gamma_cache =
-                (uu___115_8622.FStar_TypeChecker_Env.gamma_cache);
-              FStar_TypeChecker_Env.modules =
-                (uu___115_8622.FStar_TypeChecker_Env.modules);
-              FStar_TypeChecker_Env.expected_typ =
-                (uu___115_8622.FStar_TypeChecker_Env.expected_typ);
-              FStar_TypeChecker_Env.sigtab =
-                (uu___115_8622.FStar_TypeChecker_Env.sigtab);
-              FStar_TypeChecker_Env.is_pattern =
-                (uu___115_8622.FStar_TypeChecker_Env.is_pattern);
-              FStar_TypeChecker_Env.instantiate_imp =
-                (uu___115_8622.FStar_TypeChecker_Env.instantiate_imp);
-              FStar_TypeChecker_Env.effects =
-                (uu___115_8622.FStar_TypeChecker_Env.effects);
-              FStar_TypeChecker_Env.generalize =
-                (uu___115_8622.FStar_TypeChecker_Env.generalize);
-              FStar_TypeChecker_Env.letrecs =
-                (uu___115_8622.FStar_TypeChecker_Env.letrecs);
-              FStar_TypeChecker_Env.top_level = false;
-              FStar_TypeChecker_Env.check_uvars =
-                (uu___115_8622.FStar_TypeChecker_Env.check_uvars);
-              FStar_TypeChecker_Env.use_eq =
-                (uu___115_8622.FStar_TypeChecker_Env.use_eq);
-              FStar_TypeChecker_Env.is_iface =
-                (uu___115_8622.FStar_TypeChecker_Env.is_iface);
-              FStar_TypeChecker_Env.admit =
-                (uu___115_8622.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___115_8622.FStar_TypeChecker_Env.lax);
-              FStar_TypeChecker_Env.lax_universes =
-                (uu___115_8622.FStar_TypeChecker_Env.lax_universes);
-              FStar_TypeChecker_Env.type_of =
-                (uu___115_8622.FStar_TypeChecker_Env.type_of);
-              FStar_TypeChecker_Env.universe_of =
-                (uu___115_8622.FStar_TypeChecker_Env.universe_of);
-              FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___115_8622.FStar_TypeChecker_Env.use_bv_sorts);
-              FStar_TypeChecker_Env.qname_and_index =
-                (uu___115_8622.FStar_TypeChecker_Env.qname_and_index)
-            } in
-          let uu____8623 =
-            let uu____8629 =
-              let uu____8630 = FStar_TypeChecker_Env.clear_expected_typ env2 in
-              FStar_All.pipe_right uu____8630 Prims.fst in
-            check_let_bound_def false uu____8629 lb in
-          (match uu____8623 with
-           | (e1,uu____8642,c1,g1,annotated) ->
-               let x =
-                 let uu___116_8647 =
-                   FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                 {
-                   FStar_Syntax_Syntax.ppname =
-                     (uu___116_8647.FStar_Syntax_Syntax.ppname);
-                   FStar_Syntax_Syntax.index =
-                     (uu___116_8647.FStar_Syntax_Syntax.index);
-                   FStar_Syntax_Syntax.sort =
-                     (c1.FStar_Syntax_Syntax.res_typ)
-                 } in
-               let uu____8648 =
-                 let uu____8651 =
-                   let uu____8652 = FStar_Syntax_Syntax.mk_binder x in
-                   [uu____8652] in
-                 FStar_Syntax_Subst.open_term uu____8651 e2 in
-               (match uu____8648 with
-                | (xb,e21) ->
-                    let xbinder = FStar_List.hd xb in
-                    let x1 = Prims.fst xbinder in
-                    let uu____8664 =
-                      let uu____8668 = FStar_TypeChecker_Env.push_bv env2 x1 in
-                      tc_term uu____8668 e21 in
-                    (match uu____8664 with
-                     | (e22,c2,g2) ->
-                         let cres =
-                           FStar_TypeChecker_Util.bind
-                             e1.FStar_Syntax_Syntax.pos env2 (Some e1) c1
-                             ((Some x1), c2) in
-                         let e11 =
-                           FStar_TypeChecker_Util.maybe_lift env2 e1
-                             c1.FStar_Syntax_Syntax.eff_name
-                             cres.FStar_Syntax_Syntax.eff_name
-                             c1.FStar_Syntax_Syntax.res_typ in
-                         let e23 =
-                           FStar_TypeChecker_Util.maybe_lift env2 e22
-                             c2.FStar_Syntax_Syntax.eff_name
-                             cres.FStar_Syntax_Syntax.eff_name
-                             c2.FStar_Syntax_Syntax.res_typ in
-                         let lb1 =
-                           FStar_Syntax_Util.mk_letbinding
-                             (FStar_Util.Inl x1) []
-                             c1.FStar_Syntax_Syntax.res_typ
-                             c1.FStar_Syntax_Syntax.eff_name e11 in
-                         let e3 =
-                           let uu____8683 =
-                             let uu____8686 =
-                               let uu____8687 =
-                                 let uu____8695 =
-                                   FStar_Syntax_Subst.close xb e23 in
-                                 ((false, [lb1]), uu____8695) in
-                               FStar_Syntax_Syntax.Tm_let uu____8687 in
-                             FStar_Syntax_Syntax.mk uu____8686 in
-                           uu____8683
-                             (Some
-                                ((cres.FStar_Syntax_Syntax.res_typ).FStar_Syntax_Syntax.n))
-                             e.FStar_Syntax_Syntax.pos in
-                         let e4 =
-                           FStar_TypeChecker_Util.maybe_monadic env2 e3
-                             cres.FStar_Syntax_Syntax.eff_name
-                             cres.FStar_Syntax_Syntax.res_typ in
-                         let x_eq_e1 =
-                           let uu____8710 =
-                             let uu____8711 =
-                               env2.FStar_TypeChecker_Env.universe_of env2
-                                 c1.FStar_Syntax_Syntax.res_typ in
-                             let uu____8712 =
-                               FStar_Syntax_Syntax.bv_to_name x1 in
-                             FStar_Syntax_Util.mk_eq2 uu____8711
-                               c1.FStar_Syntax_Syntax.res_typ uu____8712 e11 in
-                           FStar_All.pipe_left
-                             (fun _0_32  ->
-                                FStar_TypeChecker_Common.NonTrivial _0_32)
-                             uu____8710 in
-                         let g21 =
-                           let uu____8714 =
-                             let uu____8715 =
-                               FStar_TypeChecker_Rel.guard_of_guard_formula
-                                 x_eq_e1 in
-                             FStar_TypeChecker_Rel.imp_guard uu____8715 g2 in
-                           FStar_TypeChecker_Rel.close_guard env2 xb
-                             uu____8714 in
-                         let guard = FStar_TypeChecker_Rel.conj_guard g1 g21 in
-                         let uu____8717 =
-                           let uu____8718 =
-                             FStar_TypeChecker_Env.expected_typ env2 in
-                           FStar_Option.isSome uu____8718 in
-                         if uu____8717
-                         then
-                           let tt =
-                             let uu____8724 =
-                               FStar_TypeChecker_Env.expected_typ env2 in
-                             FStar_All.pipe_right uu____8724 FStar_Option.get in
-                           ((let uu____8728 =
-                               FStar_All.pipe_left
-                                 (FStar_TypeChecker_Env.debug env2)
-                                 (FStar_Options.Other "Exports") in
-                             if uu____8728
-                             then
-                               let uu____8729 =
-                                 FStar_Syntax_Print.term_to_string tt in
-                               let uu____8730 =
-                                 FStar_Syntax_Print.term_to_string
-                                   cres.FStar_Syntax_Syntax.res_typ in
-                               FStar_Util.print2
-                                 "Got expected type from env %s\ncres.res_typ=%s\n"
-                                 uu____8729 uu____8730
-                             else ());
-                            (e4, cres, guard))
-                         else
-                           (let t =
-                              check_no_escape None env2 [x1]
-                                cres.FStar_Syntax_Syntax.res_typ in
-                            (let uu____8735 =
-                               FStar_All.pipe_left
-                                 (FStar_TypeChecker_Env.debug env2)
-                                 (FStar_Options.Other "Exports") in
-                             if uu____8735
-                             then
-                               let uu____8736 =
-                                 FStar_Syntax_Print.term_to_string
-                                   cres.FStar_Syntax_Syntax.res_typ in
-                               let uu____8737 =
-                                 FStar_Syntax_Print.term_to_string t in
-                               FStar_Util.print2
-                                 "Checked %s has no escaping types; normalized to %s\n"
-                                 uu____8736 uu____8737
-                             else ());
-                            (e4,
-                              ((let uu___117_8739 = cres in
-                                {
-                                  FStar_Syntax_Syntax.eff_name =
-                                    (uu___117_8739.FStar_Syntax_Syntax.eff_name);
-                                  FStar_Syntax_Syntax.res_typ = t;
-                                  FStar_Syntax_Syntax.cflags =
-                                    (uu___117_8739.FStar_Syntax_Syntax.cflags);
-                                  FStar_Syntax_Syntax.comp =
-                                    (uu___117_8739.FStar_Syntax_Syntax.comp)
-                                })), guard)))))
-      | uu____8740 -> failwith "Impossible"
-and check_top_level_let_rec:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun top  ->
-      let env1 = instantiate_both env in
-      match top.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____8761 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____8761 with
-           | (lbs1,e21) ->
-               let uu____8772 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____8772 with
-                | (env0,topt) ->
-                    let uu____8783 = build_let_rec_env true env0 lbs1 in
-                    (match uu____8783 with
-                     | (lbs2,rec_env) ->
-                         let uu____8794 = check_let_recs rec_env lbs2 in
-                         (match uu____8794 with
-                          | (lbs3,g_lbs) ->
-                              let g_lbs1 =
-                                let uu____8806 =
-                                  FStar_TypeChecker_Rel.solve_deferred_constraints
-                                    env1 g_lbs in
-                                FStar_All.pipe_right uu____8806
-                                  FStar_TypeChecker_Rel.resolve_implicits in
-                              let all_lb_names =
-                                let uu____8810 =
-                                  FStar_All.pipe_right lbs3
-                                    (FStar_List.map
-                                       (fun lb  ->
-                                          FStar_Util.right
-                                            lb.FStar_Syntax_Syntax.lbname)) in
-                                FStar_All.pipe_right uu____8810
-                                  (fun _0_33  -> Some _0_33) in
-                              let lbs4 =
-                                if
-                                  Prims.op_Negation
-                                    env1.FStar_TypeChecker_Env.generalize
-                                then
-                                  FStar_All.pipe_right lbs3
-                                    (FStar_List.map
-                                       (fun lb  ->
-                                          if
-                                            lb.FStar_Syntax_Syntax.lbunivs =
-                                              []
-                                          then lb
-                                          else
-                                            FStar_Syntax_Util.close_univs_and_mk_letbinding
-                                              all_lb_names
-                                              lb.FStar_Syntax_Syntax.lbname
-                                              lb.FStar_Syntax_Syntax.lbunivs
-                                              lb.FStar_Syntax_Syntax.lbtyp
-                                              lb.FStar_Syntax_Syntax.lbeff
-                                              lb.FStar_Syntax_Syntax.lbdef))
-                                else
-                                  (let ecs =
-                                     let uu____8834 =
-                                       FStar_All.pipe_right lbs3
-                                         (FStar_List.map
-                                            (fun lb  ->
-                                               let uu____8856 =
-                                                 FStar_Syntax_Syntax.mk_Total
-                                                   lb.FStar_Syntax_Syntax.lbtyp in
-                                               ((lb.FStar_Syntax_Syntax.lbname),
-                                                 (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____8856))) in
-                                     FStar_TypeChecker_Util.generalize env1
-                                       uu____8834 in
-                                   FStar_All.pipe_right ecs
-                                     (FStar_List.map
-                                        (fun uu____8876  ->
-                                           match uu____8876 with
-                                           | (x,uvs,e,c) ->
-                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
-                                                 all_lb_names x uvs
-                                                 (FStar_Syntax_Util.comp_result
-                                                    c)
-                                                 (FStar_Syntax_Util.comp_effect_name
-                                                    c) e))) in
-                              let cres =
-                                let uu____8901 =
-                                  FStar_Syntax_Syntax.mk_Total
-                                    FStar_TypeChecker_Common.t_unit in
-                                FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp uu____8901 in
-                              (FStar_ST.write e21.FStar_Syntax_Syntax.tk
-                                 (Some
-                                    (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n));
-                               (let uu____8910 =
-                                  FStar_Syntax_Subst.close_let_rec lbs4 e21 in
-                                match uu____8910 with
-                                | (lbs5,e22) ->
-                                    let uu____8921 =
-                                      (FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_let
-                                            ((true, lbs5), e22)))
-                                        (Some
-                                           (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n))
-                                        top.FStar_Syntax_Syntax.pos in
-                                    let uu____8936 =
-                                      FStar_TypeChecker_Rel.discharge_guard
-                                        env1 g_lbs1 in
-                                    (uu____8921, cres, uu____8936)))))))
-      | uu____8939 -> failwith "Impossible"
-and check_inner_let_rec:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun top  ->
-      let env1 = instantiate_both env in
-      match top.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____8960 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____8960 with
-           | (lbs1,e21) ->
-               let uu____8971 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____8971 with
-                | (env0,topt) ->
-                    let uu____8982 = build_let_rec_env false env0 lbs1 in
-                    (match uu____8982 with
-                     | (lbs2,rec_env) ->
-                         let uu____8993 = check_let_recs rec_env lbs2 in
-                         (match uu____8993 with
-                          | (lbs3,g_lbs) ->
-                              let uu____9004 =
-                                FStar_All.pipe_right lbs3
-                                  (FStar_Util.fold_map
-                                     (fun env2  ->
-                                        fun lb  ->
-                                          let x =
-                                            let uu___118_9015 =
-                                              FStar_Util.left
-                                                lb.FStar_Syntax_Syntax.lbname in
-                                            {
-                                              FStar_Syntax_Syntax.ppname =
-                                                (uu___118_9015.FStar_Syntax_Syntax.ppname);
-                                              FStar_Syntax_Syntax.index =
-                                                (uu___118_9015.FStar_Syntax_Syntax.index);
-                                              FStar_Syntax_Syntax.sort =
-                                                (lb.FStar_Syntax_Syntax.lbtyp)
-                                            } in
-                                          let lb1 =
-                                            let uu___119_9017 = lb in
-                                            {
-                                              FStar_Syntax_Syntax.lbname =
-                                                (FStar_Util.Inl x);
-                                              FStar_Syntax_Syntax.lbunivs =
-                                                (uu___119_9017.FStar_Syntax_Syntax.lbunivs);
-                                              FStar_Syntax_Syntax.lbtyp =
-                                                (uu___119_9017.FStar_Syntax_Syntax.lbtyp);
-                                              FStar_Syntax_Syntax.lbeff =
-                                                (uu___119_9017.FStar_Syntax_Syntax.lbeff);
-                                              FStar_Syntax_Syntax.lbdef =
-                                                (uu___119_9017.FStar_Syntax_Syntax.lbdef)
-                                            } in
-                                          let env3 =
-                                            FStar_TypeChecker_Env.push_let_binding
-                                              env2
-                                              lb1.FStar_Syntax_Syntax.lbname
-                                              ([],
-                                                (lb1.FStar_Syntax_Syntax.lbtyp)) in
-                                          (env3, lb1)) env1) in
-                              (match uu____9004 with
-                               | (env2,lbs4) ->
-                                   let bvs =
-                                     FStar_All.pipe_right lbs4
-                                       (FStar_List.map
-                                          (fun lb  ->
-                                             FStar_Util.left
-                                               lb.FStar_Syntax_Syntax.lbname)) in
-                                   let uu____9034 = tc_term env2 e21 in
-                                   (match uu____9034 with
-                                    | (e22,cres,g2) ->
-                                        let guard =
-                                          let uu____9045 =
-                                            let uu____9046 =
-                                              FStar_List.map
-                                                FStar_Syntax_Syntax.mk_binder
-                                                bvs in
-                                            FStar_TypeChecker_Rel.close_guard
-                                              env2 uu____9046 g2 in
-                                          FStar_TypeChecker_Rel.conj_guard
-                                            g_lbs uu____9045 in
-                                        let cres1 =
-                                          FStar_TypeChecker_Util.close_comp
-                                            env2 bvs cres in
-                                        let tres =
-                                          norm env2
-                                            cres1.FStar_Syntax_Syntax.res_typ in
-                                        let cres2 =
-                                          let uu___120_9050 = cres1 in
-                                          {
-                                            FStar_Syntax_Syntax.eff_name =
-                                              (uu___120_9050.FStar_Syntax_Syntax.eff_name);
-                                            FStar_Syntax_Syntax.res_typ =
-                                              tres;
-                                            FStar_Syntax_Syntax.cflags =
-                                              (uu___120_9050.FStar_Syntax_Syntax.cflags);
-                                            FStar_Syntax_Syntax.comp =
-                                              (uu___120_9050.FStar_Syntax_Syntax.comp)
-                                          } in
-                                        let uu____9051 =
-                                          FStar_Syntax_Subst.close_let_rec
-                                            lbs4 e22 in
-                                        (match uu____9051 with
-                                         | (lbs5,e23) ->
-                                             let e =
-                                               (FStar_Syntax_Syntax.mk
-                                                  (FStar_Syntax_Syntax.Tm_let
-                                                     ((true, lbs5), e23)))
-                                                 (Some
-                                                    (tres.FStar_Syntax_Syntax.n))
-                                                 top.FStar_Syntax_Syntax.pos in
-                                             (match topt with
-                                              | Some uu____9080 ->
-                                                  (e, cres2, guard)
-                                              | None  ->
-                                                  let tres1 =
-                                                    check_no_escape None env2
-                                                      bvs tres in
-                                                  let cres3 =
-                                                    let uu___121_9085 = cres2 in
-                                                    {
-                                                      FStar_Syntax_Syntax.eff_name
-                                                        =
-                                                        (uu___121_9085.FStar_Syntax_Syntax.eff_name);
-                                                      FStar_Syntax_Syntax.res_typ
-                                                        = tres1;
-                                                      FStar_Syntax_Syntax.cflags
-                                                        =
-                                                        (uu___121_9085.FStar_Syntax_Syntax.cflags);
-                                                      FStar_Syntax_Syntax.comp
-                                                        =
-                                                        (uu___121_9085.FStar_Syntax_Syntax.comp)
-                                                    } in
-                                                  (e, cres3, guard)))))))))
-      | uu____9088 -> failwith "Impossible"
-and build_let_rec_env:
-  Prims.bool ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.letbinding Prims.list ->
-        (FStar_Syntax_Syntax.letbinding Prims.list*
-          FStar_TypeChecker_Env.env_t)
-  =
-  fun top_level  ->
-    fun env  ->
-      fun lbs  ->
-        let env0 = env in
-        let termination_check_enabled t =
-          let uu____9104 = FStar_Syntax_Util.arrow_formals_comp t in
-          match uu____9104 with
-          | (uu____9110,c) ->
-              let quals =
-                FStar_TypeChecker_Env.lookup_effect_quals env
-                  (FStar_Syntax_Util.comp_effect_name c) in
-              FStar_All.pipe_right quals
-                (FStar_List.contains FStar_Syntax_Syntax.TotalEffect) in
-        let uu____9121 =
-          FStar_List.fold_left
-            (fun uu____9128  ->
-               fun lb  ->
-                 match uu____9128 with
-                 | (lbs1,env1) ->
-                     let uu____9140 =
-                       FStar_TypeChecker_Util.extract_let_rec_annotation env1
-                         lb in
-                     (match uu____9140 with
-                      | (univ_vars1,t,check_t) ->
-                          let env2 =
-                            FStar_TypeChecker_Env.push_univ_vars env1
-                              univ_vars1 in
-                          let e =
-                            FStar_Syntax_Util.unascribe
-                              lb.FStar_Syntax_Syntax.lbdef in
-                          let t1 =
-                            if Prims.op_Negation check_t
-                            then t
-                            else
-                              (let uu____9154 =
-                                 let uu____9158 =
-                                   let uu____9159 =
-                                     FStar_Syntax_Util.type_u () in
-                                   FStar_All.pipe_left Prims.fst uu____9159 in
-                                 tc_check_tot_or_gtot_term
-                                   (let uu___122_9164 = env0 in
-                                    {
-                                      FStar_TypeChecker_Env.solver =
-                                        (uu___122_9164.FStar_TypeChecker_Env.solver);
-                                      FStar_TypeChecker_Env.range =
-                                        (uu___122_9164.FStar_TypeChecker_Env.range);
-                                      FStar_TypeChecker_Env.curmodule =
-                                        (uu___122_9164.FStar_TypeChecker_Env.curmodule);
-                                      FStar_TypeChecker_Env.gamma =
-                                        (uu___122_9164.FStar_TypeChecker_Env.gamma);
-                                      FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___122_9164.FStar_TypeChecker_Env.gamma_cache);
-                                      FStar_TypeChecker_Env.modules =
-                                        (uu___122_9164.FStar_TypeChecker_Env.modules);
-                                      FStar_TypeChecker_Env.expected_typ =
-                                        (uu___122_9164.FStar_TypeChecker_Env.expected_typ);
-                                      FStar_TypeChecker_Env.sigtab =
-                                        (uu___122_9164.FStar_TypeChecker_Env.sigtab);
-                                      FStar_TypeChecker_Env.is_pattern =
-                                        (uu___122_9164.FStar_TypeChecker_Env.is_pattern);
-                                      FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___122_9164.FStar_TypeChecker_Env.instantiate_imp);
-                                      FStar_TypeChecker_Env.effects =
-                                        (uu___122_9164.FStar_TypeChecker_Env.effects);
-                                      FStar_TypeChecker_Env.generalize =
-                                        (uu___122_9164.FStar_TypeChecker_Env.generalize);
-                                      FStar_TypeChecker_Env.letrecs =
-                                        (uu___122_9164.FStar_TypeChecker_Env.letrecs);
-                                      FStar_TypeChecker_Env.top_level =
-                                        (uu___122_9164.FStar_TypeChecker_Env.top_level);
-                                      FStar_TypeChecker_Env.check_uvars =
-                                        true;
-                                      FStar_TypeChecker_Env.use_eq =
-                                        (uu___122_9164.FStar_TypeChecker_Env.use_eq);
-                                      FStar_TypeChecker_Env.is_iface =
-                                        (uu___122_9164.FStar_TypeChecker_Env.is_iface);
-                                      FStar_TypeChecker_Env.admit =
-                                        (uu___122_9164.FStar_TypeChecker_Env.admit);
-                                      FStar_TypeChecker_Env.lax =
-                                        (uu___122_9164.FStar_TypeChecker_Env.lax);
-                                      FStar_TypeChecker_Env.lax_universes =
-                                        (uu___122_9164.FStar_TypeChecker_Env.lax_universes);
-                                      FStar_TypeChecker_Env.type_of =
-                                        (uu___122_9164.FStar_TypeChecker_Env.type_of);
-                                      FStar_TypeChecker_Env.universe_of =
-                                        (uu___122_9164.FStar_TypeChecker_Env.universe_of);
-                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___122_9164.FStar_TypeChecker_Env.use_bv_sorts);
-                                      FStar_TypeChecker_Env.qname_and_index =
-                                        (uu___122_9164.FStar_TypeChecker_Env.qname_and_index)
-                                    }) t uu____9158 in
-                               match uu____9154 with
-                               | (t1,uu____9166,g) ->
-                                   let g1 =
-                                     FStar_TypeChecker_Rel.resolve_implicits
-                                       g in
-                                   ((let uu____9170 =
-                                       FStar_TypeChecker_Rel.discharge_guard
-                                         env2 g1 in
-                                     FStar_All.pipe_left Prims.ignore
-                                       uu____9170);
-                                    norm env0 t1)) in
-                          let env3 =
-                            let uu____9172 =
-                              (termination_check_enabled t1) &&
-                                (FStar_TypeChecker_Env.should_verify env2) in
-                            if uu____9172
-                            then
-                              let uu___123_9173 = env2 in
-                              {
-                                FStar_TypeChecker_Env.solver =
-                                  (uu___123_9173.FStar_TypeChecker_Env.solver);
-                                FStar_TypeChecker_Env.range =
-                                  (uu___123_9173.FStar_TypeChecker_Env.range);
-                                FStar_TypeChecker_Env.curmodule =
-                                  (uu___123_9173.FStar_TypeChecker_Env.curmodule);
-                                FStar_TypeChecker_Env.gamma =
-                                  (uu___123_9173.FStar_TypeChecker_Env.gamma);
-                                FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___123_9173.FStar_TypeChecker_Env.gamma_cache);
-                                FStar_TypeChecker_Env.modules =
-                                  (uu___123_9173.FStar_TypeChecker_Env.modules);
-                                FStar_TypeChecker_Env.expected_typ =
-                                  (uu___123_9173.FStar_TypeChecker_Env.expected_typ);
-                                FStar_TypeChecker_Env.sigtab =
-                                  (uu___123_9173.FStar_TypeChecker_Env.sigtab);
-                                FStar_TypeChecker_Env.is_pattern =
-                                  (uu___123_9173.FStar_TypeChecker_Env.is_pattern);
-                                FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___123_9173.FStar_TypeChecker_Env.instantiate_imp);
-                                FStar_TypeChecker_Env.effects =
-                                  (uu___123_9173.FStar_TypeChecker_Env.effects);
-                                FStar_TypeChecker_Env.generalize =
-                                  (uu___123_9173.FStar_TypeChecker_Env.generalize);
-                                FStar_TypeChecker_Env.letrecs =
-                                  (((lb.FStar_Syntax_Syntax.lbname), t1) ::
-                                  (env2.FStar_TypeChecker_Env.letrecs));
-                                FStar_TypeChecker_Env.top_level =
-                                  (uu___123_9173.FStar_TypeChecker_Env.top_level);
-                                FStar_TypeChecker_Env.check_uvars =
-                                  (uu___123_9173.FStar_TypeChecker_Env.check_uvars);
-                                FStar_TypeChecker_Env.use_eq =
-                                  (uu___123_9173.FStar_TypeChecker_Env.use_eq);
-                                FStar_TypeChecker_Env.is_iface =
-                                  (uu___123_9173.FStar_TypeChecker_Env.is_iface);
-                                FStar_TypeChecker_Env.admit =
-                                  (uu___123_9173.FStar_TypeChecker_Env.admit);
-                                FStar_TypeChecker_Env.lax =
-                                  (uu___123_9173.FStar_TypeChecker_Env.lax);
-                                FStar_TypeChecker_Env.lax_universes =
-                                  (uu___123_9173.FStar_TypeChecker_Env.lax_universes);
-                                FStar_TypeChecker_Env.type_of =
-                                  (uu___123_9173.FStar_TypeChecker_Env.type_of);
-                                FStar_TypeChecker_Env.universe_of =
-                                  (uu___123_9173.FStar_TypeChecker_Env.universe_of);
-                                FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___123_9173.FStar_TypeChecker_Env.use_bv_sorts);
-                                FStar_TypeChecker_Env.qname_and_index =
-                                  (uu___123_9173.FStar_TypeChecker_Env.qname_and_index)
-                              }
-                            else
-                              FStar_TypeChecker_Env.push_let_binding env2
-                                lb.FStar_Syntax_Syntax.lbname ([], t1) in
-                          let lb1 =
-                            let uu___124_9183 = lb in
-                            {
-                              FStar_Syntax_Syntax.lbname =
-                                (uu___124_9183.FStar_Syntax_Syntax.lbname);
-                              FStar_Syntax_Syntax.lbunivs = univ_vars1;
-                              FStar_Syntax_Syntax.lbtyp = t1;
-                              FStar_Syntax_Syntax.lbeff =
-                                (uu___124_9183.FStar_Syntax_Syntax.lbeff);
-                              FStar_Syntax_Syntax.lbdef = e
-                            } in
-                          ((lb1 :: lbs1), env3))) ([], env) lbs in
-        match uu____9121 with | (lbs1,env1) -> ((FStar_List.rev lbs1), env1)
-and check_let_recs:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.letbinding Prims.list ->
-      (FStar_Syntax_Syntax.letbinding Prims.list*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun lbs  ->
-      let uu____9197 =
-        let uu____9202 =
-          FStar_All.pipe_right lbs
-            (FStar_List.map
-               (fun lb  ->
-                  let uu____9213 =
-                    let uu____9217 =
-                      FStar_TypeChecker_Env.set_expected_typ env
-                        lb.FStar_Syntax_Syntax.lbtyp in
-                    tc_tot_or_gtot_term uu____9217
-                      lb.FStar_Syntax_Syntax.lbdef in
-                  match uu____9213 with
-                  | (e,c,g) ->
-                      ((let uu____9224 =
-                          let uu____9225 = FStar_Syntax_Util.is_total_lcomp c in
-                          Prims.op_Negation uu____9225 in
-                        if uu____9224
-                        then
-                          Prims.raise
-                            (FStar_Errors.Error
-                               ("Expected let rec to be a Tot term; got effect GTot",
-                                 (e.FStar_Syntax_Syntax.pos)))
-                        else ());
-                       (let lb1 =
-                          FStar_Syntax_Util.mk_letbinding
-                            lb.FStar_Syntax_Syntax.lbname
-                            lb.FStar_Syntax_Syntax.lbunivs
-                            lb.FStar_Syntax_Syntax.lbtyp
-                            FStar_Syntax_Const.effect_Tot_lid e in
-                        (lb1, g))))) in
-        FStar_All.pipe_right uu____9202 FStar_List.unzip in
-      match uu____9197 with
-      | (lbs1,gs) ->
-          let g_lbs =
-            FStar_List.fold_right FStar_TypeChecker_Rel.conj_guard gs
-              FStar_TypeChecker_Rel.trivial_guard in
-          (lbs1, g_lbs)
-and check_let_bound_def:
-  Prims.bool ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.letbinding ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.univ_names*
-          FStar_Syntax_Syntax.lcomp* FStar_TypeChecker_Env.guard_t*
-          Prims.bool)
-  =
-  fun top_level  ->
-    fun env  ->
-      fun lb  ->
-        let uu____9254 = FStar_TypeChecker_Env.clear_expected_typ env in
-        match uu____9254 with
-        | (env1,uu____9264) ->
-            let e1 = lb.FStar_Syntax_Syntax.lbdef in
-            let uu____9270 = check_lbtyp top_level env lb in
-            (match uu____9270 with
-             | (topt,wf_annot,univ_vars1,univ_opening,env11) ->
-                 (if (Prims.op_Negation top_level) && (univ_vars1 <> [])
-                  then
-                    Prims.raise
-                      (FStar_Errors.Error
-                         ("Inner let-bound definitions cannot be universe polymorphic",
-                           (e1.FStar_Syntax_Syntax.pos)))
-                  else ();
-                  (let e11 = FStar_Syntax_Subst.subst univ_opening e1 in
-                   let uu____9296 =
-                     tc_maybe_toplevel_term
-                       (let uu___125_9300 = env11 in
-                        {
-                          FStar_TypeChecker_Env.solver =
-                            (uu___125_9300.FStar_TypeChecker_Env.solver);
-                          FStar_TypeChecker_Env.range =
-                            (uu___125_9300.FStar_TypeChecker_Env.range);
-                          FStar_TypeChecker_Env.curmodule =
-                            (uu___125_9300.FStar_TypeChecker_Env.curmodule);
-                          FStar_TypeChecker_Env.gamma =
-                            (uu___125_9300.FStar_TypeChecker_Env.gamma);
-                          FStar_TypeChecker_Env.gamma_cache =
-                            (uu___125_9300.FStar_TypeChecker_Env.gamma_cache);
-                          FStar_TypeChecker_Env.modules =
-                            (uu___125_9300.FStar_TypeChecker_Env.modules);
-                          FStar_TypeChecker_Env.expected_typ =
-                            (uu___125_9300.FStar_TypeChecker_Env.expected_typ);
-                          FStar_TypeChecker_Env.sigtab =
-                            (uu___125_9300.FStar_TypeChecker_Env.sigtab);
-                          FStar_TypeChecker_Env.is_pattern =
-                            (uu___125_9300.FStar_TypeChecker_Env.is_pattern);
-                          FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___125_9300.FStar_TypeChecker_Env.instantiate_imp);
-                          FStar_TypeChecker_Env.effects =
-                            (uu___125_9300.FStar_TypeChecker_Env.effects);
-                          FStar_TypeChecker_Env.generalize =
-                            (uu___125_9300.FStar_TypeChecker_Env.generalize);
-                          FStar_TypeChecker_Env.letrecs =
-                            (uu___125_9300.FStar_TypeChecker_Env.letrecs);
-                          FStar_TypeChecker_Env.top_level = top_level;
-                          FStar_TypeChecker_Env.check_uvars =
-                            (uu___125_9300.FStar_TypeChecker_Env.check_uvars);
-                          FStar_TypeChecker_Env.use_eq =
-                            (uu___125_9300.FStar_TypeChecker_Env.use_eq);
-                          FStar_TypeChecker_Env.is_iface =
-                            (uu___125_9300.FStar_TypeChecker_Env.is_iface);
-                          FStar_TypeChecker_Env.admit =
-                            (uu___125_9300.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax =
-                            (uu___125_9300.FStar_TypeChecker_Env.lax);
-                          FStar_TypeChecker_Env.lax_universes =
-                            (uu___125_9300.FStar_TypeChecker_Env.lax_universes);
-                          FStar_TypeChecker_Env.type_of =
-                            (uu___125_9300.FStar_TypeChecker_Env.type_of);
-                          FStar_TypeChecker_Env.universe_of =
-                            (uu___125_9300.FStar_TypeChecker_Env.universe_of);
-                          FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___125_9300.FStar_TypeChecker_Env.use_bv_sorts);
-                          FStar_TypeChecker_Env.qname_and_index =
-                            (uu___125_9300.FStar_TypeChecker_Env.qname_and_index)
-                        }) e11 in
-                   match uu____9296 with
-                   | (e12,c1,g1) ->
-                       let uu____9309 =
-                         let uu____9312 =
-                           FStar_TypeChecker_Env.set_range env11
-                             e12.FStar_Syntax_Syntax.pos in
-                         FStar_TypeChecker_Util.strengthen_precondition
-                           (Some
-                              (fun uu____9315  ->
-                                 FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____9312 e12 c1 wf_annot in
-                       (match uu____9309 with
-                        | (c11,guard_f) ->
-                            let g11 =
-                              FStar_TypeChecker_Rel.conj_guard g1 guard_f in
-                            ((let uu____9325 =
-                                FStar_TypeChecker_Env.debug env
-                                  FStar_Options.Extreme in
-                              if uu____9325
-                              then
-                                let uu____9326 =
-                                  FStar_Syntax_Print.lbname_to_string
-                                    lb.FStar_Syntax_Syntax.lbname in
-                                let uu____9327 =
-                                  FStar_Syntax_Print.term_to_string
-                                    c11.FStar_Syntax_Syntax.res_typ in
-                                let uu____9328 =
-                                  FStar_TypeChecker_Rel.guard_to_string env
-                                    g11 in
-                                FStar_Util.print3
-                                  "checked top-level def %s, result type is %s, guard is %s\n"
-                                  uu____9326 uu____9327 uu____9328
-                              else ());
-                             (e12, univ_vars1, c11, g11,
-                               (FStar_Option.isSome topt)))))))
-and check_lbtyp:
-  Prims.bool ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.letbinding ->
-        (FStar_Syntax_Syntax.typ Prims.option* FStar_TypeChecker_Env.guard_t*
-          FStar_Syntax_Syntax.univ_names* FStar_Syntax_Syntax.subst_elt
-          Prims.list* FStar_TypeChecker_Env.env)
-  =
-  fun top_level  ->
-    fun env  ->
-      fun lb  ->
-        let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp in
-        match t.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_unknown  ->
-            (if lb.FStar_Syntax_Syntax.lbunivs <> []
-             then
-               failwith
-                 "Impossible: non-empty universe variables but the type is unknown"
-             else ();
-             (None, FStar_TypeChecker_Rel.trivial_guard, [], [], env))
-        | uu____9354 ->
-            let uu____9355 =
-              FStar_Syntax_Subst.univ_var_opening
-                lb.FStar_Syntax_Syntax.lbunivs in
-            (match uu____9355 with
-             | (univ_opening,univ_vars1) ->
-                 let t1 = FStar_Syntax_Subst.subst univ_opening t in
-                 let env1 =
-                   FStar_TypeChecker_Env.push_univ_vars env univ_vars1 in
-                 if
-                   top_level &&
-                     (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
-                 then
-                   let uu____9382 =
-                     FStar_TypeChecker_Env.set_expected_typ env1 t1 in
-                   ((Some t1), FStar_TypeChecker_Rel.trivial_guard,
-                     univ_vars1, univ_opening, uu____9382)
-                 else
-                   (let uu____9387 = FStar_Syntax_Util.type_u () in
-                    match uu____9387 with
-                    | (k,uu____9398) ->
-                        let uu____9399 = tc_check_tot_or_gtot_term env1 t1 k in
-                        (match uu____9399 with
-                         | (t2,uu____9411,g) ->
-                             ((let uu____9414 =
-                                 FStar_TypeChecker_Env.debug env
-                                   FStar_Options.Medium in
-                               if uu____9414
-                               then
-                                 let uu____9415 =
-                                   let uu____9416 =
-                                     FStar_Syntax_Syntax.range_of_lbname
-                                       lb.FStar_Syntax_Syntax.lbname in
-                                   FStar_Range.string_of_range uu____9416 in
-                                 let uu____9417 =
-                                   FStar_Syntax_Print.term_to_string t2 in
-                                 FStar_Util.print2
-                                   "(%s) Checked type annotation %s\n"
-                                   uu____9415 uu____9417
-                               else ());
-                              (let t3 = norm env1 t2 in
-                               let uu____9420 =
-                                 FStar_TypeChecker_Env.set_expected_typ env1
-                                   t3 in
-                               ((Some t3), g, univ_vars1, univ_opening,
-                                 uu____9420))))))
-and tc_binder:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) ->
-      ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual)*
-        FStar_TypeChecker_Env.env* FStar_TypeChecker_Env.guard_t*
-        FStar_Syntax_Syntax.universe)
-  =
-  fun env  ->
-    fun uu____9425  ->
-      match uu____9425 with
-      | (x,imp) ->
-          let uu____9436 = FStar_Syntax_Util.type_u () in
-          (match uu____9436 with
-           | (tu,u) ->
-               ((let uu____9448 =
-                   FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-                 if uu____9448
-                 then
-                   let uu____9449 = FStar_Syntax_Print.bv_to_string x in
-                   let uu____9450 =
-                     FStar_Syntax_Print.term_to_string
-                       x.FStar_Syntax_Syntax.sort in
-                   let uu____9451 = FStar_Syntax_Print.term_to_string tu in
-                   FStar_Util.print3 "Checking binders %s:%s at type %s\n"
-                     uu____9449 uu____9450 uu____9451
-                 else ());
-                (let uu____9453 =
-                   tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
-                     tu in
-                 match uu____9453 with
-                 | (t,uu____9464,g) ->
-                     let x1 =
-                       ((let uu___126_9469 = x in
-                         {
-                           FStar_Syntax_Syntax.ppname =
-                             (uu___126_9469.FStar_Syntax_Syntax.ppname);
-                           FStar_Syntax_Syntax.index =
-                             (uu___126_9469.FStar_Syntax_Syntax.index);
-                           FStar_Syntax_Syntax.sort = t
-                         }), imp) in
-                     ((let uu____9471 =
-                         FStar_TypeChecker_Env.debug env FStar_Options.High in
-                       if uu____9471
-                       then
-                         let uu____9472 =
-                           FStar_Syntax_Print.bv_to_string (Prims.fst x1) in
-                         let uu____9473 = FStar_Syntax_Print.term_to_string t in
-                         FStar_Util.print2 "Pushing binder %s at type %s\n"
-                           uu____9472 uu____9473
-                       else ());
-                      (let uu____9475 = push_binding env x1 in
-                       (x1, uu____9475, g, u))))))
-and tc_binders:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders ->
-      ((FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list*
-        FStar_TypeChecker_Env.env* FStar_TypeChecker_Env.guard_t*
-        FStar_Syntax_Syntax.universe Prims.list)
-  =
-  fun env  ->
-    fun bs  ->
-      let rec aux env1 bs1 =
-        match bs1 with
-        | [] -> ([], env1, FStar_TypeChecker_Rel.trivial_guard, [])
-        | b::bs2 ->
-            let uu____9526 = tc_binder env1 b in
-            (match uu____9526 with
-             | (b1,env',g,u) ->
-                 let uu____9549 = aux env' bs2 in
-                 (match uu____9549 with
-                  | (bs3,env'1,g',us) ->
-                      let uu____9578 =
-                        let uu____9579 =
-                          FStar_TypeChecker_Rel.close_guard_univs [u] [b1] g' in
-                        FStar_TypeChecker_Rel.conj_guard g uu____9579 in
-                      ((b1 :: bs3), env'1, uu____9578, (u :: us)))) in
-      aux env bs
-and tc_pats:
-  FStar_TypeChecker_Env.env ->
-    ((FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax* FStar_Syntax_Syntax.aqual) Prims.list
-      Prims.list ->
-      (FStar_Syntax_Syntax.args Prims.list* FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun pats  ->
-      let tc_args env1 args =
-        FStar_List.fold_right
-          (fun uu____9622  ->
-             fun uu____9623  ->
-               match (uu____9622, uu____9623) with
-               | ((t,imp),(args1,g)) ->
-                   let uu____9660 = tc_term env1 t in
-                   (match uu____9660 with
-                    | (t1,uu____9670,g') ->
-                        let uu____9672 =
-                          FStar_TypeChecker_Rel.conj_guard g g' in
-                        (((t1, imp) :: args1), uu____9672))) args
-          ([], FStar_TypeChecker_Rel.trivial_guard) in
-      FStar_List.fold_right
-        (fun p  ->
-           fun uu____9690  ->
-             match uu____9690 with
-             | (pats1,g) ->
-                 let uu____9704 = tc_args env p in
-                 (match uu____9704 with
-                  | (args,g') ->
-                      let uu____9712 = FStar_TypeChecker_Rel.conj_guard g g' in
-                      ((args :: pats1), uu____9712))) pats
-        ([], FStar_TypeChecker_Rel.trivial_guard)
-and tc_tot_or_gtot_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      let uu____9720 = tc_maybe_toplevel_term env e in
-      match uu____9720 with
-      | (e1,c,g) ->
-          let uu____9730 = FStar_Syntax_Util.is_tot_or_gtot_lcomp c in
-          if uu____9730
-          then (e1, c, g)
-          else
-            (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-             let c1 = c.FStar_Syntax_Syntax.comp () in
-             let c2 = norm_c env c1 in
-             let uu____9740 =
-               let uu____9743 =
-                 FStar_TypeChecker_Util.is_pure_effect env
-                   (FStar_Syntax_Util.comp_effect_name c2) in
-               if uu____9743
-               then
-                 let uu____9746 =
-                   FStar_Syntax_Syntax.mk_Total
-                     (FStar_Syntax_Util.comp_result c2) in
-                 (uu____9746, false)
-               else
-                 (let uu____9748 =
-                    FStar_Syntax_Syntax.mk_GTotal
-                      (FStar_Syntax_Util.comp_result c2) in
-                  (uu____9748, true)) in
-             match uu____9740 with
-             | (target_comp,allow_ghost) ->
-                 let uu____9754 =
-                   FStar_TypeChecker_Rel.sub_comp env c2 target_comp in
-                 (match uu____9754 with
-                  | Some g' ->
-                      let uu____9760 = FStar_TypeChecker_Rel.conj_guard g1 g' in
-                      (e1, (FStar_Syntax_Util.lcomp_of_comp target_comp),
-                        uu____9760)
-                  | uu____9761 ->
-                      if allow_ghost
-                      then
-                        let uu____9766 =
-                          let uu____9767 =
-                            let uu____9770 =
-                              FStar_TypeChecker_Err.expected_ghost_expression
-                                e1 c2 in
-                            (uu____9770, (e1.FStar_Syntax_Syntax.pos)) in
-                          FStar_Errors.Error uu____9767 in
-                        Prims.raise uu____9766
-                      else
-                        (let uu____9775 =
-                           let uu____9776 =
-                             let uu____9779 =
-                               FStar_TypeChecker_Err.expected_pure_expression
-                                 e1 c2 in
-                             (uu____9779, (e1.FStar_Syntax_Syntax.pos)) in
-                           FStar_Errors.Error uu____9776 in
-                         Prims.raise uu____9775)))
-and tc_check_tot_or_gtot_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-          FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun t  ->
-        let env1 = FStar_TypeChecker_Env.set_expected_typ env t in
-        tc_tot_or_gtot_term env1 e
-and tc_trivial_guard:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp)
-  =
-  fun env  ->
-    fun t  ->
-      let uu____9792 = tc_tot_or_gtot_term env t in
-      match uu____9792 with
-      | (t1,c,g) ->
-          (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
-let type_of_tot_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.typ*
-        FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      (let uu____9812 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck") in
-       if uu____9812
-       then
-         let uu____9813 = FStar_Syntax_Print.term_to_string e in
-         FStar_Util.print1 "Checking term %s\n" uu____9813
-       else ());
-      (let env1 =
-         let uu___127_9816 = env in
-         {
-           FStar_TypeChecker_Env.solver =
-             (uu___127_9816.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___127_9816.FStar_TypeChecker_Env.range);
-           FStar_TypeChecker_Env.curmodule =
-             (uu___127_9816.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___127_9816.FStar_TypeChecker_Env.gamma);
-           FStar_TypeChecker_Env.gamma_cache =
-             (uu___127_9816.FStar_TypeChecker_Env.gamma_cache);
-           FStar_TypeChecker_Env.modules =
-             (uu___127_9816.FStar_TypeChecker_Env.modules);
-           FStar_TypeChecker_Env.expected_typ =
-             (uu___127_9816.FStar_TypeChecker_Env.expected_typ);
-           FStar_TypeChecker_Env.sigtab =
-             (uu___127_9816.FStar_TypeChecker_Env.sigtab);
-           FStar_TypeChecker_Env.is_pattern =
-             (uu___127_9816.FStar_TypeChecker_Env.is_pattern);
-           FStar_TypeChecker_Env.instantiate_imp =
-             (uu___127_9816.FStar_TypeChecker_Env.instantiate_imp);
-           FStar_TypeChecker_Env.effects =
-             (uu___127_9816.FStar_TypeChecker_Env.effects);
-           FStar_TypeChecker_Env.generalize =
-             (uu___127_9816.FStar_TypeChecker_Env.generalize);
-           FStar_TypeChecker_Env.letrecs = [];
-           FStar_TypeChecker_Env.top_level = false;
-           FStar_TypeChecker_Env.check_uvars =
-             (uu___127_9816.FStar_TypeChecker_Env.check_uvars);
-           FStar_TypeChecker_Env.use_eq =
-             (uu___127_9816.FStar_TypeChecker_Env.use_eq);
-           FStar_TypeChecker_Env.is_iface =
-             (uu___127_9816.FStar_TypeChecker_Env.is_iface);
-           FStar_TypeChecker_Env.admit =
-             (uu___127_9816.FStar_TypeChecker_Env.admit);
-           FStar_TypeChecker_Env.lax =
-             (uu___127_9816.FStar_TypeChecker_Env.lax);
-           FStar_TypeChecker_Env.lax_universes =
-             (uu___127_9816.FStar_TypeChecker_Env.lax_universes);
-           FStar_TypeChecker_Env.type_of =
-             (uu___127_9816.FStar_TypeChecker_Env.type_of);
-           FStar_TypeChecker_Env.universe_of =
-             (uu___127_9816.FStar_TypeChecker_Env.universe_of);
-           FStar_TypeChecker_Env.use_bv_sorts = true;
-           FStar_TypeChecker_Env.qname_and_index =
-             (uu___127_9816.FStar_TypeChecker_Env.qname_and_index)
-         } in
-       let uu____9819 =
-         try tc_tot_or_gtot_term env1 e
-         with
-         | FStar_Errors.Error (msg,uu____9835) ->
-             let uu____9836 =
-               let uu____9837 =
-                 let uu____9840 = FStar_TypeChecker_Env.get_range env1 in
-                 ((Prims.strcat "Implicit argument: " msg), uu____9840) in
-               FStar_Errors.Error uu____9837 in
-             Prims.raise uu____9836 in
-       match uu____9819 with
-       | (t,c,g) ->
-           let uu____9850 = FStar_Syntax_Util.is_total_lcomp c in
-           if uu____9850
-           then (t, (c.FStar_Syntax_Syntax.res_typ), g)
-           else
-             (let uu____9857 =
-                let uu____9858 =
-                  let uu____9861 =
-                    let uu____9862 = FStar_Syntax_Print.term_to_string e in
-                    FStar_Util.format1
-                      "Implicit argument: Expected a total term; got a ghost term: %s"
-                      uu____9862 in
-                  let uu____9863 = FStar_TypeChecker_Env.get_range env1 in
-                  (uu____9861, uu____9863) in
-                FStar_Errors.Error uu____9858 in
-              Prims.raise uu____9857))
-let level_of_type_fail env e t =
-  let uu____9884 =
-    let uu____9885 =
-      let uu____9888 =
-        let uu____9889 = FStar_Syntax_Print.term_to_string e in
-        FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-          uu____9889 t in
-      let uu____9890 = FStar_TypeChecker_Env.get_range env in
-      (uu____9888, uu____9890) in
-    FStar_Errors.Error uu____9885 in
-  Prims.raise uu____9884
-let level_of_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe
-  =
-  fun env  ->
-    fun e  ->
-      fun t  ->
-        let rec aux retry t1 =
-          let uu____9907 =
-            let uu____9908 = FStar_Syntax_Util.unrefine t1 in
-            uu____9908.FStar_Syntax_Syntax.n in
-          match uu____9907 with
-          | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____9912 ->
-              if retry
-              then
-                let t2 =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.UnfoldUntil
-                       FStar_Syntax_Syntax.Delta_constant] env t1 in
-                aux false t2
-              else
-                (let uu____9915 = FStar_Syntax_Util.type_u () in
-                 match uu____9915 with
-                 | (t_u,u) ->
-                     let env1 =
-                       let uu___130_9921 = env in
-                       {
-                         FStar_TypeChecker_Env.solver =
-                           (uu___130_9921.FStar_TypeChecker_Env.solver);
-                         FStar_TypeChecker_Env.range =
-                           (uu___130_9921.FStar_TypeChecker_Env.range);
-                         FStar_TypeChecker_Env.curmodule =
-                           (uu___130_9921.FStar_TypeChecker_Env.curmodule);
-                         FStar_TypeChecker_Env.gamma =
-                           (uu___130_9921.FStar_TypeChecker_Env.gamma);
-                         FStar_TypeChecker_Env.gamma_cache =
-                           (uu___130_9921.FStar_TypeChecker_Env.gamma_cache);
-                         FStar_TypeChecker_Env.modules =
-                           (uu___130_9921.FStar_TypeChecker_Env.modules);
-                         FStar_TypeChecker_Env.expected_typ =
-                           (uu___130_9921.FStar_TypeChecker_Env.expected_typ);
-                         FStar_TypeChecker_Env.sigtab =
-                           (uu___130_9921.FStar_TypeChecker_Env.sigtab);
-                         FStar_TypeChecker_Env.is_pattern =
-                           (uu___130_9921.FStar_TypeChecker_Env.is_pattern);
-                         FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___130_9921.FStar_TypeChecker_Env.instantiate_imp);
-                         FStar_TypeChecker_Env.effects =
-                           (uu___130_9921.FStar_TypeChecker_Env.effects);
-                         FStar_TypeChecker_Env.generalize =
-                           (uu___130_9921.FStar_TypeChecker_Env.generalize);
-                         FStar_TypeChecker_Env.letrecs =
-                           (uu___130_9921.FStar_TypeChecker_Env.letrecs);
-                         FStar_TypeChecker_Env.top_level =
-                           (uu___130_9921.FStar_TypeChecker_Env.top_level);
-                         FStar_TypeChecker_Env.check_uvars =
-                           (uu___130_9921.FStar_TypeChecker_Env.check_uvars);
-                         FStar_TypeChecker_Env.use_eq =
-                           (uu___130_9921.FStar_TypeChecker_Env.use_eq);
-                         FStar_TypeChecker_Env.is_iface =
-                           (uu___130_9921.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (uu___130_9921.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax = true;
-                         FStar_TypeChecker_Env.lax_universes =
-                           (uu___130_9921.FStar_TypeChecker_Env.lax_universes);
-                         FStar_TypeChecker_Env.type_of =
-                           (uu___130_9921.FStar_TypeChecker_Env.type_of);
-                         FStar_TypeChecker_Env.universe_of =
-                           (uu___130_9921.FStar_TypeChecker_Env.universe_of);
-                         FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___130_9921.FStar_TypeChecker_Env.use_bv_sorts);
-                         FStar_TypeChecker_Env.qname_and_index =
-                           (uu___130_9921.FStar_TypeChecker_Env.qname_and_index)
-                       } in
-                     let g = FStar_TypeChecker_Rel.teq env1 t1 t_u in
-                     ((match g.FStar_TypeChecker_Env.guard_f with
-                       | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____9925 =
-                             FStar_Syntax_Print.term_to_string t1 in
-                           level_of_type_fail env1 e uu____9925
-                       | uu____9926 ->
-                           FStar_TypeChecker_Rel.force_trivial_guard env1 g);
-                      u)) in
-        aux true t
-let rec universe_of_aux:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    fun e  ->
-      let uu____9935 =
-        let uu____9936 = FStar_Syntax_Subst.compress e in
-        uu____9936.FStar_Syntax_Syntax.n in
-      match uu____9935 with
-      | FStar_Syntax_Syntax.Tm_bvar _
-        |FStar_Syntax_Syntax.Tm_unknown |FStar_Syntax_Syntax.Tm_delayed _ ->
-          failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____9945 ->
-          let e1 = FStar_TypeChecker_Normalize.normalize [] env e in
-          universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____9956) ->
-          level_of_type_fail env e "arrow type"
-      | FStar_Syntax_Syntax.Tm_uvar (uu____9981,t) -> t
-      | FStar_Syntax_Syntax.Tm_meta (t,uu____9996) -> universe_of_aux env t
-      | FStar_Syntax_Syntax.Tm_name n1 -> n1.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____10003 =
-            FStar_TypeChecker_Env.lookup_lid env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10003 with | ((uu____10014,t),uu____10016) -> t)
-      | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____10019,(FStar_Util.Inl t,uu____10021),uu____10022) -> t
-      | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____10058,(FStar_Util.Inr c,uu____10060),uu____10061) ->
-          FStar_Syntax_Util.comp_result c
-      | FStar_Syntax_Syntax.Tm_type u ->
-          (FStar_Syntax_Syntax.mk
-             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u)))
-            None e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_constant sc ->
-          tc_constant e.FStar_Syntax_Syntax.pos sc
-      | FStar_Syntax_Syntax.Tm_uinst
-          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.tk = uu____10108;
-             FStar_Syntax_Syntax.pos = uu____10109;
-             FStar_Syntax_Syntax.vars = uu____10110;_},us)
-          ->
-          let uu____10116 =
-            FStar_TypeChecker_Env.lookup_lid env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10116 with
-           | ((us',t),uu____10129) ->
-               (if (FStar_List.length us) <> (FStar_List.length us')
-                then
-                  (let uu____10137 =
-                     let uu____10138 =
-                       let uu____10141 = FStar_TypeChecker_Env.get_range env in
-                       ("Unexpected number of universe instantiations",
-                         uu____10141) in
-                     FStar_Errors.Error uu____10138 in
-                   Prims.raise uu____10137)
-                else
-                  FStar_List.iter2
-                    (fun u'  ->
-                       fun u  ->
-                         match u' with
-                         | FStar_Syntax_Syntax.U_unif u'' ->
-                             FStar_Unionfind.change u'' (Some u)
-                         | uu____10149 -> failwith "Impossible") us' us;
-                t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____10150 ->
-          failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____10158) ->
-          universe_of_aux env x.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____10175 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____10175 with
-           | (bs1,c1) ->
-               let us =
-                 FStar_List.map
-                   (fun uu____10186  ->
-                      match uu____10186 with
-                      | (b,uu____10190) ->
-                          let uu____10191 =
-                            universe_of_aux env b.FStar_Syntax_Syntax.sort in
-                          level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____10191) bs1 in
-               let u_res =
-                 let res = FStar_Syntax_Util.comp_result c1 in
-                 let uu____10196 = universe_of_aux env res in
-                 level_of_type env res uu____10196 in
-               let u_c =
-                 let uu____10198 =
-                   FStar_TypeChecker_Env.effect_repr env c1 u_res in
-                 match uu____10198 with
-                 | None  -> u_res
-                 | Some trepr ->
-                     let uu____10201 = universe_of_aux env trepr in
-                     level_of_type env trepr uu____10201 in
-               let u =
-                 FStar_TypeChecker_Normalize.normalize_universe env
-                   (FStar_Syntax_Syntax.U_max (u_c :: us)) in
-               (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)) None
-                 e.FStar_Syntax_Syntax.pos)
-      | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-          let rec type_of_head retry hd2 args1 =
-            let hd3 = FStar_Syntax_Subst.compress hd2 in
-            match hd3.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_unknown 
-              |FStar_Syntax_Syntax.Tm_bvar _|FStar_Syntax_Syntax.Tm_delayed _
-                -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar _
-              |FStar_Syntax_Syntax.Tm_name _
-               |FStar_Syntax_Syntax.Tm_uvar _
-                |FStar_Syntax_Syntax.Tm_uinst _
-                 |FStar_Syntax_Syntax.Tm_ascribed _
-                  |FStar_Syntax_Syntax.Tm_refine _
-                   |FStar_Syntax_Syntax.Tm_constant _
-                    |FStar_Syntax_Syntax.Tm_arrow _
-                     |FStar_Syntax_Syntax.Tm_meta _
-                      |FStar_Syntax_Syntax.Tm_type _
-                ->
-                let uu____10287 = universe_of_aux env hd3 in
-                (uu____10287, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____10297,hd4::uu____10299) ->
-                let uu____10346 = FStar_Syntax_Subst.open_branch hd4 in
-                (match uu____10346 with
-                 | (uu____10356,uu____10357,hd5) ->
-                     let uu____10373 = FStar_Syntax_Util.head_and_args hd5 in
-                     (match uu____10373 with
-                      | (hd6,args2) -> type_of_head retry hd6 args2))
-            | uu____10408 when retry ->
-                let e1 =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Beta;
-                    FStar_TypeChecker_Normalize.NoDeltaSteps] env e in
-                let uu____10410 = FStar_Syntax_Util.head_and_args e1 in
-                (match uu____10410 with
-                 | (hd4,args2) -> type_of_head false hd4 args2)
-            | uu____10445 ->
-                let uu____10446 =
-                  FStar_TypeChecker_Env.clear_expected_typ env in
-                (match uu____10446 with
-                 | (env1,uu____10460) ->
-                     let env2 =
-                       let uu___131_10464 = env1 in
-                       {
-                         FStar_TypeChecker_Env.solver =
-                           (uu___131_10464.FStar_TypeChecker_Env.solver);
-                         FStar_TypeChecker_Env.range =
-                           (uu___131_10464.FStar_TypeChecker_Env.range);
-                         FStar_TypeChecker_Env.curmodule =
-                           (uu___131_10464.FStar_TypeChecker_Env.curmodule);
-                         FStar_TypeChecker_Env.gamma =
-                           (uu___131_10464.FStar_TypeChecker_Env.gamma);
-                         FStar_TypeChecker_Env.gamma_cache =
-                           (uu___131_10464.FStar_TypeChecker_Env.gamma_cache);
-                         FStar_TypeChecker_Env.modules =
-                           (uu___131_10464.FStar_TypeChecker_Env.modules);
-                         FStar_TypeChecker_Env.expected_typ =
-                           (uu___131_10464.FStar_TypeChecker_Env.expected_typ);
-                         FStar_TypeChecker_Env.sigtab =
-                           (uu___131_10464.FStar_TypeChecker_Env.sigtab);
-                         FStar_TypeChecker_Env.is_pattern =
-                           (uu___131_10464.FStar_TypeChecker_Env.is_pattern);
-                         FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___131_10464.FStar_TypeChecker_Env.instantiate_imp);
-                         FStar_TypeChecker_Env.effects =
-                           (uu___131_10464.FStar_TypeChecker_Env.effects);
-                         FStar_TypeChecker_Env.generalize =
-                           (uu___131_10464.FStar_TypeChecker_Env.generalize);
-                         FStar_TypeChecker_Env.letrecs =
-                           (uu___131_10464.FStar_TypeChecker_Env.letrecs);
-                         FStar_TypeChecker_Env.top_level = false;
-                         FStar_TypeChecker_Env.check_uvars =
-                           (uu___131_10464.FStar_TypeChecker_Env.check_uvars);
-                         FStar_TypeChecker_Env.use_eq =
-                           (uu___131_10464.FStar_TypeChecker_Env.use_eq);
-                         FStar_TypeChecker_Env.is_iface =
-                           (uu___131_10464.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (uu___131_10464.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax = true;
-                         FStar_TypeChecker_Env.lax_universes =
-                           (uu___131_10464.FStar_TypeChecker_Env.lax_universes);
-                         FStar_TypeChecker_Env.type_of =
-                           (uu___131_10464.FStar_TypeChecker_Env.type_of);
-                         FStar_TypeChecker_Env.universe_of =
-                           (uu___131_10464.FStar_TypeChecker_Env.universe_of);
-                         FStar_TypeChecker_Env.use_bv_sorts = true;
-                         FStar_TypeChecker_Env.qname_and_index =
-                           (uu___131_10464.FStar_TypeChecker_Env.qname_and_index)
-                       } in
-                     ((let uu____10466 =
-                         FStar_All.pipe_left
-                           (FStar_TypeChecker_Env.debug env2)
-                           (FStar_Options.Other "UniverseOf") in
-                       if uu____10466
-                       then
-                         let uu____10467 =
-                           let uu____10468 =
-                             FStar_TypeChecker_Env.get_range env2 in
-                           FStar_Range.string_of_range uu____10468 in
-                         let uu____10469 =
-                           FStar_Syntax_Print.term_to_string hd3 in
-                         FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____10467 uu____10469
-                       else ());
-                      (let uu____10471 = tc_term env2 hd3 in
-                       match uu____10471 with
-                       | (uu____10484,{
-                                        FStar_Syntax_Syntax.eff_name =
-                                          uu____10485;
-                                        FStar_Syntax_Syntax.res_typ = t;
-                                        FStar_Syntax_Syntax.cflags =
-                                          uu____10487;
-                                        FStar_Syntax_Syntax.comp =
-                                          uu____10488;_},g)
-                           ->
-                           ((let uu____10498 =
-                               FStar_TypeChecker_Rel.solve_deferred_constraints
-                                 env2 g in
-                             FStar_All.pipe_right uu____10498 Prims.ignore);
-                            (t, args1))))) in
-          let uu____10506 = type_of_head true hd1 args in
-          (match uu____10506 with
-           | (t,args1) ->
-               let t1 =
-                 FStar_TypeChecker_Normalize.normalize
-                   [FStar_TypeChecker_Normalize.UnfoldUntil
-                      FStar_Syntax_Syntax.Delta_constant] env t in
-               let uu____10535 = FStar_Syntax_Util.arrow_formals_comp t1 in
-               (match uu____10535 with
-                | (bs,res) ->
-                    let res1 = FStar_Syntax_Util.comp_result res in
-                    if (FStar_List.length bs) = (FStar_List.length args1)
-                    then
-                      let subst1 = FStar_Syntax_Util.subst_of_list bs args1 in
-                      FStar_Syntax_Subst.subst subst1 res1
-                    else
-                      (let uu____10568 =
-                         FStar_Syntax_Print.term_to_string res1 in
-                       level_of_type_fail env e uu____10568)))
-      | FStar_Syntax_Syntax.Tm_match (uu____10571,hd1::uu____10573) ->
-          let uu____10620 = FStar_Syntax_Subst.open_branch hd1 in
-          (match uu____10620 with
-           | (uu____10623,uu____10624,hd2) -> universe_of_aux env hd2)
-      | FStar_Syntax_Syntax.Tm_match (uu____10640,[]) ->
-          level_of_type_fail env e "empty match cases"
-let universe_of:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe
-  =
-  fun env  ->
-    fun e  ->
-      let uu____10674 = universe_of_aux env e in
-      level_of_type env e uu____10674
-let tc_tparams:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.binders ->
-      (FStar_Syntax_Syntax.binders* FStar_TypeChecker_Env.env*
-        FStar_Syntax_Syntax.universes)
-  =
-  fun env  ->
-    fun tps  ->
-      let uu____10687 = tc_binders env tps in
-      match uu____10687 with
-      | (tps1,env1,g,us) ->
-          (FStar_TypeChecker_Rel.force_trivial_guard env1 g; (tps1, env1, us))
+
+let instantiate_both : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.env = (fun env -> (
+
+let uu___86_4 = env
+in {FStar_TypeChecker_Env.solver = uu___86_4.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___86_4.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___86_4.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___86_4.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___86_4.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___86_4.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___86_4.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___86_4.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___86_4.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = true; FStar_TypeChecker_Env.effects = uu___86_4.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___86_4.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___86_4.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___86_4.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___86_4.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___86_4.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___86_4.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___86_4.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___86_4.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___86_4.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___86_4.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___86_4.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___86_4.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___86_4.FStar_TypeChecker_Env.qname_and_index}))
+
+
+let no_inst : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.env = (fun env -> (
+
+let uu___87_8 = env
+in {FStar_TypeChecker_Env.solver = uu___87_8.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___87_8.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___87_8.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___87_8.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___87_8.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___87_8.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___87_8.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___87_8.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___87_8.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = false; FStar_TypeChecker_Env.effects = uu___87_8.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___87_8.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___87_8.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___87_8.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___87_8.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___87_8.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___87_8.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___87_8.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___87_8.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___87_8.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___87_8.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___87_8.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___87_8.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___87_8.FStar_TypeChecker_Env.qname_and_index}))
+
+
+let mk_lex_list : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.list  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun vs -> (FStar_List.fold_right (fun v1 tl1 -> (
+
+let r = (match ((tl1.FStar_Syntax_Syntax.pos = FStar_Range.dummyRange)) with
+| true -> begin
+v1.FStar_Syntax_Syntax.pos
+end
+| uu____33 -> begin
+(FStar_Range.union_ranges v1.FStar_Syntax_Syntax.pos tl1.FStar_Syntax_Syntax.pos)
+end)
+in (
+
+let uu____34 = (
+
+let uu____35 = (
+
+let uu____36 = (FStar_Syntax_Syntax.as_arg v1)
+in (
+
+let uu____37 = (
+
+let uu____39 = (FStar_Syntax_Syntax.as_arg tl1)
+in (uu____39)::[])
+in (uu____36)::uu____37))
+in (FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair uu____35))
+in (uu____34 (Some (FStar_Syntax_Util.lex_t.FStar_Syntax_Syntax.n)) r)))) vs FStar_Syntax_Util.lex_top))
+
+
+let is_eq : FStar_Syntax_Syntax.arg_qualifier Prims.option  ->  Prims.bool = (fun uu___80_47 -> (match (uu___80_47) with
+| Some (FStar_Syntax_Syntax.Equality) -> begin
+true
+end
+| uu____49 -> begin
+false
+end))
+
+
+let steps = (fun env -> (FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::[])
+
+
+let unfold_whnf : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.WHNF)::(FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::(FStar_TypeChecker_Normalize.Beta)::[]) env t))
+
+
+let norm : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun env t -> (FStar_TypeChecker_Normalize.normalize (steps env) env t))
+
+
+let norm_c : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp = (fun env c -> (FStar_TypeChecker_Normalize.normalize_comp (steps env) env c))
+
+
+let check_no_escape : FStar_Syntax_Syntax.term Prims.option  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.bv Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term = (fun head_opt env fvs kt -> (
+
+let rec aux = (fun try_norm t -> (match (fvs) with
+| [] -> begin
+t
+end
+| uu____100 -> begin
+(
+
+let t1 = (match (try_norm) with
+| true -> begin
+(norm env t)
+end
+| uu____103 -> begin
+t
+end)
+in (
+
+let fvs' = (FStar_Syntax_Free.names t1)
+in (
+
+let uu____106 = (FStar_List.tryFind (fun x -> (FStar_Util.set_mem x fvs')) fvs)
+in (match (uu____106) with
+| None -> begin
+t1
+end
+| Some (x) -> begin
+(match ((not (try_norm))) with
+| true -> begin
+(aux true t1)
+end
+| uu____110 -> begin
+(
+
+let fail = (fun uu____114 -> (
+
+let msg = (match (head_opt) with
+| None -> begin
+(
+
+let uu____116 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format1 "Bound variables \'%s\' escapes; add a type annotation" uu____116))
+end
+| Some (head1) -> begin
+(
+
+let uu____118 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____119 = (FStar_TypeChecker_Normalize.term_to_string env head1)
+in (FStar_Util.format2 "Bound variables \'%s\' in the type of \'%s\' escape because of impure applications; add explicit let-bindings" uu____118 uu____119)))
+end)
+in (
+
+let uu____120 = (
+
+let uu____121 = (
+
+let uu____124 = (FStar_TypeChecker_Env.get_range env)
+in ((msg), (uu____124)))
+in FStar_Errors.Error (uu____121))
+in (Prims.raise uu____120))))
+in (
+
+let s = (
+
+let uu____126 = (
+
+let uu____127 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_left Prims.fst uu____127))
+in (FStar_TypeChecker_Util.new_uvar env uu____126))
+in (
+
+let uu____132 = (FStar_TypeChecker_Rel.try_teq true env t1 s)
+in (match (uu____132) with
+| Some (g) -> begin
+((FStar_TypeChecker_Rel.force_trivial_guard env g);
+s;
+)
+end
+| uu____136 -> begin
+(fail ())
+end))))
+end)
+end))))
+end))
+in (aux false kt)))
+
+
+let push_binding = (fun env b -> (FStar_TypeChecker_Env.push_bv env (Prims.fst b)))
+
+
+let maybe_extend_subst : FStar_Syntax_Syntax.subst_t  ->  FStar_Syntax_Syntax.binder  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.subst_t = (fun s b v1 -> (
+
+let uu____167 = (FStar_Syntax_Syntax.is_null_binder b)
+in (match (uu____167) with
+| true -> begin
+s
+end
+| uu____168 -> begin
+(FStar_Syntax_Syntax.NT ((((Prims.fst b)), (v1))))::s
+end)))
+
+
+let set_lcomp_result : FStar_Syntax_Syntax.lcomp  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.lcomp = (fun lc t -> (
+
+let uu___88_181 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___88_181.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu___88_181.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____182 -> (
+
+let uu____183 = (lc.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Util.set_result_typ uu____183 t)))}))
+
+
+let memo_tk : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun e t -> ((FStar_ST.write e.FStar_Syntax_Syntax.tk (Some (t.FStar_Syntax_Syntax.n)));
+e;
+))
+
+
+let value_check_expected_typ : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.typ, FStar_Syntax_Syntax.lcomp) FStar_Util.either  ->  FStar_TypeChecker_Env.guard_t  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e tlc guard -> (
+
+let should_return = (fun t -> (
+
+let uu____222 = (
+
+let uu____223 = (FStar_Syntax_Subst.compress t)
+in uu____223.FStar_Syntax_Syntax.n)
+in (match (uu____222) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____226, c) -> begin
+(
+
+let uu____238 = (FStar_TypeChecker_Util.is_pure_or_ghost_effect env (FStar_Syntax_Util.comp_effect_name c))
+in (match (uu____238) with
+| true -> begin
+(
+
+let t1 = (FStar_All.pipe_left FStar_Syntax_Util.unrefine (FStar_Syntax_Util.comp_result c))
+in (
+
+let uu____240 = (
+
+let uu____241 = (FStar_Syntax_Subst.compress t1)
+in uu____241.FStar_Syntax_Syntax.n)
+in (match (uu____240) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.unit_lid) -> begin
+false
+end
+| FStar_Syntax_Syntax.Tm_constant (uu____245) -> begin
+false
+end
+| uu____246 -> begin
+true
+end)))
+end
+| uu____247 -> begin
+false
+end))
+end
+| uu____248 -> begin
+true
+end)))
+in (
+
+let lc = (match (tlc) with
+| FStar_Util.Inl (t) -> begin
+(
+
+let uu____251 = (
+
+let uu____254 = ((
+
+let uu____255 = (should_return t)
+in (not (uu____255))) || (
+
+let uu____256 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____256))))
+in (match (uu____254) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total t)
+end
+| uu____259 -> begin
+(FStar_TypeChecker_Util.return_value env t e)
+end))
+in (FStar_Syntax_Util.lcomp_of_comp uu____251))
+end
+| FStar_Util.Inr (lc) -> begin
+lc
+end)
+in (
+
+let t = lc.FStar_Syntax_Syntax.res_typ
+in (
+
+let uu____264 = (
+
+let uu____268 = (FStar_TypeChecker_Env.expected_typ env)
+in (match (uu____268) with
+| None -> begin
+(
+
+let uu____273 = (memo_tk e t)
+in ((uu____273), (lc), (guard)))
+end
+| Some (t') -> begin
+((
+
+let uu____276 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____276) with
+| true -> begin
+(
+
+let uu____277 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____278 = (FStar_Syntax_Print.term_to_string t')
+in (FStar_Util.print2 "Computed return type %s; expected type %s\n" uu____277 uu____278)))
+end
+| uu____279 -> begin
+()
+end));
+(
+
+let uu____280 = (FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc t')
+in (match (uu____280) with
+| (e1, lc1) -> begin
+(
+
+let t1 = lc1.FStar_Syntax_Syntax.res_typ
+in (
+
+let uu____291 = (FStar_TypeChecker_Util.check_and_ascribe env e1 t1 t')
+in (match (uu____291) with
+| (e2, g) -> begin
+((
+
+let uu____300 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____300) with
+| true -> begin
+(
+
+let uu____301 = (FStar_Syntax_Print.term_to_string t1)
+in (
+
+let uu____302 = (FStar_Syntax_Print.term_to_string t')
+in (
+
+let uu____303 = (FStar_TypeChecker_Rel.guard_to_string env g)
+in (
+
+let uu____304 = (FStar_TypeChecker_Rel.guard_to_string env guard)
+in (FStar_Util.print4 "check_and_ascribe: type is %s<:%s \tguard is %s, %s\n" uu____301 uu____302 uu____303 uu____304)))))
+end
+| uu____305 -> begin
+()
+end));
+(
+
+let msg = (
+
+let uu____310 = (FStar_TypeChecker_Rel.is_trivial g)
+in (match (uu____310) with
+| true -> begin
+None
+end
+| uu____316 -> begin
+(FStar_All.pipe_left (fun _0_28 -> Some (_0_28)) (FStar_TypeChecker_Err.subtyping_failed env t1 t'))
+end))
+in (
+
+let g1 = (FStar_TypeChecker_Rel.conj_guard g guard)
+in (
+
+let uu____325 = (FStar_TypeChecker_Util.strengthen_precondition msg env e2 lc1 g1)
+in (match (uu____325) with
+| (lc2, g2) -> begin
+(
+
+let uu____333 = (memo_tk e2 t')
+in ((uu____333), ((set_lcomp_result lc2 t')), (g2)))
+end))));
+)
+end)))
+end));
+)
+end))
+in (match (uu____264) with
+| (e1, lc1, g) -> begin
+((
+
+let uu____341 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____341) with
+| true -> begin
+(
+
+let uu____342 = (FStar_Syntax_Print.lcomp_to_string lc1)
+in (FStar_Util.print1 "Return comp type is %s\n" uu____342))
+end
+| uu____343 -> begin
+()
+end));
+((e1), (lc1), (g));
+)
+end))))))
+
+
+let comp_check_expected_typ : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e lc -> (
+
+let uu____359 = (FStar_TypeChecker_Env.expected_typ env)
+in (match (uu____359) with
+| None -> begin
+((e), (lc), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| Some (t) -> begin
+(
+
+let uu____365 = (FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc t)
+in (match (uu____365) with
+| (e1, lc1) -> begin
+(FStar_TypeChecker_Util.weaken_result_typ env e1 lc1 t)
+end))
+end)))
+
+
+let check_expected_effect : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp Prims.option  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp)  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp * FStar_TypeChecker_Env.guard_t) = (fun env copt uu____387 -> (match (uu____387) with
+| (e, c) -> begin
+(
+
+let expected_c_opt = (match (copt) with
+| Some (uu____402) -> begin
+copt
+end
+| None -> begin
+(
+
+let uu____403 = (((FStar_Options.ml_ish ()) && (FStar_Ident.lid_equals FStar_Syntax_Const.effect_ALL_lid (FStar_Syntax_Util.comp_effect_name c))) || (((FStar_Options.ml_ish ()) && env.FStar_TypeChecker_Env.lax) && (
+
+let uu____404 = (FStar_Syntax_Util.is_pure_or_ghost_comp c)
+in (not (uu____404)))))
+in (match (uu____403) with
+| true -> begin
+(
+
+let uu____406 = (FStar_Syntax_Util.ml_comp (FStar_Syntax_Util.comp_result c) e.FStar_Syntax_Syntax.pos)
+in Some (uu____406))
+end
+| uu____407 -> begin
+(
+
+let uu____408 = (FStar_Syntax_Util.is_tot_or_gtot_comp c)
+in (match (uu____408) with
+| true -> begin
+None
+end
+| uu____410 -> begin
+(
+
+let uu____411 = (FStar_Syntax_Util.is_pure_comp c)
+in (match (uu____411) with
+| true -> begin
+(
+
+let uu____413 = (FStar_Syntax_Syntax.mk_Total (FStar_Syntax_Util.comp_result c))
+in Some (uu____413))
+end
+| uu____414 -> begin
+(
+
+let uu____415 = (FStar_Syntax_Util.is_pure_or_ghost_comp c)
+in (match (uu____415) with
+| true -> begin
+(
+
+let uu____417 = (FStar_Syntax_Syntax.mk_GTotal (FStar_Syntax_Util.comp_result c))
+in Some (uu____417))
+end
+| uu____418 -> begin
+None
+end))
+end))
+end))
+end))
+end)
+in (match (expected_c_opt) with
+| None -> begin
+(
+
+let uu____422 = (norm_c env c)
+in ((e), (uu____422), (FStar_TypeChecker_Rel.trivial_guard)))
+end
+| Some (expected_c) -> begin
+((
+
+let uu____425 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____425) with
+| true -> begin
+(
+
+let uu____426 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____427 = (FStar_Syntax_Print.comp_to_string c)
+in (
+
+let uu____428 = (FStar_Syntax_Print.comp_to_string expected_c)
+in (FStar_Util.print3 "\n\n(%s) About to check\n\t%s\nagainst expected effect\n\t%s\n" uu____426 uu____427 uu____428))))
+end
+| uu____429 -> begin
+()
+end));
+(
+
+let c1 = (norm_c env c)
+in ((
+
+let uu____432 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____432) with
+| true -> begin
+(
+
+let uu____433 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____434 = (FStar_Syntax_Print.comp_to_string c1)
+in (
+
+let uu____435 = (FStar_Syntax_Print.comp_to_string expected_c)
+in (FStar_Util.print3 "\n\nAfter normalization (%s) About to check\n\t%s\nagainst expected effect\n\t%s\n" uu____433 uu____434 uu____435))))
+end
+| uu____436 -> begin
+()
+end));
+(
+
+let uu____437 = (FStar_TypeChecker_Util.check_comp env e c1 expected_c)
+in (match (uu____437) with
+| (e1, uu____445, g) -> begin
+(
+
+let g1 = (
+
+let uu____448 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_TypeChecker_Util.label_guard uu____448 "could not prove post-condition" g))
+in ((
+
+let uu____450 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____450) with
+| true -> begin
+(
+
+let uu____451 = (FStar_Range.string_of_range e1.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____452 = (FStar_TypeChecker_Rel.guard_to_string env g1)
+in (FStar_Util.print2 "(%s) DONE check_expected_effect; guard is: %s\n" uu____451 uu____452)))
+end
+| uu____453 -> begin
+()
+end));
+(
+
+let e2 = (FStar_TypeChecker_Util.maybe_lift env e1 (FStar_Syntax_Util.comp_effect_name c1) (FStar_Syntax_Util.comp_effect_name expected_c) (FStar_Syntax_Util.comp_result c1))
+in ((e2), (expected_c), (g1)));
+))
+end));
+));
+)
+end))
+end))
+
+
+let no_logical_guard = (fun env uu____474 -> (match (uu____474) with
+| (te, kt, f) -> begin
+(
+
+let uu____481 = (FStar_TypeChecker_Rel.guard_form f)
+in (match (uu____481) with
+| FStar_TypeChecker_Common.Trivial -> begin
+((te), (kt), (f))
+end
+| FStar_TypeChecker_Common.NonTrivial (f1) -> begin
+(
+
+let uu____486 = (
+
+let uu____487 = (
+
+let uu____490 = (FStar_TypeChecker_Err.unexpected_non_trivial_precondition_on_term env f1)
+in (
+
+let uu____491 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____490), (uu____491))))
+in FStar_Errors.Error (uu____487))
+in (Prims.raise uu____486))
+end))
+end))
+
+
+let print_expected_ty : FStar_TypeChecker_Env.env  ->  Prims.unit = (fun env -> (
+
+let uu____498 = (FStar_TypeChecker_Env.expected_typ env)
+in (match (uu____498) with
+| None -> begin
+(FStar_Util.print_string "Expected type is None")
+end
+| Some (t) -> begin
+(
+
+let uu____501 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print1 "Expected type is %s" uu____501))
+end)))
+
+
+let check_smt_pat = (fun env t bs c -> (
+
+let uu____536 = (FStar_Syntax_Util.is_smt_lemma t)
+in (match (uu____536) with
+| true -> begin
+(match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Comp ({FStar_Syntax_Syntax.comp_univs = uu____537; FStar_Syntax_Syntax.effect_name = uu____538; FStar_Syntax_Syntax.result_typ = uu____539; FStar_Syntax_Syntax.effect_args = (_pre)::(_post)::((pats, uu____543))::[]; FStar_Syntax_Syntax.flags = uu____544}) -> begin
+(
+
+let pat_vars = (
+
+let uu____578 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env pats)
+in (FStar_Syntax_Free.names uu____578))
+in (
+
+let uu____579 = (FStar_All.pipe_right bs (FStar_Util.find_opt (fun uu____591 -> (match (uu____591) with
+| (b, uu____595) -> begin
+(
+
+let uu____596 = (FStar_Util.set_mem b pat_vars)
+in (not (uu____596)))
+end))))
+in (match (uu____579) with
+| None -> begin
+()
+end
+| Some (x, uu____600) -> begin
+(
+
+let uu____603 = (
+
+let uu____604 = (FStar_Syntax_Print.bv_to_string x)
+in (FStar_Util.format1 "Pattern misses at least one bound variable: %s" uu____604))
+in (FStar_Errors.warn t.FStar_Syntax_Syntax.pos uu____603))
+end)))
+end
+| uu____605 -> begin
+(failwith "Impossible")
+end)
+end
+| uu____606 -> begin
+()
+end)))
+
+
+let guard_letrecs : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax  ->  (FStar_Syntax_Syntax.lbname * FStar_Syntax_Syntax.typ) Prims.list = (fun env actuals expected_c -> (
+
+let uu____626 = (
+
+let uu____627 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____627)))
+in (match (uu____626) with
+| true -> begin
+env.FStar_TypeChecker_Env.letrecs
+end
+| uu____631 -> begin
+(match (env.FStar_TypeChecker_Env.letrecs) with
+| [] -> begin
+[]
+end
+| letrecs -> begin
+(
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let env1 = (
+
+let uu___89_645 = env
+in {FStar_TypeChecker_Env.solver = uu___89_645.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___89_645.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___89_645.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___89_645.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___89_645.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___89_645.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___89_645.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___89_645.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___89_645.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___89_645.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___89_645.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___89_645.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = []; FStar_TypeChecker_Env.top_level = uu___89_645.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___89_645.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___89_645.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___89_645.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___89_645.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___89_645.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___89_645.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___89_645.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___89_645.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___89_645.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___89_645.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let precedes = (FStar_TypeChecker_Util.fvar_const env1 FStar_Syntax_Const.precedes_lid)
+in (
+
+let decreases_clause = (fun bs c -> (
+
+let filter_types_and_functions = (fun bs1 -> (FStar_All.pipe_right bs1 (FStar_List.collect (fun uu____668 -> (match (uu____668) with
+| (b, uu____673) -> begin
+(
+
+let t = (
+
+let uu____675 = (FStar_Syntax_Util.unrefine b.FStar_Syntax_Syntax.sort)
+in (unfold_whnf env1 uu____675))
+in (match (t.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) -> begin
+[]
+end
+| uu____679 -> begin
+(
+
+let uu____680 = (FStar_Syntax_Syntax.bv_to_name b)
+in (uu____680)::[])
+end))
+end)))))
+in (
+
+let as_lex_list = (fun dec -> (
+
+let uu____685 = (FStar_Syntax_Util.head_and_args dec)
+in (match (uu____685) with
+| (head1, uu____696) -> begin
+(match (head1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.lexcons_lid) -> begin
+dec
+end
+| uu____712 -> begin
+(mk_lex_list ((dec)::[]))
+end)
+end)))
+in (
+
+let cflags = (FStar_Syntax_Util.comp_flags c)
+in (
+
+let uu____715 = (FStar_All.pipe_right cflags (FStar_List.tryFind (fun uu___81_719 -> (match (uu___81_719) with
+| FStar_Syntax_Syntax.DECREASES (uu____720) -> begin
+true
+end
+| uu____723 -> begin
+false
+end))))
+in (match (uu____715) with
+| Some (FStar_Syntax_Syntax.DECREASES (dec)) -> begin
+(as_lex_list dec)
+end
+| uu____727 -> begin
+(
+
+let xs = (FStar_All.pipe_right bs filter_types_and_functions)
+in (match (xs) with
+| (x)::[] -> begin
+x
+end
+| uu____733 -> begin
+(mk_lex_list xs)
+end))
+end))))))
+in (
+
+let previous_dec = (decreases_clause actuals expected_c)
+in (
+
+let guard_one_letrec = (fun uu____745 -> (match (uu____745) with
+| (l, t) -> begin
+(
+
+let uu____754 = (
+
+let uu____755 = (FStar_Syntax_Subst.compress t)
+in uu____755.FStar_Syntax_Syntax.n)
+in (match (uu____754) with
+| FStar_Syntax_Syntax.Tm_arrow (formals, c) -> begin
+(
+
+let formals1 = (FStar_All.pipe_right formals (FStar_List.map (fun uu____788 -> (match (uu____788) with
+| (x, imp) -> begin
+(
+
+let uu____795 = (FStar_Syntax_Syntax.is_null_bv x)
+in (match (uu____795) with
+| true -> begin
+(
+
+let uu____798 = (
+
+let uu____799 = (
+
+let uu____801 = (FStar_Syntax_Syntax.range_of_bv x)
+in Some (uu____801))
+in (FStar_Syntax_Syntax.new_bv uu____799 x.FStar_Syntax_Syntax.sort))
+in ((uu____798), (imp)))
+end
+| uu____802 -> begin
+((x), (imp))
+end))
+end))))
+in (
+
+let uu____803 = (FStar_Syntax_Subst.open_comp formals1 c)
+in (match (uu____803) with
+| (formals2, c1) -> begin
+(
+
+let dec = (decreases_clause formals2 c1)
+in (
+
+let precedes1 = (
+
+let uu____816 = (
+
+let uu____817 = (
+
+let uu____818 = (FStar_Syntax_Syntax.as_arg dec)
+in (
+
+let uu____819 = (
+
+let uu____821 = (FStar_Syntax_Syntax.as_arg previous_dec)
+in (uu____821)::[])
+in (uu____818)::uu____819))
+in (FStar_Syntax_Syntax.mk_Tm_app precedes uu____817))
+in (uu____816 None r))
+in (
+
+let uu____826 = (FStar_Util.prefix formals2)
+in (match (uu____826) with
+| (bs, (last1, imp)) -> begin
+(
+
+let last2 = (
+
+let uu___90_852 = last1
+in (
+
+let uu____853 = (FStar_Syntax_Util.refine last1 precedes1)
+in {FStar_Syntax_Syntax.ppname = uu___90_852.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___90_852.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____853}))
+in (
+
+let refined_formals = (FStar_List.append bs ((((last2), (imp)))::[]))
+in (
+
+let t' = (FStar_Syntax_Util.arrow refined_formals c1)
+in ((
+
+let uu____870 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____870) with
+| true -> begin
+(
+
+let uu____871 = (FStar_Syntax_Print.lbname_to_string l)
+in (
+
+let uu____872 = (FStar_Syntax_Print.term_to_string t)
+in (
+
+let uu____873 = (FStar_Syntax_Print.term_to_string t')
+in (FStar_Util.print3 "Refined let rec %s\n\tfrom type %s\n\tto type %s\n" uu____871 uu____872 uu____873))))
+end
+| uu____874 -> begin
+()
+end));
+((l), (t'));
+))))
+end))))
+end)))
+end
+| uu____877 -> begin
+(Prims.raise (FStar_Errors.Error ((("Annotated type of \'let rec\' must be an arrow"), (t.FStar_Syntax_Syntax.pos)))))
+end))
+end))
+in (FStar_All.pipe_right letrecs (FStar_List.map guard_one_letrec))))))))
+end)
+end)))
+
+
+let rec tc_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (tc_maybe_toplevel_term (
+
+let uu___91_1149 = env
+in {FStar_TypeChecker_Env.solver = uu___91_1149.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___91_1149.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___91_1149.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___91_1149.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___91_1149.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___91_1149.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___91_1149.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___91_1149.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___91_1149.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___91_1149.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___91_1149.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___91_1149.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___91_1149.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = false; FStar_TypeChecker_Env.check_uvars = uu___91_1149.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___91_1149.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___91_1149.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___91_1149.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___91_1149.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___91_1149.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___91_1149.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___91_1149.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___91_1149.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___91_1149.FStar_TypeChecker_Env.qname_and_index}) e))
+and tc_maybe_toplevel_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (
+
+let env1 = (match ((e.FStar_Syntax_Syntax.pos = FStar_Range.dummyRange)) with
+| true -> begin
+env
+end
+| uu____1156 -> begin
+(FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos)
+end)
+in ((
+
+let uu____1158 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____1158) with
+| true -> begin
+(
+
+let uu____1159 = (
+
+let uu____1160 = (FStar_TypeChecker_Env.get_range env1)
+in (FStar_All.pipe_left FStar_Range.string_of_range uu____1160))
+in (
+
+let uu____1161 = (FStar_Syntax_Print.tag_of_term e)
+in (FStar_Util.print2 "%s (%s)\n" uu____1159 uu____1161)))
+end
+| uu____1162 -> begin
+()
+end));
+(
+
+let top = (FStar_Syntax_Subst.compress e)
+in (match (top.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_delayed (uu____1167) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_uinst (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_abs (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_refine (_)) | (FStar_Syntax_Syntax.Tm_type (_)) | (FStar_Syntax_Syntax.Tm_unknown) -> begin
+(tc_value env1 e)
+end
+| FStar_Syntax_Syntax.Tm_meta (e1, FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Meta_smt_pat)) -> begin
+(
+
+let uu____1206 = (tc_tot_or_gtot_term env1 e1)
+in (match (uu____1206) with
+| (e2, c, g) -> begin
+(
+
+let g1 = (
+
+let uu___92_1217 = g
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___92_1217.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___92_1217.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___92_1217.FStar_TypeChecker_Env.implicits})
+in ((e2), (c), (g1)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (e1, FStar_Syntax_Syntax.Meta_pattern (pats)) -> begin
+(
+
+let uu____1230 = (FStar_Syntax_Util.type_u ())
+in (match (uu____1230) with
+| (t, u) -> begin
+(
+
+let uu____1238 = (tc_check_tot_or_gtot_term env1 e1 t)
+in (match (uu____1238) with
+| (e2, c, g) -> begin
+(
+
+let uu____1248 = (
+
+let uu____1257 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____1257) with
+| (env2, uu____1270) -> begin
+(tc_pats env2 pats)
+end))
+in (match (uu____1248) with
+| (pats1, g') -> begin
+(
+
+let g'1 = (
+
+let uu___93_1291 = g'
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___93_1291.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___93_1291.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___93_1291.FStar_TypeChecker_Env.implicits})
+in (
+
+let uu____1292 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e2), (FStar_Syntax_Syntax.Meta_pattern (pats1)))))) (Some (t.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____1303 = (FStar_TypeChecker_Rel.conj_guard g g'1)
+in ((uu____1292), (c), (uu____1303)))))
+end))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (e1, FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Sequence)) -> begin
+(
+
+let uu____1311 = (
+
+let uu____1312 = (FStar_Syntax_Subst.compress e1)
+in uu____1312.FStar_Syntax_Syntax.n)
+in (match (uu____1311) with
+| FStar_Syntax_Syntax.Tm_let ((uu____1318, ({FStar_Syntax_Syntax.lbname = x; FStar_Syntax_Syntax.lbunivs = uu____1320; FStar_Syntax_Syntax.lbtyp = uu____1321; FStar_Syntax_Syntax.lbeff = uu____1322; FStar_Syntax_Syntax.lbdef = e11})::[]), e2) -> begin
+(
+
+let uu____1340 = (
+
+let uu____1344 = (FStar_TypeChecker_Env.set_expected_typ env1 FStar_TypeChecker_Common.t_unit)
+in (tc_term uu____1344 e11))
+in (match (uu____1340) with
+| (e12, c1, g1) -> begin
+(
+
+let uu____1351 = (tc_term env1 e2)
+in (match (uu____1351) with
+| (e21, c2, g2) -> begin
+(
+
+let c = (FStar_TypeChecker_Util.bind e12.FStar_Syntax_Syntax.pos env1 (Some (e12)) c1 ((None), (c2)))
+in (
+
+let e13 = (FStar_TypeChecker_Util.maybe_lift env1 e12 c1.FStar_Syntax_Syntax.eff_name c.FStar_Syntax_Syntax.eff_name c1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let e22 = (FStar_TypeChecker_Util.maybe_lift env1 e21 c2.FStar_Syntax_Syntax.eff_name c.FStar_Syntax_Syntax.eff_name c2.FStar_Syntax_Syntax.res_typ)
+in (
+
+let e3 = (
+
+let uu____1368 = (
+
+let uu____1371 = (
+
+let uu____1372 = (
+
+let uu____1380 = (
+
+let uu____1384 = (
+
+let uu____1386 = (FStar_Syntax_Syntax.mk_lb ((x), ([]), (c1.FStar_Syntax_Syntax.eff_name), (FStar_TypeChecker_Common.t_unit), (e13)))
+in (uu____1386)::[])
+in ((false), (uu____1384)))
+in ((uu____1380), (e22)))
+in FStar_Syntax_Syntax.Tm_let (uu____1372))
+in (FStar_Syntax_Syntax.mk uu____1371))
+in (uu____1368 (Some (c.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) e1.FStar_Syntax_Syntax.pos))
+in (
+
+let e4 = (FStar_TypeChecker_Util.maybe_monadic env1 e3 c.FStar_Syntax_Syntax.eff_name c.FStar_Syntax_Syntax.res_typ)
+in (
+
+let e5 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e4), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Sequence)))))) (Some (c.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____1416 = (FStar_TypeChecker_Rel.conj_guard g1 g2)
+in ((e5), (c), (uu____1416)))))))))
+end))
+end))
+end
+| uu____1419 -> begin
+(
+
+let uu____1420 = (tc_term env1 e1)
+in (match (uu____1420) with
+| (e2, c, g) -> begin
+(
+
+let e3 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e2), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Sequence)))))) (Some (c.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in ((e3), (c), (g)))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_meta (e1, FStar_Syntax_Syntax.Meta_monadic (uu____1444)) -> begin
+(tc_term env1 e1)
+end
+| FStar_Syntax_Syntax.Tm_meta (e1, m) -> begin
+(
+
+let uu____1459 = (tc_term env1 e1)
+in (match (uu____1459) with
+| (e2, c, g) -> begin
+(
+
+let e3 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e2), (m))))) (Some (c.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in ((e3), (c), (g)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e1, (FStar_Util.Inr (expected_c), topt), uu____1485) -> begin
+(
+
+let uu____1521 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____1521) with
+| (env0, uu____1529) -> begin
+(
+
+let uu____1532 = (tc_comp env0 expected_c)
+in (match (uu____1532) with
+| (expected_c1, uu____1540, g) -> begin
+(
+
+let t_res = (FStar_Syntax_Util.comp_result expected_c1)
+in (
+
+let uu____1545 = (
+
+let uu____1549 = (FStar_TypeChecker_Env.set_expected_typ env0 t_res)
+in (tc_term uu____1549 e1))
+in (match (uu____1545) with
+| (e2, c', g') -> begin
+(
+
+let uu____1556 = (
+
+let uu____1560 = (
+
+let uu____1563 = (c'.FStar_Syntax_Syntax.comp ())
+in ((e2), (uu____1563)))
+in (check_expected_effect env0 (Some (expected_c1)) uu____1560))
+in (match (uu____1556) with
+| (e3, expected_c2, g'') -> begin
+(
+
+let e4 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_ascribed (((e3), (((FStar_Util.Inl (t_res)), (None))), (Some ((FStar_Syntax_Util.comp_effect_name expected_c2))))))) (Some (t_res.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let lc = (FStar_Syntax_Util.lcomp_of_comp expected_c2)
+in (
+
+let f = (
+
+let uu____1614 = (FStar_TypeChecker_Rel.conj_guard g' g'')
+in (FStar_TypeChecker_Rel.conj_guard g uu____1614))
+in (
+
+let topt1 = (tc_tactic_opt env0 topt)
+in (
+
+let f1 = (match (topt1) with
+| None -> begin
+f
+end
+| Some (tactic) -> begin
+(FStar_TypeChecker_Rel.map_guard f (FStar_TypeChecker_Common.mk_by_tactic tactic))
+end)
+in (
+
+let uu____1619 = (comp_check_expected_typ env1 e4 lc)
+in (match (uu____1619) with
+| (e5, c, f2) -> begin
+(
+
+let uu____1629 = (FStar_TypeChecker_Rel.conj_guard f1 f2)
+in ((e5), (c), (uu____1629)))
+end)))))))
+end))
+end)))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e1, (FStar_Util.Inl (t), topt), uu____1633) -> begin
+(
+
+let uu____1669 = (FStar_Syntax_Util.type_u ())
+in (match (uu____1669) with
+| (k, u) -> begin
+(
+
+let uu____1677 = (tc_check_tot_or_gtot_term env1 t k)
+in (match (uu____1677) with
+| (t1, uu____1685, f) -> begin
+(
+
+let uu____1687 = (
+
+let uu____1691 = (FStar_TypeChecker_Env.set_expected_typ env1 t1)
+in (tc_term uu____1691 e1))
+in (match (uu____1687) with
+| (e2, c, g) -> begin
+(
+
+let uu____1698 = (
+
+let uu____1701 = (FStar_TypeChecker_Env.set_range env1 t1.FStar_Syntax_Syntax.pos)
+in (FStar_TypeChecker_Util.strengthen_precondition (Some ((fun uu____1704 -> FStar_TypeChecker_Err.ill_kinded_type))) uu____1701 e2 c f))
+in (match (uu____1698) with
+| (c1, f1) -> begin
+(
+
+let uu____1710 = (
+
+let uu____1714 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_ascribed (((e2), (((FStar_Util.Inl (t1)), (None))), (Some (c1.FStar_Syntax_Syntax.eff_name)))))) (Some (t1.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (comp_check_expected_typ env1 uu____1714 c1))
+in (match (uu____1710) with
+| (e3, c2, f2) -> begin
+(
+
+let uu____1750 = (
+
+let uu____1751 = (FStar_TypeChecker_Rel.conj_guard g f2)
+in (FStar_TypeChecker_Rel.conj_guard f1 uu____1751))
+in ((e3), (c2), (uu____1750)))
+end))
+end))
+end))
+end))
+end))
+end
+| (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (a)::(hd1)::rest)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (_)); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, (a)::(hd1)::rest)) -> begin
+(
+
+let rest1 = (hd1)::rest
+in (
+
+let uu____1828 = (FStar_Syntax_Util.head_and_args top)
+in (match (uu____1828) with
+| (unary_op, uu____1842) -> begin
+(
+
+let head1 = (
+
+let uu____1860 = (FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos (Prims.fst a).FStar_Syntax_Syntax.pos)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((unary_op), ((a)::[]))))) None uu____1860))
+in (
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((head1), (rest1))))) None top.FStar_Syntax_Syntax.pos)
+in (tc_term env1 t)))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify); FStar_Syntax_Syntax.tk = uu____1904; FStar_Syntax_Syntax.pos = uu____1905; FStar_Syntax_Syntax.vars = uu____1906}, ((e1, aqual))::[]) -> begin
+((match ((FStar_Option.isSome aqual)) with
+| true -> begin
+(FStar_Errors.warn e1.FStar_Syntax_Syntax.pos "Qualifier on argument to reify is irrelevant and will be ignored")
+end
+| uu____1931 -> begin
+()
+end);
+(
+
+let uu____1932 = (
+
+let uu____1936 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____1936) with
+| (env0, uu____1944) -> begin
+(tc_term env0 e1)
+end))
+in (match (uu____1932) with
+| (e2, c, g) -> begin
+(
+
+let uu____1953 = (FStar_Syntax_Util.head_and_args top)
+in (match (uu____1953) with
+| (reify_op, uu____1967) -> begin
+(
+
+let u_c = (
+
+let uu____1983 = (tc_term env1 c.FStar_Syntax_Syntax.res_typ)
+in (match (uu____1983) with
+| (uu____1987, c', uu____1989) -> begin
+(
+
+let uu____1990 = (
+
+let uu____1991 = (FStar_Syntax_Subst.compress c'.FStar_Syntax_Syntax.res_typ)
+in uu____1991.FStar_Syntax_Syntax.n)
+in (match (uu____1990) with
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+u
+end
+| uu____1995 -> begin
+(
+
+let uu____1996 = (FStar_Syntax_Util.type_u ())
+in (match (uu____1996) with
+| (t, u) -> begin
+(
+
+let g_opt = (FStar_TypeChecker_Rel.try_teq true env1 c'.FStar_Syntax_Syntax.res_typ t)
+in ((match (g_opt) with
+| Some (g') -> begin
+(FStar_TypeChecker_Rel.force_trivial_guard env1 g')
+end
+| None -> begin
+(
+
+let uu____2005 = (
+
+let uu____2006 = (FStar_Syntax_Print.lcomp_to_string c')
+in (
+
+let uu____2007 = (FStar_Syntax_Print.term_to_string c.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____2008 = (FStar_Syntax_Print.term_to_string c'.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.format3 "Unexpected result type of computation. The computation type %s of the term %s should have type Type n for some level n but has type %s" uu____2006 uu____2007 uu____2008))))
+in (failwith uu____2005))
+end);
+u;
+))
+end))
+end))
+end))
+in (
+
+let repr = (
+
+let uu____2010 = (c.FStar_Syntax_Syntax.comp ())
+in (FStar_TypeChecker_Env.reify_comp env1 uu____2010 u_c))
+in (
+
+let e3 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((reify_op), ((((e2), (aqual)))::[]))))) (Some (repr.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let c1 = (
+
+let uu____2032 = (FStar_Syntax_Syntax.mk_Total repr)
+in (FStar_All.pipe_right uu____2032 FStar_Syntax_Util.lcomp_of_comp))
+in (
+
+let uu____2033 = (comp_check_expected_typ env1 e3 c1)
+in (match (uu____2033) with
+| (e4, c2, g') -> begin
+(
+
+let uu____2043 = (FStar_TypeChecker_Rel.conj_guard g g')
+in ((e4), (c2), (uu____2043)))
+end))))))
+end))
+end));
+)
+end
+| FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect (l)); FStar_Syntax_Syntax.tk = uu____2045; FStar_Syntax_Syntax.pos = uu____2046; FStar_Syntax_Syntax.vars = uu____2047}, ((e1, aqual))::[]) -> begin
+((match ((FStar_Option.isSome aqual)) with
+| true -> begin
+(FStar_Errors.warn e1.FStar_Syntax_Syntax.pos "Qualifier on argument to reflect is irrelevant and will be ignored")
+end
+| uu____2072 -> begin
+()
+end);
+(
+
+let no_reflect = (fun uu____2079 -> (
+
+let uu____2080 = (
+
+let uu____2081 = (
+
+let uu____2084 = (FStar_Util.format1 "Effect %s cannot be reified" l.FStar_Ident.str)
+in ((uu____2084), (e1.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____2081))
+in (Prims.raise uu____2080)))
+in (
+
+let uu____2088 = (FStar_Syntax_Util.head_and_args top)
+in (match (uu____2088) with
+| (reflect_op, uu____2102) -> begin
+(
+
+let uu____2117 = (FStar_TypeChecker_Env.effect_decl_opt env1 l)
+in (match (uu____2117) with
+| None -> begin
+(no_reflect ())
+end
+| Some (ed) -> begin
+(
+
+let uu____2123 = (
+
+let uu____2124 = (FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers FStar_Syntax_Syntax.contains_reflectable)
+in (not (uu____2124)))
+in (match (uu____2123) with
+| true -> begin
+(no_reflect ())
+end
+| uu____2129 -> begin
+(
+
+let uu____2130 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____2130) with
+| (env_no_ex, topt) -> begin
+(
+
+let uu____2141 = (
+
+let u = (FStar_TypeChecker_Env.new_u_univ ())
+in (
+
+let repr = (FStar_TypeChecker_Env.inst_effect_fun_with ((u)::[]) env1 ed (([]), (ed.FStar_Syntax_Syntax.repr)))
+in (
+
+let t = (
+
+let uu____2156 = (
+
+let uu____2159 = (
+
+let uu____2160 = (
+
+let uu____2170 = (
+
+let uu____2172 = (FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun)
+in (
+
+let uu____2173 = (
+
+let uu____2175 = (FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun)
+in (uu____2175)::[])
+in (uu____2172)::uu____2173))
+in ((repr), (uu____2170)))
+in FStar_Syntax_Syntax.Tm_app (uu____2160))
+in (FStar_Syntax_Syntax.mk uu____2159))
+in (uu____2156 None top.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____2185 = (
+
+let uu____2189 = (
+
+let uu____2190 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (FStar_All.pipe_right uu____2190 Prims.fst))
+in (tc_tot_or_gtot_term uu____2189 t))
+in (match (uu____2185) with
+| (t1, uu____2207, g) -> begin
+(
+
+let uu____2209 = (
+
+let uu____2210 = (FStar_Syntax_Subst.compress t1)
+in uu____2210.FStar_Syntax_Syntax.n)
+in (match (uu____2209) with
+| FStar_Syntax_Syntax.Tm_app (uu____2221, ((res, uu____2223))::((wp, uu____2225))::[]) -> begin
+((t1), (res), (wp), (g))
+end
+| uu____2259 -> begin
+(failwith "Impossible")
+end))
+end)))))
+in (match (uu____2141) with
+| (expected_repr_typ, res_typ, wp, g0) -> begin
+(
+
+let uu____2283 = (
+
+let uu____2286 = (tc_tot_or_gtot_term env_no_ex e1)
+in (match (uu____2286) with
+| (e2, c, g) -> begin
+((
+
+let uu____2296 = (
+
+let uu____2297 = (FStar_Syntax_Util.is_total_lcomp c)
+in (FStar_All.pipe_left Prims.op_Negation uu____2297))
+in (match (uu____2296) with
+| true -> begin
+(FStar_TypeChecker_Err.add_errors env1 (((("Expected Tot, got a GTot computation"), (e2.FStar_Syntax_Syntax.pos)))::[]))
+end
+| uu____2302 -> begin
+()
+end));
+(
+
+let uu____2303 = (FStar_TypeChecker_Rel.try_teq true env_no_ex c.FStar_Syntax_Syntax.res_typ expected_repr_typ)
+in (match (uu____2303) with
+| None -> begin
+((
+
+let uu____2308 = (
+
+let uu____2312 = (
+
+let uu____2315 = (
+
+let uu____2316 = (FStar_Syntax_Print.term_to_string ed.FStar_Syntax_Syntax.repr)
+in (
+
+let uu____2317 = (FStar_Syntax_Print.term_to_string c.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.format2 "Expected an instance of %s; got %s" uu____2316 uu____2317)))
+in ((uu____2315), (e2.FStar_Syntax_Syntax.pos)))
+in (uu____2312)::[])
+in (FStar_TypeChecker_Err.add_errors env1 uu____2308));
+(
+
+let uu____2322 = (FStar_TypeChecker_Rel.conj_guard g g0)
+in ((e2), (uu____2322)));
+)
+end
+| Some (g') -> begin
+(
+
+let uu____2324 = (
+
+let uu____2325 = (FStar_TypeChecker_Rel.conj_guard g g0)
+in (FStar_TypeChecker_Rel.conj_guard g' uu____2325))
+in ((e2), (uu____2324)))
+end));
+)
+end))
+in (match (uu____2283) with
+| (e2, g) -> begin
+(
+
+let c = (
+
+let uu____2332 = (
+
+let uu____2333 = (
+
+let uu____2334 = (
+
+let uu____2335 = (env1.FStar_TypeChecker_Env.universe_of env1 res_typ)
+in (uu____2335)::[])
+in (
+
+let uu____2336 = (
+
+let uu____2342 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____2342)::[])
+in {FStar_Syntax_Syntax.comp_univs = uu____2334; FStar_Syntax_Syntax.effect_name = ed.FStar_Syntax_Syntax.mname; FStar_Syntax_Syntax.result_typ = res_typ; FStar_Syntax_Syntax.effect_args = uu____2336; FStar_Syntax_Syntax.flags = []}))
+in (FStar_Syntax_Syntax.mk_Comp uu____2333))
+in (FStar_All.pipe_right uu____2332 FStar_Syntax_Util.lcomp_of_comp))
+in (
+
+let e3 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (((reflect_op), ((((e2), (aqual)))::[]))))) (Some (res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2363 = (comp_check_expected_typ env1 e3 c)
+in (match (uu____2363) with
+| (e4, c1, g') -> begin
+(
+
+let uu____2373 = (FStar_TypeChecker_Rel.conj_guard g' g)
+in ((e4), (c1), (uu____2373)))
+end))))
+end))
+end))
+end))
+end))
+end))
+end)));
+)
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let env0 = env1
+in (
+
+let env2 = (
+
+let uu____2392 = (
+
+let uu____2393 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (FStar_All.pipe_right uu____2393 Prims.fst))
+in (FStar_All.pipe_right uu____2392 instantiate_both))
+in ((
+
+let uu____2402 = (FStar_TypeChecker_Env.debug env2 FStar_Options.High)
+in (match (uu____2402) with
+| true -> begin
+(
+
+let uu____2403 = (FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2404 = (FStar_Syntax_Print.term_to_string top)
+in (FStar_Util.print2 "(%s) Checking app %s\n" uu____2403 uu____2404)))
+end
+| uu____2405 -> begin
+()
+end));
+(
+
+let uu____2406 = (tc_term (no_inst env2) head1)
+in (match (uu____2406) with
+| (head2, chead, g_head) -> begin
+(
+
+let uu____2416 = (
+
+let uu____2420 = ((not (env2.FStar_TypeChecker_Env.lax)) && (FStar_TypeChecker_Util.short_circuit_head head2))
+in (match (uu____2420) with
+| true -> begin
+(
+
+let uu____2424 = (FStar_TypeChecker_Env.expected_typ env0)
+in (check_short_circuit_args env2 head2 chead g_head args uu____2424))
+end
+| uu____2426 -> begin
+(
+
+let uu____2427 = (FStar_TypeChecker_Env.expected_typ env0)
+in (check_application_args env2 head2 chead g_head args uu____2427))
+end))
+in (match (uu____2416) with
+| (e1, c, g) -> begin
+((
+
+let uu____2436 = (FStar_TypeChecker_Env.debug env2 FStar_Options.Extreme)
+in (match (uu____2436) with
+| true -> begin
+(
+
+let uu____2437 = (FStar_TypeChecker_Rel.print_pending_implicits g)
+in (FStar_Util.print1 "Introduced {%s} implicits in application\n" uu____2437))
+end
+| uu____2438 -> begin
+()
+end));
+(
+
+let c1 = (
+
+let uu____2440 = (((FStar_TypeChecker_Env.should_verify env2) && (
+
+let uu____2441 = (FStar_Syntax_Util.is_lcomp_partial_return c)
+in (not (uu____2441)))) && (FStar_Syntax_Util.is_pure_or_ghost_lcomp c))
+in (match (uu____2440) with
+| true -> begin
+(FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term env2 e1 c)
+end
+| uu____2442 -> begin
+c
+end))
+in (
+
+let uu____2443 = (comp_check_expected_typ env0 e1 c1)
+in (match (uu____2443) with
+| (e2, c2, g') -> begin
+(
+
+let gimp = (
+
+let uu____2454 = (
+
+let uu____2455 = (FStar_Syntax_Subst.compress head2)
+in uu____2455.FStar_Syntax_Syntax.n)
+in (match (uu____2454) with
+| FStar_Syntax_Syntax.Tm_uvar (u, uu____2459) -> begin
+(
+
+let imp = (("head of application is a uvar"), (env0), (u), (e2), (c2.FStar_Syntax_Syntax.res_typ), (head2.FStar_Syntax_Syntax.pos))
+in (
+
+let uu___94_2491 = FStar_TypeChecker_Rel.trivial_guard
+in {FStar_TypeChecker_Env.guard_f = uu___94_2491.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___94_2491.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___94_2491.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = (imp)::[]}))
+end
+| uu____2516 -> begin
+FStar_TypeChecker_Rel.trivial_guard
+end))
+in (
+
+let gres = (
+
+let uu____2518 = (FStar_TypeChecker_Rel.conj_guard g' gimp)
+in (FStar_TypeChecker_Rel.conj_guard g uu____2518))
+in ((
+
+let uu____2520 = (FStar_TypeChecker_Env.debug env2 FStar_Options.Extreme)
+in (match (uu____2520) with
+| true -> begin
+(
+
+let uu____2521 = (FStar_Syntax_Print.term_to_string e2)
+in (
+
+let uu____2522 = (FStar_TypeChecker_Rel.guard_to_string env2 gres)
+in (FStar_Util.print2 "Guard from application node %s is %s\n" uu____2521 uu____2522)))
+end
+| uu____2523 -> begin
+()
+end));
+((e2), (c2), (gres));
+)))
+end)));
+)
+end))
+end));
+)))
+end
+| FStar_Syntax_Syntax.Tm_match (e1, eqns) -> begin
+(
+
+let uu____2552 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____2552) with
+| (env11, topt) -> begin
+(
+
+let env12 = (instantiate_both env11)
+in (
+
+let uu____2564 = (tc_term env12 e1)
+in (match (uu____2564) with
+| (e11, c1, g1) -> begin
+(
+
+let uu____2574 = (match (topt) with
+| Some (t) -> begin
+((env1), (t))
+end
+| None -> begin
+(
+
+let uu____2580 = (FStar_Syntax_Util.type_u ())
+in (match (uu____2580) with
+| (k, uu____2586) -> begin
+(
+
+let res_t = (FStar_TypeChecker_Util.new_uvar env1 k)
+in (
+
+let uu____2588 = (FStar_TypeChecker_Env.set_expected_typ env1 res_t)
+in ((uu____2588), (res_t))))
+end))
+end)
+in (match (uu____2574) with
+| (env_branches, res_t) -> begin
+((
+
+let uu____2595 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Extreme)
+in (match (uu____2595) with
+| true -> begin
+(
+
+let uu____2596 = (FStar_Syntax_Print.term_to_string res_t)
+in (FStar_Util.print1 "Tm_match: expected type of branches is %s\n" uu____2596))
+end
+| uu____2597 -> begin
+()
+end));
+(
+
+let guard_x = (FStar_Syntax_Syntax.new_bv (Some (e11.FStar_Syntax_Syntax.pos)) c1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let t_eqns = (FStar_All.pipe_right eqns (FStar_List.map (tc_eqn guard_x env_branches)))
+in (
+
+let uu____2647 = (
+
+let uu____2650 = (FStar_List.fold_right (fun uu____2669 uu____2670 -> (match (((uu____2669), (uu____2670))) with
+| ((uu____2702, f, c, g), (caccum, gaccum)) -> begin
+(
+
+let uu____2735 = (FStar_TypeChecker_Rel.conj_guard g gaccum)
+in (((((f), (c)))::caccum), (uu____2735)))
+end)) t_eqns (([]), (FStar_TypeChecker_Rel.trivial_guard)))
+in (match (uu____2650) with
+| (cases, g) -> begin
+(
+
+let uu____2756 = (FStar_TypeChecker_Util.bind_cases env1 res_t cases)
+in ((uu____2756), (g)))
+end))
+in (match (uu____2647) with
+| (c_branches, g_branches) -> begin
+(
+
+let cres = (FStar_TypeChecker_Util.bind e11.FStar_Syntax_Syntax.pos env1 (Some (e11)) c1 ((Some (guard_x)), (c_branches)))
+in (
+
+let e2 = (
+
+let mk_match = (fun scrutinee -> (
+
+let branches = (FStar_All.pipe_right t_eqns (FStar_List.map (fun uu____2809 -> (match (uu____2809) with
+| ((pat, wopt, br), uu____2825, lc, uu____2827) -> begin
+(
+
+let uu____2834 = (FStar_TypeChecker_Util.maybe_lift env1 br lc.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.eff_name lc.FStar_Syntax_Syntax.res_typ)
+in ((pat), (wopt), (uu____2834)))
+end))))
+in (
+
+let e2 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (((scrutinee), (branches))))) (Some (cres.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let e3 = (FStar_TypeChecker_Util.maybe_monadic env1 e2 cres.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.res_typ)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_ascribed (((e3), (((FStar_Util.Inl (cres.FStar_Syntax_Syntax.res_typ)), (None))), (Some (cres.FStar_Syntax_Syntax.eff_name)))))) None e3.FStar_Syntax_Syntax.pos)))))
+in (
+
+let uu____2890 = (FStar_TypeChecker_Util.is_pure_or_ghost_effect env1 c1.FStar_Syntax_Syntax.eff_name)
+in (match (uu____2890) with
+| true -> begin
+(mk_match e11)
+end
+| uu____2893 -> begin
+(
+
+let e_match = (
+
+let uu____2897 = (FStar_Syntax_Syntax.bv_to_name guard_x)
+in (mk_match uu____2897))
+in (
+
+let lb = (
+
+let uu____2901 = (FStar_TypeChecker_Env.norm_eff_name env1 c1.FStar_Syntax_Syntax.eff_name)
+in {FStar_Syntax_Syntax.lbname = FStar_Util.Inl (guard_x); FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = c1.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.lbeff = uu____2901; FStar_Syntax_Syntax.lbdef = e11})
+in (
+
+let e2 = (
+
+let uu____2905 = (
+
+let uu____2908 = (
+
+let uu____2909 = (
+
+let uu____2917 = (
+
+let uu____2918 = (
+
+let uu____2919 = (FStar_Syntax_Syntax.mk_binder guard_x)
+in (uu____2919)::[])
+in (FStar_Syntax_Subst.close uu____2918 e_match))
+in ((((false), ((lb)::[]))), (uu____2917)))
+in FStar_Syntax_Syntax.Tm_let (uu____2909))
+in (FStar_Syntax_Syntax.mk uu____2908))
+in (uu____2905 (Some (cres.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos))
+in (FStar_TypeChecker_Util.maybe_monadic env1 e2 cres.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.res_typ))))
+end)))
+in ((
+
+let uu____2933 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Extreme)
+in (match (uu____2933) with
+| true -> begin
+(
+
+let uu____2934 = (FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2935 = (
+
+let uu____2936 = (cres.FStar_Syntax_Syntax.comp ())
+in (FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____2936))
+in (FStar_Util.print2 "(%s) comp type = %s\n" uu____2934 uu____2935)))
+end
+| uu____2937 -> begin
+()
+end));
+(
+
+let uu____2938 = (FStar_TypeChecker_Rel.conj_guard g1 g_branches)
+in ((e2), (cres), (uu____2938)));
+)))
+end))));
+)
+end))
+end)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_let ((false, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (uu____2941); FStar_Syntax_Syntax.lbunivs = uu____2942; FStar_Syntax_Syntax.lbtyp = uu____2943; FStar_Syntax_Syntax.lbeff = uu____2944; FStar_Syntax_Syntax.lbdef = uu____2945})::[]), uu____2946) -> begin
+((
+
+let uu____2961 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____2961) with
+| true -> begin
+(
+
+let uu____2962 = (FStar_Syntax_Print.term_to_string top)
+in (FStar_Util.print1 "%s\n" uu____2962))
+end
+| uu____2963 -> begin
+()
+end));
+(check_top_level_let env1 top);
+)
+end
+| FStar_Syntax_Syntax.Tm_let ((false, uu____2964), uu____2965) -> begin
+(check_inner_let env1 top)
+end
+| FStar_Syntax_Syntax.Tm_let ((true, ({FStar_Syntax_Syntax.lbname = FStar_Util.Inr (uu____2975); FStar_Syntax_Syntax.lbunivs = uu____2976; FStar_Syntax_Syntax.lbtyp = uu____2977; FStar_Syntax_Syntax.lbeff = uu____2978; FStar_Syntax_Syntax.lbdef = uu____2979})::uu____2980), uu____2981) -> begin
+((
+
+let uu____2997 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____2997) with
+| true -> begin
+(
+
+let uu____2998 = (FStar_Syntax_Print.term_to_string top)
+in (FStar_Util.print1 "%s\n" uu____2998))
+end
+| uu____2999 -> begin
+()
+end));
+(check_top_level_let_rec env1 top);
+)
+end
+| FStar_Syntax_Syntax.Tm_let ((true, uu____3000), uu____3001) -> begin
+(check_inner_let_rec env1 top)
+end));
+)))
+and tc_tactic_opt : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.option  ->  FStar_Syntax_Syntax.term Prims.option = (fun env topt -> (match (topt) with
+| None -> begin
+None
+end
+| Some (tactic) -> begin
+(
+
+let uu____3024 = (tc_check_tot_or_gtot_term env tactic FStar_TypeChecker_Common.t_tactic_unit)
+in (match (uu____3024) with
+| (tactic1, uu____3030, uu____3031) -> begin
+Some (tactic1)
+end))
+end))
+and tc_value : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (
+
+let check_instantiated_fvar = (fun env1 v1 dc e1 t -> (
+
+let uu____3066 = (FStar_TypeChecker_Util.maybe_instantiate env1 e1 t)
+in (match (uu____3066) with
+| (e2, t1, implicits) -> begin
+(
+
+let tc = (
+
+let uu____3079 = (FStar_TypeChecker_Env.should_verify env1)
+in (match (uu____3079) with
+| true -> begin
+FStar_Util.Inl (t1)
+end
+| uu____3082 -> begin
+(
+
+let uu____3083 = (
+
+let uu____3084 = (FStar_Syntax_Syntax.mk_Total t1)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____3084))
+in FStar_Util.Inr (uu____3083))
+end))
+in (
+
+let is_data_ctor = (fun uu___82_3093 -> (match (uu___82_3093) with
+| (Some (FStar_Syntax_Syntax.Data_ctor)) | (Some (FStar_Syntax_Syntax.Record_ctor (_))) -> begin
+true
+end
+| uu____3096 -> begin
+false
+end))
+in (
+
+let uu____3098 = ((is_data_ctor dc) && (
+
+let uu____3099 = (FStar_TypeChecker_Env.is_datacon env1 v1.FStar_Syntax_Syntax.v)
+in (not (uu____3099))))
+in (match (uu____3098) with
+| true -> begin
+(
+
+let uu____3105 = (
+
+let uu____3106 = (
+
+let uu____3109 = (FStar_Util.format1 "Expected a data constructor; got %s" v1.FStar_Syntax_Syntax.v.FStar_Ident.str)
+in (
+
+let uu____3112 = (FStar_TypeChecker_Env.get_range env1)
+in ((uu____3109), (uu____3112))))
+in FStar_Errors.Error (uu____3106))
+in (Prims.raise uu____3105))
+end
+| uu____3116 -> begin
+(value_check_expected_typ env1 e2 tc implicits)
+end))))
+end)))
+in (
+
+let env1 = (FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos)
+in (
+
+let top = (FStar_Syntax_Subst.compress e)
+in (match (top.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_bvar (x) -> begin
+(
+
+let uu____3123 = (
+
+let uu____3124 = (FStar_Syntax_Print.term_to_string top)
+in (FStar_Util.format1 "Impossible: Violation of locally nameless convention: %s" uu____3124))
+in (failwith uu____3123))
+end
+| FStar_Syntax_Syntax.Tm_uvar (u, t1) -> begin
+(
+
+let g = (
+
+let uu____3143 = (
+
+let uu____3144 = (FStar_Syntax_Subst.compress t1)
+in uu____3144.FStar_Syntax_Syntax.n)
+in (match (uu____3143) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____3147) -> begin
+FStar_TypeChecker_Rel.trivial_guard
+end
+| uu____3155 -> begin
+(
+
+let imp = (("uvar in term"), (env1), (u), (top), (t1), (top.FStar_Syntax_Syntax.pos))
+in (
+
+let uu___95_3175 = FStar_TypeChecker_Rel.trivial_guard
+in {FStar_TypeChecker_Env.guard_f = uu___95_3175.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___95_3175.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___95_3175.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = (imp)::[]}))
+end))
+in (value_check_expected_typ env1 e (FStar_Util.Inl (t1)) g))
+end
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+(
+
+let r = (FStar_TypeChecker_Env.get_range env1)
+in (
+
+let uu____3203 = (
+
+let uu____3210 = (FStar_TypeChecker_Env.expected_typ env1)
+in (match (uu____3210) with
+| None -> begin
+(
+
+let uu____3218 = (FStar_Syntax_Util.type_u ())
+in (match (uu____3218) with
+| (k, u) -> begin
+(FStar_TypeChecker_Util.new_implicit_var "type of user-provided implicit term" r env1 k)
+end))
+end
+| Some (t) -> begin
+((t), ([]), (FStar_TypeChecker_Rel.trivial_guard))
+end))
+in (match (uu____3203) with
+| (t, uu____3239, g0) -> begin
+(
+
+let uu____3247 = (FStar_TypeChecker_Util.new_implicit_var "user-provided implicit term" r env1 t)
+in (match (uu____3247) with
+| (e1, uu____3258, g1) -> begin
+(
+
+let uu____3266 = (
+
+let uu____3267 = (FStar_Syntax_Syntax.mk_Total t)
+in (FStar_All.pipe_right uu____3267 FStar_Syntax_Util.lcomp_of_comp))
+in (
+
+let uu____3268 = (FStar_TypeChecker_Rel.conj_guard g0 g1)
+in ((e1), (uu____3266), (uu____3268))))
+end))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+(
+
+let uu____3270 = (match (env1.FStar_TypeChecker_Env.use_bv_sorts) with
+| true -> begin
+(
+
+let uu____3279 = (FStar_Syntax_Syntax.range_of_bv x)
+in ((x.FStar_Syntax_Syntax.sort), (uu____3279)))
+end
+| uu____3282 -> begin
+(FStar_TypeChecker_Env.lookup_bv env1 x)
+end)
+in (match (uu____3270) with
+| (t, rng) -> begin
+(
+
+let x1 = (FStar_Syntax_Syntax.set_range_of_bv (
+
+let uu___96_3293 = x
+in {FStar_Syntax_Syntax.ppname = uu___96_3293.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___96_3293.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t}) rng)
+in ((FStar_TypeChecker_Common.insert_bv x1 t);
+(
+
+let e1 = (FStar_Syntax_Syntax.bv_to_name x1)
+in (
+
+let uu____3296 = (FStar_TypeChecker_Util.maybe_instantiate env1 e1 t)
+in (match (uu____3296) with
+| (e2, t1, implicits) -> begin
+(
+
+let tc = (
+
+let uu____3309 = (FStar_TypeChecker_Env.should_verify env1)
+in (match (uu____3309) with
+| true -> begin
+FStar_Util.Inl (t1)
+end
+| uu____3312 -> begin
+(
+
+let uu____3313 = (
+
+let uu____3314 = (FStar_Syntax_Syntax.mk_Total t1)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____3314))
+in FStar_Util.Inr (uu____3313))
+end))
+in (value_check_expected_typ env1 e2 tc implicits))
+end)));
+))
+end))
+end
+| FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____3320; FStar_Syntax_Syntax.pos = uu____3321; FStar_Syntax_Syntax.vars = uu____3322}, us) -> begin
+(
+
+let us1 = (FStar_List.map (tc_universe env1) us)
+in (
+
+let uu____3330 = (FStar_TypeChecker_Env.lookup_lid env1 fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____3330) with
+| ((us', t), range) -> begin
+((match (((FStar_List.length us1) <> (FStar_List.length us'))) with
+| true -> begin
+(
+
+let uu____3352 = (
+
+let uu____3353 = (
+
+let uu____3356 = (FStar_TypeChecker_Env.get_range env1)
+in (("Unexpected number of universe instantiations"), (uu____3356)))
+in FStar_Errors.Error (uu____3353))
+in (Prims.raise uu____3352))
+end
+| uu____3357 -> begin
+(FStar_List.iter2 (fun u' u -> (match (u') with
+| FStar_Syntax_Syntax.U_unif (u'') -> begin
+(FStar_Unionfind.change u'' (Some (u)))
+end
+| uu____3364 -> begin
+(failwith "Impossible")
+end)) us' us1)
+end);
+(
+
+let fv' = (
+
+let uu___97_3366 = fv
+in {FStar_Syntax_Syntax.fv_name = (
+
+let uu___98_3367 = fv.FStar_Syntax_Syntax.fv_name
+in {FStar_Syntax_Syntax.v = uu___98_3367.FStar_Syntax_Syntax.v; FStar_Syntax_Syntax.ty = t; FStar_Syntax_Syntax.p = uu___98_3367.FStar_Syntax_Syntax.p}); FStar_Syntax_Syntax.fv_delta = uu___97_3366.FStar_Syntax_Syntax.fv_delta; FStar_Syntax_Syntax.fv_qual = uu___97_3366.FStar_Syntax_Syntax.fv_qual})
+in (
+
+let fv'1 = (FStar_Syntax_Syntax.set_range_of_fv fv' range)
+in ((FStar_TypeChecker_Common.insert_fv fv'1 t);
+(
+
+let e1 = (
+
+let uu____3383 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar (fv'1))) (Some (t.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____3383 us1))
+in (check_instantiated_fvar env1 fv'1.FStar_Syntax_Syntax.fv_name fv'1.FStar_Syntax_Syntax.fv_qual e1 t));
+)));
+)
+end)))
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____3395 = (FStar_TypeChecker_Env.lookup_lid env1 fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____3395) with
+| ((us, t), range) -> begin
+((
+
+let uu____3413 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Range")))
+in (match (uu____3413) with
+| true -> begin
+(
+
+let uu____3414 = (
+
+let uu____3415 = (FStar_Syntax_Syntax.lid_of_fv fv)
+in (FStar_Syntax_Print.lid_to_string uu____3415))
+in (
+
+let uu____3416 = (FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3417 = (FStar_Range.string_of_range range)
+in (
+
+let uu____3418 = (FStar_Range.string_of_use_range range)
+in (
+
+let uu____3419 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print5 "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got type %s" uu____3414 uu____3416 uu____3417 uu____3418 uu____3419))))))
+end
+| uu____3420 -> begin
+()
+end));
+(
+
+let fv' = (
+
+let uu___99_3422 = fv
+in {FStar_Syntax_Syntax.fv_name = (
+
+let uu___100_3423 = fv.FStar_Syntax_Syntax.fv_name
+in {FStar_Syntax_Syntax.v = uu___100_3423.FStar_Syntax_Syntax.v; FStar_Syntax_Syntax.ty = t; FStar_Syntax_Syntax.p = uu___100_3423.FStar_Syntax_Syntax.p}); FStar_Syntax_Syntax.fv_delta = uu___99_3422.FStar_Syntax_Syntax.fv_delta; FStar_Syntax_Syntax.fv_qual = uu___99_3422.FStar_Syntax_Syntax.fv_qual})
+in (
+
+let fv'1 = (FStar_Syntax_Syntax.set_range_of_fv fv' range)
+in ((FStar_TypeChecker_Common.insert_fv fv'1 t);
+(
+
+let e1 = (
+
+let uu____3439 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar (fv'1))) (Some (t.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____3439 us))
+in (check_instantiated_fvar env1 fv'1.FStar_Syntax_Syntax.fv_name fv'1.FStar_Syntax_Syntax.fv_qual e1 t));
+)));
+)
+end))
+end
+| FStar_Syntax_Syntax.Tm_constant (c) -> begin
+(
+
+let t = (tc_constant top.FStar_Syntax_Syntax.pos c)
+in (
+
+let e1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (c))) (Some (t.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos)
+in (value_check_expected_typ env1 e1 (FStar_Util.Inl (t)) FStar_TypeChecker_Rel.trivial_guard)))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____3475 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____3475) with
+| (bs1, c1) -> begin
+(
+
+let env0 = env1
+in (
+
+let uu____3484 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____3484) with
+| (env2, uu____3492) -> begin
+(
+
+let uu____3495 = (tc_binders env2 bs1)
+in (match (uu____3495) with
+| (bs2, env3, g, us) -> begin
+(
+
+let uu____3507 = (tc_comp env3 c1)
+in (match (uu____3507) with
+| (c2, uc, f) -> begin
+(
+
+let e1 = (
+
+let uu___101_3520 = (FStar_Syntax_Util.arrow bs2 c2)
+in {FStar_Syntax_Syntax.n = uu___101_3520.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___101_3520.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = top.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___101_3520.FStar_Syntax_Syntax.vars})
+in ((check_smt_pat env3 e1 bs2 c2);
+(
+
+let u = FStar_Syntax_Syntax.U_max ((uc)::us)
+in (
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (u))) None top.FStar_Syntax_Syntax.pos)
+in (
+
+let g1 = (
+
+let uu____3541 = (FStar_TypeChecker_Rel.close_guard_univs us bs2 f)
+in (FStar_TypeChecker_Rel.conj_guard g uu____3541))
+in (value_check_expected_typ env0 e1 (FStar_Util.Inl (t)) g1))));
+))
+end))
+end))
+end)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+(
+
+let u1 = (tc_universe env1 u)
+in (
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ (u1)))) None top.FStar_Syntax_Syntax.pos)
+in (
+
+let e1 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (u1))) (Some (t.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (value_check_expected_typ env1 e1 (FStar_Util.Inl (t)) FStar_TypeChecker_Rel.trivial_guard))))
+end
+| FStar_Syntax_Syntax.Tm_refine (x, phi) -> begin
+(
+
+let uu____3576 = (
+
+let uu____3579 = (
+
+let uu____3580 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____3580)::[])
+in (FStar_Syntax_Subst.open_term uu____3579 phi))
+in (match (uu____3576) with
+| (x1, phi1) -> begin
+(
+
+let env0 = env1
+in (
+
+let uu____3587 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____3587) with
+| (env2, uu____3595) -> begin
+(
+
+let uu____3598 = (
+
+let uu____3605 = (FStar_List.hd x1)
+in (tc_binder env2 uu____3605))
+in (match (uu____3598) with
+| (x2, env3, f1, u) -> begin
+((
+
+let uu____3622 = (FStar_TypeChecker_Env.debug env3 FStar_Options.High)
+in (match (uu____3622) with
+| true -> begin
+(
+
+let uu____3623 = (FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3624 = (FStar_Syntax_Print.term_to_string phi1)
+in (
+
+let uu____3625 = (FStar_Syntax_Print.bv_to_string (Prims.fst x2))
+in (FStar_Util.print3 "(%s) Checking refinement formula %s; binder is %s\n" uu____3623 uu____3624 uu____3625))))
+end
+| uu____3626 -> begin
+()
+end));
+(
+
+let uu____3627 = (FStar_Syntax_Util.type_u ())
+in (match (uu____3627) with
+| (t_phi, uu____3634) -> begin
+(
+
+let uu____3635 = (tc_check_tot_or_gtot_term env3 phi1 t_phi)
+in (match (uu____3635) with
+| (phi2, uu____3643, f2) -> begin
+(
+
+let e1 = (
+
+let uu___102_3648 = (FStar_Syntax_Util.refine (Prims.fst x2) phi2)
+in {FStar_Syntax_Syntax.n = uu___102_3648.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu___102_3648.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = top.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___102_3648.FStar_Syntax_Syntax.vars})
+in (
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (u))) None top.FStar_Syntax_Syntax.pos)
+in (
+
+let g = (
+
+let uu____3667 = (FStar_TypeChecker_Rel.close_guard_univs ((u)::[]) ((x2)::[]) f2)
+in (FStar_TypeChecker_Rel.conj_guard f1 uu____3667))
+in (value_check_expected_typ env0 e1 (FStar_Util.Inl (t)) g))))
+end))
+end));
+)
+end))
+end)))
+end))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, uu____3676) -> begin
+(
+
+let bs1 = (FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs)
+in ((
+
+let uu____3701 = (FStar_TypeChecker_Env.debug env1 FStar_Options.Low)
+in (match (uu____3701) with
+| true -> begin
+(
+
+let uu____3702 = (FStar_Syntax_Print.term_to_string (
+
+let uu___103_3703 = top
+in {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs (((bs1), (body), (None))); FStar_Syntax_Syntax.tk = uu___103_3703.FStar_Syntax_Syntax.tk; FStar_Syntax_Syntax.pos = uu___103_3703.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___103_3703.FStar_Syntax_Syntax.vars}))
+in (FStar_Util.print1 "Abstraction is: %s\n" uu____3702))
+end
+| uu____3721 -> begin
+()
+end));
+(
+
+let uu____3722 = (FStar_Syntax_Subst.open_term bs1 body)
+in (match (uu____3722) with
+| (bs2, body1) -> begin
+(tc_abs env1 top bs2 body1)
+end));
+))
+end
+| uu____3730 -> begin
+(
+
+let uu____3731 = (
+
+let uu____3732 = (FStar_Syntax_Print.term_to_string top)
+in (
+
+let uu____3733 = (FStar_Syntax_Print.tag_of_term top)
+in (FStar_Util.format2 "Unexpected value: %s (%s)" uu____3732 uu____3733)))
+in (failwith uu____3731))
+end)))))
+and tc_constant : FStar_Range.range  ->  FStar_Const.sconst  ->  FStar_Syntax_Syntax.typ = (fun r c -> (match (c) with
+| FStar_Const.Const_unit -> begin
+FStar_TypeChecker_Common.t_unit
+end
+| FStar_Const.Const_bool (uu____3739) -> begin
+FStar_TypeChecker_Common.t_bool
+end
+| FStar_Const.Const_int (uu____3740, None) -> begin
+FStar_TypeChecker_Common.t_int
+end
+| FStar_Const.Const_int (uu____3746, Some (uu____3747)) -> begin
+(failwith "machine integers should be desugared")
+end
+| FStar_Const.Const_string (uu____3755) -> begin
+FStar_TypeChecker_Common.t_string
+end
+| FStar_Const.Const_float (uu____3759) -> begin
+FStar_TypeChecker_Common.t_float
+end
+| FStar_Const.Const_char (uu____3760) -> begin
+FStar_TypeChecker_Common.t_char
+end
+| FStar_Const.Const_effect -> begin
+FStar_Syntax_Util.ktype0
+end
+| FStar_Const.Const_range (uu____3761) -> begin
+FStar_TypeChecker_Common.t_range
+end
+| uu____3762 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unsupported constant"), (r)))))
+end))
+and tc_comp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.comp * FStar_Syntax_Syntax.universe * FStar_TypeChecker_Env.guard_t) = (fun env c -> (
+
+let c0 = c
+in (match (c.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Total (t, uu____3773) -> begin
+(
+
+let uu____3780 = (FStar_Syntax_Util.type_u ())
+in (match (uu____3780) with
+| (k, u) -> begin
+(
+
+let uu____3788 = (tc_check_tot_or_gtot_term env t k)
+in (match (uu____3788) with
+| (t1, uu____3796, g) -> begin
+(
+
+let uu____3798 = (FStar_Syntax_Syntax.mk_Total' t1 (Some (u)))
+in ((uu____3798), (u), (g)))
+end))
+end))
+end
+| FStar_Syntax_Syntax.GTotal (t, uu____3800) -> begin
+(
+
+let uu____3807 = (FStar_Syntax_Util.type_u ())
+in (match (uu____3807) with
+| (k, u) -> begin
+(
+
+let uu____3815 = (tc_check_tot_or_gtot_term env t k)
+in (match (uu____3815) with
+| (t1, uu____3823, g) -> begin
+(
+
+let uu____3825 = (FStar_Syntax_Syntax.mk_GTotal' t1 (Some (u)))
+in ((uu____3825), (u), (g)))
+end))
+end))
+end
+| FStar_Syntax_Syntax.Comp (c1) -> begin
+(
+
+let head1 = (FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name FStar_Syntax_Syntax.Delta_constant None)
+in (
+
+let head2 = (match (c1.FStar_Syntax_Syntax.comp_univs) with
+| [] -> begin
+head1
+end
+| us -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uinst (((head1), (us))))) None c0.FStar_Syntax_Syntax.pos)
+end)
+in (
+
+let tc = (
+
+let uu____3841 = (
+
+let uu____3842 = (
+
+let uu____3843 = (FStar_Syntax_Syntax.as_arg c1.FStar_Syntax_Syntax.result_typ)
+in (uu____3843)::c1.FStar_Syntax_Syntax.effect_args)
+in (FStar_Syntax_Syntax.mk_Tm_app head2 uu____3842))
+in (uu____3841 None c1.FStar_Syntax_Syntax.result_typ.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____3848 = (tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff)
+in (match (uu____3848) with
+| (tc1, uu____3856, f) -> begin
+(
+
+let uu____3858 = (FStar_Syntax_Util.head_and_args tc1)
+in (match (uu____3858) with
+| (head3, args) -> begin
+(
+
+let comp_univs = (
+
+let uu____3888 = (
+
+let uu____3889 = (FStar_Syntax_Subst.compress head3)
+in uu____3889.FStar_Syntax_Syntax.n)
+in (match (uu____3888) with
+| FStar_Syntax_Syntax.Tm_uinst (uu____3892, us) -> begin
+us
+end
+| uu____3898 -> begin
+[]
+end))
+in (
+
+let uu____3899 = (FStar_Syntax_Util.head_and_args tc1)
+in (match (uu____3899) with
+| (uu____3912, args1) -> begin
+(
+
+let uu____3928 = (
+
+let uu____3940 = (FStar_List.hd args1)
+in (
+
+let uu____3949 = (FStar_List.tl args1)
+in ((uu____3940), (uu____3949))))
+in (match (uu____3928) with
+| (res, args2) -> begin
+(
+
+let uu____3991 = (
+
+let uu____3996 = (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags (FStar_List.map (fun uu___83_4006 -> (match (uu___83_4006) with
+| FStar_Syntax_Syntax.DECREASES (e) -> begin
+(
+
+let uu____4012 = (FStar_TypeChecker_Env.clear_expected_typ env)
+in (match (uu____4012) with
+| (env1, uu____4019) -> begin
+(
+
+let uu____4022 = (tc_tot_or_gtot_term env1 e)
+in (match (uu____4022) with
+| (e1, uu____4029, g) -> begin
+((FStar_Syntax_Syntax.DECREASES (e1)), (g))
+end))
+end))
+end
+| f1 -> begin
+((f1), (FStar_TypeChecker_Rel.trivial_guard))
+end))))
+in (FStar_All.pipe_right uu____3996 FStar_List.unzip))
+in (match (uu____3991) with
+| (flags, guards) -> begin
+(
+
+let u = (env.FStar_TypeChecker_Env.universe_of env (Prims.fst res))
+in (
+
+let c2 = (FStar_Syntax_Syntax.mk_Comp (
+
+let uu___104_4052 = c1
+in {FStar_Syntax_Syntax.comp_univs = comp_univs; FStar_Syntax_Syntax.effect_name = uu___104_4052.FStar_Syntax_Syntax.effect_name; FStar_Syntax_Syntax.result_typ = (Prims.fst res); FStar_Syntax_Syntax.effect_args = args2; FStar_Syntax_Syntax.flags = uu___104_4052.FStar_Syntax_Syntax.flags}))
+in (
+
+let u_c = (
+
+let uu____4056 = (FStar_TypeChecker_Env.effect_repr env c2 u)
+in (match (uu____4056) with
+| None -> begin
+u
+end
+| Some (tm) -> begin
+(env.FStar_TypeChecker_Env.universe_of env tm)
+end))
+in (
+
+let uu____4059 = (FStar_List.fold_left FStar_TypeChecker_Rel.conj_guard f guards)
+in ((c2), (u_c), (uu____4059))))))
+end))
+end))
+end)))
+end))
+end)))))
+end)))
+and tc_universe : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.universe = (fun env u -> (
+
+let rec aux = (fun u1 -> (
+
+let u2 = (FStar_Syntax_Subst.compress_univ u1)
+in (match (u2) with
+| FStar_Syntax_Syntax.U_bvar (uu____4067) -> begin
+(failwith "Impossible: locally nameless")
+end
+| FStar_Syntax_Syntax.U_unknown -> begin
+(failwith "Unknown universe")
+end
+| (FStar_Syntax_Syntax.U_unif (_)) | (FStar_Syntax_Syntax.U_zero) -> begin
+u2
+end
+| FStar_Syntax_Syntax.U_succ (u3) -> begin
+(
+
+let uu____4070 = (aux u3)
+in FStar_Syntax_Syntax.U_succ (uu____4070))
+end
+| FStar_Syntax_Syntax.U_max (us) -> begin
+(
+
+let uu____4073 = (FStar_List.map aux us)
+in FStar_Syntax_Syntax.U_max (uu____4073))
+end
+| FStar_Syntax_Syntax.U_name (x) -> begin
+u2
+end)))
+in (match (env.FStar_TypeChecker_Env.lax_universes) with
+| true -> begin
+FStar_Syntax_Syntax.U_zero
+end
+| uu____4076 -> begin
+(match (u) with
+| FStar_Syntax_Syntax.U_unknown -> begin
+(
+
+let uu____4077 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____4077 Prims.snd))
+end
+| uu____4082 -> begin
+(aux u)
+end)
+end)))
+and tc_abs : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env top bs body -> (
+
+let fail = (fun msg t -> (
+
+let uu____4103 = (
+
+let uu____4104 = (
+
+let uu____4107 = (FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function env msg t top)
+in ((uu____4107), (top.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____4104))
+in (Prims.raise uu____4103)))
+in (
+
+let check_binders = (fun env1 bs1 bs_expected -> (
+
+let rec aux = (fun uu____4161 bs2 bs_expected1 -> (match (uu____4161) with
+| (env2, out, g, subst1) -> begin
+(match (((bs2), (bs_expected1))) with
+| ([], []) -> begin
+((env2), ((FStar_List.rev out)), (None), (g), (subst1))
+end
+| (((hd1, imp))::bs3, ((hd_expected, imp'))::bs_expected2) -> begin
+((match (((imp), (imp'))) with
+| ((None, Some (FStar_Syntax_Syntax.Implicit (_)))) | ((Some (FStar_Syntax_Syntax.Implicit (_)), None)) -> begin
+(
+
+let uu____4258 = (
+
+let uu____4259 = (
+
+let uu____4262 = (
+
+let uu____4263 = (FStar_Syntax_Print.bv_to_string hd1)
+in (FStar_Util.format1 "Inconsistent implicit argument annotation on argument %s" uu____4263))
+in (
+
+let uu____4264 = (FStar_Syntax_Syntax.range_of_bv hd1)
+in ((uu____4262), (uu____4264))))
+in FStar_Errors.Error (uu____4259))
+in (Prims.raise uu____4258))
+end
+| uu____4265 -> begin
+()
+end);
+(
+
+let expected_t = (FStar_Syntax_Subst.subst subst1 hd_expected.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____4269 = (
+
+let uu____4272 = (
+
+let uu____4273 = (FStar_Syntax_Util.unmeta hd1.FStar_Syntax_Syntax.sort)
+in uu____4273.FStar_Syntax_Syntax.n)
+in (match (uu____4272) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+((expected_t), (g))
+end
+| uu____4278 -> begin
+((
+
+let uu____4280 = (FStar_TypeChecker_Env.debug env2 FStar_Options.High)
+in (match (uu____4280) with
+| true -> begin
+(
+
+let uu____4281 = (FStar_Syntax_Print.bv_to_string hd1)
+in (FStar_Util.print1 "Checking binder %s\n" uu____4281))
+end
+| uu____4282 -> begin
+()
+end));
+(
+
+let uu____4283 = (tc_tot_or_gtot_term env2 hd1.FStar_Syntax_Syntax.sort)
+in (match (uu____4283) with
+| (t, uu____4290, g1) -> begin
+(
+
+let g2 = (
+
+let uu____4293 = (FStar_TypeChecker_Env.get_range env2)
+in (
+
+let uu____4294 = (FStar_TypeChecker_Rel.teq env2 t expected_t)
+in (FStar_TypeChecker_Util.label_guard uu____4293 "Type annotation on parameter incompatible with the expected type" uu____4294)))
+in (
+
+let g3 = (
+
+let uu____4296 = (FStar_TypeChecker_Rel.conj_guard g1 g2)
+in (FStar_TypeChecker_Rel.conj_guard g uu____4296))
+in ((t), (g3))))
+end));
+)
+end))
+in (match (uu____4269) with
+| (t, g1) -> begin
+(
+
+let hd2 = (
+
+let uu___105_4312 = hd1
+in {FStar_Syntax_Syntax.ppname = uu___105_4312.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___105_4312.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t})
+in (
+
+let b = ((hd2), (imp))
+in (
+
+let b_expected = ((hd_expected), (imp'))
+in (
+
+let env3 = (push_binding env2 b)
+in (
+
+let subst2 = (
+
+let uu____4321 = (FStar_Syntax_Syntax.bv_to_name hd2)
+in (maybe_extend_subst subst1 b_expected uu____4321))
+in (aux ((env3), ((b)::out), (g1), (subst2)) bs3 bs_expected2))))))
+end)));
+)
+end
+| (rest, []) -> begin
+((env2), ((FStar_List.rev out)), (Some (FStar_Util.Inl (rest))), (g), (subst1))
+end
+| ([], rest) -> begin
+((env2), ((FStar_List.rev out)), (Some (FStar_Util.Inr (rest))), (g), (subst1))
+end)
+end))
+in (aux ((env1), ([]), (FStar_TypeChecker_Rel.trivial_guard), ([])) bs1 bs_expected)))
+in (
+
+let rec expected_function_typ1 = (fun env1 t0 body1 -> (match (t0) with
+| None -> begin
+((match (env1.FStar_TypeChecker_Env.letrecs) with
+| [] -> begin
+()
+end
+| uu____4423 -> begin
+(failwith "Impossible: Can\'t have a let rec annotation but no expected type")
+end);
+(
+
+let uu____4427 = (tc_binders env1 bs)
+in (match (uu____4427) with
+| (bs1, envbody, g, uu____4448) -> begin
+(
+
+let uu____4449 = (
+
+let uu____4456 = (
+
+let uu____4457 = (FStar_Syntax_Subst.compress body1)
+in uu____4457.FStar_Syntax_Syntax.n)
+in (match (uu____4456) with
+| FStar_Syntax_Syntax.Tm_ascribed (e, (FStar_Util.Inr (c), tacopt), uu____4469) -> begin
+(
+
+let uu____4505 = (tc_comp envbody c)
+in (match (uu____4505) with
+| (c1, uu____4516, g') -> begin
+(
+
+let uu____4518 = (tc_tactic_opt envbody tacopt)
+in (
+
+let uu____4520 = (FStar_TypeChecker_Rel.conj_guard g g')
+in ((Some (c1)), (uu____4518), (body1), (uu____4520))))
+end))
+end
+| uu____4523 -> begin
+((None), (None), (body1), (g))
+end))
+in (match (uu____4449) with
+| (copt, tacopt, body2, g1) -> begin
+((None), (bs1), ([]), (copt), (tacopt), (envbody), (body2), (g1))
+end))
+end));
+)
+end
+| Some (t) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (
+
+let rec as_function_typ = (fun norm1 t2 -> (
+
+let uu____4582 = (
+
+let uu____4583 = (FStar_Syntax_Subst.compress t2)
+in uu____4583.FStar_Syntax_Syntax.n)
+in (match (uu____4582) with
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) -> begin
+((match (env1.FStar_TypeChecker_Env.letrecs) with
+| [] -> begin
+()
+end
+| uu____4616 -> begin
+(failwith "Impossible")
+end);
+(
+
+let uu____4620 = (tc_binders env1 bs)
+in (match (uu____4620) with
+| (bs1, envbody, g, uu____4642) -> begin
+(
+
+let uu____4643 = (FStar_TypeChecker_Env.clear_expected_typ envbody)
+in (match (uu____4643) with
+| (envbody1, uu____4662) -> begin
+((Some (((t2), (true)))), (bs1), ([]), (None), (None), (envbody1), (body1), (g))
+end))
+end));
+)
+end
+| FStar_Syntax_Syntax.Tm_refine (b, uu____4674) -> begin
+(
+
+let uu____4679 = (as_function_typ norm1 b.FStar_Syntax_Syntax.sort)
+in (match (uu____4679) with
+| (uu____4708, bs1, bs', copt, tacopt, env2, body2, g) -> begin
+((Some (((t2), (false)))), (bs1), (bs'), (copt), (tacopt), (env2), (body2), (g))
+end))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs_expected, c_expected) -> begin
+(
+
+let uu____4748 = (FStar_Syntax_Subst.open_comp bs_expected c_expected)
+in (match (uu____4748) with
+| (bs_expected1, c_expected1) -> begin
+(
+
+let check_actuals_against_formals = (fun env2 bs1 bs_expected2 -> (
+
+let rec handle_more = (fun uu____4811 c_expected2 -> (match (uu____4811) with
+| (env3, bs2, more, guard, subst1) -> begin
+(match (more) with
+| None -> begin
+(
+
+let uu____4872 = (FStar_Syntax_Subst.subst_comp subst1 c_expected2)
+in ((env3), (bs2), (guard), (uu____4872)))
+end
+| Some (FStar_Util.Inr (more_bs_expected)) -> begin
+(
+
+let c = (
+
+let uu____4889 = (FStar_Syntax_Util.arrow more_bs_expected c_expected2)
+in (FStar_Syntax_Syntax.mk_Total uu____4889))
+in (
+
+let uu____4890 = (FStar_Syntax_Subst.subst_comp subst1 c)
+in ((env3), (bs2), (guard), (uu____4890))))
+end
+| Some (FStar_Util.Inl (more_bs)) -> begin
+(
+
+let c = (FStar_Syntax_Subst.subst_comp subst1 c_expected2)
+in (match ((FStar_Syntax_Util.is_named_tot c)) with
+| true -> begin
+(
+
+let t3 = (unfold_whnf env3 (FStar_Syntax_Util.comp_result c))
+in (match (t3.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs_expected3, c_expected3) -> begin
+(
+
+let uu____4931 = (check_binders env3 more_bs bs_expected3)
+in (match (uu____4931) with
+| (env4, bs', more1, guard', subst2) -> begin
+(
+
+let uu____4958 = (
+
+let uu____4974 = (FStar_TypeChecker_Rel.conj_guard guard guard')
+in ((env4), ((FStar_List.append bs2 bs')), (more1), (uu____4974), (subst2)))
+in (handle_more uu____4958 c_expected3))
+end))
+end
+| uu____4983 -> begin
+(
+
+let uu____4984 = (
+
+let uu____4985 = (FStar_Syntax_Print.term_to_string t3)
+in (FStar_Util.format1 "More arguments than annotated type (%s)" uu____4985))
+in (fail uu____4984 t3))
+end))
+end
+| uu____4993 -> begin
+(fail "Function definition takes more arguments than expected from its annotated type" t2)
+end))
+end)
+end))
+in (
+
+let uu____5001 = (check_binders env2 bs1 bs_expected2)
+in (handle_more uu____5001 c_expected1))))
+in (
+
+let mk_letrec_env = (fun envbody bs1 c -> (
+
+let letrecs = (guard_letrecs envbody bs1 c)
+in (
+
+let envbody1 = (
+
+let uu___106_5039 = envbody
+in {FStar_TypeChecker_Env.solver = uu___106_5039.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___106_5039.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___106_5039.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___106_5039.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___106_5039.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___106_5039.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___106_5039.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___106_5039.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___106_5039.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___106_5039.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___106_5039.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___106_5039.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = []; FStar_TypeChecker_Env.top_level = uu___106_5039.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___106_5039.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___106_5039.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___106_5039.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___106_5039.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___106_5039.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___106_5039.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___106_5039.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___106_5039.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___106_5039.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___106_5039.FStar_TypeChecker_Env.qname_and_index})
+in (FStar_All.pipe_right letrecs (FStar_List.fold_left (fun uu____5053 uu____5054 -> (match (((uu____5053), (uu____5054))) with
+| ((env2, letrec_binders), (l, t3)) -> begin
+(
+
+let uu____5079 = (
+
+let uu____5083 = (
+
+let uu____5084 = (FStar_TypeChecker_Env.clear_expected_typ env2)
+in (FStar_All.pipe_right uu____5084 Prims.fst))
+in (tc_term uu____5083 t3))
+in (match (uu____5079) with
+| (t4, uu____5096, uu____5097) -> begin
+(
+
+let env3 = (FStar_TypeChecker_Env.push_let_binding env2 l (([]), (t4)))
+in (
+
+let lb = (match (l) with
+| FStar_Util.Inl (x) -> begin
+(
+
+let uu____5104 = (FStar_Syntax_Syntax.mk_binder (
+
+let uu___107_5105 = x
+in {FStar_Syntax_Syntax.ppname = uu___107_5105.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___107_5105.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t4}))
+in (uu____5104)::letrec_binders)
+end
+| uu____5106 -> begin
+letrec_binders
+end)
+in ((env3), (lb))))
+end))
+end)) ((envbody1), ([])))))))
+in (
+
+let uu____5109 = (check_actuals_against_formals env1 bs bs_expected1)
+in (match (uu____5109) with
+| (envbody, bs1, g, c) -> begin
+(
+
+let uu____5141 = (
+
+let uu____5145 = (FStar_TypeChecker_Env.should_verify env1)
+in (match (uu____5145) with
+| true -> begin
+(mk_letrec_env envbody bs1 c)
+end
+| uu____5149 -> begin
+((envbody), ([]))
+end))
+in (match (uu____5141) with
+| (envbody1, letrecs) -> begin
+(
+
+let envbody2 = (FStar_TypeChecker_Env.set_expected_typ envbody1 (FStar_Syntax_Util.comp_result c))
+in ((Some (((t2), (false)))), (bs1), (letrecs), (Some (c)), (None), (envbody2), (body1), (g)))
+end))
+end))))
+end))
+end
+| uu____5181 -> begin
+(match ((not (norm1))) with
+| true -> begin
+(
+
+let uu____5196 = (unfold_whnf env1 t2)
+in (as_function_typ true uu____5196))
+end
+| uu____5197 -> begin
+(
+
+let uu____5198 = (expected_function_typ1 env1 None body1)
+in (match (uu____5198) with
+| (uu____5226, bs1, uu____5228, c_opt, tacopt, envbody, body2, g) -> begin
+((Some (((t2), (false)))), (bs1), ([]), (c_opt), (tacopt), (envbody), (body2), (g))
+end))
+end)
+end)))
+in (as_function_typ false t1)))
+end))
+in (
+
+let use_eq = env.FStar_TypeChecker_Env.use_eq
+in (
+
+let uu____5253 = (FStar_TypeChecker_Env.clear_expected_typ env)
+in (match (uu____5253) with
+| (env1, topt) -> begin
+((
+
+let uu____5265 = (FStar_TypeChecker_Env.debug env1 FStar_Options.High)
+in (match (uu____5265) with
+| true -> begin
+(
+
+let uu____5266 = (match (topt) with
+| None -> begin
+"None"
+end
+| Some (t) -> begin
+(FStar_Syntax_Print.term_to_string t)
+end)
+in (FStar_Util.print2 "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n" uu____5266 (match (env1.FStar_TypeChecker_Env.top_level) with
+| true -> begin
+"true"
+end
+| uu____5268 -> begin
+"false"
+end)))
+end
+| uu____5269 -> begin
+()
+end));
+(
+
+let uu____5270 = (expected_function_typ1 env1 topt body)
+in (match (uu____5270) with
+| (tfun_opt, bs1, letrec_binders, c_opt, tacopt, envbody, body1, g) -> begin
+(
+
+let uu____5305 = (tc_term (
+
+let uu___108_5309 = envbody
+in {FStar_TypeChecker_Env.solver = uu___108_5309.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___108_5309.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___108_5309.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___108_5309.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___108_5309.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___108_5309.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___108_5309.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___108_5309.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___108_5309.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___108_5309.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___108_5309.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___108_5309.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___108_5309.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = false; FStar_TypeChecker_Env.check_uvars = uu___108_5309.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = use_eq; FStar_TypeChecker_Env.is_iface = uu___108_5309.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___108_5309.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___108_5309.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___108_5309.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___108_5309.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___108_5309.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___108_5309.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___108_5309.FStar_TypeChecker_Env.qname_and_index}) body1)
+in (match (uu____5305) with
+| (body2, cbody, guard_body) -> begin
+(
+
+let guard_body1 = (FStar_TypeChecker_Rel.solve_deferred_constraints envbody guard_body)
+in ((
+
+let uu____5318 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1) (FStar_Options.Other ("Implicits")))
+in (match (uu____5318) with
+| true -> begin
+(
+
+let uu____5319 = (FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length guard_body1.FStar_TypeChecker_Env.implicits))
+in (
+
+let uu____5328 = (
+
+let uu____5329 = (cbody.FStar_Syntax_Syntax.comp ())
+in (FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____5329))
+in (FStar_Util.print2 "Introduced %s implicits in body of abstraction\nAfter solving constraints, cbody is %s\n" uu____5319 uu____5328)))
+end
+| uu____5330 -> begin
+()
+end));
+(
+
+let uu____5331 = (
+
+let uu____5335 = (
+
+let uu____5338 = (cbody.FStar_Syntax_Syntax.comp ())
+in ((body2), (uu____5338)))
+in (check_expected_effect (
+
+let uu___109_5343 = envbody
+in {FStar_TypeChecker_Env.solver = uu___109_5343.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___109_5343.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___109_5343.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___109_5343.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___109_5343.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___109_5343.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___109_5343.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___109_5343.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___109_5343.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___109_5343.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___109_5343.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___109_5343.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___109_5343.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___109_5343.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___109_5343.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = use_eq; FStar_TypeChecker_Env.is_iface = uu___109_5343.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___109_5343.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___109_5343.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___109_5343.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___109_5343.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___109_5343.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___109_5343.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___109_5343.FStar_TypeChecker_Env.qname_and_index}) c_opt uu____5335))
+in (match (uu____5331) with
+| (body3, cbody1, guard) -> begin
+(
+
+let guard1 = (FStar_TypeChecker_Rel.conj_guard guard_body1 guard)
+in (
+
+let guard2 = (
+
+let uu____5352 = (env1.FStar_TypeChecker_Env.top_level || (
+
+let uu____5353 = (FStar_TypeChecker_Env.should_verify env1)
+in (not (uu____5353))))
+in (match (uu____5352) with
+| true -> begin
+(
+
+let uu____5354 = (FStar_TypeChecker_Rel.conj_guard g guard1)
+in (FStar_TypeChecker_Rel.discharge_guard envbody uu____5354))
+end
+| uu____5355 -> begin
+(
+
+let guard2 = (
+
+let uu____5357 = (FStar_TypeChecker_Rel.conj_guard g guard1)
+in (FStar_TypeChecker_Rel.close_guard env1 (FStar_List.append bs1 letrec_binders) uu____5357))
+in guard2)
+end))
+in (
+
+let tfun_computed = (FStar_Syntax_Util.arrow bs1 cbody1)
+in (
+
+let e = (
+
+let uu____5364 = (
+
+let uu____5371 = (
+
+let uu____5377 = (FStar_All.pipe_right (FStar_Util.dflt cbody1 c_opt) FStar_Syntax_Util.lcomp_of_comp)
+in (FStar_All.pipe_right uu____5377 (fun _0_29 -> FStar_Util.Inl (_0_29))))
+in Some (uu____5371))
+in (FStar_Syntax_Util.abs bs1 body3 uu____5364))
+in (
+
+let uu____5391 = (match (tfun_opt) with
+| Some (t, use_teq) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____5406) -> begin
+((e), (t1), (guard2))
+end
+| uu____5414 -> begin
+(
+
+let uu____5415 = (match (use_teq) with
+| true -> begin
+(
+
+let uu____5420 = (FStar_TypeChecker_Rel.teq env1 t1 tfun_computed)
+in ((e), (uu____5420)))
+end
+| uu____5421 -> begin
+(FStar_TypeChecker_Util.check_and_ascribe env1 e tfun_computed t1)
+end)
+in (match (uu____5415) with
+| (e1, guard') -> begin
+(
+
+let uu____5427 = (FStar_TypeChecker_Rel.conj_guard guard2 guard')
+in ((e1), (t1), (uu____5427)))
+end))
+end))
+end
+| None -> begin
+((e), (tfun_computed), (guard2))
+end)
+in (match (uu____5391) with
+| (e1, tfun, guard3) -> begin
+(
+
+let c = (match (env1.FStar_TypeChecker_Env.top_level) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total tfun)
+end
+| uu____5439 -> begin
+(FStar_TypeChecker_Util.return_value env1 tfun e1)
+end)
+in (
+
+let uu____5440 = (FStar_TypeChecker_Util.strengthen_precondition None env1 e1 (FStar_Syntax_Util.lcomp_of_comp c) guard3)
+in (match (uu____5440) with
+| (c1, g1) -> begin
+((e1), (c1), (g1))
+end)))
+end))))))
+end));
+))
+end))
+end));
+)
+end)))))))
+and check_application_args : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_TypeChecker_Env.guard_t  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.typ Prims.option  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env head1 chead ghead args expected_topt -> (
+
+let n_args = (FStar_List.length args)
+in (
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let thead = chead.FStar_Syntax_Syntax.res_typ
+in ((
+
+let uu____5476 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____5476) with
+| true -> begin
+(
+
+let uu____5477 = (FStar_Range.string_of_range head1.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____5478 = (FStar_Syntax_Print.term_to_string thead)
+in (FStar_Util.print2 "(%s) Type of head is %s\n" uu____5477 uu____5478)))
+end
+| uu____5479 -> begin
+()
+end));
+(
+
+let monadic_application = (fun uu____5520 subst1 arg_comps_rev arg_rets guard fvs bs -> (match (uu____5520) with
+| (head2, chead1, ghead1, cres) -> begin
+(
+
+let rt = (check_no_escape (Some (head2)) env fvs cres.FStar_Syntax_Syntax.res_typ)
+in (
+
+let cres1 = (
+
+let uu___110_5561 = cres
+in {FStar_Syntax_Syntax.eff_name = uu___110_5561.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = rt; FStar_Syntax_Syntax.cflags = uu___110_5561.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___110_5561.FStar_Syntax_Syntax.comp})
+in (
+
+let uu____5562 = (match (bs) with
+| [] -> begin
+(
+
+let cres2 = (FStar_TypeChecker_Util.subst_lcomp subst1 cres1)
+in (
+
+let g = (FStar_TypeChecker_Rel.conj_guard ghead1 guard)
+in (
+
+let refine_with_equality = ((FStar_Syntax_Util.is_pure_or_ghost_lcomp cres2) && (FStar_All.pipe_right arg_comps_rev (FStar_Util.for_some (fun uu___84_5589 -> (match (uu___84_5589) with
+| (uu____5598, uu____5599, FStar_Util.Inl (uu____5600)) -> begin
+false
+end
+| (uu____5611, uu____5612, FStar_Util.Inr (c)) -> begin
+(
+
+let uu____5622 = (FStar_Syntax_Util.is_pure_or_ghost_lcomp c)
+in (not (uu____5622)))
+end)))))
+in (
+
+let cres3 = (match (refine_with_equality) with
+| true -> begin
+(
+
+let uu____5624 = ((FStar_Syntax_Syntax.mk_Tm_app head2 (FStar_List.rev arg_rets)) (Some (cres2.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) r)
+in (FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term env uu____5624 cres2))
+end
+| uu____5633 -> begin
+((
+
+let uu____5635 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____5635) with
+| true -> begin
+(
+
+let uu____5636 = (FStar_Syntax_Print.term_to_string head2)
+in (
+
+let uu____5637 = (FStar_Syntax_Print.lcomp_to_string cres2)
+in (
+
+let uu____5638 = (FStar_TypeChecker_Rel.guard_to_string env g)
+in (FStar_Util.print3 "Not refining result: f=%s; cres=%s; guard=%s\n" uu____5636 uu____5637 uu____5638))))
+end
+| uu____5639 -> begin
+()
+end));
+cres2;
+)
+end)
+in ((cres3), (g))))))
+end
+| uu____5640 -> begin
+(
+
+let g = (
+
+let uu____5645 = (FStar_TypeChecker_Rel.conj_guard ghead1 guard)
+in (FStar_All.pipe_right uu____5645 (FStar_TypeChecker_Rel.solve_deferred_constraints env)))
+in (
+
+let uu____5646 = (
+
+let uu____5647 = (
+
+let uu____5650 = (
+
+let uu____5651 = (
+
+let uu____5652 = (cres1.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Util.arrow bs uu____5652))
+in (FStar_All.pipe_left (FStar_Syntax_Subst.subst subst1) uu____5651))
+in (FStar_Syntax_Syntax.mk_Total uu____5650))
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____5647))
+in ((uu____5646), (g))))
+end)
+in (match (uu____5562) with
+| (cres2, guard1) -> begin
+((
+
+let uu____5663 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____5663) with
+| true -> begin
+(
+
+let uu____5664 = (FStar_Syntax_Print.lcomp_to_string cres2)
+in (FStar_Util.print1 "\t Type of result cres is %s\n" uu____5664))
+end
+| uu____5665 -> begin
+()
+end));
+(
+
+let comp = (FStar_List.fold_left (fun out_c uu____5680 -> (match (uu____5680) with
+| ((e, q), x, c) -> begin
+(match (c) with
+| FStar_Util.Inl (eff_name, arg_typ) -> begin
+out_c
+end
+| FStar_Util.Inr (c1) -> begin
+(FStar_TypeChecker_Util.bind e.FStar_Syntax_Syntax.pos env None c1 ((x), (out_c)))
+end)
+end)) cres2 arg_comps_rev)
+in (
+
+let comp1 = (FStar_TypeChecker_Util.bind head2.FStar_Syntax_Syntax.pos env None chead1 ((None), (comp)))
+in (
+
+let shortcuts_evaluation_order = (
+
+let uu____5726 = (
+
+let uu____5727 = (FStar_Syntax_Subst.compress head2)
+in uu____5727.FStar_Syntax_Syntax.n)
+in (match (uu____5726) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.op_And) || (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.op_Or))
+end
+| uu____5731 -> begin
+false
+end))
+in (
+
+let app = (match (shortcuts_evaluation_order) with
+| true -> begin
+(
+
+let args1 = (FStar_List.fold_left (fun args1 uu____5745 -> (match (uu____5745) with
+| (arg, uu____5757, uu____5758) -> begin
+(arg)::args1
+end)) [] arg_comps_rev)
+in (
+
+let app = ((FStar_Syntax_Syntax.mk_Tm_app head2 args1) (Some (comp1.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) r)
+in (
+
+let app1 = (FStar_TypeChecker_Util.maybe_lift env app cres2.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.res_typ)
+in (FStar_TypeChecker_Util.maybe_monadic env app1 comp1.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.res_typ))))
+end
+| uu____5777 -> begin
+(
+
+let uu____5778 = (
+
+let map_fun = (fun uu____5817 -> (match (uu____5817) with
+| ((e, q), uu____5841, c0) -> begin
+(match (c0) with
+| FStar_Util.Inl (uu____5866) -> begin
+((None), (((e), (q))))
+end
+| FStar_Util.Inr (c) when (FStar_Syntax_Util.is_pure_or_ghost_lcomp c) -> begin
+((None), (((e), (q))))
+end
+| FStar_Util.Inr (c) -> begin
+(
+
+let x = (FStar_Syntax_Syntax.new_bv None c.FStar_Syntax_Syntax.res_typ)
+in (
+
+let e1 = (FStar_TypeChecker_Util.maybe_lift env e c.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.eff_name c.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____5909 = (
+
+let uu____5912 = (FStar_Syntax_Syntax.bv_to_name x)
+in ((uu____5912), (q)))
+in ((Some (((x), (c.FStar_Syntax_Syntax.eff_name), (c.FStar_Syntax_Syntax.res_typ), (e1)))), (uu____5909)))))
+end)
+end))
+in (
+
+let uu____5930 = (
+
+let uu____5944 = (
+
+let uu____5957 = (
+
+let uu____5969 = (
+
+let uu____5978 = (FStar_Syntax_Syntax.as_arg head2)
+in ((uu____5978), (None), (FStar_Util.Inr (chead1))))
+in (uu____5969)::arg_comps_rev)
+in (FStar_List.map map_fun uu____5957))
+in (FStar_All.pipe_left FStar_List.split uu____5944))
+in (match (uu____5930) with
+| (lifted_args, reverse_args) -> begin
+(
+
+let uu____6087 = (
+
+let uu____6088 = (FStar_List.hd reverse_args)
+in (Prims.fst uu____6088))
+in (
+
+let uu____6093 = (
+
+let uu____6097 = (FStar_List.tl reverse_args)
+in (FStar_List.rev uu____6097))
+in ((lifted_args), (uu____6087), (uu____6093))))
+end)))
+in (match (uu____5778) with
+| (lifted_args, head3, args1) -> begin
+(
+
+let app = ((FStar_Syntax_Syntax.mk_Tm_app head3 args1) (Some (comp1.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) r)
+in (
+
+let app1 = (FStar_TypeChecker_Util.maybe_lift env app cres2.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let app2 = (FStar_TypeChecker_Util.maybe_monadic env app1 comp1.FStar_Syntax_Syntax.eff_name comp1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let bind_lifted_args = (fun e uu___85_6165 -> (match (uu___85_6165) with
+| None -> begin
+e
+end
+| Some (x, m, t, e1) -> begin
+(
+
+let lb = (FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl (x)) [] t m e1)
+in (
+
+let letbinding = (
+
+let uu____6207 = (
+
+let uu____6210 = (
+
+let uu____6211 = (
+
+let uu____6219 = (
+
+let uu____6220 = (
+
+let uu____6221 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____6221)::[])
+in (FStar_Syntax_Subst.close uu____6220 e))
+in ((((false), ((lb)::[]))), (uu____6219)))
+in FStar_Syntax_Syntax.Tm_let (uu____6211))
+in (FStar_Syntax_Syntax.mk uu____6210))
+in (uu____6207 None e.FStar_Syntax_Syntax.pos))
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((letbinding), (FStar_Syntax_Syntax.Meta_monadic (((m), (comp1.FStar_Syntax_Syntax.res_typ)))))))) None e.FStar_Syntax_Syntax.pos)))
+end))
+in (FStar_List.fold_left bind_lifted_args app2 lifted_args)))))
+end))
+end)
+in (
+
+let uu____6255 = (FStar_TypeChecker_Util.strengthen_precondition None env app comp1 guard1)
+in (match (uu____6255) with
+| (comp2, g) -> begin
+((app), (comp2), (g))
+end))))));
+)
+end))))
+end))
+in (
+
+let rec tc_args = (fun head_info uu____6313 bs args1 -> (match (uu____6313) with
+| (subst1, outargs, arg_rets, g, fvs) -> begin
+(match (((bs), (args1))) with
+| (((x, Some (FStar_Syntax_Syntax.Implicit (uu____6408))))::rest, ((uu____6410, None))::uu____6411) -> begin
+(
+
+let t = (FStar_Syntax_Subst.subst subst1 x.FStar_Syntax_Syntax.sort)
+in (
+
+let t1 = (check_no_escape (Some (head1)) env fvs t)
+in (
+
+let uu____6448 = (FStar_TypeChecker_Util.new_implicit_var "Instantiating implicit argument in application" head1.FStar_Syntax_Syntax.pos env t1)
+in (match (uu____6448) with
+| (varg, uu____6459, implicits) -> begin
+(
+
+let subst2 = (FStar_Syntax_Syntax.NT (((x), (varg))))::subst1
+in (
+
+let arg = (
+
+let uu____6472 = (FStar_Syntax_Syntax.as_implicit true)
+in ((varg), (uu____6472)))
+in (
+
+let uu____6473 = (
+
+let uu____6495 = (FStar_TypeChecker_Rel.conj_guard implicits g)
+in ((subst2), ((((arg), (None), (FStar_Util.Inl (((FStar_Syntax_Const.effect_Tot_lid), (t1))))))::outargs), ((arg)::arg_rets), (uu____6495), (fvs)))
+in (tc_args head_info uu____6473 rest args1))))
+end))))
+end
+| (((x, aqual))::rest, ((e, aq))::rest') -> begin
+((match (((aqual), (aq))) with
+| ((Some (FStar_Syntax_Syntax.Implicit (_)), Some (FStar_Syntax_Syntax.Implicit (_)))) | ((None, None)) | ((Some (FStar_Syntax_Syntax.Equality), None)) -> begin
+()
+end
+| uu____6586 -> begin
+(Prims.raise (FStar_Errors.Error ((("Inconsistent implicit qualifier"), (e.FStar_Syntax_Syntax.pos)))))
+end);
+(
+
+let targ = (FStar_Syntax_Subst.subst subst1 x.FStar_Syntax_Syntax.sort)
+in (
+
+let x1 = (
+
+let uu___111_6593 = x
+in {FStar_Syntax_Syntax.ppname = uu___111_6593.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___111_6593.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = targ})
+in ((
+
+let uu____6595 = (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
+in (match (uu____6595) with
+| true -> begin
+(
+
+let uu____6596 = (FStar_Syntax_Print.term_to_string targ)
+in (FStar_Util.print1 "\tType of arg (after subst) = %s\n" uu____6596))
+end
+| uu____6597 -> begin
+()
+end));
+(
+
+let targ1 = (check_no_escape (Some (head1)) env fvs targ)
+in (
+
+let env1 = (FStar_TypeChecker_Env.set_expected_typ env targ1)
+in (
+
+let env2 = (
+
+let uu___112_6601 = env1
+in {FStar_TypeChecker_Env.solver = uu___112_6601.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___112_6601.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___112_6601.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___112_6601.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___112_6601.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___112_6601.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___112_6601.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___112_6601.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___112_6601.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___112_6601.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___112_6601.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___112_6601.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___112_6601.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___112_6601.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___112_6601.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = (is_eq aqual); FStar_TypeChecker_Env.is_iface = uu___112_6601.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___112_6601.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___112_6601.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___112_6601.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___112_6601.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___112_6601.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___112_6601.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___112_6601.FStar_TypeChecker_Env.qname_and_index})
+in ((
+
+let uu____6603 = (FStar_TypeChecker_Env.debug env2 FStar_Options.High)
+in (match (uu____6603) with
+| true -> begin
+(
+
+let uu____6604 = (FStar_Syntax_Print.tag_of_term e)
+in (
+
+let uu____6605 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____6606 = (FStar_Syntax_Print.term_to_string targ1)
+in (FStar_Util.print3 "Checking arg (%s) %s at type %s\n" uu____6604 uu____6605 uu____6606))))
+end
+| uu____6607 -> begin
+()
+end));
+(
+
+let uu____6608 = (tc_term env2 e)
+in (match (uu____6608) with
+| (e1, c, g_e) -> begin
+(
+
+let g1 = (FStar_TypeChecker_Rel.conj_guard g g_e)
+in (
+
+let arg = ((e1), (aq))
+in (
+
+let uu____6624 = (FStar_Syntax_Util.is_tot_or_gtot_lcomp c)
+in (match (uu____6624) with
+| true -> begin
+(
+
+let subst2 = (
+
+let uu____6629 = (FStar_List.hd bs)
+in (maybe_extend_subst subst1 uu____6629 e1))
+in (tc_args head_info ((subst2), ((((arg), (None), (FStar_Util.Inl (((c.FStar_Syntax_Syntax.eff_name), (c.FStar_Syntax_Syntax.res_typ))))))::outargs), ((arg)::arg_rets), (g1), (fvs)) rest rest'))
+end
+| uu____6684 -> begin
+(
+
+let uu____6685 = (FStar_TypeChecker_Util.is_pure_or_ghost_effect env2 c.FStar_Syntax_Syntax.eff_name)
+in (match (uu____6685) with
+| true -> begin
+(
+
+let subst2 = (
+
+let uu____6690 = (FStar_List.hd bs)
+in (maybe_extend_subst subst1 uu____6690 e1))
+in (tc_args head_info ((subst2), ((((arg), (Some (x1)), (FStar_Util.Inr (c))))::outargs), ((arg)::arg_rets), (g1), (fvs)) rest rest'))
+end
+| uu____6735 -> begin
+(
+
+let uu____6736 = (
+
+let uu____6737 = (FStar_List.hd bs)
+in (FStar_Syntax_Syntax.is_null_binder uu____6737))
+in (match (uu____6736) with
+| true -> begin
+(
+
+let newx = (FStar_Syntax_Syntax.new_bv (Some (e1.FStar_Syntax_Syntax.pos)) c.FStar_Syntax_Syntax.res_typ)
+in (
+
+let arg' = (
+
+let uu____6746 = (FStar_Syntax_Syntax.bv_to_name newx)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____6746))
+in (tc_args head_info ((subst1), ((((arg), (Some (newx)), (FStar_Util.Inr (c))))::outargs), ((arg')::arg_rets), (g1), (fvs)) rest rest')))
+end
+| uu____6783 -> begin
+(
+
+let uu____6784 = (
+
+let uu____6806 = (
+
+let uu____6808 = (
+
+let uu____6809 = (FStar_Syntax_Syntax.bv_to_name x1)
+in (FStar_Syntax_Syntax.as_arg uu____6809))
+in (uu____6808)::arg_rets)
+in ((subst1), ((((arg), (Some (x1)), (FStar_Util.Inr (c))))::outargs), (uu____6806), (g1), ((x1)::fvs)))
+in (tc_args head_info uu____6784 rest rest'))
+end))
+end))
+end))))
+end));
+))));
+)));
+)
+end
+| (uu____6846, []) -> begin
+(monadic_application head_info subst1 outargs arg_rets g fvs bs)
+end
+| ([], (arg)::uu____6867) -> begin
+(
+
+let uu____6897 = (monadic_application head_info subst1 outargs arg_rets g fvs [])
+in (match (uu____6897) with
+| (head2, chead1, ghead1) -> begin
+(
+
+let rec aux = (fun norm1 tres -> (
+
+let tres1 = (
+
+let uu____6920 = (FStar_Syntax_Subst.compress tres)
+in (FStar_All.pipe_right uu____6920 FStar_Syntax_Util.unrefine))
+in (match (tres1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs1, cres') -> begin
+(
+
+let uu____6936 = (FStar_Syntax_Subst.open_comp bs1 cres')
+in (match (uu____6936) with
+| (bs2, cres'1) -> begin
+(
+
+let head_info1 = ((head2), (chead1), (ghead1), ((FStar_Syntax_Util.lcomp_of_comp cres'1)))
+in ((
+
+let uu____6950 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____6950) with
+| true -> begin
+(
+
+let uu____6951 = (FStar_Range.string_of_range tres1.FStar_Syntax_Syntax.pos)
+in (FStar_Util.print1 "%s: Warning: Potentially redundant explicit currying of a function type \n" uu____6951))
+end
+| uu____6952 -> begin
+()
+end));
+(tc_args head_info1 (([]), ([]), ([]), (FStar_TypeChecker_Rel.trivial_guard), ([])) bs2 args1);
+))
+end))
+end
+| uu____6981 when (not (norm1)) -> begin
+(
+
+let uu____6982 = (unfold_whnf env tres1)
+in (aux true uu____6982))
+end
+| uu____6983 -> begin
+(
+
+let uu____6984 = (
+
+let uu____6985 = (
+
+let uu____6988 = (
+
+let uu____6989 = (FStar_TypeChecker_Normalize.term_to_string env thead)
+in (
+
+let uu____6990 = (FStar_Util.string_of_int n_args)
+in (FStar_Util.format2 "Too many arguments to function of type %s; got %s arguments" uu____6989 uu____6990)))
+in (
+
+let uu____6994 = (FStar_Syntax_Syntax.argpos arg)
+in ((uu____6988), (uu____6994))))
+in FStar_Errors.Error (uu____6985))
+in (Prims.raise uu____6984))
+end)))
+in (aux false chead1.FStar_Syntax_Syntax.res_typ))
+end))
+end)
+end))
+in (
+
+let rec check_function_app = (fun norm1 tf -> (
+
+let uu____7010 = (
+
+let uu____7011 = (FStar_Syntax_Util.unrefine tf)
+in uu____7011.FStar_Syntax_Syntax.n)
+in (match (uu____7010) with
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) -> begin
+(
+
+let rec tc_args1 = (fun env1 args1 -> (match (args1) with
+| [] -> begin
+(([]), ([]), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| ((e, imp))::tl1 -> begin
+(
+
+let uu____7087 = (tc_term env1 e)
+in (match (uu____7087) with
+| (e1, c, g_e) -> begin
+(
+
+let uu____7100 = (tc_args1 env1 tl1)
+in (match (uu____7100) with
+| (args2, comps, g_rest) -> begin
+(
+
+let uu____7122 = (FStar_TypeChecker_Rel.conj_guard g_e g_rest)
+in (((((e1), (imp)))::args2), ((((e1.FStar_Syntax_Syntax.pos), (c)))::comps), (uu____7122)))
+end))
+end))
+end))
+in (
+
+let uu____7133 = (tc_args1 env args)
+in (match (uu____7133) with
+| (args1, comps, g_args) -> begin
+(
+
+let bs = (
+
+let uu____7155 = (FStar_All.pipe_right comps (FStar_List.map (fun uu____7175 -> (match (uu____7175) with
+| (uu____7183, c) -> begin
+((c.FStar_Syntax_Syntax.res_typ), (None))
+end))))
+in (FStar_Syntax_Util.null_binders_of_tks uu____7155))
+in (
+
+let ml_or_tot = (fun t r1 -> (
+
+let uu____7199 = (FStar_Options.ml_ish ())
+in (match (uu____7199) with
+| true -> begin
+(FStar_Syntax_Util.ml_comp t r1)
+end
+| uu____7200 -> begin
+(FStar_Syntax_Syntax.mk_Total t)
+end)))
+in (
+
+let cres = (
+
+let uu____7202 = (
+
+let uu____7205 = (
+
+let uu____7206 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_right uu____7206 Prims.fst))
+in (FStar_TypeChecker_Util.new_uvar env uu____7205))
+in (ml_or_tot uu____7202 r))
+in (
+
+let bs_cres = (FStar_Syntax_Util.arrow bs cres)
+in ((
+
+let uu____7215 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____7215) with
+| true -> begin
+(
+
+let uu____7216 = (FStar_Syntax_Print.term_to_string head1)
+in (
+
+let uu____7217 = (FStar_Syntax_Print.term_to_string tf)
+in (
+
+let uu____7218 = (FStar_Syntax_Print.term_to_string bs_cres)
+in (FStar_Util.print3 "Forcing the type of %s from %s to %s\n" uu____7216 uu____7217 uu____7218))))
+end
+| uu____7219 -> begin
+()
+end));
+(
+
+let uu____7221 = (FStar_TypeChecker_Rel.teq env tf bs_cres)
+in (FStar_All.pipe_left (FStar_TypeChecker_Rel.force_trivial_guard env) uu____7221));
+(
+
+let comp = (
+
+let uu____7223 = (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp cres)
+in (FStar_List.fold_right (fun uu____7228 out -> (match (uu____7228) with
+| (r1, c) -> begin
+(FStar_TypeChecker_Util.bind r1 env None c ((None), (out)))
+end)) ((((head1.FStar_Syntax_Syntax.pos), (chead)))::comps) uu____7223))
+in (
+
+let uu____7237 = ((FStar_Syntax_Syntax.mk_Tm_app head1 args1) (Some (comp.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) r)
+in (
+
+let uu____7244 = (FStar_TypeChecker_Rel.conj_guard ghead g_args)
+in ((uu____7237), (comp), (uu____7244)))));
+)))))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____7259 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____7259) with
+| (bs1, c1) -> begin
+(
+
+let head_info = ((head1), (chead), (ghead), ((FStar_Syntax_Util.lcomp_of_comp c1)))
+in (tc_args head_info (([]), ([]), ([]), (FStar_TypeChecker_Rel.trivial_guard), ([])) bs1 args))
+end))
+end
+| uu____7302 -> begin
+(match ((not (norm1))) with
+| true -> begin
+(
+
+let uu____7308 = (unfold_whnf env tf)
+in (check_function_app true uu____7308))
+end
+| uu____7309 -> begin
+(
+
+let uu____7310 = (
+
+let uu____7311 = (
+
+let uu____7314 = (FStar_TypeChecker_Err.expected_function_typ env tf)
+in ((uu____7314), (head1.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____7311))
+in (Prims.raise uu____7310))
+end)
+end)))
+in (
+
+let uu____7320 = (
+
+let uu____7321 = (FStar_Syntax_Util.unrefine thead)
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.WHNF)::[]) env uu____7321))
+in (check_function_app false uu____7320)))));
+)))))
+and check_short_circuit_args : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_TypeChecker_Env.guard_t  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list  ->  FStar_Syntax_Syntax.typ Prims.option  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env head1 chead g_head args expected_topt -> (
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let tf = (FStar_Syntax_Subst.compress chead.FStar_Syntax_Syntax.res_typ)
+in (match (tf.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) when ((FStar_Syntax_Util.is_total_comp c) && ((FStar_List.length bs) = (FStar_List.length args))) -> begin
+(
+
+let res_t = (FStar_Syntax_Util.comp_result c)
+in (
+
+let uu____7367 = (FStar_List.fold_left2 (fun uu____7380 uu____7381 uu____7382 -> (match (((uu____7380), (uu____7381), (uu____7382))) with
+| ((seen, guard, ghost), (e, aq), (b, aq')) -> begin
+((match ((aq <> aq')) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Inconsistent implicit qualifiers"), (e.FStar_Syntax_Syntax.pos)))))
+end
+| uu____7425 -> begin
+()
+end);
+(
+
+let uu____7426 = (tc_check_tot_or_gtot_term env e b.FStar_Syntax_Syntax.sort)
+in (match (uu____7426) with
+| (e1, c1, g) -> begin
+(
+
+let short = (FStar_TypeChecker_Util.short_circuit head1 seen)
+in (
+
+let g1 = (
+
+let uu____7438 = (FStar_TypeChecker_Rel.guard_of_guard_formula short)
+in (FStar_TypeChecker_Rel.imp_guard uu____7438 g))
+in (
+
+let ghost1 = (ghost || ((
+
+let uu____7440 = (FStar_Syntax_Util.is_total_lcomp c1)
+in (not (uu____7440))) && (
+
+let uu____7441 = (FStar_TypeChecker_Util.is_pure_effect env c1.FStar_Syntax_Syntax.eff_name)
+in (not (uu____7441)))))
+in (
+
+let uu____7442 = (
+
+let uu____7448 = (
+
+let uu____7454 = (FStar_Syntax_Syntax.as_arg e1)
+in (uu____7454)::[])
+in (FStar_List.append seen uu____7448))
+in (
+
+let uu____7459 = (FStar_TypeChecker_Rel.conj_guard guard g1)
+in ((uu____7442), (uu____7459), (ghost1)))))))
+end));
+)
+end)) (([]), (g_head), (false)) args bs)
+in (match (uu____7367) with
+| (args1, guard, ghost) -> begin
+(
+
+let e = ((FStar_Syntax_Syntax.mk_Tm_app head1 args1) (Some (res_t.FStar_Syntax_Syntax.n)) r)
+in (
+
+let c1 = (match (ghost) with
+| true -> begin
+(
+
+let uu____7488 = (FStar_Syntax_Syntax.mk_GTotal res_t)
+in (FStar_All.pipe_right uu____7488 FStar_Syntax_Util.lcomp_of_comp))
+end
+| uu____7489 -> begin
+(FStar_Syntax_Util.lcomp_of_comp c)
+end)
+in (
+
+let uu____7490 = (FStar_TypeChecker_Util.strengthen_precondition None env e c1 guard)
+in (match (uu____7490) with
+| (c2, g) -> begin
+((e), (c2), (g))
+end))))
+end)))
+end
+| uu____7502 -> begin
+(check_application_args env head1 chead g_head args expected_topt)
+end))))
+and tc_eqn : FStar_Syntax_Syntax.bv  ->  FStar_TypeChecker_Env.env  ->  ((FStar_Syntax_Syntax.pat', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.withinfo_t * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax Prims.option * (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax)  ->  ((FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term Prims.option * FStar_Syntax_Syntax.term) * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun scrutinee env branch1 -> (
+
+let uu____7524 = (FStar_Syntax_Subst.open_branch branch1)
+in (match (uu____7524) with
+| (pattern, when_clause, branch_exp) -> begin
+(
+
+let uu____7550 = branch1
+in (match (uu____7550) with
+| (cpat, uu____7570, cbr) -> begin
+(
+
+let tc_pat = (fun allow_implicits pat_t p0 -> (
+
+let uu____7612 = (FStar_TypeChecker_Util.pat_as_exps allow_implicits env p0)
+in (match (uu____7612) with
+| (pat_bvs1, exps, p) -> begin
+((
+
+let uu____7634 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____7634) with
+| true -> begin
+(
+
+let uu____7635 = (FStar_Syntax_Print.pat_to_string p0)
+in (
+
+let uu____7636 = (FStar_Syntax_Print.pat_to_string p)
+in (FStar_Util.print2 "Pattern %s elaborated to %s\n" uu____7635 uu____7636)))
+end
+| uu____7637 -> begin
+()
+end));
+(
+
+let pat_env = (FStar_List.fold_left FStar_TypeChecker_Env.push_bv env pat_bvs1)
+in (
+
+let uu____7639 = (FStar_TypeChecker_Env.clear_expected_typ pat_env)
+in (match (uu____7639) with
+| (env1, uu____7652) -> begin
+(
+
+let env11 = (
+
+let uu___113_7656 = env1
+in {FStar_TypeChecker_Env.solver = uu___113_7656.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___113_7656.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___113_7656.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___113_7656.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___113_7656.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___113_7656.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___113_7656.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___113_7656.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = true; FStar_TypeChecker_Env.instantiate_imp = uu___113_7656.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___113_7656.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___113_7656.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___113_7656.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___113_7656.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___113_7656.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___113_7656.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___113_7656.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___113_7656.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___113_7656.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___113_7656.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___113_7656.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___113_7656.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___113_7656.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___113_7656.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let expected_pat_t = (FStar_TypeChecker_Rel.unrefine env pat_t)
+in (
+
+let uu____7658 = (
+
+let uu____7663 = (FStar_All.pipe_right exps (FStar_List.map (fun e -> ((
+
+let uu____7675 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____7675) with
+| true -> begin
+(
+
+let uu____7676 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____7677 = (FStar_Syntax_Print.term_to_string pat_t)
+in (FStar_Util.print2 "Checking pattern expression %s against expected type %s\n" uu____7676 uu____7677)))
+end
+| uu____7678 -> begin
+()
+end));
+(
+
+let uu____7679 = (tc_term env11 e)
+in (match (uu____7679) with
+| (e1, lc, g) -> begin
+((
+
+let uu____7689 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____7689) with
+| true -> begin
+(
+
+let uu____7690 = (FStar_TypeChecker_Normalize.term_to_string env e1)
+in (
+
+let uu____7691 = (FStar_TypeChecker_Normalize.term_to_string env lc.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.print2 "Pre-checked pattern expression %s at type %s\n" uu____7690 uu____7691)))
+end
+| uu____7692 -> begin
+()
+end));
+(
+
+let g' = (FStar_TypeChecker_Rel.teq env lc.FStar_Syntax_Syntax.res_typ expected_pat_t)
+in (
+
+let g1 = (FStar_TypeChecker_Rel.conj_guard g g')
+in (
+
+let uu____7695 = (
+
+let uu____7696 = (FStar_TypeChecker_Rel.discharge_guard env (
+
+let uu___114_7697 = g1
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___114_7697.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___114_7697.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___114_7697.FStar_TypeChecker_Env.implicits}))
+in (FStar_All.pipe_right uu____7696 FStar_TypeChecker_Rel.resolve_implicits))
+in (
+
+let e' = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env e1)
+in (
+
+let uvars_to_string = (fun uvs -> (
+
+let uu____7711 = (
+
+let uu____7713 = (FStar_All.pipe_right uvs FStar_Util.set_elements)
+in (FStar_All.pipe_right uu____7713 (FStar_List.map (fun uu____7737 -> (match (uu____7737) with
+| (u, uu____7742) -> begin
+(FStar_Syntax_Print.uvar_to_string u)
+end)))))
+in (FStar_All.pipe_right uu____7711 (FStar_String.concat ", "))))
+in (
+
+let uvs1 = (FStar_Syntax_Free.uvars e')
+in (
+
+let uvs2 = (FStar_Syntax_Free.uvars expected_pat_t)
+in ((
+
+let uu____7755 = (
+
+let uu____7756 = (FStar_Util.set_is_subset_of uvs1 uvs2)
+in (FStar_All.pipe_left Prims.op_Negation uu____7756))
+in (match (uu____7755) with
+| true -> begin
+(
+
+let unresolved = (
+
+let uu____7763 = (FStar_Util.set_difference uvs1 uvs2)
+in (FStar_All.pipe_right uu____7763 FStar_Util.set_elements))
+in (
+
+let uu____7777 = (
+
+let uu____7778 = (
+
+let uu____7781 = (
+
+let uu____7782 = (FStar_TypeChecker_Normalize.term_to_string env e')
+in (
+
+let uu____7783 = (FStar_TypeChecker_Normalize.term_to_string env expected_pat_t)
+in (
+
+let uu____7784 = (
+
+let uu____7785 = (FStar_All.pipe_right unresolved (FStar_List.map (fun uu____7797 -> (match (uu____7797) with
+| (u, uu____7805) -> begin
+(FStar_Syntax_Print.uvar_to_string u)
+end))))
+in (FStar_All.pipe_right uu____7785 (FStar_String.concat ", ")))
+in (FStar_Util.format3 "Implicit pattern variables in %s could not be resolved against expected type %s;Variables {%s} were unresolved; please bind them explicitly" uu____7782 uu____7783 uu____7784))))
+in ((uu____7781), (p.FStar_Syntax_Syntax.p)))
+in FStar_Errors.Error (uu____7778))
+in (Prims.raise uu____7777)))
+end
+| uu____7818 -> begin
+()
+end));
+(
+
+let uu____7820 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____7820) with
+| true -> begin
+(
+
+let uu____7821 = (FStar_TypeChecker_Normalize.term_to_string env e1)
+in (FStar_Util.print1 "Done checking pattern expression %s\n" uu____7821))
+end
+| uu____7822 -> begin
+()
+end));
+((e1), (e'));
+))))))));
+)
+end));
+))))
+in (FStar_All.pipe_right uu____7663 FStar_List.unzip))
+in (match (uu____7658) with
+| (exps1, norm_exps) -> begin
+(
+
+let p1 = (FStar_TypeChecker_Util.decorate_pattern env p exps1)
+in ((p1), (pat_bvs1), (pat_env), (exps1), (norm_exps)))
+end))))
+end)));
+)
+end)))
+in (
+
+let pat_t = scrutinee.FStar_Syntax_Syntax.sort
+in (
+
+let scrutinee_tm = (FStar_Syntax_Syntax.bv_to_name scrutinee)
+in (
+
+let uu____7852 = (
+
+let uu____7856 = (FStar_TypeChecker_Env.push_bv env scrutinee)
+in (FStar_All.pipe_right uu____7856 FStar_TypeChecker_Env.clear_expected_typ))
+in (match (uu____7852) with
+| (scrutinee_env, uu____7869) -> begin
+(
+
+let uu____7872 = (tc_pat true pat_t pattern)
+in (match (uu____7872) with
+| (pattern1, pat_bvs1, pat_env, disj_exps, norm_disj_exps) -> begin
+(
+
+let uu____7900 = (match (when_clause) with
+| None -> begin
+((None), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| Some (e) -> begin
+(
+
+let uu____7915 = (FStar_TypeChecker_Env.should_verify env)
+in (match (uu____7915) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("When clauses are not yet supported in --verify mode; they will be some day"), (e.FStar_Syntax_Syntax.pos)))))
+end
+| uu____7922 -> begin
+(
+
+let uu____7923 = (
+
+let uu____7927 = (FStar_TypeChecker_Env.set_expected_typ pat_env FStar_TypeChecker_Common.t_bool)
+in (tc_term uu____7927 e))
+in (match (uu____7923) with
+| (e1, c, g) -> begin
+((Some (e1)), (g))
+end))
+end))
+end)
+in (match (uu____7900) with
+| (when_clause1, g_when) -> begin
+(
+
+let uu____7947 = (tc_term pat_env branch_exp)
+in (match (uu____7947) with
+| (branch_exp1, c, g_branch) -> begin
+(
+
+let when_condition = (match (when_clause1) with
+| None -> begin
+None
+end
+| Some (w) -> begin
+(
+
+let uu____7966 = (FStar_Syntax_Util.mk_eq2 FStar_Syntax_Syntax.U_zero FStar_Syntax_Util.t_bool w FStar_Syntax_Const.exp_true_bool)
+in (FStar_All.pipe_left (fun _0_30 -> Some (_0_30)) uu____7966))
+end)
+in (
+
+let uu____7968 = (
+
+let eqs = (
+
+let uu____7974 = (
+
+let uu____7975 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____7975)))
+in (match (uu____7974) with
+| true -> begin
+None
+end
+| uu____7977 -> begin
+(FStar_All.pipe_right disj_exps (FStar_List.fold_left (fun fopt e -> (
+
+let e1 = (FStar_Syntax_Subst.compress e)
+in (match (e1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+fopt
+end
+| uu____7989 -> begin
+(
+
+let clause = (
+
+let uu____7991 = (env.FStar_TypeChecker_Env.universe_of env pat_t)
+in (FStar_Syntax_Util.mk_eq2 uu____7991 pat_t scrutinee_tm e1))
+in (match (fopt) with
+| None -> begin
+Some (clause)
+end
+| Some (f) -> begin
+(
+
+let uu____7994 = (FStar_Syntax_Util.mk_disj clause f)
+in (FStar_All.pipe_left (fun _0_31 -> Some (_0_31)) uu____7994))
+end))
+end))) None))
+end))
+in (
+
+let uu____8004 = (FStar_TypeChecker_Util.strengthen_precondition None env branch_exp1 c g_branch)
+in (match (uu____8004) with
+| (c1, g_branch1) -> begin
+(
+
+let uu____8014 = (match (((eqs), (when_condition))) with
+| uu____8021 when (
+
+let uu____8026 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____8026))) -> begin
+((c1), (g_when))
+end
+| (None, None) -> begin
+((c1), (g_when))
+end
+| (Some (f), None) -> begin
+(
+
+let gf = FStar_TypeChecker_Common.NonTrivial (f)
+in (
+
+let g = (FStar_TypeChecker_Rel.guard_of_guard_formula gf)
+in (
+
+let uu____8034 = (FStar_TypeChecker_Util.weaken_precondition env c1 gf)
+in (
+
+let uu____8035 = (FStar_TypeChecker_Rel.imp_guard g g_when)
+in ((uu____8034), (uu____8035))))))
+end
+| (Some (f), Some (w)) -> begin
+(
+
+let g_f = FStar_TypeChecker_Common.NonTrivial (f)
+in (
+
+let g_fw = (
+
+let uu____8042 = (FStar_Syntax_Util.mk_conj f w)
+in FStar_TypeChecker_Common.NonTrivial (uu____8042))
+in (
+
+let uu____8043 = (FStar_TypeChecker_Util.weaken_precondition env c1 g_fw)
+in (
+
+let uu____8044 = (
+
+let uu____8045 = (FStar_TypeChecker_Rel.guard_of_guard_formula g_f)
+in (FStar_TypeChecker_Rel.imp_guard uu____8045 g_when))
+in ((uu____8043), (uu____8044))))))
+end
+| (None, Some (w)) -> begin
+(
+
+let g_w = FStar_TypeChecker_Common.NonTrivial (w)
+in (
+
+let g = (FStar_TypeChecker_Rel.guard_of_guard_formula g_w)
+in (
+
+let uu____8051 = (FStar_TypeChecker_Util.weaken_precondition env c1 g_w)
+in ((uu____8051), (g_when)))))
+end)
+in (match (uu____8014) with
+| (c_weak, g_when_weak) -> begin
+(
+
+let binders = (FStar_List.map FStar_Syntax_Syntax.mk_binder pat_bvs1)
+in (
+
+let uu____8059 = (FStar_TypeChecker_Util.close_comp env pat_bvs1 c_weak)
+in (
+
+let uu____8060 = (FStar_TypeChecker_Rel.close_guard env binders g_when_weak)
+in ((uu____8059), (uu____8060), (g_branch1)))))
+end))
+end)))
+in (match (uu____7968) with
+| (c1, g_when1, g_branch1) -> begin
+(
+
+let branch_guard = (
+
+let uu____8073 = (
+
+let uu____8074 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____8074)))
+in (match (uu____8073) with
+| true -> begin
+FStar_Syntax_Util.t_true
+end
+| uu____8075 -> begin
+(
+
+let rec build_branch_guard = (fun scrutinee_tm1 pat_exp -> (
+
+let discriminate = (fun scrutinee_tm2 f -> (
+
+let uu____8105 = (
+
+let uu____8106 = (
+
+let uu____8107 = (
+
+let uu____8109 = (
+
+let uu____8113 = (FStar_TypeChecker_Env.typ_of_datacon env f.FStar_Syntax_Syntax.v)
+in (FStar_TypeChecker_Env.datacons_of_typ env uu____8113))
+in (Prims.snd uu____8109))
+in (FStar_List.length uu____8107))
+in (uu____8106 > (Prims.parse_int "1")))
+in (match (uu____8105) with
+| true -> begin
+(
+
+let discriminator = (FStar_Syntax_Util.mk_discriminator f.FStar_Syntax_Syntax.v)
+in (
+
+let uu____8122 = (FStar_TypeChecker_Env.try_lookup_lid env discriminator)
+in (match (uu____8122) with
+| None -> begin
+[]
+end
+| uu____8133 -> begin
+(
+
+let disc = (FStar_Syntax_Syntax.fvar discriminator FStar_Syntax_Syntax.Delta_equational None)
+in (
+
+let disc1 = (
+
+let uu____8143 = (
+
+let uu____8144 = (
+
+let uu____8145 = (FStar_Syntax_Syntax.as_arg scrutinee_tm2)
+in (uu____8145)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app disc uu____8144))
+in (uu____8143 None scrutinee_tm2.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____8150 = (FStar_Syntax_Util.mk_eq2 FStar_Syntax_Syntax.U_zero FStar_Syntax_Util.t_bool disc1 FStar_Syntax_Const.exp_true_bool)
+in (uu____8150)::[])))
+end)))
+end
+| uu____8151 -> begin
+[]
+end)))
+in (
+
+let fail = (fun uu____8158 -> (
+
+let uu____8159 = (
+
+let uu____8160 = (FStar_Range.string_of_range pat_exp.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____8161 = (FStar_Syntax_Print.term_to_string pat_exp)
+in (
+
+let uu____8162 = (FStar_Syntax_Print.tag_of_term pat_exp)
+in (FStar_Util.format3 "tc_eqn: Impossible (%s) %s (%s)" uu____8160 uu____8161 uu____8162))))
+in (failwith uu____8159)))
+in (
+
+let rec head_constructor = (fun t -> (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+fv.FStar_Syntax_Syntax.fv_name
+end
+| FStar_Syntax_Syntax.Tm_uinst (t1, uu____8183) -> begin
+(head_constructor t1)
+end
+| uu____8189 -> begin
+(fail ())
+end))
+in (
+
+let pat_exp1 = (
+
+let uu____8192 = (FStar_Syntax_Subst.compress pat_exp)
+in (FStar_All.pipe_right uu____8192 FStar_Syntax_Util.unmeta))
+in (match (pat_exp1.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (_); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit)) -> begin
+[]
+end
+| FStar_Syntax_Syntax.Tm_constant (c2) -> begin
+(
+
+let uu____8209 = (
+
+let uu____8210 = (tc_constant pat_exp1.FStar_Syntax_Syntax.pos c2)
+in (FStar_Syntax_Util.mk_eq2 FStar_Syntax_Syntax.U_zero uu____8210 scrutinee_tm1 pat_exp1))
+in (uu____8209)::[])
+end
+| (FStar_Syntax_Syntax.Tm_uinst (_)) | (FStar_Syntax_Syntax.Tm_fvar (_)) -> begin
+(
+
+let f = (head_constructor pat_exp1)
+in (
+
+let uu____8218 = (
+
+let uu____8219 = (FStar_TypeChecker_Env.is_datacon env f.FStar_Syntax_Syntax.v)
+in (not (uu____8219)))
+in (match (uu____8218) with
+| true -> begin
+[]
+end
+| uu____8225 -> begin
+(
+
+let uu____8226 = (head_constructor pat_exp1)
+in (discriminate scrutinee_tm1 uu____8226))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_app (head1, args) -> begin
+(
+
+let f = (head_constructor head1)
+in (
+
+let uu____8253 = (
+
+let uu____8254 = (FStar_TypeChecker_Env.is_datacon env f.FStar_Syntax_Syntax.v)
+in (not (uu____8254)))
+in (match (uu____8253) with
+| true -> begin
+[]
+end
+| uu____8260 -> begin
+(
+
+let sub_term_guards = (
+
+let uu____8263 = (FStar_All.pipe_right args (FStar_List.mapi (fun i uu____8279 -> (match (uu____8279) with
+| (ei, uu____8286) -> begin
+(
+
+let projector = (FStar_TypeChecker_Env.lookup_projector env f.FStar_Syntax_Syntax.v i)
+in (
+
+let uu____8296 = (FStar_TypeChecker_Env.try_lookup_lid env projector)
+in (match (uu____8296) with
+| None -> begin
+[]
+end
+| uu____8307 -> begin
+(
+
+let sub_term = (
+
+let uu____8316 = (
+
+let uu____8317 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range projector f.FStar_Syntax_Syntax.p) FStar_Syntax_Syntax.Delta_equational None)
+in (
+
+let uu____8322 = (
+
+let uu____8323 = (FStar_Syntax_Syntax.as_arg scrutinee_tm1)
+in (uu____8323)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____8317 uu____8322)))
+in (uu____8316 None f.FStar_Syntax_Syntax.p))
+in (build_branch_guard sub_term ei))
+end)))
+end))))
+in (FStar_All.pipe_right uu____8263 FStar_List.flatten))
+in (
+
+let uu____8335 = (discriminate scrutinee_tm1 f)
+in (FStar_List.append uu____8335 sub_term_guards)))
+end)))
+end
+| uu____8339 -> begin
+[]
+end))))))
+in (
+
+let build_and_check_branch_guard = (fun scrutinee_tm1 pat -> (
+
+let uu____8351 = (
+
+let uu____8352 = (FStar_TypeChecker_Env.should_verify env)
+in (not (uu____8352)))
+in (match (uu____8351) with
+| true -> begin
+(FStar_TypeChecker_Util.fvar_const env FStar_Syntax_Const.true_lid)
+end
+| uu____8353 -> begin
+(
+
+let t = (
+
+let uu____8355 = (build_branch_guard scrutinee_tm1 pat)
+in (FStar_All.pipe_left FStar_Syntax_Util.mk_conj_l uu____8355))
+in (
+
+let uu____8358 = (FStar_Syntax_Util.type_u ())
+in (match (uu____8358) with
+| (k, uu____8362) -> begin
+(
+
+let uu____8363 = (tc_check_tot_or_gtot_term scrutinee_env t k)
+in (match (uu____8363) with
+| (t1, uu____8368, uu____8369) -> begin
+t1
+end))
+end)))
+end)))
+in (
+
+let branch_guard = (
+
+let uu____8371 = (FStar_All.pipe_right norm_disj_exps (FStar_List.map (build_and_check_branch_guard scrutinee_tm)))
+in (FStar_All.pipe_right uu____8371 FStar_Syntax_Util.mk_disj_l))
+in (
+
+let branch_guard1 = (match (when_condition) with
+| None -> begin
+branch_guard
+end
+| Some (w) -> begin
+(FStar_Syntax_Util.mk_conj branch_guard w)
+end)
+in branch_guard1))))
+end))
+in (
+
+let guard = (FStar_TypeChecker_Rel.conj_guard g_when1 g_branch1)
+in ((
+
+let uu____8382 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____8382) with
+| true -> begin
+(
+
+let uu____8383 = (FStar_TypeChecker_Rel.guard_to_string env guard)
+in (FStar_All.pipe_left (FStar_Util.print1 "Carrying guard from match: %s\n") uu____8383))
+end
+| uu____8384 -> begin
+()
+end));
+(
+
+let uu____8385 = (FStar_Syntax_Subst.close_branch ((pattern1), (when_clause1), (branch_exp1)))
+in ((uu____8385), (branch_guard), (c1), (guard)));
+)))
+end)))
+end))
+end))
+end))
+end)))))
+end))
+end)))
+and check_top_level_let : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (
+
+let env1 = (instantiate_both env)
+in (match (e.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), e2) -> begin
+(
+
+let uu____8403 = (check_let_bound_def true env1 lb)
+in (match (uu____8403) with
+| (e1, univ_vars1, c1, g1, annotated) -> begin
+(
+
+let uu____8417 = (match ((annotated && (not (env1.FStar_TypeChecker_Env.generalize)))) with
+| true -> begin
+((g1), (e1), (univ_vars1), (c1))
+end
+| uu____8426 -> begin
+(
+
+let g11 = (
+
+let uu____8428 = (FStar_TypeChecker_Rel.solve_deferred_constraints env1 g1)
+in (FStar_All.pipe_right uu____8428 FStar_TypeChecker_Rel.resolve_implicits))
+in (
+
+let uu____8430 = (
+
+let uu____8435 = (
+
+let uu____8441 = (
+
+let uu____8446 = (
+
+let uu____8454 = (c1.FStar_Syntax_Syntax.comp ())
+in ((lb.FStar_Syntax_Syntax.lbname), (e1), (uu____8454)))
+in (uu____8446)::[])
+in (FStar_TypeChecker_Util.generalize env1 uu____8441))
+in (FStar_List.hd uu____8435))
+in (match (uu____8430) with
+| (uu____8483, univs1, e11, c11) -> begin
+((g11), (e11), (univs1), ((FStar_Syntax_Util.lcomp_of_comp c11)))
+end)))
+end)
+in (match (uu____8417) with
+| (g11, e11, univ_vars2, c11) -> begin
+(
+
+let uu____8494 = (
+
+let uu____8499 = (FStar_TypeChecker_Env.should_verify env1)
+in (match (uu____8499) with
+| true -> begin
+(
+
+let uu____8504 = (FStar_TypeChecker_Util.check_top_level env1 g11 c11)
+in (match (uu____8504) with
+| (ok, c12) -> begin
+(match (ok) with
+| true -> begin
+((e2), (c12))
+end
+| uu____8519 -> begin
+((
+
+let uu____8521 = (FStar_Options.warn_top_level_effects ())
+in (match (uu____8521) with
+| true -> begin
+(
+
+let uu____8522 = (FStar_TypeChecker_Env.get_range env1)
+in (FStar_Errors.warn uu____8522 FStar_TypeChecker_Err.top_level_effect))
+end
+| uu____8523 -> begin
+()
+end));
+(
+
+let uu____8524 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e2), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Masked_effect)))))) None e2.FStar_Syntax_Syntax.pos)
+in ((uu____8524), (c12)));
+)
+end)
+end))
+end
+| uu____8539 -> begin
+((FStar_TypeChecker_Rel.force_trivial_guard env1 g11);
+(
+
+let c = (
+
+let uu____8542 = (c11.FStar_Syntax_Syntax.comp ())
+in (FStar_All.pipe_right uu____8542 (FStar_TypeChecker_Normalize.normalize_comp ((FStar_TypeChecker_Normalize.Beta)::[]) env1)))
+in (
+
+let e21 = (
+
+let uu____8550 = (FStar_Syntax_Util.is_pure_comp c)
+in (match (uu____8550) with
+| true -> begin
+e2
+end
+| uu____8553 -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e2), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Masked_effect)))))) None e2.FStar_Syntax_Syntax.pos)
+end))
+in ((e21), (c))));
+)
+end))
+in (match (uu____8494) with
+| (e21, c12) -> begin
+(
+
+let cres = (FStar_TypeChecker_Env.null_wp_for_eff env1 (FStar_Syntax_Util.comp_effect_name c12) FStar_Syntax_Syntax.U_zero FStar_TypeChecker_Common.t_unit)
+in ((FStar_ST.write e21.FStar_Syntax_Syntax.tk (Some (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n)));
+(
+
+let lb1 = (FStar_Syntax_Util.close_univs_and_mk_letbinding None lb.FStar_Syntax_Syntax.lbname univ_vars2 (FStar_Syntax_Util.comp_result c12) (FStar_Syntax_Util.comp_effect_name c12) e11)
+in (
+
+let uu____8582 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_let (((((false), ((lb1)::[]))), (e21))))) (Some (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos)
+in ((uu____8582), ((FStar_Syntax_Util.lcomp_of_comp cres)), (FStar_TypeChecker_Rel.trivial_guard))));
+))
+end))
+end))
+end))
+end
+| uu____8601 -> begin
+(failwith "Impossible")
+end)))
+and check_inner_let : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (
+
+let env1 = (instantiate_both env)
+in (match (e.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_let ((false, (lb)::[]), e2) -> begin
+(
+
+let env2 = (
+
+let uu___115_8622 = env1
+in {FStar_TypeChecker_Env.solver = uu___115_8622.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___115_8622.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___115_8622.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___115_8622.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___115_8622.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___115_8622.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___115_8622.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___115_8622.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___115_8622.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___115_8622.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___115_8622.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___115_8622.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___115_8622.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = false; FStar_TypeChecker_Env.check_uvars = uu___115_8622.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___115_8622.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___115_8622.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___115_8622.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___115_8622.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___115_8622.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___115_8622.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___115_8622.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___115_8622.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___115_8622.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let uu____8623 = (
+
+let uu____8629 = (
+
+let uu____8630 = (FStar_TypeChecker_Env.clear_expected_typ env2)
+in (FStar_All.pipe_right uu____8630 Prims.fst))
+in (check_let_bound_def false uu____8629 lb))
+in (match (uu____8623) with
+| (e1, uu____8642, c1, g1, annotated) -> begin
+(
+
+let x = (
+
+let uu___116_8647 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in {FStar_Syntax_Syntax.ppname = uu___116_8647.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___116_8647.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = c1.FStar_Syntax_Syntax.res_typ})
+in (
+
+let uu____8648 = (
+
+let uu____8651 = (
+
+let uu____8652 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____8652)::[])
+in (FStar_Syntax_Subst.open_term uu____8651 e2))
+in (match (uu____8648) with
+| (xb, e21) -> begin
+(
+
+let xbinder = (FStar_List.hd xb)
+in (
+
+let x1 = (Prims.fst xbinder)
+in (
+
+let uu____8664 = (
+
+let uu____8668 = (FStar_TypeChecker_Env.push_bv env2 x1)
+in (tc_term uu____8668 e21))
+in (match (uu____8664) with
+| (e22, c2, g2) -> begin
+(
+
+let cres = (FStar_TypeChecker_Util.bind e1.FStar_Syntax_Syntax.pos env2 (Some (e1)) c1 ((Some (x1)), (c2)))
+in (
+
+let e11 = (FStar_TypeChecker_Util.maybe_lift env2 e1 c1.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.eff_name c1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let e23 = (FStar_TypeChecker_Util.maybe_lift env2 e22 c2.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.eff_name c2.FStar_Syntax_Syntax.res_typ)
+in (
+
+let lb1 = (FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl (x1)) [] c1.FStar_Syntax_Syntax.res_typ c1.FStar_Syntax_Syntax.eff_name e11)
+in (
+
+let e3 = (
+
+let uu____8683 = (
+
+let uu____8686 = (
+
+let uu____8687 = (
+
+let uu____8695 = (FStar_Syntax_Subst.close xb e23)
+in ((((false), ((lb1)::[]))), (uu____8695)))
+in FStar_Syntax_Syntax.Tm_let (uu____8687))
+in (FStar_Syntax_Syntax.mk uu____8686))
+in (uu____8683 (Some (cres.FStar_Syntax_Syntax.res_typ.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos))
+in (
+
+let e4 = (FStar_TypeChecker_Util.maybe_monadic env2 e3 cres.FStar_Syntax_Syntax.eff_name cres.FStar_Syntax_Syntax.res_typ)
+in (
+
+let x_eq_e1 = (
+
+let uu____8710 = (
+
+let uu____8711 = (env2.FStar_TypeChecker_Env.universe_of env2 c1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____8712 = (FStar_Syntax_Syntax.bv_to_name x1)
+in (FStar_Syntax_Util.mk_eq2 uu____8711 c1.FStar_Syntax_Syntax.res_typ uu____8712 e11)))
+in (FStar_All.pipe_left (fun _0_32 -> FStar_TypeChecker_Common.NonTrivial (_0_32)) uu____8710))
+in (
+
+let g21 = (
+
+let uu____8714 = (
+
+let uu____8715 = (FStar_TypeChecker_Rel.guard_of_guard_formula x_eq_e1)
+in (FStar_TypeChecker_Rel.imp_guard uu____8715 g2))
+in (FStar_TypeChecker_Rel.close_guard env2 xb uu____8714))
+in (
+
+let guard = (FStar_TypeChecker_Rel.conj_guard g1 g21)
+in (
+
+let uu____8717 = (
+
+let uu____8718 = (FStar_TypeChecker_Env.expected_typ env2)
+in (FStar_Option.isSome uu____8718))
+in (match (uu____8717) with
+| true -> begin
+(
+
+let tt = (
+
+let uu____8724 = (FStar_TypeChecker_Env.expected_typ env2)
+in (FStar_All.pipe_right uu____8724 FStar_Option.get))
+in ((
+
+let uu____8728 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("Exports")))
+in (match (uu____8728) with
+| true -> begin
+(
+
+let uu____8729 = (FStar_Syntax_Print.term_to_string tt)
+in (
+
+let uu____8730 = (FStar_Syntax_Print.term_to_string cres.FStar_Syntax_Syntax.res_typ)
+in (FStar_Util.print2 "Got expected type from env %s\ncres.res_typ=%s\n" uu____8729 uu____8730)))
+end
+| uu____8731 -> begin
+()
+end));
+((e4), (cres), (guard));
+))
+end
+| uu____8732 -> begin
+(
+
+let t = (check_no_escape None env2 ((x1)::[]) cres.FStar_Syntax_Syntax.res_typ)
+in ((
+
+let uu____8735 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("Exports")))
+in (match (uu____8735) with
+| true -> begin
+(
+
+let uu____8736 = (FStar_Syntax_Print.term_to_string cres.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____8737 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print2 "Checked %s has no escaping types; normalized to %s\n" uu____8736 uu____8737)))
+end
+| uu____8738 -> begin
+()
+end));
+((e4), ((
+
+let uu___117_8739 = cres
+in {FStar_Syntax_Syntax.eff_name = uu___117_8739.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu___117_8739.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___117_8739.FStar_Syntax_Syntax.comp})), (guard));
+))
+end)))))))))))
+end))))
+end)))
+end)))
+end
+| uu____8740 -> begin
+(failwith "Impossible")
+end)))
+and check_top_level_let_rec : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env top -> (
+
+let env1 = (instantiate_both env)
+in (match (top.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) -> begin
+(
+
+let uu____8761 = (FStar_Syntax_Subst.open_let_rec lbs e2)
+in (match (uu____8761) with
+| (lbs1, e21) -> begin
+(
+
+let uu____8772 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____8772) with
+| (env0, topt) -> begin
+(
+
+let uu____8783 = (build_let_rec_env true env0 lbs1)
+in (match (uu____8783) with
+| (lbs2, rec_env) -> begin
+(
+
+let uu____8794 = (check_let_recs rec_env lbs2)
+in (match (uu____8794) with
+| (lbs3, g_lbs) -> begin
+(
+
+let g_lbs1 = (
+
+let uu____8806 = (FStar_TypeChecker_Rel.solve_deferred_constraints env1 g_lbs)
+in (FStar_All.pipe_right uu____8806 FStar_TypeChecker_Rel.resolve_implicits))
+in (
+
+let all_lb_names = (
+
+let uu____8810 = (FStar_All.pipe_right lbs3 (FStar_List.map (fun lb -> (FStar_Util.right lb.FStar_Syntax_Syntax.lbname))))
+in (FStar_All.pipe_right uu____8810 (fun _0_33 -> Some (_0_33))))
+in (
+
+let lbs4 = (match ((not (env1.FStar_TypeChecker_Env.generalize))) with
+| true -> begin
+(FStar_All.pipe_right lbs3 (FStar_List.map (fun lb -> (match ((lb.FStar_Syntax_Syntax.lbunivs = [])) with
+| true -> begin
+lb
+end
+| uu____8826 -> begin
+(FStar_Syntax_Util.close_univs_and_mk_letbinding all_lb_names lb.FStar_Syntax_Syntax.lbname lb.FStar_Syntax_Syntax.lbunivs lb.FStar_Syntax_Syntax.lbtyp lb.FStar_Syntax_Syntax.lbeff lb.FStar_Syntax_Syntax.lbdef)
+end))))
+end
+| uu____8827 -> begin
+(
+
+let ecs = (
+
+let uu____8834 = (FStar_All.pipe_right lbs3 (FStar_List.map (fun lb -> (
+
+let uu____8856 = (FStar_Syntax_Syntax.mk_Total lb.FStar_Syntax_Syntax.lbtyp)
+in ((lb.FStar_Syntax_Syntax.lbname), (lb.FStar_Syntax_Syntax.lbdef), (uu____8856))))))
+in (FStar_TypeChecker_Util.generalize env1 uu____8834))
+in (FStar_All.pipe_right ecs (FStar_List.map (fun uu____8876 -> (match (uu____8876) with
+| (x, uvs, e, c) -> begin
+(FStar_Syntax_Util.close_univs_and_mk_letbinding all_lb_names x uvs (FStar_Syntax_Util.comp_result c) (FStar_Syntax_Util.comp_effect_name c) e)
+end)))))
+end)
+in (
+
+let cres = (
+
+let uu____8901 = (FStar_Syntax_Syntax.mk_Total FStar_TypeChecker_Common.t_unit)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____8901))
+in ((FStar_ST.write e21.FStar_Syntax_Syntax.tk (Some (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n)));
+(
+
+let uu____8910 = (FStar_Syntax_Subst.close_let_rec lbs4 e21)
+in (match (uu____8910) with
+| (lbs5, e22) -> begin
+(
+
+let uu____8921 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_let (((((true), (lbs5))), (e22))))) (Some (FStar_TypeChecker_Common.t_unit.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____8936 = (FStar_TypeChecker_Rel.discharge_guard env1 g_lbs1)
+in ((uu____8921), (cres), (uu____8936))))
+end));
+)))))
+end))
+end))
+end))
+end))
+end
+| uu____8939 -> begin
+(failwith "Impossible")
+end)))
+and check_inner_let_rec : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env top -> (
+
+let env1 = (instantiate_both env)
+in (match (top.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) -> begin
+(
+
+let uu____8960 = (FStar_Syntax_Subst.open_let_rec lbs e2)
+in (match (uu____8960) with
+| (lbs1, e21) -> begin
+(
+
+let uu____8971 = (FStar_TypeChecker_Env.clear_expected_typ env1)
+in (match (uu____8971) with
+| (env0, topt) -> begin
+(
+
+let uu____8982 = (build_let_rec_env false env0 lbs1)
+in (match (uu____8982) with
+| (lbs2, rec_env) -> begin
+(
+
+let uu____8993 = (check_let_recs rec_env lbs2)
+in (match (uu____8993) with
+| (lbs3, g_lbs) -> begin
+(
+
+let uu____9004 = (FStar_All.pipe_right lbs3 (FStar_Util.fold_map (fun env2 lb -> (
+
+let x = (
+
+let uu___118_9015 = (FStar_Util.left lb.FStar_Syntax_Syntax.lbname)
+in {FStar_Syntax_Syntax.ppname = uu___118_9015.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___118_9015.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = lb.FStar_Syntax_Syntax.lbtyp})
+in (
+
+let lb1 = (
+
+let uu___119_9017 = lb
+in {FStar_Syntax_Syntax.lbname = FStar_Util.Inl (x); FStar_Syntax_Syntax.lbunivs = uu___119_9017.FStar_Syntax_Syntax.lbunivs; FStar_Syntax_Syntax.lbtyp = uu___119_9017.FStar_Syntax_Syntax.lbtyp; FStar_Syntax_Syntax.lbeff = uu___119_9017.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = uu___119_9017.FStar_Syntax_Syntax.lbdef})
+in (
+
+let env3 = (FStar_TypeChecker_Env.push_let_binding env2 lb1.FStar_Syntax_Syntax.lbname (([]), (lb1.FStar_Syntax_Syntax.lbtyp)))
+in ((env3), (lb1)))))) env1))
+in (match (uu____9004) with
+| (env2, lbs4) -> begin
+(
+
+let bvs = (FStar_All.pipe_right lbs4 (FStar_List.map (fun lb -> (FStar_Util.left lb.FStar_Syntax_Syntax.lbname))))
+in (
+
+let uu____9034 = (tc_term env2 e21)
+in (match (uu____9034) with
+| (e22, cres, g2) -> begin
+(
+
+let guard = (
+
+let uu____9045 = (
+
+let uu____9046 = (FStar_List.map FStar_Syntax_Syntax.mk_binder bvs)
+in (FStar_TypeChecker_Rel.close_guard env2 uu____9046 g2))
+in (FStar_TypeChecker_Rel.conj_guard g_lbs uu____9045))
+in (
+
+let cres1 = (FStar_TypeChecker_Util.close_comp env2 bvs cres)
+in (
+
+let tres = (norm env2 cres1.FStar_Syntax_Syntax.res_typ)
+in (
+
+let cres2 = (
+
+let uu___120_9050 = cres1
+in {FStar_Syntax_Syntax.eff_name = uu___120_9050.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = tres; FStar_Syntax_Syntax.cflags = uu___120_9050.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___120_9050.FStar_Syntax_Syntax.comp})
+in (
+
+let uu____9051 = (FStar_Syntax_Subst.close_let_rec lbs4 e22)
+in (match (uu____9051) with
+| (lbs5, e23) -> begin
+(
+
+let e = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_let (((((true), (lbs5))), (e23))))) (Some (tres.FStar_Syntax_Syntax.n)) top.FStar_Syntax_Syntax.pos)
+in (match (topt) with
+| Some (uu____9080) -> begin
+((e), (cres2), (guard))
+end
+| None -> begin
+(
+
+let tres1 = (check_no_escape None env2 bvs tres)
+in (
+
+let cres3 = (
+
+let uu___121_9085 = cres2
+in {FStar_Syntax_Syntax.eff_name = uu___121_9085.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = tres1; FStar_Syntax_Syntax.cflags = uu___121_9085.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___121_9085.FStar_Syntax_Syntax.comp})
+in ((e), (cres3), (guard))))
+end))
+end))))))
+end)))
+end))
+end))
+end))
+end))
+end))
+end
+| uu____9088 -> begin
+(failwith "Impossible")
+end)))
+and build_let_rec_env : Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.letbinding Prims.list  ->  (FStar_Syntax_Syntax.letbinding Prims.list * FStar_TypeChecker_Env.env_t) = (fun top_level env lbs -> (
+
+let env0 = env
+in (
+
+let termination_check_enabled = (fun t -> (
+
+let uu____9104 = (FStar_Syntax_Util.arrow_formals_comp t)
+in (match (uu____9104) with
+| (uu____9110, c) -> begin
+(
+
+let quals = (FStar_TypeChecker_Env.lookup_effect_quals env (FStar_Syntax_Util.comp_effect_name c))
+in (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.TotalEffect)))
+end)))
+in (
+
+let uu____9121 = (FStar_List.fold_left (fun uu____9128 lb -> (match (uu____9128) with
+| (lbs1, env1) -> begin
+(
+
+let uu____9140 = (FStar_TypeChecker_Util.extract_let_rec_annotation env1 lb)
+in (match (uu____9140) with
+| (univ_vars1, t, check_t) -> begin
+(
+
+let env2 = (FStar_TypeChecker_Env.push_univ_vars env1 univ_vars1)
+in (
+
+let e = (FStar_Syntax_Util.unascribe lb.FStar_Syntax_Syntax.lbdef)
+in (
+
+let t1 = (match ((not (check_t))) with
+| true -> begin
+t
+end
+| uu____9153 -> begin
+(
+
+let uu____9154 = (
+
+let uu____9158 = (
+
+let uu____9159 = (FStar_Syntax_Util.type_u ())
+in (FStar_All.pipe_left Prims.fst uu____9159))
+in (tc_check_tot_or_gtot_term (
+
+let uu___122_9164 = env0
+in {FStar_TypeChecker_Env.solver = uu___122_9164.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___122_9164.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___122_9164.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___122_9164.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___122_9164.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___122_9164.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___122_9164.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___122_9164.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___122_9164.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___122_9164.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___122_9164.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___122_9164.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___122_9164.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___122_9164.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = true; FStar_TypeChecker_Env.use_eq = uu___122_9164.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___122_9164.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___122_9164.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___122_9164.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___122_9164.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___122_9164.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___122_9164.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___122_9164.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___122_9164.FStar_TypeChecker_Env.qname_and_index}) t uu____9158))
+in (match (uu____9154) with
+| (t1, uu____9166, g) -> begin
+(
+
+let g1 = (FStar_TypeChecker_Rel.resolve_implicits g)
+in ((
+
+let uu____9170 = (FStar_TypeChecker_Rel.discharge_guard env2 g1)
+in (FStar_All.pipe_left Prims.ignore uu____9170));
+(norm env0 t1);
+))
+end))
+end)
+in (
+
+let env3 = (
+
+let uu____9172 = ((termination_check_enabled t1) && (FStar_TypeChecker_Env.should_verify env2))
+in (match (uu____9172) with
+| true -> begin
+(
+
+let uu___123_9173 = env2
+in {FStar_TypeChecker_Env.solver = uu___123_9173.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___123_9173.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___123_9173.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___123_9173.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___123_9173.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___123_9173.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___123_9173.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___123_9173.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___123_9173.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___123_9173.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___123_9173.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___123_9173.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = (((lb.FStar_Syntax_Syntax.lbname), (t1)))::env2.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___123_9173.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___123_9173.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___123_9173.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___123_9173.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___123_9173.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___123_9173.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___123_9173.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___123_9173.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___123_9173.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___123_9173.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___123_9173.FStar_TypeChecker_Env.qname_and_index})
+end
+| uu____9180 -> begin
+(FStar_TypeChecker_Env.push_let_binding env2 lb.FStar_Syntax_Syntax.lbname (([]), (t1)))
+end))
+in (
+
+let lb1 = (
+
+let uu___124_9183 = lb
+in {FStar_Syntax_Syntax.lbname = uu___124_9183.FStar_Syntax_Syntax.lbname; FStar_Syntax_Syntax.lbunivs = univ_vars1; FStar_Syntax_Syntax.lbtyp = t1; FStar_Syntax_Syntax.lbeff = uu___124_9183.FStar_Syntax_Syntax.lbeff; FStar_Syntax_Syntax.lbdef = e})
+in (((lb1)::lbs1), (env3)))))))
+end))
+end)) (([]), (env)) lbs)
+in (match (uu____9121) with
+| (lbs1, env1) -> begin
+(((FStar_List.rev lbs1)), (env1))
+end)))))
+and check_let_recs : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.letbinding Prims.list  ->  (FStar_Syntax_Syntax.letbinding Prims.list * FStar_TypeChecker_Env.guard_t) = (fun env lbs -> (
+
+let uu____9197 = (
+
+let uu____9202 = (FStar_All.pipe_right lbs (FStar_List.map (fun lb -> (
+
+let uu____9213 = (
+
+let uu____9217 = (FStar_TypeChecker_Env.set_expected_typ env lb.FStar_Syntax_Syntax.lbtyp)
+in (tc_tot_or_gtot_term uu____9217 lb.FStar_Syntax_Syntax.lbdef))
+in (match (uu____9213) with
+| (e, c, g) -> begin
+((
+
+let uu____9224 = (
+
+let uu____9225 = (FStar_Syntax_Util.is_total_lcomp c)
+in (not (uu____9225)))
+in (match (uu____9224) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Expected let rec to be a Tot term; got effect GTot"), (e.FStar_Syntax_Syntax.pos)))))
+end
+| uu____9226 -> begin
+()
+end));
+(
+
+let lb1 = (FStar_Syntax_Util.mk_letbinding lb.FStar_Syntax_Syntax.lbname lb.FStar_Syntax_Syntax.lbunivs lb.FStar_Syntax_Syntax.lbtyp FStar_Syntax_Const.effect_Tot_lid e)
+in ((lb1), (g)));
+)
+end)))))
+in (FStar_All.pipe_right uu____9202 FStar_List.unzip))
+in (match (uu____9197) with
+| (lbs1, gs) -> begin
+(
+
+let g_lbs = (FStar_List.fold_right FStar_TypeChecker_Rel.conj_guard gs FStar_TypeChecker_Rel.trivial_guard)
+in ((lbs1), (g_lbs)))
+end)))
+and check_let_bound_def : Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.letbinding  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t * Prims.bool) = (fun top_level env lb -> (
+
+let uu____9254 = (FStar_TypeChecker_Env.clear_expected_typ env)
+in (match (uu____9254) with
+| (env1, uu____9264) -> begin
+(
+
+let e1 = lb.FStar_Syntax_Syntax.lbdef
+in (
+
+let uu____9270 = (check_lbtyp top_level env lb)
+in (match (uu____9270) with
+| (topt, wf_annot, univ_vars1, univ_opening, env11) -> begin
+((match (((not (top_level)) && (univ_vars1 <> []))) with
+| true -> begin
+(Prims.raise (FStar_Errors.Error ((("Inner let-bound definitions cannot be universe polymorphic"), (e1.FStar_Syntax_Syntax.pos)))))
+end
+| uu____9293 -> begin
+()
+end);
+(
+
+let e11 = (FStar_Syntax_Subst.subst univ_opening e1)
+in (
+
+let uu____9296 = (tc_maybe_toplevel_term (
+
+let uu___125_9300 = env11
+in {FStar_TypeChecker_Env.solver = uu___125_9300.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___125_9300.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___125_9300.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___125_9300.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___125_9300.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___125_9300.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___125_9300.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___125_9300.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___125_9300.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___125_9300.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___125_9300.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___125_9300.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___125_9300.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = top_level; FStar_TypeChecker_Env.check_uvars = uu___125_9300.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___125_9300.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___125_9300.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___125_9300.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___125_9300.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___125_9300.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___125_9300.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___125_9300.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___125_9300.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___125_9300.FStar_TypeChecker_Env.qname_and_index}) e11)
+in (match (uu____9296) with
+| (e12, c1, g1) -> begin
+(
+
+let uu____9309 = (
+
+let uu____9312 = (FStar_TypeChecker_Env.set_range env11 e12.FStar_Syntax_Syntax.pos)
+in (FStar_TypeChecker_Util.strengthen_precondition (Some ((fun uu____9315 -> FStar_TypeChecker_Err.ill_kinded_type))) uu____9312 e12 c1 wf_annot))
+in (match (uu____9309) with
+| (c11, guard_f) -> begin
+(
+
+let g11 = (FStar_TypeChecker_Rel.conj_guard g1 guard_f)
+in ((
+
+let uu____9325 = (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
+in (match (uu____9325) with
+| true -> begin
+(
+
+let uu____9326 = (FStar_Syntax_Print.lbname_to_string lb.FStar_Syntax_Syntax.lbname)
+in (
+
+let uu____9327 = (FStar_Syntax_Print.term_to_string c11.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____9328 = (FStar_TypeChecker_Rel.guard_to_string env g11)
+in (FStar_Util.print3 "checked top-level def %s, result type is %s, guard is %s\n" uu____9326 uu____9327 uu____9328))))
+end
+| uu____9329 -> begin
+()
+end));
+((e12), (univ_vars1), (c11), (g11), ((FStar_Option.isSome topt)));
+))
+end))
+end)));
+)
+end)))
+end)))
+and check_lbtyp : Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.letbinding  ->  (FStar_Syntax_Syntax.typ Prims.option * FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.subst_elt Prims.list * FStar_TypeChecker_Env.env) = (fun top_level env lb -> (
+
+let t = (FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp)
+in (match (t.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+((match ((lb.FStar_Syntax_Syntax.lbunivs <> [])) with
+| true -> begin
+(failwith "Impossible: non-empty universe variables but the type is unknown")
+end
+| uu____9350 -> begin
+()
+end);
+((None), (FStar_TypeChecker_Rel.trivial_guard), ([]), ([]), (env));
+)
+end
+| uu____9354 -> begin
+(
+
+let uu____9355 = (FStar_Syntax_Subst.univ_var_opening lb.FStar_Syntax_Syntax.lbunivs)
+in (match (uu____9355) with
+| (univ_opening, univ_vars1) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.subst univ_opening t)
+in (
+
+let env1 = (FStar_TypeChecker_Env.push_univ_vars env univ_vars1)
+in (match ((top_level && (not (env.FStar_TypeChecker_Env.generalize)))) with
+| true -> begin
+(
+
+let uu____9382 = (FStar_TypeChecker_Env.set_expected_typ env1 t1)
+in ((Some (t1)), (FStar_TypeChecker_Rel.trivial_guard), (univ_vars1), (univ_opening), (uu____9382)))
+end
+| uu____9386 -> begin
+(
+
+let uu____9387 = (FStar_Syntax_Util.type_u ())
+in (match (uu____9387) with
+| (k, uu____9398) -> begin
+(
+
+let uu____9399 = (tc_check_tot_or_gtot_term env1 t1 k)
+in (match (uu____9399) with
+| (t2, uu____9411, g) -> begin
+((
+
+let uu____9414 = (FStar_TypeChecker_Env.debug env FStar_Options.Medium)
+in (match (uu____9414) with
+| true -> begin
+(
+
+let uu____9415 = (
+
+let uu____9416 = (FStar_Syntax_Syntax.range_of_lbname lb.FStar_Syntax_Syntax.lbname)
+in (FStar_Range.string_of_range uu____9416))
+in (
+
+let uu____9417 = (FStar_Syntax_Print.term_to_string t2)
+in (FStar_Util.print2 "(%s) Checked type annotation %s\n" uu____9415 uu____9417)))
+end
+| uu____9418 -> begin
+()
+end));
+(
+
+let t3 = (norm env1 t2)
+in (
+
+let uu____9420 = (FStar_TypeChecker_Env.set_expected_typ env1 t3)
+in ((Some (t3)), (g), (univ_vars1), (univ_opening), (uu____9420))));
+)
+end))
+end))
+end)))
+end))
+end)))
+and tc_binder : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)  ->  ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) * FStar_TypeChecker_Env.env * FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe) = (fun env uu____9425 -> (match (uu____9425) with
+| (x, imp) -> begin
+(
+
+let uu____9436 = (FStar_Syntax_Util.type_u ())
+in (match (uu____9436) with
+| (tu, u) -> begin
+((
+
+let uu____9448 = (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
+in (match (uu____9448) with
+| true -> begin
+(
+
+let uu____9449 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____9450 = (FStar_Syntax_Print.term_to_string x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____9451 = (FStar_Syntax_Print.term_to_string tu)
+in (FStar_Util.print3 "Checking binders %s:%s at type %s\n" uu____9449 uu____9450 uu____9451))))
+end
+| uu____9452 -> begin
+()
+end));
+(
+
+let uu____9453 = (tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort tu)
+in (match (uu____9453) with
+| (t, uu____9464, g) -> begin
+(
+
+let x1 = (((
+
+let uu___126_9469 = x
+in {FStar_Syntax_Syntax.ppname = uu___126_9469.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___126_9469.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t})), (imp))
+in ((
+
+let uu____9471 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____9471) with
+| true -> begin
+(
+
+let uu____9472 = (FStar_Syntax_Print.bv_to_string (Prims.fst x1))
+in (
+
+let uu____9473 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print2 "Pushing binder %s at type %s\n" uu____9472 uu____9473)))
+end
+| uu____9474 -> begin
+()
+end));
+(
+
+let uu____9475 = (push_binding env x1)
+in ((x1), (uu____9475), (g), (u)));
+))
+end));
+)
+end))
+end))
+and tc_binders : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.binders * FStar_TypeChecker_Env.env * FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universes) = (fun env bs -> (
+
+let rec aux = (fun env1 bs1 -> (match (bs1) with
+| [] -> begin
+(([]), (env1), (FStar_TypeChecker_Rel.trivial_guard), ([]))
+end
+| (b)::bs2 -> begin
+(
+
+let uu____9526 = (tc_binder env1 b)
+in (match (uu____9526) with
+| (b1, env', g, u) -> begin
+(
+
+let uu____9549 = (aux env' bs2)
+in (match (uu____9549) with
+| (bs3, env'1, g', us) -> begin
+(
+
+let uu____9578 = (
+
+let uu____9579 = (FStar_TypeChecker_Rel.close_guard_univs ((u)::[]) ((b1)::[]) g')
+in (FStar_TypeChecker_Rel.conj_guard g uu____9579))
+in (((b1)::bs3), (env'1), (uu____9578), ((u)::us)))
+end))
+end))
+end))
+in (aux env bs)))
+and tc_pats : FStar_TypeChecker_Env.env  ->  ((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list Prims.list  ->  (((FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.aqual) Prims.list Prims.list * FStar_TypeChecker_Env.guard_t) = (fun env pats -> (
+
+let tc_args = (fun env1 args -> (FStar_List.fold_right (fun uu____9622 uu____9623 -> (match (((uu____9622), (uu____9623))) with
+| ((t, imp), (args1, g)) -> begin
+(
+
+let uu____9660 = (tc_term env1 t)
+in (match (uu____9660) with
+| (t1, uu____9670, g') -> begin
+(
+
+let uu____9672 = (FStar_TypeChecker_Rel.conj_guard g g')
+in (((((t1), (imp)))::args1), (uu____9672)))
+end))
+end)) args (([]), (FStar_TypeChecker_Rel.trivial_guard))))
+in (FStar_List.fold_right (fun p uu____9690 -> (match (uu____9690) with
+| (pats1, g) -> begin
+(
+
+let uu____9704 = (tc_args env p)
+in (match (uu____9704) with
+| (args, g') -> begin
+(
+
+let uu____9712 = (FStar_TypeChecker_Rel.conj_guard g g')
+in (((args)::pats1), (uu____9712)))
+end))
+end)) pats (([]), (FStar_TypeChecker_Rel.trivial_guard)))))
+and tc_tot_or_gtot_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e -> (
+
+let uu____9720 = (tc_maybe_toplevel_term env e)
+in (match (uu____9720) with
+| (e1, c, g) -> begin
+(
+
+let uu____9730 = (FStar_Syntax_Util.is_tot_or_gtot_lcomp c)
+in (match (uu____9730) with
+| true -> begin
+((e1), (c), (g))
+end
+| uu____9734 -> begin
+(
+
+let g1 = (FStar_TypeChecker_Rel.solve_deferred_constraints env g)
+in (
+
+let c1 = (c.FStar_Syntax_Syntax.comp ())
+in (
+
+let c2 = (norm_c env c1)
+in (
+
+let uu____9740 = (
+
+let uu____9743 = (FStar_TypeChecker_Util.is_pure_effect env (FStar_Syntax_Util.comp_effect_name c2))
+in (match (uu____9743) with
+| true -> begin
+(
+
+let uu____9746 = (FStar_Syntax_Syntax.mk_Total (FStar_Syntax_Util.comp_result c2))
+in ((uu____9746), (false)))
+end
+| uu____9747 -> begin
+(
+
+let uu____9748 = (FStar_Syntax_Syntax.mk_GTotal (FStar_Syntax_Util.comp_result c2))
+in ((uu____9748), (true)))
+end))
+in (match (uu____9740) with
+| (target_comp, allow_ghost) -> begin
+(
+
+let uu____9754 = (FStar_TypeChecker_Rel.sub_comp env c2 target_comp)
+in (match (uu____9754) with
+| Some (g') -> begin
+(
+
+let uu____9760 = (FStar_TypeChecker_Rel.conj_guard g1 g')
+in ((e1), ((FStar_Syntax_Util.lcomp_of_comp target_comp)), (uu____9760)))
+end
+| uu____9761 -> begin
+(match (allow_ghost) with
+| true -> begin
+(
+
+let uu____9766 = (
+
+let uu____9767 = (
+
+let uu____9770 = (FStar_TypeChecker_Err.expected_ghost_expression e1 c2)
+in ((uu____9770), (e1.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____9767))
+in (Prims.raise uu____9766))
+end
+| uu____9774 -> begin
+(
+
+let uu____9775 = (
+
+let uu____9776 = (
+
+let uu____9779 = (FStar_TypeChecker_Err.expected_pure_expression e1 c2)
+in ((uu____9779), (e1.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____9776))
+in (Prims.raise uu____9775))
+end)
+end))
+end)))))
+end))
+end)))
+and tc_check_tot_or_gtot_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e t -> (
+
+let env1 = (FStar_TypeChecker_Env.set_expected_typ env t)
+in (tc_tot_or_gtot_term env1 e)))
+and tc_trivial_guard : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp) = (fun env t -> (
+
+let uu____9792 = (tc_tot_or_gtot_term env t)
+in (match (uu____9792) with
+| (t1, c, g) -> begin
+((FStar_TypeChecker_Rel.force_trivial_guard env g);
+((t1), (c));
+)
+end)))
+
+
+let type_of_tot_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * FStar_TypeChecker_Env.guard_t) = (fun env e -> ((
+
+let uu____9812 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("RelCheck")))
+in (match (uu____9812) with
+| true -> begin
+(
+
+let uu____9813 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.print1 "Checking term %s\n" uu____9813))
+end
+| uu____9814 -> begin
+()
+end));
+(
+
+let env1 = (
+
+let uu___127_9816 = env
+in {FStar_TypeChecker_Env.solver = uu___127_9816.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___127_9816.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___127_9816.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___127_9816.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___127_9816.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___127_9816.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___127_9816.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___127_9816.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___127_9816.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___127_9816.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___127_9816.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___127_9816.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = []; FStar_TypeChecker_Env.top_level = false; FStar_TypeChecker_Env.check_uvars = uu___127_9816.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___127_9816.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___127_9816.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___127_9816.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___127_9816.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___127_9816.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___127_9816.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___127_9816.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = true; FStar_TypeChecker_Env.qname_and_index = uu___127_9816.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let uu____9819 = try
+(match (()) with
+| () -> begin
+(tc_tot_or_gtot_term env1 e)
+end)
+with
+| FStar_Errors.Error (msg, uu____9835) -> begin
+(
+
+let uu____9836 = (
+
+let uu____9837 = (
+
+let uu____9840 = (FStar_TypeChecker_Env.get_range env1)
+in (((Prims.strcat "Implicit argument: " msg)), (uu____9840)))
+in FStar_Errors.Error (uu____9837))
+in (Prims.raise uu____9836))
+end
+in (match (uu____9819) with
+| (t, c, g) -> begin
+(
+
+let uu____9850 = (FStar_Syntax_Util.is_total_lcomp c)
+in (match (uu____9850) with
+| true -> begin
+((t), (c.FStar_Syntax_Syntax.res_typ), (g))
+end
+| uu____9856 -> begin
+(
+
+let uu____9857 = (
+
+let uu____9858 = (
+
+let uu____9861 = (
+
+let uu____9862 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format1 "Implicit argument: Expected a total term; got a ghost term: %s" uu____9862))
+in (
+
+let uu____9863 = (FStar_TypeChecker_Env.get_range env1)
+in ((uu____9861), (uu____9863))))
+in FStar_Errors.Error (uu____9858))
+in (Prims.raise uu____9857))
+end))
+end)));
+))
+
+
+let level_of_type_fail = (fun env e t -> (
+
+let uu____9884 = (
+
+let uu____9885 = (
+
+let uu____9888 = (
+
+let uu____9889 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format2 "Expected a term of type \'Type\'; got %s : %s" uu____9889 t))
+in (
+
+let uu____9890 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____9888), (uu____9890))))
+in FStar_Errors.Error (uu____9885))
+in (Prims.raise uu____9884)))
+
+
+let level_of_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.universe = (fun env e t -> (
+
+let rec aux = (fun retry t1 -> (
+
+let uu____9907 = (
+
+let uu____9908 = (FStar_Syntax_Util.unrefine t1)
+in uu____9908.FStar_Syntax_Syntax.n)
+in (match (uu____9907) with
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+u
+end
+| uu____9912 -> begin
+(match (retry) with
+| true -> begin
+(
+
+let t2 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env t1)
+in (aux false t2))
+end
+| uu____9914 -> begin
+(
+
+let uu____9915 = (FStar_Syntax_Util.type_u ())
+in (match (uu____9915) with
+| (t_u, u) -> begin
+(
+
+let env1 = (
+
+let uu___130_9921 = env
+in {FStar_TypeChecker_Env.solver = uu___130_9921.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___130_9921.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___130_9921.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___130_9921.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___130_9921.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___130_9921.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___130_9921.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___130_9921.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___130_9921.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___130_9921.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___130_9921.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___130_9921.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___130_9921.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___130_9921.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___130_9921.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___130_9921.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___130_9921.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___130_9921.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___130_9921.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___130_9921.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___130_9921.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___130_9921.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___130_9921.FStar_TypeChecker_Env.qname_and_index})
+in (
+
+let g = (FStar_TypeChecker_Rel.teq env1 t1 t_u)
+in ((match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu____9925 = (FStar_Syntax_Print.term_to_string t1)
+in (level_of_type_fail env1 e uu____9925))
+end
+| uu____9926 -> begin
+(FStar_TypeChecker_Rel.force_trivial_guard env1 g)
+end);
+u;
+)))
+end))
+end)
+end)))
+in (aux true t)))
+
+
+let rec universe_of_aux : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax = (fun env e -> (
+
+let uu____9935 = (
+
+let uu____9936 = (FStar_Syntax_Subst.compress e)
+in uu____9936.FStar_Syntax_Syntax.n)
+in (match (uu____9935) with
+| (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_delayed (_)) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Tm_let (uu____9945) -> begin
+(
+
+let e1 = (FStar_TypeChecker_Normalize.normalize [] env e)
+in (universe_of_aux env e1))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, t, uu____9956) -> begin
+(level_of_type_fail env e "arrow type")
+end
+| FStar_Syntax_Syntax.Tm_uvar (uu____9981, t) -> begin
+t
+end
+| FStar_Syntax_Syntax.Tm_meta (t, uu____9996) -> begin
+(universe_of_aux env t)
+end
+| FStar_Syntax_Syntax.Tm_name (n1) -> begin
+n1.FStar_Syntax_Syntax.sort
+end
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let uu____10003 = (FStar_TypeChecker_Env.lookup_lid env fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____10003) with
+| ((uu____10014, t), uu____10016) -> begin
+t
+end))
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____10019, (FStar_Util.Inl (t), uu____10021), uu____10022) -> begin
+t
+end
+| FStar_Syntax_Syntax.Tm_ascribed (uu____10058, (FStar_Util.Inr (c), uu____10060), uu____10061) -> begin
+(FStar_Syntax_Util.comp_result c)
+end
+| FStar_Syntax_Syntax.Tm_type (u) -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ (u)))) None e.FStar_Syntax_Syntax.pos)
+end
+| FStar_Syntax_Syntax.Tm_constant (sc) -> begin
+(tc_constant e.FStar_Syntax_Syntax.pos sc)
+end
+| FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____10108; FStar_Syntax_Syntax.pos = uu____10109; FStar_Syntax_Syntax.vars = uu____10110}, us) -> begin
+(
+
+let uu____10116 = (FStar_TypeChecker_Env.lookup_lid env fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____10116) with
+| ((us', t), uu____10129) -> begin
+((match (((FStar_List.length us) <> (FStar_List.length us'))) with
+| true -> begin
+(
+
+let uu____10137 = (
+
+let uu____10138 = (
+
+let uu____10141 = (FStar_TypeChecker_Env.get_range env)
+in (("Unexpected number of universe instantiations"), (uu____10141)))
+in FStar_Errors.Error (uu____10138))
+in (Prims.raise uu____10137))
+end
+| uu____10142 -> begin
+(FStar_List.iter2 (fun u' u -> (match (u') with
+| FStar_Syntax_Syntax.U_unif (u'') -> begin
+(FStar_Unionfind.change u'' (Some (u)))
+end
+| uu____10149 -> begin
+(failwith "Impossible")
+end)) us' us)
+end);
+t;
+)
+end))
+end
+| FStar_Syntax_Syntax.Tm_uinst (uu____10150) -> begin
+(failwith "Impossible: Tm_uinst\'s head must be an fvar")
+end
+| FStar_Syntax_Syntax.Tm_refine (x, uu____10158) -> begin
+(universe_of_aux env x.FStar_Syntax_Syntax.sort)
+end
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____10175 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____10175) with
+| (bs1, c1) -> begin
+(
+
+let us = (FStar_List.map (fun uu____10186 -> (match (uu____10186) with
+| (b, uu____10190) -> begin
+(
+
+let uu____10191 = (universe_of_aux env b.FStar_Syntax_Syntax.sort)
+in (level_of_type env b.FStar_Syntax_Syntax.sort uu____10191))
+end)) bs1)
+in (
+
+let u_res = (
+
+let res = (FStar_Syntax_Util.comp_result c1)
+in (
+
+let uu____10196 = (universe_of_aux env res)
+in (level_of_type env res uu____10196)))
+in (
+
+let u_c = (
+
+let uu____10198 = (FStar_TypeChecker_Env.effect_repr env c1 u_res)
+in (match (uu____10198) with
+| None -> begin
+u_res
+end
+| Some (trepr) -> begin
+(
+
+let uu____10201 = (universe_of_aux env trepr)
+in (level_of_type env trepr uu____10201))
+end))
+in (
+
+let u = (FStar_TypeChecker_Normalize.normalize_universe env (FStar_Syntax_Syntax.U_max ((u_c)::us)))
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type (u))) None e.FStar_Syntax_Syntax.pos)))))
+end))
+end
+| FStar_Syntax_Syntax.Tm_app (hd1, args) -> begin
+(
+
+let rec type_of_head = (fun retry hd2 args1 -> (
+
+let hd3 = (FStar_Syntax_Subst.compress hd2)
+in (match (hd3.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.Tm_unknown) | (FStar_Syntax_Syntax.Tm_bvar (_)) | (FStar_Syntax_Syntax.Tm_delayed (_)) -> begin
+(failwith "Impossible")
+end
+| (FStar_Syntax_Syntax.Tm_fvar (_)) | (FStar_Syntax_Syntax.Tm_name (_)) | (FStar_Syntax_Syntax.Tm_uvar (_)) | (FStar_Syntax_Syntax.Tm_uinst (_)) | (FStar_Syntax_Syntax.Tm_ascribed (_)) | (FStar_Syntax_Syntax.Tm_refine (_)) | (FStar_Syntax_Syntax.Tm_constant (_)) | (FStar_Syntax_Syntax.Tm_arrow (_)) | (FStar_Syntax_Syntax.Tm_meta (_)) | (FStar_Syntax_Syntax.Tm_type (_)) -> begin
+(
+
+let uu____10287 = (universe_of_aux env hd3)
+in ((uu____10287), (args1)))
+end
+| FStar_Syntax_Syntax.Tm_match (uu____10297, (hd4)::uu____10299) -> begin
+(
+
+let uu____10346 = (FStar_Syntax_Subst.open_branch hd4)
+in (match (uu____10346) with
+| (uu____10356, uu____10357, hd5) -> begin
+(
+
+let uu____10373 = (FStar_Syntax_Util.head_and_args hd5)
+in (match (uu____10373) with
+| (hd6, args2) -> begin
+(type_of_head retry hd6 args2)
+end))
+end))
+end
+| uu____10408 when retry -> begin
+(
+
+let e1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoDeltaSteps)::[]) env e)
+in (
+
+let uu____10410 = (FStar_Syntax_Util.head_and_args e1)
+in (match (uu____10410) with
+| (hd4, args2) -> begin
+(type_of_head false hd4 args2)
+end)))
+end
+| uu____10445 -> begin
+(
+
+let uu____10446 = (FStar_TypeChecker_Env.clear_expected_typ env)
+in (match (uu____10446) with
+| (env1, uu____10460) -> begin
+(
+
+let env2 = (
+
+let uu___131_10464 = env1
+in {FStar_TypeChecker_Env.solver = uu___131_10464.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___131_10464.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___131_10464.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___131_10464.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___131_10464.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___131_10464.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___131_10464.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___131_10464.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___131_10464.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___131_10464.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___131_10464.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___131_10464.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___131_10464.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = false; FStar_TypeChecker_Env.check_uvars = uu___131_10464.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu___131_10464.FStar_TypeChecker_Env.use_eq; FStar_TypeChecker_Env.is_iface = uu___131_10464.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___131_10464.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = true; FStar_TypeChecker_Env.lax_universes = uu___131_10464.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___131_10464.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___131_10464.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = true; FStar_TypeChecker_Env.qname_and_index = uu___131_10464.FStar_TypeChecker_Env.qname_and_index})
+in ((
+
+let uu____10466 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("UniverseOf")))
+in (match (uu____10466) with
+| true -> begin
+(
+
+let uu____10467 = (
+
+let uu____10468 = (FStar_TypeChecker_Env.get_range env2)
+in (FStar_Range.string_of_range uu____10468))
+in (
+
+let uu____10469 = (FStar_Syntax_Print.term_to_string hd3)
+in (FStar_Util.print2 "%s: About to type-check %s\n" uu____10467 uu____10469)))
+end
+| uu____10470 -> begin
+()
+end));
+(
+
+let uu____10471 = (tc_term env2 hd3)
+in (match (uu____10471) with
+| (uu____10484, {FStar_Syntax_Syntax.eff_name = uu____10485; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu____10487; FStar_Syntax_Syntax.comp = uu____10488}, g) -> begin
+((
+
+let uu____10498 = (FStar_TypeChecker_Rel.solve_deferred_constraints env2 g)
+in (FStar_All.pipe_right uu____10498 Prims.ignore));
+((t), (args1));
+)
+end));
+))
+end))
+end)))
+in (
+
+let uu____10506 = (type_of_head true hd1 args)
+in (match (uu____10506) with
+| (t, args1) -> begin
+(
+
+let t1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.UnfoldUntil (FStar_Syntax_Syntax.Delta_constant))::[]) env t)
+in (
+
+let uu____10535 = (FStar_Syntax_Util.arrow_formals_comp t1)
+in (match (uu____10535) with
+| (bs, res) -> begin
+(
+
+let res1 = (FStar_Syntax_Util.comp_result res)
+in (match (((FStar_List.length bs) = (FStar_List.length args1))) with
+| true -> begin
+(
+
+let subst1 = (FStar_Syntax_Util.subst_of_list bs args1)
+in (FStar_Syntax_Subst.subst subst1 res1))
+end
+| uu____10567 -> begin
+(
+
+let uu____10568 = (FStar_Syntax_Print.term_to_string res1)
+in (level_of_type_fail env e uu____10568))
+end))
+end)))
+end)))
+end
+| FStar_Syntax_Syntax.Tm_match (uu____10571, (hd1)::uu____10573) -> begin
+(
+
+let uu____10620 = (FStar_Syntax_Subst.open_branch hd1)
+in (match (uu____10620) with
+| (uu____10623, uu____10624, hd2) -> begin
+(universe_of_aux env hd2)
+end))
+end
+| FStar_Syntax_Syntax.Tm_match (uu____10640, []) -> begin
+(level_of_type_fail env e "empty match cases")
+end)))
+
+
+let universe_of : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.universe = (fun env e -> (
+
+let uu____10674 = (universe_of_aux env e)
+in (level_of_type env e uu____10674)))
+
+
+let tc_tparams : FStar_TypeChecker_Env.env_t  ->  FStar_Syntax_Syntax.binders  ->  (FStar_Syntax_Syntax.binders * FStar_TypeChecker_Env.env * FStar_Syntax_Syntax.universes) = (fun env tps -> (
+
+let uu____10687 = (tc_binders env tps)
+in (match (uu____10687) with
+| (tps1, env1, g, us) -> begin
+((FStar_TypeChecker_Rel.force_trivial_guard env1 g);
+((tps1), (env1), (us));
+)
+end)))
+
+
+
+

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -1,4770 +1,5446 @@
+
 open Prims
+
 type lcomp_with_binder =
-  (FStar_Syntax_Syntax.bv Prims.option* FStar_Syntax_Syntax.lcomp)
-let report:
-  FStar_TypeChecker_Env.env -> Prims.string Prims.list -> Prims.unit =
-  fun env  ->
-    fun errs  ->
-      let uu____12 = FStar_TypeChecker_Env.get_range env in
-      let uu____13 = FStar_TypeChecker_Err.failed_to_prove_specification errs in
-      FStar_Errors.report uu____12 uu____13
-let is_type: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____17 =
-      let uu____18 = FStar_Syntax_Subst.compress t in
-      uu____18.FStar_Syntax_Syntax.n in
-    match uu____17 with
-    | FStar_Syntax_Syntax.Tm_type uu____21 -> true
-    | uu____22 -> false
-let t_binders:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.bv* FStar_Syntax_Syntax.aqual) Prims.list
-  =
-  fun env  ->
-    let uu____29 = FStar_TypeChecker_Env.all_binders env in
-    FStar_All.pipe_right uu____29
-      (FStar_List.filter
-         (fun uu____35  ->
-            match uu____35 with
-            | (x,uu____39) -> is_type x.FStar_Syntax_Syntax.sort))
-let new_uvar_aux:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      (FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.typ)
-  =
-  fun env  ->
-    fun k  ->
-      let bs =
-        let uu____49 =
-          (FStar_Options.full_context_dependency ()) ||
-            (let uu____50 = FStar_TypeChecker_Env.current_module env in
-             FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____50) in
-        if uu____49
-        then FStar_TypeChecker_Env.all_binders env
-        else t_binders env in
-      let uu____52 = FStar_TypeChecker_Env.get_range env in
-      FStar_TypeChecker_Rel.new_uvar uu____52 bs k
-let new_uvar:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-  =
-  fun env  ->
-    fun k  -> let uu____59 = new_uvar_aux env k in Prims.fst uu____59
-let as_uvar: FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.uvar =
-  fun uu___94_64  ->
-    match uu___94_64 with
-    | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (uv,uu____66);
-        FStar_Syntax_Syntax.tk = uu____67;
-        FStar_Syntax_Syntax.pos = uu____68;
-        FStar_Syntax_Syntax.vars = uu____69;_} -> uv
-    | uu____84 -> failwith "Impossible"
-let new_implicit_var:
-  Prims.string ->
-    FStar_Range.range ->
-      FStar_TypeChecker_Env.env ->
-        FStar_Syntax_Syntax.typ ->
-          (FStar_Syntax_Syntax.term* (FStar_Syntax_Syntax.uvar*
-            FStar_Range.range) Prims.list* FStar_TypeChecker_Env.guard_t)
-  =
-  fun reason  ->
-    fun r  ->
-      fun env  ->
-        fun k  ->
-          let uu____103 =
-            FStar_Syntax_Util.destruct k FStar_Syntax_Const.range_of_lid in
-          match uu____103 with
-          | Some (uu____116::(tm,uu____118)::[]) ->
-              let t =
-                (FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_constant
-                      (FStar_Const.Const_range (tm.FStar_Syntax_Syntax.pos))))
-                  None tm.FStar_Syntax_Syntax.pos in
-              (t, [], FStar_TypeChecker_Rel.trivial_guard)
-          | uu____162 ->
-              let uu____169 = new_uvar_aux env k in
-              (match uu____169 with
-               | (t,u) ->
-                   let g =
-                     let uu___114_181 = FStar_TypeChecker_Rel.trivial_guard in
-                     let uu____182 =
-                       let uu____190 =
-                         let uu____197 = as_uvar u in
-                         (reason, env, uu____197, t, k, r) in
-                       [uu____190] in
-                     {
-                       FStar_TypeChecker_Env.guard_f =
-                         (uu___114_181.FStar_TypeChecker_Env.guard_f);
-                       FStar_TypeChecker_Env.deferred =
-                         (uu___114_181.FStar_TypeChecker_Env.deferred);
-                       FStar_TypeChecker_Env.univ_ineqs =
-                         (uu___114_181.FStar_TypeChecker_Env.univ_ineqs);
-                       FStar_TypeChecker_Env.implicits = uu____182
-                     } in
-                   let uu____210 =
-                     let uu____214 =
-                       let uu____217 = as_uvar u in (uu____217, r) in
-                     [uu____214] in
-                   (t, uu____210, g))
-let check_uvars: FStar_Range.range -> FStar_Syntax_Syntax.typ -> Prims.unit =
-  fun r  ->
-    fun t  ->
-      let uvs = FStar_Syntax_Free.uvars t in
-      let uu____235 =
-        let uu____236 = FStar_Util.set_is_empty uvs in
-        Prims.op_Negation uu____236 in
-      if uu____235
-      then
-        let us =
-          let uu____240 =
-            let uu____242 = FStar_Util.set_elements uvs in
-            FStar_List.map
-              (fun uu____258  ->
-                 match uu____258 with
-                 | (x,uu____266) -> FStar_Syntax_Print.uvar_to_string x)
-              uu____242 in
-          FStar_All.pipe_right uu____240 (FStar_String.concat ", ") in
-        (FStar_Options.push ();
-         FStar_Options.set_option "hide_uvar_nums" (FStar_Options.Bool false);
-         FStar_Options.set_option "print_implicits" (FStar_Options.Bool true);
-         (let uu____283 =
-            let uu____284 = FStar_Syntax_Print.term_to_string t in
-            FStar_Util.format2
-              "Unconstrained unification variables %s in type signature %s; please add an annotation"
-              us uu____284 in
-          FStar_Errors.report r uu____283);
-         FStar_Options.pop ())
-      else ()
-let force_sort':
-  (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-    FStar_Syntax_Syntax.syntax -> FStar_Syntax_Syntax.term'
-  =
-  fun s  ->
-    let uu____293 = FStar_ST.read s.FStar_Syntax_Syntax.tk in
-    match uu____293 with
-    | None  ->
-        let uu____298 =
-          let uu____299 =
-            FStar_Range.string_of_range s.FStar_Syntax_Syntax.pos in
-          let uu____300 = FStar_Syntax_Print.term_to_string s in
-          FStar_Util.format2 "(%s) Impossible: Forced tk not present on %s"
-            uu____299 uu____300 in
-        failwith uu____298
-    | Some tk -> tk
-let force_sort s =
-  let uu____315 =
-    let uu____318 = force_sort' s in FStar_Syntax_Syntax.mk uu____318 in
-  uu____315 None s.FStar_Syntax_Syntax.pos
-let extract_let_rec_annotation:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.letbinding ->
-      (FStar_Syntax_Syntax.univ_name Prims.list* FStar_Syntax_Syntax.typ*
-        Prims.bool)
-  =
-  fun env  ->
-    fun uu____335  ->
-      match uu____335 with
-      | { FStar_Syntax_Syntax.lbname = lbname;
-          FStar_Syntax_Syntax.lbunivs = univ_vars1;
-          FStar_Syntax_Syntax.lbtyp = t;
-          FStar_Syntax_Syntax.lbeff = uu____342;
-          FStar_Syntax_Syntax.lbdef = e;_} ->
-          let rng = FStar_Syntax_Syntax.range_of_lbname lbname in
-          let t1 = FStar_Syntax_Subst.compress t in
-          (match t1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_unknown  ->
-               (if univ_vars1 <> []
-                then
-                  failwith
-                    "Impossible: non-empty universe variables but the type is unknown"
-                else ();
-                (let r = FStar_TypeChecker_Env.get_range env in
-                 let mk_binder1 scope a =
-                   let uu____374 =
-                     let uu____375 =
-                       FStar_Syntax_Subst.compress a.FStar_Syntax_Syntax.sort in
-                     uu____375.FStar_Syntax_Syntax.n in
-                   match uu____374 with
-                   | FStar_Syntax_Syntax.Tm_unknown  ->
-                       let uu____380 = FStar_Syntax_Util.type_u () in
-                       (match uu____380 with
-                        | (k,uu____386) ->
-                            let t2 =
-                              let uu____388 =
-                                FStar_TypeChecker_Rel.new_uvar
-                                  e.FStar_Syntax_Syntax.pos scope k in
-                              FStar_All.pipe_right uu____388 Prims.fst in
-                            ((let uu___115_393 = a in
-                              {
-                                FStar_Syntax_Syntax.ppname =
-                                  (uu___115_393.FStar_Syntax_Syntax.ppname);
-                                FStar_Syntax_Syntax.index =
-                                  (uu___115_393.FStar_Syntax_Syntax.index);
-                                FStar_Syntax_Syntax.sort = t2
-                              }), false))
-                   | uu____394 -> (a, true) in
-                 let rec aux must_check_ty vars e1 =
-                   let e2 = FStar_Syntax_Subst.compress e1 in
-                   match e2.FStar_Syntax_Syntax.n with
-                   | FStar_Syntax_Syntax.Tm_meta (e3,uu____419) ->
-                       aux must_check_ty vars e3
-                   | FStar_Syntax_Syntax.Tm_ascribed (e3,t2,uu____426) ->
-                       ((Prims.fst t2), true)
-                   | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____472) ->
-                       let uu____495 =
-                         FStar_All.pipe_right bs
-                           (FStar_List.fold_left
-                              (fun uu____519  ->
-                                 fun uu____520  ->
-                                   match (uu____519, uu____520) with
-                                   | ((scope,bs1,must_check_ty1),(a,imp)) ->
-                                       let uu____562 =
-                                         if must_check_ty1
-                                         then (a, true)
-                                         else mk_binder1 scope a in
-                                       (match uu____562 with
-                                        | (tb,must_check_ty2) ->
-                                            let b = (tb, imp) in
-                                            let bs2 =
-                                              FStar_List.append bs1 [b] in
-                                            let scope1 =
-                                              FStar_List.append scope [b] in
-                                            (scope1, bs2, must_check_ty2)))
-                              (vars, [], must_check_ty)) in
-                       (match uu____495 with
-                        | (scope,bs1,must_check_ty1) ->
-                            let uu____623 = aux must_check_ty1 scope body in
-                            (match uu____623 with
-                             | (res,must_check_ty2) ->
-                                 let c =
-                                   match res with
-                                   | FStar_Util.Inl t2 ->
-                                       let uu____640 =
-                                         FStar_Options.ml_ish () in
-                                       if uu____640
-                                       then FStar_Syntax_Util.ml_comp t2 r
-                                       else FStar_Syntax_Syntax.mk_Total t2
-                                   | FStar_Util.Inr c -> c in
-                                 let t2 = FStar_Syntax_Util.arrow bs1 c in
-                                 ((let uu____647 =
-                                     FStar_TypeChecker_Env.debug env
-                                       FStar_Options.High in
-                                   if uu____647
-                                   then
-                                     let uu____648 =
-                                       FStar_Range.string_of_range r in
-                                     let uu____649 =
-                                       FStar_Syntax_Print.term_to_string t2 in
-                                     let uu____650 =
-                                       FStar_Util.string_of_bool
-                                         must_check_ty2 in
-                                     FStar_Util.print3
-                                       "(%s) Using type %s .... must check = %s\n"
-                                       uu____648 uu____649 uu____650
-                                   else ());
-                                  ((FStar_Util.Inl t2), must_check_ty2))))
-                   | uu____658 ->
-                       if must_check_ty
-                       then ((FStar_Util.Inl FStar_Syntax_Syntax.tun), true)
-                       else
-                         (let uu____666 =
-                            let uu____669 =
-                              let uu____670 =
-                                FStar_TypeChecker_Rel.new_uvar r vars
-                                  FStar_Syntax_Util.ktype0 in
-                              FStar_All.pipe_right uu____670 Prims.fst in
-                            FStar_Util.Inl uu____669 in
-                          (uu____666, false)) in
-                 let uu____677 =
-                   let uu____682 = t_binders env in aux false uu____682 e in
-                 match uu____677 with
-                 | (t2,b) ->
-                     let t3 =
-                       match t2 with
-                       | FStar_Util.Inr c ->
-                           let uu____699 =
-                             FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                           if uu____699
-                           then FStar_Syntax_Util.comp_result c
-                           else
-                             (let uu____703 =
-                                let uu____704 =
-                                  let uu____707 =
-                                    let uu____708 =
-                                      FStar_Syntax_Print.comp_to_string c in
-                                    FStar_Util.format1
-                                      "Expected a 'let rec' to be annotated with a value type; got a computation type %s"
-                                      uu____708 in
-                                  (uu____707, rng) in
-                                FStar_Errors.Error uu____704 in
-                              Prims.raise uu____703)
-                       | FStar_Util.Inl t3 -> t3 in
-                     ([], t3, b)))
-           | uu____715 ->
-               let uu____716 =
-                 FStar_Syntax_Subst.open_univ_vars univ_vars1 t1 in
-               (match uu____716 with
-                | (univ_vars2,t2) -> (univ_vars2, t2, false)))
-let pat_as_exps:
-  Prims.bool ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.pat ->
-        (FStar_Syntax_Syntax.bv Prims.list* FStar_Syntax_Syntax.term
-          Prims.list* FStar_Syntax_Syntax.pat)
-  =
-  fun allow_implicits  ->
-    fun env  ->
-      fun p  ->
-        let rec pat_as_arg_with_env allow_wc_dependence env1 p1 =
-          match p1.FStar_Syntax_Syntax.v with
-          | FStar_Syntax_Syntax.Pat_constant c ->
-              let e =
-                (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c))
-                  None p1.FStar_Syntax_Syntax.p in
-              ([], [], [], env1, e, p1)
-          | FStar_Syntax_Syntax.Pat_dot_term (x,uu____799) ->
-              let uu____804 = FStar_Syntax_Util.type_u () in
-              (match uu____804 with
-               | (k,uu____817) ->
-                   let t = new_uvar env1 k in
-                   let x1 =
-                     let uu___116_820 = x in
-                     {
-                       FStar_Syntax_Syntax.ppname =
-                         (uu___116_820.FStar_Syntax_Syntax.ppname);
-                       FStar_Syntax_Syntax.index =
-                         (uu___116_820.FStar_Syntax_Syntax.index);
-                       FStar_Syntax_Syntax.sort = t
-                     } in
-                   let uu____821 =
-                     let uu____824 = FStar_TypeChecker_Env.all_binders env1 in
-                     FStar_TypeChecker_Rel.new_uvar p1.FStar_Syntax_Syntax.p
-                       uu____824 t in
-                   (match uu____821 with
-                    | (e,u) ->
-                        let p2 =
-                          let uu___117_839 = p1 in
-                          {
-                            FStar_Syntax_Syntax.v =
-                              (FStar_Syntax_Syntax.Pat_dot_term (x1, e));
-                            FStar_Syntax_Syntax.ty =
-                              (uu___117_839.FStar_Syntax_Syntax.ty);
-                            FStar_Syntax_Syntax.p =
-                              (uu___117_839.FStar_Syntax_Syntax.p)
-                          } in
-                        ([], [], [], env1, e, p2)))
-          | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu____846 = FStar_Syntax_Util.type_u () in
-              (match uu____846 with
-               | (t,uu____859) ->
-                   let x1 =
-                     let uu___118_861 = x in
-                     let uu____862 = new_uvar env1 t in
-                     {
-                       FStar_Syntax_Syntax.ppname =
-                         (uu___118_861.FStar_Syntax_Syntax.ppname);
-                       FStar_Syntax_Syntax.index =
-                         (uu___118_861.FStar_Syntax_Syntax.index);
-                       FStar_Syntax_Syntax.sort = uu____862
-                     } in
-                   let env2 =
-                     if allow_wc_dependence
-                     then FStar_TypeChecker_Env.push_bv env1 x1
-                     else env1 in
-                   let e =
-                     (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1))
-                       None p1.FStar_Syntax_Syntax.p in
-                   ([x1], [], [x1], env2, e, p1))
-          | FStar_Syntax_Syntax.Pat_var x ->
-              let uu____884 = FStar_Syntax_Util.type_u () in
-              (match uu____884 with
-               | (t,uu____897) ->
-                   let x1 =
-                     let uu___119_899 = x in
-                     let uu____900 = new_uvar env1 t in
-                     {
-                       FStar_Syntax_Syntax.ppname =
-                         (uu___119_899.FStar_Syntax_Syntax.ppname);
-                       FStar_Syntax_Syntax.index =
-                         (uu___119_899.FStar_Syntax_Syntax.index);
-                       FStar_Syntax_Syntax.sort = uu____900
-                     } in
-                   let env2 = FStar_TypeChecker_Env.push_bv env1 x1 in
-                   let e =
-                     (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1))
-                       None p1.FStar_Syntax_Syntax.p in
-                   ([x1], [x1], [], env2, e, p1))
-          | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-              let uu____932 =
-                FStar_All.pipe_right pats
-                  (FStar_List.fold_left
-                     (fun uu____988  ->
-                        fun uu____989  ->
-                          match (uu____988, uu____989) with
-                          | ((b,a,w,env2,args,pats1),(p2,imp)) ->
-                              let uu____1088 =
-                                pat_as_arg_with_env allow_wc_dependence env2
-                                  p2 in
-                              (match uu____1088 with
-                               | (b',a',w',env3,te,pat) ->
-                                   let arg =
-                                     if imp
-                                     then FStar_Syntax_Syntax.iarg te
-                                     else FStar_Syntax_Syntax.as_arg te in
-                                   ((b' :: b), (a' :: a), (w' :: w), env3,
-                                     (arg :: args), ((pat, imp) :: pats1))))
-                     ([], [], [], env1, [], [])) in
-              (match uu____932 with
-               | (b,a,w,env2,args,pats1) ->
-                   let e =
-                     let uu____1196 =
-                       let uu____1199 =
-                         let uu____1200 =
-                           let uu____1205 =
-                             let uu____1208 =
-                               let uu____1209 =
-                                 FStar_Syntax_Syntax.fv_to_tm fv in
-                               let uu____1210 =
-                                 FStar_All.pipe_right args FStar_List.rev in
-                               FStar_Syntax_Syntax.mk_Tm_app uu____1209
-                                 uu____1210 in
-                             uu____1208 None p1.FStar_Syntax_Syntax.p in
-                           (uu____1205,
-                             (FStar_Syntax_Syntax.Meta_desugared
-                                FStar_Syntax_Syntax.Data_app)) in
-                         FStar_Syntax_Syntax.Tm_meta uu____1200 in
-                       FStar_Syntax_Syntax.mk uu____1199 in
-                     uu____1196 None p1.FStar_Syntax_Syntax.p in
-                   let uu____1227 =
-                     FStar_All.pipe_right (FStar_List.rev b)
-                       FStar_List.flatten in
-                   let uu____1233 =
-                     FStar_All.pipe_right (FStar_List.rev a)
-                       FStar_List.flatten in
-                   let uu____1239 =
-                     FStar_All.pipe_right (FStar_List.rev w)
-                       FStar_List.flatten in
-                   (uu____1227, uu____1233, uu____1239, env2, e,
-                     (let uu___120_1252 = p1 in
-                      {
-                        FStar_Syntax_Syntax.v =
-                          (FStar_Syntax_Syntax.Pat_cons
-                             (fv, (FStar_List.rev pats1)));
-                        FStar_Syntax_Syntax.ty =
-                          (uu___120_1252.FStar_Syntax_Syntax.ty);
-                        FStar_Syntax_Syntax.p =
-                          (uu___120_1252.FStar_Syntax_Syntax.p)
-                      })))
-          | FStar_Syntax_Syntax.Pat_disj uu____1258 -> failwith "impossible" in
-        let rec elaborate_pat env1 p1 =
-          let maybe_dot inaccessible a r =
-            if allow_implicits && inaccessible
-            then
-              FStar_Syntax_Syntax.withinfo
-                (FStar_Syntax_Syntax.Pat_dot_term
-                   (a, FStar_Syntax_Syntax.tun))
-                FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r
-            else
-              FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_var a)
-                FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r in
-          match p1.FStar_Syntax_Syntax.v with
-          | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-              let pats1 =
-                FStar_List.map
-                  (fun uu____1327  ->
-                     match uu____1327 with
-                     | (p2,imp) ->
-                         let uu____1342 = elaborate_pat env1 p2 in
-                         (uu____1342, imp)) pats in
-              let uu____1347 =
-                FStar_TypeChecker_Env.lookup_datacon env1
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              (match uu____1347 with
-               | (uu____1356,t) ->
-                   let uu____1358 = FStar_Syntax_Util.arrow_formals t in
-                   (match uu____1358 with
-                    | (f,uu____1369) ->
-                        let rec aux formals pats2 =
-                          match (formals, pats2) with
-                          | ([],[]) -> []
-                          | ([],uu____1444::uu____1445) ->
-                              Prims.raise
-                                (FStar_Errors.Error
-                                   ("Too many pattern arguments",
-                                     (FStar_Ident.range_of_lid
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)))
-                          | (uu____1480::uu____1481,[]) ->
-                              FStar_All.pipe_right formals
-                                (FStar_List.map
-                                   (fun uu____1521  ->
-                                      match uu____1521 with
-                                      | (t1,imp) ->
-                                          (match imp with
-                                           | Some
-                                               (FStar_Syntax_Syntax.Implicit
-                                               inaccessible) ->
-                                               let a =
-                                                 let uu____1539 =
-                                                   let uu____1541 =
-                                                     FStar_Syntax_Syntax.range_of_bv
-                                                       t1 in
-                                                   Some uu____1541 in
-                                                 FStar_Syntax_Syntax.new_bv
-                                                   uu____1539
-                                                   FStar_Syntax_Syntax.tun in
-                                               let r =
-                                                 FStar_Ident.range_of_lid
-                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                               let uu____1547 =
-                                                 maybe_dot inaccessible a r in
-                                               (uu____1547, true)
-                                           | uu____1552 ->
-                                               let uu____1554 =
-                                                 let uu____1555 =
-                                                   let uu____1558 =
-                                                     let uu____1559 =
-                                                       FStar_Syntax_Print.pat_to_string
-                                                         p1 in
-                                                     FStar_Util.format1
-                                                       "Insufficient pattern arguments (%s)"
-                                                       uu____1559 in
-                                                   (uu____1558,
-                                                     (FStar_Ident.range_of_lid
-                                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
-                                                 FStar_Errors.Error
-                                                   uu____1555 in
-                                               Prims.raise uu____1554)))
-                          | (f1::formals',(p2,p_imp)::pats') ->
-                              (match f1 with
-                               | (uu____1610,Some
-                                  (FStar_Syntax_Syntax.Implicit uu____1611))
-                                   when p_imp ->
-                                   let uu____1613 = aux formals' pats' in
-                                   (p2, true) :: uu____1613
-                               | (uu____1625,Some
-                                  (FStar_Syntax_Syntax.Implicit
-                                  inaccessible)) ->
-                                   let a =
-                                     FStar_Syntax_Syntax.new_bv
-                                       (Some (p2.FStar_Syntax_Syntax.p))
-                                       FStar_Syntax_Syntax.tun in
-                                   let p3 =
-                                     maybe_dot inaccessible a
-                                       (FStar_Ident.range_of_lid
-                                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                   let uu____1636 = aux formals' pats2 in
-                                   (p3, true) :: uu____1636
-                               | (uu____1648,imp) ->
-                                   let uu____1652 =
-                                     let uu____1657 =
-                                       FStar_Syntax_Syntax.is_implicit imp in
-                                     (p2, uu____1657) in
-                                   let uu____1660 = aux formals' pats' in
-                                   uu____1652 :: uu____1660) in
-                        let uu___121_1670 = p1 in
-                        let uu____1673 =
-                          let uu____1674 =
-                            let uu____1682 = aux f pats1 in (fv, uu____1682) in
-                          FStar_Syntax_Syntax.Pat_cons uu____1674 in
-                        {
-                          FStar_Syntax_Syntax.v = uu____1673;
-                          FStar_Syntax_Syntax.ty =
-                            (uu___121_1670.FStar_Syntax_Syntax.ty);
-                          FStar_Syntax_Syntax.p =
-                            (uu___121_1670.FStar_Syntax_Syntax.p)
-                        }))
-          | uu____1693 -> p1 in
-        let one_pat allow_wc_dependence env1 p1 =
-          let p2 = elaborate_pat env1 p1 in
-          let uu____1719 = pat_as_arg_with_env allow_wc_dependence env1 p2 in
-          match uu____1719 with
-          | (b,a,w,env2,arg,p3) ->
-              let uu____1749 =
-                FStar_All.pipe_right b
-                  (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq) in
-              (match uu____1749 with
-               | Some x ->
-                   let uu____1762 =
-                     let uu____1763 =
-                       let uu____1766 =
-                         FStar_TypeChecker_Err.nonlinear_pattern_variable x in
-                       (uu____1766, (p3.FStar_Syntax_Syntax.p)) in
-                     FStar_Errors.Error uu____1763 in
-                   Prims.raise uu____1762
-               | uu____1775 -> (b, a, w, arg, p3)) in
-        let top_level_pat_as_args env1 p1 =
-          match p1.FStar_Syntax_Syntax.v with
-          | FStar_Syntax_Syntax.Pat_disj [] -> failwith "impossible"
-          | FStar_Syntax_Syntax.Pat_disj (q::pats) ->
-              let uu____1818 = one_pat false env1 q in
-              (match uu____1818 with
-               | (b,a,uu____1834,te,q1) ->
-                   let uu____1843 =
-                     FStar_List.fold_right
-                       (fun p2  ->
-                          fun uu____1859  ->
-                            match uu____1859 with
-                            | (w,args,pats1) ->
-                                let uu____1883 = one_pat false env1 p2 in
-                                (match uu____1883 with
-                                 | (b',a',w',arg,p3) ->
-                                     let uu____1909 =
-                                       let uu____1910 =
-                                         FStar_Util.multiset_equiv
-                                           FStar_Syntax_Syntax.bv_eq a a' in
-                                       Prims.op_Negation uu____1910 in
-                                     if uu____1909
-                                     then
-                                       let uu____1917 =
-                                         let uu____1918 =
-                                           let uu____1921 =
-                                             FStar_TypeChecker_Err.disjunctive_pattern_vars
-                                               a a' in
-                                           let uu____1922 =
-                                             FStar_TypeChecker_Env.get_range
-                                               env1 in
-                                           (uu____1921, uu____1922) in
-                                         FStar_Errors.Error uu____1918 in
-                                       Prims.raise uu____1917
-                                     else
-                                       (let uu____1930 =
-                                          let uu____1932 =
-                                            FStar_Syntax_Syntax.as_arg arg in
-                                          uu____1932 :: args in
-                                        ((FStar_List.append w' w),
-                                          uu____1930, (p3 :: pats1))))) pats
-                       ([], [], []) in
-                   (match uu____1843 with
-                    | (w,args,pats1) ->
-                        let uu____1953 =
-                          let uu____1955 = FStar_Syntax_Syntax.as_arg te in
-                          uu____1955 :: args in
-                        ((FStar_List.append b w), uu____1953,
-                          (let uu___122_1960 = p1 in
-                           {
-                             FStar_Syntax_Syntax.v =
-                               (FStar_Syntax_Syntax.Pat_disj (q1 :: pats1));
-                             FStar_Syntax_Syntax.ty =
-                               (uu___122_1960.FStar_Syntax_Syntax.ty);
-                             FStar_Syntax_Syntax.p =
-                               (uu___122_1960.FStar_Syntax_Syntax.p)
-                           }))))
-          | uu____1961 ->
-              let uu____1962 = one_pat true env1 p1 in
-              (match uu____1962 with
-               | (b,uu____1977,uu____1978,arg,p2) ->
-                   let uu____1987 =
-                     let uu____1989 = FStar_Syntax_Syntax.as_arg arg in
-                     [uu____1989] in
-                   (b, uu____1987, p2)) in
-        let uu____1992 = top_level_pat_as_args env p in
-        match uu____1992 with
-        | (b,args,p1) ->
-            let exps = FStar_All.pipe_right args (FStar_List.map Prims.fst) in
-            (b, exps, p1)
-let decorate_pattern:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.pat ->
-      FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.pat
-  =
-  fun env  ->
-    fun p  ->
-      fun exps  ->
-        let qq = p in
-        let rec aux p1 e =
-          let pkg q t =
-            FStar_Syntax_Syntax.withinfo q t p1.FStar_Syntax_Syntax.p in
-          let e1 = FStar_Syntax_Util.unmeta e in
-          match ((p1.FStar_Syntax_Syntax.v), (e1.FStar_Syntax_Syntax.n)) with
-          | (uu____2063,FStar_Syntax_Syntax.Tm_uinst (e2,uu____2065)) ->
-              aux p1 e2
-          | (FStar_Syntax_Syntax.Pat_constant
-             uu____2070,FStar_Syntax_Syntax.Tm_constant uu____2071) ->
-              let uu____2072 = force_sort' e1 in
-              pkg p1.FStar_Syntax_Syntax.v uu____2072
-          | (FStar_Syntax_Syntax.Pat_var x,FStar_Syntax_Syntax.Tm_name y) ->
-              (if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x y)
-               then
-                 (let uu____2076 =
-                    let uu____2077 = FStar_Syntax_Print.bv_to_string x in
-                    let uu____2078 = FStar_Syntax_Print.bv_to_string y in
-                    FStar_Util.format2 "Expected pattern variable %s; got %s"
-                      uu____2077 uu____2078 in
-                  failwith uu____2076)
-               else ();
-               (let uu____2081 =
-                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Pat") in
-                if uu____2081
-                then
-                  let uu____2082 = FStar_Syntax_Print.bv_to_string x in
-                  let uu____2083 =
-                    FStar_TypeChecker_Normalize.term_to_string env
-                      y.FStar_Syntax_Syntax.sort in
-                  FStar_Util.print2
-                    "Pattern variable %s introduced at type %s\n" uu____2082
-                    uu____2083
-                else ());
-               (let s =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Beta] env
-                    y.FStar_Syntax_Syntax.sort in
-                let x1 =
-                  let uu___123_2087 = x in
-                  {
-                    FStar_Syntax_Syntax.ppname =
-                      (uu___123_2087.FStar_Syntax_Syntax.ppname);
-                    FStar_Syntax_Syntax.index =
-                      (uu___123_2087.FStar_Syntax_Syntax.index);
-                    FStar_Syntax_Syntax.sort = s
-                  } in
-                pkg (FStar_Syntax_Syntax.Pat_var x1) s.FStar_Syntax_Syntax.n))
-          | (FStar_Syntax_Syntax.Pat_wild x,FStar_Syntax_Syntax.Tm_name y) ->
-              ((let uu____2091 =
-                  FStar_All.pipe_right (FStar_Syntax_Syntax.bv_eq x y)
-                    Prims.op_Negation in
-                if uu____2091
-                then
-                  let uu____2092 =
-                    let uu____2093 = FStar_Syntax_Print.bv_to_string x in
-                    let uu____2094 = FStar_Syntax_Print.bv_to_string y in
-                    FStar_Util.format2 "Expected pattern variable %s; got %s"
-                      uu____2093 uu____2094 in
-                  failwith uu____2092
-                else ());
-               (let s =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Normalize.Beta] env
-                    y.FStar_Syntax_Syntax.sort in
-                let x1 =
-                  let uu___124_2098 = x in
-                  {
-                    FStar_Syntax_Syntax.ppname =
-                      (uu___124_2098.FStar_Syntax_Syntax.ppname);
-                    FStar_Syntax_Syntax.index =
-                      (uu___124_2098.FStar_Syntax_Syntax.index);
-                    FStar_Syntax_Syntax.sort = s
-                  } in
-                pkg (FStar_Syntax_Syntax.Pat_wild x1) s.FStar_Syntax_Syntax.n))
-          | (FStar_Syntax_Syntax.Pat_dot_term (x,uu____2100),uu____2101) ->
-              let s = force_sort e1 in
-              let x1 =
-                let uu___125_2110 = x in
-                {
-                  FStar_Syntax_Syntax.ppname =
-                    (uu___125_2110.FStar_Syntax_Syntax.ppname);
-                  FStar_Syntax_Syntax.index =
-                    (uu___125_2110.FStar_Syntax_Syntax.index);
-                  FStar_Syntax_Syntax.sort = s
-                } in
-              pkg (FStar_Syntax_Syntax.Pat_dot_term (x1, e1))
-                s.FStar_Syntax_Syntax.n
-          | (FStar_Syntax_Syntax.Pat_cons (fv,[]),FStar_Syntax_Syntax.Tm_fvar
-             fv') ->
-              ((let uu____2123 =
-                  let uu____2124 = FStar_Syntax_Syntax.fv_eq fv fv' in
-                  Prims.op_Negation uu____2124 in
-                if uu____2123
-                then
-                  let uu____2125 =
-                    FStar_Util.format2
-                      "Expected pattern constructor %s; got %s"
-                      ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
-                  failwith uu____2125
-                else ());
-               (let uu____2135 = force_sort' e1 in
-                pkg (FStar_Syntax_Syntax.Pat_cons (fv', [])) uu____2135))
-          | (FStar_Syntax_Syntax.Pat_cons
-             (fv,argpats),FStar_Syntax_Syntax.Tm_app
-             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv';
-                FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                FStar_Syntax_Syntax.vars = _;_},args))
-            |(FStar_Syntax_Syntax.Pat_cons
-              (fv,argpats),FStar_Syntax_Syntax.Tm_app
-              ({
-                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
-                   ({
-                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv';
-                      FStar_Syntax_Syntax.tk = _;
-                      FStar_Syntax_Syntax.pos = _;
-                      FStar_Syntax_Syntax.vars = _;_},_);
-                 FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _;
-                 FStar_Syntax_Syntax.vars = _;_},args))
-              ->
-              ((let uu____2206 =
-                  let uu____2207 = FStar_Syntax_Syntax.fv_eq fv fv' in
-                  FStar_All.pipe_right uu____2207 Prims.op_Negation in
-                if uu____2206
-                then
-                  let uu____2208 =
-                    FStar_Util.format2
-                      "Expected pattern constructor %s; got %s"
-                      ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
-                  failwith uu____2208
-                else ());
-               (let fv1 = fv' in
-                let rec match_args matched_pats args1 argpats1 =
-                  match (args1, argpats1) with
-                  | ([],[]) ->
-                      let uu____2296 = force_sort' e1 in
-                      pkg
-                        (FStar_Syntax_Syntax.Pat_cons
-                           (fv1, (FStar_List.rev matched_pats))) uu____2296
-                  | (arg::args2,(argpat,uu____2309)::argpats2) ->
-                      (match (arg, (argpat.FStar_Syntax_Syntax.v)) with
-                       | ((e2,Some (FStar_Syntax_Syntax.Implicit (true ))),FStar_Syntax_Syntax.Pat_dot_term
-                          uu____2359) ->
-                           let x =
-                             let uu____2375 = force_sort e2 in
-                             FStar_Syntax_Syntax.new_bv
-                               (Some (p1.FStar_Syntax_Syntax.p)) uu____2375 in
-                           let q =
-                             FStar_Syntax_Syntax.withinfo
-                               (FStar_Syntax_Syntax.Pat_dot_term (x, e2))
-                               (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.n
-                               p1.FStar_Syntax_Syntax.p in
-                           match_args ((q, true) :: matched_pats) args2
-                             argpats2
-                       | ((e2,imp),uu____2389) ->
-                           let pat =
-                             let uu____2404 = aux argpat e2 in
-                             let uu____2405 =
-                               FStar_Syntax_Syntax.is_implicit imp in
-                             (uu____2404, uu____2405) in
-                           match_args (pat :: matched_pats) args2 argpats2)
-                  | uu____2408 ->
-                      let uu____2422 =
-                        let uu____2423 = FStar_Syntax_Print.pat_to_string p1 in
-                        let uu____2424 = FStar_Syntax_Print.term_to_string e1 in
-                        FStar_Util.format2
-                          "Unexpected number of pattern arguments: \n\t%s\n\t%s\n"
-                          uu____2423 uu____2424 in
-                      failwith uu____2422 in
-                match_args [] args argpats))
-          | uu____2431 ->
-              let uu____2434 =
-                let uu____2435 =
-                  FStar_Range.string_of_range qq.FStar_Syntax_Syntax.p in
-                let uu____2436 = FStar_Syntax_Print.pat_to_string qq in
-                let uu____2437 =
-                  let uu____2438 =
-                    FStar_All.pipe_right exps
-                      (FStar_List.map FStar_Syntax_Print.term_to_string) in
-                  FStar_All.pipe_right uu____2438
-                    (FStar_String.concat "\n\t") in
-                FStar_Util.format3
-                  "(%s) Impossible: pattern to decorate is %s; expression is %s\n"
-                  uu____2435 uu____2436 uu____2437 in
-              failwith uu____2434 in
-        match ((p.FStar_Syntax_Syntax.v), exps) with
-        | (FStar_Syntax_Syntax.Pat_disj ps,uu____2445) when
-            (FStar_List.length ps) = (FStar_List.length exps) ->
-            let ps1 = FStar_List.map2 aux ps exps in
-            FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_disj ps1)
-              FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n
-              p.FStar_Syntax_Syntax.p
-        | (uu____2461,e::[]) -> aux p e
-        | uu____2464 -> failwith "Unexpected number of patterns"
-let rec decorated_pattern_as_term:
-  FStar_Syntax_Syntax.pat ->
-    (FStar_Syntax_Syntax.bv Prims.list* FStar_Syntax_Syntax.term)
-  =
-  fun pat  ->
-    let topt = Some (pat.FStar_Syntax_Syntax.ty) in
-    let mk1 f = (FStar_Syntax_Syntax.mk f) topt pat.FStar_Syntax_Syntax.p in
-    let pat_as_arg uu____2501 =
-      match uu____2501 with
-      | (p,i) ->
-          let uu____2511 = decorated_pattern_as_term p in
-          (match uu____2511 with
-           | (vars,te) ->
-               let uu____2524 =
-                 let uu____2527 = FStar_Syntax_Syntax.as_implicit i in
-                 (te, uu____2527) in
-               (vars, uu____2524)) in
-    match pat.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_disj uu____2534 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Pat_constant c ->
-        let uu____2542 = mk1 (FStar_Syntax_Syntax.Tm_constant c) in
-        ([], uu____2542)
-    | FStar_Syntax_Syntax.Pat_wild x|FStar_Syntax_Syntax.Pat_var x ->
-        let uu____2545 = mk1 (FStar_Syntax_Syntax.Tm_name x) in
-        ([x], uu____2545)
-    | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-        let uu____2559 =
-          let uu____2567 =
-            FStar_All.pipe_right pats (FStar_List.map pat_as_arg) in
-          FStar_All.pipe_right uu____2567 FStar_List.unzip in
-        (match uu____2559 with
-         | (vars,args) ->
-             let vars1 = FStar_List.flatten vars in
-             let uu____2625 =
-               let uu____2626 =
-                 let uu____2627 =
-                   let uu____2637 = FStar_Syntax_Syntax.fv_to_tm fv in
-                   (uu____2637, args) in
-                 FStar_Syntax_Syntax.Tm_app uu____2627 in
-               mk1 uu____2626 in
-             (vars1, uu____2625))
-    | FStar_Syntax_Syntax.Pat_dot_term (x,e) -> ([], e)
-let destruct_comp:
-  FStar_Syntax_Syntax.comp_typ ->
-    (FStar_Syntax_Syntax.universe*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax*
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-      FStar_Syntax_Syntax.syntax)
-  =
-  fun c  ->
-    let wp =
-      match c.FStar_Syntax_Syntax.effect_args with
-      | (wp,uu____2666)::[] -> wp
-      | uu____2679 ->
-          let uu____2685 =
-            let uu____2686 =
-              let uu____2687 =
-                FStar_List.map
-                  (fun uu____2691  ->
-                     match uu____2691 with
-                     | (x,uu____2695) -> FStar_Syntax_Print.term_to_string x)
-                  c.FStar_Syntax_Syntax.effect_args in
-              FStar_All.pipe_right uu____2687 (FStar_String.concat ", ") in
-            FStar_Util.format2
-              "Impossible: Got a computation %s with effect args [%s]"
-              (c.FStar_Syntax_Syntax.effect_name).FStar_Ident.str uu____2686 in
-          failwith uu____2685 in
-    let uu____2699 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs in
-    (uu____2699, (c.FStar_Syntax_Syntax.result_typ), wp)
-let lift_comp:
-  FStar_Syntax_Syntax.comp_typ ->
-    FStar_Ident.lident ->
-      FStar_TypeChecker_Env.mlift -> FStar_Syntax_Syntax.comp_typ
-  =
-  fun c  ->
-    fun m  ->
-      fun lift  ->
-        let uu____2713 = destruct_comp c in
-        match uu____2713 with
-        | (u,uu____2718,wp) ->
-            let uu____2720 =
-              let uu____2726 =
-                let uu____2727 =
-                  lift.FStar_TypeChecker_Env.mlift_wp
-                    c.FStar_Syntax_Syntax.result_typ wp in
-                FStar_Syntax_Syntax.as_arg uu____2727 in
-              [uu____2726] in
-            {
-              FStar_Syntax_Syntax.comp_univs = [u];
-              FStar_Syntax_Syntax.effect_name = m;
-              FStar_Syntax_Syntax.result_typ =
-                (c.FStar_Syntax_Syntax.result_typ);
-              FStar_Syntax_Syntax.effect_args = uu____2720;
-              FStar_Syntax_Syntax.flags = []
-            }
-let join_effects:
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident -> FStar_Ident.lident -> FStar_Ident.lident
-  =
-  fun env  ->
-    fun l1  ->
-      fun l2  ->
-        let uu____2737 =
-          let uu____2741 = FStar_TypeChecker_Env.norm_eff_name env l1 in
-          let uu____2742 = FStar_TypeChecker_Env.norm_eff_name env l2 in
-          FStar_TypeChecker_Env.join env uu____2741 uu____2742 in
-        match uu____2737 with | (m,uu____2744,uu____2745) -> m
-let join_lcomp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.lcomp ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Ident.lident
-  =
-  fun env  ->
-    fun c1  ->
-      fun c2  ->
-        let uu____2755 =
-          (FStar_Syntax_Util.is_total_lcomp c1) &&
-            (FStar_Syntax_Util.is_total_lcomp c2) in
-        if uu____2755
-        then FStar_Syntax_Const.effect_Tot_lid
-        else
-          join_effects env c1.FStar_Syntax_Syntax.eff_name
-            c2.FStar_Syntax_Syntax.eff_name
-let lift_and_destruct:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.comp ->
-        ((FStar_Syntax_Syntax.eff_decl* FStar_Syntax_Syntax.bv*
-          FStar_Syntax_Syntax.term)* (FStar_Syntax_Syntax.universe*
-          FStar_Syntax_Syntax.typ* FStar_Syntax_Syntax.typ)*
-          (FStar_Syntax_Syntax.universe* FStar_Syntax_Syntax.typ*
-          FStar_Syntax_Syntax.typ))
-  =
-  fun env  ->
-    fun c1  ->
-      fun c2  ->
-        let c11 = FStar_TypeChecker_Env.unfold_effect_abbrev env c1 in
-        let c21 = FStar_TypeChecker_Env.unfold_effect_abbrev env c2 in
-        let uu____2780 =
-          FStar_TypeChecker_Env.join env c11.FStar_Syntax_Syntax.effect_name
-            c21.FStar_Syntax_Syntax.effect_name in
-        match uu____2780 with
-        | (m,lift1,lift2) ->
-            let m1 = lift_comp c11 m lift1 in
-            let m2 = lift_comp c21 m lift2 in
-            let md = FStar_TypeChecker_Env.get_effect_decl env m in
-            let uu____2802 =
-              FStar_TypeChecker_Env.wp_signature env
-                md.FStar_Syntax_Syntax.mname in
-            (match uu____2802 with
-             | (a,kwp) ->
-                 let uu____2819 = destruct_comp m1 in
-                 let uu____2823 = destruct_comp m2 in
-                 ((md, a, kwp), uu____2819, uu____2823))
-let is_pure_effect:
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun l  ->
-      let l1 = FStar_TypeChecker_Env.norm_eff_name env l in
-      FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid
-let is_pure_or_ghost_effect:
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool =
-  fun env  ->
-    fun l  ->
-      let l1 = FStar_TypeChecker_Env.norm_eff_name env l in
-      (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid) ||
-        (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GHOST_lid)
-let mk_comp_l:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.universe ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
-  =
-  fun mname  ->
-    fun u_result  ->
-      fun result  ->
-        fun wp  ->
-          fun flags  ->
-            let uu____2871 =
-              let uu____2872 =
-                let uu____2878 = FStar_Syntax_Syntax.as_arg wp in
-                [uu____2878] in
-              {
-                FStar_Syntax_Syntax.comp_univs = [u_result];
-                FStar_Syntax_Syntax.effect_name = mname;
-                FStar_Syntax_Syntax.result_typ = result;
-                FStar_Syntax_Syntax.effect_args = uu____2872;
-                FStar_Syntax_Syntax.flags = flags
-              } in
-            FStar_Syntax_Syntax.mk_Comp uu____2871
-let mk_comp:
-  FStar_Syntax_Syntax.eff_decl ->
-    FStar_Syntax_Syntax.universe ->
-      (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
-  = fun md  -> mk_comp_l md.FStar_Syntax_Syntax.mname
-let lax_mk_tot_or_comp_l:
-  FStar_Ident.lident ->
-    FStar_Syntax_Syntax.universe ->
-      FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
-  =
-  fun mname  ->
-    fun u_result  ->
-      fun result  ->
-        fun flags  ->
-          if FStar_Ident.lid_equals mname FStar_Syntax_Const.effect_Tot_lid
-          then FStar_Syntax_Syntax.mk_Total' result (Some u_result)
-          else mk_comp_l mname u_result result FStar_Syntax_Syntax.tun flags
-let subst_lcomp:
-  FStar_Syntax_Syntax.subst_t ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun subst1  ->
-    fun lc  ->
-      let uu___126_2914 = lc in
-      let uu____2915 =
-        FStar_Syntax_Subst.subst subst1 lc.FStar_Syntax_Syntax.res_typ in
-      {
-        FStar_Syntax_Syntax.eff_name =
-          (uu___126_2914.FStar_Syntax_Syntax.eff_name);
-        FStar_Syntax_Syntax.res_typ = uu____2915;
-        FStar_Syntax_Syntax.cflags =
-          (uu___126_2914.FStar_Syntax_Syntax.cflags);
-        FStar_Syntax_Syntax.comp =
-          (fun uu____2918  ->
-             let uu____2919 = lc.FStar_Syntax_Syntax.comp () in
-             FStar_Syntax_Subst.subst_comp subst1 uu____2919)
-      }
-let is_function: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun t  ->
-    let uu____2923 =
-      let uu____2924 = FStar_Syntax_Subst.compress t in
-      uu____2924.FStar_Syntax_Syntax.n in
-    match uu____2923 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____2927 -> true
-    | uu____2935 -> false
-let return_value:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp
-  =
-  fun env  ->
-    fun t  ->
-      fun v1  ->
-        let c =
-          let uu____2946 =
-            let uu____2947 =
-              FStar_TypeChecker_Env.lid_exists env
-                FStar_Syntax_Const.effect_GTot_lid in
-            FStar_All.pipe_left Prims.op_Negation uu____2947 in
-          if uu____2946
-          then FStar_Syntax_Syntax.mk_Total t
-          else
-            (let m =
-               let uu____2950 =
-                 FStar_TypeChecker_Env.effect_decl_opt env
-                   FStar_Syntax_Const.effect_PURE_lid in
-               FStar_Util.must uu____2950 in
-             let u_t = env.FStar_TypeChecker_Env.universe_of env t in
-             let wp =
-               let uu____2954 =
-                 env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-               if uu____2954
-               then FStar_Syntax_Syntax.tun
-               else
-                 (let uu____2956 =
-                    FStar_TypeChecker_Env.wp_signature env
-                      FStar_Syntax_Const.effect_PURE_lid in
-                  match uu____2956 with
-                  | (a,kwp) ->
-                      let k =
-                        FStar_Syntax_Subst.subst
-                          [FStar_Syntax_Syntax.NT (a, t)] kwp in
-                      let uu____2962 =
-                        let uu____2963 =
-                          let uu____2964 =
-                            FStar_TypeChecker_Env.inst_effect_fun_with 
-                              [u_t] env m m.FStar_Syntax_Syntax.ret_wp in
-                          let uu____2965 =
-                            let uu____2966 = FStar_Syntax_Syntax.as_arg t in
-                            let uu____2967 =
-                              let uu____2969 = FStar_Syntax_Syntax.as_arg v1 in
-                              [uu____2969] in
-                            uu____2966 :: uu____2967 in
-                          FStar_Syntax_Syntax.mk_Tm_app uu____2964 uu____2965 in
-                        uu____2963 (Some (k.FStar_Syntax_Syntax.n))
-                          v1.FStar_Syntax_Syntax.pos in
-                      FStar_TypeChecker_Normalize.normalize
-                        [FStar_TypeChecker_Normalize.Beta] env uu____2962) in
-             (mk_comp m) u_t t wp [FStar_Syntax_Syntax.RETURN]) in
-        (let uu____2975 =
-           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Return") in
-         if uu____2975
-         then
-           let uu____2976 =
-             FStar_Range.string_of_range v1.FStar_Syntax_Syntax.pos in
-           let uu____2977 = FStar_Syntax_Print.term_to_string v1 in
-           let uu____2978 = FStar_TypeChecker_Normalize.comp_to_string env c in
-           FStar_Util.print3 "(%s) returning %s at comp type %s\n" uu____2976
-             uu____2977 uu____2978
-         else ());
-        c
-let bind:
-  FStar_Range.range ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term Prims.option ->
-        FStar_Syntax_Syntax.lcomp ->
-          lcomp_with_binder -> FStar_Syntax_Syntax.lcomp
-  =
-  fun r1  ->
-    fun env  ->
-      fun e1opt  ->
-        fun lc1  ->
-          fun uu____2995  ->
-            match uu____2995 with
-            | (b,lc2) ->
-                let lc11 =
-                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1 in
-                let lc21 =
-                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2 in
-                let joined_eff = join_lcomp env lc11 lc21 in
-                ((let uu____3005 =
-                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-                  if uu____3005
-                  then
-                    let bstr =
-                      match b with
-                      | None  -> "none"
-                      | Some x -> FStar_Syntax_Print.bv_to_string x in
-                    let uu____3008 =
-                      match e1opt with
-                      | None  -> "None"
-                      | Some e -> FStar_Syntax_Print.term_to_string e in
-                    let uu____3010 = FStar_Syntax_Print.lcomp_to_string lc11 in
-                    let uu____3011 = FStar_Syntax_Print.lcomp_to_string lc21 in
-                    FStar_Util.print4
-                      "Before lift: Making bind (e1=%s)@c1=%s\nb=%s\t\tc2=%s\n"
-                      uu____3008 uu____3010 bstr uu____3011
-                  else ());
-                 (let bind_it uu____3016 =
-                    let uu____3017 =
-                      env.FStar_TypeChecker_Env.lax &&
-                        (FStar_Options.ml_ish ()) in
-                    if uu____3017
-                    then
-                      let u_t =
-                        env.FStar_TypeChecker_Env.universe_of env
-                          lc21.FStar_Syntax_Syntax.res_typ in
-                      lax_mk_tot_or_comp_l joined_eff u_t
-                        lc21.FStar_Syntax_Syntax.res_typ []
-                    else
-                      (let c1 = lc11.FStar_Syntax_Syntax.comp () in
-                       let c2 = lc21.FStar_Syntax_Syntax.comp () in
-                       (let uu____3027 =
-                          FStar_TypeChecker_Env.debug env
-                            FStar_Options.Extreme in
-                        if uu____3027
-                        then
-                          let uu____3028 =
-                            match b with
-                            | None  -> "none"
-                            | Some x -> FStar_Syntax_Print.bv_to_string x in
-                          let uu____3030 =
-                            FStar_Syntax_Print.lcomp_to_string lc11 in
-                          let uu____3031 =
-                            FStar_Syntax_Print.comp_to_string c1 in
-                          let uu____3032 =
-                            FStar_Syntax_Print.lcomp_to_string lc21 in
-                          let uu____3033 =
-                            FStar_Syntax_Print.comp_to_string c2 in
-                          FStar_Util.print5
-                            "b=%s,Evaluated %s to %s\n And %s to %s\n"
-                            uu____3028 uu____3030 uu____3031 uu____3032
-                            uu____3033
-                        else ());
-                       (let try_simplify uu____3041 =
-                          let aux uu____3050 =
-                            let uu____3051 =
-                              FStar_Syntax_Util.is_trivial_wp c1 in
-                            if uu____3051
-                            then
-                              match b with
-                              | None  -> Some (c2, "trivial no binder")
-                              | Some uu____3068 ->
-                                  let uu____3069 =
-                                    FStar_Syntax_Util.is_ml_comp c2 in
-                                  (if uu____3069
-                                   then Some (c2, "trivial ml")
-                                   else None)
-                            else
-                              (let uu____3087 =
-                                 (FStar_Syntax_Util.is_ml_comp c1) &&
-                                   (FStar_Syntax_Util.is_ml_comp c2) in
-                               if uu____3087
-                               then Some (c2, "both ml")
-                               else None) in
-                          let subst_c2 reason =
-                            match (e1opt, b) with
-                            | (Some e,Some x) ->
-                                let uu____3120 =
-                                  let uu____3123 =
-                                    FStar_Syntax_Subst.subst_comp
-                                      [FStar_Syntax_Syntax.NT (x, e)] c2 in
-                                  (uu____3123, reason) in
-                                Some uu____3120
-                            | uu____3126 -> aux () in
-                          let uu____3131 =
-                            (FStar_Syntax_Util.is_total_comp c1) &&
-                              (FStar_Syntax_Util.is_total_comp c2) in
-                          if uu____3131
-                          then subst_c2 "both total"
-                          else
-                            (let uu____3136 =
-                               (FStar_Syntax_Util.is_tot_or_gtot_comp c1) &&
-                                 (FStar_Syntax_Util.is_tot_or_gtot_comp c2) in
-                             if uu____3136
-                             then
-                               let uu____3140 =
-                                 let uu____3143 =
-                                   FStar_Syntax_Syntax.mk_GTotal
-                                     (FStar_Syntax_Util.comp_result c2) in
-                                 (uu____3143, "both gtot") in
-                               Some uu____3140
-                             else
-                               (match (e1opt, b) with
-                                | (Some e,Some x) ->
-                                    let uu____3156 =
-                                      (FStar_Syntax_Util.is_total_comp c1) &&
-                                        (let uu____3157 =
-                                           FStar_Syntax_Syntax.is_null_bv x in
-                                         Prims.op_Negation uu____3157) in
-                                    if uu____3156
-                                    then subst_c2 "substituted e"
-                                    else aux ()
-                                | uu____3162 -> aux ())) in
-                        let uu____3167 = try_simplify () in
-                        match uu____3167 with
-                        | Some (c,reason) -> c
-                        | None  ->
-                            let uu____3177 = lift_and_destruct env c1 c2 in
-                            (match uu____3177 with
-                             | ((md,a,kwp),(u_t1,t1,wp1),(u_t2,t2,wp2)) ->
-                                 let bs =
-                                   match b with
-                                   | None  ->
-                                       let uu____3211 =
-                                         FStar_Syntax_Syntax.null_binder t1 in
-                                       [uu____3211]
-                                   | Some x ->
-                                       let uu____3213 =
-                                         FStar_Syntax_Syntax.mk_binder x in
-                                       [uu____3213] in
-                                 let mk_lam wp =
-                                   FStar_Syntax_Util.abs bs wp
-                                     (Some
-                                        (FStar_Util.Inr
-                                           (FStar_Syntax_Const.effect_Tot_lid,
-                                             [FStar_Syntax_Syntax.TOTAL]))) in
-                                 let r11 =
-                                   (FStar_Syntax_Syntax.mk
-                                      (FStar_Syntax_Syntax.Tm_constant
-                                         (FStar_Const.Const_range r1))) None
-                                     r1 in
-                                 let wp_args =
-                                   let uu____3240 =
-                                     FStar_Syntax_Syntax.as_arg r11 in
-                                   let uu____3241 =
-                                     let uu____3243 =
-                                       FStar_Syntax_Syntax.as_arg t1 in
-                                     let uu____3244 =
-                                       let uu____3246 =
-                                         FStar_Syntax_Syntax.as_arg t2 in
-                                       let uu____3247 =
-                                         let uu____3249 =
-                                           FStar_Syntax_Syntax.as_arg wp1 in
-                                         let uu____3250 =
-                                           let uu____3252 =
-                                             let uu____3253 = mk_lam wp2 in
-                                             FStar_Syntax_Syntax.as_arg
-                                               uu____3253 in
-                                           [uu____3252] in
-                                         uu____3249 :: uu____3250 in
-                                       uu____3246 :: uu____3247 in
-                                     uu____3243 :: uu____3244 in
-                                   uu____3240 :: uu____3241 in
-                                 let k =
-                                   FStar_Syntax_Subst.subst
-                                     [FStar_Syntax_Syntax.NT (a, t2)] kwp in
-                                 let wp =
-                                   let uu____3258 =
-                                     let uu____3259 =
-                                       FStar_TypeChecker_Env.inst_effect_fun_with
-                                         [u_t1; u_t2] env md
-                                         md.FStar_Syntax_Syntax.bind_wp in
-                                     FStar_Syntax_Syntax.mk_Tm_app uu____3259
-                                       wp_args in
-                                   uu____3258 None t2.FStar_Syntax_Syntax.pos in
-                                 let c = (mk_comp md) u_t2 t2 wp [] in c))) in
-                  {
-                    FStar_Syntax_Syntax.eff_name = joined_eff;
-                    FStar_Syntax_Syntax.res_typ =
-                      (lc21.FStar_Syntax_Syntax.res_typ);
-                    FStar_Syntax_Syntax.cflags = [];
-                    FStar_Syntax_Syntax.comp = bind_it
-                  }))
-let label:
-  Prims.string ->
-    FStar_Range.range ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax
-  =
-  fun reason  ->
-    fun r  ->
-      fun f  ->
-        (FStar_Syntax_Syntax.mk
-           (FStar_Syntax_Syntax.Tm_meta
-              (f, (FStar_Syntax_Syntax.Meta_labeled (reason, r, false)))))
-          None f.FStar_Syntax_Syntax.pos
-let label_opt:
-  FStar_TypeChecker_Env.env ->
-    (Prims.unit -> Prims.string) Prims.option ->
-      FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-  =
-  fun env  ->
-    fun reason  ->
-      fun r  ->
-        fun f  ->
-          match reason with
-          | None  -> f
-          | Some reason1 ->
-              let uu____3308 =
-                let uu____3309 = FStar_TypeChecker_Env.should_verify env in
-                FStar_All.pipe_left Prims.op_Negation uu____3309 in
-              if uu____3308
-              then f
-              else (let uu____3311 = reason1 () in label uu____3311 r f)
-let label_guard:
-  FStar_Range.range ->
-    Prims.string ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
-  =
-  fun r  ->
-    fun reason  ->
-      fun g  ->
-        match g.FStar_TypeChecker_Env.guard_f with
-        | FStar_TypeChecker_Common.Trivial  -> g
-        | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___127_3322 = g in
-            let uu____3323 =
-              let uu____3324 = label reason r f in
-              FStar_TypeChecker_Common.NonTrivial uu____3324 in
-            {
-              FStar_TypeChecker_Env.guard_f = uu____3323;
-              FStar_TypeChecker_Env.deferred =
-                (uu___127_3322.FStar_TypeChecker_Env.deferred);
-              FStar_TypeChecker_Env.univ_ineqs =
-                (uu___127_3322.FStar_TypeChecker_Env.univ_ineqs);
-              FStar_TypeChecker_Env.implicits =
-                (uu___127_3322.FStar_TypeChecker_Env.implicits)
-            }
-let weaken_guard:
-  FStar_TypeChecker_Common.guard_formula ->
-    FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula
-  =
-  fun g1  ->
-    fun g2  ->
-      match (g1, g2) with
-      | (FStar_TypeChecker_Common.NonTrivial
-         f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let g = FStar_Syntax_Util.mk_imp f1 f2 in
-          FStar_TypeChecker_Common.NonTrivial g
-      | uu____3334 -> g2
-let weaken_precondition:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.lcomp ->
-      FStar_TypeChecker_Common.guard_formula -> FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun lc  ->
-      fun f  ->
-        let weaken uu____3351 =
-          let c = lc.FStar_Syntax_Syntax.comp () in
-          let uu____3355 =
-            env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-          if uu____3355
-          then c
-          else
-            (match f with
-             | FStar_TypeChecker_Common.Trivial  -> c
-             | FStar_TypeChecker_Common.NonTrivial f1 ->
-                 let uu____3362 = FStar_Syntax_Util.is_ml_comp c in
-                 if uu____3362
-                 then c
-                 else
-                   (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                    let uu____3367 = destruct_comp c1 in
-                    match uu____3367 with
-                    | (u_res_t,res_t,wp) ->
-                        let md =
-                          FStar_TypeChecker_Env.get_effect_decl env
-                            c1.FStar_Syntax_Syntax.effect_name in
-                        let wp1 =
-                          let uu____3380 =
-                            let uu____3381 =
-                              FStar_TypeChecker_Env.inst_effect_fun_with
-                                [u_res_t] env md
-                                md.FStar_Syntax_Syntax.assume_p in
-                            let uu____3382 =
-                              let uu____3383 =
-                                FStar_Syntax_Syntax.as_arg res_t in
-                              let uu____3384 =
-                                let uu____3386 =
-                                  FStar_Syntax_Syntax.as_arg f1 in
-                                let uu____3387 =
-                                  let uu____3389 =
-                                    FStar_Syntax_Syntax.as_arg wp in
-                                  [uu____3389] in
-                                uu____3386 :: uu____3387 in
-                              uu____3383 :: uu____3384 in
-                            FStar_Syntax_Syntax.mk_Tm_app uu____3381
-                              uu____3382 in
-                          uu____3380 None wp.FStar_Syntax_Syntax.pos in
-                        (mk_comp md) u_res_t res_t wp1
-                          c1.FStar_Syntax_Syntax.flags)) in
-        let uu___128_3394 = lc in
-        {
-          FStar_Syntax_Syntax.eff_name =
-            (uu___128_3394.FStar_Syntax_Syntax.eff_name);
-          FStar_Syntax_Syntax.res_typ =
-            (uu___128_3394.FStar_Syntax_Syntax.res_typ);
-          FStar_Syntax_Syntax.cflags =
-            (uu___128_3394.FStar_Syntax_Syntax.cflags);
-          FStar_Syntax_Syntax.comp = weaken
-        }
-let strengthen_precondition:
-  (Prims.unit -> Prims.string) Prims.option ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.lcomp ->
-          FStar_TypeChecker_Env.guard_t ->
-            (FStar_Syntax_Syntax.lcomp* FStar_TypeChecker_Env.guard_t)
-  =
-  fun reason  ->
-    fun env  ->
-      fun e  ->
-        fun lc  ->
-          fun g0  ->
-            let uu____3421 = FStar_TypeChecker_Rel.is_trivial g0 in
-            if uu____3421
-            then (lc, g0)
-            else
-              ((let uu____3426 =
-                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    FStar_Options.Extreme in
-                if uu____3426
-                then
-                  let uu____3427 =
-                    FStar_TypeChecker_Normalize.term_to_string env e in
-                  let uu____3428 =
-                    FStar_TypeChecker_Rel.guard_to_string env g0 in
-                  FStar_Util.print2
-                    "+++++++++++++Strengthening pre-condition of term %s with guard %s\n"
-                    uu____3427 uu____3428
-                else ());
-               (let flags =
-                  FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
-                    (FStar_List.collect
-                       (fun uu___95_3434  ->
-                          match uu___95_3434 with
-                          | FStar_Syntax_Syntax.RETURN 
-                            |FStar_Syntax_Syntax.PARTIAL_RETURN  ->
-                              [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                          | uu____3436 -> [])) in
-                let strengthen uu____3442 =
-                  let c = lc.FStar_Syntax_Syntax.comp () in
-                  if env.FStar_TypeChecker_Env.lax
-                  then c
-                  else
-                    (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0 in
-                     let uu____3450 = FStar_TypeChecker_Rel.guard_form g01 in
-                     match uu____3450 with
-                     | FStar_TypeChecker_Common.Trivial  -> c
-                     | FStar_TypeChecker_Common.NonTrivial f ->
-                         let c1 =
-                           let uu____3457 =
-                             (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
-                               (let uu____3458 =
-                                  FStar_Syntax_Util.is_partial_return c in
-                                Prims.op_Negation uu____3458) in
-                           if uu____3457
-                           then
-                             let x =
-                               FStar_Syntax_Syntax.gen_bv "strengthen_pre_x"
-                                 None (FStar_Syntax_Util.comp_result c) in
-                             let xret =
-                               let uu____3465 =
-                                 let uu____3466 =
-                                   FStar_Syntax_Syntax.bv_to_name x in
-                                 return_value env x.FStar_Syntax_Syntax.sort
-                                   uu____3466 in
-                               FStar_Syntax_Util.comp_set_flags uu____3465
-                                 [FStar_Syntax_Syntax.PARTIAL_RETURN] in
-                             let lc1 =
-                               bind e.FStar_Syntax_Syntax.pos env (Some e)
-                                 (FStar_Syntax_Util.lcomp_of_comp c)
-                                 ((Some x),
-                                   (FStar_Syntax_Util.lcomp_of_comp xret)) in
-                             lc1.FStar_Syntax_Syntax.comp ()
-                           else c in
-                         ((let uu____3471 =
-                             FStar_All.pipe_left
-                               (FStar_TypeChecker_Env.debug env)
-                               FStar_Options.Extreme in
-                           if uu____3471
-                           then
-                             let uu____3472 =
-                               FStar_TypeChecker_Normalize.term_to_string env
-                                 e in
-                             let uu____3473 =
-                               FStar_TypeChecker_Normalize.term_to_string env
-                                 f in
-                             FStar_Util.print2
-                               "-------------Strengthening pre-condition of term %s with guard %s\n"
-                               uu____3472 uu____3473
-                           else ());
-                          (let c2 =
-                             FStar_TypeChecker_Env.unfold_effect_abbrev env
-                               c1 in
-                           let uu____3476 = destruct_comp c2 in
-                           match uu____3476 with
-                           | (u_res_t,res_t,wp) ->
-                               let md =
-                                 FStar_TypeChecker_Env.get_effect_decl env
-                                   c2.FStar_Syntax_Syntax.effect_name in
-                               let wp1 =
-                                 let uu____3489 =
-                                   let uu____3490 =
-                                     FStar_TypeChecker_Env.inst_effect_fun_with
-                                       [u_res_t] env md
-                                       md.FStar_Syntax_Syntax.assert_p in
-                                   let uu____3491 =
-                                     let uu____3492 =
-                                       FStar_Syntax_Syntax.as_arg res_t in
-                                     let uu____3493 =
-                                       let uu____3495 =
-                                         let uu____3496 =
-                                           let uu____3497 =
-                                             FStar_TypeChecker_Env.get_range
-                                               env in
-                                           label_opt env reason uu____3497 f in
-                                         FStar_All.pipe_left
-                                           FStar_Syntax_Syntax.as_arg
-                                           uu____3496 in
-                                       let uu____3498 =
-                                         let uu____3500 =
-                                           FStar_Syntax_Syntax.as_arg wp in
-                                         [uu____3500] in
-                                       uu____3495 :: uu____3498 in
-                                     uu____3492 :: uu____3493 in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____3490
-                                     uu____3491 in
-                                 uu____3489 None wp.FStar_Syntax_Syntax.pos in
-                               ((let uu____3506 =
-                                   FStar_All.pipe_left
-                                     (FStar_TypeChecker_Env.debug env)
-                                     FStar_Options.Extreme in
-                                 if uu____3506
-                                 then
-                                   let uu____3507 =
-                                     FStar_Syntax_Print.term_to_string wp1 in
-                                   FStar_Util.print1
-                                     "-------------Strengthened pre-condition is %s\n"
-                                     uu____3507
-                                 else ());
-                                (let c21 =
-                                   (mk_comp md) u_res_t res_t wp1 flags in
-                                 c21))))) in
-                let uu____3510 =
-                  let uu___129_3511 = lc in
-                  let uu____3512 =
-                    FStar_TypeChecker_Env.norm_eff_name env
-                      lc.FStar_Syntax_Syntax.eff_name in
-                  let uu____3513 =
-                    let uu____3515 =
-                      (FStar_Syntax_Util.is_pure_lcomp lc) &&
-                        (let uu____3516 =
-                           FStar_Syntax_Util.is_function_typ
-                             lc.FStar_Syntax_Syntax.res_typ in
-                         FStar_All.pipe_left Prims.op_Negation uu____3516) in
-                    if uu____3515 then flags else [] in
-                  {
-                    FStar_Syntax_Syntax.eff_name = uu____3512;
-                    FStar_Syntax_Syntax.res_typ =
-                      (uu___129_3511.FStar_Syntax_Syntax.res_typ);
-                    FStar_Syntax_Syntax.cflags = uu____3513;
-                    FStar_Syntax_Syntax.comp = strengthen
-                  } in
-                (uu____3510,
-                  (let uu___130_3519 = g0 in
-                   {
-                     FStar_TypeChecker_Env.guard_f =
-                       FStar_TypeChecker_Common.Trivial;
-                     FStar_TypeChecker_Env.deferred =
-                       (uu___130_3519.FStar_TypeChecker_Env.deferred);
-                     FStar_TypeChecker_Env.univ_ineqs =
-                       (uu___130_3519.FStar_TypeChecker_Env.univ_ineqs);
-                     FStar_TypeChecker_Env.implicits =
-                       (uu___130_3519.FStar_TypeChecker_Env.implicits)
-                   }))))
-let add_equality_to_post_condition:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.comp',Prims.unit) FStar_Syntax_Syntax.syntax
-  =
-  fun env  ->
-    fun comp  ->
-      fun res_t  ->
-        let md_pure =
-          FStar_TypeChecker_Env.get_effect_decl env
-            FStar_Syntax_Const.effect_PURE_lid in
-        let x = FStar_Syntax_Syntax.new_bv None res_t in
-        let y = FStar_Syntax_Syntax.new_bv None res_t in
-        let uu____3534 =
-          let uu____3537 = FStar_Syntax_Syntax.bv_to_name x in
-          let uu____3538 = FStar_Syntax_Syntax.bv_to_name y in
-          (uu____3537, uu____3538) in
-        match uu____3534 with
-        | (xexp,yexp) ->
-            let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t in
-            let yret =
-              let uu____3547 =
-                let uu____3548 =
-                  FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t] env
-                    md_pure md_pure.FStar_Syntax_Syntax.ret_wp in
-                let uu____3549 =
-                  let uu____3550 = FStar_Syntax_Syntax.as_arg res_t in
-                  let uu____3551 =
-                    let uu____3553 = FStar_Syntax_Syntax.as_arg yexp in
-                    [uu____3553] in
-                  uu____3550 :: uu____3551 in
-                FStar_Syntax_Syntax.mk_Tm_app uu____3548 uu____3549 in
-              uu____3547 None res_t.FStar_Syntax_Syntax.pos in
-            let x_eq_y_yret =
-              let uu____3561 =
-                let uu____3562 =
-                  FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t] env
-                    md_pure md_pure.FStar_Syntax_Syntax.assume_p in
-                let uu____3563 =
-                  let uu____3564 = FStar_Syntax_Syntax.as_arg res_t in
-                  let uu____3565 =
-                    let uu____3567 =
-                      let uu____3568 =
-                        FStar_Syntax_Util.mk_eq2 u_res_t res_t xexp yexp in
-                      FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
-                        uu____3568 in
-                    let uu____3569 =
-                      let uu____3571 =
-                        FStar_All.pipe_left FStar_Syntax_Syntax.as_arg yret in
-                      [uu____3571] in
-                    uu____3567 :: uu____3569 in
-                  uu____3564 :: uu____3565 in
-                FStar_Syntax_Syntax.mk_Tm_app uu____3562 uu____3563 in
-              uu____3561 None res_t.FStar_Syntax_Syntax.pos in
-            let forall_y_x_eq_y_yret =
-              let uu____3579 =
-                let uu____3580 =
-                  FStar_TypeChecker_Env.inst_effect_fun_with
-                    [u_res_t; u_res_t] env md_pure
-                    md_pure.FStar_Syntax_Syntax.close_wp in
-                let uu____3581 =
-                  let uu____3582 = FStar_Syntax_Syntax.as_arg res_t in
-                  let uu____3583 =
-                    let uu____3585 = FStar_Syntax_Syntax.as_arg res_t in
-                    let uu____3586 =
-                      let uu____3588 =
-                        let uu____3589 =
-                          let uu____3590 =
-                            let uu____3594 = FStar_Syntax_Syntax.mk_binder y in
-                            [uu____3594] in
-                          FStar_Syntax_Util.abs uu____3590 x_eq_y_yret
-                            (Some
-                               (FStar_Util.Inr
-                                  (FStar_Syntax_Const.effect_Tot_lid,
-                                    [FStar_Syntax_Syntax.TOTAL]))) in
-                        FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
-                          uu____3589 in
-                      [uu____3588] in
-                    uu____3585 :: uu____3586 in
-                  uu____3582 :: uu____3583 in
-                FStar_Syntax_Syntax.mk_Tm_app uu____3580 uu____3581 in
-              uu____3579 None res_t.FStar_Syntax_Syntax.pos in
-            let lc2 =
-              (mk_comp md_pure) u_res_t res_t forall_y_x_eq_y_yret
-                [FStar_Syntax_Syntax.PARTIAL_RETURN] in
-            let lc =
-              let uu____3610 = FStar_TypeChecker_Env.get_range env in
-              bind uu____3610 env None (FStar_Syntax_Util.lcomp_of_comp comp)
-                ((Some x), (FStar_Syntax_Util.lcomp_of_comp lc2)) in
-            lc.FStar_Syntax_Syntax.comp ()
-let ite:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.formula ->
-      FStar_Syntax_Syntax.lcomp ->
-        FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun guard  ->
-      fun lcomp_then  ->
-        fun lcomp_else  ->
-          let joined_eff = join_lcomp env lcomp_then lcomp_else in
-          let comp uu____3628 =
-            let uu____3629 =
-              env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-            if uu____3629
-            then
-              let u_t =
-                env.FStar_TypeChecker_Env.universe_of env
-                  lcomp_then.FStar_Syntax_Syntax.res_typ in
-              lax_mk_tot_or_comp_l joined_eff u_t
-                lcomp_then.FStar_Syntax_Syntax.res_typ []
-            else
-              (let uu____3632 =
-                 let uu____3645 = lcomp_then.FStar_Syntax_Syntax.comp () in
-                 let uu____3646 = lcomp_else.FStar_Syntax_Syntax.comp () in
-                 lift_and_destruct env uu____3645 uu____3646 in
-               match uu____3632 with
-               | ((md,uu____3648,uu____3649),(u_res_t,res_t,wp_then),
-                  (uu____3653,uu____3654,wp_else)) ->
-                   let ifthenelse md1 res_t1 g wp_t wp_e =
-                     let uu____3683 =
-                       FStar_Range.union_ranges wp_t.FStar_Syntax_Syntax.pos
-                         wp_e.FStar_Syntax_Syntax.pos in
-                     let uu____3684 =
-                       let uu____3685 =
-                         FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t]
-                           env md1 md1.FStar_Syntax_Syntax.if_then_else in
-                       let uu____3686 =
-                         let uu____3687 = FStar_Syntax_Syntax.as_arg res_t1 in
-                         let uu____3688 =
-                           let uu____3690 = FStar_Syntax_Syntax.as_arg g in
-                           let uu____3691 =
-                             let uu____3693 = FStar_Syntax_Syntax.as_arg wp_t in
-                             let uu____3694 =
-                               let uu____3696 =
-                                 FStar_Syntax_Syntax.as_arg wp_e in
-                               [uu____3696] in
-                             uu____3693 :: uu____3694 in
-                           uu____3690 :: uu____3691 in
-                         uu____3687 :: uu____3688 in
-                       FStar_Syntax_Syntax.mk_Tm_app uu____3685 uu____3686 in
-                     uu____3684 None uu____3683 in
-                   let wp = ifthenelse md res_t guard wp_then wp_else in
-                   let uu____3704 =
-                     let uu____3705 = FStar_Options.split_cases () in
-                     uu____3705 > (Prims.parse_int "0") in
-                   if uu____3704
-                   then
-                     let comp = (mk_comp md) u_res_t res_t wp [] in
-                     add_equality_to_post_condition env comp res_t
-                   else
-                     (let wp1 =
-                        let uu____3711 =
-                          let uu____3712 =
-                            FStar_TypeChecker_Env.inst_effect_fun_with
-                              [u_res_t] env md md.FStar_Syntax_Syntax.ite_wp in
-                          let uu____3713 =
-                            let uu____3714 = FStar_Syntax_Syntax.as_arg res_t in
-                            let uu____3715 =
-                              let uu____3717 = FStar_Syntax_Syntax.as_arg wp in
-                              [uu____3717] in
-                            uu____3714 :: uu____3715 in
-                          FStar_Syntax_Syntax.mk_Tm_app uu____3712 uu____3713 in
-                        uu____3711 None wp.FStar_Syntax_Syntax.pos in
-                      (mk_comp md) u_res_t res_t wp1 [])) in
-          let uu____3722 =
-            join_effects env lcomp_then.FStar_Syntax_Syntax.eff_name
-              lcomp_else.FStar_Syntax_Syntax.eff_name in
-          {
-            FStar_Syntax_Syntax.eff_name = uu____3722;
-            FStar_Syntax_Syntax.res_typ =
-              (lcomp_then.FStar_Syntax_Syntax.res_typ);
-            FStar_Syntax_Syntax.cflags = [];
-            FStar_Syntax_Syntax.comp = comp
-          }
-let fvar_const:
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun lid  ->
-      let uu____3729 =
-        let uu____3730 = FStar_TypeChecker_Env.get_range env in
-        FStar_Ident.set_lid_range lid uu____3730 in
-      FStar_Syntax_Syntax.fvar uu____3729 FStar_Syntax_Syntax.Delta_constant
-        None
-let bind_cases:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ ->
-      (FStar_Syntax_Syntax.formula* FStar_Syntax_Syntax.lcomp) Prims.list ->
-        FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun res_t  ->
-      fun lcases  ->
-        let eff =
-          FStar_List.fold_left
-            (fun eff  ->
-               fun uu____3750  ->
-                 match uu____3750 with
-                 | (uu____3753,lc) ->
-                     join_effects env eff lc.FStar_Syntax_Syntax.eff_name)
-            FStar_Syntax_Const.effect_PURE_lid lcases in
-        let bind_cases uu____3758 =
-          let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t in
-          let uu____3760 =
-            env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-          if uu____3760
-          then lax_mk_tot_or_comp_l eff u_res_t res_t []
-          else
-            (let ifthenelse md res_t1 g wp_t wp_e =
-               let uu____3780 =
-                 FStar_Range.union_ranges wp_t.FStar_Syntax_Syntax.pos
-                   wp_e.FStar_Syntax_Syntax.pos in
-               let uu____3781 =
-                 let uu____3782 =
-                   FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t] env
-                     md md.FStar_Syntax_Syntax.if_then_else in
-                 let uu____3783 =
-                   let uu____3784 = FStar_Syntax_Syntax.as_arg res_t1 in
-                   let uu____3785 =
-                     let uu____3787 = FStar_Syntax_Syntax.as_arg g in
-                     let uu____3788 =
-                       let uu____3790 = FStar_Syntax_Syntax.as_arg wp_t in
-                       let uu____3791 =
-                         let uu____3793 = FStar_Syntax_Syntax.as_arg wp_e in
-                         [uu____3793] in
-                       uu____3790 :: uu____3791 in
-                     uu____3787 :: uu____3788 in
-                   uu____3784 :: uu____3785 in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____3782 uu____3783 in
-               uu____3781 None uu____3780 in
-             let default_case =
-               let post_k =
-                 let uu____3802 =
-                   let uu____3806 = FStar_Syntax_Syntax.null_binder res_t in
-                   [uu____3806] in
-                 let uu____3807 =
-                   FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-                 FStar_Syntax_Util.arrow uu____3802 uu____3807 in
-               let kwp =
-                 let uu____3813 =
-                   let uu____3817 = FStar_Syntax_Syntax.null_binder post_k in
-                   [uu____3817] in
-                 let uu____3818 =
-                   FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-                 FStar_Syntax_Util.arrow uu____3813 uu____3818 in
-               let post = FStar_Syntax_Syntax.new_bv None post_k in
-               let wp =
-                 let uu____3823 =
-                   let uu____3827 = FStar_Syntax_Syntax.mk_binder post in
-                   [uu____3827] in
-                 let uu____3828 =
-                   let uu____3829 =
-                     let uu____3832 = FStar_TypeChecker_Env.get_range env in
-                     label FStar_TypeChecker_Err.exhaustiveness_check
-                       uu____3832 in
-                   let uu____3833 =
-                     fvar_const env FStar_Syntax_Const.false_lid in
-                   FStar_All.pipe_left uu____3829 uu____3833 in
-                 FStar_Syntax_Util.abs uu____3823 uu____3828
-                   (Some
-                      (FStar_Util.Inr
-                         (FStar_Syntax_Const.effect_Tot_lid,
-                           [FStar_Syntax_Syntax.TOTAL]))) in
-               let md =
-                 FStar_TypeChecker_Env.get_effect_decl env
-                   FStar_Syntax_Const.effect_PURE_lid in
-               (mk_comp md) u_res_t res_t wp [] in
-             let comp =
-               FStar_List.fold_right
-                 (fun uu____3847  ->
-                    fun celse  ->
-                      match uu____3847 with
-                      | (g,cthen) ->
-                          let uu____3853 =
-                            let uu____3866 =
-                              cthen.FStar_Syntax_Syntax.comp () in
-                            lift_and_destruct env uu____3866 celse in
-                          (match uu____3853 with
-                           | ((md,uu____3868,uu____3869),(uu____3870,uu____3871,wp_then),
-                              (uu____3873,uu____3874,wp_else)) ->
-                               let uu____3885 =
-                                 ifthenelse md res_t g wp_then wp_else in
-                               (mk_comp md) u_res_t res_t uu____3885 []))
-                 lcases default_case in
-             let uu____3886 =
-               let uu____3887 = FStar_Options.split_cases () in
-               uu____3887 > (Prims.parse_int "0") in
-             if uu____3886
-             then add_equality_to_post_condition env comp res_t
-             else
-               (let comp1 = FStar_TypeChecker_Env.comp_to_comp_typ env comp in
-                let md =
-                  FStar_TypeChecker_Env.get_effect_decl env
-                    comp1.FStar_Syntax_Syntax.effect_name in
-                let uu____3891 = destruct_comp comp1 in
-                match uu____3891 with
-                | (uu____3895,uu____3896,wp) ->
-                    let wp1 =
-                      let uu____3901 =
-                        let uu____3902 =
-                          FStar_TypeChecker_Env.inst_effect_fun_with
-                            [u_res_t] env md md.FStar_Syntax_Syntax.ite_wp in
-                        let uu____3903 =
-                          let uu____3904 = FStar_Syntax_Syntax.as_arg res_t in
-                          let uu____3905 =
-                            let uu____3907 = FStar_Syntax_Syntax.as_arg wp in
-                            [uu____3907] in
-                          uu____3904 :: uu____3905 in
-                        FStar_Syntax_Syntax.mk_Tm_app uu____3902 uu____3903 in
-                      uu____3901 None wp.FStar_Syntax_Syntax.pos in
-                    (mk_comp md) u_res_t res_t wp1 [])) in
-        {
-          FStar_Syntax_Syntax.eff_name = eff;
-          FStar_Syntax_Syntax.res_typ = res_t;
-          FStar_Syntax_Syntax.cflags = [];
-          FStar_Syntax_Syntax.comp = bind_cases
-        }
-let close_comp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.bv Prims.list ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun bvs  ->
-      fun lc  ->
-        let close1 uu____3928 =
-          let c = lc.FStar_Syntax_Syntax.comp () in
-          let uu____3932 = FStar_Syntax_Util.is_ml_comp c in
-          if uu____3932
-          then c
-          else
-            (let uu____3936 =
-               env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-             if uu____3936
-             then c
-             else
-               (let close_wp u_res md res_t bvs1 wp0 =
-                  FStar_List.fold_right
-                    (fun x  ->
-                       fun wp  ->
-                         let bs =
-                           let uu____3968 = FStar_Syntax_Syntax.mk_binder x in
-                           [uu____3968] in
-                         let us =
-                           let uu____3971 =
-                             let uu____3973 =
-                               env.FStar_TypeChecker_Env.universe_of env
-                                 x.FStar_Syntax_Syntax.sort in
-                             [uu____3973] in
-                           u_res :: uu____3971 in
-                         let wp1 =
-                           FStar_Syntax_Util.abs bs wp
-                             (Some
-                                (FStar_Util.Inr
-                                   (FStar_Syntax_Const.effect_Tot_lid,
-                                     [FStar_Syntax_Syntax.TOTAL]))) in
-                         let uu____3984 =
-                           let uu____3985 =
-                             FStar_TypeChecker_Env.inst_effect_fun_with us
-                               env md md.FStar_Syntax_Syntax.close_wp in
-                           let uu____3986 =
-                             let uu____3987 =
-                               FStar_Syntax_Syntax.as_arg res_t in
-                             let uu____3988 =
-                               let uu____3990 =
-                                 FStar_Syntax_Syntax.as_arg
-                                   x.FStar_Syntax_Syntax.sort in
-                               let uu____3991 =
-                                 let uu____3993 =
-                                   FStar_Syntax_Syntax.as_arg wp1 in
-                                 [uu____3993] in
-                               uu____3990 :: uu____3991 in
-                             uu____3987 :: uu____3988 in
-                           FStar_Syntax_Syntax.mk_Tm_app uu____3985
-                             uu____3986 in
-                         uu____3984 None wp0.FStar_Syntax_Syntax.pos) bvs1
-                    wp0 in
-                let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                let uu____3999 = destruct_comp c1 in
-                match uu____3999 with
-                | (u_res_t,res_t,wp) ->
-                    let md =
-                      FStar_TypeChecker_Env.get_effect_decl env
-                        c1.FStar_Syntax_Syntax.effect_name in
-                    let wp1 = close_wp u_res_t md res_t bvs wp in
-                    (mk_comp md) u_res_t c1.FStar_Syntax_Syntax.result_typ
-                      wp1 c1.FStar_Syntax_Syntax.flags)) in
-        let uu___131_4010 = lc in
-        {
-          FStar_Syntax_Syntax.eff_name =
-            (uu___131_4010.FStar_Syntax_Syntax.eff_name);
-          FStar_Syntax_Syntax.res_typ =
-            (uu___131_4010.FStar_Syntax_Syntax.res_typ);
-          FStar_Syntax_Syntax.cflags =
-            (uu___131_4010.FStar_Syntax_Syntax.cflags);
-          FStar_Syntax_Syntax.comp = close1
-        }
-let maybe_assume_result_eq_pure_term:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
-  =
-  fun env  ->
-    fun e  ->
-      fun lc  ->
-        let refine1 uu____4025 =
-          let c = lc.FStar_Syntax_Syntax.comp () in
-          let uu____4029 =
-            (let uu____4030 =
-               is_pure_or_ghost_effect env lc.FStar_Syntax_Syntax.eff_name in
-             Prims.op_Negation uu____4030) || env.FStar_TypeChecker_Env.lax in
-          if uu____4029
-          then c
-          else
-            (let uu____4034 = FStar_Syntax_Util.is_partial_return c in
-             if uu____4034
-             then c
-             else
-               (let uu____4038 =
-                  (FStar_Syntax_Util.is_tot_or_gtot_comp c) &&
-                    (let uu____4039 =
-                       FStar_TypeChecker_Env.lid_exists env
-                         FStar_Syntax_Const.effect_GTot_lid in
-                     Prims.op_Negation uu____4039) in
-                if uu____4038
-                then
-                  let uu____4042 =
-                    let uu____4043 =
-                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                    let uu____4044 = FStar_Syntax_Print.term_to_string e in
-                    FStar_Util.format2 "%s: %s\n" uu____4043 uu____4044 in
-                  failwith uu____4042
-                else
-                  (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                   let t = c1.FStar_Syntax_Syntax.result_typ in
-                   let c2 = FStar_Syntax_Syntax.mk_Comp c1 in
-                   let x =
-                     FStar_Syntax_Syntax.new_bv
-                       (Some (t.FStar_Syntax_Syntax.pos)) t in
-                   let xexp = FStar_Syntax_Syntax.bv_to_name x in
-                   let ret1 =
-                     let uu____4056 =
-                       let uu____4059 = return_value env t xexp in
-                       FStar_Syntax_Util.comp_set_flags uu____4059
-                         [FStar_Syntax_Syntax.PARTIAL_RETURN] in
-                     FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                       uu____4056 in
-                   let eq1 =
-                     let uu____4063 =
-                       env.FStar_TypeChecker_Env.universe_of env t in
-                     FStar_Syntax_Util.mk_eq2 uu____4063 t xexp e in
-                   let eq_ret =
-                     weaken_precondition env ret1
-                       (FStar_TypeChecker_Common.NonTrivial eq1) in
-                   let c3 =
-                     let uu____4068 =
-                       let uu____4069 =
-                         let uu____4074 =
-                           bind e.FStar_Syntax_Syntax.pos env None
-                             (FStar_Syntax_Util.lcomp_of_comp c2)
-                             ((Some x), eq_ret) in
-                         uu____4074.FStar_Syntax_Syntax.comp in
-                       uu____4069 () in
-                     FStar_Syntax_Util.comp_set_flags uu____4068
-                       (FStar_Syntax_Syntax.PARTIAL_RETURN ::
-                       (FStar_Syntax_Util.comp_flags c2)) in
-                   c3))) in
-        let flags =
-          let uu____4078 =
-            ((let uu____4079 =
-                FStar_Syntax_Util.is_function_typ
-                  lc.FStar_Syntax_Syntax.res_typ in
-              Prims.op_Negation uu____4079) &&
-               (FStar_Syntax_Util.is_pure_or_ghost_lcomp lc))
-              &&
-              (let uu____4080 = FStar_Syntax_Util.is_lcomp_partial_return lc in
-               Prims.op_Negation uu____4080) in
-          if uu____4078
-          then FStar_Syntax_Syntax.PARTIAL_RETURN ::
-            (lc.FStar_Syntax_Syntax.cflags)
-          else lc.FStar_Syntax_Syntax.cflags in
-        let uu___132_4083 = lc in
-        {
-          FStar_Syntax_Syntax.eff_name =
-            (uu___132_4083.FStar_Syntax_Syntax.eff_name);
-          FStar_Syntax_Syntax.res_typ =
-            (uu___132_4083.FStar_Syntax_Syntax.res_typ);
-          FStar_Syntax_Syntax.cflags = flags;
-          FStar_Syntax_Syntax.comp = refine1
-        }
-let check_comp:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.comp ->
-        FStar_Syntax_Syntax.comp ->
-          (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.comp*
-            FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun c  ->
-        fun c'  ->
-          let uu____4102 = FStar_TypeChecker_Rel.sub_comp env c c' in
-          match uu____4102 with
-          | None  ->
-              let uu____4107 =
-                let uu____4108 =
-                  let uu____4111 =
-                    FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation
-                      env e c c' in
-                  let uu____4112 = FStar_TypeChecker_Env.get_range env in
-                  (uu____4111, uu____4112) in
-                FStar_Errors.Error uu____4108 in
-              Prims.raise uu____4107
-          | Some g -> (e, c', g)
-let maybe_coerce_bool_to_type:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp ->
-        FStar_Syntax_Syntax.term ->
-          (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp)
-  =
-  fun env  ->
-    fun e  ->
-      fun lc  ->
-        fun t  ->
-          let uu____4133 =
-            let uu____4134 = FStar_Syntax_Subst.compress t in
-            uu____4134.FStar_Syntax_Syntax.n in
-          match uu____4133 with
-          | FStar_Syntax_Syntax.Tm_type uu____4139 ->
-              let uu____4140 =
-                let uu____4141 =
-                  FStar_Syntax_Subst.compress lc.FStar_Syntax_Syntax.res_typ in
-                uu____4141.FStar_Syntax_Syntax.n in
-              (match uu____4140 with
-               | FStar_Syntax_Syntax.Tm_fvar fv when
-                   FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Syntax_Const.bool_lid
-                   ->
-                   let uu____4147 =
-                     FStar_TypeChecker_Env.lookup_lid env
-                       FStar_Syntax_Const.b2t_lid in
-                   let b2t1 =
-                     FStar_Syntax_Syntax.fvar
-                       (FStar_Ident.set_lid_range FStar_Syntax_Const.b2t_lid
-                          e.FStar_Syntax_Syntax.pos)
-                       (FStar_Syntax_Syntax.Delta_defined_at_level
-                          (Prims.parse_int "1")) None in
-                   let lc1 =
-                     let uu____4154 =
-                       let uu____4155 =
-                         let uu____4156 =
-                           FStar_Syntax_Syntax.mk_Total
-                             FStar_Syntax_Util.ktype0 in
-                         FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                           uu____4156 in
-                       (None, uu____4155) in
-                     bind e.FStar_Syntax_Syntax.pos env (Some e) lc
-                       uu____4154 in
-                   let e1 =
-                     let uu____4165 =
-                       let uu____4166 =
-                         let uu____4167 = FStar_Syntax_Syntax.as_arg e in
-                         [uu____4167] in
-                       FStar_Syntax_Syntax.mk_Tm_app b2t1 uu____4166 in
-                     uu____4165
-                       (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                       e.FStar_Syntax_Syntax.pos in
-                   (e1, lc1)
-               | uu____4174 -> (e, lc))
-          | uu____4175 -> (e, lc)
-let weaken_result_typ:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp ->
-        FStar_Syntax_Syntax.typ ->
-          (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.lcomp*
-            FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun lc  ->
-        fun t  ->
-          let use_eq =
-            env.FStar_TypeChecker_Env.use_eq ||
-              (let uu____4195 =
-                 FStar_TypeChecker_Env.effect_decl_opt env
-                   lc.FStar_Syntax_Syntax.eff_name in
-               match uu____4195 with
-               | Some ed ->
-                   FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers
-                     (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-               | uu____4199 -> false) in
-          let gopt =
-            if use_eq
-            then
-              let uu____4208 =
-                FStar_TypeChecker_Rel.try_teq true env
-                  lc.FStar_Syntax_Syntax.res_typ t in
-              (uu____4208, false)
-            else
-              (let uu____4212 =
-                 FStar_TypeChecker_Rel.try_subtype env
-                   lc.FStar_Syntax_Syntax.res_typ t in
-               (uu____4212, true)) in
-          match gopt with
-          | (None ,uu____4218) ->
-              (FStar_TypeChecker_Rel.subtype_fail env e
-                 lc.FStar_Syntax_Syntax.res_typ t;
-               (e,
-                 ((let uu___133_4221 = lc in
-                   {
-                     FStar_Syntax_Syntax.eff_name =
-                       (uu___133_4221.FStar_Syntax_Syntax.eff_name);
-                     FStar_Syntax_Syntax.res_typ = t;
-                     FStar_Syntax_Syntax.cflags =
-                       (uu___133_4221.FStar_Syntax_Syntax.cflags);
-                     FStar_Syntax_Syntax.comp =
-                       (uu___133_4221.FStar_Syntax_Syntax.comp)
-                   })), FStar_TypeChecker_Rel.trivial_guard))
-          | (Some g,apply_guard1) ->
-              let uu____4225 = FStar_TypeChecker_Rel.guard_form g in
-              (match uu____4225 with
-               | FStar_TypeChecker_Common.Trivial  ->
-                   let lc1 =
-                     let uu___134_4230 = lc in
-                     {
-                       FStar_Syntax_Syntax.eff_name =
-                         (uu___134_4230.FStar_Syntax_Syntax.eff_name);
-                       FStar_Syntax_Syntax.res_typ = t;
-                       FStar_Syntax_Syntax.cflags =
-                         (uu___134_4230.FStar_Syntax_Syntax.cflags);
-                       FStar_Syntax_Syntax.comp =
-                         (uu___134_4230.FStar_Syntax_Syntax.comp)
-                     } in
-                   (e, lc1, g)
-               | FStar_TypeChecker_Common.NonTrivial f ->
-                   let g1 =
-                     let uu___135_4233 = g in
-                     {
-                       FStar_TypeChecker_Env.guard_f =
-                         FStar_TypeChecker_Common.Trivial;
-                       FStar_TypeChecker_Env.deferred =
-                         (uu___135_4233.FStar_TypeChecker_Env.deferred);
-                       FStar_TypeChecker_Env.univ_ineqs =
-                         (uu___135_4233.FStar_TypeChecker_Env.univ_ineqs);
-                       FStar_TypeChecker_Env.implicits =
-                         (uu___135_4233.FStar_TypeChecker_Env.implicits)
-                     } in
-                   let strengthen uu____4239 =
-                     let uu____4240 =
-                       env.FStar_TypeChecker_Env.lax &&
-                         (FStar_Options.ml_ish ()) in
-                     if uu____4240
-                     then lc.FStar_Syntax_Syntax.comp ()
-                     else
-                       (let f1 =
-                          FStar_TypeChecker_Normalize.normalize
-                            [FStar_TypeChecker_Normalize.Beta;
-                            FStar_TypeChecker_Normalize.Eager_unfolding;
-                            FStar_TypeChecker_Normalize.Simplify] env f in
-                        let uu____4245 =
-                          let uu____4246 = FStar_Syntax_Subst.compress f1 in
-                          uu____4246.FStar_Syntax_Syntax.n in
-                        match uu____4245 with
-                        | FStar_Syntax_Syntax.Tm_abs
-                            (uu____4251,{
-                                          FStar_Syntax_Syntax.n =
-                                            FStar_Syntax_Syntax.Tm_fvar fv;
-                                          FStar_Syntax_Syntax.tk = uu____4253;
-                                          FStar_Syntax_Syntax.pos =
-                                            uu____4254;
-                                          FStar_Syntax_Syntax.vars =
-                                            uu____4255;_},uu____4256)
-                            when
-                            FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Syntax_Const.true_lid
-                            ->
-                            let lc1 =
-                              let uu___136_4280 = lc in
-                              {
-                                FStar_Syntax_Syntax.eff_name =
-                                  (uu___136_4280.FStar_Syntax_Syntax.eff_name);
-                                FStar_Syntax_Syntax.res_typ = t;
-                                FStar_Syntax_Syntax.cflags =
-                                  (uu___136_4280.FStar_Syntax_Syntax.cflags);
-                                FStar_Syntax_Syntax.comp =
-                                  (uu___136_4280.FStar_Syntax_Syntax.comp)
-                              } in
-                            lc1.FStar_Syntax_Syntax.comp ()
-                        | uu____4281 ->
-                            let c = lc.FStar_Syntax_Syntax.comp () in
-                            ((let uu____4286 =
-                                FStar_All.pipe_left
-                                  (FStar_TypeChecker_Env.debug env)
-                                  FStar_Options.Extreme in
-                              if uu____4286
-                              then
-                                let uu____4287 =
-                                  FStar_TypeChecker_Normalize.term_to_string
-                                    env lc.FStar_Syntax_Syntax.res_typ in
-                                let uu____4288 =
-                                  FStar_TypeChecker_Normalize.term_to_string
-                                    env t in
-                                let uu____4289 =
-                                  FStar_TypeChecker_Normalize.comp_to_string
-                                    env c in
-                                let uu____4290 =
-                                  FStar_TypeChecker_Normalize.term_to_string
-                                    env f1 in
-                                FStar_Util.print4
-                                  "Weakened from %s to %s\nStrengthening %s with guard %s\n"
-                                  uu____4287 uu____4288 uu____4289 uu____4290
-                              else ());
-                             (let ct =
-                                FStar_TypeChecker_Env.unfold_effect_abbrev
-                                  env c in
-                              let uu____4293 =
-                                FStar_TypeChecker_Env.wp_signature env
-                                  FStar_Syntax_Const.effect_PURE_lid in
-                              match uu____4293 with
-                              | (a,kwp) ->
-                                  let k =
-                                    FStar_Syntax_Subst.subst
-                                      [FStar_Syntax_Syntax.NT (a, t)] kwp in
-                                  let md =
-                                    FStar_TypeChecker_Env.get_effect_decl env
-                                      ct.FStar_Syntax_Syntax.effect_name in
-                                  let x =
-                                    FStar_Syntax_Syntax.new_bv
-                                      (Some (t.FStar_Syntax_Syntax.pos)) t in
-                                  let xexp = FStar_Syntax_Syntax.bv_to_name x in
-                                  let uu____4304 = destruct_comp ct in
-                                  (match uu____4304 with
-                                   | (u_t,uu____4311,uu____4312) ->
-                                       let wp =
-                                         let uu____4316 =
-                                           let uu____4317 =
-                                             FStar_TypeChecker_Env.inst_effect_fun_with
-                                               [u_t] env md
-                                               md.FStar_Syntax_Syntax.ret_wp in
-                                           let uu____4318 =
-                                             let uu____4319 =
-                                               FStar_Syntax_Syntax.as_arg t in
-                                             let uu____4320 =
-                                               let uu____4322 =
-                                                 FStar_Syntax_Syntax.as_arg
-                                                   xexp in
-                                               [uu____4322] in
-                                             uu____4319 :: uu____4320 in
-                                           FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____4317 uu____4318 in
-                                         uu____4316
-                                           (Some (k.FStar_Syntax_Syntax.n))
-                                           xexp.FStar_Syntax_Syntax.pos in
-                                       let cret =
-                                         let uu____4328 =
-                                           (mk_comp md) u_t t wp
-                                             [FStar_Syntax_Syntax.RETURN] in
-                                         FStar_All.pipe_left
-                                           FStar_Syntax_Util.lcomp_of_comp
-                                           uu____4328 in
-                                       let guard =
-                                         if apply_guard1
-                                         then
-                                           let uu____4338 =
-                                             let uu____4339 =
-                                               let uu____4340 =
-                                                 FStar_Syntax_Syntax.as_arg
-                                                   xexp in
-                                               [uu____4340] in
-                                             FStar_Syntax_Syntax.mk_Tm_app f1
-                                               uu____4339 in
-                                           uu____4338
-                                             (Some
-                                                (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                                             f1.FStar_Syntax_Syntax.pos
-                                         else f1 in
-                                       let uu____4346 =
-                                         let uu____4349 =
-                                           FStar_All.pipe_left
-                                             (fun _0_28  -> Some _0_28)
-                                             (FStar_TypeChecker_Err.subtyping_failed
-                                                env
-                                                lc.FStar_Syntax_Syntax.res_typ
-                                                t) in
-                                         let uu____4360 =
-                                           FStar_TypeChecker_Env.set_range
-                                             env e.FStar_Syntax_Syntax.pos in
-                                         let uu____4361 =
-                                           FStar_All.pipe_left
-                                             FStar_TypeChecker_Rel.guard_of_guard_formula
-                                             (FStar_TypeChecker_Common.NonTrivial
-                                                guard) in
-                                         strengthen_precondition uu____4349
-                                           uu____4360 e cret uu____4361 in
-                                       (match uu____4346 with
-                                        | (eq_ret,_trivial_so_ok_to_discard)
-                                            ->
-                                            let x1 =
-                                              let uu___137_4367 = x in
-                                              {
-                                                FStar_Syntax_Syntax.ppname =
-                                                  (uu___137_4367.FStar_Syntax_Syntax.ppname);
-                                                FStar_Syntax_Syntax.index =
-                                                  (uu___137_4367.FStar_Syntax_Syntax.index);
-                                                FStar_Syntax_Syntax.sort =
-                                                  (lc.FStar_Syntax_Syntax.res_typ)
-                                              } in
-                                            let c1 =
-                                              let uu____4369 =
-                                                let uu____4370 =
-                                                  FStar_Syntax_Syntax.mk_Comp
-                                                    ct in
-                                                FStar_All.pipe_left
-                                                  FStar_Syntax_Util.lcomp_of_comp
-                                                  uu____4370 in
-                                              bind e.FStar_Syntax_Syntax.pos
-                                                env (Some e) uu____4369
-                                                ((Some x1), eq_ret) in
-                                            let c2 =
-                                              c1.FStar_Syntax_Syntax.comp () in
-                                            ((let uu____4380 =
-                                                FStar_All.pipe_left
-                                                  (FStar_TypeChecker_Env.debug
-                                                     env)
-                                                  FStar_Options.Extreme in
-                                              if uu____4380
-                                              then
-                                                let uu____4381 =
-                                                  FStar_TypeChecker_Normalize.comp_to_string
-                                                    env c2 in
-                                                FStar_Util.print1
-                                                  "Strengthened to %s\n"
-                                                  uu____4381
-                                              else ());
-                                             c2)))))) in
-                   let flags =
-                     FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
-                       (FStar_List.collect
-                          (fun uu___96_4387  ->
-                             match uu___96_4387 with
-                             | FStar_Syntax_Syntax.RETURN 
-                               |FStar_Syntax_Syntax.PARTIAL_RETURN  ->
-                                 [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                             | FStar_Syntax_Syntax.CPS  ->
-                                 [FStar_Syntax_Syntax.CPS]
-                             | uu____4389 -> [])) in
-                   let lc1 =
-                     let uu___138_4391 = lc in
-                     let uu____4392 =
-                       FStar_TypeChecker_Env.norm_eff_name env
-                         lc.FStar_Syntax_Syntax.eff_name in
-                     {
-                       FStar_Syntax_Syntax.eff_name = uu____4392;
-                       FStar_Syntax_Syntax.res_typ = t;
-                       FStar_Syntax_Syntax.cflags = flags;
-                       FStar_Syntax_Syntax.comp = strengthen
-                     } in
-                   let g2 =
-                     let uu___139_4394 = g1 in
-                     {
-                       FStar_TypeChecker_Env.guard_f =
-                         FStar_TypeChecker_Common.Trivial;
-                       FStar_TypeChecker_Env.deferred =
-                         (uu___139_4394.FStar_TypeChecker_Env.deferred);
-                       FStar_TypeChecker_Env.univ_ineqs =
-                         (uu___139_4394.FStar_TypeChecker_Env.univ_ineqs);
-                       FStar_TypeChecker_Env.implicits =
-                         (uu___139_4394.FStar_TypeChecker_Env.implicits)
-                     } in
-                   (e, lc1, g2))
-let pure_or_ghost_pre_and_post:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp ->
-      (FStar_Syntax_Syntax.typ Prims.option* FStar_Syntax_Syntax.typ)
-  =
-  fun env  ->
-    fun comp  ->
-      let mk_post_type res_t ens =
-        let x = FStar_Syntax_Syntax.new_bv None res_t in
-        let uu____4414 =
-          let uu____4415 =
-            let uu____4416 =
-              let uu____4417 =
-                let uu____4418 = FStar_Syntax_Syntax.bv_to_name x in
-                FStar_Syntax_Syntax.as_arg uu____4418 in
-              [uu____4417] in
-            FStar_Syntax_Syntax.mk_Tm_app ens uu____4416 in
-          uu____4415 None res_t.FStar_Syntax_Syntax.pos in
-        FStar_Syntax_Util.refine x uu____4414 in
-      let norm t =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta;
-          FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.EraseUniverses] env t in
-      let uu____4427 = FStar_Syntax_Util.is_tot_or_gtot_comp comp in
-      if uu____4427
-      then (None, (FStar_Syntax_Util.comp_result comp))
-      else
-        (match comp.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.GTotal _|FStar_Syntax_Syntax.Total _ ->
-             failwith "Impossible"
-         | FStar_Syntax_Syntax.Comp ct ->
-             if
-               (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
-                  FStar_Syntax_Const.effect_Pure_lid)
-                 ||
-                 (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
-                    FStar_Syntax_Const.effect_Ghost_lid)
-             then
-               (match ct.FStar_Syntax_Syntax.effect_args with
-                | (req,uu____4451)::(ens,uu____4453)::uu____4454 ->
-                    let uu____4476 =
-                      let uu____4478 = norm req in Some uu____4478 in
-                    let uu____4479 =
-                      let uu____4480 =
-                        mk_post_type ct.FStar_Syntax_Syntax.result_typ ens in
-                      FStar_All.pipe_left norm uu____4480 in
-                    (uu____4476, uu____4479)
-                | uu____4482 ->
-                    let uu____4488 =
-                      let uu____4489 =
-                        let uu____4492 =
-                          let uu____4493 =
-                            FStar_Syntax_Print.comp_to_string comp in
-                          FStar_Util.format1
-                            "Effect constructor is not fully applied; got %s"
-                            uu____4493 in
-                        (uu____4492, (comp.FStar_Syntax_Syntax.pos)) in
-                      FStar_Errors.Error uu____4489 in
-                    Prims.raise uu____4488)
-             else
-               (let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env comp in
-                match ct1.FStar_Syntax_Syntax.effect_args with
-                | (wp,uu____4503)::uu____4504 ->
-                    let uu____4518 =
-                      let uu____4521 =
-                        FStar_TypeChecker_Env.lookup_lid env
-                          FStar_Syntax_Const.as_requires in
-                      FStar_All.pipe_left Prims.fst uu____4521 in
-                    (match uu____4518 with
-                     | (us_r,uu____4538) ->
-                         let uu____4539 =
-                           let uu____4542 =
-                             FStar_TypeChecker_Env.lookup_lid env
-                               FStar_Syntax_Const.as_ensures in
-                           FStar_All.pipe_left Prims.fst uu____4542 in
-                         (match uu____4539 with
-                          | (us_e,uu____4559) ->
-                              let r =
-                                (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-                              let as_req =
-                                let uu____4562 =
-                                  FStar_Syntax_Syntax.fvar
-                                    (FStar_Ident.set_lid_range
-                                       FStar_Syntax_Const.as_requires r)
-                                    FStar_Syntax_Syntax.Delta_equational None in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____4562
-                                  us_r in
-                              let as_ens =
-                                let uu____4564 =
-                                  FStar_Syntax_Syntax.fvar
-                                    (FStar_Ident.set_lid_range
-                                       FStar_Syntax_Const.as_ensures r)
-                                    FStar_Syntax_Syntax.Delta_equational None in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____4564
-                                  us_e in
-                              let req =
-                                let uu____4568 =
-                                  let uu____4569 =
-                                    let uu____4570 =
-                                      let uu____4577 =
-                                        FStar_Syntax_Syntax.as_arg wp in
-                                      [uu____4577] in
-                                    ((ct1.FStar_Syntax_Syntax.result_typ),
-                                      (Some FStar_Syntax_Syntax.imp_tag)) ::
-                                      uu____4570 in
-                                  FStar_Syntax_Syntax.mk_Tm_app as_req
-                                    uu____4569 in
-                                uu____4568
-                                  (Some
-                                     (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-                              let ens =
-                                let uu____4593 =
-                                  let uu____4594 =
-                                    let uu____4595 =
-                                      let uu____4602 =
-                                        FStar_Syntax_Syntax.as_arg wp in
-                                      [uu____4602] in
-                                    ((ct1.FStar_Syntax_Syntax.result_typ),
-                                      (Some FStar_Syntax_Syntax.imp_tag)) ::
-                                      uu____4595 in
-                                  FStar_Syntax_Syntax.mk_Tm_app as_ens
-                                    uu____4594 in
-                                uu____4593 None
-                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-                              let uu____4615 =
-                                let uu____4617 = norm req in Some uu____4617 in
-                              let uu____4618 =
-                                let uu____4619 =
-                                  mk_post_type
-                                    ct1.FStar_Syntax_Syntax.result_typ ens in
-                                norm uu____4619 in
-                              (uu____4615, uu____4618)))
-                | uu____4621 -> failwith "Impossible"))
-let maybe_instantiate:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ ->
-        (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.typ*
-          FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun t  ->
-        let torig = FStar_Syntax_Subst.compress t in
-        if Prims.op_Negation env.FStar_TypeChecker_Env.instantiate_imp
-        then (e, torig, FStar_TypeChecker_Rel.trivial_guard)
-        else
-          (let number_of_implicits t1 =
-             let uu____4651 = FStar_Syntax_Util.arrow_formals t1 in
-             match uu____4651 with
-             | (formals,uu____4660) ->
-                 let n_implicits =
-                   let uu____4672 =
-                     FStar_All.pipe_right formals
-                       (FStar_Util.prefix_until
-                          (fun uu____4709  ->
-                             match uu____4709 with
-                             | (uu____4713,imp) ->
-                                 (imp = None) ||
-                                   (imp = (Some FStar_Syntax_Syntax.Equality)))) in
-                   match uu____4672 with
-                   | None  -> FStar_List.length formals
-                   | Some (implicits,_first_explicit,_rest) ->
-                       FStar_List.length implicits in
-                 n_implicits in
-           let inst_n_binders t1 =
-             let uu____4785 = FStar_TypeChecker_Env.expected_typ env in
-             match uu____4785 with
-             | None  -> None
-             | Some expected_t ->
-                 let n_expected = number_of_implicits expected_t in
-                 let n_available = number_of_implicits t1 in
-                 if n_available < n_expected
-                 then
-                   let uu____4799 =
-                     let uu____4800 =
-                       let uu____4803 =
-                         let uu____4804 = FStar_Util.string_of_int n_expected in
-                         let uu____4808 = FStar_Syntax_Print.term_to_string e in
-                         let uu____4809 =
-                           FStar_Util.string_of_int n_available in
-                         FStar_Util.format3
-                           "Expected a term with %s implicit arguments, but %s has only %s"
-                           uu____4804 uu____4808 uu____4809 in
-                       let uu____4813 = FStar_TypeChecker_Env.get_range env in
-                       (uu____4803, uu____4813) in
-                     FStar_Errors.Error uu____4800 in
-                   Prims.raise uu____4799
-                 else Some (n_available - n_expected) in
-           let decr_inst uu___97_4826 =
-             match uu___97_4826 with
-             | None  -> None
-             | Some i -> Some (i - (Prims.parse_int "1")) in
-           match torig.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-               let uu____4845 = FStar_Syntax_Subst.open_comp bs c in
-               (match uu____4845 with
-                | (bs1,c1) ->
-                    let rec aux subst1 inst_n bs2 =
-                      match (inst_n, bs2) with
-                      | (Some _0_29,uu____4906) when
-                          _0_29 = (Prims.parse_int "0") ->
-                          ([], bs2, subst1,
-                            FStar_TypeChecker_Rel.trivial_guard)
-                      | (uu____4928,(x,Some (FStar_Syntax_Syntax.Implicit
-                                     dot))::rest)
-                          ->
-                          let t1 =
-                            FStar_Syntax_Subst.subst subst1
-                              x.FStar_Syntax_Syntax.sort in
-                          let uu____4947 =
-                            new_implicit_var
-                              "Instantiation of implicit argument"
-                              e.FStar_Syntax_Syntax.pos env t1 in
-                          (match uu____4947 with
-                           | (v1,uu____4968,g) ->
-                               let subst2 = (FStar_Syntax_Syntax.NT (x, v1))
-                                 :: subst1 in
-                               let uu____4978 =
-                                 aux subst2 (decr_inst inst_n) rest in
-                               (match uu____4978 with
-                                | (args,bs3,subst3,g') ->
-                                    let uu____5027 =
-                                      FStar_TypeChecker_Rel.conj_guard g g' in
-                                    (((v1,
-                                        (Some
-                                           (FStar_Syntax_Syntax.Implicit dot)))
-                                      :: args), bs3, subst3, uu____5027)))
-                      | (uu____5041,bs3) ->
-                          ([], bs3, subst1,
-                            FStar_TypeChecker_Rel.trivial_guard) in
-                    let uu____5065 =
-                      let uu____5079 = inst_n_binders t in
-                      aux [] uu____5079 bs1 in
-                    (match uu____5065 with
-                     | (args,bs2,subst1,guard) ->
-                         (match (args, bs2) with
-                          | ([],uu____5117) -> (e, torig, guard)
-                          | (uu____5133,[]) when
-                              let uu____5149 =
-                                FStar_Syntax_Util.is_total_comp c1 in
-                              Prims.op_Negation uu____5149 ->
-                              (e, torig, FStar_TypeChecker_Rel.trivial_guard)
-                          | uu____5150 ->
-                              let t1 =
-                                match bs2 with
-                                | [] -> FStar_Syntax_Util.comp_result c1
-                                | uu____5169 ->
-                                    FStar_Syntax_Util.arrow bs2 c1 in
-                              let t2 = FStar_Syntax_Subst.subst subst1 t1 in
-                              let e1 =
-                                (FStar_Syntax_Syntax.mk_Tm_app e args)
-                                  (Some (t2.FStar_Syntax_Syntax.n))
-                                  e.FStar_Syntax_Syntax.pos in
-                              (e1, t2, guard))))
-           | uu____5184 -> (e, t, FStar_TypeChecker_Rel.trivial_guard))
-let string_of_univs univs1 =
-  let uu____5196 =
-    let uu____5198 = FStar_Util.set_elements univs1 in
-    FStar_All.pipe_right uu____5198
-      (FStar_List.map
-         (fun u  ->
-            let uu____5208 = FStar_Unionfind.uvar_id u in
-            FStar_All.pipe_right uu____5208 FStar_Util.string_of_int)) in
-  FStar_All.pipe_right uu____5196 (FStar_String.concat ", ")
-let gen_univs:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe_uvar FStar_Util.set ->
-      FStar_Syntax_Syntax.univ_name Prims.list
-  =
-  fun env  ->
-    fun x  ->
-      let uu____5220 = FStar_Util.set_is_empty x in
-      if uu____5220
-      then []
-      else
-        (let s =
-           let uu____5225 =
-             let uu____5227 = FStar_TypeChecker_Env.univ_vars env in
-             FStar_Util.set_difference x uu____5227 in
-           FStar_All.pipe_right uu____5225 FStar_Util.set_elements in
-         (let uu____5232 =
-            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-              (FStar_Options.Other "Gen") in
-          if uu____5232
-          then
-            let uu____5233 =
-              let uu____5234 = FStar_TypeChecker_Env.univ_vars env in
-              string_of_univs uu____5234 in
-            FStar_Util.print1 "univ_vars in env: %s\n" uu____5233
-          else ());
-         (let r =
-            let uu____5242 = FStar_TypeChecker_Env.get_range env in
-            Some uu____5242 in
-          let u_names =
-            FStar_All.pipe_right s
-              (FStar_List.map
-                 (fun u  ->
-                    let u_name = FStar_Syntax_Syntax.new_univ_name r in
-                    (let uu____5254 =
-                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "Gen") in
-                     if uu____5254
-                     then
-                       let uu____5255 =
-                         let uu____5256 = FStar_Unionfind.uvar_id u in
-                         FStar_All.pipe_left FStar_Util.string_of_int
-                           uu____5256 in
-                       let uu____5258 =
-                         FStar_Syntax_Print.univ_to_string
-                           (FStar_Syntax_Syntax.U_unif u) in
-                       let uu____5259 =
-                         FStar_Syntax_Print.univ_to_string
-                           (FStar_Syntax_Syntax.U_name u_name) in
-                       FStar_Util.print3 "Setting ?%s (%s) to %s\n"
-                         uu____5255 uu____5258 uu____5259
-                     else ());
-                    FStar_Unionfind.change u
-                      (Some (FStar_Syntax_Syntax.U_name u_name));
-                    u_name)) in
-          u_names))
-let gather_free_univnames:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list
-  =
-  fun env  ->
-    fun t  ->
-      let ctx_univnames = FStar_TypeChecker_Env.univnames env in
-      let tm_univnames = FStar_Syntax_Free.univnames t in
-      let univnames1 =
-        let uu____5277 =
-          FStar_Util.fifo_set_difference tm_univnames ctx_univnames in
-        FStar_All.pipe_right uu____5277 FStar_Util.fifo_set_elements in
-      univnames1
-let maybe_set_tk ts uu___98_5304 =
-  match uu___98_5304 with
-  | None  -> ts
-  | Some t ->
-      let t1 = FStar_Syntax_Syntax.mk t None FStar_Range.dummyRange in
-      let t2 = FStar_Syntax_Subst.close_univ_vars (Prims.fst ts) t1 in
-      (FStar_ST.write (Prims.snd ts).FStar_Syntax_Syntax.tk
-         (Some (t2.FStar_Syntax_Syntax.n));
-       ts)
-let check_universe_generalization:
-  FStar_Syntax_Syntax.univ_name Prims.list ->
-    FStar_Syntax_Syntax.univ_name Prims.list ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list
-  =
-  fun explicit_univ_names  ->
-    fun generalized_univ_names  ->
-      fun t  ->
-        match (explicit_univ_names, generalized_univ_names) with
-        | ([],uu____5345) -> generalized_univ_names
-        | (uu____5349,[]) -> explicit_univ_names
-        | uu____5353 ->
-            let uu____5358 =
-              let uu____5359 =
-                let uu____5362 =
-                  let uu____5363 = FStar_Syntax_Print.term_to_string t in
-                  Prims.strcat
-                    "Generalized universe in a term containing explicit universe annotation : "
-                    uu____5363 in
-                (uu____5362, (t.FStar_Syntax_Syntax.pos)) in
-              FStar_Errors.Error uu____5359 in
-            Prims.raise uu____5358
-let generalize_universes:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.univ_names*
-        (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-        FStar_Syntax_Syntax.syntax)
-  =
-  fun env  ->
-    fun t0  ->
-      let t =
-        FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.NoFullNorm;
-          FStar_TypeChecker_Normalize.Beta] env t0 in
-      let univnames1 = gather_free_univnames env t in
-      let univs1 = FStar_Syntax_Free.univs t in
-      (let uu____5377 =
-         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "Gen") in
-       if uu____5377
-       then
-         let uu____5378 = string_of_univs univs1 in
-         FStar_Util.print1 "univs to gen : %s\n" uu____5378
-       else ());
-      (let gen1 = gen_univs env univs1 in
-       (let uu____5384 =
-          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-            (FStar_Options.Other "Gen") in
-        if uu____5384
-        then
-          let uu____5385 = FStar_Syntax_Print.term_to_string t in
-          FStar_Util.print1 "After generalization: %s\n" uu____5385
-        else ());
-       (let univs2 = check_universe_generalization univnames1 gen1 t0 in
-        let ts = FStar_Syntax_Subst.close_univ_vars univs2 t in
-        let uu____5390 = FStar_ST.read t0.FStar_Syntax_Syntax.tk in
-        maybe_set_tk (univs2, ts) uu____5390))
-let gen:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.comp) Prims.list ->
-      (FStar_Syntax_Syntax.univ_name Prims.list* FStar_Syntax_Syntax.term*
-        FStar_Syntax_Syntax.comp) Prims.list Prims.option
-  =
-  fun env  ->
-    fun ecs  ->
-      let uu____5420 =
-        let uu____5421 =
-          FStar_Util.for_all
-            (fun uu____5426  ->
-               match uu____5426 with
-               | (uu____5431,c) -> FStar_Syntax_Util.is_pure_or_ghost_comp c)
-            ecs in
-        FStar_All.pipe_left Prims.op_Negation uu____5421 in
-      if uu____5420
-      then None
-      else
-        (let norm c =
-           (let uu____5454 =
-              FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-            if uu____5454
-            then
-              let uu____5455 = FStar_Syntax_Print.comp_to_string c in
-              FStar_Util.print1 "Normalizing before generalizing:\n\t %s\n"
-                uu____5455
-            else ());
-           (let c1 =
-              let uu____5458 = FStar_TypeChecker_Env.should_verify env in
-              if uu____5458
-              then
-                FStar_TypeChecker_Normalize.normalize_comp
-                  [FStar_TypeChecker_Normalize.Beta;
-                  FStar_TypeChecker_Normalize.Eager_unfolding;
-                  FStar_TypeChecker_Normalize.NoFullNorm] env c
-              else
-                FStar_TypeChecker_Normalize.normalize_comp
-                  [FStar_TypeChecker_Normalize.Beta;
-                  FStar_TypeChecker_Normalize.NoFullNorm] env c in
-            (let uu____5461 =
-               FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-             if uu____5461
-             then
-               let uu____5462 = FStar_Syntax_Print.comp_to_string c1 in
-               FStar_Util.print1 "Normalized to:\n\t %s\n" uu____5462
-             else ());
-            c1) in
-         let env_uvars = FStar_TypeChecker_Env.uvars_in_env env in
-         let gen_uvars uvs =
-           let uu____5496 = FStar_Util.set_difference uvs env_uvars in
-           FStar_All.pipe_right uu____5496 FStar_Util.set_elements in
-         let uu____5540 =
-           let uu____5558 =
-             FStar_All.pipe_right ecs
-               (FStar_List.map
-                  (fun uu____5613  ->
-                     match uu____5613 with
-                     | (e,c) ->
-                         let t =
-                           FStar_All.pipe_right
-                             (FStar_Syntax_Util.comp_result c)
-                             FStar_Syntax_Subst.compress in
-                         let c1 = norm c in
-                         let t1 = FStar_Syntax_Util.comp_result c1 in
-                         let univs1 = FStar_Syntax_Free.univs t1 in
-                         let uvt = FStar_Syntax_Free.uvars t1 in
-                         let uvs = gen_uvars uvt in (univs1, (uvs, e, c1)))) in
-           FStar_All.pipe_right uu____5558 FStar_List.unzip in
-         match uu____5540 with
-         | (univs1,uvars1) ->
-             let univs2 =
-               FStar_List.fold_left FStar_Util.set_union
-                 FStar_Syntax_Syntax.no_universe_uvars univs1 in
-             let gen_univs1 = gen_univs env univs2 in
-             ((let uu____5775 =
-                 FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-               if uu____5775
-               then
-                 FStar_All.pipe_right gen_univs1
-                   (FStar_List.iter
-                      (fun x  ->
-                         FStar_Util.print1 "Generalizing uvar %s\n"
-                           x.FStar_Ident.idText))
-               else ());
-              (let ecs1 =
-                 FStar_All.pipe_right uvars1
-                   (FStar_List.map
-                      (fun uu____5817  ->
-                         match uu____5817 with
-                         | (uvs,e,c) ->
-                             let tvars =
-                               FStar_All.pipe_right uvs
-                                 (FStar_List.map
-                                    (fun uu____5874  ->
-                                       match uu____5874 with
-                                       | (u,k) ->
-                                           let uu____5894 =
-                                             FStar_Unionfind.find u in
-                                           (match uu____5894 with
-                                            | FStar_Syntax_Syntax.Fixed
-                                              {
-                                                FStar_Syntax_Syntax.n =
-                                                  FStar_Syntax_Syntax.Tm_name
-                                                  a;
-                                                FStar_Syntax_Syntax.tk = _;
-                                                FStar_Syntax_Syntax.pos = _;
-                                                FStar_Syntax_Syntax.vars = _;_}
-                                              |FStar_Syntax_Syntax.Fixed
-                                              {
-                                                FStar_Syntax_Syntax.n =
-                                                  FStar_Syntax_Syntax.Tm_abs
-                                                  (_,{
-                                                       FStar_Syntax_Syntax.n
-                                                         =
-                                                         FStar_Syntax_Syntax.Tm_name
-                                                         a;
-                                                       FStar_Syntax_Syntax.tk
-                                                         = _;
-                                                       FStar_Syntax_Syntax.pos
-                                                         = _;
-                                                       FStar_Syntax_Syntax.vars
-                                                         = _;_},_);
-                                                FStar_Syntax_Syntax.tk = _;
-                                                FStar_Syntax_Syntax.pos = _;
-                                                FStar_Syntax_Syntax.vars = _;_}
-                                                ->
-                                                (a,
-                                                  (Some
-                                                     FStar_Syntax_Syntax.imp_tag))
-                                            | FStar_Syntax_Syntax.Fixed
-                                                uu____5932 ->
-                                                failwith
-                                                  "Unexpected instantiation of mutually recursive uvar"
-                                            | uu____5940 ->
-                                                let k1 =
-                                                  FStar_TypeChecker_Normalize.normalize
-                                                    [FStar_TypeChecker_Normalize.Beta]
-                                                    env k in
-                                                let uu____5945 =
-                                                  FStar_Syntax_Util.arrow_formals
-                                                    k1 in
-                                                (match uu____5945 with
-                                                 | (bs,kres) ->
-                                                     let a =
-                                                       let uu____5969 =
-                                                         let uu____5971 =
-                                                           FStar_TypeChecker_Env.get_range
-                                                             env in
-                                                         FStar_All.pipe_left
-                                                           (fun _0_30  ->
-                                                              Some _0_30)
-                                                           uu____5971 in
-                                                       FStar_Syntax_Syntax.new_bv
-                                                         uu____5969 kres in
-                                                     let t =
-                                                       let uu____5974 =
-                                                         FStar_Syntax_Syntax.bv_to_name
-                                                           a in
-                                                       let uu____5975 =
-                                                         let uu____5982 =
-                                                           let uu____5988 =
-                                                             let uu____5989 =
-                                                               FStar_Syntax_Syntax.mk_Total
-                                                                 kres in
-                                                             FStar_Syntax_Util.lcomp_of_comp
-                                                               uu____5989 in
-                                                           FStar_Util.Inl
-                                                             uu____5988 in
-                                                         Some uu____5982 in
-                                                       FStar_Syntax_Util.abs
-                                                         bs uu____5974
-                                                         uu____5975 in
-                                                     (FStar_Syntax_Util.set_uvar
-                                                        u t;
-                                                      (a,
-                                                        (Some
-                                                           FStar_Syntax_Syntax.imp_tag))))))) in
-                             let uu____6004 =
-                               match (tvars, gen_univs1) with
-                               | ([],[]) -> (e, c)
-                               | ([],uu____6022) ->
-                                   let c1 =
-                                     FStar_TypeChecker_Normalize.normalize_comp
-                                       [FStar_TypeChecker_Normalize.Beta;
-                                       FStar_TypeChecker_Normalize.NoDeltaSteps;
-                                       FStar_TypeChecker_Normalize.NoFullNorm]
-                                       env c in
-                                   let e1 =
-                                     FStar_TypeChecker_Normalize.normalize
-                                       [FStar_TypeChecker_Normalize.Beta;
-                                       FStar_TypeChecker_Normalize.NoDeltaSteps;
-                                       FStar_TypeChecker_Normalize.NoFullNorm]
-                                       env e in
-                                   (e1, c1)
-                               | uu____6034 ->
-                                   let uu____6042 = (e, c) in
-                                   (match uu____6042 with
-                                    | (e0,c0) ->
-                                        let c1 =
-                                          FStar_TypeChecker_Normalize.normalize_comp
-                                            [FStar_TypeChecker_Normalize.Beta;
-                                            FStar_TypeChecker_Normalize.NoDeltaSteps;
-                                            FStar_TypeChecker_Normalize.CompressUvars;
-                                            FStar_TypeChecker_Normalize.NoFullNorm]
-                                            env c in
-                                        let e1 =
-                                          FStar_TypeChecker_Normalize.normalize
-                                            [FStar_TypeChecker_Normalize.Beta;
-                                            FStar_TypeChecker_Normalize.NoDeltaSteps;
-                                            FStar_TypeChecker_Normalize.CompressUvars;
-                                            FStar_TypeChecker_Normalize.Exclude
-                                              FStar_TypeChecker_Normalize.Zeta;
-                                            FStar_TypeChecker_Normalize.Exclude
-                                              FStar_TypeChecker_Normalize.Iota;
-                                            FStar_TypeChecker_Normalize.NoFullNorm]
-                                            env e in
-                                        let t =
-                                          let uu____6054 =
-                                            let uu____6055 =
-                                              FStar_Syntax_Subst.compress
-                                                (FStar_Syntax_Util.comp_result
-                                                   c1) in
-                                            uu____6055.FStar_Syntax_Syntax.n in
-                                          match uu____6054 with
-                                          | FStar_Syntax_Syntax.Tm_arrow
-                                              (bs,cod) ->
-                                              let uu____6072 =
-                                                FStar_Syntax_Subst.open_comp
-                                                  bs cod in
-                                              (match uu____6072 with
-                                               | (bs1,cod1) ->
-                                                   FStar_Syntax_Util.arrow
-                                                     (FStar_List.append tvars
-                                                        bs1) cod1)
-                                          | uu____6082 ->
-                                              FStar_Syntax_Util.arrow tvars
-                                                c1 in
-                                        let e' =
-                                          FStar_Syntax_Util.abs tvars e1
-                                            (Some
-                                               (FStar_Util.Inl
-                                                  (FStar_Syntax_Util.lcomp_of_comp
-                                                     c1))) in
-                                        let uu____6092 =
-                                          FStar_Syntax_Syntax.mk_Total t in
-                                        (e', uu____6092)) in
-                             (match uu____6004 with
-                              | (e1,c1) -> (gen_univs1, e1, c1)))) in
-               Some ecs1)))
-let generalize:
-  FStar_TypeChecker_Env.env ->
-    (FStar_Syntax_Syntax.lbname* FStar_Syntax_Syntax.term*
-      FStar_Syntax_Syntax.comp) Prims.list ->
-      (FStar_Syntax_Syntax.lbname* FStar_Syntax_Syntax.univ_name Prims.list*
-        FStar_Syntax_Syntax.term* FStar_Syntax_Syntax.comp) Prims.list
-  =
-  fun env  ->
-    fun lecs  ->
-      (let uu____6130 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
-       if uu____6130
-       then
-         let uu____6131 =
-           let uu____6132 =
-             FStar_List.map
-               (fun uu____6137  ->
-                  match uu____6137 with
-                  | (lb,uu____6142,uu____6143) ->
-                      FStar_Syntax_Print.lbname_to_string lb) lecs in
-           FStar_All.pipe_right uu____6132 (FStar_String.concat ", ") in
-         FStar_Util.print1 "Generalizing: %s\n" uu____6131
-       else ());
-      (let univnames_lecs =
-         FStar_List.map
-           (fun uu____6153  ->
-              match uu____6153 with | (l,t,c) -> gather_free_univnames env t)
-           lecs in
-       let generalized_lecs =
-         let uu____6168 =
-           let uu____6175 =
-             FStar_All.pipe_right lecs
-               (FStar_List.map
-                  (fun uu____6191  ->
-                     match uu____6191 with | (uu____6197,e,c) -> (e, c))) in
-           gen env uu____6175 in
-         match uu____6168 with
-         | None  ->
-             FStar_All.pipe_right lecs
-               (FStar_List.map
-                  (fun uu____6229  ->
-                     match uu____6229 with | (l,t,c) -> (l, [], t, c)))
-         | Some ecs ->
-             FStar_List.map2
-               (fun uu____6273  ->
-                  fun uu____6274  ->
-                    match (uu____6273, uu____6274) with
-                    | ((l,uu____6307,uu____6308),(us,e,c)) ->
-                        ((let uu____6334 =
-                            FStar_TypeChecker_Env.debug env
-                              FStar_Options.Medium in
-                          if uu____6334
-                          then
-                            let uu____6335 =
-                              FStar_Range.string_of_range
-                                e.FStar_Syntax_Syntax.pos in
-                            let uu____6336 =
-                              FStar_Syntax_Print.lbname_to_string l in
-                            let uu____6337 =
-                              FStar_Syntax_Print.term_to_string
-                                (FStar_Syntax_Util.comp_result c) in
-                            let uu____6338 =
-                              FStar_Syntax_Print.term_to_string e in
-                            FStar_Util.print4
-                              "(%s) Generalized %s at type %s\n%s\n"
-                              uu____6335 uu____6336 uu____6337 uu____6338
-                          else ());
-                         (l, us, e, c))) lecs ecs in
-       FStar_List.map2
-         (fun univnames1  ->
-            fun uu____6357  ->
-              match uu____6357 with
-              | (l,generalized_univs,t,c) ->
-                  let uu____6375 =
-                    check_universe_generalization univnames1
-                      generalized_univs t in
-                  (l, uu____6375, t, c)) univnames_lecs generalized_lecs)
-let check_and_ascribe:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.typ ->
-          (FStar_Syntax_Syntax.term* FStar_TypeChecker_Env.guard_t)
-  =
-  fun env  ->
-    fun e  ->
-      fun t1  ->
-        fun t2  ->
-          let env1 =
-            FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
-          let check env2 t11 t21 =
-            if env2.FStar_TypeChecker_Env.use_eq
-            then FStar_TypeChecker_Rel.try_teq true env2 t11 t21
-            else
-              (let uu____6408 =
-                 FStar_TypeChecker_Rel.try_subtype env2 t11 t21 in
-               match uu____6408 with
-               | None  -> None
-               | Some f ->
-                   let uu____6412 = FStar_TypeChecker_Rel.apply_guard f e in
-                   FStar_All.pipe_left (fun _0_31  -> Some _0_31) uu____6412) in
-          let is_var e1 =
-            let uu____6418 =
-              let uu____6419 = FStar_Syntax_Subst.compress e1 in
-              uu____6419.FStar_Syntax_Syntax.n in
-            match uu____6418 with
-            | FStar_Syntax_Syntax.Tm_name uu____6422 -> true
-            | uu____6423 -> false in
-          let decorate e1 t =
-            let e2 = FStar_Syntax_Subst.compress e1 in
-            match e2.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_name x ->
-                (FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_name
-                      (let uu___140_6445 = x in
-                       {
-                         FStar_Syntax_Syntax.ppname =
-                           (uu___140_6445.FStar_Syntax_Syntax.ppname);
-                         FStar_Syntax_Syntax.index =
-                           (uu___140_6445.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = t2
-                       }))) (Some (t2.FStar_Syntax_Syntax.n))
-                  e2.FStar_Syntax_Syntax.pos
-            | uu____6446 ->
-                let uu___141_6447 = e2 in
-                let uu____6448 =
-                  FStar_Util.mk_ref (Some (t2.FStar_Syntax_Syntax.n)) in
-                {
-                  FStar_Syntax_Syntax.n =
-                    (uu___141_6447.FStar_Syntax_Syntax.n);
-                  FStar_Syntax_Syntax.tk = uu____6448;
-                  FStar_Syntax_Syntax.pos =
-                    (uu___141_6447.FStar_Syntax_Syntax.pos);
-                  FStar_Syntax_Syntax.vars =
-                    (uu___141_6447.FStar_Syntax_Syntax.vars)
-                } in
-          let env2 =
-            let uu___142_6457 = env1 in
-            let uu____6458 =
-              env1.FStar_TypeChecker_Env.use_eq ||
-                (env1.FStar_TypeChecker_Env.is_pattern && (is_var e)) in
-            {
-              FStar_TypeChecker_Env.solver =
-                (uu___142_6457.FStar_TypeChecker_Env.solver);
-              FStar_TypeChecker_Env.range =
-                (uu___142_6457.FStar_TypeChecker_Env.range);
-              FStar_TypeChecker_Env.curmodule =
-                (uu___142_6457.FStar_TypeChecker_Env.curmodule);
-              FStar_TypeChecker_Env.gamma =
-                (uu___142_6457.FStar_TypeChecker_Env.gamma);
-              FStar_TypeChecker_Env.gamma_cache =
-                (uu___142_6457.FStar_TypeChecker_Env.gamma_cache);
-              FStar_TypeChecker_Env.modules =
-                (uu___142_6457.FStar_TypeChecker_Env.modules);
-              FStar_TypeChecker_Env.expected_typ =
-                (uu___142_6457.FStar_TypeChecker_Env.expected_typ);
-              FStar_TypeChecker_Env.sigtab =
-                (uu___142_6457.FStar_TypeChecker_Env.sigtab);
-              FStar_TypeChecker_Env.is_pattern =
-                (uu___142_6457.FStar_TypeChecker_Env.is_pattern);
-              FStar_TypeChecker_Env.instantiate_imp =
-                (uu___142_6457.FStar_TypeChecker_Env.instantiate_imp);
-              FStar_TypeChecker_Env.effects =
-                (uu___142_6457.FStar_TypeChecker_Env.effects);
-              FStar_TypeChecker_Env.generalize =
-                (uu___142_6457.FStar_TypeChecker_Env.generalize);
-              FStar_TypeChecker_Env.letrecs =
-                (uu___142_6457.FStar_TypeChecker_Env.letrecs);
-              FStar_TypeChecker_Env.top_level =
-                (uu___142_6457.FStar_TypeChecker_Env.top_level);
-              FStar_TypeChecker_Env.check_uvars =
-                (uu___142_6457.FStar_TypeChecker_Env.check_uvars);
-              FStar_TypeChecker_Env.use_eq = uu____6458;
-              FStar_TypeChecker_Env.is_iface =
-                (uu___142_6457.FStar_TypeChecker_Env.is_iface);
-              FStar_TypeChecker_Env.admit =
-                (uu___142_6457.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___142_6457.FStar_TypeChecker_Env.lax);
-              FStar_TypeChecker_Env.lax_universes =
-                (uu___142_6457.FStar_TypeChecker_Env.lax_universes);
-              FStar_TypeChecker_Env.type_of =
-                (uu___142_6457.FStar_TypeChecker_Env.type_of);
-              FStar_TypeChecker_Env.universe_of =
-                (uu___142_6457.FStar_TypeChecker_Env.universe_of);
-              FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___142_6457.FStar_TypeChecker_Env.use_bv_sorts);
-              FStar_TypeChecker_Env.qname_and_index =
-                (uu___142_6457.FStar_TypeChecker_Env.qname_and_index)
-            } in
-          let uu____6459 = check env2 t1 t2 in
-          match uu____6459 with
-          | None  ->
-              let uu____6463 =
-                let uu____6464 =
-                  let uu____6467 =
-                    FStar_TypeChecker_Err.expected_expression_of_type env2 t2
-                      e t1 in
-                  let uu____6468 = FStar_TypeChecker_Env.get_range env2 in
-                  (uu____6467, uu____6468) in
-                FStar_Errors.Error uu____6464 in
-              Prims.raise uu____6463
-          | Some g ->
-              ((let uu____6473 =
-                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
-                    (FStar_Options.Other "Rel") in
-                if uu____6473
-                then
-                  let uu____6474 =
-                    FStar_TypeChecker_Rel.guard_to_string env2 g in
-                  FStar_All.pipe_left
-                    (FStar_Util.print1 "Applied guard is %s\n") uu____6474
-                else ());
-               (let uu____6476 = decorate e t2 in (uu____6476, g)))
-let check_top_level:
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t ->
-      FStar_Syntax_Syntax.lcomp -> (Prims.bool* FStar_Syntax_Syntax.comp)
-  =
-  fun env  ->
-    fun g  ->
-      fun lc  ->
-        let discharge g1 =
-          FStar_TypeChecker_Rel.force_trivial_guard env g1;
-          FStar_Syntax_Util.is_pure_lcomp lc in
-        let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-        let uu____6500 = FStar_Syntax_Util.is_total_lcomp lc in
-        if uu____6500
-        then
-          let uu____6503 = discharge g1 in
-          let uu____6504 = lc.FStar_Syntax_Syntax.comp () in
-          (uu____6503, uu____6504)
-        else
-          (let c = lc.FStar_Syntax_Syntax.comp () in
-           let steps = [FStar_TypeChecker_Normalize.Beta] in
-           let c1 =
-             let uu____6516 =
-               let uu____6517 =
-                 let uu____6518 =
-                   FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                 FStar_All.pipe_right uu____6518 FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____6517
-                 (FStar_TypeChecker_Normalize.normalize_comp steps env) in
-             FStar_All.pipe_right uu____6516
-               (FStar_TypeChecker_Env.comp_to_comp_typ env) in
-           let md =
-             FStar_TypeChecker_Env.get_effect_decl env
-               c1.FStar_Syntax_Syntax.effect_name in
-           let uu____6520 = destruct_comp c1 in
-           match uu____6520 with
-           | (u_t,t,wp) ->
-               let vc =
-                 let uu____6532 = FStar_TypeChecker_Env.get_range env in
-                 let uu____6533 =
-                   let uu____6534 =
-                     FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md
-                       md.FStar_Syntax_Syntax.trivial in
-                   let uu____6535 =
-                     let uu____6536 = FStar_Syntax_Syntax.as_arg t in
-                     let uu____6537 =
-                       let uu____6539 = FStar_Syntax_Syntax.as_arg wp in
-                       [uu____6539] in
-                     uu____6536 :: uu____6537 in
-                   FStar_Syntax_Syntax.mk_Tm_app uu____6534 uu____6535 in
-                 uu____6533
-                   (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n))
-                   uu____6532 in
-               ((let uu____6545 =
-                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                     (FStar_Options.Other "Simplification") in
-                 if uu____6545
-                 then
-                   let uu____6546 = FStar_Syntax_Print.term_to_string vc in
-                   FStar_Util.print1 "top-level VC: %s\n" uu____6546
-                 else ());
-                (let g2 =
-                   let uu____6549 =
-                     FStar_All.pipe_left
-                       FStar_TypeChecker_Rel.guard_of_guard_formula
-                       (FStar_TypeChecker_Common.NonTrivial vc) in
-                   FStar_TypeChecker_Rel.conj_guard g1 uu____6549 in
-                 let uu____6550 = discharge g2 in
-                 let uu____6551 = FStar_Syntax_Syntax.mk_Comp c1 in
-                 (uu____6550, uu____6551))))
-let short_circuit:
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.args -> FStar_TypeChecker_Common.guard_formula
-  =
-  fun head1  ->
-    fun seen_args  ->
-      let short_bin_op f uu___99_6575 =
-        match uu___99_6575 with
-        | [] -> FStar_TypeChecker_Common.Trivial
-        | (fst1,uu____6581)::[] -> f fst1
-        | uu____6594 -> failwith "Unexpexted args to binary operator" in
-      let op_and_e e =
-        let uu____6599 = FStar_Syntax_Util.b2t e in
-        FStar_All.pipe_right uu____6599
-          (fun _0_32  -> FStar_TypeChecker_Common.NonTrivial _0_32) in
-      let op_or_e e =
-        let uu____6608 =
-          let uu____6611 = FStar_Syntax_Util.b2t e in
-          FStar_Syntax_Util.mk_neg uu____6611 in
-        FStar_All.pipe_right uu____6608
-          (fun _0_33  -> FStar_TypeChecker_Common.NonTrivial _0_33) in
-      let op_and_t t =
-        FStar_All.pipe_right t
-          (fun _0_34  -> FStar_TypeChecker_Common.NonTrivial _0_34) in
-      let op_or_t t =
-        let uu____6622 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg in
-        FStar_All.pipe_right uu____6622
-          (fun _0_35  -> FStar_TypeChecker_Common.NonTrivial _0_35) in
-      let op_imp_t t =
-        FStar_All.pipe_right t
-          (fun _0_36  -> FStar_TypeChecker_Common.NonTrivial _0_36) in
-      let short_op_ite uu___100_6636 =
-        match uu___100_6636 with
-        | [] -> FStar_TypeChecker_Common.Trivial
-        | (guard,uu____6642)::[] -> FStar_TypeChecker_Common.NonTrivial guard
-        | _then::(guard,uu____6657)::[] ->
-            let uu____6678 = FStar_Syntax_Util.mk_neg guard in
-            FStar_All.pipe_right uu____6678
-              (fun _0_37  -> FStar_TypeChecker_Common.NonTrivial _0_37)
-        | uu____6683 -> failwith "Unexpected args to ITE" in
-      let table =
-        let uu____6690 =
-          let uu____6695 = short_bin_op op_and_e in
-          (FStar_Syntax_Const.op_And, uu____6695) in
-        let uu____6700 =
-          let uu____6706 =
-            let uu____6711 = short_bin_op op_or_e in
-            (FStar_Syntax_Const.op_Or, uu____6711) in
-          let uu____6716 =
-            let uu____6722 =
-              let uu____6727 = short_bin_op op_and_t in
-              (FStar_Syntax_Const.and_lid, uu____6727) in
-            let uu____6732 =
-              let uu____6738 =
-                let uu____6743 = short_bin_op op_or_t in
-                (FStar_Syntax_Const.or_lid, uu____6743) in
-              let uu____6748 =
-                let uu____6754 =
-                  let uu____6759 = short_bin_op op_imp_t in
-                  (FStar_Syntax_Const.imp_lid, uu____6759) in
-                [uu____6754; (FStar_Syntax_Const.ite_lid, short_op_ite)] in
-              uu____6738 :: uu____6748 in
-            uu____6722 :: uu____6732 in
-          uu____6706 :: uu____6716 in
-        uu____6690 :: uu____6700 in
-      match head1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          let uu____6800 =
-            FStar_Util.find_map table
-              (fun uu____6806  ->
-                 match uu____6806 with
-                 | (x,mk1) ->
-                     if FStar_Ident.lid_equals x lid
-                     then let uu____6819 = mk1 seen_args in Some uu____6819
-                     else None) in
-          (match uu____6800 with
-           | None  -> FStar_TypeChecker_Common.Trivial
-           | Some g -> g)
-      | uu____6822 -> FStar_TypeChecker_Common.Trivial
-let short_circuit_head: FStar_Syntax_Syntax.term -> Prims.bool =
-  fun l  ->
-    let uu____6826 =
-      let uu____6827 = FStar_Syntax_Util.un_uinst l in
-      uu____6827.FStar_Syntax_Syntax.n in
-    match uu____6826 with
-    | FStar_Syntax_Syntax.Tm_fvar fv ->
-        FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)
-          [FStar_Syntax_Const.op_And;
-          FStar_Syntax_Const.op_Or;
-          FStar_Syntax_Const.and_lid;
-          FStar_Syntax_Const.or_lid;
-          FStar_Syntax_Const.imp_lid;
-          FStar_Syntax_Const.ite_lid]
-    | uu____6831 -> false
-let maybe_add_implicit_binders:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
-  =
-  fun env  ->
-    fun bs  ->
-      let pos bs1 =
-        match bs1 with
-        | (hd1,uu____6849)::uu____6850 -> FStar_Syntax_Syntax.range_of_bv hd1
-        | uu____6856 -> FStar_TypeChecker_Env.get_range env in
-      match bs with
-      | (uu____6860,Some (FStar_Syntax_Syntax.Implicit uu____6861))::uu____6862
-          -> bs
-      | uu____6871 ->
-          let uu____6872 = FStar_TypeChecker_Env.expected_typ env in
-          (match uu____6872 with
-           | None  -> bs
-           | Some t ->
-               let uu____6875 =
-                 let uu____6876 = FStar_Syntax_Subst.compress t in
-                 uu____6876.FStar_Syntax_Syntax.n in
-               (match uu____6875 with
-                | FStar_Syntax_Syntax.Tm_arrow (bs',uu____6880) ->
-                    let uu____6891 =
-                      FStar_Util.prefix_until
-                        (fun uu___101_6910  ->
-                           match uu___101_6910 with
-                           | (uu____6914,Some (FStar_Syntax_Syntax.Implicit
-                              uu____6915)) -> false
-                           | uu____6917 -> true) bs' in
-                    (match uu____6891 with
-                     | None  -> bs
-                     | Some ([],uu____6935,uu____6936) -> bs
-                     | Some (imps,uu____6973,uu____6974) ->
-                         let uu____7011 =
-                           FStar_All.pipe_right imps
-                             (FStar_Util.for_all
-                                (fun uu____7019  ->
-                                   match uu____7019 with
-                                   | (x,uu____7024) ->
-                                       FStar_Util.starts_with
-                                         (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                         "'")) in
-                         if uu____7011
-                         then
-                           let r = pos bs in
-                           let imps1 =
-                             FStar_All.pipe_right imps
-                               (FStar_List.map
-                                  (fun uu____7047  ->
-                                     match uu____7047 with
-                                     | (x,i) ->
-                                         let uu____7058 =
-                                           FStar_Syntax_Syntax.set_range_of_bv
-                                             x r in
-                                         (uu____7058, i))) in
-                           FStar_List.append imps1 bs
-                         else bs)
-                | uu____7064 -> bs))
-let maybe_lift:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Ident.lident ->
-        FStar_Ident.lident ->
-          FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun e  ->
-      fun c1  ->
-        fun c2  ->
-          fun t  ->
-            let m1 = FStar_TypeChecker_Env.norm_eff_name env c1 in
-            let m2 = FStar_TypeChecker_Env.norm_eff_name env c2 in
-            if
-              ((FStar_Ident.lid_equals m1 m2) ||
-                 ((FStar_Syntax_Util.is_pure_effect c1) &&
-                    (FStar_Syntax_Util.is_ghost_effect c2)))
-                ||
-                ((FStar_Syntax_Util.is_pure_effect c2) &&
-                   (FStar_Syntax_Util.is_ghost_effect c1))
-            then e
-            else
-              (let uu____7083 = FStar_ST.read e.FStar_Syntax_Syntax.tk in
-               (FStar_Syntax_Syntax.mk
-                  (FStar_Syntax_Syntax.Tm_meta
-                     (e, (FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t)))))
-                 uu____7083 e.FStar_Syntax_Syntax.pos)
-let maybe_monadic:
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Ident.lident ->
-        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
-  =
-  fun env  ->
-    fun e  ->
-      fun c  ->
-        fun t  ->
-          let m = FStar_TypeChecker_Env.norm_eff_name env c in
-          let uu____7109 =
-            ((is_pure_or_ghost_effect env m) ||
-               (FStar_Ident.lid_equals m FStar_Syntax_Const.effect_Tot_lid))
-              ||
-              (FStar_Ident.lid_equals m FStar_Syntax_Const.effect_GTot_lid) in
-          if uu____7109
-          then e
-          else
-            (let uu____7111 = FStar_ST.read e.FStar_Syntax_Syntax.tk in
-             (FStar_Syntax_Syntax.mk
-                (FStar_Syntax_Syntax.Tm_meta
-                   (e, (FStar_Syntax_Syntax.Meta_monadic (m, t)))))
-               uu____7111 e.FStar_Syntax_Syntax.pos)
-let d: Prims.string -> Prims.unit =
-  fun s  -> FStar_Util.print1 "\\x1b[01;36m%s\\x1b[00m\n" s
-let mk_toplevel_definition:
-  FStar_TypeChecker_Env.env_t ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term ->
-        (FStar_Syntax_Syntax.sigelt*
-          (FStar_Syntax_Syntax.term',FStar_Syntax_Syntax.term')
-          FStar_Syntax_Syntax.syntax)
-  =
-  fun env  ->
-    fun lident  ->
-      fun def  ->
-        (let uu____7141 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-         if uu____7141
-         then
-           (d (FStar_Ident.text_of_lid lident);
-            (let uu____7143 = FStar_Syntax_Print.term_to_string def in
-             FStar_Util.print2 "Registering top-level definition: %s\n%s\n"
-               (FStar_Ident.text_of_lid lident) uu____7143))
-         else ());
-        (let fv =
-           let uu____7146 = FStar_Syntax_Util.incr_delta_qualifier def in
-           FStar_Syntax_Syntax.lid_as_fv lident uu____7146 None in
-         let lbname = FStar_Util.Inr fv in
-         let lb =
-           (false,
-             [{
-                FStar_Syntax_Syntax.lbname = lbname;
-                FStar_Syntax_Syntax.lbunivs = [];
-                FStar_Syntax_Syntax.lbtyp = FStar_Syntax_Syntax.tun;
-                FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid;
-                FStar_Syntax_Syntax.lbdef = def
-              }]) in
-         let sig_ctx =
-           FStar_Syntax_Syntax.Sig_let
-             (lb, FStar_Range.dummyRange, [lident],
-               [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen], []) in
-         let uu____7154 =
-           (FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)) None
-             FStar_Range.dummyRange in
-         (sig_ctx, uu____7154))
-let check_sigelt_quals:
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
-  fun env  ->
-    fun se  ->
-      let visibility uu___102_7176 =
-        match uu___102_7176 with
-        | FStar_Syntax_Syntax.Private  -> true
-        | uu____7177 -> false in
-      let reducibility uu___103_7181 =
-        match uu___103_7181 with
-        | FStar_Syntax_Syntax.Abstract 
-          |FStar_Syntax_Syntax.Irreducible 
-           |FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen 
-            |FStar_Syntax_Syntax.Visible_default 
-             |FStar_Syntax_Syntax.Inline_for_extraction 
-            -> true
-        | uu____7182 -> false in
-      let assumption uu___104_7186 =
-        match uu___104_7186 with
-        | FStar_Syntax_Syntax.Assumption |FStar_Syntax_Syntax.New  -> true
-        | uu____7187 -> false in
-      let reification uu___105_7191 =
-        match uu___105_7191 with
-        | FStar_Syntax_Syntax.Reifiable |FStar_Syntax_Syntax.Reflectable _ ->
-            true
-        | uu____7193 -> false in
-      let inferred uu___106_7197 =
-        match uu___106_7197 with
-        | FStar_Syntax_Syntax.Discriminator _
-          |FStar_Syntax_Syntax.Projector _
-           |FStar_Syntax_Syntax.RecordType _
-            |FStar_Syntax_Syntax.RecordConstructor _
-             |FStar_Syntax_Syntax.ExceptionConstructor 
-              |FStar_Syntax_Syntax.HasMaskedEffect 
-               |FStar_Syntax_Syntax.Effect 
-            -> true
-        | uu____7202 -> false in
-      let has_eq uu___107_7206 =
-        match uu___107_7206 with
-        | FStar_Syntax_Syntax.Noeq |FStar_Syntax_Syntax.Unopteq  -> true
-        | uu____7207 -> false in
-      let quals_combo_ok quals q =
-        match q with
-        | FStar_Syntax_Syntax.Assumption  ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    (((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                         (inferred x))
-                        || (visibility x))
-                       || (assumption x))
-                      ||
-                      (env.FStar_TypeChecker_Env.is_iface &&
-                         (x = FStar_Syntax_Syntax.Inline_for_extraction))))
-        | FStar_Syntax_Syntax.New  ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    (((x = q) || (inferred x)) || (visibility x)) ||
-                      (assumption x)))
-        | FStar_Syntax_Syntax.Inline_for_extraction  ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    ((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                          (visibility x))
-                         || (reducibility x))
-                        || (reification x))
-                       || (inferred x))
-                      ||
-                      (env.FStar_TypeChecker_Env.is_iface &&
-                         (x = FStar_Syntax_Syntax.Assumption))))
-        | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen 
-          |FStar_Syntax_Syntax.Visible_default 
-           |FStar_Syntax_Syntax.Irreducible 
-            |FStar_Syntax_Syntax.Abstract 
-             |FStar_Syntax_Syntax.Noeq |FStar_Syntax_Syntax.Unopteq 
-            ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    ((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                          (x = FStar_Syntax_Syntax.Abstract))
-                         || (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                        || (has_eq x))
-                       || (inferred x))
-                      || (visibility x)))
-        | FStar_Syntax_Syntax.TotalEffect  ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    (((x = q) || (inferred x)) || (visibility x)) ||
-                      (reification x)))
-        | FStar_Syntax_Syntax.Logic  ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    ((((x = q) || (x = FStar_Syntax_Syntax.Assumption)) ||
-                        (inferred x))
-                       || (visibility x))
-                      || (reducibility x)))
-        | FStar_Syntax_Syntax.Reifiable |FStar_Syntax_Syntax.Reflectable _ ->
-            FStar_All.pipe_right quals
-              (FStar_List.for_all
-                 (fun x  ->
-                    (((reification x) || (inferred x)) || (visibility x)) ||
-                      (x = FStar_Syntax_Syntax.TotalEffect)))
-        | FStar_Syntax_Syntax.Private  -> true
-        | uu____7232 -> true in
-      let quals = FStar_Syntax_Util.quals_of_sigelt se in
-      let uu____7235 =
-        let uu____7236 =
-          FStar_All.pipe_right quals
-            (FStar_Util.for_some
-               (fun uu___108_7238  ->
-                  match uu___108_7238 with
-                  | FStar_Syntax_Syntax.OnlyName  -> true
-                  | uu____7239 -> false)) in
-        FStar_All.pipe_right uu____7236 Prims.op_Negation in
-      if uu____7235
-      then
-        let r = FStar_Syntax_Util.range_of_sigelt se in
-        let no_dup_quals =
-          FStar_Util.remove_dups (fun x  -> fun y  -> x = y) quals in
-        let err' msg =
-          let uu____7249 =
-            let uu____7250 =
-              let uu____7253 =
-                let uu____7254 = FStar_Syntax_Print.quals_to_string quals in
-                FStar_Util.format2
-                  "The qualifier list \"[%s]\" is not permissible for this element%s"
-                  uu____7254 msg in
-              (uu____7253, r) in
-            FStar_Errors.Error uu____7250 in
-          Prims.raise uu____7249 in
-        let err msg = err' (Prims.strcat ": " msg) in
-        let err'1 uu____7262 = err' "" in
-        (if (FStar_List.length quals) <> (FStar_List.length no_dup_quals)
-         then err "duplicate qualifiers"
-         else ();
-         (let uu____7270 =
-            let uu____7271 =
-              FStar_All.pipe_right quals
-                (FStar_List.for_all (quals_combo_ok quals)) in
-            Prims.op_Negation uu____7271 in
-          if uu____7270 then err "ill-formed combination" else ());
-         (match se with
-          | FStar_Syntax_Syntax.Sig_let
-              ((is_rec,uu____7275),uu____7276,uu____7277,uu____7278,uu____7279)
-              ->
-              ((let uu____7292 =
-                  is_rec &&
-                    (FStar_All.pipe_right quals
-                       (FStar_List.contains
-                          FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) in
-                if uu____7292
-                then err "recursive definitions cannot be marked inline"
-                else ());
-               (let uu____7295 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_some
-                       (fun x  -> (assumption x) || (has_eq x))) in
-                if uu____7295
-                then
-                  err
-                    "definitions cannot be assumed or marked with equality qualifiers"
-                else ()))
-          | FStar_Syntax_Syntax.Sig_bundle uu____7299 ->
-              let uu____7307 =
-                let uu____7308 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_all
-                       (fun x  ->
-                          (((x = FStar_Syntax_Syntax.Abstract) ||
-                              (inferred x))
-                             || (visibility x))
-                            || (has_eq x))) in
-                Prims.op_Negation uu____7308 in
-              if uu____7307 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_declare_typ uu____7312 ->
-              let uu____7319 =
-                FStar_All.pipe_right quals (FStar_Util.for_some has_eq) in
-              if uu____7319 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_assume uu____7322 ->
-              let uu____7328 =
-                let uu____7329 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_all
-                       (fun x  ->
-                          (visibility x) ||
-                            (x = FStar_Syntax_Syntax.Assumption))) in
-                Prims.op_Negation uu____7329 in
-              if uu____7328 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____7333 ->
-              let uu____7336 =
-                let uu____7337 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_all
-                       (fun x  ->
-                          (((x = FStar_Syntax_Syntax.TotalEffect) ||
-                              (inferred x))
-                             || (visibility x))
-                            || (reification x))) in
-                Prims.op_Negation uu____7337 in
-              if uu____7336 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____7341 ->
-              let uu____7344 =
-                let uu____7345 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_all
-                       (fun x  ->
-                          (((x = FStar_Syntax_Syntax.TotalEffect) ||
-                              (inferred x))
-                             || (visibility x))
-                            || (reification x))) in
-                Prims.op_Negation uu____7345 in
-              if uu____7344 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____7349 ->
-              let uu____7359 =
-                let uu____7360 =
-                  FStar_All.pipe_right quals
-                    (FStar_Util.for_all
-                       (fun x  -> (inferred x) || (visibility x))) in
-                Prims.op_Negation uu____7360 in
-              if uu____7359 then err'1 () else ()
-          | uu____7364 -> ()))
-      else ()
-let mk_discriminator_and_indexed_projectors:
-  FStar_Syntax_Syntax.qualifier Prims.list ->
-    FStar_Syntax_Syntax.fv_qual ->
-      Prims.bool ->
-        FStar_TypeChecker_Env.env ->
-          FStar_Ident.lident ->
-            FStar_Ident.lident ->
-              FStar_Syntax_Syntax.univ_names ->
-                FStar_Syntax_Syntax.binders ->
-                  FStar_Syntax_Syntax.binders ->
-                    FStar_Syntax_Syntax.binders ->
-                      FStar_Syntax_Syntax.sigelt Prims.list
-  =
-  fun iquals  ->
-    fun fvq  ->
-      fun refine_domain  ->
-        fun env  ->
-          fun tc  ->
-            fun lid  ->
-              fun uvs  ->
-                fun inductive_tps  ->
-                  fun indices  ->
-                    fun fields  ->
-                      let p = FStar_Ident.range_of_lid lid in
-                      let pos q =
-                        FStar_Syntax_Syntax.withinfo q
-                          FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n p in
-                      let projectee ptyp =
-                        FStar_Syntax_Syntax.gen_bv "projectee" (Some p) ptyp in
-                      let inst_univs =
-                        FStar_List.map
-                          (fun u  -> FStar_Syntax_Syntax.U_name u) uvs in
-                      let tps = inductive_tps in
-                      let arg_typ =
-                        let inst_tc =
-                          let uu____7421 =
-                            let uu____7424 =
-                              let uu____7425 =
-                                let uu____7430 =
-                                  let uu____7431 =
-                                    FStar_Syntax_Syntax.lid_as_fv tc
-                                      FStar_Syntax_Syntax.Delta_constant None in
-                                  FStar_Syntax_Syntax.fv_to_tm uu____7431 in
-                                (uu____7430, inst_univs) in
-                              FStar_Syntax_Syntax.Tm_uinst uu____7425 in
-                            FStar_Syntax_Syntax.mk uu____7424 in
-                          uu____7421 None p in
-                        let args =
-                          FStar_All.pipe_right
-                            (FStar_List.append tps indices)
-                            (FStar_List.map
-                               (fun uu____7457  ->
-                                  match uu____7457 with
-                                  | (x,imp) ->
-                                      let uu____7464 =
-                                        FStar_Syntax_Syntax.bv_to_name x in
-                                      (uu____7464, imp))) in
-                        (FStar_Syntax_Syntax.mk_Tm_app inst_tc args) None p in
-                      let unrefined_arg_binder =
-                        let uu____7470 = projectee arg_typ in
-                        FStar_Syntax_Syntax.mk_binder uu____7470 in
-                      let arg_binder =
-                        if Prims.op_Negation refine_domain
-                        then unrefined_arg_binder
-                        else
-                          (let disc_name =
-                             FStar_Syntax_Util.mk_discriminator lid in
-                           let x =
-                             FStar_Syntax_Syntax.new_bv (Some p) arg_typ in
-                           let sort =
-                             let disc_fvar =
-                               FStar_Syntax_Syntax.fvar
-                                 (FStar_Ident.set_lid_range disc_name p)
-                                 FStar_Syntax_Syntax.Delta_equational None in
-                             let uu____7479 =
-                               let uu____7480 =
-                                 let uu____7481 =
-                                   let uu____7482 =
-                                     FStar_Syntax_Syntax.mk_Tm_uinst
-                                       disc_fvar inst_univs in
-                                   let uu____7483 =
-                                     let uu____7484 =
-                                       let uu____7485 =
-                                         FStar_Syntax_Syntax.bv_to_name x in
-                                       FStar_All.pipe_left
-                                         FStar_Syntax_Syntax.as_arg
-                                         uu____7485 in
-                                     [uu____7484] in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____7482
-                                     uu____7483 in
-                                 uu____7481 None p in
-                               FStar_Syntax_Util.b2t uu____7480 in
-                             FStar_Syntax_Util.refine x uu____7479 in
-                           let uu____7490 =
-                             let uu___143_7491 = projectee arg_typ in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (uu___143_7491.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (uu___143_7491.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = sort
-                             } in
-                           FStar_Syntax_Syntax.mk_binder uu____7490) in
-                      let ntps = FStar_List.length tps in
-                      let all_params =
-                        let uu____7501 =
-                          FStar_List.map
-                            (fun uu____7511  ->
-                               match uu____7511 with
-                               | (x,uu____7518) ->
-                                   (x, (Some FStar_Syntax_Syntax.imp_tag)))
-                            tps in
-                        FStar_List.append uu____7501 fields in
-                      let imp_binders =
-                        FStar_All.pipe_right (FStar_List.append tps indices)
-                          (FStar_List.map
-                             (fun uu____7542  ->
-                                match uu____7542 with
-                                | (x,uu____7549) ->
-                                    (x, (Some FStar_Syntax_Syntax.imp_tag)))) in
-                      let discriminator_ses =
-                        if fvq <> FStar_Syntax_Syntax.Data_ctor
-                        then []
-                        else
-                          (let discriminator_name =
-                             FStar_Syntax_Util.mk_discriminator lid in
-                           let no_decl = false in
-                           let only_decl =
-                             (let uu____7558 =
-                                FStar_TypeChecker_Env.current_module env in
-                              FStar_Ident.lid_equals
-                                FStar_Syntax_Const.prims_lid uu____7558)
-                               ||
-                               (let uu____7559 =
-                                  let uu____7560 =
-                                    FStar_TypeChecker_Env.current_module env in
-                                  uu____7560.FStar_Ident.str in
-                                FStar_Options.dont_gen_projectors uu____7559) in
-                           let quals =
-                             let uu____7563 =
-                               let uu____7565 =
-                                 let uu____7567 =
-                                   only_decl &&
-                                     ((FStar_All.pipe_left Prims.op_Negation
-                                         env.FStar_TypeChecker_Env.is_iface)
-                                        || env.FStar_TypeChecker_Env.admit) in
-                                 if uu____7567
-                                 then [FStar_Syntax_Syntax.Assumption]
-                                 else [] in
-                               let uu____7570 =
-                                 FStar_List.filter
-                                   (fun uu___109_7572  ->
-                                      match uu___109_7572 with
-                                      | FStar_Syntax_Syntax.Abstract  ->
-                                          Prims.op_Negation only_decl
-                                      | FStar_Syntax_Syntax.Private  -> true
-                                      | uu____7573 -> false) iquals in
-                               FStar_List.append uu____7565 uu____7570 in
-                             FStar_List.append
-                               ((FStar_Syntax_Syntax.Discriminator lid) ::
-                               (if only_decl
-                                then [FStar_Syntax_Syntax.Logic]
-                                else [])) uu____7563 in
-                           let binders =
-                             FStar_List.append imp_binders
-                               [unrefined_arg_binder] in
-                           let t =
-                             let bool_typ =
-                               let uu____7586 =
-                                 let uu____7587 =
-                                   FStar_Syntax_Syntax.lid_as_fv
-                                     FStar_Syntax_Const.bool_lid
-                                     FStar_Syntax_Syntax.Delta_constant None in
-                                 FStar_Syntax_Syntax.fv_to_tm uu____7587 in
-                               FStar_Syntax_Syntax.mk_Total uu____7586 in
-                             let uu____7588 =
-                               FStar_Syntax_Util.arrow binders bool_typ in
-                             FStar_All.pipe_left
-                               (FStar_Syntax_Subst.close_univ_vars uvs)
-                               uu____7588 in
-                           let decl =
-                             FStar_Syntax_Syntax.Sig_declare_typ
-                               (discriminator_name, uvs, t, quals,
-                                 (FStar_Ident.range_of_lid discriminator_name)) in
-                           (let uu____7592 =
-                              FStar_TypeChecker_Env.debug env
-                                (FStar_Options.Other "LogTypes") in
-                            if uu____7592
-                            then
-                              let uu____7593 =
-                                FStar_Syntax_Print.sigelt_to_string decl in
-                              FStar_Util.print1
-                                "Declaration of a discriminator %s\n"
-                                uu____7593
-                            else ());
-                           if only_decl
-                           then [decl]
-                           else
-                             (let body =
-                                if Prims.op_Negation refine_domain
-                                then FStar_Syntax_Const.exp_true_bool
-                                else
-                                  (let arg_pats =
-                                     FStar_All.pipe_right all_params
-                                       (FStar_List.mapi
-                                          (fun j  ->
-                                             fun uu____7621  ->
-                                               match uu____7621 with
-                                               | (x,imp) ->
-                                                   let b =
-                                                     FStar_Syntax_Syntax.is_implicit
-                                                       imp in
-                                                   if b && (j < ntps)
-                                                   then
-                                                     let uu____7637 =
-                                                       let uu____7640 =
-                                                         let uu____7641 =
-                                                           let uu____7646 =
-                                                             FStar_Syntax_Syntax.gen_bv
-                                                               (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                               None
-                                                               FStar_Syntax_Syntax.tun in
-                                                           (uu____7646,
-                                                             FStar_Syntax_Syntax.tun) in
-                                                         FStar_Syntax_Syntax.Pat_dot_term
-                                                           uu____7641 in
-                                                       pos uu____7640 in
-                                                     (uu____7637, b)
-                                                   else
-                                                     (let uu____7650 =
-                                                        let uu____7653 =
-                                                          let uu____7654 =
-                                                            FStar_Syntax_Syntax.gen_bv
-                                                              (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                              None
-                                                              FStar_Syntax_Syntax.tun in
-                                                          FStar_Syntax_Syntax.Pat_wild
-                                                            uu____7654 in
-                                                        pos uu____7653 in
-                                                      (uu____7650, b)))) in
-                                   let pat_true =
-                                     let uu____7666 =
-                                       let uu____7669 =
-                                         let uu____7670 =
-                                           let uu____7678 =
-                                             FStar_Syntax_Syntax.lid_as_fv
-                                               lid
-                                               FStar_Syntax_Syntax.Delta_constant
-                                               (Some fvq) in
-                                           (uu____7678, arg_pats) in
-                                         FStar_Syntax_Syntax.Pat_cons
-                                           uu____7670 in
-                                       pos uu____7669 in
-                                     (uu____7666, None,
-                                       FStar_Syntax_Const.exp_true_bool) in
-                                   let pat_false =
-                                     let uu____7700 =
-                                       let uu____7703 =
-                                         let uu____7704 =
-                                           FStar_Syntax_Syntax.new_bv None
-                                             FStar_Syntax_Syntax.tun in
-                                         FStar_Syntax_Syntax.Pat_wild
-                                           uu____7704 in
-                                       pos uu____7703 in
-                                     (uu____7700, None,
-                                       FStar_Syntax_Const.exp_false_bool) in
-                                   let arg_exp =
-                                     FStar_Syntax_Syntax.bv_to_name
-                                       (Prims.fst unrefined_arg_binder) in
-                                   let uu____7713 =
-                                     let uu____7716 =
-                                       let uu____7717 =
-                                         let uu____7733 =
-                                           let uu____7735 =
-                                             FStar_Syntax_Util.branch
-                                               pat_true in
-                                           let uu____7736 =
-                                             let uu____7738 =
-                                               FStar_Syntax_Util.branch
-                                                 pat_false in
-                                             [uu____7738] in
-                                           uu____7735 :: uu____7736 in
-                                         (arg_exp, uu____7733) in
-                                       FStar_Syntax_Syntax.Tm_match
-                                         uu____7717 in
-                                     FStar_Syntax_Syntax.mk uu____7716 in
-                                   uu____7713 None p) in
-                              let dd =
-                                let uu____7749 =
-                                  FStar_All.pipe_right quals
-                                    (FStar_List.contains
-                                       FStar_Syntax_Syntax.Abstract) in
-                                if uu____7749
-                                then
-                                  FStar_Syntax_Syntax.Delta_abstract
-                                    FStar_Syntax_Syntax.Delta_equational
-                                else FStar_Syntax_Syntax.Delta_equational in
-                              let imp =
-                                FStar_Syntax_Util.abs binders body None in
-                              let lbtyp =
-                                if no_decl
-                                then t
-                                else FStar_Syntax_Syntax.tun in
-                              let lb =
-                                let uu____7761 =
-                                  let uu____7764 =
-                                    FStar_Syntax_Syntax.lid_as_fv
-                                      discriminator_name dd None in
-                                  FStar_Util.Inr uu____7764 in
-                                let uu____7765 =
-                                  FStar_Syntax_Subst.close_univ_vars uvs imp in
-                                {
-                                  FStar_Syntax_Syntax.lbname = uu____7761;
-                                  FStar_Syntax_Syntax.lbunivs = uvs;
-                                  FStar_Syntax_Syntax.lbtyp = lbtyp;
-                                  FStar_Syntax_Syntax.lbeff =
-                                    FStar_Syntax_Const.effect_Tot_lid;
-                                  FStar_Syntax_Syntax.lbdef = uu____7765
-                                } in
-                              let impl =
-                                let uu____7769 =
-                                  let uu____7778 =
-                                    let uu____7780 =
-                                      let uu____7781 =
-                                        FStar_All.pipe_right
-                                          lb.FStar_Syntax_Syntax.lbname
-                                          FStar_Util.right in
-                                      FStar_All.pipe_right uu____7781
-                                        (fun fv  ->
-                                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                    [uu____7780] in
-                                  ((false, [lb]), p, uu____7778, quals, []) in
-                                FStar_Syntax_Syntax.Sig_let uu____7769 in
-                              (let uu____7797 =
-                                 FStar_TypeChecker_Env.debug env
-                                   (FStar_Options.Other "LogTypes") in
-                               if uu____7797
-                               then
-                                 let uu____7798 =
-                                   FStar_Syntax_Print.sigelt_to_string impl in
-                                 FStar_Util.print1
-                                   "Implementation of a discriminator %s\n"
-                                   uu____7798
-                               else ());
-                              [decl; impl])) in
-                      let arg_exp =
-                        FStar_Syntax_Syntax.bv_to_name (Prims.fst arg_binder) in
-                      let binders =
-                        FStar_List.append imp_binders [arg_binder] in
-                      let arg =
-                        FStar_Syntax_Util.arg_of_non_null_binder arg_binder in
-                      let subst1 =
-                        FStar_All.pipe_right fields
-                          (FStar_List.mapi
-                             (fun i  ->
-                                fun uu____7818  ->
-                                  match uu____7818 with
-                                  | (a,uu____7822) ->
-                                      let uu____7823 =
-                                        FStar_Syntax_Util.mk_field_projector_name
-                                          lid a i in
-                                      (match uu____7823 with
-                                       | (field_name,uu____7827) ->
-                                           let field_proj_tm =
-                                             let uu____7829 =
-                                               let uu____7830 =
-                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                   field_name
-                                                   FStar_Syntax_Syntax.Delta_equational
-                                                   None in
-                                               FStar_Syntax_Syntax.fv_to_tm
-                                                 uu____7830 in
-                                             FStar_Syntax_Syntax.mk_Tm_uinst
-                                               uu____7829 inst_univs in
-                                           let proj =
-                                             (FStar_Syntax_Syntax.mk_Tm_app
-                                                field_proj_tm [arg]) None p in
-                                           FStar_Syntax_Syntax.NT (a, proj)))) in
-                      let projectors_ses =
-                        let uu____7846 =
-                          FStar_All.pipe_right fields
-                            (FStar_List.mapi
-                               (fun i  ->
-                                  fun uu____7855  ->
-                                    match uu____7855 with
-                                    | (x,uu____7860) ->
-                                        let p1 =
-                                          FStar_Syntax_Syntax.range_of_bv x in
-                                        let uu____7862 =
-                                          FStar_Syntax_Util.mk_field_projector_name
-                                            lid x i in
-                                        (match uu____7862 with
-                                         | (field_name,uu____7867) ->
-                                             let t =
-                                               let uu____7869 =
-                                                 let uu____7870 =
-                                                   let uu____7873 =
-                                                     FStar_Syntax_Subst.subst
-                                                       subst1
-                                                       x.FStar_Syntax_Syntax.sort in
-                                                   FStar_Syntax_Syntax.mk_Total
-                                                     uu____7873 in
-                                                 FStar_Syntax_Util.arrow
-                                                   binders uu____7870 in
-                                               FStar_All.pipe_left
-                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                    uvs) uu____7869 in
-                                             let only_decl =
-                                               ((let uu____7875 =
-                                                   FStar_TypeChecker_Env.current_module
-                                                     env in
-                                                 FStar_Ident.lid_equals
-                                                   FStar_Syntax_Const.prims_lid
-                                                   uu____7875)
-                                                  ||
-                                                  (fvq <>
-                                                     FStar_Syntax_Syntax.Data_ctor))
-                                                 ||
-                                                 (let uu____7876 =
-                                                    let uu____7877 =
-                                                      FStar_TypeChecker_Env.current_module
-                                                        env in
-                                                    uu____7877.FStar_Ident.str in
-                                                  FStar_Options.dont_gen_projectors
-                                                    uu____7876) in
-                                             let no_decl = false in
-                                             let quals q =
-                                               if only_decl
-                                               then
-                                                 let uu____7887 =
-                                                   FStar_List.filter
-                                                     (fun uu___110_7889  ->
-                                                        match uu___110_7889
-                                                        with
-                                                        | FStar_Syntax_Syntax.Abstract
-                                                             -> false
-                                                        | uu____7890 -> true)
-                                                     q in
-                                                 FStar_Syntax_Syntax.Assumption
-                                                   :: uu____7887
-                                               else q in
-                                             let quals1 =
-                                               let iquals1 =
-                                                 FStar_All.pipe_right iquals
-                                                   (FStar_List.filter
-                                                      (fun uu___111_7898  ->
-                                                         match uu___111_7898
-                                                         with
-                                                         | FStar_Syntax_Syntax.Abstract
-                                                           
-                                                           |FStar_Syntax_Syntax.Private
-                                                            -> true
-                                                         | uu____7899 ->
-                                                             false)) in
-                                               quals
-                                                 ((FStar_Syntax_Syntax.Projector
-                                                     (lid,
-                                                       (x.FStar_Syntax_Syntax.ppname)))
-                                                 :: iquals1) in
-                                             let decl =
-                                               FStar_Syntax_Syntax.Sig_declare_typ
-                                                 (field_name, uvs, t, quals1,
-                                                   (FStar_Ident.range_of_lid
-                                                      field_name)) in
-                                             ((let uu____7903 =
-                                                 FStar_TypeChecker_Env.debug
-                                                   env
-                                                   (FStar_Options.Other
-                                                      "LogTypes") in
-                                               if uu____7903
-                                               then
-                                                 let uu____7904 =
-                                                   FStar_Syntax_Print.sigelt_to_string
-                                                     decl in
-                                                 FStar_Util.print1
-                                                   "Declaration of a projector %s\n"
-                                                   uu____7904
-                                               else ());
-                                              if only_decl
-                                              then [decl]
-                                              else
-                                                (let projection =
-                                                   FStar_Syntax_Syntax.gen_bv
-                                                     (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                     None
-                                                     FStar_Syntax_Syntax.tun in
-                                                 let arg_pats =
-                                                   FStar_All.pipe_right
-                                                     all_params
-                                                     (FStar_List.mapi
-                                                        (fun j  ->
-                                                           fun uu____7931  ->
-                                                             match uu____7931
-                                                             with
-                                                             | (x1,imp) ->
-                                                                 let b =
-                                                                   FStar_Syntax_Syntax.is_implicit
-                                                                    imp in
-                                                                 if
-                                                                   (i + ntps)
-                                                                    = j
-                                                                 then
-                                                                   let uu____7947
-                                                                    =
-                                                                    pos
-                                                                    (FStar_Syntax_Syntax.Pat_var
-                                                                    projection) in
-                                                                   (uu____7947,
-                                                                    b)
-                                                                 else
-                                                                   if
-                                                                    b &&
-                                                                    (j < ntps)
-                                                                   then
-                                                                    (let uu____7959
-                                                                    =
-                                                                    let uu____7962
-                                                                    =
-                                                                    let uu____7963
-                                                                    =
-                                                                    let uu____7968
-                                                                    =
-                                                                    FStar_Syntax_Syntax.gen_bv
-                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                                    None
-                                                                    FStar_Syntax_Syntax.tun in
-                                                                    (uu____7968,
-                                                                    FStar_Syntax_Syntax.tun) in
-                                                                    FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____7963 in
-                                                                    pos
-                                                                    uu____7962 in
-                                                                    (uu____7959,
-                                                                    b))
-                                                                   else
-                                                                    (let uu____7972
-                                                                    =
-                                                                    let uu____7975
-                                                                    =
-                                                                    let uu____7976
-                                                                    =
-                                                                    FStar_Syntax_Syntax.gen_bv
-                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                                                    None
-                                                                    FStar_Syntax_Syntax.tun in
-                                                                    FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____7976 in
-                                                                    pos
-                                                                    uu____7975 in
-                                                                    (uu____7972,
-                                                                    b)))) in
-                                                 let pat =
-                                                   let uu____7988 =
-                                                     let uu____7991 =
-                                                       let uu____7992 =
-                                                         let uu____8000 =
-                                                           FStar_Syntax_Syntax.lid_as_fv
-                                                             lid
-                                                             FStar_Syntax_Syntax.Delta_constant
-                                                             (Some fvq) in
-                                                         (uu____8000,
-                                                           arg_pats) in
-                                                       FStar_Syntax_Syntax.Pat_cons
-                                                         uu____7992 in
-                                                     pos uu____7991 in
-                                                   let uu____8006 =
-                                                     FStar_Syntax_Syntax.bv_to_name
-                                                       projection in
-                                                   (uu____7988, None,
-                                                     uu____8006) in
-                                                 let body =
-                                                   let uu____8017 =
-                                                     let uu____8020 =
-                                                       let uu____8021 =
-                                                         let uu____8037 =
-                                                           let uu____8039 =
-                                                             FStar_Syntax_Util.branch
-                                                               pat in
-                                                           [uu____8039] in
-                                                         (arg_exp,
-                                                           uu____8037) in
-                                                       FStar_Syntax_Syntax.Tm_match
-                                                         uu____8021 in
-                                                     FStar_Syntax_Syntax.mk
-                                                       uu____8020 in
-                                                   uu____8017 None p1 in
-                                                 let imp =
-                                                   FStar_Syntax_Util.abs
-                                                     binders body None in
-                                                 let dd =
-                                                   let uu____8056 =
-                                                     FStar_All.pipe_right
-                                                       quals1
-                                                       (FStar_List.contains
-                                                          FStar_Syntax_Syntax.Abstract) in
-                                                   if uu____8056
-                                                   then
-                                                     FStar_Syntax_Syntax.Delta_abstract
-                                                       FStar_Syntax_Syntax.Delta_equational
-                                                   else
-                                                     FStar_Syntax_Syntax.Delta_equational in
-                                                 let lbtyp =
-                                                   if no_decl
-                                                   then t
-                                                   else
-                                                     FStar_Syntax_Syntax.tun in
-                                                 let lb =
-                                                   let uu____8062 =
-                                                     let uu____8065 =
-                                                       FStar_Syntax_Syntax.lid_as_fv
-                                                         field_name dd None in
-                                                     FStar_Util.Inr
-                                                       uu____8065 in
-                                                   let uu____8066 =
-                                                     FStar_Syntax_Subst.close_univ_vars
-                                                       uvs imp in
-                                                   {
-                                                     FStar_Syntax_Syntax.lbname
-                                                       = uu____8062;
-                                                     FStar_Syntax_Syntax.lbunivs
-                                                       = uvs;
-                                                     FStar_Syntax_Syntax.lbtyp
-                                                       = lbtyp;
-                                                     FStar_Syntax_Syntax.lbeff
-                                                       =
-                                                       FStar_Syntax_Const.effect_Tot_lid;
-                                                     FStar_Syntax_Syntax.lbdef
-                                                       = uu____8066
-                                                   } in
-                                                 let impl =
-                                                   let uu____8070 =
-                                                     let uu____8079 =
-                                                       let uu____8081 =
-                                                         let uu____8082 =
-                                                           FStar_All.pipe_right
-                                                             lb.FStar_Syntax_Syntax.lbname
-                                                             FStar_Util.right in
-                                                         FStar_All.pipe_right
-                                                           uu____8082
-                                                           (fun fv  ->
-                                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                                       [uu____8081] in
-                                                     ((false, [lb]), p1,
-                                                       uu____8079, quals1,
-                                                       []) in
-                                                   FStar_Syntax_Syntax.Sig_let
-                                                     uu____8070 in
-                                                 (let uu____8098 =
-                                                    FStar_TypeChecker_Env.debug
-                                                      env
-                                                      (FStar_Options.Other
-                                                         "LogTypes") in
-                                                  if uu____8098
-                                                  then
-                                                    let uu____8099 =
-                                                      FStar_Syntax_Print.sigelt_to_string
-                                                        impl in
-                                                    FStar_Util.print1
-                                                      "Implementation of a projector %s\n"
-                                                      uu____8099
-                                                  else ());
-                                                 if no_decl
-                                                 then [impl]
-                                                 else [decl; impl]))))) in
-                        FStar_All.pipe_right uu____7846 FStar_List.flatten in
-                      FStar_List.append discriminator_ses projectors_ses
-let mk_data_operations:
-  FStar_Syntax_Syntax.qualifier Prims.list ->
-    FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.sigelt Prims.list ->
-        FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list
-  =
-  fun iquals  ->
-    fun env  ->
-      fun tcs  ->
-        fun se  ->
-          match se with
-          | FStar_Syntax_Syntax.Sig_datacon
-              (constr_lid,uvs,t,typ_lid,n_typars,quals,uu____8130,r) when
-              Prims.op_Negation
-                (FStar_Ident.lid_equals constr_lid
-                   FStar_Syntax_Const.lexcons_lid)
-              ->
-              let uu____8136 = FStar_Syntax_Subst.univ_var_opening uvs in
-              (match uu____8136 with
-               | (univ_opening,uvs1) ->
-                   let t1 = FStar_Syntax_Subst.subst univ_opening t in
-                   let uu____8149 = FStar_Syntax_Util.arrow_formals t1 in
-                   (match uu____8149 with
-                    | (formals,uu____8159) ->
-                        let uu____8170 =
-                          let tps_opt =
-                            FStar_Util.find_map tcs
-                              (fun se1  ->
-                                 let uu____8183 =
-                                   let uu____8184 =
-                                     let uu____8185 =
-                                       FStar_Syntax_Util.lid_of_sigelt se1 in
-                                     FStar_Util.must uu____8185 in
-                                   FStar_Ident.lid_equals typ_lid uu____8184 in
-                                 if uu____8183
-                                 then
-                                   match se1 with
-                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                       (uu____8195,uvs',tps,typ0,uu____8199,constrs,uu____8201,uu____8202)
-                                       ->
-                                       Some
-                                         (tps, typ0,
-                                           ((FStar_List.length constrs) >
-                                              (Prims.parse_int "1")))
-                                   | uu____8216 -> failwith "Impossible"
-                                 else None) in
-                          match tps_opt with
-                          | Some x -> x
-                          | None  ->
-                              if
-                                FStar_Ident.lid_equals typ_lid
-                                  FStar_Syntax_Const.exn_lid
-                              then ([], FStar_Syntax_Util.ktype0, true)
-                              else
-                                Prims.raise
-                                  (FStar_Errors.Error
-                                     ("Unexpected data constructor", r)) in
-                        (match uu____8170 with
-                         | (inductive_tps,typ0,should_refine) ->
-                             let inductive_tps1 =
-                               FStar_Syntax_Subst.subst_binders univ_opening
-                                 inductive_tps in
-                             let typ01 =
-                               FStar_Syntax_Subst.subst univ_opening typ0 in
-                             let uu____8258 =
-                               FStar_Syntax_Util.arrow_formals typ01 in
-                             (match uu____8258 with
-                              | (indices,uu____8268) ->
-                                  let refine_domain =
-                                    let uu____8280 =
-                                      FStar_All.pipe_right quals
-                                        (FStar_Util.for_some
-                                           (fun uu___112_8282  ->
-                                              match uu___112_8282 with
-                                              | FStar_Syntax_Syntax.RecordConstructor
-                                                  uu____8283 -> true
-                                              | uu____8288 -> false)) in
-                                    if uu____8280
-                                    then false
-                                    else should_refine in
-                                  let fv_qual =
-                                    let filter_records uu___113_8295 =
-                                      match uu___113_8295 with
-                                      | FStar_Syntax_Syntax.RecordConstructor
-                                          (uu____8297,fns) ->
-                                          Some
-                                            (FStar_Syntax_Syntax.Record_ctor
-                                               (constr_lid, fns))
-                                      | uu____8304 -> None in
-                                    let uu____8305 =
-                                      FStar_Util.find_map quals
-                                        filter_records in
-                                    match uu____8305 with
-                                    | None  -> FStar_Syntax_Syntax.Data_ctor
-                                    | Some q -> q in
-                                  let iquals1 =
-                                    if
-                                      FStar_List.contains
-                                        FStar_Syntax_Syntax.Abstract iquals
-                                    then FStar_Syntax_Syntax.Private ::
-                                      iquals
-                                    else iquals in
-                                  let fields =
-                                    let uu____8313 =
-                                      FStar_Util.first_N n_typars formals in
-                                    match uu____8313 with
-                                    | (imp_tps,fields) ->
-                                        let rename =
-                                          FStar_List.map2
-                                            (fun uu____8344  ->
-                                               fun uu____8345  ->
-                                                 match (uu____8344,
-                                                         uu____8345)
-                                                 with
-                                                 | ((x,uu____8355),(x',uu____8357))
-                                                     ->
-                                                     let uu____8362 =
-                                                       let uu____8367 =
-                                                         FStar_Syntax_Syntax.bv_to_name
-                                                           x' in
-                                                       (x, uu____8367) in
-                                                     FStar_Syntax_Syntax.NT
-                                                       uu____8362) imp_tps
-                                            inductive_tps1 in
-                                        FStar_Syntax_Subst.subst_binders
-                                          rename fields in
-                                  mk_discriminator_and_indexed_projectors
-                                    iquals1 fv_qual refine_domain env typ_lid
-                                    constr_lid uvs1 inductive_tps1 indices
-                                    fields))))
-          | uu____8368 -> []
+(FStar_Syntax_Syntax.bv Prims.option * FStar_Syntax_Syntax.lcomp)
+
+
+let report : FStar_TypeChecker_Env.env  ->  Prims.string Prims.list  ->  Prims.unit = (fun env errs -> (
+
+let uu____12 = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let uu____13 = (FStar_TypeChecker_Err.failed_to_prove_specification errs)
+in (FStar_Errors.report uu____12 uu____13))))
+
+
+let is_type : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____17 = (
+
+let uu____18 = (FStar_Syntax_Subst.compress t)
+in uu____18.FStar_Syntax_Syntax.n)
+in (match (uu____17) with
+| FStar_Syntax_Syntax.Tm_type (uu____21) -> begin
+true
+end
+| uu____22 -> begin
+false
+end)))
+
+
+let t_binders : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) Prims.list = (fun env -> (
+
+let uu____29 = (FStar_TypeChecker_Env.all_binders env)
+in (FStar_All.pipe_right uu____29 (FStar_List.filter (fun uu____35 -> (match (uu____35) with
+| (x, uu____39) -> begin
+(is_type x.FStar_Syntax_Syntax.sort)
+end))))))
+
+
+let new_uvar_aux : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.typ) = (fun env k -> (
+
+let bs = (
+
+let uu____49 = ((FStar_Options.full_context_dependency ()) || (
+
+let uu____50 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____50)))
+in (match (uu____49) with
+| true -> begin
+(FStar_TypeChecker_Env.all_binders env)
+end
+| uu____51 -> begin
+(t_binders env)
+end))
+in (
+
+let uu____52 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_TypeChecker_Rel.new_uvar uu____52 bs k))))
+
+
+let new_uvar : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun env k -> (
+
+let uu____59 = (new_uvar_aux env k)
+in (Prims.fst uu____59)))
+
+
+let as_uvar : FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.uvar = (fun uu___94_64 -> (match (uu___94_64) with
+| {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (uv, uu____66); FStar_Syntax_Syntax.tk = uu____67; FStar_Syntax_Syntax.pos = uu____68; FStar_Syntax_Syntax.vars = uu____69} -> begin
+uv
+end
+| uu____84 -> begin
+(failwith "Impossible")
+end))
+
+
+let new_implicit_var : Prims.string  ->  FStar_Range.range  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.uvar * FStar_Range.range) Prims.list * FStar_TypeChecker_Env.guard_t) = (fun reason r env k -> (
+
+let uu____103 = (FStar_Syntax_Util.destruct k FStar_Syntax_Const.range_of_lid)
+in (match (uu____103) with
+| Some ((uu____116)::((tm, uu____118))::[]) -> begin
+(
+
+let t = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range (tm.FStar_Syntax_Syntax.pos)))) None tm.FStar_Syntax_Syntax.pos)
+in ((t), ([]), (FStar_TypeChecker_Rel.trivial_guard)))
+end
+| uu____162 -> begin
+(
+
+let uu____169 = (new_uvar_aux env k)
+in (match (uu____169) with
+| (t, u) -> begin
+(
+
+let g = (
+
+let uu___114_181 = FStar_TypeChecker_Rel.trivial_guard
+in (
+
+let uu____182 = (
+
+let uu____190 = (
+
+let uu____197 = (as_uvar u)
+in ((reason), (env), (uu____197), (t), (k), (r)))
+in (uu____190)::[])
+in {FStar_TypeChecker_Env.guard_f = uu___114_181.FStar_TypeChecker_Env.guard_f; FStar_TypeChecker_Env.deferred = uu___114_181.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___114_181.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu____182}))
+in (
+
+let uu____210 = (
+
+let uu____214 = (
+
+let uu____217 = (as_uvar u)
+in ((uu____217), (r)))
+in (uu____214)::[])
+in ((t), (uu____210), (g))))
+end))
+end)))
+
+
+let check_uvars : FStar_Range.range  ->  FStar_Syntax_Syntax.typ  ->  Prims.unit = (fun r t -> (
+
+let uvs = (FStar_Syntax_Free.uvars t)
+in (
+
+let uu____235 = (
+
+let uu____236 = (FStar_Util.set_is_empty uvs)
+in (not (uu____236)))
+in (match (uu____235) with
+| true -> begin
+(
+
+let us = (
+
+let uu____240 = (
+
+let uu____242 = (FStar_Util.set_elements uvs)
+in (FStar_List.map (fun uu____258 -> (match (uu____258) with
+| (x, uu____266) -> begin
+(FStar_Syntax_Print.uvar_to_string x)
+end)) uu____242))
+in (FStar_All.pipe_right uu____240 (FStar_String.concat ", ")))
+in ((FStar_Options.push ());
+(FStar_Options.set_option "hide_uvar_nums" (FStar_Options.Bool (false)));
+(FStar_Options.set_option "print_implicits" (FStar_Options.Bool (true)));
+(
+
+let uu____283 = (
+
+let uu____284 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.format2 "Unconstrained unification variables %s in type signature %s; please add an annotation" us uu____284))
+in (FStar_Errors.report r uu____283));
+(FStar_Options.pop ());
+))
+end
+| uu____285 -> begin
+()
+end))))
+
+
+let force_sort' : (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term' = (fun s -> (
+
+let uu____293 = (FStar_ST.read s.FStar_Syntax_Syntax.tk)
+in (match (uu____293) with
+| None -> begin
+(
+
+let uu____298 = (
+
+let uu____299 = (FStar_Range.string_of_range s.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____300 = (FStar_Syntax_Print.term_to_string s)
+in (FStar_Util.format2 "(%s) Impossible: Forced tk not present on %s" uu____299 uu____300)))
+in (failwith uu____298))
+end
+| Some (tk) -> begin
+tk
+end)))
+
+
+let force_sort = (fun s -> (
+
+let uu____315 = (
+
+let uu____318 = (force_sort' s)
+in (FStar_Syntax_Syntax.mk uu____318))
+in (uu____315 None s.FStar_Syntax_Syntax.pos)))
+
+
+let extract_let_rec_annotation : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.letbinding  ->  (FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.typ * Prims.bool) = (fun env uu____335 -> (match (uu____335) with
+| {FStar_Syntax_Syntax.lbname = lbname; FStar_Syntax_Syntax.lbunivs = univ_vars1; FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = uu____342; FStar_Syntax_Syntax.lbdef = e} -> begin
+(
+
+let rng = (FStar_Syntax_Syntax.range_of_lbname lbname)
+in (
+
+let t1 = (FStar_Syntax_Subst.compress t)
+in (match (t1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+((match ((univ_vars1 <> [])) with
+| true -> begin
+(failwith "Impossible: non-empty universe variables but the type is unknown")
+end
+| uu____363 -> begin
+()
+end);
+(
+
+let r = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let mk_binder1 = (fun scope a -> (
+
+let uu____374 = (
+
+let uu____375 = (FStar_Syntax_Subst.compress a.FStar_Syntax_Syntax.sort)
+in uu____375.FStar_Syntax_Syntax.n)
+in (match (uu____374) with
+| FStar_Syntax_Syntax.Tm_unknown -> begin
+(
+
+let uu____380 = (FStar_Syntax_Util.type_u ())
+in (match (uu____380) with
+| (k, uu____386) -> begin
+(
+
+let t2 = (
+
+let uu____388 = (FStar_TypeChecker_Rel.new_uvar e.FStar_Syntax_Syntax.pos scope k)
+in (FStar_All.pipe_right uu____388 Prims.fst))
+in (((
+
+let uu___115_393 = a
+in {FStar_Syntax_Syntax.ppname = uu___115_393.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___115_393.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t2})), (false)))
+end))
+end
+| uu____394 -> begin
+((a), (true))
+end)))
+in (
+
+let rec aux = (fun must_check_ty vars e1 -> (
+
+let e2 = (FStar_Syntax_Subst.compress e1)
+in (match (e2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_meta (e3, uu____419) -> begin
+(aux must_check_ty vars e3)
+end
+| FStar_Syntax_Syntax.Tm_ascribed (e3, t2, uu____426) -> begin
+(((Prims.fst t2)), (true))
+end
+| FStar_Syntax_Syntax.Tm_abs (bs, body, uu____472) -> begin
+(
+
+let uu____495 = (FStar_All.pipe_right bs (FStar_List.fold_left (fun uu____519 uu____520 -> (match (((uu____519), (uu____520))) with
+| ((scope, bs1, must_check_ty1), (a, imp)) -> begin
+(
+
+let uu____562 = (match (must_check_ty1) with
+| true -> begin
+((a), (true))
+end
+| uu____567 -> begin
+(mk_binder1 scope a)
+end)
+in (match (uu____562) with
+| (tb, must_check_ty2) -> begin
+(
+
+let b = ((tb), (imp))
+in (
+
+let bs2 = (FStar_List.append bs1 ((b)::[]))
+in (
+
+let scope1 = (FStar_List.append scope ((b)::[]))
+in ((scope1), (bs2), (must_check_ty2)))))
+end))
+end)) ((vars), ([]), (must_check_ty))))
+in (match (uu____495) with
+| (scope, bs1, must_check_ty1) -> begin
+(
+
+let uu____623 = (aux must_check_ty1 scope body)
+in (match (uu____623) with
+| (res, must_check_ty2) -> begin
+(
+
+let c = (match (res) with
+| FStar_Util.Inl (t2) -> begin
+(
+
+let uu____640 = (FStar_Options.ml_ish ())
+in (match (uu____640) with
+| true -> begin
+(FStar_Syntax_Util.ml_comp t2 r)
+end
+| uu____641 -> begin
+(FStar_Syntax_Syntax.mk_Total t2)
+end))
+end
+| FStar_Util.Inr (c) -> begin
+c
+end)
+in (
+
+let t2 = (FStar_Syntax_Util.arrow bs1 c)
+in ((
+
+let uu____647 = (FStar_TypeChecker_Env.debug env FStar_Options.High)
+in (match (uu____647) with
+| true -> begin
+(
+
+let uu____648 = (FStar_Range.string_of_range r)
+in (
+
+let uu____649 = (FStar_Syntax_Print.term_to_string t2)
+in (
+
+let uu____650 = (FStar_Util.string_of_bool must_check_ty2)
+in (FStar_Util.print3 "(%s) Using type %s .... must check = %s\n" uu____648 uu____649 uu____650))))
+end
+| uu____651 -> begin
+()
+end));
+((FStar_Util.Inl (t2)), (must_check_ty2));
+)))
+end))
+end))
+end
+| uu____658 -> begin
+(match (must_check_ty) with
+| true -> begin
+((FStar_Util.Inl (FStar_Syntax_Syntax.tun)), (true))
+end
+| uu____665 -> begin
+(
+
+let uu____666 = (
+
+let uu____669 = (
+
+let uu____670 = (FStar_TypeChecker_Rel.new_uvar r vars FStar_Syntax_Util.ktype0)
+in (FStar_All.pipe_right uu____670 Prims.fst))
+in FStar_Util.Inl (uu____669))
+in ((uu____666), (false)))
+end)
+end)))
+in (
+
+let uu____677 = (
+
+let uu____682 = (t_binders env)
+in (aux false uu____682 e))
+in (match (uu____677) with
+| (t2, b) -> begin
+(
+
+let t3 = (match (t2) with
+| FStar_Util.Inr (c) -> begin
+(
+
+let uu____699 = (FStar_Syntax_Util.is_tot_or_gtot_comp c)
+in (match (uu____699) with
+| true -> begin
+(FStar_Syntax_Util.comp_result c)
+end
+| uu____702 -> begin
+(
+
+let uu____703 = (
+
+let uu____704 = (
+
+let uu____707 = (
+
+let uu____708 = (FStar_Syntax_Print.comp_to_string c)
+in (FStar_Util.format1 "Expected a \'let rec\' to be annotated with a value type; got a computation type %s" uu____708))
+in ((uu____707), (rng)))
+in FStar_Errors.Error (uu____704))
+in (Prims.raise uu____703))
+end))
+end
+| FStar_Util.Inl (t3) -> begin
+t3
+end)
+in (([]), (t3), (b)))
+end)))));
+)
+end
+| uu____715 -> begin
+(
+
+let uu____716 = (FStar_Syntax_Subst.open_univ_vars univ_vars1 t1)
+in (match (uu____716) with
+| (univ_vars2, t2) -> begin
+((univ_vars2), (t2), (false))
+end))
+end)))
+end))
+
+
+let pat_as_exps : Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.pat  ->  (FStar_Syntax_Syntax.bv Prims.list * FStar_Syntax_Syntax.term Prims.list * FStar_Syntax_Syntax.pat) = (fun allow_implicits env p -> (
+
+let rec pat_as_arg_with_env = (fun allow_wc_dependence env1 p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_constant (c) -> begin
+(
+
+let e = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (c))) None p1.FStar_Syntax_Syntax.p)
+in (([]), ([]), ([]), (env1), (e), (p1)))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, uu____799) -> begin
+(
+
+let uu____804 = (FStar_Syntax_Util.type_u ())
+in (match (uu____804) with
+| (k, uu____817) -> begin
+(
+
+let t = (new_uvar env1 k)
+in (
+
+let x1 = (
+
+let uu___116_820 = x
+in {FStar_Syntax_Syntax.ppname = uu___116_820.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___116_820.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t})
+in (
+
+let uu____821 = (
+
+let uu____824 = (FStar_TypeChecker_Env.all_binders env1)
+in (FStar_TypeChecker_Rel.new_uvar p1.FStar_Syntax_Syntax.p uu____824 t))
+in (match (uu____821) with
+| (e, u) -> begin
+(
+
+let p2 = (
+
+let uu___117_839 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_dot_term (((x1), (e))); FStar_Syntax_Syntax.ty = uu___117_839.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___117_839.FStar_Syntax_Syntax.p})
+in (([]), ([]), ([]), (env1), (e), (p2)))
+end))))
+end))
+end
+| FStar_Syntax_Syntax.Pat_wild (x) -> begin
+(
+
+let uu____846 = (FStar_Syntax_Util.type_u ())
+in (match (uu____846) with
+| (t, uu____859) -> begin
+(
+
+let x1 = (
+
+let uu___118_861 = x
+in (
+
+let uu____862 = (new_uvar env1 t)
+in {FStar_Syntax_Syntax.ppname = uu___118_861.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___118_861.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____862}))
+in (
+
+let env2 = (match (allow_wc_dependence) with
+| true -> begin
+(FStar_TypeChecker_Env.push_bv env1 x1)
+end
+| uu____866 -> begin
+env1
+end)
+in (
+
+let e = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name (x1))) None p1.FStar_Syntax_Syntax.p)
+in (((x1)::[]), ([]), ((x1)::[]), (env2), (e), (p1)))))
+end))
+end
+| FStar_Syntax_Syntax.Pat_var (x) -> begin
+(
+
+let uu____884 = (FStar_Syntax_Util.type_u ())
+in (match (uu____884) with
+| (t, uu____897) -> begin
+(
+
+let x1 = (
+
+let uu___119_899 = x
+in (
+
+let uu____900 = (new_uvar env1 t)
+in {FStar_Syntax_Syntax.ppname = uu___119_899.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___119_899.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = uu____900}))
+in (
+
+let env2 = (FStar_TypeChecker_Env.push_bv env1 x1)
+in (
+
+let e = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name (x1))) None p1.FStar_Syntax_Syntax.p)
+in (((x1)::[]), ((x1)::[]), ([]), (env2), (e), (p1)))))
+end))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____932 = (FStar_All.pipe_right pats (FStar_List.fold_left (fun uu____988 uu____989 -> (match (((uu____988), (uu____989))) with
+| ((b, a, w, env2, args, pats1), (p2, imp)) -> begin
+(
+
+let uu____1088 = (pat_as_arg_with_env allow_wc_dependence env2 p2)
+in (match (uu____1088) with
+| (b', a', w', env3, te, pat) -> begin
+(
+
+let arg = (match (imp) with
+| true -> begin
+(FStar_Syntax_Syntax.iarg te)
+end
+| uu____1127 -> begin
+(FStar_Syntax_Syntax.as_arg te)
+end)
+in (((b')::b), ((a')::a), ((w')::w), (env3), ((arg)::args), ((((pat), (imp)))::pats1)))
+end))
+end)) (([]), ([]), ([]), (env1), ([]), ([]))))
+in (match (uu____932) with
+| (b, a, w, env2, args, pats1) -> begin
+(
+
+let e = (
+
+let uu____1196 = (
+
+let uu____1199 = (
+
+let uu____1200 = (
+
+let uu____1205 = (
+
+let uu____1208 = (
+
+let uu____1209 = (FStar_Syntax_Syntax.fv_to_tm fv)
+in (
+
+let uu____1210 = (FStar_All.pipe_right args FStar_List.rev)
+in (FStar_Syntax_Syntax.mk_Tm_app uu____1209 uu____1210)))
+in (uu____1208 None p1.FStar_Syntax_Syntax.p))
+in ((uu____1205), (FStar_Syntax_Syntax.Meta_desugared (FStar_Syntax_Syntax.Data_app))))
+in FStar_Syntax_Syntax.Tm_meta (uu____1200))
+in (FStar_Syntax_Syntax.mk uu____1199))
+in (uu____1196 None p1.FStar_Syntax_Syntax.p))
+in (
+
+let uu____1227 = (FStar_All.pipe_right (FStar_List.rev b) FStar_List.flatten)
+in (
+
+let uu____1233 = (FStar_All.pipe_right (FStar_List.rev a) FStar_List.flatten)
+in (
+
+let uu____1239 = (FStar_All.pipe_right (FStar_List.rev w) FStar_List.flatten)
+in ((uu____1227), (uu____1233), (uu____1239), (env2), (e), ((
+
+let uu___120_1252 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_cons (((fv), ((FStar_List.rev pats1)))); FStar_Syntax_Syntax.ty = uu___120_1252.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___120_1252.FStar_Syntax_Syntax.p})))))))
+end))
+end
+| FStar_Syntax_Syntax.Pat_disj (uu____1258) -> begin
+(failwith "impossible")
+end))
+in (
+
+let rec elaborate_pat = (fun env1 p1 -> (
+
+let maybe_dot = (fun inaccessible a r -> (match ((allow_implicits && inaccessible)) with
+| true -> begin
+(FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_dot_term (((a), (FStar_Syntax_Syntax.tun)))) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r)
+end
+| uu____1298 -> begin
+(FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_var (a)) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n r)
+end))
+in (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let pats1 = (FStar_List.map (fun uu____1327 -> (match (uu____1327) with
+| (p2, imp) -> begin
+(
+
+let uu____1342 = (elaborate_pat env1 p2)
+in ((uu____1342), (imp)))
+end)) pats)
+in (
+
+let uu____1347 = (FStar_TypeChecker_Env.lookup_datacon env1 fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (match (uu____1347) with
+| (uu____1356, t) -> begin
+(
+
+let uu____1358 = (FStar_Syntax_Util.arrow_formals t)
+in (match (uu____1358) with
+| (f, uu____1369) -> begin
+(
+
+let rec aux = (fun formals pats2 -> (match (((formals), (pats2))) with
+| ([], []) -> begin
+[]
+end
+| ([], (uu____1444)::uu____1445) -> begin
+(Prims.raise (FStar_Errors.Error ((("Too many pattern arguments"), ((FStar_Ident.range_of_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v))))))
+end
+| ((uu____1480)::uu____1481, []) -> begin
+(FStar_All.pipe_right formals (FStar_List.map (fun uu____1521 -> (match (uu____1521) with
+| (t1, imp) -> begin
+(match (imp) with
+| Some (FStar_Syntax_Syntax.Implicit (inaccessible)) -> begin
+(
+
+let a = (
+
+let uu____1539 = (
+
+let uu____1541 = (FStar_Syntax_Syntax.range_of_bv t1)
+in Some (uu____1541))
+in (FStar_Syntax_Syntax.new_bv uu____1539 FStar_Syntax_Syntax.tun))
+in (
+
+let r = (FStar_Ident.range_of_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)
+in (
+
+let uu____1547 = (maybe_dot inaccessible a r)
+in ((uu____1547), (true)))))
+end
+| uu____1552 -> begin
+(
+
+let uu____1554 = (
+
+let uu____1555 = (
+
+let uu____1558 = (
+
+let uu____1559 = (FStar_Syntax_Print.pat_to_string p1)
+in (FStar_Util.format1 "Insufficient pattern arguments (%s)" uu____1559))
+in ((uu____1558), ((FStar_Ident.range_of_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v))))
+in FStar_Errors.Error (uu____1555))
+in (Prims.raise uu____1554))
+end)
+end))))
+end
+| ((f1)::formals', ((p2, p_imp))::pats') -> begin
+(match (f1) with
+| (uu____1610, Some (FStar_Syntax_Syntax.Implicit (uu____1611))) when p_imp -> begin
+(
+
+let uu____1613 = (aux formals' pats')
+in (((p2), (true)))::uu____1613)
+end
+| (uu____1625, Some (FStar_Syntax_Syntax.Implicit (inaccessible))) -> begin
+(
+
+let a = (FStar_Syntax_Syntax.new_bv (Some (p2.FStar_Syntax_Syntax.p)) FStar_Syntax_Syntax.tun)
+in (
+
+let p3 = (maybe_dot inaccessible a (FStar_Ident.range_of_lid fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v))
+in (
+
+let uu____1636 = (aux formals' pats2)
+in (((p3), (true)))::uu____1636)))
+end
+| (uu____1648, imp) -> begin
+(
+
+let uu____1652 = (
+
+let uu____1657 = (FStar_Syntax_Syntax.is_implicit imp)
+in ((p2), (uu____1657)))
+in (
+
+let uu____1660 = (aux formals' pats')
+in (uu____1652)::uu____1660))
+end)
+end))
+in (
+
+let uu___121_1670 = p1
+in (
+
+let uu____1673 = (
+
+let uu____1674 = (
+
+let uu____1682 = (aux f pats1)
+in ((fv), (uu____1682)))
+in FStar_Syntax_Syntax.Pat_cons (uu____1674))
+in {FStar_Syntax_Syntax.v = uu____1673; FStar_Syntax_Syntax.ty = uu___121_1670.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___121_1670.FStar_Syntax_Syntax.p})))
+end))
+end)))
+end
+| uu____1693 -> begin
+p1
+end)))
+in (
+
+let one_pat = (fun allow_wc_dependence env1 p1 -> (
+
+let p2 = (elaborate_pat env1 p1)
+in (
+
+let uu____1719 = (pat_as_arg_with_env allow_wc_dependence env1 p2)
+in (match (uu____1719) with
+| (b, a, w, env2, arg, p3) -> begin
+(
+
+let uu____1749 = (FStar_All.pipe_right b (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq))
+in (match (uu____1749) with
+| Some (x) -> begin
+(
+
+let uu____1762 = (
+
+let uu____1763 = (
+
+let uu____1766 = (FStar_TypeChecker_Err.nonlinear_pattern_variable x)
+in ((uu____1766), (p3.FStar_Syntax_Syntax.p)))
+in FStar_Errors.Error (uu____1763))
+in (Prims.raise uu____1762))
+end
+| uu____1775 -> begin
+((b), (a), (w), (arg), (p3))
+end))
+end))))
+in (
+
+let top_level_pat_as_args = (fun env1 p1 -> (match (p1.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj ([]) -> begin
+(failwith "impossible")
+end
+| FStar_Syntax_Syntax.Pat_disj ((q)::pats) -> begin
+(
+
+let uu____1818 = (one_pat false env1 q)
+in (match (uu____1818) with
+| (b, a, uu____1834, te, q1) -> begin
+(
+
+let uu____1843 = (FStar_List.fold_right (fun p2 uu____1859 -> (match (uu____1859) with
+| (w, args, pats1) -> begin
+(
+
+let uu____1883 = (one_pat false env1 p2)
+in (match (uu____1883) with
+| (b', a', w', arg, p3) -> begin
+(
+
+let uu____1909 = (
+
+let uu____1910 = (FStar_Util.multiset_equiv FStar_Syntax_Syntax.bv_eq a a')
+in (not (uu____1910)))
+in (match (uu____1909) with
+| true -> begin
+(
+
+let uu____1917 = (
+
+let uu____1918 = (
+
+let uu____1921 = (FStar_TypeChecker_Err.disjunctive_pattern_vars a a')
+in (
+
+let uu____1922 = (FStar_TypeChecker_Env.get_range env1)
+in ((uu____1921), (uu____1922))))
+in FStar_Errors.Error (uu____1918))
+in (Prims.raise uu____1917))
+end
+| uu____1929 -> begin
+(
+
+let uu____1930 = (
+
+let uu____1932 = (FStar_Syntax_Syntax.as_arg arg)
+in (uu____1932)::args)
+in (((FStar_List.append w' w)), (uu____1930), ((p3)::pats1)))
+end))
+end))
+end)) pats (([]), ([]), ([])))
+in (match (uu____1843) with
+| (w, args, pats1) -> begin
+(
+
+let uu____1953 = (
+
+let uu____1955 = (FStar_Syntax_Syntax.as_arg te)
+in (uu____1955)::args)
+in (((FStar_List.append b w)), (uu____1953), ((
+
+let uu___122_1960 = p1
+in {FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_disj ((q1)::pats1); FStar_Syntax_Syntax.ty = uu___122_1960.FStar_Syntax_Syntax.ty; FStar_Syntax_Syntax.p = uu___122_1960.FStar_Syntax_Syntax.p}))))
+end))
+end))
+end
+| uu____1961 -> begin
+(
+
+let uu____1962 = (one_pat true env1 p1)
+in (match (uu____1962) with
+| (b, uu____1977, uu____1978, arg, p2) -> begin
+(
+
+let uu____1987 = (
+
+let uu____1989 = (FStar_Syntax_Syntax.as_arg arg)
+in (uu____1989)::[])
+in ((b), (uu____1987), (p2)))
+end))
+end))
+in (
+
+let uu____1992 = (top_level_pat_as_args env p)
+in (match (uu____1992) with
+| (b, args, p1) -> begin
+(
+
+let exps = (FStar_All.pipe_right args (FStar_List.map Prims.fst))
+in ((b), (exps), (p1)))
+end)))))))
+
+
+let decorate_pattern : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.pat  ->  FStar_Syntax_Syntax.term Prims.list  ->  FStar_Syntax_Syntax.pat = (fun env p exps -> (
+
+let qq = p
+in (
+
+let rec aux = (fun p1 e -> (
+
+let pkg = (fun q t -> (FStar_Syntax_Syntax.withinfo q t p1.FStar_Syntax_Syntax.p))
+in (
+
+let e1 = (FStar_Syntax_Util.unmeta e)
+in (match (((p1.FStar_Syntax_Syntax.v), (e1.FStar_Syntax_Syntax.n))) with
+| (uu____2063, FStar_Syntax_Syntax.Tm_uinst (e2, uu____2065)) -> begin
+(aux p1 e2)
+end
+| (FStar_Syntax_Syntax.Pat_constant (uu____2070), FStar_Syntax_Syntax.Tm_constant (uu____2071)) -> begin
+(
+
+let uu____2072 = (force_sort' e1)
+in (pkg p1.FStar_Syntax_Syntax.v uu____2072))
+end
+| (FStar_Syntax_Syntax.Pat_var (x), FStar_Syntax_Syntax.Tm_name (y)) -> begin
+((match ((not ((FStar_Syntax_Syntax.bv_eq x y)))) with
+| true -> begin
+(
+
+let uu____2076 = (
+
+let uu____2077 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____2078 = (FStar_Syntax_Print.bv_to_string y)
+in (FStar_Util.format2 "Expected pattern variable %s; got %s" uu____2077 uu____2078)))
+in (failwith uu____2076))
+end
+| uu____2079 -> begin
+()
+end);
+(
+
+let uu____2081 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Pat")))
+in (match (uu____2081) with
+| true -> begin
+(
+
+let uu____2082 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____2083 = (FStar_TypeChecker_Normalize.term_to_string env y.FStar_Syntax_Syntax.sort)
+in (FStar_Util.print2 "Pattern variable %s introduced at type %s\n" uu____2082 uu____2083)))
+end
+| uu____2084 -> begin
+()
+end));
+(
+
+let s = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env y.FStar_Syntax_Syntax.sort)
+in (
+
+let x1 = (
+
+let uu___123_2087 = x
+in {FStar_Syntax_Syntax.ppname = uu___123_2087.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___123_2087.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = s})
+in (pkg (FStar_Syntax_Syntax.Pat_var (x1)) s.FStar_Syntax_Syntax.n)));
+)
+end
+| (FStar_Syntax_Syntax.Pat_wild (x), FStar_Syntax_Syntax.Tm_name (y)) -> begin
+((
+
+let uu____2091 = (FStar_All.pipe_right (FStar_Syntax_Syntax.bv_eq x y) Prims.op_Negation)
+in (match (uu____2091) with
+| true -> begin
+(
+
+let uu____2092 = (
+
+let uu____2093 = (FStar_Syntax_Print.bv_to_string x)
+in (
+
+let uu____2094 = (FStar_Syntax_Print.bv_to_string y)
+in (FStar_Util.format2 "Expected pattern variable %s; got %s" uu____2093 uu____2094)))
+in (failwith uu____2092))
+end
+| uu____2095 -> begin
+()
+end));
+(
+
+let s = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env y.FStar_Syntax_Syntax.sort)
+in (
+
+let x1 = (
+
+let uu___124_2098 = x
+in {FStar_Syntax_Syntax.ppname = uu___124_2098.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___124_2098.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = s})
+in (pkg (FStar_Syntax_Syntax.Pat_wild (x1)) s.FStar_Syntax_Syntax.n)));
+)
+end
+| (FStar_Syntax_Syntax.Pat_dot_term (x, uu____2100), uu____2101) -> begin
+(
+
+let s = (force_sort e1)
+in (
+
+let x1 = (
+
+let uu___125_2110 = x
+in {FStar_Syntax_Syntax.ppname = uu___125_2110.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___125_2110.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = s})
+in (pkg (FStar_Syntax_Syntax.Pat_dot_term (((x1), (e1)))) s.FStar_Syntax_Syntax.n)))
+end
+| (FStar_Syntax_Syntax.Pat_cons (fv, []), FStar_Syntax_Syntax.Tm_fvar (fv')) -> begin
+((
+
+let uu____2123 = (
+
+let uu____2124 = (FStar_Syntax_Syntax.fv_eq fv fv')
+in (not (uu____2124)))
+in (match (uu____2123) with
+| true -> begin
+(
+
+let uu____2125 = (FStar_Util.format2 "Expected pattern constructor %s; got %s" fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str fv'.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str)
+in (failwith uu____2125))
+end
+| uu____2134 -> begin
+()
+end));
+(
+
+let uu____2135 = (force_sort' e1)
+in (pkg (FStar_Syntax_Syntax.Pat_cons (((fv'), ([])))) uu____2135));
+)
+end
+| ((FStar_Syntax_Syntax.Pat_cons (fv, argpats), FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv'); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, args))) | ((FStar_Syntax_Syntax.Pat_cons (fv, argpats), FStar_Syntax_Syntax.Tm_app ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv'); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, args))) -> begin
+((
+
+let uu____2206 = (
+
+let uu____2207 = (FStar_Syntax_Syntax.fv_eq fv fv')
+in (FStar_All.pipe_right uu____2207 Prims.op_Negation))
+in (match (uu____2206) with
+| true -> begin
+(
+
+let uu____2208 = (FStar_Util.format2 "Expected pattern constructor %s; got %s" fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str fv'.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v.FStar_Ident.str)
+in (failwith uu____2208))
+end
+| uu____2217 -> begin
+()
+end));
+(
+
+let fv1 = fv'
+in (
+
+let rec match_args = (fun matched_pats args1 argpats1 -> (match (((args1), (argpats1))) with
+| ([], []) -> begin
+(
+
+let uu____2296 = (force_sort' e1)
+in (pkg (FStar_Syntax_Syntax.Pat_cons (((fv1), ((FStar_List.rev matched_pats))))) uu____2296))
+end
+| ((arg)::args2, ((argpat, uu____2309))::argpats2) -> begin
+(match (((arg), (argpat.FStar_Syntax_Syntax.v))) with
+| ((e2, Some (FStar_Syntax_Syntax.Implicit (true))), FStar_Syntax_Syntax.Pat_dot_term (uu____2359)) -> begin
+(
+
+let x = (
+
+let uu____2375 = (force_sort e2)
+in (FStar_Syntax_Syntax.new_bv (Some (p1.FStar_Syntax_Syntax.p)) uu____2375))
+in (
+
+let q = (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_dot_term (((x), (e2)))) x.FStar_Syntax_Syntax.sort.FStar_Syntax_Syntax.n p1.FStar_Syntax_Syntax.p)
+in (match_args ((((q), (true)))::matched_pats) args2 argpats2)))
+end
+| ((e2, imp), uu____2389) -> begin
+(
+
+let pat = (
+
+let uu____2404 = (aux argpat e2)
+in (
+
+let uu____2405 = (FStar_Syntax_Syntax.is_implicit imp)
+in ((uu____2404), (uu____2405))))
+in (match_args ((pat)::matched_pats) args2 argpats2))
+end)
+end
+| uu____2408 -> begin
+(
+
+let uu____2422 = (
+
+let uu____2423 = (FStar_Syntax_Print.pat_to_string p1)
+in (
+
+let uu____2424 = (FStar_Syntax_Print.term_to_string e1)
+in (FStar_Util.format2 "Unexpected number of pattern arguments: \n\t%s\n\t%s\n" uu____2423 uu____2424)))
+in (failwith uu____2422))
+end))
+in (match_args [] args argpats)));
+)
+end
+| uu____2431 -> begin
+(
+
+let uu____2434 = (
+
+let uu____2435 = (FStar_Range.string_of_range qq.FStar_Syntax_Syntax.p)
+in (
+
+let uu____2436 = (FStar_Syntax_Print.pat_to_string qq)
+in (
+
+let uu____2437 = (
+
+let uu____2438 = (FStar_All.pipe_right exps (FStar_List.map FStar_Syntax_Print.term_to_string))
+in (FStar_All.pipe_right uu____2438 (FStar_String.concat "\n\t")))
+in (FStar_Util.format3 "(%s) Impossible: pattern to decorate is %s; expression is %s\n" uu____2435 uu____2436 uu____2437))))
+in (failwith uu____2434))
+end))))
+in (match (((p.FStar_Syntax_Syntax.v), (exps))) with
+| (FStar_Syntax_Syntax.Pat_disj (ps), uu____2445) when ((FStar_List.length ps) = (FStar_List.length exps)) -> begin
+(
+
+let ps1 = (FStar_List.map2 aux ps exps)
+in (FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_disj (ps1)) FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n p.FStar_Syntax_Syntax.p))
+end
+| (uu____2461, (e)::[]) -> begin
+(aux p e)
+end
+| uu____2464 -> begin
+(failwith "Unexpected number of patterns")
+end))))
+
+
+let rec decorated_pattern_as_term : FStar_Syntax_Syntax.pat  ->  (FStar_Syntax_Syntax.bv Prims.list * FStar_Syntax_Syntax.term) = (fun pat -> (
+
+let topt = Some (pat.FStar_Syntax_Syntax.ty)
+in (
+
+let mk1 = (fun f -> ((FStar_Syntax_Syntax.mk f) topt pat.FStar_Syntax_Syntax.p))
+in (
+
+let pat_as_arg = (fun uu____2501 -> (match (uu____2501) with
+| (p, i) -> begin
+(
+
+let uu____2511 = (decorated_pattern_as_term p)
+in (match (uu____2511) with
+| (vars, te) -> begin
+(
+
+let uu____2524 = (
+
+let uu____2527 = (FStar_Syntax_Syntax.as_implicit i)
+in ((te), (uu____2527)))
+in ((vars), (uu____2524)))
+end))
+end))
+in (match (pat.FStar_Syntax_Syntax.v) with
+| FStar_Syntax_Syntax.Pat_disj (uu____2534) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Pat_constant (c) -> begin
+(
+
+let uu____2542 = (mk1 (FStar_Syntax_Syntax.Tm_constant (c)))
+in (([]), (uu____2542)))
+end
+| (FStar_Syntax_Syntax.Pat_wild (x)) | (FStar_Syntax_Syntax.Pat_var (x)) -> begin
+(
+
+let uu____2545 = (mk1 (FStar_Syntax_Syntax.Tm_name (x)))
+in (((x)::[]), (uu____2545)))
+end
+| FStar_Syntax_Syntax.Pat_cons (fv, pats) -> begin
+(
+
+let uu____2559 = (
+
+let uu____2567 = (FStar_All.pipe_right pats (FStar_List.map pat_as_arg))
+in (FStar_All.pipe_right uu____2567 FStar_List.unzip))
+in (match (uu____2559) with
+| (vars, args) -> begin
+(
+
+let vars1 = (FStar_List.flatten vars)
+in (
+
+let uu____2625 = (
+
+let uu____2626 = (
+
+let uu____2627 = (
+
+let uu____2637 = (FStar_Syntax_Syntax.fv_to_tm fv)
+in ((uu____2637), (args)))
+in FStar_Syntax_Syntax.Tm_app (uu____2627))
+in (mk1 uu____2626))
+in ((vars1), (uu____2625))))
+end))
+end
+| FStar_Syntax_Syntax.Pat_dot_term (x, e) -> begin
+(([]), (e))
+end)))))
+
+
+let destruct_comp : FStar_Syntax_Syntax.comp_typ  ->  (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.typ) = (fun c -> (
+
+let wp = (match (c.FStar_Syntax_Syntax.effect_args) with
+| ((wp, uu____2666))::[] -> begin
+wp
+end
+| uu____2679 -> begin
+(
+
+let uu____2685 = (
+
+let uu____2686 = (
+
+let uu____2687 = (FStar_List.map (fun uu____2691 -> (match (uu____2691) with
+| (x, uu____2695) -> begin
+(FStar_Syntax_Print.term_to_string x)
+end)) c.FStar_Syntax_Syntax.effect_args)
+in (FStar_All.pipe_right uu____2687 (FStar_String.concat ", ")))
+in (FStar_Util.format2 "Impossible: Got a computation %s with effect args [%s]" c.FStar_Syntax_Syntax.effect_name.FStar_Ident.str uu____2686))
+in (failwith uu____2685))
+end)
+in (
+
+let uu____2699 = (FStar_List.hd c.FStar_Syntax_Syntax.comp_univs)
+in ((uu____2699), (c.FStar_Syntax_Syntax.result_typ), (wp)))))
+
+
+let lift_comp : FStar_Syntax_Syntax.comp_typ  ->  FStar_Ident.lident  ->  FStar_TypeChecker_Env.mlift  ->  FStar_Syntax_Syntax.comp_typ = (fun c m lift -> (
+
+let uu____2713 = (destruct_comp c)
+in (match (uu____2713) with
+| (u, uu____2718, wp) -> begin
+(
+
+let uu____2720 = (
+
+let uu____2726 = (
+
+let uu____2727 = (lift.FStar_TypeChecker_Env.mlift_wp c.FStar_Syntax_Syntax.result_typ wp)
+in (FStar_Syntax_Syntax.as_arg uu____2727))
+in (uu____2726)::[])
+in {FStar_Syntax_Syntax.comp_univs = (u)::[]; FStar_Syntax_Syntax.effect_name = m; FStar_Syntax_Syntax.result_typ = c.FStar_Syntax_Syntax.result_typ; FStar_Syntax_Syntax.effect_args = uu____2720; FStar_Syntax_Syntax.flags = []})
+end)))
+
+
+let join_effects : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Ident.lident = (fun env l1 l2 -> (
+
+let uu____2737 = (
+
+let uu____2741 = (FStar_TypeChecker_Env.norm_eff_name env l1)
+in (
+
+let uu____2742 = (FStar_TypeChecker_Env.norm_eff_name env l2)
+in (FStar_TypeChecker_Env.join env uu____2741 uu____2742)))
+in (match (uu____2737) with
+| (m, uu____2744, uu____2745) -> begin
+m
+end)))
+
+
+let join_lcomp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Ident.lident = (fun env c1 c2 -> (
+
+let uu____2755 = ((FStar_Syntax_Util.is_total_lcomp c1) && (FStar_Syntax_Util.is_total_lcomp c2))
+in (match (uu____2755) with
+| true -> begin
+FStar_Syntax_Const.effect_Tot_lid
+end
+| uu____2756 -> begin
+(join_effects env c1.FStar_Syntax_Syntax.eff_name c2.FStar_Syntax_Syntax.eff_name)
+end)))
+
+
+let lift_and_destruct : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp  ->  ((FStar_Syntax_Syntax.eff_decl * FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) * (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.typ) * (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.typ)) = (fun env c1 c2 -> (
+
+let c11 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c1)
+in (
+
+let c21 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c2)
+in (
+
+let uu____2780 = (FStar_TypeChecker_Env.join env c11.FStar_Syntax_Syntax.effect_name c21.FStar_Syntax_Syntax.effect_name)
+in (match (uu____2780) with
+| (m, lift1, lift2) -> begin
+(
+
+let m1 = (lift_comp c11 m lift1)
+in (
+
+let m2 = (lift_comp c21 m lift2)
+in (
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env m)
+in (
+
+let uu____2802 = (FStar_TypeChecker_Env.wp_signature env md.FStar_Syntax_Syntax.mname)
+in (match (uu____2802) with
+| (a, kwp) -> begin
+(
+
+let uu____2819 = (destruct_comp m1)
+in (
+
+let uu____2823 = (destruct_comp m2)
+in ((((md), (a), (kwp))), (uu____2819), (uu____2823))))
+end)))))
+end)))))
+
+
+let is_pure_effect : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env l -> (
+
+let l1 = (FStar_TypeChecker_Env.norm_eff_name env l)
+in (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid)))
+
+
+let is_pure_or_ghost_effect : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  Prims.bool = (fun env l -> (
+
+let l1 = (FStar_TypeChecker_Env.norm_eff_name env l)
+in ((FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_PURE_lid) || (FStar_Ident.lid_equals l1 FStar_Syntax_Const.effect_GHOST_lid))))
+
+
+let mk_comp_l : FStar_Ident.lident  ->  FStar_Syntax_Syntax.universe  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.cflags Prims.list  ->  FStar_Syntax_Syntax.comp = (fun mname u_result result wp flags -> (
+
+let uu____2871 = (
+
+let uu____2872 = (
+
+let uu____2878 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____2878)::[])
+in {FStar_Syntax_Syntax.comp_univs = (u_result)::[]; FStar_Syntax_Syntax.effect_name = mname; FStar_Syntax_Syntax.result_typ = result; FStar_Syntax_Syntax.effect_args = uu____2872; FStar_Syntax_Syntax.flags = flags})
+in (FStar_Syntax_Syntax.mk_Comp uu____2871)))
+
+
+let mk_comp : FStar_Syntax_Syntax.eff_decl  ->  FStar_Syntax_Syntax.universe  ->  (FStar_Syntax_Syntax.term', FStar_Syntax_Syntax.term') FStar_Syntax_Syntax.syntax  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.cflags Prims.list  ->  FStar_Syntax_Syntax.comp = (fun md -> (mk_comp_l md.FStar_Syntax_Syntax.mname))
+
+
+let lax_mk_tot_or_comp_l : FStar_Ident.lident  ->  FStar_Syntax_Syntax.universe  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.cflags Prims.list  ->  FStar_Syntax_Syntax.comp = (fun mname u_result result flags -> (match ((FStar_Ident.lid_equals mname FStar_Syntax_Const.effect_Tot_lid)) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total' result (Some (u_result)))
+end
+| uu____2907 -> begin
+(mk_comp_l mname u_result result FStar_Syntax_Syntax.tun flags)
+end))
+
+
+let subst_lcomp : FStar_Syntax_Syntax.subst_t  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun subst1 lc -> (
+
+let uu___126_2914 = lc
+in (
+
+let uu____2915 = (FStar_Syntax_Subst.subst subst1 lc.FStar_Syntax_Syntax.res_typ)
+in {FStar_Syntax_Syntax.eff_name = uu___126_2914.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu____2915; FStar_Syntax_Syntax.cflags = uu___126_2914.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = (fun uu____2918 -> (
+
+let uu____2919 = (lc.FStar_Syntax_Syntax.comp ())
+in (FStar_Syntax_Subst.subst_comp subst1 uu____2919)))})))
+
+
+let is_function : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun t -> (
+
+let uu____2923 = (
+
+let uu____2924 = (FStar_Syntax_Subst.compress t)
+in uu____2924.FStar_Syntax_Syntax.n)
+in (match (uu____2923) with
+| FStar_Syntax_Syntax.Tm_arrow (uu____2927) -> begin
+true
+end
+| uu____2935 -> begin
+false
+end)))
+
+
+let return_value : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.comp = (fun env t v1 -> (
+
+let c = (
+
+let uu____2946 = (
+
+let uu____2947 = (FStar_TypeChecker_Env.lid_exists env FStar_Syntax_Const.effect_GTot_lid)
+in (FStar_All.pipe_left Prims.op_Negation uu____2947))
+in (match (uu____2946) with
+| true -> begin
+(FStar_Syntax_Syntax.mk_Total t)
+end
+| uu____2948 -> begin
+(
+
+let m = (
+
+let uu____2950 = (FStar_TypeChecker_Env.effect_decl_opt env FStar_Syntax_Const.effect_PURE_lid)
+in (FStar_Util.must uu____2950))
+in (
+
+let u_t = (env.FStar_TypeChecker_Env.universe_of env t)
+in (
+
+let wp = (
+
+let uu____2954 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____2954) with
+| true -> begin
+FStar_Syntax_Syntax.tun
+end
+| uu____2955 -> begin
+(
+
+let uu____2956 = (FStar_TypeChecker_Env.wp_signature env FStar_Syntax_Const.effect_PURE_lid)
+in (match (uu____2956) with
+| (a, kwp) -> begin
+(
+
+let k = (FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.NT (((a), (t))))::[]) kwp)
+in (
+
+let uu____2962 = (
+
+let uu____2963 = (
+
+let uu____2964 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_t)::[]) env m m.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____2965 = (
+
+let uu____2966 = (FStar_Syntax_Syntax.as_arg t)
+in (
+
+let uu____2967 = (
+
+let uu____2969 = (FStar_Syntax_Syntax.as_arg v1)
+in (uu____2969)::[])
+in (uu____2966)::uu____2967))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____2964 uu____2965)))
+in (uu____2963 (Some (k.FStar_Syntax_Syntax.n)) v1.FStar_Syntax_Syntax.pos))
+in (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env uu____2962)))
+end))
+end))
+in ((mk_comp m) u_t t wp ((FStar_Syntax_Syntax.RETURN)::[])))))
+end))
+in ((
+
+let uu____2975 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Return")))
+in (match (uu____2975) with
+| true -> begin
+(
+
+let uu____2976 = (FStar_Range.string_of_range v1.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____2977 = (FStar_Syntax_Print.term_to_string v1)
+in (
+
+let uu____2978 = (FStar_TypeChecker_Normalize.comp_to_string env c)
+in (FStar_Util.print3 "(%s) returning %s at comp type %s\n" uu____2976 uu____2977 uu____2978))))
+end
+| uu____2979 -> begin
+()
+end));
+c;
+)))
+
+
+let bind : FStar_Range.range  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term Prims.option  ->  FStar_Syntax_Syntax.lcomp  ->  lcomp_with_binder  ->  FStar_Syntax_Syntax.lcomp = (fun r1 env e1opt lc1 uu____2995 -> (match (uu____2995) with
+| (b, lc2) -> begin
+(
+
+let lc11 = (FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1)
+in (
+
+let lc21 = (FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2)
+in (
+
+let joined_eff = (join_lcomp env lc11 lc21)
+in ((
+
+let uu____3005 = (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
+in (match (uu____3005) with
+| true -> begin
+(
+
+let bstr = (match (b) with
+| None -> begin
+"none"
+end
+| Some (x) -> begin
+(FStar_Syntax_Print.bv_to_string x)
+end)
+in (
+
+let uu____3008 = (match (e1opt) with
+| None -> begin
+"None"
+end
+| Some (e) -> begin
+(FStar_Syntax_Print.term_to_string e)
+end)
+in (
+
+let uu____3010 = (FStar_Syntax_Print.lcomp_to_string lc11)
+in (
+
+let uu____3011 = (FStar_Syntax_Print.lcomp_to_string lc21)
+in (FStar_Util.print4 "Before lift: Making bind (e1=%s)@c1=%s\nb=%s\t\tc2=%s\n" uu____3008 uu____3010 bstr uu____3011)))))
+end
+| uu____3012 -> begin
+()
+end));
+(
+
+let bind_it = (fun uu____3016 -> (
+
+let uu____3017 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____3017) with
+| true -> begin
+(
+
+let u_t = (env.FStar_TypeChecker_Env.universe_of env lc21.FStar_Syntax_Syntax.res_typ)
+in (lax_mk_tot_or_comp_l joined_eff u_t lc21.FStar_Syntax_Syntax.res_typ []))
+end
+| uu____3019 -> begin
+(
+
+let c1 = (lc11.FStar_Syntax_Syntax.comp ())
+in (
+
+let c2 = (lc21.FStar_Syntax_Syntax.comp ())
+in ((
+
+let uu____3027 = (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
+in (match (uu____3027) with
+| true -> begin
+(
+
+let uu____3028 = (match (b) with
+| None -> begin
+"none"
+end
+| Some (x) -> begin
+(FStar_Syntax_Print.bv_to_string x)
+end)
+in (
+
+let uu____3030 = (FStar_Syntax_Print.lcomp_to_string lc11)
+in (
+
+let uu____3031 = (FStar_Syntax_Print.comp_to_string c1)
+in (
+
+let uu____3032 = (FStar_Syntax_Print.lcomp_to_string lc21)
+in (
+
+let uu____3033 = (FStar_Syntax_Print.comp_to_string c2)
+in (FStar_Util.print5 "b=%s,Evaluated %s to %s\n And %s to %s\n" uu____3028 uu____3030 uu____3031 uu____3032 uu____3033))))))
+end
+| uu____3034 -> begin
+()
+end));
+(
+
+let try_simplify = (fun uu____3041 -> (
+
+let aux = (fun uu____3050 -> (
+
+let uu____3051 = (FStar_Syntax_Util.is_trivial_wp c1)
+in (match (uu____3051) with
+| true -> begin
+(match (b) with
+| None -> begin
+Some (((c2), ("trivial no binder")))
+end
+| Some (uu____3068) -> begin
+(
+
+let uu____3069 = (FStar_Syntax_Util.is_ml_comp c2)
+in (match (uu____3069) with
+| true -> begin
+Some (((c2), ("trivial ml")))
+end
+| uu____3081 -> begin
+None
+end))
+end)
+end
+| uu____3086 -> begin
+(
+
+let uu____3087 = ((FStar_Syntax_Util.is_ml_comp c1) && (FStar_Syntax_Util.is_ml_comp c2))
+in (match (uu____3087) with
+| true -> begin
+Some (((c2), ("both ml")))
+end
+| uu____3099 -> begin
+None
+end))
+end)))
+in (
+
+let subst_c2 = (fun reason -> (match (((e1opt), (b))) with
+| (Some (e), Some (x)) -> begin
+(
+
+let uu____3120 = (
+
+let uu____3123 = (FStar_Syntax_Subst.subst_comp ((FStar_Syntax_Syntax.NT (((x), (e))))::[]) c2)
+in ((uu____3123), (reason)))
+in Some (uu____3120))
+end
+| uu____3126 -> begin
+(aux ())
+end))
+in (
+
+let uu____3131 = ((FStar_Syntax_Util.is_total_comp c1) && (FStar_Syntax_Util.is_total_comp c2))
+in (match (uu____3131) with
+| true -> begin
+(subst_c2 "both total")
+end
+| uu____3135 -> begin
+(
+
+let uu____3136 = ((FStar_Syntax_Util.is_tot_or_gtot_comp c1) && (FStar_Syntax_Util.is_tot_or_gtot_comp c2))
+in (match (uu____3136) with
+| true -> begin
+(
+
+let uu____3140 = (
+
+let uu____3143 = (FStar_Syntax_Syntax.mk_GTotal (FStar_Syntax_Util.comp_result c2))
+in ((uu____3143), ("both gtot")))
+in Some (uu____3140))
+end
+| uu____3146 -> begin
+(match (((e1opt), (b))) with
+| (Some (e), Some (x)) -> begin
+(
+
+let uu____3156 = ((FStar_Syntax_Util.is_total_comp c1) && (
+
+let uu____3157 = (FStar_Syntax_Syntax.is_null_bv x)
+in (not (uu____3157))))
+in (match (uu____3156) with
+| true -> begin
+(subst_c2 "substituted e")
+end
+| uu____3161 -> begin
+(aux ())
+end))
+end
+| uu____3162 -> begin
+(aux ())
+end)
+end))
+end)))))
+in (
+
+let uu____3167 = (try_simplify ())
+in (match (uu____3167) with
+| Some (c, reason) -> begin
+c
+end
+| None -> begin
+(
+
+let uu____3177 = (lift_and_destruct env c1 c2)
+in (match (uu____3177) with
+| ((md, a, kwp), (u_t1, t1, wp1), (u_t2, t2, wp2)) -> begin
+(
+
+let bs = (match (b) with
+| None -> begin
+(
+
+let uu____3211 = (FStar_Syntax_Syntax.null_binder t1)
+in (uu____3211)::[])
+end
+| Some (x) -> begin
+(
+
+let uu____3213 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____3213)::[])
+end)
+in (
+
+let mk_lam = (fun wp -> (FStar_Syntax_Util.abs bs wp (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[])))))))
+in (
+
+let r11 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range (r1)))) None r1)
+in (
+
+let wp_args = (
+
+let uu____3240 = (FStar_Syntax_Syntax.as_arg r11)
+in (
+
+let uu____3241 = (
+
+let uu____3243 = (FStar_Syntax_Syntax.as_arg t1)
+in (
+
+let uu____3244 = (
+
+let uu____3246 = (FStar_Syntax_Syntax.as_arg t2)
+in (
+
+let uu____3247 = (
+
+let uu____3249 = (FStar_Syntax_Syntax.as_arg wp1)
+in (
+
+let uu____3250 = (
+
+let uu____3252 = (
+
+let uu____3253 = (mk_lam wp2)
+in (FStar_Syntax_Syntax.as_arg uu____3253))
+in (uu____3252)::[])
+in (uu____3249)::uu____3250))
+in (uu____3246)::uu____3247))
+in (uu____3243)::uu____3244))
+in (uu____3240)::uu____3241))
+in (
+
+let k = (FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.NT (((a), (t2))))::[]) kwp)
+in (
+
+let wp = (
+
+let uu____3258 = (
+
+let uu____3259 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_t1)::(u_t2)::[]) env md md.FStar_Syntax_Syntax.bind_wp)
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3259 wp_args))
+in (uu____3258 None t2.FStar_Syntax_Syntax.pos))
+in (
+
+let c = ((mk_comp md) u_t2 t2 wp [])
+in c)))))))
+end))
+end)));
+)))
+end)))
+in {FStar_Syntax_Syntax.eff_name = joined_eff; FStar_Syntax_Syntax.res_typ = lc21.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = []; FStar_Syntax_Syntax.comp = bind_it});
+))))
+end))
+
+
+let label : Prims.string  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun reason r f -> ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((f), (FStar_Syntax_Syntax.Meta_labeled (((reason), (r), (false)))))))) None f.FStar_Syntax_Syntax.pos))
+
+
+let label_opt : FStar_TypeChecker_Env.env  ->  (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_Range.range  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ = (fun env reason r f -> (match (reason) with
+| None -> begin
+f
+end
+| Some (reason1) -> begin
+(
+
+let uu____3308 = (
+
+let uu____3309 = (FStar_TypeChecker_Env.should_verify env)
+in (FStar_All.pipe_left Prims.op_Negation uu____3309))
+in (match (uu____3308) with
+| true -> begin
+f
+end
+| uu____3310 -> begin
+(
+
+let uu____3311 = (reason1 ())
+in (label uu____3311 r f))
+end))
+end))
+
+
+let label_guard : FStar_Range.range  ->  Prims.string  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_TypeChecker_Env.guard_t = (fun r reason g -> (match (g.FStar_TypeChecker_Env.guard_f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+g
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let uu___127_3322 = g
+in (
+
+let uu____3323 = (
+
+let uu____3324 = (label reason r f)
+in FStar_TypeChecker_Common.NonTrivial (uu____3324))
+in {FStar_TypeChecker_Env.guard_f = uu____3323; FStar_TypeChecker_Env.deferred = uu___127_3322.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___127_3322.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___127_3322.FStar_TypeChecker_Env.implicits}))
+end))
+
+
+let weaken_guard : FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula  ->  FStar_TypeChecker_Common.guard_formula = (fun g1 g2 -> (match (((g1), (g2))) with
+| (FStar_TypeChecker_Common.NonTrivial (f1), FStar_TypeChecker_Common.NonTrivial (f2)) -> begin
+(
+
+let g = (FStar_Syntax_Util.mk_imp f1 f2)
+in FStar_TypeChecker_Common.NonTrivial (g))
+end
+| uu____3334 -> begin
+g2
+end))
+
+
+let weaken_precondition : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_TypeChecker_Common.guard_formula  ->  FStar_Syntax_Syntax.lcomp = (fun env lc f -> (
+
+let weaken = (fun uu____3351 -> (
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (
+
+let uu____3355 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____3355) with
+| true -> begin
+c
+end
+| uu____3358 -> begin
+(match (f) with
+| FStar_TypeChecker_Common.Trivial -> begin
+c
+end
+| FStar_TypeChecker_Common.NonTrivial (f1) -> begin
+(
+
+let uu____3362 = (FStar_Syntax_Util.is_ml_comp c)
+in (match (uu____3362) with
+| true -> begin
+c
+end
+| uu____3365 -> begin
+(
+
+let c1 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c)
+in (
+
+let uu____3367 = (destruct_comp c1)
+in (match (uu____3367) with
+| (u_res_t, res_t, wp) -> begin
+(
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env c1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let wp1 = (
+
+let uu____3380 = (
+
+let uu____3381 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md md.FStar_Syntax_Syntax.assume_p)
+in (
+
+let uu____3382 = (
+
+let uu____3383 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3384 = (
+
+let uu____3386 = (FStar_Syntax_Syntax.as_arg f1)
+in (
+
+let uu____3387 = (
+
+let uu____3389 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____3389)::[])
+in (uu____3386)::uu____3387))
+in (uu____3383)::uu____3384))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3381 uu____3382)))
+in (uu____3380 None wp.FStar_Syntax_Syntax.pos))
+in ((mk_comp md) u_res_t res_t wp1 c1.FStar_Syntax_Syntax.flags)))
+end)))
+end))
+end)
+end))))
+in (
+
+let uu___128_3394 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___128_3394.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu___128_3394.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = uu___128_3394.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = weaken})))
+
+
+let strengthen_precondition : (Prims.unit  ->  Prims.string) Prims.option  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_TypeChecker_Env.guard_t  ->  (FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun reason env e lc g0 -> (
+
+let uu____3421 = (FStar_TypeChecker_Rel.is_trivial g0)
+in (match (uu____3421) with
+| true -> begin
+((lc), (g0))
+end
+| uu____3424 -> begin
+((
+
+let uu____3426 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____3426) with
+| true -> begin
+(
+
+let uu____3427 = (FStar_TypeChecker_Normalize.term_to_string env e)
+in (
+
+let uu____3428 = (FStar_TypeChecker_Rel.guard_to_string env g0)
+in (FStar_Util.print2 "+++++++++++++Strengthening pre-condition of term %s with guard %s\n" uu____3427 uu____3428)))
+end
+| uu____3429 -> begin
+()
+end));
+(
+
+let flags = (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags (FStar_List.collect (fun uu___95_3434 -> (match (uu___95_3434) with
+| (FStar_Syntax_Syntax.RETURN) | (FStar_Syntax_Syntax.PARTIAL_RETURN) -> begin
+(FStar_Syntax_Syntax.PARTIAL_RETURN)::[]
+end
+| uu____3436 -> begin
+[]
+end))))
+in (
+
+let strengthen = (fun uu____3442 -> (
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (match (env.FStar_TypeChecker_Env.lax) with
+| true -> begin
+c
+end
+| uu____3448 -> begin
+(
+
+let g01 = (FStar_TypeChecker_Rel.simplify_guard env g0)
+in (
+
+let uu____3450 = (FStar_TypeChecker_Rel.guard_form g01)
+in (match (uu____3450) with
+| FStar_TypeChecker_Common.Trivial -> begin
+c
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let c1 = (
+
+let uu____3457 = ((FStar_Syntax_Util.is_pure_or_ghost_comp c) && (
+
+let uu____3458 = (FStar_Syntax_Util.is_partial_return c)
+in (not (uu____3458))))
+in (match (uu____3457) with
+| true -> begin
+(
+
+let x = (FStar_Syntax_Syntax.gen_bv "strengthen_pre_x" None (FStar_Syntax_Util.comp_result c))
+in (
+
+let xret = (
+
+let uu____3465 = (
+
+let uu____3466 = (FStar_Syntax_Syntax.bv_to_name x)
+in (return_value env x.FStar_Syntax_Syntax.sort uu____3466))
+in (FStar_Syntax_Util.comp_set_flags uu____3465 ((FStar_Syntax_Syntax.PARTIAL_RETURN)::[])))
+in (
+
+let lc1 = (bind e.FStar_Syntax_Syntax.pos env (Some (e)) (FStar_Syntax_Util.lcomp_of_comp c) ((Some (x)), ((FStar_Syntax_Util.lcomp_of_comp xret))))
+in (lc1.FStar_Syntax_Syntax.comp ()))))
+end
+| uu____3469 -> begin
+c
+end))
+in ((
+
+let uu____3471 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____3471) with
+| true -> begin
+(
+
+let uu____3472 = (FStar_TypeChecker_Normalize.term_to_string env e)
+in (
+
+let uu____3473 = (FStar_TypeChecker_Normalize.term_to_string env f)
+in (FStar_Util.print2 "-------------Strengthening pre-condition of term %s with guard %s\n" uu____3472 uu____3473)))
+end
+| uu____3474 -> begin
+()
+end));
+(
+
+let c2 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c1)
+in (
+
+let uu____3476 = (destruct_comp c2)
+in (match (uu____3476) with
+| (u_res_t, res_t, wp) -> begin
+(
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env c2.FStar_Syntax_Syntax.effect_name)
+in (
+
+let wp1 = (
+
+let uu____3489 = (
+
+let uu____3490 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md md.FStar_Syntax_Syntax.assert_p)
+in (
+
+let uu____3491 = (
+
+let uu____3492 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3493 = (
+
+let uu____3495 = (
+
+let uu____3496 = (
+
+let uu____3497 = (FStar_TypeChecker_Env.get_range env)
+in (label_opt env reason uu____3497 f))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3496))
+in (
+
+let uu____3498 = (
+
+let uu____3500 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____3500)::[])
+in (uu____3495)::uu____3498))
+in (uu____3492)::uu____3493))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3490 uu____3491)))
+in (uu____3489 None wp.FStar_Syntax_Syntax.pos))
+in ((
+
+let uu____3506 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____3506) with
+| true -> begin
+(
+
+let uu____3507 = (FStar_Syntax_Print.term_to_string wp1)
+in (FStar_Util.print1 "-------------Strengthened pre-condition is %s\n" uu____3507))
+end
+| uu____3508 -> begin
+()
+end));
+(
+
+let c21 = ((mk_comp md) u_res_t res_t wp1 flags)
+in c21);
+)))
+end)));
+))
+end)))
+end)))
+in (
+
+let uu____3510 = (
+
+let uu___129_3511 = lc
+in (
+
+let uu____3512 = (FStar_TypeChecker_Env.norm_eff_name env lc.FStar_Syntax_Syntax.eff_name)
+in (
+
+let uu____3513 = (
+
+let uu____3515 = ((FStar_Syntax_Util.is_pure_lcomp lc) && (
+
+let uu____3516 = (FStar_Syntax_Util.is_function_typ lc.FStar_Syntax_Syntax.res_typ)
+in (FStar_All.pipe_left Prims.op_Negation uu____3516)))
+in (match (uu____3515) with
+| true -> begin
+flags
+end
+| uu____3518 -> begin
+[]
+end))
+in {FStar_Syntax_Syntax.eff_name = uu____3512; FStar_Syntax_Syntax.res_typ = uu___129_3511.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = uu____3513; FStar_Syntax_Syntax.comp = strengthen})))
+in ((uu____3510), ((
+
+let uu___130_3519 = g0
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___130_3519.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___130_3519.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___130_3519.FStar_TypeChecker_Env.implicits}))))));
+)
+end)))
+
+
+let add_equality_to_post_condition : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.comp', Prims.unit) FStar_Syntax_Syntax.syntax = (fun env comp res_t -> (
+
+let md_pure = (FStar_TypeChecker_Env.get_effect_decl env FStar_Syntax_Const.effect_PURE_lid)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv None res_t)
+in (
+
+let y = (FStar_Syntax_Syntax.new_bv None res_t)
+in (
+
+let uu____3534 = (
+
+let uu____3537 = (FStar_Syntax_Syntax.bv_to_name x)
+in (
+
+let uu____3538 = (FStar_Syntax_Syntax.bv_to_name y)
+in ((uu____3537), (uu____3538))))
+in (match (uu____3534) with
+| (xexp, yexp) -> begin
+(
+
+let u_res_t = (env.FStar_TypeChecker_Env.universe_of env res_t)
+in (
+
+let yret = (
+
+let uu____3547 = (
+
+let uu____3548 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md_pure md_pure.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____3549 = (
+
+let uu____3550 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3551 = (
+
+let uu____3553 = (FStar_Syntax_Syntax.as_arg yexp)
+in (uu____3553)::[])
+in (uu____3550)::uu____3551))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3548 uu____3549)))
+in (uu____3547 None res_t.FStar_Syntax_Syntax.pos))
+in (
+
+let x_eq_y_yret = (
+
+let uu____3561 = (
+
+let uu____3562 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md_pure md_pure.FStar_Syntax_Syntax.assume_p)
+in (
+
+let uu____3563 = (
+
+let uu____3564 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3565 = (
+
+let uu____3567 = (
+
+let uu____3568 = (FStar_Syntax_Util.mk_eq2 u_res_t res_t xexp yexp)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3568))
+in (
+
+let uu____3569 = (
+
+let uu____3571 = (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg yret)
+in (uu____3571)::[])
+in (uu____3567)::uu____3569))
+in (uu____3564)::uu____3565))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3562 uu____3563)))
+in (uu____3561 None res_t.FStar_Syntax_Syntax.pos))
+in (
+
+let forall_y_x_eq_y_yret = (
+
+let uu____3579 = (
+
+let uu____3580 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::(u_res_t)::[]) env md_pure md_pure.FStar_Syntax_Syntax.close_wp)
+in (
+
+let uu____3581 = (
+
+let uu____3582 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3583 = (
+
+let uu____3585 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3586 = (
+
+let uu____3588 = (
+
+let uu____3589 = (
+
+let uu____3590 = (
+
+let uu____3594 = (FStar_Syntax_Syntax.mk_binder y)
+in (uu____3594)::[])
+in (FStar_Syntax_Util.abs uu____3590 x_eq_y_yret (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[])))))))
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____3589))
+in (uu____3588)::[])
+in (uu____3585)::uu____3586))
+in (uu____3582)::uu____3583))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3580 uu____3581)))
+in (uu____3579 None res_t.FStar_Syntax_Syntax.pos))
+in (
+
+let lc2 = ((mk_comp md_pure) u_res_t res_t forall_y_x_eq_y_yret ((FStar_Syntax_Syntax.PARTIAL_RETURN)::[]))
+in (
+
+let lc = (
+
+let uu____3610 = (FStar_TypeChecker_Env.get_range env)
+in (bind uu____3610 env None (FStar_Syntax_Util.lcomp_of_comp comp) ((Some (x)), ((FStar_Syntax_Util.lcomp_of_comp lc2)))))
+in (lc.FStar_Syntax_Syntax.comp ())))))))
+end))))))
+
+
+let ite : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.formula  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun env guard lcomp_then lcomp_else -> (
+
+let joined_eff = (join_lcomp env lcomp_then lcomp_else)
+in (
+
+let comp = (fun uu____3628 -> (
+
+let uu____3629 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____3629) with
+| true -> begin
+(
+
+let u_t = (env.FStar_TypeChecker_Env.universe_of env lcomp_then.FStar_Syntax_Syntax.res_typ)
+in (lax_mk_tot_or_comp_l joined_eff u_t lcomp_then.FStar_Syntax_Syntax.res_typ []))
+end
+| uu____3631 -> begin
+(
+
+let uu____3632 = (
+
+let uu____3645 = (lcomp_then.FStar_Syntax_Syntax.comp ())
+in (
+
+let uu____3646 = (lcomp_else.FStar_Syntax_Syntax.comp ())
+in (lift_and_destruct env uu____3645 uu____3646)))
+in (match (uu____3632) with
+| ((md, uu____3648, uu____3649), (u_res_t, res_t, wp_then), (uu____3653, uu____3654, wp_else)) -> begin
+(
+
+let ifthenelse = (fun md1 res_t1 g wp_t wp_e -> (
+
+let uu____3683 = (FStar_Range.union_ranges wp_t.FStar_Syntax_Syntax.pos wp_e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3684 = (
+
+let uu____3685 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md1 md1.FStar_Syntax_Syntax.if_then_else)
+in (
+
+let uu____3686 = (
+
+let uu____3687 = (FStar_Syntax_Syntax.as_arg res_t1)
+in (
+
+let uu____3688 = (
+
+let uu____3690 = (FStar_Syntax_Syntax.as_arg g)
+in (
+
+let uu____3691 = (
+
+let uu____3693 = (FStar_Syntax_Syntax.as_arg wp_t)
+in (
+
+let uu____3694 = (
+
+let uu____3696 = (FStar_Syntax_Syntax.as_arg wp_e)
+in (uu____3696)::[])
+in (uu____3693)::uu____3694))
+in (uu____3690)::uu____3691))
+in (uu____3687)::uu____3688))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3685 uu____3686)))
+in (uu____3684 None uu____3683))))
+in (
+
+let wp = (ifthenelse md res_t guard wp_then wp_else)
+in (
+
+let uu____3704 = (
+
+let uu____3705 = (FStar_Options.split_cases ())
+in (uu____3705 > (Prims.parse_int "0")))
+in (match (uu____3704) with
+| true -> begin
+(
+
+let comp = ((mk_comp md) u_res_t res_t wp [])
+in (add_equality_to_post_condition env comp res_t))
+end
+| uu____3707 -> begin
+(
+
+let wp1 = (
+
+let uu____3711 = (
+
+let uu____3712 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md md.FStar_Syntax_Syntax.ite_wp)
+in (
+
+let uu____3713 = (
+
+let uu____3714 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3715 = (
+
+let uu____3717 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____3717)::[])
+in (uu____3714)::uu____3715))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3712 uu____3713)))
+in (uu____3711 None wp.FStar_Syntax_Syntax.pos))
+in ((mk_comp md) u_res_t res_t wp1 []))
+end))))
+end))
+end)))
+in (
+
+let uu____3722 = (join_effects env lcomp_then.FStar_Syntax_Syntax.eff_name lcomp_else.FStar_Syntax_Syntax.eff_name)
+in {FStar_Syntax_Syntax.eff_name = uu____3722; FStar_Syntax_Syntax.res_typ = lcomp_then.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = []; FStar_Syntax_Syntax.comp = comp}))))
+
+
+let fvar_const : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term = (fun env lid -> (
+
+let uu____3729 = (
+
+let uu____3730 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_Ident.set_lid_range lid uu____3730))
+in (FStar_Syntax_Syntax.fvar uu____3729 FStar_Syntax_Syntax.Delta_constant None)))
+
+
+let bind_cases : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.lcomp) Prims.list  ->  FStar_Syntax_Syntax.lcomp = (fun env res_t lcases -> (
+
+let eff = (FStar_List.fold_left (fun eff uu____3750 -> (match (uu____3750) with
+| (uu____3753, lc) -> begin
+(join_effects env eff lc.FStar_Syntax_Syntax.eff_name)
+end)) FStar_Syntax_Const.effect_PURE_lid lcases)
+in (
+
+let bind_cases = (fun uu____3758 -> (
+
+let u_res_t = (env.FStar_TypeChecker_Env.universe_of env res_t)
+in (
+
+let uu____3760 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____3760) with
+| true -> begin
+(lax_mk_tot_or_comp_l eff u_res_t res_t [])
+end
+| uu____3761 -> begin
+(
+
+let ifthenelse = (fun md res_t1 g wp_t wp_e -> (
+
+let uu____3780 = (FStar_Range.union_ranges wp_t.FStar_Syntax_Syntax.pos wp_e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____3781 = (
+
+let uu____3782 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md md.FStar_Syntax_Syntax.if_then_else)
+in (
+
+let uu____3783 = (
+
+let uu____3784 = (FStar_Syntax_Syntax.as_arg res_t1)
+in (
+
+let uu____3785 = (
+
+let uu____3787 = (FStar_Syntax_Syntax.as_arg g)
+in (
+
+let uu____3788 = (
+
+let uu____3790 = (FStar_Syntax_Syntax.as_arg wp_t)
+in (
+
+let uu____3791 = (
+
+let uu____3793 = (FStar_Syntax_Syntax.as_arg wp_e)
+in (uu____3793)::[])
+in (uu____3790)::uu____3791))
+in (uu____3787)::uu____3788))
+in (uu____3784)::uu____3785))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3782 uu____3783)))
+in (uu____3781 None uu____3780))))
+in (
+
+let default_case = (
+
+let post_k = (
+
+let uu____3802 = (
+
+let uu____3806 = (FStar_Syntax_Syntax.null_binder res_t)
+in (uu____3806)::[])
+in (
+
+let uu____3807 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.arrow uu____3802 uu____3807)))
+in (
+
+let kwp = (
+
+let uu____3813 = (
+
+let uu____3817 = (FStar_Syntax_Syntax.null_binder post_k)
+in (uu____3817)::[])
+in (
+
+let uu____3818 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_Syntax_Util.arrow uu____3813 uu____3818)))
+in (
+
+let post = (FStar_Syntax_Syntax.new_bv None post_k)
+in (
+
+let wp = (
+
+let uu____3823 = (
+
+let uu____3827 = (FStar_Syntax_Syntax.mk_binder post)
+in (uu____3827)::[])
+in (
+
+let uu____3828 = (
+
+let uu____3829 = (
+
+let uu____3832 = (FStar_TypeChecker_Env.get_range env)
+in (label FStar_TypeChecker_Err.exhaustiveness_check uu____3832))
+in (
+
+let uu____3833 = (fvar_const env FStar_Syntax_Const.false_lid)
+in (FStar_All.pipe_left uu____3829 uu____3833)))
+in (FStar_Syntax_Util.abs uu____3823 uu____3828 (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[]))))))))
+in (
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env FStar_Syntax_Const.effect_PURE_lid)
+in ((mk_comp md) u_res_t res_t wp []))))))
+in (
+
+let comp = (FStar_List.fold_right (fun uu____3847 celse -> (match (uu____3847) with
+| (g, cthen) -> begin
+(
+
+let uu____3853 = (
+
+let uu____3866 = (cthen.FStar_Syntax_Syntax.comp ())
+in (lift_and_destruct env uu____3866 celse))
+in (match (uu____3853) with
+| ((md, uu____3868, uu____3869), (uu____3870, uu____3871, wp_then), (uu____3873, uu____3874, wp_else)) -> begin
+(
+
+let uu____3885 = (ifthenelse md res_t g wp_then wp_else)
+in ((mk_comp md) u_res_t res_t uu____3885 []))
+end))
+end)) lcases default_case)
+in (
+
+let uu____3886 = (
+
+let uu____3887 = (FStar_Options.split_cases ())
+in (uu____3887 > (Prims.parse_int "0")))
+in (match (uu____3886) with
+| true -> begin
+(add_equality_to_post_condition env comp res_t)
+end
+| uu____3888 -> begin
+(
+
+let comp1 = (FStar_TypeChecker_Env.comp_to_comp_typ env comp)
+in (
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env comp1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____3891 = (destruct_comp comp1)
+in (match (uu____3891) with
+| (uu____3895, uu____3896, wp) -> begin
+(
+
+let wp1 = (
+
+let uu____3901 = (
+
+let uu____3902 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_res_t)::[]) env md md.FStar_Syntax_Syntax.ite_wp)
+in (
+
+let uu____3903 = (
+
+let uu____3904 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3905 = (
+
+let uu____3907 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____3907)::[])
+in (uu____3904)::uu____3905))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3902 uu____3903)))
+in (uu____3901 None wp.FStar_Syntax_Syntax.pos))
+in ((mk_comp md) u_res_t res_t wp1 []))
+end))))
+end)))))
+end))))
+in {FStar_Syntax_Syntax.eff_name = eff; FStar_Syntax_Syntax.res_typ = res_t; FStar_Syntax_Syntax.cflags = []; FStar_Syntax_Syntax.comp = bind_cases})))
+
+
+let close_comp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.bv Prims.list  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun env bvs lc -> (
+
+let close1 = (fun uu____3928 -> (
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (
+
+let uu____3932 = (FStar_Syntax_Util.is_ml_comp c)
+in (match (uu____3932) with
+| true -> begin
+c
+end
+| uu____3935 -> begin
+(
+
+let uu____3936 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____3936) with
+| true -> begin
+c
+end
+| uu____3939 -> begin
+(
+
+let close_wp = (fun u_res md res_t bvs1 wp0 -> (FStar_List.fold_right (fun x wp -> (
+
+let bs = (
+
+let uu____3968 = (FStar_Syntax_Syntax.mk_binder x)
+in (uu____3968)::[])
+in (
+
+let us = (
+
+let uu____3971 = (
+
+let uu____3973 = (env.FStar_TypeChecker_Env.universe_of env x.FStar_Syntax_Syntax.sort)
+in (uu____3973)::[])
+in (u_res)::uu____3971)
+in (
+
+let wp1 = (FStar_Syntax_Util.abs bs wp (Some (FStar_Util.Inr (((FStar_Syntax_Const.effect_Tot_lid), ((FStar_Syntax_Syntax.TOTAL)::[]))))))
+in (
+
+let uu____3984 = (
+
+let uu____3985 = (FStar_TypeChecker_Env.inst_effect_fun_with us env md md.FStar_Syntax_Syntax.close_wp)
+in (
+
+let uu____3986 = (
+
+let uu____3987 = (FStar_Syntax_Syntax.as_arg res_t)
+in (
+
+let uu____3988 = (
+
+let uu____3990 = (FStar_Syntax_Syntax.as_arg x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____3991 = (
+
+let uu____3993 = (FStar_Syntax_Syntax.as_arg wp1)
+in (uu____3993)::[])
+in (uu____3990)::uu____3991))
+in (uu____3987)::uu____3988))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____3985 uu____3986)))
+in (uu____3984 None wp0.FStar_Syntax_Syntax.pos)))))) bvs1 wp0))
+in (
+
+let c1 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c)
+in (
+
+let uu____3999 = (destruct_comp c1)
+in (match (uu____3999) with
+| (u_res_t, res_t, wp) -> begin
+(
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env c1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let wp1 = (close_wp u_res_t md res_t bvs wp)
+in ((mk_comp md) u_res_t c1.FStar_Syntax_Syntax.result_typ wp1 c1.FStar_Syntax_Syntax.flags)))
+end))))
+end))
+end))))
+in (
+
+let uu___131_4010 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___131_4010.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu___131_4010.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = uu___131_4010.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = close1})))
+
+
+let maybe_assume_result_eq_pure_term : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.lcomp = (fun env e lc -> (
+
+let refine1 = (fun uu____4025 -> (
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (
+
+let uu____4029 = ((
+
+let uu____4030 = (is_pure_or_ghost_effect env lc.FStar_Syntax_Syntax.eff_name)
+in (not (uu____4030))) || env.FStar_TypeChecker_Env.lax)
+in (match (uu____4029) with
+| true -> begin
+c
+end
+| uu____4033 -> begin
+(
+
+let uu____4034 = (FStar_Syntax_Util.is_partial_return c)
+in (match (uu____4034) with
+| true -> begin
+c
+end
+| uu____4037 -> begin
+(
+
+let uu____4038 = ((FStar_Syntax_Util.is_tot_or_gtot_comp c) && (
+
+let uu____4039 = (FStar_TypeChecker_Env.lid_exists env FStar_Syntax_Const.effect_GTot_lid)
+in (not (uu____4039))))
+in (match (uu____4038) with
+| true -> begin
+(
+
+let uu____4042 = (
+
+let uu____4043 = (FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____4044 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.format2 "%s: %s\n" uu____4043 uu____4044)))
+in (failwith uu____4042))
+end
+| uu____4047 -> begin
+(
+
+let c1 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c)
+in (
+
+let t = c1.FStar_Syntax_Syntax.result_typ
+in (
+
+let c2 = (FStar_Syntax_Syntax.mk_Comp c1)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (t.FStar_Syntax_Syntax.pos)) t)
+in (
+
+let xexp = (FStar_Syntax_Syntax.bv_to_name x)
+in (
+
+let ret1 = (
+
+let uu____4056 = (
+
+let uu____4059 = (return_value env t xexp)
+in (FStar_Syntax_Util.comp_set_flags uu____4059 ((FStar_Syntax_Syntax.PARTIAL_RETURN)::[])))
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____4056))
+in (
+
+let eq1 = (
+
+let uu____4063 = (env.FStar_TypeChecker_Env.universe_of env t)
+in (FStar_Syntax_Util.mk_eq2 uu____4063 t xexp e))
+in (
+
+let eq_ret = (weaken_precondition env ret1 (FStar_TypeChecker_Common.NonTrivial (eq1)))
+in (
+
+let c3 = (
+
+let uu____4068 = (
+
+let uu____4069 = (
+
+let uu____4074 = (bind e.FStar_Syntax_Syntax.pos env None (FStar_Syntax_Util.lcomp_of_comp c2) ((Some (x)), (eq_ret)))
+in uu____4074.FStar_Syntax_Syntax.comp)
+in (uu____4069 ()))
+in (FStar_Syntax_Util.comp_set_flags uu____4068 ((FStar_Syntax_Syntax.PARTIAL_RETURN)::(FStar_Syntax_Util.comp_flags c2))))
+in c3)))))))))
+end))
+end))
+end))))
+in (
+
+let flags = (
+
+let uu____4078 = (((
+
+let uu____4079 = (FStar_Syntax_Util.is_function_typ lc.FStar_Syntax_Syntax.res_typ)
+in (not (uu____4079))) && (FStar_Syntax_Util.is_pure_or_ghost_lcomp lc)) && (
+
+let uu____4080 = (FStar_Syntax_Util.is_lcomp_partial_return lc)
+in (not (uu____4080))))
+in (match (uu____4078) with
+| true -> begin
+(FStar_Syntax_Syntax.PARTIAL_RETURN)::lc.FStar_Syntax_Syntax.cflags
+end
+| uu____4082 -> begin
+lc.FStar_Syntax_Syntax.cflags
+end))
+in (
+
+let uu___132_4083 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___132_4083.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = uu___132_4083.FStar_Syntax_Syntax.res_typ; FStar_Syntax_Syntax.cflags = flags; FStar_Syntax_Syntax.comp = refine1}))))
+
+
+let check_comp : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.comp  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp * FStar_TypeChecker_Env.guard_t) = (fun env e c c' -> (
+
+let uu____4102 = (FStar_TypeChecker_Rel.sub_comp env c c')
+in (match (uu____4102) with
+| None -> begin
+(
+
+let uu____4107 = (
+
+let uu____4108 = (
+
+let uu____4111 = (FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation env e c c')
+in (
+
+let uu____4112 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____4111), (uu____4112))))
+in FStar_Errors.Error (uu____4108))
+in (Prims.raise uu____4107))
+end
+| Some (g) -> begin
+((e), (c'), (g))
+end)))
+
+
+let maybe_coerce_bool_to_type : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp) = (fun env e lc t -> (
+
+let uu____4133 = (
+
+let uu____4134 = (FStar_Syntax_Subst.compress t)
+in uu____4134.FStar_Syntax_Syntax.n)
+in (match (uu____4133) with
+| FStar_Syntax_Syntax.Tm_type (uu____4139) -> begin
+(
+
+let uu____4140 = (
+
+let uu____4141 = (FStar_Syntax_Subst.compress lc.FStar_Syntax_Syntax.res_typ)
+in uu____4141.FStar_Syntax_Syntax.n)
+in (match (uu____4140) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.bool_lid) -> begin
+(
+
+let uu____4147 = (FStar_TypeChecker_Env.lookup_lid env FStar_Syntax_Const.b2t_lid)
+in (
+
+let b2t1 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.b2t_lid e.FStar_Syntax_Syntax.pos) (FStar_Syntax_Syntax.Delta_defined_at_level ((Prims.parse_int "1"))) None)
+in (
+
+let lc1 = (
+
+let uu____4154 = (
+
+let uu____4155 = (
+
+let uu____4156 = (FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____4156))
+in ((None), (uu____4155)))
+in (bind e.FStar_Syntax_Syntax.pos env (Some (e)) lc uu____4154))
+in (
+
+let e1 = (
+
+let uu____4165 = (
+
+let uu____4166 = (
+
+let uu____4167 = (FStar_Syntax_Syntax.as_arg e)
+in (uu____4167)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app b2t1 uu____4166))
+in (uu____4165 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos))
+in ((e1), (lc1))))))
+end
+| uu____4174 -> begin
+((e), (lc))
+end))
+end
+| uu____4175 -> begin
+((e), (lc))
+end)))
+
+
+let weaken_result_typ : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.lcomp  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.lcomp * FStar_TypeChecker_Env.guard_t) = (fun env e lc t -> (
+
+let use_eq = (env.FStar_TypeChecker_Env.use_eq || (
+
+let uu____4195 = (FStar_TypeChecker_Env.effect_decl_opt env lc.FStar_Syntax_Syntax.eff_name)
+in (match (uu____4195) with
+| Some (ed) -> begin
+(FStar_All.pipe_right ed.FStar_Syntax_Syntax.qualifiers (FStar_List.contains FStar_Syntax_Syntax.Reifiable))
+end
+| uu____4199 -> begin
+false
+end)))
+in (
+
+let gopt = (match (use_eq) with
+| true -> begin
+(
+
+let uu____4208 = (FStar_TypeChecker_Rel.try_teq true env lc.FStar_Syntax_Syntax.res_typ t)
+in ((uu____4208), (false)))
+end
+| uu____4211 -> begin
+(
+
+let uu____4212 = (FStar_TypeChecker_Rel.try_subtype env lc.FStar_Syntax_Syntax.res_typ t)
+in ((uu____4212), (true)))
+end)
+in (match (gopt) with
+| (None, uu____4218) -> begin
+((FStar_TypeChecker_Rel.subtype_fail env e lc.FStar_Syntax_Syntax.res_typ t);
+((e), ((
+
+let uu___133_4221 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___133_4221.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu___133_4221.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___133_4221.FStar_Syntax_Syntax.comp})), (FStar_TypeChecker_Rel.trivial_guard));
+)
+end
+| (Some (g), apply_guard1) -> begin
+(
+
+let uu____4225 = (FStar_TypeChecker_Rel.guard_form g)
+in (match (uu____4225) with
+| FStar_TypeChecker_Common.Trivial -> begin
+(
+
+let lc1 = (
+
+let uu___134_4230 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___134_4230.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu___134_4230.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___134_4230.FStar_Syntax_Syntax.comp})
+in ((e), (lc1), (g)))
+end
+| FStar_TypeChecker_Common.NonTrivial (f) -> begin
+(
+
+let g1 = (
+
+let uu___135_4233 = g
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___135_4233.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___135_4233.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___135_4233.FStar_TypeChecker_Env.implicits})
+in (
+
+let strengthen = (fun uu____4239 -> (
+
+let uu____4240 = (env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()))
+in (match (uu____4240) with
+| true -> begin
+(lc.FStar_Syntax_Syntax.comp ())
+end
+| uu____4243 -> begin
+(
+
+let f1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.Simplify)::[]) env f)
+in (
+
+let uu____4245 = (
+
+let uu____4246 = (FStar_Syntax_Subst.compress f1)
+in uu____4246.FStar_Syntax_Syntax.n)
+in (match (uu____4245) with
+| FStar_Syntax_Syntax.Tm_abs (uu____4251, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar (fv); FStar_Syntax_Syntax.tk = uu____4253; FStar_Syntax_Syntax.pos = uu____4254; FStar_Syntax_Syntax.vars = uu____4255}, uu____4256) when (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Syntax_Const.true_lid) -> begin
+(
+
+let lc1 = (
+
+let uu___136_4280 = lc
+in {FStar_Syntax_Syntax.eff_name = uu___136_4280.FStar_Syntax_Syntax.eff_name; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = uu___136_4280.FStar_Syntax_Syntax.cflags; FStar_Syntax_Syntax.comp = uu___136_4280.FStar_Syntax_Syntax.comp})
+in (lc1.FStar_Syntax_Syntax.comp ()))
+end
+| uu____4281 -> begin
+(
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in ((
+
+let uu____4286 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____4286) with
+| true -> begin
+(
+
+let uu____4287 = (FStar_TypeChecker_Normalize.term_to_string env lc.FStar_Syntax_Syntax.res_typ)
+in (
+
+let uu____4288 = (FStar_TypeChecker_Normalize.term_to_string env t)
+in (
+
+let uu____4289 = (FStar_TypeChecker_Normalize.comp_to_string env c)
+in (
+
+let uu____4290 = (FStar_TypeChecker_Normalize.term_to_string env f1)
+in (FStar_Util.print4 "Weakened from %s to %s\nStrengthening %s with guard %s\n" uu____4287 uu____4288 uu____4289 uu____4290)))))
+end
+| uu____4291 -> begin
+()
+end));
+(
+
+let ct = (FStar_TypeChecker_Env.unfold_effect_abbrev env c)
+in (
+
+let uu____4293 = (FStar_TypeChecker_Env.wp_signature env FStar_Syntax_Const.effect_PURE_lid)
+in (match (uu____4293) with
+| (a, kwp) -> begin
+(
+
+let k = (FStar_Syntax_Subst.subst ((FStar_Syntax_Syntax.NT (((a), (t))))::[]) kwp)
+in (
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env ct.FStar_Syntax_Syntax.effect_name)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (t.FStar_Syntax_Syntax.pos)) t)
+in (
+
+let xexp = (FStar_Syntax_Syntax.bv_to_name x)
+in (
+
+let uu____4304 = (destruct_comp ct)
+in (match (uu____4304) with
+| (u_t, uu____4311, uu____4312) -> begin
+(
+
+let wp = (
+
+let uu____4316 = (
+
+let uu____4317 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_t)::[]) env md md.FStar_Syntax_Syntax.ret_wp)
+in (
+
+let uu____4318 = (
+
+let uu____4319 = (FStar_Syntax_Syntax.as_arg t)
+in (
+
+let uu____4320 = (
+
+let uu____4322 = (FStar_Syntax_Syntax.as_arg xexp)
+in (uu____4322)::[])
+in (uu____4319)::uu____4320))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____4317 uu____4318)))
+in (uu____4316 (Some (k.FStar_Syntax_Syntax.n)) xexp.FStar_Syntax_Syntax.pos))
+in (
+
+let cret = (
+
+let uu____4328 = ((mk_comp md) u_t t wp ((FStar_Syntax_Syntax.RETURN)::[]))
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____4328))
+in (
+
+let guard = (match (apply_guard1) with
+| true -> begin
+(
+
+let uu____4338 = (
+
+let uu____4339 = (
+
+let uu____4340 = (FStar_Syntax_Syntax.as_arg xexp)
+in (uu____4340)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app f1 uu____4339))
+in (uu____4338 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) f1.FStar_Syntax_Syntax.pos))
+end
+| uu____4345 -> begin
+f1
+end)
+in (
+
+let uu____4346 = (
+
+let uu____4349 = (FStar_All.pipe_left (fun _0_28 -> Some (_0_28)) (FStar_TypeChecker_Err.subtyping_failed env lc.FStar_Syntax_Syntax.res_typ t))
+in (
+
+let uu____4360 = (FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____4361 = (FStar_All.pipe_left FStar_TypeChecker_Rel.guard_of_guard_formula (FStar_TypeChecker_Common.NonTrivial (guard)))
+in (strengthen_precondition uu____4349 uu____4360 e cret uu____4361))))
+in (match (uu____4346) with
+| (eq_ret, _trivial_so_ok_to_discard) -> begin
+(
+
+let x1 = (
+
+let uu___137_4367 = x
+in {FStar_Syntax_Syntax.ppname = uu___137_4367.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___137_4367.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = lc.FStar_Syntax_Syntax.res_typ})
+in (
+
+let c1 = (
+
+let uu____4369 = (
+
+let uu____4370 = (FStar_Syntax_Syntax.mk_Comp ct)
+in (FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____4370))
+in (bind e.FStar_Syntax_Syntax.pos env (Some (e)) uu____4369 ((Some (x1)), (eq_ret))))
+in (
+
+let c2 = (c1.FStar_Syntax_Syntax.comp ())
+in ((
+
+let uu____4380 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme)
+in (match (uu____4380) with
+| true -> begin
+(
+
+let uu____4381 = (FStar_TypeChecker_Normalize.comp_to_string env c2)
+in (FStar_Util.print1 "Strengthened to %s\n" uu____4381))
+end
+| uu____4382 -> begin
+()
+end));
+c2;
+))))
+end)))))
+end))))))
+end)));
+))
+end)))
+end)))
+in (
+
+let flags = (FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags (FStar_List.collect (fun uu___96_4387 -> (match (uu___96_4387) with
+| (FStar_Syntax_Syntax.RETURN) | (FStar_Syntax_Syntax.PARTIAL_RETURN) -> begin
+(FStar_Syntax_Syntax.PARTIAL_RETURN)::[]
+end
+| FStar_Syntax_Syntax.CPS -> begin
+(FStar_Syntax_Syntax.CPS)::[]
+end
+| uu____4389 -> begin
+[]
+end))))
+in (
+
+let lc1 = (
+
+let uu___138_4391 = lc
+in (
+
+let uu____4392 = (FStar_TypeChecker_Env.norm_eff_name env lc.FStar_Syntax_Syntax.eff_name)
+in {FStar_Syntax_Syntax.eff_name = uu____4392; FStar_Syntax_Syntax.res_typ = t; FStar_Syntax_Syntax.cflags = flags; FStar_Syntax_Syntax.comp = strengthen}))
+in (
+
+let g2 = (
+
+let uu___139_4394 = g1
+in {FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial; FStar_TypeChecker_Env.deferred = uu___139_4394.FStar_TypeChecker_Env.deferred; FStar_TypeChecker_Env.univ_ineqs = uu___139_4394.FStar_TypeChecker_Env.univ_ineqs; FStar_TypeChecker_Env.implicits = uu___139_4394.FStar_TypeChecker_Env.implicits})
+in ((e), (lc1), (g2)))))))
+end))
+end))))
+
+
+let pure_or_ghost_pre_and_post : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.comp  ->  (FStar_Syntax_Syntax.typ Prims.option * FStar_Syntax_Syntax.typ) = (fun env comp -> (
+
+let mk_post_type = (fun res_t ens -> (
+
+let x = (FStar_Syntax_Syntax.new_bv None res_t)
+in (
+
+let uu____4414 = (
+
+let uu____4415 = (
+
+let uu____4416 = (
+
+let uu____4417 = (
+
+let uu____4418 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_Syntax_Syntax.as_arg uu____4418))
+in (uu____4417)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app ens uu____4416))
+in (uu____4415 None res_t.FStar_Syntax_Syntax.pos))
+in (FStar_Syntax_Util.refine x uu____4414))))
+in (
+
+let norm = (fun t -> (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.EraseUniverses)::[]) env t))
+in (
+
+let uu____4427 = (FStar_Syntax_Util.is_tot_or_gtot_comp comp)
+in (match (uu____4427) with
+| true -> begin
+((None), ((FStar_Syntax_Util.comp_result comp)))
+end
+| uu____4434 -> begin
+(match (comp.FStar_Syntax_Syntax.n) with
+| (FStar_Syntax_Syntax.GTotal (_)) | (FStar_Syntax_Syntax.Total (_)) -> begin
+(failwith "Impossible")
+end
+| FStar_Syntax_Syntax.Comp (ct) -> begin
+(match (((FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_Pure_lid) || (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name FStar_Syntax_Const.effect_Ghost_lid))) with
+| true -> begin
+(match (ct.FStar_Syntax_Syntax.effect_args) with
+| ((req, uu____4451))::((ens, uu____4453))::uu____4454 -> begin
+(
+
+let uu____4476 = (
+
+let uu____4478 = (norm req)
+in Some (uu____4478))
+in (
+
+let uu____4479 = (
+
+let uu____4480 = (mk_post_type ct.FStar_Syntax_Syntax.result_typ ens)
+in (FStar_All.pipe_left norm uu____4480))
+in ((uu____4476), (uu____4479))))
+end
+| uu____4482 -> begin
+(
+
+let uu____4488 = (
+
+let uu____4489 = (
+
+let uu____4492 = (
+
+let uu____4493 = (FStar_Syntax_Print.comp_to_string comp)
+in (FStar_Util.format1 "Effect constructor is not fully applied; got %s" uu____4493))
+in ((uu____4492), (comp.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____4489))
+in (Prims.raise uu____4488))
+end)
+end
+| uu____4497 -> begin
+(
+
+let ct1 = (FStar_TypeChecker_Env.unfold_effect_abbrev env comp)
+in (match (ct1.FStar_Syntax_Syntax.effect_args) with
+| ((wp, uu____4503))::uu____4504 -> begin
+(
+
+let uu____4518 = (
+
+let uu____4521 = (FStar_TypeChecker_Env.lookup_lid env FStar_Syntax_Const.as_requires)
+in (FStar_All.pipe_left Prims.fst uu____4521))
+in (match (uu____4518) with
+| (us_r, uu____4538) -> begin
+(
+
+let uu____4539 = (
+
+let uu____4542 = (FStar_TypeChecker_Env.lookup_lid env FStar_Syntax_Const.as_ensures)
+in (FStar_All.pipe_left Prims.fst uu____4542))
+in (match (uu____4539) with
+| (us_e, uu____4559) -> begin
+(
+
+let r = ct1.FStar_Syntax_Syntax.result_typ.FStar_Syntax_Syntax.pos
+in (
+
+let as_req = (
+
+let uu____4562 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.as_requires r) FStar_Syntax_Syntax.Delta_equational None)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____4562 us_r))
+in (
+
+let as_ens = (
+
+let uu____4564 = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range FStar_Syntax_Const.as_ensures r) FStar_Syntax_Syntax.Delta_equational None)
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____4564 us_e))
+in (
+
+let req = (
+
+let uu____4568 = (
+
+let uu____4569 = (
+
+let uu____4570 = (
+
+let uu____4577 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____4577)::[])
+in (((ct1.FStar_Syntax_Syntax.result_typ), (Some (FStar_Syntax_Syntax.imp_tag))))::uu____4570)
+in (FStar_Syntax_Syntax.mk_Tm_app as_req uu____4569))
+in (uu____4568 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) ct1.FStar_Syntax_Syntax.result_typ.FStar_Syntax_Syntax.pos))
+in (
+
+let ens = (
+
+let uu____4593 = (
+
+let uu____4594 = (
+
+let uu____4595 = (
+
+let uu____4602 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____4602)::[])
+in (((ct1.FStar_Syntax_Syntax.result_typ), (Some (FStar_Syntax_Syntax.imp_tag))))::uu____4595)
+in (FStar_Syntax_Syntax.mk_Tm_app as_ens uu____4594))
+in (uu____4593 None ct1.FStar_Syntax_Syntax.result_typ.FStar_Syntax_Syntax.pos))
+in (
+
+let uu____4615 = (
+
+let uu____4617 = (norm req)
+in Some (uu____4617))
+in (
+
+let uu____4618 = (
+
+let uu____4619 = (mk_post_type ct1.FStar_Syntax_Syntax.result_typ ens)
+in (norm uu____4619))
+in ((uu____4615), (uu____4618)))))))))
+end))
+end))
+end
+| uu____4621 -> begin
+(failwith "Impossible")
+end))
+end)
+end)
+end)))))
+
+
+let maybe_instantiate : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ * FStar_TypeChecker_Env.guard_t) = (fun env e t -> (
+
+let torig = (FStar_Syntax_Subst.compress t)
+in (match ((not (env.FStar_TypeChecker_Env.instantiate_imp))) with
+| true -> begin
+((e), (torig), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| uu____4646 -> begin
+(
+
+let number_of_implicits = (fun t1 -> (
+
+let uu____4651 = (FStar_Syntax_Util.arrow_formals t1)
+in (match (uu____4651) with
+| (formals, uu____4660) -> begin
+(
+
+let n_implicits = (
+
+let uu____4672 = (FStar_All.pipe_right formals (FStar_Util.prefix_until (fun uu____4709 -> (match (uu____4709) with
+| (uu____4713, imp) -> begin
+((imp = None) || (imp = Some (FStar_Syntax_Syntax.Equality)))
+end))))
+in (match (uu____4672) with
+| None -> begin
+(FStar_List.length formals)
+end
+| Some (implicits, _first_explicit, _rest) -> begin
+(FStar_List.length implicits)
+end))
+in n_implicits)
+end)))
+in (
+
+let inst_n_binders = (fun t1 -> (
+
+let uu____4785 = (FStar_TypeChecker_Env.expected_typ env)
+in (match (uu____4785) with
+| None -> begin
+None
+end
+| Some (expected_t) -> begin
+(
+
+let n_expected = (number_of_implicits expected_t)
+in (
+
+let n_available = (number_of_implicits t1)
+in (match ((n_available < n_expected)) with
+| true -> begin
+(
+
+let uu____4799 = (
+
+let uu____4800 = (
+
+let uu____4803 = (
+
+let uu____4804 = (FStar_Util.string_of_int n_expected)
+in (
+
+let uu____4808 = (FStar_Syntax_Print.term_to_string e)
+in (
+
+let uu____4809 = (FStar_Util.string_of_int n_available)
+in (FStar_Util.format3 "Expected a term with %s implicit arguments, but %s has only %s" uu____4804 uu____4808 uu____4809))))
+in (
+
+let uu____4813 = (FStar_TypeChecker_Env.get_range env)
+in ((uu____4803), (uu____4813))))
+in FStar_Errors.Error (uu____4800))
+in (Prims.raise uu____4799))
+end
+| uu____4815 -> begin
+Some ((n_available - n_expected))
+end)))
+end)))
+in (
+
+let decr_inst = (fun uu___97_4826 -> (match (uu___97_4826) with
+| None -> begin
+None
+end
+| Some (i) -> begin
+Some ((i - (Prims.parse_int "1")))
+end))
+in (match (torig.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, c) -> begin
+(
+
+let uu____4845 = (FStar_Syntax_Subst.open_comp bs c)
+in (match (uu____4845) with
+| (bs1, c1) -> begin
+(
+
+let rec aux = (fun subst1 inst_n bs2 -> (match (((inst_n), (bs2))) with
+| (Some (_0_29), uu____4906) when (_0_29 = (Prims.parse_int "0")) -> begin
+(([]), (bs2), (subst1), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| (uu____4928, ((x, Some (FStar_Syntax_Syntax.Implicit (dot))))::rest) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.subst subst1 x.FStar_Syntax_Syntax.sort)
+in (
+
+let uu____4947 = (new_implicit_var "Instantiation of implicit argument" e.FStar_Syntax_Syntax.pos env t1)
+in (match (uu____4947) with
+| (v1, uu____4968, g) -> begin
+(
+
+let subst2 = (FStar_Syntax_Syntax.NT (((x), (v1))))::subst1
+in (
+
+let uu____4978 = (aux subst2 (decr_inst inst_n) rest)
+in (match (uu____4978) with
+| (args, bs3, subst3, g') -> begin
+(
+
+let uu____5027 = (FStar_TypeChecker_Rel.conj_guard g g')
+in (((((v1), (Some (FStar_Syntax_Syntax.Implicit (dot)))))::args), (bs3), (subst3), (uu____5027)))
+end)))
+end)))
+end
+| (uu____5041, bs3) -> begin
+(([]), (bs3), (subst1), (FStar_TypeChecker_Rel.trivial_guard))
+end))
+in (
+
+let uu____5065 = (
+
+let uu____5079 = (inst_n_binders t)
+in (aux [] uu____5079 bs1))
+in (match (uu____5065) with
+| (args, bs2, subst1, guard) -> begin
+(match (((args), (bs2))) with
+| ([], uu____5117) -> begin
+((e), (torig), (guard))
+end
+| (uu____5133, []) when (
+
+let uu____5149 = (FStar_Syntax_Util.is_total_comp c1)
+in (not (uu____5149))) -> begin
+((e), (torig), (FStar_TypeChecker_Rel.trivial_guard))
+end
+| uu____5150 -> begin
+(
+
+let t1 = (match (bs2) with
+| [] -> begin
+(FStar_Syntax_Util.comp_result c1)
+end
+| uu____5169 -> begin
+(FStar_Syntax_Util.arrow bs2 c1)
+end)
+in (
+
+let t2 = (FStar_Syntax_Subst.subst subst1 t1)
+in (
+
+let e1 = ((FStar_Syntax_Syntax.mk_Tm_app e args) (Some (t2.FStar_Syntax_Syntax.n)) e.FStar_Syntax_Syntax.pos)
+in ((e1), (t2), (guard)))))
+end)
+end)))
+end))
+end
+| uu____5184 -> begin
+((e), (t), (FStar_TypeChecker_Rel.trivial_guard))
+end))))
+end)))
+
+
+let string_of_univs = (fun univs1 -> (
+
+let uu____5196 = (
+
+let uu____5198 = (FStar_Util.set_elements univs1)
+in (FStar_All.pipe_right uu____5198 (FStar_List.map (fun u -> (
+
+let uu____5208 = (FStar_Unionfind.uvar_id u)
+in (FStar_All.pipe_right uu____5208 FStar_Util.string_of_int))))))
+in (FStar_All.pipe_right uu____5196 (FStar_String.concat ", "))))
+
+
+let gen_univs : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.universe_uvar FStar_Util.set  ->  FStar_Syntax_Syntax.univ_name Prims.list = (fun env x -> (
+
+let uu____5220 = (FStar_Util.set_is_empty x)
+in (match (uu____5220) with
+| true -> begin
+[]
+end
+| uu____5222 -> begin
+(
+
+let s = (
+
+let uu____5225 = (
+
+let uu____5227 = (FStar_TypeChecker_Env.univ_vars env)
+in (FStar_Util.set_difference x uu____5227))
+in (FStar_All.pipe_right uu____5225 FStar_Util.set_elements))
+in ((
+
+let uu____5232 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Gen")))
+in (match (uu____5232) with
+| true -> begin
+(
+
+let uu____5233 = (
+
+let uu____5234 = (FStar_TypeChecker_Env.univ_vars env)
+in (string_of_univs uu____5234))
+in (FStar_Util.print1 "univ_vars in env: %s\n" uu____5233))
+end
+| uu____5239 -> begin
+()
+end));
+(
+
+let r = (
+
+let uu____5242 = (FStar_TypeChecker_Env.get_range env)
+in Some (uu____5242))
+in (
+
+let u_names = (FStar_All.pipe_right s (FStar_List.map (fun u -> (
+
+let u_name = (FStar_Syntax_Syntax.new_univ_name r)
+in ((
+
+let uu____5254 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Gen")))
+in (match (uu____5254) with
+| true -> begin
+(
+
+let uu____5255 = (
+
+let uu____5256 = (FStar_Unionfind.uvar_id u)
+in (FStar_All.pipe_left FStar_Util.string_of_int uu____5256))
+in (
+
+let uu____5258 = (FStar_Syntax_Print.univ_to_string (FStar_Syntax_Syntax.U_unif (u)))
+in (
+
+let uu____5259 = (FStar_Syntax_Print.univ_to_string (FStar_Syntax_Syntax.U_name (u_name)))
+in (FStar_Util.print3 "Setting ?%s (%s) to %s\n" uu____5255 uu____5258 uu____5259))))
+end
+| uu____5260 -> begin
+()
+end));
+(FStar_Unionfind.change u (Some (FStar_Syntax_Syntax.U_name (u_name))));
+u_name;
+)))))
+in u_names));
+))
+end)))
+
+
+let gather_free_univnames : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.univ_name Prims.list = (fun env t -> (
+
+let ctx_univnames = (FStar_TypeChecker_Env.univnames env)
+in (
+
+let tm_univnames = (FStar_Syntax_Free.univnames t)
+in (
+
+let univnames1 = (
+
+let uu____5277 = (FStar_Util.fifo_set_difference tm_univnames ctx_univnames)
+in (FStar_All.pipe_right uu____5277 FStar_Util.fifo_set_elements))
+in univnames1))))
+
+
+let maybe_set_tk = (fun ts uu___98_5304 -> (match (uu___98_5304) with
+| None -> begin
+ts
+end
+| Some (t) -> begin
+(
+
+let t1 = (FStar_Syntax_Syntax.mk t None FStar_Range.dummyRange)
+in (
+
+let t2 = (FStar_Syntax_Subst.close_univ_vars (Prims.fst ts) t1)
+in ((FStar_ST.write (Prims.snd ts).FStar_Syntax_Syntax.tk (Some (t2.FStar_Syntax_Syntax.n)));
+ts;
+)))
+end))
+
+
+let check_universe_generalization : FStar_Syntax_Syntax.univ_name Prims.list  ->  FStar_Syntax_Syntax.univ_name Prims.list  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.univ_name Prims.list = (fun explicit_univ_names generalized_univ_names t -> (match (((explicit_univ_names), (generalized_univ_names))) with
+| ([], uu____5345) -> begin
+generalized_univ_names
+end
+| (uu____5349, []) -> begin
+explicit_univ_names
+end
+| uu____5353 -> begin
+(
+
+let uu____5358 = (
+
+let uu____5359 = (
+
+let uu____5362 = (
+
+let uu____5363 = (FStar_Syntax_Print.term_to_string t)
+in (Prims.strcat "Generalized universe in a term containing explicit universe annotation : " uu____5363))
+in ((uu____5362), (t.FStar_Syntax_Syntax.pos)))
+in FStar_Errors.Error (uu____5359))
+in (Prims.raise uu____5358))
+end))
+
+
+let generalize_universes : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.tscheme = (fun env t0 -> (
+
+let t = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.NoFullNorm)::(FStar_TypeChecker_Normalize.Beta)::[]) env t0)
+in (
+
+let univnames1 = (gather_free_univnames env t)
+in (
+
+let univs1 = (FStar_Syntax_Free.univs t)
+in ((
+
+let uu____5377 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Gen")))
+in (match (uu____5377) with
+| true -> begin
+(
+
+let uu____5378 = (string_of_univs univs1)
+in (FStar_Util.print1 "univs to gen : %s\n" uu____5378))
+end
+| uu____5380 -> begin
+()
+end));
+(
+
+let gen1 = (gen_univs env univs1)
+in ((
+
+let uu____5384 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Gen")))
+in (match (uu____5384) with
+| true -> begin
+(
+
+let uu____5385 = (FStar_Syntax_Print.term_to_string t)
+in (FStar_Util.print1 "After generalization: %s\n" uu____5385))
+end
+| uu____5386 -> begin
+()
+end));
+(
+
+let univs2 = (check_universe_generalization univnames1 gen1 t0)
+in (
+
+let ts = (FStar_Syntax_Subst.close_univ_vars univs2 t)
+in (
+
+let uu____5390 = (FStar_ST.read t0.FStar_Syntax_Syntax.tk)
+in (maybe_set_tk ((univs2), (ts)) uu____5390))));
+));
+)))))
+
+
+let gen : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp) Prims.list  ->  (FStar_Syntax_Syntax.univ_name Prims.list * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp) Prims.list Prims.option = (fun env ecs -> (
+
+let uu____5420 = (
+
+let uu____5421 = (FStar_Util.for_all (fun uu____5426 -> (match (uu____5426) with
+| (uu____5431, c) -> begin
+(FStar_Syntax_Util.is_pure_or_ghost_comp c)
+end)) ecs)
+in (FStar_All.pipe_left Prims.op_Negation uu____5421))
+in (match (uu____5420) with
+| true -> begin
+None
+end
+| uu____5448 -> begin
+(
+
+let norm = (fun c -> ((
+
+let uu____5454 = (FStar_TypeChecker_Env.debug env FStar_Options.Medium)
+in (match (uu____5454) with
+| true -> begin
+(
+
+let uu____5455 = (FStar_Syntax_Print.comp_to_string c)
+in (FStar_Util.print1 "Normalizing before generalizing:\n\t %s\n" uu____5455))
+end
+| uu____5456 -> begin
+()
+end));
+(
+
+let c1 = (
+
+let uu____5458 = (FStar_TypeChecker_Env.should_verify env)
+in (match (uu____5458) with
+| true -> begin
+(FStar_TypeChecker_Normalize.normalize_comp ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.Eager_unfolding)::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env c)
+end
+| uu____5459 -> begin
+(FStar_TypeChecker_Normalize.normalize_comp ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env c)
+end))
+in ((
+
+let uu____5461 = (FStar_TypeChecker_Env.debug env FStar_Options.Medium)
+in (match (uu____5461) with
+| true -> begin
+(
+
+let uu____5462 = (FStar_Syntax_Print.comp_to_string c1)
+in (FStar_Util.print1 "Normalized to:\n\t %s\n" uu____5462))
+end
+| uu____5463 -> begin
+()
+end));
+c1;
+));
+))
+in (
+
+let env_uvars = (FStar_TypeChecker_Env.uvars_in_env env)
+in (
+
+let gen_uvars = (fun uvs -> (
+
+let uu____5496 = (FStar_Util.set_difference uvs env_uvars)
+in (FStar_All.pipe_right uu____5496 FStar_Util.set_elements)))
+in (
+
+let uu____5540 = (
+
+let uu____5558 = (FStar_All.pipe_right ecs (FStar_List.map (fun uu____5613 -> (match (uu____5613) with
+| (e, c) -> begin
+(
+
+let t = (FStar_All.pipe_right (FStar_Syntax_Util.comp_result c) FStar_Syntax_Subst.compress)
+in (
+
+let c1 = (norm c)
+in (
+
+let t1 = (FStar_Syntax_Util.comp_result c1)
+in (
+
+let univs1 = (FStar_Syntax_Free.univs t1)
+in (
+
+let uvt = (FStar_Syntax_Free.uvars t1)
+in (
+
+let uvs = (gen_uvars uvt)
+in ((univs1), (((uvs), (e), (c1))))))))))
+end))))
+in (FStar_All.pipe_right uu____5558 FStar_List.unzip))
+in (match (uu____5540) with
+| (univs1, uvars1) -> begin
+(
+
+let univs2 = (FStar_List.fold_left FStar_Util.set_union FStar_Syntax_Syntax.no_universe_uvars univs1)
+in (
+
+let gen_univs1 = (gen_univs env univs2)
+in ((
+
+let uu____5775 = (FStar_TypeChecker_Env.debug env FStar_Options.Medium)
+in (match (uu____5775) with
+| true -> begin
+(FStar_All.pipe_right gen_univs1 (FStar_List.iter (fun x -> (FStar_Util.print1 "Generalizing uvar %s\n" x.FStar_Ident.idText))))
+end
+| uu____5778 -> begin
+()
+end));
+(
+
+let ecs1 = (FStar_All.pipe_right uvars1 (FStar_List.map (fun uu____5817 -> (match (uu____5817) with
+| (uvs, e, c) -> begin
+(
+
+let tvars = (FStar_All.pipe_right uvs (FStar_List.map (fun uu____5874 -> (match (uu____5874) with
+| (u, k) -> begin
+(
+
+let uu____5894 = (FStar_Unionfind.find u)
+in (match (uu____5894) with
+| (FStar_Syntax_Syntax.Fixed ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_name (a); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) | (FStar_Syntax_Syntax.Fixed ({FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs (_, {FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_name (a); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _}, _); FStar_Syntax_Syntax.tk = _; FStar_Syntax_Syntax.pos = _; FStar_Syntax_Syntax.vars = _})) -> begin
+((a), (Some (FStar_Syntax_Syntax.imp_tag)))
+end
+| FStar_Syntax_Syntax.Fixed (uu____5932) -> begin
+(failwith "Unexpected instantiation of mutually recursive uvar")
+end
+| uu____5940 -> begin
+(
+
+let k1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::[]) env k)
+in (
+
+let uu____5945 = (FStar_Syntax_Util.arrow_formals k1)
+in (match (uu____5945) with
+| (bs, kres) -> begin
+(
+
+let a = (
+
+let uu____5969 = (
+
+let uu____5971 = (FStar_TypeChecker_Env.get_range env)
+in (FStar_All.pipe_left (fun _0_30 -> Some (_0_30)) uu____5971))
+in (FStar_Syntax_Syntax.new_bv uu____5969 kres))
+in (
+
+let t = (
+
+let uu____5974 = (FStar_Syntax_Syntax.bv_to_name a)
+in (
+
+let uu____5975 = (
+
+let uu____5982 = (
+
+let uu____5988 = (
+
+let uu____5989 = (FStar_Syntax_Syntax.mk_Total kres)
+in (FStar_Syntax_Util.lcomp_of_comp uu____5989))
+in FStar_Util.Inl (uu____5988))
+in Some (uu____5982))
+in (FStar_Syntax_Util.abs bs uu____5974 uu____5975)))
+in ((FStar_Syntax_Util.set_uvar u t);
+((a), (Some (FStar_Syntax_Syntax.imp_tag)));
+)))
+end)))
+end))
+end))))
+in (
+
+let uu____6004 = (match (((tvars), (gen_univs1))) with
+| ([], []) -> begin
+((e), (c))
+end
+| ([], uu____6022) -> begin
+(
+
+let c1 = (FStar_TypeChecker_Normalize.normalize_comp ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoDeltaSteps)::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env c)
+in (
+
+let e1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoDeltaSteps)::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env e)
+in ((e1), (c1))))
+end
+| uu____6034 -> begin
+(
+
+let uu____6042 = ((e), (c))
+in (match (uu____6042) with
+| (e0, c0) -> begin
+(
+
+let c1 = (FStar_TypeChecker_Normalize.normalize_comp ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoDeltaSteps)::(FStar_TypeChecker_Normalize.CompressUvars)::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env c)
+in (
+
+let e1 = (FStar_TypeChecker_Normalize.normalize ((FStar_TypeChecker_Normalize.Beta)::(FStar_TypeChecker_Normalize.NoDeltaSteps)::(FStar_TypeChecker_Normalize.CompressUvars)::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Zeta))::(FStar_TypeChecker_Normalize.Exclude (FStar_TypeChecker_Normalize.Iota))::(FStar_TypeChecker_Normalize.NoFullNorm)::[]) env e)
+in (
+
+let t = (
+
+let uu____6054 = (
+
+let uu____6055 = (FStar_Syntax_Subst.compress (FStar_Syntax_Util.comp_result c1))
+in uu____6055.FStar_Syntax_Syntax.n)
+in (match (uu____6054) with
+| FStar_Syntax_Syntax.Tm_arrow (bs, cod) -> begin
+(
+
+let uu____6072 = (FStar_Syntax_Subst.open_comp bs cod)
+in (match (uu____6072) with
+| (bs1, cod1) -> begin
+(FStar_Syntax_Util.arrow (FStar_List.append tvars bs1) cod1)
+end))
+end
+| uu____6082 -> begin
+(FStar_Syntax_Util.arrow tvars c1)
+end))
+in (
+
+let e' = (FStar_Syntax_Util.abs tvars e1 (Some (FStar_Util.Inl ((FStar_Syntax_Util.lcomp_of_comp c1)))))
+in (
+
+let uu____6092 = (FStar_Syntax_Syntax.mk_Total t)
+in ((e'), (uu____6092)))))))
+end))
+end)
+in (match (uu____6004) with
+| (e1, c1) -> begin
+((gen_univs1), (e1), (c1))
+end)))
+end))))
+in Some (ecs1));
+)))
+end)))))
+end)))
+
+
+let generalize : FStar_TypeChecker_Env.env  ->  (FStar_Syntax_Syntax.lbname * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp) Prims.list  ->  (FStar_Syntax_Syntax.lbname * FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp) Prims.list = (fun env lecs -> ((
+
+let uu____6130 = (FStar_TypeChecker_Env.debug env FStar_Options.Low)
+in (match (uu____6130) with
+| true -> begin
+(
+
+let uu____6131 = (
+
+let uu____6132 = (FStar_List.map (fun uu____6137 -> (match (uu____6137) with
+| (lb, uu____6142, uu____6143) -> begin
+(FStar_Syntax_Print.lbname_to_string lb)
+end)) lecs)
+in (FStar_All.pipe_right uu____6132 (FStar_String.concat ", ")))
+in (FStar_Util.print1 "Generalizing: %s\n" uu____6131))
+end
+| uu____6145 -> begin
+()
+end));
+(
+
+let univnames_lecs = (FStar_List.map (fun uu____6153 -> (match (uu____6153) with
+| (l, t, c) -> begin
+(gather_free_univnames env t)
+end)) lecs)
+in (
+
+let generalized_lecs = (
+
+let uu____6168 = (
+
+let uu____6175 = (FStar_All.pipe_right lecs (FStar_List.map (fun uu____6191 -> (match (uu____6191) with
+| (uu____6197, e, c) -> begin
+((e), (c))
+end))))
+in (gen env uu____6175))
+in (match (uu____6168) with
+| None -> begin
+(FStar_All.pipe_right lecs (FStar_List.map (fun uu____6229 -> (match (uu____6229) with
+| (l, t, c) -> begin
+((l), ([]), (t), (c))
+end))))
+end
+| Some (ecs) -> begin
+(FStar_List.map2 (fun uu____6273 uu____6274 -> (match (((uu____6273), (uu____6274))) with
+| ((l, uu____6307, uu____6308), (us, e, c)) -> begin
+((
+
+let uu____6334 = (FStar_TypeChecker_Env.debug env FStar_Options.Medium)
+in (match (uu____6334) with
+| true -> begin
+(
+
+let uu____6335 = (FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos)
+in (
+
+let uu____6336 = (FStar_Syntax_Print.lbname_to_string l)
+in (
+
+let uu____6337 = (FStar_Syntax_Print.term_to_string (FStar_Syntax_Util.comp_result c))
+in (
+
+let uu____6338 = (FStar_Syntax_Print.term_to_string e)
+in (FStar_Util.print4 "(%s) Generalized %s at type %s\n%s\n" uu____6335 uu____6336 uu____6337 uu____6338)))))
+end
+| uu____6339 -> begin
+()
+end));
+((l), (us), (e), (c));
+)
+end)) lecs ecs)
+end))
+in (FStar_List.map2 (fun univnames1 uu____6357 -> (match (uu____6357) with
+| (l, generalized_univs, t, c) -> begin
+(
+
+let uu____6375 = (check_universe_generalization univnames1 generalized_univs t)
+in ((l), (uu____6375), (t), (c)))
+end)) univnames_lecs generalized_lecs)));
+))
+
+
+let check_and_ascribe : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.typ  ->  (FStar_Syntax_Syntax.term * FStar_TypeChecker_Env.guard_t) = (fun env e t1 t2 -> (
+
+let env1 = (FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos)
+in (
+
+let check = (fun env2 t11 t21 -> (match (env2.FStar_TypeChecker_Env.use_eq) with
+| true -> begin
+(FStar_TypeChecker_Rel.try_teq true env2 t11 t21)
+end
+| uu____6407 -> begin
+(
+
+let uu____6408 = (FStar_TypeChecker_Rel.try_subtype env2 t11 t21)
+in (match (uu____6408) with
+| None -> begin
+None
+end
+| Some (f) -> begin
+(
+
+let uu____6412 = (FStar_TypeChecker_Rel.apply_guard f e)
+in (FStar_All.pipe_left (fun _0_31 -> Some (_0_31)) uu____6412))
+end))
+end))
+in (
+
+let is_var = (fun e1 -> (
+
+let uu____6418 = (
+
+let uu____6419 = (FStar_Syntax_Subst.compress e1)
+in uu____6419.FStar_Syntax_Syntax.n)
+in (match (uu____6418) with
+| FStar_Syntax_Syntax.Tm_name (uu____6422) -> begin
+true
+end
+| uu____6423 -> begin
+false
+end)))
+in (
+
+let decorate = (fun e1 t -> (
+
+let e2 = (FStar_Syntax_Subst.compress e1)
+in (match (e2.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_name (x) -> begin
+((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name ((
+
+let uu___140_6445 = x
+in {FStar_Syntax_Syntax.ppname = uu___140_6445.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___140_6445.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = t2})))) (Some (t2.FStar_Syntax_Syntax.n)) e2.FStar_Syntax_Syntax.pos)
+end
+| uu____6446 -> begin
+(
+
+let uu___141_6447 = e2
+in (
+
+let uu____6448 = (FStar_Util.mk_ref (Some (t2.FStar_Syntax_Syntax.n)))
+in {FStar_Syntax_Syntax.n = uu___141_6447.FStar_Syntax_Syntax.n; FStar_Syntax_Syntax.tk = uu____6448; FStar_Syntax_Syntax.pos = uu___141_6447.FStar_Syntax_Syntax.pos; FStar_Syntax_Syntax.vars = uu___141_6447.FStar_Syntax_Syntax.vars}))
+end)))
+in (
+
+let env2 = (
+
+let uu___142_6457 = env1
+in (
+
+let uu____6458 = (env1.FStar_TypeChecker_Env.use_eq || (env1.FStar_TypeChecker_Env.is_pattern && (is_var e)))
+in {FStar_TypeChecker_Env.solver = uu___142_6457.FStar_TypeChecker_Env.solver; FStar_TypeChecker_Env.range = uu___142_6457.FStar_TypeChecker_Env.range; FStar_TypeChecker_Env.curmodule = uu___142_6457.FStar_TypeChecker_Env.curmodule; FStar_TypeChecker_Env.gamma = uu___142_6457.FStar_TypeChecker_Env.gamma; FStar_TypeChecker_Env.gamma_cache = uu___142_6457.FStar_TypeChecker_Env.gamma_cache; FStar_TypeChecker_Env.modules = uu___142_6457.FStar_TypeChecker_Env.modules; FStar_TypeChecker_Env.expected_typ = uu___142_6457.FStar_TypeChecker_Env.expected_typ; FStar_TypeChecker_Env.sigtab = uu___142_6457.FStar_TypeChecker_Env.sigtab; FStar_TypeChecker_Env.is_pattern = uu___142_6457.FStar_TypeChecker_Env.is_pattern; FStar_TypeChecker_Env.instantiate_imp = uu___142_6457.FStar_TypeChecker_Env.instantiate_imp; FStar_TypeChecker_Env.effects = uu___142_6457.FStar_TypeChecker_Env.effects; FStar_TypeChecker_Env.generalize = uu___142_6457.FStar_TypeChecker_Env.generalize; FStar_TypeChecker_Env.letrecs = uu___142_6457.FStar_TypeChecker_Env.letrecs; FStar_TypeChecker_Env.top_level = uu___142_6457.FStar_TypeChecker_Env.top_level; FStar_TypeChecker_Env.check_uvars = uu___142_6457.FStar_TypeChecker_Env.check_uvars; FStar_TypeChecker_Env.use_eq = uu____6458; FStar_TypeChecker_Env.is_iface = uu___142_6457.FStar_TypeChecker_Env.is_iface; FStar_TypeChecker_Env.admit = uu___142_6457.FStar_TypeChecker_Env.admit; FStar_TypeChecker_Env.lax = uu___142_6457.FStar_TypeChecker_Env.lax; FStar_TypeChecker_Env.lax_universes = uu___142_6457.FStar_TypeChecker_Env.lax_universes; FStar_TypeChecker_Env.type_of = uu___142_6457.FStar_TypeChecker_Env.type_of; FStar_TypeChecker_Env.universe_of = uu___142_6457.FStar_TypeChecker_Env.universe_of; FStar_TypeChecker_Env.use_bv_sorts = uu___142_6457.FStar_TypeChecker_Env.use_bv_sorts; FStar_TypeChecker_Env.qname_and_index = uu___142_6457.FStar_TypeChecker_Env.qname_and_index}))
+in (
+
+let uu____6459 = (check env2 t1 t2)
+in (match (uu____6459) with
+| None -> begin
+(
+
+let uu____6463 = (
+
+let uu____6464 = (
+
+let uu____6467 = (FStar_TypeChecker_Err.expected_expression_of_type env2 t2 e t1)
+in (
+
+let uu____6468 = (FStar_TypeChecker_Env.get_range env2)
+in ((uu____6467), (uu____6468))))
+in FStar_Errors.Error (uu____6464))
+in (Prims.raise uu____6463))
+end
+| Some (g) -> begin
+((
+
+let uu____6473 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2) (FStar_Options.Other ("Rel")))
+in (match (uu____6473) with
+| true -> begin
+(
+
+let uu____6474 = (FStar_TypeChecker_Rel.guard_to_string env2 g)
+in (FStar_All.pipe_left (FStar_Util.print1 "Applied guard is %s\n") uu____6474))
+end
+| uu____6475 -> begin
+()
+end));
+(
+
+let uu____6476 = (decorate e t2)
+in ((uu____6476), (g)));
+)
+end))))))))
+
+
+let check_top_level : FStar_TypeChecker_Env.env  ->  FStar_TypeChecker_Env.guard_t  ->  FStar_Syntax_Syntax.lcomp  ->  (Prims.bool * FStar_Syntax_Syntax.comp) = (fun env g lc -> (
+
+let discharge = (fun g1 -> ((FStar_TypeChecker_Rel.force_trivial_guard env g1);
+(FStar_Syntax_Util.is_pure_lcomp lc);
+))
+in (
+
+let g1 = (FStar_TypeChecker_Rel.solve_deferred_constraints env g)
+in (
+
+let uu____6500 = (FStar_Syntax_Util.is_total_lcomp lc)
+in (match (uu____6500) with
+| true -> begin
+(
+
+let uu____6503 = (discharge g1)
+in (
+
+let uu____6504 = (lc.FStar_Syntax_Syntax.comp ())
+in ((uu____6503), (uu____6504))))
+end
+| uu____6509 -> begin
+(
+
+let c = (lc.FStar_Syntax_Syntax.comp ())
+in (
+
+let steps = (FStar_TypeChecker_Normalize.Beta)::[]
+in (
+
+let c1 = (
+
+let uu____6516 = (
+
+let uu____6517 = (
+
+let uu____6518 = (FStar_TypeChecker_Env.unfold_effect_abbrev env c)
+in (FStar_All.pipe_right uu____6518 FStar_Syntax_Syntax.mk_Comp))
+in (FStar_All.pipe_right uu____6517 (FStar_TypeChecker_Normalize.normalize_comp steps env)))
+in (FStar_All.pipe_right uu____6516 (FStar_TypeChecker_Env.comp_to_comp_typ env)))
+in (
+
+let md = (FStar_TypeChecker_Env.get_effect_decl env c1.FStar_Syntax_Syntax.effect_name)
+in (
+
+let uu____6520 = (destruct_comp c1)
+in (match (uu____6520) with
+| (u_t, t, wp) -> begin
+(
+
+let vc = (
+
+let uu____6532 = (FStar_TypeChecker_Env.get_range env)
+in (
+
+let uu____6533 = (
+
+let uu____6534 = (FStar_TypeChecker_Env.inst_effect_fun_with ((u_t)::[]) env md md.FStar_Syntax_Syntax.trivial)
+in (
+
+let uu____6535 = (
+
+let uu____6536 = (FStar_Syntax_Syntax.as_arg t)
+in (
+
+let uu____6537 = (
+
+let uu____6539 = (FStar_Syntax_Syntax.as_arg wp)
+in (uu____6539)::[])
+in (uu____6536)::uu____6537))
+in (FStar_Syntax_Syntax.mk_Tm_app uu____6534 uu____6535)))
+in (uu____6533 (Some (FStar_Syntax_Util.ktype0.FStar_Syntax_Syntax.n)) uu____6532)))
+in ((
+
+let uu____6545 = (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env) (FStar_Options.Other ("Simplification")))
+in (match (uu____6545) with
+| true -> begin
+(
+
+let uu____6546 = (FStar_Syntax_Print.term_to_string vc)
+in (FStar_Util.print1 "top-level VC: %s\n" uu____6546))
+end
+| uu____6547 -> begin
+()
+end));
+(
+
+let g2 = (
+
+let uu____6549 = (FStar_All.pipe_left FStar_TypeChecker_Rel.guard_of_guard_formula (FStar_TypeChecker_Common.NonTrivial (vc)))
+in (FStar_TypeChecker_Rel.conj_guard g1 uu____6549))
+in (
+
+let uu____6550 = (discharge g2)
+in (
+
+let uu____6551 = (FStar_Syntax_Syntax.mk_Comp c1)
+in ((uu____6550), (uu____6551)))));
+))
+end))))))
+end)))))
+
+
+let short_circuit : FStar_Syntax_Syntax.term  ->  FStar_Syntax_Syntax.args  ->  FStar_TypeChecker_Common.guard_formula = (fun head1 seen_args -> (
+
+let short_bin_op = (fun f uu___99_6575 -> (match (uu___99_6575) with
+| [] -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| ((fst1, uu____6581))::[] -> begin
+(f fst1)
+end
+| uu____6594 -> begin
+(failwith "Unexpexted args to binary operator")
+end))
+in (
+
+let op_and_e = (fun e -> (
+
+let uu____6599 = (FStar_Syntax_Util.b2t e)
+in (FStar_All.pipe_right uu____6599 (fun _0_32 -> FStar_TypeChecker_Common.NonTrivial (_0_32)))))
+in (
+
+let op_or_e = (fun e -> (
+
+let uu____6608 = (
+
+let uu____6611 = (FStar_Syntax_Util.b2t e)
+in (FStar_Syntax_Util.mk_neg uu____6611))
+in (FStar_All.pipe_right uu____6608 (fun _0_33 -> FStar_TypeChecker_Common.NonTrivial (_0_33)))))
+in (
+
+let op_and_t = (fun t -> (FStar_All.pipe_right t (fun _0_34 -> FStar_TypeChecker_Common.NonTrivial (_0_34))))
+in (
+
+let op_or_t = (fun t -> (
+
+let uu____6622 = (FStar_All.pipe_right t FStar_Syntax_Util.mk_neg)
+in (FStar_All.pipe_right uu____6622 (fun _0_35 -> FStar_TypeChecker_Common.NonTrivial (_0_35)))))
+in (
+
+let op_imp_t = (fun t -> (FStar_All.pipe_right t (fun _0_36 -> FStar_TypeChecker_Common.NonTrivial (_0_36))))
+in (
+
+let short_op_ite = (fun uu___100_6636 -> (match (uu___100_6636) with
+| [] -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| ((guard, uu____6642))::[] -> begin
+FStar_TypeChecker_Common.NonTrivial (guard)
+end
+| (_then)::((guard, uu____6657))::[] -> begin
+(
+
+let uu____6678 = (FStar_Syntax_Util.mk_neg guard)
+in (FStar_All.pipe_right uu____6678 (fun _0_37 -> FStar_TypeChecker_Common.NonTrivial (_0_37))))
+end
+| uu____6683 -> begin
+(failwith "Unexpected args to ITE")
+end))
+in (
+
+let table = (
+
+let uu____6690 = (
+
+let uu____6695 = (short_bin_op op_and_e)
+in ((FStar_Syntax_Const.op_And), (uu____6695)))
+in (
+
+let uu____6700 = (
+
+let uu____6706 = (
+
+let uu____6711 = (short_bin_op op_or_e)
+in ((FStar_Syntax_Const.op_Or), (uu____6711)))
+in (
+
+let uu____6716 = (
+
+let uu____6722 = (
+
+let uu____6727 = (short_bin_op op_and_t)
+in ((FStar_Syntax_Const.and_lid), (uu____6727)))
+in (
+
+let uu____6732 = (
+
+let uu____6738 = (
+
+let uu____6743 = (short_bin_op op_or_t)
+in ((FStar_Syntax_Const.or_lid), (uu____6743)))
+in (
+
+let uu____6748 = (
+
+let uu____6754 = (
+
+let uu____6759 = (short_bin_op op_imp_t)
+in ((FStar_Syntax_Const.imp_lid), (uu____6759)))
+in (uu____6754)::(((FStar_Syntax_Const.ite_lid), (short_op_ite)))::[])
+in (uu____6738)::uu____6748))
+in (uu____6722)::uu____6732))
+in (uu____6706)::uu____6716))
+in (uu____6690)::uu____6700))
+in (match (head1.FStar_Syntax_Syntax.n) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(
+
+let lid = fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v
+in (
+
+let uu____6800 = (FStar_Util.find_map table (fun uu____6806 -> (match (uu____6806) with
+| (x, mk1) -> begin
+(match ((FStar_Ident.lid_equals x lid)) with
+| true -> begin
+(
+
+let uu____6819 = (mk1 seen_args)
+in Some (uu____6819))
+end
+| uu____6820 -> begin
+None
+end)
+end)))
+in (match (uu____6800) with
+| None -> begin
+FStar_TypeChecker_Common.Trivial
+end
+| Some (g) -> begin
+g
+end)))
+end
+| uu____6822 -> begin
+FStar_TypeChecker_Common.Trivial
+end))))))))))
+
+
+let short_circuit_head : FStar_Syntax_Syntax.term  ->  Prims.bool = (fun l -> (
+
+let uu____6826 = (
+
+let uu____6827 = (FStar_Syntax_Util.un_uinst l)
+in uu____6827.FStar_Syntax_Syntax.n)
+in (match (uu____6826) with
+| FStar_Syntax_Syntax.Tm_fvar (fv) -> begin
+(FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv) ((FStar_Syntax_Const.op_And)::(FStar_Syntax_Const.op_Or)::(FStar_Syntax_Const.and_lid)::(FStar_Syntax_Const.or_lid)::(FStar_Syntax_Const.imp_lid)::(FStar_Syntax_Const.ite_lid)::[]))
+end
+| uu____6831 -> begin
+false
+end)))
+
+
+let maybe_add_implicit_binders : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders = (fun env bs -> (
+
+let pos = (fun bs1 -> (match (bs1) with
+| ((hd1, uu____6849))::uu____6850 -> begin
+(FStar_Syntax_Syntax.range_of_bv hd1)
+end
+| uu____6856 -> begin
+(FStar_TypeChecker_Env.get_range env)
+end))
+in (match (bs) with
+| ((uu____6860, Some (FStar_Syntax_Syntax.Implicit (uu____6861))))::uu____6862 -> begin
+bs
+end
+| uu____6871 -> begin
+(
+
+let uu____6872 = (FStar_TypeChecker_Env.expected_typ env)
+in (match (uu____6872) with
+| None -> begin
+bs
+end
+| Some (t) -> begin
+(
+
+let uu____6875 = (
+
+let uu____6876 = (FStar_Syntax_Subst.compress t)
+in uu____6876.FStar_Syntax_Syntax.n)
+in (match (uu____6875) with
+| FStar_Syntax_Syntax.Tm_arrow (bs', uu____6880) -> begin
+(
+
+let uu____6891 = (FStar_Util.prefix_until (fun uu___101_6910 -> (match (uu___101_6910) with
+| (uu____6914, Some (FStar_Syntax_Syntax.Implicit (uu____6915))) -> begin
+false
+end
+| uu____6917 -> begin
+true
+end)) bs')
+in (match (uu____6891) with
+| None -> begin
+bs
+end
+| Some ([], uu____6935, uu____6936) -> begin
+bs
+end
+| Some (imps, uu____6973, uu____6974) -> begin
+(
+
+let uu____7011 = (FStar_All.pipe_right imps (FStar_Util.for_all (fun uu____7019 -> (match (uu____7019) with
+| (x, uu____7024) -> begin
+(FStar_Util.starts_with x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText "\'")
+end))))
+in (match (uu____7011) with
+| true -> begin
+(
+
+let r = (pos bs)
+in (
+
+let imps1 = (FStar_All.pipe_right imps (FStar_List.map (fun uu____7047 -> (match (uu____7047) with
+| (x, i) -> begin
+(
+
+let uu____7058 = (FStar_Syntax_Syntax.set_range_of_bv x r)
+in ((uu____7058), (i)))
+end))))
+in (FStar_List.append imps1 bs)))
+end
+| uu____7063 -> begin
+bs
+end))
+end))
+end
+| uu____7064 -> begin
+bs
+end))
+end))
+end)))
+
+
+let maybe_lift : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun env e c1 c2 t -> (
+
+let m1 = (FStar_TypeChecker_Env.norm_eff_name env c1)
+in (
+
+let m2 = (FStar_TypeChecker_Env.norm_eff_name env c2)
+in (match ((((FStar_Ident.lid_equals m1 m2) || ((FStar_Syntax_Util.is_pure_effect c1) && (FStar_Syntax_Util.is_ghost_effect c2))) || ((FStar_Syntax_Util.is_pure_effect c2) && (FStar_Syntax_Util.is_ghost_effect c1)))) with
+| true -> begin
+e
+end
+| uu____7082 -> begin
+(
+
+let uu____7083 = (FStar_ST.read e.FStar_Syntax_Syntax.tk)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e), (FStar_Syntax_Syntax.Meta_monadic_lift (((m1), (m2), (t)))))))) uu____7083 e.FStar_Syntax_Syntax.pos))
+end))))
+
+
+let maybe_monadic : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.term  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.typ  ->  FStar_Syntax_Syntax.term = (fun env e c t -> (
+
+let m = (FStar_TypeChecker_Env.norm_eff_name env c)
+in (
+
+let uu____7109 = (((is_pure_or_ghost_effect env m) || (FStar_Ident.lid_equals m FStar_Syntax_Const.effect_Tot_lid)) || (FStar_Ident.lid_equals m FStar_Syntax_Const.effect_GTot_lid))
+in (match (uu____7109) with
+| true -> begin
+e
+end
+| uu____7110 -> begin
+(
+
+let uu____7111 = (FStar_ST.read e.FStar_Syntax_Syntax.tk)
+in ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (((e), (FStar_Syntax_Syntax.Meta_monadic (((m), (t)))))))) uu____7111 e.FStar_Syntax_Syntax.pos))
+end))))
+
+
+let d : Prims.string  ->  Prims.unit = (fun s -> (FStar_Util.print1 "[01;36m%s[00m\n" s))
+
+
+let mk_toplevel_definition : FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.term  ->  (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.term) = (fun env lident def -> ((
+
+let uu____7141 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("ED")))
+in (match (uu____7141) with
+| true -> begin
+((d (FStar_Ident.text_of_lid lident));
+(
+
+let uu____7143 = (FStar_Syntax_Print.term_to_string def)
+in (FStar_Util.print2 "Registering top-level definition: %s\n%s\n" (FStar_Ident.text_of_lid lident) uu____7143));
+)
+end
+| uu____7144 -> begin
+()
+end));
+(
+
+let fv = (
+
+let uu____7146 = (FStar_Syntax_Util.incr_delta_qualifier def)
+in (FStar_Syntax_Syntax.lid_as_fv lident uu____7146 None))
+in (
+
+let lbname = FStar_Util.Inr (fv)
+in (
+
+let lb = ((false), (({FStar_Syntax_Syntax.lbname = lbname; FStar_Syntax_Syntax.lbunivs = []; FStar_Syntax_Syntax.lbtyp = FStar_Syntax_Syntax.tun; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid; FStar_Syntax_Syntax.lbdef = def})::[]))
+in (
+
+let sig_ctx = (FStar_Syntax_Syntax.mk_sigelt (FStar_Syntax_Syntax.Sig_let (((lb), ((lident)::[]), ((FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)::[]), ([])))))
+in (
+
+let uu____7154 = ((FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar (fv))) None FStar_Range.dummyRange)
+in ((sig_ctx), (uu____7154)))))));
+))
+
+
+let check_sigelt_quals : FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt  ->  Prims.unit = (fun env se -> (
+
+let visibility = (fun uu___102_7176 -> (match (uu___102_7176) with
+| FStar_Syntax_Syntax.Private -> begin
+true
+end
+| uu____7177 -> begin
+false
+end))
+in (
+
+let reducibility = (fun uu___103_7181 -> (match (uu___103_7181) with
+| (FStar_Syntax_Syntax.Abstract) | (FStar_Syntax_Syntax.Irreducible) | (FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen) | (FStar_Syntax_Syntax.Visible_default) | (FStar_Syntax_Syntax.Inline_for_extraction) -> begin
+true
+end
+| uu____7182 -> begin
+false
+end))
+in (
+
+let assumption = (fun uu___104_7186 -> (match (uu___104_7186) with
+| (FStar_Syntax_Syntax.Assumption) | (FStar_Syntax_Syntax.New) -> begin
+true
+end
+| uu____7187 -> begin
+false
+end))
+in (
+
+let reification = (fun uu___105_7191 -> (match (uu___105_7191) with
+| (FStar_Syntax_Syntax.Reifiable) | (FStar_Syntax_Syntax.Reflectable (_)) -> begin
+true
+end
+| uu____7193 -> begin
+false
+end))
+in (
+
+let inferred = (fun uu___106_7197 -> (match (uu___106_7197) with
+| (FStar_Syntax_Syntax.Discriminator (_)) | (FStar_Syntax_Syntax.Projector (_)) | (FStar_Syntax_Syntax.RecordType (_)) | (FStar_Syntax_Syntax.RecordConstructor (_)) | (FStar_Syntax_Syntax.ExceptionConstructor) | (FStar_Syntax_Syntax.HasMaskedEffect) | (FStar_Syntax_Syntax.Effect) -> begin
+true
+end
+| uu____7202 -> begin
+false
+end))
+in (
+
+let has_eq = (fun uu___107_7206 -> (match (uu___107_7206) with
+| (FStar_Syntax_Syntax.Noeq) | (FStar_Syntax_Syntax.Unopteq) -> begin
+true
+end
+| uu____7207 -> begin
+false
+end))
+in (
+
+let quals_combo_ok = (fun quals q -> (match (q) with
+| FStar_Syntax_Syntax.Assumption -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> ((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) || (inferred x)) || (visibility x)) || (assumption x)) || (env.FStar_TypeChecker_Env.is_iface && (x = FStar_Syntax_Syntax.Inline_for_extraction))))))
+end
+| FStar_Syntax_Syntax.New -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> ((((x = q) || (inferred x)) || (visibility x)) || (assumption x)))))
+end
+| FStar_Syntax_Syntax.Inline_for_extraction -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) || (visibility x)) || (reducibility x)) || (reification x)) || (inferred x)) || (env.FStar_TypeChecker_Env.is_iface && (x = FStar_Syntax_Syntax.Assumption))))))
+end
+| (FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen) | (FStar_Syntax_Syntax.Visible_default) | (FStar_Syntax_Syntax.Irreducible) | (FStar_Syntax_Syntax.Abstract) | (FStar_Syntax_Syntax.Noeq) | (FStar_Syntax_Syntax.Unopteq) -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) || (x = FStar_Syntax_Syntax.Abstract)) || (x = FStar_Syntax_Syntax.Inline_for_extraction)) || (has_eq x)) || (inferred x)) || (visibility x)))))
+end
+| FStar_Syntax_Syntax.TotalEffect -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> ((((x = q) || (inferred x)) || (visibility x)) || (reification x)))))
+end
+| FStar_Syntax_Syntax.Logic -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> (((((x = q) || (x = FStar_Syntax_Syntax.Assumption)) || (inferred x)) || (visibility x)) || (reducibility x)))))
+end
+| (FStar_Syntax_Syntax.Reifiable) | (FStar_Syntax_Syntax.Reflectable (_)) -> begin
+(FStar_All.pipe_right quals (FStar_List.for_all (fun x -> ((((reification x) || (inferred x)) || (visibility x)) || (x = FStar_Syntax_Syntax.TotalEffect)))))
+end
+| FStar_Syntax_Syntax.Private -> begin
+true
+end
+| uu____7232 -> begin
+true
+end))
+in (
+
+let quals = (FStar_Syntax_Util.quals_of_sigelt se)
+in (
+
+let uu____7235 = (
+
+let uu____7236 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___108_7238 -> (match (uu___108_7238) with
+| FStar_Syntax_Syntax.OnlyName -> begin
+true
+end
+| uu____7239 -> begin
+false
+end))))
+in (FStar_All.pipe_right uu____7236 Prims.op_Negation))
+in (match (uu____7235) with
+| true -> begin
+(
+
+let r = (FStar_Syntax_Util.range_of_sigelt se)
+in (
+
+let no_dup_quals = (FStar_Util.remove_dups (fun x y -> (x = y)) quals)
+in (
+
+let err' = (fun msg -> (
+
+let uu____7249 = (
+
+let uu____7250 = (
+
+let uu____7253 = (
+
+let uu____7254 = (FStar_Syntax_Print.quals_to_string quals)
+in (FStar_Util.format2 "The qualifier list \"[%s]\" is not permissible for this element%s" uu____7254 msg))
+in ((uu____7253), (r)))
+in FStar_Errors.Error (uu____7250))
+in (Prims.raise uu____7249)))
+in (
+
+let err = (fun msg -> (err' (Prims.strcat ": " msg)))
+in (
+
+let err'1 = (fun uu____7262 -> (err' ""))
+in ((match (((FStar_List.length quals) <> (FStar_List.length no_dup_quals))) with
+| true -> begin
+(err "duplicate qualifiers")
+end
+| uu____7268 -> begin
+()
+end);
+(
+
+let uu____7270 = (
+
+let uu____7271 = (FStar_All.pipe_right quals (FStar_List.for_all (quals_combo_ok quals)))
+in (not (uu____7271)))
+in (match (uu____7270) with
+| true -> begin
+(err "ill-formed combination")
+end
+| uu____7273 -> begin
+()
+end));
+(match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_let ((is_rec, uu____7275), uu____7276, uu____7277, uu____7278) -> begin
+((
+
+let uu____7291 = (is_rec && (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)))
+in (match (uu____7291) with
+| true -> begin
+(err "recursive definitions cannot be marked inline")
+end
+| uu____7293 -> begin
+()
+end));
+(
+
+let uu____7294 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun x -> ((assumption x) || (has_eq x)))))
+in (match (uu____7294) with
+| true -> begin
+(err "definitions cannot be assumed or marked with equality qualifiers")
+end
+| uu____7297 -> begin
+()
+end));
+)
+end
+| FStar_Syntax_Syntax.Sig_bundle (uu____7298) -> begin
+(
+
+let uu____7305 = (
+
+let uu____7306 = (FStar_All.pipe_right quals (FStar_Util.for_all (fun x -> ((((x = FStar_Syntax_Syntax.Abstract) || (inferred x)) || (visibility x)) || (has_eq x)))))
+in (not (uu____7306)))
+in (match (uu____7305) with
+| true -> begin
+(err'1 ())
+end
+| uu____7309 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_declare_typ (uu____7310) -> begin
+(
+
+let uu____7316 = (FStar_All.pipe_right quals (FStar_Util.for_some has_eq))
+in (match (uu____7316) with
+| true -> begin
+(err'1 ())
+end
+| uu____7318 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_assume (uu____7319) -> begin
+(
+
+let uu____7324 = (
+
+let uu____7325 = (FStar_All.pipe_right quals (FStar_Util.for_all (fun x -> ((visibility x) || (x = FStar_Syntax_Syntax.Assumption)))))
+in (not (uu____7325)))
+in (match (uu____7324) with
+| true -> begin
+(err'1 ())
+end
+| uu____7328 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_new_effect (uu____7329) -> begin
+(
+
+let uu____7330 = (
+
+let uu____7331 = (FStar_All.pipe_right quals (FStar_Util.for_all (fun x -> ((((x = FStar_Syntax_Syntax.TotalEffect) || (inferred x)) || (visibility x)) || (reification x)))))
+in (not (uu____7331)))
+in (match (uu____7330) with
+| true -> begin
+(err'1 ())
+end
+| uu____7334 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_new_effect_for_free (uu____7335) -> begin
+(
+
+let uu____7336 = (
+
+let uu____7337 = (FStar_All.pipe_right quals (FStar_Util.for_all (fun x -> ((((x = FStar_Syntax_Syntax.TotalEffect) || (inferred x)) || (visibility x)) || (reification x)))))
+in (not (uu____7337)))
+in (match (uu____7336) with
+| true -> begin
+(err'1 ())
+end
+| uu____7340 -> begin
+()
+end))
+end
+| FStar_Syntax_Syntax.Sig_effect_abbrev (uu____7341) -> begin
+(
+
+let uu____7350 = (
+
+let uu____7351 = (FStar_All.pipe_right quals (FStar_Util.for_all (fun x -> ((inferred x) || (visibility x)))))
+in (not (uu____7351)))
+in (match (uu____7350) with
+| true -> begin
+(err'1 ())
+end
+| uu____7354 -> begin
+()
+end))
+end
+| uu____7355 -> begin
+()
+end);
+))))))
+end
+| uu____7356 -> begin
+()
+end)))))))))))
+
+
+let mk_discriminator_and_indexed_projectors : FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_Syntax_Syntax.fv_qual  ->  Prims.bool  ->  FStar_TypeChecker_Env.env  ->  FStar_Ident.lident  ->  FStar_Ident.lident  ->  FStar_Syntax_Syntax.univ_names  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.binders  ->  FStar_Syntax_Syntax.sigelt Prims.list = (fun iquals fvq refine_domain env tc lid uvs inductive_tps indices fields -> (
+
+let p = (FStar_Ident.range_of_lid lid)
+in (
+
+let pos = (fun q -> (FStar_Syntax_Syntax.withinfo q FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n p))
+in (
+
+let projectee = (fun ptyp -> (FStar_Syntax_Syntax.gen_bv "projectee" (Some (p)) ptyp))
+in (
+
+let inst_univs = (FStar_List.map (fun u -> FStar_Syntax_Syntax.U_name (u)) uvs)
+in (
+
+let tps = inductive_tps
+in (
+
+let arg_typ = (
+
+let inst_tc = (
+
+let uu____7412 = (
+
+let uu____7415 = (
+
+let uu____7416 = (
+
+let uu____7421 = (
+
+let uu____7422 = (FStar_Syntax_Syntax.lid_as_fv tc FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____7422))
+in ((uu____7421), (inst_univs)))
+in FStar_Syntax_Syntax.Tm_uinst (uu____7416))
+in (FStar_Syntax_Syntax.mk uu____7415))
+in (uu____7412 None p))
+in (
+
+let args = (FStar_All.pipe_right (FStar_List.append tps indices) (FStar_List.map (fun uu____7448 -> (match (uu____7448) with
+| (x, imp) -> begin
+(
+
+let uu____7455 = (FStar_Syntax_Syntax.bv_to_name x)
+in ((uu____7455), (imp)))
+end))))
+in ((FStar_Syntax_Syntax.mk_Tm_app inst_tc args) None p)))
+in (
+
+let unrefined_arg_binder = (
+
+let uu____7461 = (projectee arg_typ)
+in (FStar_Syntax_Syntax.mk_binder uu____7461))
+in (
+
+let arg_binder = (match ((not (refine_domain))) with
+| true -> begin
+unrefined_arg_binder
+end
+| uu____7463 -> begin
+(
+
+let disc_name = (FStar_Syntax_Util.mk_discriminator lid)
+in (
+
+let x = (FStar_Syntax_Syntax.new_bv (Some (p)) arg_typ)
+in (
+
+let sort = (
+
+let disc_fvar = (FStar_Syntax_Syntax.fvar (FStar_Ident.set_lid_range disc_name p) FStar_Syntax_Syntax.Delta_equational None)
+in (
+
+let uu____7470 = (
+
+let uu____7471 = (
+
+let uu____7472 = (
+
+let uu____7473 = (FStar_Syntax_Syntax.mk_Tm_uinst disc_fvar inst_univs)
+in (
+
+let uu____7474 = (
+
+let uu____7475 = (
+
+let uu____7476 = (FStar_Syntax_Syntax.bv_to_name x)
+in (FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____7476))
+in (uu____7475)::[])
+in (FStar_Syntax_Syntax.mk_Tm_app uu____7473 uu____7474)))
+in (uu____7472 None p))
+in (FStar_Syntax_Util.b2t uu____7471))
+in (FStar_Syntax_Util.refine x uu____7470)))
+in (
+
+let uu____7481 = (
+
+let uu___143_7482 = (projectee arg_typ)
+in {FStar_Syntax_Syntax.ppname = uu___143_7482.FStar_Syntax_Syntax.ppname; FStar_Syntax_Syntax.index = uu___143_7482.FStar_Syntax_Syntax.index; FStar_Syntax_Syntax.sort = sort})
+in (FStar_Syntax_Syntax.mk_binder uu____7481)))))
+end)
+in (
+
+let ntps = (FStar_List.length tps)
+in (
+
+let all_params = (
+
+let uu____7492 = (FStar_List.map (fun uu____7502 -> (match (uu____7502) with
+| (x, uu____7509) -> begin
+((x), (Some (FStar_Syntax_Syntax.imp_tag)))
+end)) tps)
+in (FStar_List.append uu____7492 fields))
+in (
+
+let imp_binders = (FStar_All.pipe_right (FStar_List.append tps indices) (FStar_List.map (fun uu____7533 -> (match (uu____7533) with
+| (x, uu____7540) -> begin
+((x), (Some (FStar_Syntax_Syntax.imp_tag)))
+end))))
+in (
+
+let discriminator_ses = (match ((fvq <> FStar_Syntax_Syntax.Data_ctor)) with
+| true -> begin
+[]
+end
+| uu____7545 -> begin
+(
+
+let discriminator_name = (FStar_Syntax_Util.mk_discriminator lid)
+in (
+
+let no_decl = false
+in (
+
+let only_decl = ((
+
+let uu____7549 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____7549)) || (
+
+let uu____7550 = (
+
+let uu____7551 = (FStar_TypeChecker_Env.current_module env)
+in uu____7551.FStar_Ident.str)
+in (FStar_Options.dont_gen_projectors uu____7550)))
+in (
+
+let quals = (
+
+let uu____7554 = (
+
+let uu____7556 = (
+
+let uu____7558 = (only_decl && ((FStar_All.pipe_left Prims.op_Negation env.FStar_TypeChecker_Env.is_iface) || env.FStar_TypeChecker_Env.admit))
+in (match (uu____7558) with
+| true -> begin
+(FStar_Syntax_Syntax.Assumption)::[]
+end
+| uu____7560 -> begin
+[]
+end))
+in (
+
+let uu____7561 = (FStar_List.filter (fun uu___109_7563 -> (match (uu___109_7563) with
+| FStar_Syntax_Syntax.Abstract -> begin
+(not (only_decl))
+end
+| FStar_Syntax_Syntax.Private -> begin
+true
+end
+| uu____7564 -> begin
+false
+end)) iquals)
+in (FStar_List.append uu____7556 uu____7561)))
+in (FStar_List.append ((FStar_Syntax_Syntax.Discriminator (lid))::(match (only_decl) with
+| true -> begin
+(FStar_Syntax_Syntax.Logic)::[]
+end
+| uu____7566 -> begin
+[]
+end)) uu____7554))
+in (
+
+let binders = (FStar_List.append imp_binders ((unrefined_arg_binder)::[]))
+in (
+
+let t = (
+
+let bool_typ = (
+
+let uu____7577 = (
+
+let uu____7578 = (FStar_Syntax_Syntax.lid_as_fv FStar_Syntax_Const.bool_lid FStar_Syntax_Syntax.Delta_constant None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____7578))
+in (FStar_Syntax_Syntax.mk_Total uu____7577))
+in (
+
+let uu____7579 = (FStar_Syntax_Util.arrow binders bool_typ)
+in (FStar_All.pipe_left (FStar_Syntax_Subst.close_univ_vars uvs) uu____7579)))
+in (
+
+let decl = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((discriminator_name), (uvs), (t), (quals))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid discriminator_name)}
+in ((
+
+let uu____7583 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("LogTypes")))
+in (match (uu____7583) with
+| true -> begin
+(
+
+let uu____7584 = (FStar_Syntax_Print.sigelt_to_string decl)
+in (FStar_Util.print1 "Declaration of a discriminator %s\n" uu____7584))
+end
+| uu____7585 -> begin
+()
+end));
+(match (only_decl) with
+| true -> begin
+(decl)::[]
+end
+| uu____7587 -> begin
+(
+
+let body = (match ((not (refine_domain))) with
+| true -> begin
+FStar_Syntax_Const.exp_true_bool
+end
+| uu____7589 -> begin
+(
+
+let arg_pats = (FStar_All.pipe_right all_params (FStar_List.mapi (fun j uu____7612 -> (match (uu____7612) with
+| (x, imp) -> begin
+(
+
+let b = (FStar_Syntax_Syntax.is_implicit imp)
+in (match ((b && (j < ntps))) with
+| true -> begin
+(
+
+let uu____7628 = (
+
+let uu____7631 = (
+
+let uu____7632 = (
+
+let uu____7637 = (FStar_Syntax_Syntax.gen_bv x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText None FStar_Syntax_Syntax.tun)
+in ((uu____7637), (FStar_Syntax_Syntax.tun)))
+in FStar_Syntax_Syntax.Pat_dot_term (uu____7632))
+in (pos uu____7631))
+in ((uu____7628), (b)))
+end
+| uu____7640 -> begin
+(
+
+let uu____7641 = (
+
+let uu____7644 = (
+
+let uu____7645 = (FStar_Syntax_Syntax.gen_bv x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText None FStar_Syntax_Syntax.tun)
+in FStar_Syntax_Syntax.Pat_wild (uu____7645))
+in (pos uu____7644))
+in ((uu____7641), (b)))
+end))
+end))))
+in (
+
+let pat_true = (
+
+let uu____7657 = (
+
+let uu____7660 = (
+
+let uu____7661 = (
+
+let uu____7669 = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_constant (Some (fvq)))
+in ((uu____7669), (arg_pats)))
+in FStar_Syntax_Syntax.Pat_cons (uu____7661))
+in (pos uu____7660))
+in ((uu____7657), (None), (FStar_Syntax_Const.exp_true_bool)))
+in (
+
+let pat_false = (
+
+let uu____7691 = (
+
+let uu____7694 = (
+
+let uu____7695 = (FStar_Syntax_Syntax.new_bv None FStar_Syntax_Syntax.tun)
+in FStar_Syntax_Syntax.Pat_wild (uu____7695))
+in (pos uu____7694))
+in ((uu____7691), (None), (FStar_Syntax_Const.exp_false_bool)))
+in (
+
+let arg_exp = (FStar_Syntax_Syntax.bv_to_name (Prims.fst unrefined_arg_binder))
+in (
+
+let uu____7704 = (
+
+let uu____7707 = (
+
+let uu____7708 = (
+
+let uu____7724 = (
+
+let uu____7726 = (FStar_Syntax_Util.branch pat_true)
+in (
+
+let uu____7727 = (
+
+let uu____7729 = (FStar_Syntax_Util.branch pat_false)
+in (uu____7729)::[])
+in (uu____7726)::uu____7727))
+in ((arg_exp), (uu____7724)))
+in FStar_Syntax_Syntax.Tm_match (uu____7708))
+in (FStar_Syntax_Syntax.mk uu____7707))
+in (uu____7704 None p))))))
+end)
+in (
+
+let dd = (
+
+let uu____7740 = (FStar_All.pipe_right quals (FStar_List.contains FStar_Syntax_Syntax.Abstract))
+in (match (uu____7740) with
+| true -> begin
+FStar_Syntax_Syntax.Delta_abstract (FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____7742 -> begin
+FStar_Syntax_Syntax.Delta_equational
+end))
+in (
+
+let imp = (FStar_Syntax_Util.abs binders body None)
+in (
+
+let lbtyp = (match (no_decl) with
+| true -> begin
+t
+end
+| uu____7750 -> begin
+FStar_Syntax_Syntax.tun
+end)
+in (
+
+let lb = (
+
+let uu____7752 = (
+
+let uu____7755 = (FStar_Syntax_Syntax.lid_as_fv discriminator_name dd None)
+in FStar_Util.Inr (uu____7755))
+in (
+
+let uu____7756 = (FStar_Syntax_Subst.close_univ_vars uvs imp)
+in {FStar_Syntax_Syntax.lbname = uu____7752; FStar_Syntax_Syntax.lbunivs = uvs; FStar_Syntax_Syntax.lbtyp = lbtyp; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid; FStar_Syntax_Syntax.lbdef = uu____7756}))
+in (
+
+let impl = (
+
+let uu____7760 = (
+
+let uu____7761 = (
+
+let uu____7769 = (
+
+let uu____7771 = (
+
+let uu____7772 = (FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbname FStar_Util.right)
+in (FStar_All.pipe_right uu____7772 (fun fv -> fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))
+in (uu____7771)::[])
+in ((((false), ((lb)::[]))), (uu____7769), (quals), ([])))
+in FStar_Syntax_Syntax.Sig_let (uu____7761))
+in {FStar_Syntax_Syntax.sigel = uu____7760; FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = p})
+in ((
+
+let uu____7788 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("LogTypes")))
+in (match (uu____7788) with
+| true -> begin
+(
+
+let uu____7789 = (FStar_Syntax_Print.sigelt_to_string impl)
+in (FStar_Util.print1 "Implementation of a discriminator %s\n" uu____7789))
+end
+| uu____7790 -> begin
+()
+end));
+(decl)::(impl)::[];
+)))))))
+end);
+))))))))
+end)
+in (
+
+let arg_exp = (FStar_Syntax_Syntax.bv_to_name (Prims.fst arg_binder))
+in (
+
+let binders = (FStar_List.append imp_binders ((arg_binder)::[]))
+in (
+
+let arg = (FStar_Syntax_Util.arg_of_non_null_binder arg_binder)
+in (
+
+let subst1 = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____7809 -> (match (uu____7809) with
+| (a, uu____7813) -> begin
+(
+
+let uu____7814 = (FStar_Syntax_Util.mk_field_projector_name lid a i)
+in (match (uu____7814) with
+| (field_name, uu____7818) -> begin
+(
+
+let field_proj_tm = (
+
+let uu____7820 = (
+
+let uu____7821 = (FStar_Syntax_Syntax.lid_as_fv field_name FStar_Syntax_Syntax.Delta_equational None)
+in (FStar_Syntax_Syntax.fv_to_tm uu____7821))
+in (FStar_Syntax_Syntax.mk_Tm_uinst uu____7820 inst_univs))
+in (
+
+let proj = ((FStar_Syntax_Syntax.mk_Tm_app field_proj_tm ((arg)::[])) None p)
+in FStar_Syntax_Syntax.NT (((a), (proj)))))
+end))
+end))))
+in (
+
+let projectors_ses = (
+
+let uu____7837 = (FStar_All.pipe_right fields (FStar_List.mapi (fun i uu____7846 -> (match (uu____7846) with
+| (x, uu____7851) -> begin
+(
+
+let p1 = (FStar_Syntax_Syntax.range_of_bv x)
+in (
+
+let uu____7853 = (FStar_Syntax_Util.mk_field_projector_name lid x i)
+in (match (uu____7853) with
+| (field_name, uu____7858) -> begin
+(
+
+let t = (
+
+let uu____7860 = (
+
+let uu____7861 = (
+
+let uu____7864 = (FStar_Syntax_Subst.subst subst1 x.FStar_Syntax_Syntax.sort)
+in (FStar_Syntax_Syntax.mk_Total uu____7864))
+in (FStar_Syntax_Util.arrow binders uu____7861))
+in (FStar_All.pipe_left (FStar_Syntax_Subst.close_univ_vars uvs) uu____7860))
+in (
+
+let only_decl = (((
+
+let uu____7866 = (FStar_TypeChecker_Env.current_module env)
+in (FStar_Ident.lid_equals FStar_Syntax_Const.prims_lid uu____7866)) || (fvq <> FStar_Syntax_Syntax.Data_ctor)) || (
+
+let uu____7867 = (
+
+let uu____7868 = (FStar_TypeChecker_Env.current_module env)
+in uu____7868.FStar_Ident.str)
+in (FStar_Options.dont_gen_projectors uu____7867)))
+in (
+
+let no_decl = false
+in (
+
+let quals = (fun q -> (match (only_decl) with
+| true -> begin
+(
+
+let uu____7878 = (FStar_List.filter (fun uu___110_7880 -> (match (uu___110_7880) with
+| FStar_Syntax_Syntax.Abstract -> begin
+false
+end
+| uu____7881 -> begin
+true
+end)) q)
+in (FStar_Syntax_Syntax.Assumption)::uu____7878)
+end
+| uu____7882 -> begin
+q
+end))
+in (
+
+let quals1 = (
+
+let iquals1 = (FStar_All.pipe_right iquals (FStar_List.filter (fun uu___111_7889 -> (match (uu___111_7889) with
+| (FStar_Syntax_Syntax.Abstract) | (FStar_Syntax_Syntax.Private) -> begin
+true
+end
+| uu____7890 -> begin
+false
+end))))
+in (quals ((FStar_Syntax_Syntax.Projector (((lid), (x.FStar_Syntax_Syntax.ppname))))::iquals1)))
+in (
+
+let decl = {FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ (((field_name), (uvs), (t), (quals1))); FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = (FStar_Ident.range_of_lid field_name)}
+in ((
+
+let uu____7894 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("LogTypes")))
+in (match (uu____7894) with
+| true -> begin
+(
+
+let uu____7895 = (FStar_Syntax_Print.sigelt_to_string decl)
+in (FStar_Util.print1 "Declaration of a projector %s\n" uu____7895))
+end
+| uu____7896 -> begin
+()
+end));
+(match (only_decl) with
+| true -> begin
+(decl)::[]
+end
+| uu____7898 -> begin
+(
+
+let projection = (FStar_Syntax_Syntax.gen_bv x.FStar_Syntax_Syntax.ppname.FStar_Ident.idText None FStar_Syntax_Syntax.tun)
+in (
+
+let arg_pats = (FStar_All.pipe_right all_params (FStar_List.mapi (fun j uu____7922 -> (match (uu____7922) with
+| (x1, imp) -> begin
+(
+
+let b = (FStar_Syntax_Syntax.is_implicit imp)
+in (match (((i + ntps) = j)) with
+| true -> begin
+(
+
+let uu____7938 = (pos (FStar_Syntax_Syntax.Pat_var (projection)))
+in ((uu____7938), (b)))
+end
+| uu____7943 -> begin
+(match ((b && (j < ntps))) with
+| true -> begin
+(
+
+let uu____7950 = (
+
+let uu____7953 = (
+
+let uu____7954 = (
+
+let uu____7959 = (FStar_Syntax_Syntax.gen_bv x1.FStar_Syntax_Syntax.ppname.FStar_Ident.idText None FStar_Syntax_Syntax.tun)
+in ((uu____7959), (FStar_Syntax_Syntax.tun)))
+in FStar_Syntax_Syntax.Pat_dot_term (uu____7954))
+in (pos uu____7953))
+in ((uu____7950), (b)))
+end
+| uu____7962 -> begin
+(
+
+let uu____7963 = (
+
+let uu____7966 = (
+
+let uu____7967 = (FStar_Syntax_Syntax.gen_bv x1.FStar_Syntax_Syntax.ppname.FStar_Ident.idText None FStar_Syntax_Syntax.tun)
+in FStar_Syntax_Syntax.Pat_wild (uu____7967))
+in (pos uu____7966))
+in ((uu____7963), (b)))
+end)
+end))
+end))))
+in (
+
+let pat = (
+
+let uu____7979 = (
+
+let uu____7982 = (
+
+let uu____7983 = (
+
+let uu____7991 = (FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.Delta_constant (Some (fvq)))
+in ((uu____7991), (arg_pats)))
+in FStar_Syntax_Syntax.Pat_cons (uu____7983))
+in (pos uu____7982))
+in (
+
+let uu____7997 = (FStar_Syntax_Syntax.bv_to_name projection)
+in ((uu____7979), (None), (uu____7997))))
+in (
+
+let body = (
+
+let uu____8008 = (
+
+let uu____8011 = (
+
+let uu____8012 = (
+
+let uu____8028 = (
+
+let uu____8030 = (FStar_Syntax_Util.branch pat)
+in (uu____8030)::[])
+in ((arg_exp), (uu____8028)))
+in FStar_Syntax_Syntax.Tm_match (uu____8012))
+in (FStar_Syntax_Syntax.mk uu____8011))
+in (uu____8008 None p1))
+in (
+
+let imp = (FStar_Syntax_Util.abs binders body None)
+in (
+
+let dd = (
+
+let uu____8047 = (FStar_All.pipe_right quals1 (FStar_List.contains FStar_Syntax_Syntax.Abstract))
+in (match (uu____8047) with
+| true -> begin
+FStar_Syntax_Syntax.Delta_abstract (FStar_Syntax_Syntax.Delta_equational)
+end
+| uu____8049 -> begin
+FStar_Syntax_Syntax.Delta_equational
+end))
+in (
+
+let lbtyp = (match (no_decl) with
+| true -> begin
+t
+end
+| uu____8051 -> begin
+FStar_Syntax_Syntax.tun
+end)
+in (
+
+let lb = (
+
+let uu____8053 = (
+
+let uu____8056 = (FStar_Syntax_Syntax.lid_as_fv field_name dd None)
+in FStar_Util.Inr (uu____8056))
+in (
+
+let uu____8057 = (FStar_Syntax_Subst.close_univ_vars uvs imp)
+in {FStar_Syntax_Syntax.lbname = uu____8053; FStar_Syntax_Syntax.lbunivs = uvs; FStar_Syntax_Syntax.lbtyp = lbtyp; FStar_Syntax_Syntax.lbeff = FStar_Syntax_Const.effect_Tot_lid; FStar_Syntax_Syntax.lbdef = uu____8057}))
+in (
+
+let impl = (
+
+let uu____8061 = (
+
+let uu____8062 = (
+
+let uu____8070 = (
+
+let uu____8072 = (
+
+let uu____8073 = (FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbname FStar_Util.right)
+in (FStar_All.pipe_right uu____8073 (fun fv -> fv.FStar_Syntax_Syntax.fv_name.FStar_Syntax_Syntax.v)))
+in (uu____8072)::[])
+in ((((false), ((lb)::[]))), (uu____8070), (quals1), ([])))
+in FStar_Syntax_Syntax.Sig_let (uu____8062))
+in {FStar_Syntax_Syntax.sigel = uu____8061; FStar_Syntax_Syntax.sigdoc = None; FStar_Syntax_Syntax.sigrng = p1})
+in ((
+
+let uu____8089 = (FStar_TypeChecker_Env.debug env (FStar_Options.Other ("LogTypes")))
+in (match (uu____8089) with
+| true -> begin
+(
+
+let uu____8090 = (FStar_Syntax_Print.sigelt_to_string impl)
+in (FStar_Util.print1 "Implementation of a projector %s\n" uu____8090))
+end
+| uu____8091 -> begin
+()
+end));
+(match (no_decl) with
+| true -> begin
+(impl)::[]
+end
+| uu____8093 -> begin
+(decl)::(impl)::[]
+end);
+))))))))))
+end);
+)))))))
+end)))
+end))))
+in (FStar_All.pipe_right uu____7837 FStar_List.flatten))
+in (FStar_List.append discriminator_ses projectors_ses)))))))))))))))))))
+
+
+let mk_data_operations : FStar_Syntax_Syntax.qualifier Prims.list  ->  FStar_TypeChecker_Env.env  ->  FStar_Syntax_Syntax.sigelt Prims.list  ->  FStar_Syntax_Syntax.sigelt  ->  FStar_Syntax_Syntax.sigelt Prims.list = (fun iquals env tcs se -> (match (se.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_datacon (constr_lid, uvs, t, typ_lid, n_typars, quals, uu____8121) when (not ((FStar_Ident.lid_equals constr_lid FStar_Syntax_Const.lexcons_lid))) -> begin
+(
+
+let uu____8126 = (FStar_Syntax_Subst.univ_var_opening uvs)
+in (match (uu____8126) with
+| (univ_opening, uvs1) -> begin
+(
+
+let t1 = (FStar_Syntax_Subst.subst univ_opening t)
+in (
+
+let uu____8139 = (FStar_Syntax_Util.arrow_formals t1)
+in (match (uu____8139) with
+| (formals, uu____8149) -> begin
+(
+
+let uu____8160 = (
+
+let tps_opt = (FStar_Util.find_map tcs (fun se1 -> (
+
+let uu____8173 = (
+
+let uu____8174 = (
+
+let uu____8175 = (FStar_Syntax_Util.lid_of_sigelt se1)
+in (FStar_Util.must uu____8175))
+in (FStar_Ident.lid_equals typ_lid uu____8174))
+in (match (uu____8173) with
+| true -> begin
+(match (se1.FStar_Syntax_Syntax.sigel) with
+| FStar_Syntax_Syntax.Sig_inductive_typ (uu____8185, uvs', tps, typ0, uu____8189, constrs, uu____8191) -> begin
+Some (((tps), (typ0), (((FStar_List.length constrs) > (Prims.parse_int "1")))))
+end
+| uu____8205 -> begin
+(failwith "Impossible")
+end)
+end
+| uu____8210 -> begin
+None
+end))))
+in (match (tps_opt) with
+| Some (x) -> begin
+x
+end
+| None -> begin
+(match ((FStar_Ident.lid_equals typ_lid FStar_Syntax_Const.exn_lid)) with
+| true -> begin
+(([]), (FStar_Syntax_Util.ktype0), (true))
+end
+| uu____8237 -> begin
+(Prims.raise (FStar_Errors.Error ((("Unexpected data constructor"), (se.FStar_Syntax_Syntax.sigrng)))))
+end)
+end))
+in (match (uu____8160) with
+| (inductive_tps, typ0, should_refine) -> begin
+(
+
+let inductive_tps1 = (FStar_Syntax_Subst.subst_binders univ_opening inductive_tps)
+in (
+
+let typ01 = (FStar_Syntax_Subst.subst univ_opening typ0)
+in (
+
+let uu____8247 = (FStar_Syntax_Util.arrow_formals typ01)
+in (match (uu____8247) with
+| (indices, uu____8257) -> begin
+(
+
+let refine_domain = (
+
+let uu____8269 = (FStar_All.pipe_right quals (FStar_Util.for_some (fun uu___112_8271 -> (match (uu___112_8271) with
+| FStar_Syntax_Syntax.RecordConstructor (uu____8272) -> begin
+true
+end
+| uu____8277 -> begin
+false
+end))))
+in (match (uu____8269) with
+| true -> begin
+false
+end
+| uu____8278 -> begin
+should_refine
+end))
+in (
+
+let fv_qual = (
+
+let filter_records = (fun uu___113_8284 -> (match (uu___113_8284) with
+| FStar_Syntax_Syntax.RecordConstructor (uu____8286, fns) -> begin
+Some (FStar_Syntax_Syntax.Record_ctor (((constr_lid), (fns))))
+end
+| uu____8293 -> begin
+None
+end))
+in (
+
+let uu____8294 = (FStar_Util.find_map quals filter_records)
+in (match (uu____8294) with
+| None -> begin
+FStar_Syntax_Syntax.Data_ctor
+end
+| Some (q) -> begin
+q
+end)))
+in (
+
+let iquals1 = (match ((FStar_List.contains FStar_Syntax_Syntax.Abstract iquals)) with
+| true -> begin
+(FStar_Syntax_Syntax.Private)::iquals
+end
+| uu____8300 -> begin
+iquals
+end)
+in (
+
+let fields = (
+
+let uu____8302 = (FStar_Util.first_N n_typars formals)
+in (match (uu____8302) with
+| (imp_tps, fields) -> begin
+(
+
+let rename = (FStar_List.map2 (fun uu____8333 uu____8334 -> (match (((uu____8333), (uu____8334))) with
+| ((x, uu____8344), (x', uu____8346)) -> begin
+(
+
+let uu____8351 = (
+
+let uu____8356 = (FStar_Syntax_Syntax.bv_to_name x')
+in ((x), (uu____8356)))
+in FStar_Syntax_Syntax.NT (uu____8351))
+end)) imp_tps inductive_tps1)
+in (FStar_Syntax_Subst.subst_binders rename fields))
+end))
+in (mk_discriminator_and_indexed_projectors iquals1 fv_qual refine_domain env typ_lid constr_lid uvs1 inductive_tps1 indices fields)))))
+end))))
+end))
+end)))
+end))
+end
+| uu____8357 -> begin
+[]
+end))
+
+
+
+

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -1,400 +1,448 @@
+
 open Prims
-let module_or_interface_name:
-  FStar_Syntax_Syntax.modul -> (Prims.bool* FStar_Ident.lident) =
-  fun m  ->
-    ((m.FStar_Syntax_Syntax.is_interface), (m.FStar_Syntax_Syntax.name))
-let parse:
-  FStar_ToSyntax_Env.env ->
-    Prims.string Prims.option ->
-      Prims.string ->
-        (FStar_ToSyntax_Env.env* FStar_Syntax_Syntax.modul Prims.list)
-  =
-  fun env  ->
-    fun pre_fn  ->
-      fun fn  ->
-        let uu____23 = FStar_Parser_Driver.parse_file fn in
-        match uu____23 with
-        | (ast,uu____33) ->
-            let ast1 =
-              match pre_fn with
-              | None  -> ast
-              | Some pre_fn1 ->
-                  let uu____42 = FStar_Parser_Driver.parse_file pre_fn1 in
-                  (match uu____42 with
-                   | (pre_ast,uu____49) ->
-                       (match (pre_ast, ast) with
-                        | ((FStar_Parser_AST.Interface
-                           (lid1,decls1,uu____58))::[],(FStar_Parser_AST.Module
-                           (lid2,decls2))::[]) when
-                            FStar_Ident.lid_equals lid1 lid2 ->
-                            let uu____67 =
-                              let uu____68 =
-                                let uu____72 =
-                                  FStar_Parser_Interleave.interleave decls1
-                                    decls2 in
-                                (lid1, uu____72) in
-                              FStar_Parser_AST.Module uu____68 in
-                            [uu____67]
-                        | uu____75 ->
-                            Prims.raise
-                              (FStar_Errors.Err
-                                 "mismatch between pre-module and module\n"))) in
-            FStar_ToSyntax_ToSyntax.desugar_file env ast1
-let tc_prims:
-  Prims.unit ->
-    ((FStar_Syntax_Syntax.modul* Prims.int)* FStar_ToSyntax_Env.env*
-      FStar_TypeChecker_Env.env)
-  =
-  fun uu____85  ->
-    let solver1 =
-      let uu____92 = FStar_Options.lax () in
-      if uu____92
-      then FStar_SMTEncoding_Solver.dummy
-      else
-        (let uu___219_94 = FStar_SMTEncoding_Solver.solver in
-         {
-           FStar_TypeChecker_Env.init =
-             (uu___219_94.FStar_TypeChecker_Env.init);
-           FStar_TypeChecker_Env.push =
-             (uu___219_94.FStar_TypeChecker_Env.push);
-           FStar_TypeChecker_Env.pop =
-             (uu___219_94.FStar_TypeChecker_Env.pop);
-           FStar_TypeChecker_Env.mark =
-             (uu___219_94.FStar_TypeChecker_Env.mark);
-           FStar_TypeChecker_Env.reset_mark =
-             (uu___219_94.FStar_TypeChecker_Env.reset_mark);
-           FStar_TypeChecker_Env.commit_mark =
-             (uu___219_94.FStar_TypeChecker_Env.commit_mark);
-           FStar_TypeChecker_Env.encode_modul =
-             (uu___219_94.FStar_TypeChecker_Env.encode_modul);
-           FStar_TypeChecker_Env.encode_sig =
-             (uu___219_94.FStar_TypeChecker_Env.encode_sig);
-           FStar_TypeChecker_Env.preprocess =
-             FStar_Tactics_Interpreter.preprocess;
-           FStar_TypeChecker_Env.solve =
-             (uu___219_94.FStar_TypeChecker_Env.solve);
-           FStar_TypeChecker_Env.is_trivial =
-             (uu___219_94.FStar_TypeChecker_Env.is_trivial);
-           FStar_TypeChecker_Env.finish =
-             (uu___219_94.FStar_TypeChecker_Env.finish);
-           FStar_TypeChecker_Env.refresh =
-             (uu___219_94.FStar_TypeChecker_Env.refresh)
-         }) in
-    let env =
-      FStar_TypeChecker_Env.initial_env
-        FStar_TypeChecker_TcTerm.type_of_tot_term
-        FStar_TypeChecker_TcTerm.universe_of solver1
-        FStar_Syntax_Const.prims_lid in
-    (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env;
-    (let prims_filename = FStar_Options.prims () in
-     let uu____98 =
-       let uu____102 = FStar_ToSyntax_Env.empty_env () in
-       parse uu____102 None prims_filename in
-     match uu____98 with
-     | (dsenv,prims_mod) ->
-         let uu____112 =
-           FStar_Util.record_time
-             (fun uu____119  ->
-                let uu____120 = FStar_List.hd prims_mod in
-                FStar_TypeChecker_Tc.check_module env uu____120) in
-         (match uu____112 with
-          | ((prims_mod1,env1),elapsed_time) ->
-              ((prims_mod1, elapsed_time), dsenv, env1)))
-let tc_one_fragment:
-  FStar_Syntax_Syntax.modul Prims.option ->
-    FStar_ToSyntax_Env.env ->
-      FStar_TypeChecker_Env.env ->
-        FStar_Parser_ParseIt.input_frag ->
-          (FStar_Syntax_Syntax.modul Prims.option* FStar_ToSyntax_Env.env*
-            FStar_TypeChecker_Env.env) Prims.option
-  =
-  fun curmod  ->
-    fun dsenv  ->
-      fun env  ->
-        fun frag  ->
-          try
-            let uu____163 = FStar_Parser_Driver.parse_fragment frag in
-            match uu____163 with
-            | FStar_Parser_Driver.Empty  -> Some (curmod, dsenv, env)
-            | FStar_Parser_Driver.Modul ast_modul ->
-                let uu____175 =
-                  FStar_ToSyntax_ToSyntax.desugar_partial_modul curmod dsenv
-                    ast_modul in
-                (match uu____175 with
-                 | (dsenv1,modul) ->
-                     let env1 =
-                       match curmod with
-                       | Some modul1 ->
-                           let uu____187 =
-                             let uu____188 =
-                               let uu____189 =
-                                 let uu____190 = FStar_Options.file_list () in
-                                 FStar_List.hd uu____190 in
-                               FStar_Parser_Dep.lowercase_module_name
-                                 uu____189 in
-                             let uu____192 =
-                               let uu____193 =
-                                 FStar_Ident.string_of_lid
-                                   modul1.FStar_Syntax_Syntax.name in
-                               FStar_String.lowercase uu____193 in
-                             uu____188 <> uu____192 in
-                           if uu____187
-                           then
-                             Prims.raise
-                               (FStar_Errors.Err
-                                  "Interactive mode only supports a single module at the top-level")
-                           else env
-                       | None  -> env in
-                     let uu____195 =
-                       FStar_TypeChecker_Tc.tc_partial_modul env1 modul in
-                     (match uu____195 with
-                      | (modul1,uu____206,env2) ->
-                          Some ((Some modul1), dsenv1, env2)))
-            | FStar_Parser_Driver.Decls ast_decls ->
-                let uu____217 =
-                  FStar_ToSyntax_ToSyntax.desugar_decls dsenv ast_decls in
-                (match uu____217 with
-                 | (dsenv1,decls) ->
-                     (match curmod with
-                      | None  ->
-                          (FStar_Util.print_error
-                             "fragment without an enclosing module";
-                           FStar_All.exit (Prims.parse_int "1"))
-                      | Some modul ->
-                          let uu____239 =
-                            FStar_TypeChecker_Tc.tc_more_partial_modul env
-                              modul decls in
-                          (match uu____239 with
-                           | (modul1,uu____250,env1) ->
-                               Some ((Some modul1), dsenv1, env1))))
-          with
-          | FStar_Errors.Error (msg,r) when
-              let uu____267 = FStar_Options.trace_error () in
-              Prims.op_Negation uu____267 ->
-              (FStar_TypeChecker_Err.add_errors env [(msg, r)]; None)
-          | FStar_Errors.Err msg when
-              let uu____278 = FStar_Options.trace_error () in
-              Prims.op_Negation uu____278 ->
-              (FStar_TypeChecker_Err.add_errors env
-                 [(msg, FStar_Range.dummyRange)];
-               None)
-          | e when
-              let uu____289 = FStar_Options.trace_error () in
-              Prims.op_Negation uu____289 -> Prims.raise e
-let tc_one_file:
-  FStar_ToSyntax_Env.env ->
-    FStar_TypeChecker_Env.env ->
-      Prims.string Prims.option ->
-        Prims.string ->
-          ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list*
-            FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun dsenv  ->
-    fun env  ->
-      fun pre_fn  ->
-        fun fn  ->
-          let uu____321 = parse dsenv pre_fn fn in
-          match uu____321 with
-          | (dsenv1,fmods) ->
-              let check_mods uu____344 =
-                let uu____345 =
-                  FStar_All.pipe_right fmods
-                    (FStar_List.fold_left
-                       (fun uu____362  ->
-                          fun m  ->
-                            match uu____362 with
-                            | (env1,all_mods) ->
-                                let uu____382 =
-                                  FStar_Util.record_time
-                                    (fun uu____389  ->
-                                       FStar_TypeChecker_Tc.check_module env1
-                                         m) in
-                                (match uu____382 with
-                                 | ((m1,env2),elapsed_ms) ->
-                                     (env2, ((m1, elapsed_ms) :: all_mods))))
-                       (env, [])) in
-                match uu____345 with
-                | (env1,all_mods) ->
-                    ((FStar_List.rev all_mods), dsenv1, env1) in
-              (match fmods with
-               | m::[] when
-                   (FStar_Options.should_verify
-                      (m.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                     &&
-                     ((FStar_Options.record_hints ()) ||
-                        (FStar_Options.use_hints ()))
-                   ->
-                   let uu____436 = FStar_Parser_ParseIt.find_file fn in
-                   FStar_SMTEncoding_Solver.with_hints_db uu____436
-                     check_mods
-               | uu____443 -> check_mods ())
-let needs_interleaving: Prims.string -> Prims.string -> Prims.bool =
-  fun intf  ->
-    fun impl  ->
-      let m1 = FStar_Parser_Dep.lowercase_module_name intf in
-      let m2 = FStar_Parser_Dep.lowercase_module_name impl in
-      ((m1 = m2) &&
-         (let uu____453 = FStar_Util.get_file_extension intf in
-          uu____453 = "fsti"))
-        &&
-        (let uu____454 = FStar_Util.get_file_extension impl in
-         uu____454 = "fst")
-let pop_context: FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit =
-  fun env  ->
-    fun msg  ->
-      (let uu____462 = FStar_ToSyntax_Env.pop () in
-       FStar_All.pipe_right uu____462 Prims.ignore);
-      (let uu____464 = FStar_TypeChecker_Env.pop env msg in
-       FStar_All.pipe_right uu____464 Prims.ignore);
-      (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh ()
-let push_context:
-  (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env) ->
-    Prims.string -> (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun uu____473  ->
-    fun msg  ->
-      match uu____473 with
-      | (dsenv,env) ->
-          let dsenv1 = FStar_ToSyntax_Env.push dsenv in
-          let env1 = FStar_TypeChecker_Env.push env msg in (dsenv1, env1)
-let tc_one_file_and_intf:
-  Prims.string Prims.option ->
-    Prims.string ->
-      FStar_ToSyntax_Env.env ->
-        FStar_TypeChecker_Env.env ->
-          ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list*
-            FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun intf  ->
-    fun impl  ->
-      fun dsenv  ->
-        fun env  ->
-          FStar_Syntax_Syntax.reset_gensym ();
-          (match intf with
-           | None  -> tc_one_file dsenv env None impl
-           | Some uu____510 when
-               let uu____511 = FStar_Options.codegen () in uu____511 <> None
-               ->
-               ((let uu____515 =
-                   let uu____516 = FStar_Options.lax () in
-                   Prims.op_Negation uu____516 in
-                 if uu____515
-                 then
-                   Prims.raise
-                     (FStar_Errors.Err
-                        "Verification and code generation are no supported together with partial modules (i.e, *.fsti); use --lax to extract code separately")
-                 else ());
-                tc_one_file dsenv env intf impl)
-           | Some iname ->
-               ((let uu____520 = FStar_Options.debug_any () in
-                 if uu____520
-                 then
-                   FStar_Util.print1 "Interleaving iface+module: %s\n" iname
-                 else ());
-                (let caption = Prims.strcat "interface: " iname in
-                 let uu____523 = push_context (dsenv, env) caption in
-                 match uu____523 with
-                 | (dsenv',env') ->
-                     let uu____534 = tc_one_file dsenv' env' intf impl in
-                     (match uu____534 with
-                      | (uu____547,dsenv'1,env'1) ->
-                          (pop_context env'1 caption;
-                           tc_one_file dsenv env None iname)))))
-type uenv = (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-let tc_one_file_from_remaining:
-  Prims.string Prims.list ->
-    uenv ->
-      (Prims.string Prims.list* (FStar_Syntax_Syntax.modul* Prims.int)
-        Prims.list* (FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env))
-  =
-  fun remaining  ->
-    fun uenv  ->
-      let uu____576 = uenv in
-      match uu____576 with
-      | (dsenv,env) ->
-          let uu____588 =
-            match remaining with
-            | intf::impl::remaining1 when needs_interleaving intf impl ->
-                let uu____611 =
-                  tc_one_file_and_intf (Some intf) impl dsenv env in
-                (remaining1, uu____611)
-            | intf_or_impl::remaining1 ->
-                let uu____628 =
-                  tc_one_file_and_intf None intf_or_impl dsenv env in
-                (remaining1, uu____628)
-            | [] -> ([], ([], dsenv, env)) in
-          (match uu____588 with
-           | (remaining1,(nmods,dsenv1,env1)) ->
-               (remaining1, nmods, (dsenv1, env1)))
-let rec tc_fold_interleave:
-  ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list* uenv) ->
-    Prims.string Prims.list ->
-      ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list* uenv)
-  =
-  fun acc  ->
-    fun remaining  ->
-      match remaining with
-      | [] -> acc
-      | uu____715 ->
-          let uu____717 = acc in
-          (match uu____717 with
-           | (mods,uenv) ->
-               let uu____736 = tc_one_file_from_remaining remaining uenv in
-               (match uu____736 with
-                | (remaining1,nmods,(dsenv,env)) ->
-                    tc_fold_interleave
-                      ((FStar_List.append mods nmods), (dsenv, env))
-                      remaining1))
-let batch_mode_tc_no_prims:
-  FStar_ToSyntax_Env.env ->
-    FStar_TypeChecker_Env.env ->
-      Prims.string Prims.list ->
-        ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list*
-          FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun dsenv  ->
-    fun env  ->
-      fun filenames  ->
-        let uu____789 = tc_fold_interleave ([], (dsenv, env)) filenames in
-        match uu____789 with
-        | (all_mods,(dsenv1,env1)) ->
-            ((let uu____820 =
-                (FStar_Options.interactive ()) &&
-                  (let uu____821 = FStar_Errors.get_err_count () in
-                   uu____821 = (Prims.parse_int "0")) in
-              if uu____820
-              then
-                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
-                  ()
-              else
-                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.finish
-                  ());
-             (all_mods, dsenv1, env1))
-let batch_mode_tc:
-  Prims.string Prims.list ->
-    ((FStar_Syntax_Syntax.modul* Prims.int) Prims.list*
-      FStar_ToSyntax_Env.env* FStar_TypeChecker_Env.env)
-  =
-  fun filenames  ->
-    let uu____837 = tc_prims () in
-    match uu____837 with
-    | (prims_mod,dsenv,env) ->
-        ((let uu____857 =
-            (let uu____858 = FStar_Options.explicit_deps () in
-             Prims.op_Negation uu____858) && (FStar_Options.debug_any ()) in
-          if uu____857
-          then
-            (FStar_Util.print_endline
-               "Auto-deps kicked in; here's some info.";
-             FStar_Util.print1
-               "Here's the list of filenames we will process: %s\n"
-               (FStar_String.concat " " filenames);
-             (let uu____861 =
-                let uu____862 = FStar_Options.verify_module () in
-                FStar_String.concat " " uu____862 in
-              FStar_Util.print1
-                "Here's the list of modules we will verify: %s\n" uu____861))
-          else ());
-         (let uu____865 = batch_mode_tc_no_prims dsenv env filenames in
-          match uu____865 with
-          | (all_mods,dsenv1,env1) -> ((prims_mod :: all_mods), dsenv1, env1)))
+
+let module_or_interface_name : FStar_Syntax_Syntax.modul  ->  (Prims.bool * FStar_Ident.lident) = (fun m -> ((m.FStar_Syntax_Syntax.is_interface), (m.FStar_Syntax_Syntax.name)))
+
+
+let parse : FStar_ToSyntax_Env.env  ->  Prims.string Prims.option  ->  Prims.string  ->  (FStar_ToSyntax_Env.env * FStar_Syntax_Syntax.modul Prims.list) = (fun env pre_fn fn -> (
+
+let uu____23 = (FStar_Parser_Driver.parse_file fn)
+in (match (uu____23) with
+| (ast, uu____33) -> begin
+(
+
+let ast1 = (match (pre_fn) with
+| None -> begin
+ast
+end
+| Some (pre_fn1) -> begin
+(
+
+let uu____42 = (FStar_Parser_Driver.parse_file pre_fn1)
+in (match (uu____42) with
+| (pre_ast, uu____49) -> begin
+(match (((pre_ast), (ast))) with
+| ((FStar_Parser_AST.Interface (lid1, decls1, uu____58))::[], (FStar_Parser_AST.Module (lid2, decls2))::[]) when (FStar_Ident.lid_equals lid1 lid2) -> begin
+(
+
+let uu____67 = (
+
+let uu____68 = (
+
+let uu____72 = (FStar_Parser_Interleave.interleave decls1 decls2)
+in ((lid1), (uu____72)))
+in FStar_Parser_AST.Module (uu____68))
+in (uu____67)::[])
+end
+| uu____75 -> begin
+(Prims.raise (FStar_Errors.Err ("mismatch between pre-module and module\n")))
+end)
+end))
+end)
+in (FStar_ToSyntax_ToSyntax.desugar_file env ast1))
+end)))
+
+
+let tc_prims : Prims.unit  ->  ((FStar_Syntax_Syntax.modul * Prims.int) * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____85 -> (
+
+let solver1 = (
+
+let uu____92 = (FStar_Options.lax ())
+in (match (uu____92) with
+| true -> begin
+FStar_SMTEncoding_Solver.dummy
+end
+| uu____93 -> begin
+(
+
+let uu___216_94 = FStar_SMTEncoding_Solver.solver
+in {FStar_TypeChecker_Env.init = uu___216_94.FStar_TypeChecker_Env.init; FStar_TypeChecker_Env.push = uu___216_94.FStar_TypeChecker_Env.push; FStar_TypeChecker_Env.pop = uu___216_94.FStar_TypeChecker_Env.pop; FStar_TypeChecker_Env.mark = uu___216_94.FStar_TypeChecker_Env.mark; FStar_TypeChecker_Env.reset_mark = uu___216_94.FStar_TypeChecker_Env.reset_mark; FStar_TypeChecker_Env.commit_mark = uu___216_94.FStar_TypeChecker_Env.commit_mark; FStar_TypeChecker_Env.encode_modul = uu___216_94.FStar_TypeChecker_Env.encode_modul; FStar_TypeChecker_Env.encode_sig = uu___216_94.FStar_TypeChecker_Env.encode_sig; FStar_TypeChecker_Env.preprocess = FStar_Tactics_Interpreter.preprocess; FStar_TypeChecker_Env.solve = uu___216_94.FStar_TypeChecker_Env.solve; FStar_TypeChecker_Env.is_trivial = uu___216_94.FStar_TypeChecker_Env.is_trivial; FStar_TypeChecker_Env.finish = uu___216_94.FStar_TypeChecker_Env.finish; FStar_TypeChecker_Env.refresh = uu___216_94.FStar_TypeChecker_Env.refresh})
+end))
+in (
+
+let env = (FStar_TypeChecker_Env.initial_env FStar_TypeChecker_TcTerm.type_of_tot_term FStar_TypeChecker_TcTerm.universe_of solver1 FStar_Syntax_Const.prims_lid)
+in ((env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.init env);
+(
+
+let prims_filename = (FStar_Options.prims ())
+in (
+
+let uu____98 = (
+
+let uu____102 = (FStar_ToSyntax_Env.empty_env ())
+in (parse uu____102 None prims_filename))
+in (match (uu____98) with
+| (dsenv, prims_mod) -> begin
+(
+
+let uu____112 = (FStar_Util.record_time (fun uu____119 -> (
+
+let uu____120 = (FStar_List.hd prims_mod)
+in (FStar_TypeChecker_Tc.check_module env uu____120))))
+in (match (uu____112) with
+| ((prims_mod1, env1), elapsed_time) -> begin
+((((prims_mod1), (elapsed_time))), (dsenv), (env1))
+end))
+end)));
+))))
+
+
+let tc_one_fragment : FStar_Syntax_Syntax.modul Prims.option  ->  FStar_ToSyntax_Env.env  ->  FStar_TypeChecker_Env.env  ->  FStar_Parser_ParseIt.input_frag  ->  (FStar_Syntax_Syntax.modul Prims.option * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) Prims.option = (fun curmod dsenv env frag -> try
+(match (()) with
+| () -> begin
+(
+
+let uu____163 = (FStar_Parser_Driver.parse_fragment frag)
+in (match (uu____163) with
+| FStar_Parser_Driver.Empty -> begin
+Some (((curmod), (dsenv), (env)))
+end
+| FStar_Parser_Driver.Modul (ast_modul) -> begin
+(
+
+let uu____175 = (FStar_ToSyntax_ToSyntax.desugar_partial_modul curmod dsenv ast_modul)
+in (match (uu____175) with
+| (dsenv1, modul) -> begin
+(
+
+let env1 = (match (curmod) with
+| Some (modul1) -> begin
+(
+
+let uu____187 = (
+
+let uu____188 = (
+
+let uu____189 = (
+
+let uu____190 = (FStar_Options.file_list ())
+in (FStar_List.hd uu____190))
+in (FStar_Parser_Dep.lowercase_module_name uu____189))
+in (
+
+let uu____192 = (
+
+let uu____193 = (FStar_Ident.string_of_lid modul1.FStar_Syntax_Syntax.name)
+in (FStar_String.lowercase uu____193))
+in (uu____188 <> uu____192)))
+in (match (uu____187) with
+| true -> begin
+(Prims.raise (FStar_Errors.Err ("Interactive mode only supports a single module at the top-level")))
+end
+| uu____194 -> begin
+env
+end))
+end
+| None -> begin
+env
+end)
+in (
+
+let uu____195 = (FStar_TypeChecker_Tc.tc_partial_modul env1 modul)
+in (match (uu____195) with
+| (modul1, uu____206, env2) -> begin
+Some (((Some (modul1)), (dsenv1), (env2)))
+end)))
+end))
+end
+| FStar_Parser_Driver.Decls (ast_decls) -> begin
+(
+
+let uu____217 = (FStar_ToSyntax_ToSyntax.desugar_decls dsenv ast_decls)
+in (match (uu____217) with
+| (dsenv1, decls) -> begin
+(match (curmod) with
+| None -> begin
+((FStar_Util.print_error "fragment without an enclosing module");
+(FStar_All.exit (Prims.parse_int "1"));
+)
+end
+| Some (modul) -> begin
+(
+
+let uu____239 = (FStar_TypeChecker_Tc.tc_more_partial_modul env modul decls)
+in (match (uu____239) with
+| (modul1, uu____250, env1) -> begin
+Some (((Some (modul1)), (dsenv1), (env1)))
+end))
+end)
+end))
+end))
+end)
+with
+| FStar_Errors.Error (msg, r) when (
+
+let uu____267 = (FStar_Options.trace_error ())
+in (not (uu____267))) -> begin
+((FStar_TypeChecker_Err.add_errors env ((((msg), (r)))::[]));
+None;
+)
+end
+| FStar_Errors.Err (msg) when (
+
+let uu____278 = (FStar_Options.trace_error ())
+in (not (uu____278))) -> begin
+((FStar_TypeChecker_Err.add_errors env ((((msg), (FStar_Range.dummyRange)))::[]));
+None;
+)
+end
+| e when (
+
+let uu____289 = (FStar_Options.trace_error ())
+in (not (uu____289))) -> begin
+(Prims.raise e)
+end)
+
+
+let tc_one_file : FStar_ToSyntax_Env.env  ->  FStar_TypeChecker_Env.env  ->  Prims.string Prims.option  ->  Prims.string  ->  ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun dsenv env pre_fn fn -> (
+
+let uu____321 = (parse dsenv pre_fn fn)
+in (match (uu____321) with
+| (dsenv1, fmods) -> begin
+(
+
+let check_mods = (fun uu____344 -> (
+
+let uu____345 = (FStar_All.pipe_right fmods (FStar_List.fold_left (fun uu____362 m -> (match (uu____362) with
+| (env1, all_mods) -> begin
+(
+
+let uu____382 = (FStar_Util.record_time (fun uu____389 -> (FStar_TypeChecker_Tc.check_module env1 m)))
+in (match (uu____382) with
+| ((m1, env2), elapsed_ms) -> begin
+((env2), ((((m1), (elapsed_ms)))::all_mods))
+end))
+end)) ((env), ([]))))
+in (match (uu____345) with
+| (env1, all_mods) -> begin
+(((FStar_List.rev all_mods)), (dsenv1), (env1))
+end)))
+in (match (fmods) with
+| (m)::[] when ((FStar_Options.should_verify m.FStar_Syntax_Syntax.name.FStar_Ident.str) && ((FStar_Options.record_hints ()) || (FStar_Options.use_hints ()))) -> begin
+(
+
+let uu____436 = (FStar_Parser_ParseIt.find_file fn)
+in (FStar_SMTEncoding_Solver.with_hints_db uu____436 check_mods))
+end
+| uu____443 -> begin
+(check_mods ())
+end))
+end)))
+
+
+let needs_interleaving : Prims.string  ->  Prims.string  ->  Prims.bool = (fun intf impl -> (
+
+let m1 = (FStar_Parser_Dep.lowercase_module_name intf)
+in (
+
+let m2 = (FStar_Parser_Dep.lowercase_module_name impl)
+in (((m1 = m2) && (
+
+let uu____453 = (FStar_Util.get_file_extension intf)
+in (uu____453 = "fsti"))) && (
+
+let uu____454 = (FStar_Util.get_file_extension impl)
+in (uu____454 = "fst"))))))
+
+
+let pop_context : FStar_TypeChecker_Env.env  ->  Prims.string  ->  Prims.unit = (fun env msg -> ((
+
+let uu____462 = (FStar_ToSyntax_Env.pop ())
+in (FStar_All.pipe_right uu____462 Prims.ignore));
+(
+
+let uu____464 = (FStar_TypeChecker_Env.pop env msg)
+in (FStar_All.pipe_right uu____464 Prims.ignore));
+(env.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.refresh ());
+))
+
+
+let push_context : (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)  ->  Prims.string  ->  (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun uu____473 msg -> (match (uu____473) with
+| (dsenv, env) -> begin
+(
+
+let dsenv1 = (FStar_ToSyntax_Env.push dsenv)
+in (
+
+let env1 = (FStar_TypeChecker_Env.push env msg)
+in ((dsenv1), (env1))))
+end))
+
+
+let tc_one_file_and_intf : Prims.string Prims.option  ->  Prims.string  ->  FStar_ToSyntax_Env.env  ->  FStar_TypeChecker_Env.env  ->  ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun intf impl dsenv env -> ((FStar_Syntax_Syntax.reset_gensym ());
+(match (intf) with
+| None -> begin
+(tc_one_file dsenv env None impl)
+end
+| Some (uu____510) when (
+
+let uu____511 = (FStar_Options.codegen ())
+in (uu____511 <> None)) -> begin
+((
+
+let uu____515 = (
+
+let uu____516 = (FStar_Options.lax ())
+in (not (uu____516)))
+in (match (uu____515) with
+| true -> begin
+(Prims.raise (FStar_Errors.Err ("Verification and code generation are no supported together with partial modules (i.e, *.fsti); use --lax to extract code separately")))
+end
+| uu____517 -> begin
+()
+end));
+(tc_one_file dsenv env intf impl);
+)
+end
+| Some (iname) -> begin
+((
+
+let uu____520 = (FStar_Options.debug_any ())
+in (match (uu____520) with
+| true -> begin
+(FStar_Util.print1 "Interleaving iface+module: %s\n" iname)
+end
+| uu____521 -> begin
+()
+end));
+(
+
+let caption = (Prims.strcat "interface: " iname)
+in (
+
+let uu____523 = (push_context ((dsenv), (env)) caption)
+in (match (uu____523) with
+| (dsenv', env') -> begin
+(
+
+let uu____534 = (tc_one_file dsenv' env' intf impl)
+in (match (uu____534) with
+| (uu____547, dsenv'1, env'1) -> begin
+((pop_context env'1 caption);
+(tc_one_file dsenv env None iname);
+)
+end))
+end)));
+)
+end);
+))
+
+
+type uenv =
+(FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)
+
+
+let tc_one_file_from_remaining : Prims.string Prims.list  ->  uenv  ->  (Prims.string Prims.list * (FStar_Syntax_Syntax.modul * Prims.int) Prims.list * (FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env)) = (fun remaining uenv -> (
+
+let uu____576 = uenv
+in (match (uu____576) with
+| (dsenv, env) -> begin
+(
+
+let uu____588 = (match (remaining) with
+| (intf)::(impl)::remaining1 when (needs_interleaving intf impl) -> begin
+(
+
+let uu____611 = (tc_one_file_and_intf (Some (intf)) impl dsenv env)
+in ((remaining1), (uu____611)))
+end
+| (intf_or_impl)::remaining1 -> begin
+(
+
+let uu____628 = (tc_one_file_and_intf None intf_or_impl dsenv env)
+in ((remaining1), (uu____628)))
+end
+| [] -> begin
+(([]), ((([]), (dsenv), (env))))
+end)
+in (match (uu____588) with
+| (remaining1, (nmods, dsenv1, env1)) -> begin
+((remaining1), (nmods), (((dsenv1), (env1))))
+end))
+end)))
+
+
+let rec tc_fold_interleave : ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * uenv)  ->  Prims.string Prims.list  ->  ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * uenv) = (fun acc remaining -> (match (remaining) with
+| [] -> begin
+acc
+end
+| uu____715 -> begin
+(
+
+let uu____717 = acc
+in (match (uu____717) with
+| (mods, uenv) -> begin
+(
+
+let uu____736 = (tc_one_file_from_remaining remaining uenv)
+in (match (uu____736) with
+| (remaining1, nmods, (dsenv, env)) -> begin
+(tc_fold_interleave (((FStar_List.append mods nmods)), (((dsenv), (env)))) remaining1)
+end))
+end))
+end))
+
+
+let batch_mode_tc_no_prims : FStar_ToSyntax_Env.env  ->  FStar_TypeChecker_Env.env  ->  Prims.string Prims.list  ->  ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun dsenv env filenames -> (
+
+let uu____789 = (tc_fold_interleave (([]), (((dsenv), (env)))) filenames)
+in (match (uu____789) with
+| (all_mods, (dsenv1, env1)) -> begin
+((
+
+let uu____820 = ((FStar_Options.interactive ()) && (
+
+let uu____821 = (FStar_Errors.get_err_count ())
+in (uu____821 = (Prims.parse_int "0"))))
+in (match (uu____820) with
+| true -> begin
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.refresh ())
+end
+| uu____822 -> begin
+(env1.FStar_TypeChecker_Env.solver.FStar_TypeChecker_Env.finish ())
+end));
+((all_mods), (dsenv1), (env1));
+)
+end)))
+
+
+let batch_mode_tc : Prims.string Prims.list  ->  ((FStar_Syntax_Syntax.modul * Prims.int) Prims.list * FStar_ToSyntax_Env.env * FStar_TypeChecker_Env.env) = (fun filenames -> (
+
+let uu____837 = (tc_prims ())
+in (match (uu____837) with
+| (prims_mod, dsenv, env) -> begin
+((
+
+let uu____857 = ((
+
+let uu____858 = (FStar_Options.explicit_deps ())
+in (not (uu____858))) && (FStar_Options.debug_any ()))
+in (match (uu____857) with
+| true -> begin
+((FStar_Util.print_endline "Auto-deps kicked in; here\'s some info.");
+(FStar_Util.print1 "Here\'s the list of filenames we will process: %s\n" (FStar_String.concat " " filenames));
+(
+
+let uu____861 = (
+
+let uu____862 = (FStar_Options.verify_module ())
+in (FStar_String.concat " " uu____862))
+in (FStar_Util.print1 "Here\'s the list of modules we will verify: %s\n" uu____861));
+)
+end
+| uu____864 -> begin
+()
+end));
+(
+
+let uu____865 = (batch_mode_tc_no_prims dsenv env filenames)
+in (match (uu____865) with
+| (all_mods, dsenv1, env1) -> begin
+(((prims_mod)::all_mods), (dsenv1), (env1))
+end));
+)
+end)))
+
+
+
+

--- a/src/parser/FStar.Parser.AST.fs
+++ b/src/parser/FStar.Parser.AST.fs
@@ -143,19 +143,12 @@ type knd = term
 type typ = term
 type expr = term
 
-// Documentation comment. May appear appear as follows:
-//  - Immediately before a top-level declaration
-//  - Immediately after a type constructor or record field
-//  - In the middle of a file, as a standalone documentation declaration
-(* KM : Would need some range information on fsdocs to be able to print them correctly *)
-type fsdoc = string * list<(string * string)> // comment + (name,value) keywords
-
 (* TODO (KM) : it would be useful for the printer to have range information for those *)
 type tycon =
   | TyconAbstract of ident * list<binder> * option<knd>
   | TyconAbbrev   of ident * list<binder> * option<knd> * term
-  | TyconRecord   of ident * list<binder> * option<knd> * list<(ident * term * option<fsdoc>)>
-  | TyconVariant  of ident * list<binder> * option<knd> * list<(ident * option<term> * option<fsdoc> * bool)> (* using 'of' notion *)
+  | TyconRecord   of ident * list<binder> * option<knd> * list<(ident * term * option<S.fsdoc>)>
+  | TyconVariant  of ident * list<binder> * option<knd> * list<(ident * option<term> * option<S.fsdoc> * bool)> (* using 'of' notion *)
 
 type qualifier =
   | Private
@@ -185,7 +178,7 @@ type attributes_ = list<term>
 type decoration =
   | Qualifier of qualifier
   | DeclAttributes of list<term>
-  | Doc of fsdoc
+  | Doc of S.fsdoc
 
 type lift_op =
   | NonReifiableLift of term
@@ -210,20 +203,20 @@ type decl' =
   | ModuleAbbrev of ident * lid
   | TopLevelLet of let_qualifier * list<(pattern * term)>
   | Main of term
-  | Tycon of bool * list<(tycon * option<fsdoc>)>
+  | Tycon of bool * list<(tycon * option<S.fsdoc>)>
     (* bool is for effect *)
   | Val of ident * term  (* bool is for logic val *)
   | Exception of ident * option<term>
   | NewEffect of effect_decl
   | SubEffect of lift
   | Pragma of pragma
-  | Fsdoc of fsdoc
+  | Fsdoc of S.fsdoc
   | Assume of ident * term
 
 and decl = {
   d:decl';
   drange:range;
-  doc:option<fsdoc>;
+  doc:option<S.fsdoc>;
   quals: qualifiers;
   attrs: attributes_
 }
@@ -258,6 +251,10 @@ let mk_decl d r decorations =
   let attributes_ = Util.dflt [] attributes_ in
   let qualifiers = List.choose (function Qualifier q -> Some q | _ -> None) decorations in
   { d=d; drange=r; doc=doc; quals=qualifiers; attrs=attributes_ }
+
+let sigelt_of_decl (d: decl) (e: S.sigelt') =
+  { S.elt = e; S.sigrng = d.drange; S.doc = d.doc }
+
 
 let mk_binder b r l i = {b=b; brange=r; blevel=l; aqual=i}
 let mk_term t r l = {tm=t; range=r; level=l}
@@ -507,9 +504,6 @@ let compile_op' s =
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Printing ASTs, mostly for debugging
 //////////////////////////////////////////////////////////////////////////////////////////////
-
-let string_of_fsdoc (comment,keywords) =
-    comment ^ (String.concat "," (List.map (fun (k,v) -> k ^ "->" ^ v) keywords))
 
 let string_of_let_qualifier = function
   | NoLetQualifier -> ""

--- a/src/parser/FStar.Parser.AST.fs
+++ b/src/parser/FStar.Parser.AST.fs
@@ -253,7 +253,7 @@ let mk_decl d r decorations =
   { d=d; drange=r; doc=doc; quals=qualifiers; attrs=attributes_ }
 
 let sigelt_of_decl (d: decl) (e: S.sigelt') =
-  { S.elt = e; S.sigrng = d.drange; S.doc = d.doc }
+  { S.sigel = e; S.sigrng = d.drange; S.sigdoc = d.doc }
 
 
 let mk_binder b r l i = {b=b; brange=r; blevel=l; aqual=i}

--- a/src/parser/ml/parse.mly
+++ b/src/parser/ml/parse.mly
@@ -85,8 +85,8 @@ open FStar_String
 %token EXISTS
 %token FALSE
 %token FORALL
-%token <FStar_Parser_AST.fsdoc> FSDOC
-%token <FStar_Parser_AST.fsdoc> FSDOC_STANDALONE
+%token <FStar_Syntax_Syntax.fsdoc> FSDOC
+%token <FStar_Syntax_Syntax.fsdoc> FSDOC_STANDALONE
 %token FUN
 %token FUNCTION
 %token HASH

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -70,8 +70,8 @@ open FStar_String
 %token <float> IEEE64
 %token <char> CHAR
 %token <bool> LET
-%token <FStar_Parser_AST.fsdoc> FSDOC
-%token <FStar_Parser_AST.fsdoc> FSDOC_STANDALONE
+%token <FStar_Syntax_Syntax.fsdoc> FSDOC
+%token <FStar_Syntax_Syntax.fsdoc> FSDOC_STANDALONE
 
 %token FORALL EXISTS ASSUME NEW LOGIC ATTRIBUTES
 %token IRREDUCIBLE UNFOLDABLE INLINE OPAQUE ABSTRACT UNFOLD INLINE_FOR_EXTRACTION

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -1833,7 +1833,7 @@ let rec encode_sigelt (env:env_t) (se:sigelt) : (decls_t * env_t) =
      | _ -> Caption (BU.format1 "<Start encoding %s>" nm)::g@[Caption (BU.format1 "</end encoding %s>" nm)], e
 
 and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
-    match se with
+    match se.elt with
      | Sig_new_effect_for_free _ ->
          failwith "impossible -- removed by tc.fs"
      | Sig_pragma _
@@ -1841,7 +1841,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
      | Sig_effect_abbrev _
      | Sig_sub_effect _ -> [], env
 
-     | Sig_new_effect(ed, _) ->
+     | Sig_new_effect(ed) ->
        if ed.qualifiers |> List.contains Reifiable |> not
        then [], env
        else (* The basic idea:
@@ -1895,11 +1895,11 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
             let env, decls2 = BU.fold_map encode_action env ed.actions in
             List.flatten decls2, env
 
-     | Sig_declare_typ(lid, _, _, _, _) when (lid_equals lid Const.precedes_lid) ->
+     | Sig_declare_typ(lid, _, _, _) when (lid_equals lid Const.precedes_lid) ->
         let tname, ttok, env = new_term_constant_and_tok_from_lid env lid in
         [], env
 
-     | Sig_declare_typ(lid, _, t, quals, _) ->
+     | Sig_declare_typ(lid, _, t, quals) ->
         let will_encode_definition = not (quals |> BU.for_some (function
             | Assumption | Projector _ | Discriminator _ | Irreducible -> true
             | _ -> false)) in
@@ -1913,22 +1913,22 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
              @ primitive_type_axioms env.tcenv lid tname tsym,
              env
 
-     | Sig_assume(l, f, _, _) ->
+     | Sig_assume(l, f, _) ->
         let f, decls = encode_formula f env in
         let g = [Term.Assume(f, Some (BU.format1 "Assumption: %s" (Print.lid_to_string l)), Some (varops.mk_unique ("assumption_"^l.str)))] in
         decls@g, env
 
-     | Sig_let(lbs, r, _, quals, _) when (quals |> List.contains S.Irreducible) ->
+     | Sig_let(lbs, _, quals, _) when (quals |> List.contains S.Irreducible) ->
        let env, decls = BU.fold_map (fun env lb ->
         let lid = (BU.right lb.lbname).fv_name.v in
         if Option.isNone <| Env.try_lookup_val_decl env.tcenv lid
-        then let val_decl = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, quals, r) in
+        then let val_decl = { elt = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, quals); sigrng = se.sigrng; doc = None } in // FIXME: Doc
              let decls, env = encode_sigelt' env val_decl in
              env, decls
         else env, []) env (snd lbs) in
        List.flatten decls, env
 
-     | Sig_let((_, [{lbname=BU.Inr b2t}]), _, _, _, _) when S.fv_eq_lid b2t Const.b2t_lid ->
+     | Sig_let((_, [{lbname=BU.Inr b2t}]), _, _, _) when S.fv_eq_lid b2t Const.b2t_lid ->
        let tname, ttok, env = new_term_constant_and_tok_from_lid env b2t.fv_name.v in
        let xx = ("x", Term_sort) in
        let x = mkFreeV xx in
@@ -1940,16 +1940,16 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                                 Some "b2t_def")] in
        decls, env
 
-    | Sig_let(_, _, _, quals, _) when (quals |> BU.for_some (function Discriminator _ -> true | _ -> false)) ->
+    | Sig_let(_, _, quals, _) when (quals |> BU.for_some (function Discriminator _ -> true | _ -> false)) ->
       //Discriminators are encoded directly via (our encoding of) theory of datatypes
       [], env
 
-    | Sig_let(_, _, lids, quals, _) when (lids |> BU.for_some (fun (l:lident) -> (List.hd l.ns).idText = "Prims")
+    | Sig_let(_, lids, quals, _) when (lids |> BU.for_some (fun (l:lident) -> (List.hd l.ns).idText = "Prims")
                                     && quals |> BU.for_some (function Unfold_for_unification_and_vcgen -> true | _ -> false)) ->
         //inline lets from prims are never encoded as definitions --- since they will be inlined
       [], env
 
-    | Sig_let((false, [lb]), _, _, quals, _) when (quals |> BU.for_some (function Projector _ -> true | _ -> false)) ->
+    | Sig_let((false, [lb]), _, quals, _) when (quals |> BU.for_some (function Projector _ -> true | _ -> false)) ->
      //Projectors are also are encoded directly via (our encoding of) theory of datatypes
      //Except in some cases where the front-end does not emit a declare_typ for some projector, because it doesn't know how to compute it
      let fv = BU.right lb.lbname in
@@ -1958,14 +1958,14 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         | Some _ ->
           [], env //already encoded
         | None ->
-          let se = Sig_declare_typ(l, lb.lbunivs, lb.lbtyp, quals, Ident.range_of_lid l) in
+          let se = { elt = Sig_declare_typ(l, lb.lbunivs, lb.lbtyp, quals); sigrng = Ident.range_of_lid l; doc = None } in // FIXME: Doc
           encode_sigelt env se
      end
 
-    | Sig_let((is_rec, bindings), _, _, quals, _) ->
+    | Sig_let((is_rec, bindings), _, quals, _) ->
       encode_top_level_let env (is_rec, bindings) quals
 
-    | Sig_bundle(ses, _, _, _) ->
+    | Sig_bundle(ses, _, _) ->
        let g, env = encode_signature env ses in
        let g', inversions = g |> List.partition (function
         | Term.Assume(_, Some "inversion axiom", _) -> false
@@ -1975,7 +1975,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         | _ -> false) in
        decls@rest@inversions, env
 
-     | Sig_inductive_typ(t, _, tps, k, _, datas, quals, _) ->
+     | Sig_inductive_typ(t, _, tps, k, _, datas, quals) ->
         let is_logical = quals |> BU.for_some (function Logic | Assumption -> true | _ -> false) in
         let constructor_or_logic_type_decl (c:constructor_t) =
             if is_logical
@@ -2078,9 +2078,9 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                 @aux in
         g, env
 
-    | Sig_datacon(d, _, _, _, _, _, _, _) when (lid_equals d Const.lexcons_lid) -> [], env
+    | Sig_datacon(d, _, _, _, _, _, _) when (lid_equals d Const.lexcons_lid) -> [], env
 
-    | Sig_datacon(d, _, t, _, n_tps, quals, _, drange) ->
+    | Sig_datacon(d, _, t, _, n_tps, quals, _) ->
         let ddconstrsym, ddtok, env = new_term_constant_and_tok_from_lid env d in
         let ddtok_tm = mkApp(ddtok, []) in
         let formals, t_res = U.arrow_formals t in
@@ -2171,7 +2171,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                   arg_decls, [typing_inversion; subterm_ordering]
 
                 | _ ->
-                  Errors.warn drange (BU.format2 "Constructor %s builds an unexpected type %s\n"
+                  Errors.warn se.sigrng (BU.format2 "Constructor %s builds an unexpected type %s\n"
                         (Print.lid_to_string d) (Print.term_to_string head));
                   [], [] in
         let decls2, elim = encode_elim () in

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -1833,7 +1833,7 @@ let rec encode_sigelt (env:env_t) (se:sigelt) : (decls_t * env_t) =
      | _ -> Caption (BU.format1 "<Start encoding %s>" nm)::g@[Caption (BU.format1 "</end encoding %s>" nm)], e
 
 and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
-    match se.elt with
+    match se.sigel with
      | Sig_new_effect_for_free _ ->
          failwith "impossible -- removed by tc.fs"
      | Sig_pragma _
@@ -1922,7 +1922,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
        let env, decls = BU.fold_map (fun env lb ->
         let lid = (BU.right lb.lbname).fv_name.v in
         if Option.isNone <| Env.try_lookup_val_decl env.tcenv lid
-        then let val_decl = { elt = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, quals); sigrng = se.sigrng; doc = None } in // FIXME: Doc
+        then let val_decl = { sigel = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, quals); sigrng = se.sigrng; sigdoc = None } in // FIXME: Doc
              let decls, env = encode_sigelt' env val_decl in
              env, decls
         else env, []) env (snd lbs) in
@@ -1958,7 +1958,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         | Some _ ->
           [], env //already encoded
         | None ->
-          let se = { elt = Sig_declare_typ(l, lb.lbunivs, lb.lbtyp, quals); sigrng = Ident.range_of_lid l; doc = None } in // FIXME: Doc
+          let se = { sigel = Sig_declare_typ(l, lb.lbunivs, lb.lbtyp, quals); sigrng = Ident.range_of_lid l; sigdoc = None } in // FIXME: Doc
           encode_sigelt env se
      end
 

--- a/src/syntax/FStar.Syntax.MutRecTy.fsi
+++ b/src/syntax/FStar.Syntax.MutRecTy.fsi
@@ -20,4 +20,5 @@ open FStar.All
 open FStar.Syntax.Syntax
 open FStar.Ident
 
-val disentangle_abbrevs_from_bundle: list<sigelt> -> list<qualifier> -> list<lident> -> FStar.Range.range -> sigelt * list<sigelt>
+val disentangle_abbrevs_from_bundle: list<sigelt> -> list<qualifier> -> list<lident> ->
+                                     FStar.Range.range -> option<fsdoc> -> sigelt * list<sigelt>

--- a/src/syntax/FStar.Syntax.Print.fs
+++ b/src/syntax/FStar.Syntax.Print.fs
@@ -488,37 +488,36 @@ let eff_decl_to_string for_free ed =
          tscheme_to_string ed.return_repr;
          actions_to_string ed.actions]
 
-let rec sigelt_to_string x = match x with
-  | Sig_pragma(LightOff, _) -> "#light \"off\""
-  | Sig_pragma(ResetOptions None, _) -> "#reset-options"
-  | Sig_pragma(ResetOptions (Some s), _) -> U.format1 "#reset-options \"%s\"" s
-  | Sig_pragma(SetOptions s, _) -> U.format1 "#set-options \"%s\"" s
-  | Sig_pragma(LightOff, _) -> "#light \"off\""
-  | Sig_inductive_typ(lid, univs, tps, k, _, _, quals, _) ->
+let rec sigelt_to_string (x: sigelt) = match x.elt with
+  | Sig_pragma(LightOff) -> "#light \"off\""
+  | Sig_pragma(ResetOptions None) -> "#reset-options"
+  | Sig_pragma(ResetOptions (Some s)) -> U.format1 "#reset-options \"%s\"" s
+  | Sig_pragma(SetOptions s) -> U.format1 "#set-options \"%s\"" s
+  | Sig_inductive_typ(lid, univs, tps, k, _, _, quals) ->
     U.format4 "%stype %s %s : %s"
              (quals_to_string' quals)
              lid.str
              (binders_to_string " " tps)
              (term_to_string k)
-  | Sig_datacon(lid, univs, t, _, _, _, _, _) ->
+  | Sig_datacon(lid, univs, t, _, _, _, _) ->
     if (Options.print_universes())
     then let univs, t = Subst.open_univ_vars univs t in
          U.format3 "datacon<%s> %s : %s" (univ_names_to_string univs) lid.str (term_to_string t)
     else U.format2 "datacon %s : %s" lid.str (term_to_string t)
-  | Sig_declare_typ(lid, univs, t, quals, _) ->
+  | Sig_declare_typ(lid, univs, t, quals) ->
     let univs, t = Subst.open_univ_vars univs t in
     U.format4 "%sval %s %s : %s" (quals_to_string' quals) lid.str
         (if (Options.print_universes())
          then U.format1 "<%s>" (univ_names_to_string univs)
          else "")
         (term_to_string t)
-  | Sig_assume(lid, f, _, _) -> U.format2 "val %s : %s" lid.str (term_to_string f)
-  | Sig_let(lbs, _, _, qs, _) -> lbs_to_string qs lbs
-  | Sig_main(e, _) -> U.format1 "let _ = %s" (term_to_string e)
-  | Sig_bundle(ses, _, _, _) -> List.map sigelt_to_string ses |> String.concat "\n"
-  | Sig_new_effect(ed, _) -> eff_decl_to_string false ed
-  | Sig_new_effect_for_free (ed, _) -> eff_decl_to_string true ed
-  | Sig_sub_effect (se, r) ->
+  | Sig_assume(lid, f, _) -> U.format2 "val %s : %s" lid.str (term_to_string f)
+  | Sig_let(lbs, _, qs, _) -> lbs_to_string qs lbs
+  | Sig_main(e) -> U.format1 "let _ = %s" (term_to_string e)
+  | Sig_bundle(ses, _, _) -> List.map sigelt_to_string ses |> String.concat "\n"
+  | Sig_new_effect(ed) -> eff_decl_to_string false ed
+  | Sig_new_effect_for_free (ed) -> eff_decl_to_string true ed
+  | Sig_sub_effect (se) ->
     let lift_wp = match se.lift_wp, se.lift with
       // TODO pretty-print this better
       | None, None ->
@@ -532,7 +531,7 @@ let rec sigelt_to_string x = match x with
     U.format4 "sub_effect %s ~> %s : <%s> %s"
         (lid_to_string se.source) (lid_to_string se.target)
         (univ_names_to_string us) (term_to_string t)
-  | Sig_effect_abbrev(l, univs, tps, c, _, flags, _) ->
+  | Sig_effect_abbrev(l, univs, tps, c, _, flags) ->
     if (Options.print_universes())
     then let univs, t = Subst.open_univ_vars univs (mk (Tm_arrow(tps, c)) None Range.dummyRange) in
          let tps, c = match (Subst.compress t).n with
@@ -544,8 +543,8 @@ let rec sigelt_to_string x = match x with
 
 let format_error r msg = format2 "%s: %s\n" (Range.string_of_range r) msg
 
-let rec sigelt_to_string_short x = match x with
-  | Sig_let((_, [{lbname=lb; lbtyp=t}]), _, _, _, _) -> U.format2 "let %s : %s" (lbname_to_string lb) (term_to_string t)
+let rec sigelt_to_string_short (x: sigelt) = match x.elt with
+  | Sig_let((_, [{lbname=lb; lbtyp=t}]), _, _, _) -> U.format2 "let %s : %s" (lbname_to_string lb) (term_to_string t)
   | _ -> lids_of_sigelt x |> List.map (fun l -> l.str) |> String.concat ", "
 
 let rec modul_to_string (m:modul) =

--- a/src/syntax/FStar.Syntax.Print.fs
+++ b/src/syntax/FStar.Syntax.Print.fs
@@ -488,7 +488,7 @@ let eff_decl_to_string for_free ed =
          tscheme_to_string ed.return_repr;
          actions_to_string ed.actions]
 
-let rec sigelt_to_string (x: sigelt) = match x.elt with
+let rec sigelt_to_string (x: sigelt) = match x.sigel with
   | Sig_pragma(LightOff) -> "#light \"off\""
   | Sig_pragma(ResetOptions None) -> "#reset-options"
   | Sig_pragma(ResetOptions (Some s)) -> U.format1 "#reset-options \"%s\"" s
@@ -543,7 +543,7 @@ let rec sigelt_to_string (x: sigelt) = match x.elt with
 
 let format_error r msg = format2 "%s: %s\n" (Range.string_of_range r) msg
 
-let rec sigelt_to_string_short (x: sigelt) = match x.elt with
+let rec sigelt_to_string_short (x: sigelt) = match x.sigel with
   | Sig_let((_, [{lbname=lb; lbtyp=t}]), _, _, _) -> U.format2 "let %s : %s" (lbname_to_string lb) (term_to_string t)
   | _ -> lids_of_sigelt x |> List.map (fun l -> l.str) |> String.concat ", "
 

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -338,8 +338,8 @@ and sigelt' =
                        * list<cflags>
   | Sig_pragma         of pragma
 and sigelt = {
-    elt: sigelt';
-    doc: option<fsdoc>;
+    sigel: sigelt';
+    sigdoc: option<fsdoc>;
     sigrng: Range.range;
 }
 
@@ -448,7 +448,7 @@ let mk_Total t = mk_Total' t None
 let mk_GTotal t = mk_GTotal' t None
 let mk_Comp (ct:comp_typ) : comp  = mk (Comp ct) None ct.result_typ.pos
 let mk_lb (x, univs, eff, t, e) = {lbname=x; lbunivs=univs; lbeff=eff; lbtyp=t; lbdef=e}
-let mk_sigelt (e: sigelt') = { elt = e; doc = None; sigrng = Range.dummyRange }
+let mk_sigelt (e: sigelt') = { sigel = e; sigdoc = None; sigrng = Range.dummyRange }
 let mk_subst (s:subst_t)   = s
 let extend_subst x s : subst_t = x::s
 let argpos (x:arg) = (fst x).pos

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -360,8 +360,8 @@ and sigelt' =
                        * list<cflags>
   | Sig_pragma         of pragma
 and sigelt = {
-    elt: sigelt';
-    doc: option<fsdoc>;
+    sigel: sigelt';
+    sigdoc: option<fsdoc>;
     sigrng: Range.range;
 }
 

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -487,16 +487,16 @@ let destruct typ lid =
     | Tm_fvar tc when fv_eq_lid tc lid -> Some []
     | _ -> None
 
-let lids_of_sigelt se = match se with
-  | Sig_let(_, _, lids, _, _)
-  | Sig_bundle(_, _, lids, _) -> lids
-  | Sig_inductive_typ (lid, _, _,  _, _, _, _, _)
-  | Sig_effect_abbrev(lid, _, _, _,  _, _, _)
-  | Sig_datacon (lid, _, _, _, _, _, _, _)
-  | Sig_declare_typ (lid, _, _, _, _)
-  | Sig_assume (lid, _, _, _) -> [lid]
-  | Sig_new_effect_for_free(n, _)
-  | Sig_new_effect(n, _) -> [n.mname]
+let lids_of_sigelt (se: sigelt) = match se.elt with
+  | Sig_let(_, lids, _, _)
+  | Sig_bundle(_, _, lids) -> lids
+  | Sig_inductive_typ (lid, _, _,  _, _, _, _)
+  | Sig_effect_abbrev(lid, _, _, _,  _, _)
+  | Sig_datacon (lid, _, _, _, _, _, _)
+  | Sig_declare_typ (lid, _, _, _)
+  | Sig_assume (lid, _, _) -> [lid]
+  | Sig_new_effect_for_free(n)
+  | Sig_new_effect(n) -> [n.mname]
   | Sig_sub_effect _
   | Sig_pragma _
   | Sig_main _ -> []
@@ -505,34 +505,24 @@ let lid_of_sigelt se : option<lident> = match lids_of_sigelt se with
   | [l] -> Some l
   | _ -> None
 
-let quals_of_sigelt x = match x with
-  | Sig_bundle(_, quals, _, _)
-  | Sig_inductive_typ (_, _, _,  _, _, _, quals, _)
-  | Sig_effect_abbrev  (_, _, _, _, quals, _, _)
-  | Sig_datacon (_, _, _, _, _, quals, _, _)
-  | Sig_declare_typ (_, _, _, quals, _)
-  | Sig_assume (_, _, quals, _)
-  | Sig_let(_, _, _, quals, _)
-  | Sig_new_effect({qualifiers=quals}, _)
-  | Sig_new_effect_for_free({qualifiers=quals}, _) ->
+let quals_of_sigelt (x: sigelt) = match x.elt with
+  | Sig_bundle(_, quals, _)
+  | Sig_inductive_typ (_, _, _,  _, _, _, quals)
+  | Sig_effect_abbrev  (_, _, _, _, quals, _)
+  | Sig_datacon (_, _, _, _, _, quals, _)
+  | Sig_declare_typ (_, _, _, quals)
+  | Sig_assume (_, _, quals)
+  | Sig_let(_, _, quals, _)
+  | Sig_new_effect({qualifiers=quals})
+  | Sig_new_effect_for_free({qualifiers=quals}) ->
     quals
-  | Sig_sub_effect(_, _)
-  | Sig_pragma(_, _)
-  | Sig_main(_, _) -> []
+  | Sig_sub_effect _
+  | Sig_pragma _
+  | Sig_main _ -> []
 
-let range_of_sigelt x = match x with
-  | Sig_bundle(_, _, _, r)
-  | Sig_inductive_typ (_, _, _,  _, _, _, _, r)
-  | Sig_effect_abbrev  (_, _, _, _, _, _, r)
-  | Sig_datacon (_, _, _, _, _, _, _, r)
-  | Sig_declare_typ (_, _, _, _, r)
-  | Sig_assume (_, _, _, r)
-  | Sig_let(_, r, _, _, _)
-  | Sig_main(_, r)
-  | Sig_pragma(_, r)
-  | Sig_new_effect(_, r)
-  | Sig_new_effect_for_free(_, r)
-  | Sig_sub_effect(_, r) -> r
+let range_of_sigelt (x: sigelt) = x.sigrng
+
+let docs_of_sigelt (x: sigelt) = x.doc
 
 let range_of_lb = function
   | (Inl x, _, _) -> range_of_bv  x
@@ -1025,7 +1015,8 @@ let destruct_typ_as_formula f : option<connective> =
                 a.action_typ
                 Const.effect_Tot_lid
                 a.action_defn in
-    Sig_let((false, [lb]), a.action_defn.pos, [a.action_name], [Visible_default ; Action eff_lid], [])
+                // CPC @ a.action_defn.pos
+    mk_sigelt (Sig_let((false, [lb]), [a.action_name], [Visible_default ; Action eff_lid], []))
 
 (* Some reification utilities *)
 let mk_reify t =

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -487,7 +487,7 @@ let destruct typ lid =
     | Tm_fvar tc when fv_eq_lid tc lid -> Some []
     | _ -> None
 
-let lids_of_sigelt (se: sigelt) = match se.elt with
+let lids_of_sigelt (se: sigelt) = match se.sigel with
   | Sig_let(_, lids, _, _)
   | Sig_bundle(_, _, lids) -> lids
   | Sig_inductive_typ (lid, _, _,  _, _, _, _)
@@ -505,7 +505,7 @@ let lid_of_sigelt se : option<lident> = match lids_of_sigelt se with
   | [l] -> Some l
   | _ -> None
 
-let quals_of_sigelt (x: sigelt) = match x.elt with
+let quals_of_sigelt (x: sigelt) = match x.sigel with
   | Sig_bundle(_, quals, _)
   | Sig_inductive_typ (_, _, _,  _, _, _, quals)
   | Sig_effect_abbrev  (_, _, _, _, quals, _)
@@ -522,7 +522,7 @@ let quals_of_sigelt (x: sigelt) = match x.elt with
 
 let range_of_sigelt (x: sigelt) = x.sigrng
 
-let docs_of_sigelt (x: sigelt) = x.doc
+let docs_of_sigelt (x: sigelt) = x.sigdoc
 
 let range_of_lb = function
   | (Inl x, _, _) -> range_of_bv  x

--- a/src/tosyntax/FStar.ToSyntax.Env.fs
+++ b/src/tosyntax/FStar.ToSyntax.Env.fs
@@ -423,7 +423,7 @@ let resolve_in_open_namespaces'
   let l_default k i = lookup_default_id env i (k_global_def' k) k in
   resolve_in_open_namespaces'' env lid Exported_id_term_type (fun l -> cont_of_option Cont_fail (k_local_binding l)) (fun r -> cont_of_option Cont_fail (k_rec_binding r)) (fun _ -> Cont_ignore) f_module l_default
 
-let fv_qual_of_se = fun se -> match se.elt with
+let fv_qual_of_se = fun se -> match se.sigel with
     | Sig_datacon(_, _, _, l, _, quals, _) ->
       let qopt = BU.find_map quals (function
           | RecordConstructor (_, fs) -> Some (Record_ctor(l, fs))
@@ -451,7 +451,7 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option<foundname> 
   let k_global_def source_lid = function
       | (_, true) when exclude_interf -> None
       | (se, _) ->
-        begin match se.elt with
+        begin match se.sigel with
           | Sig_inductive_typ _ ->   Some (Term_name(S.fvar source_lid Delta_constant None, false))
           | Sig_datacon _ ->         Some (Term_name(S.fvar source_lid Delta_constant (fv_qual_of_se se), false))
           | Sig_let((_, lbs), _, _, _) ->
@@ -506,14 +506,14 @@ let try_lookup_effect_name env l =
         | _ -> None
 let try_lookup_effect_name_and_attributes env l =
     match try_lookup_effect_name' (not env.iface) env l with
-        | Some ({ elt = Sig_new_effect(ne) }, l) -> Some (l, ne.cattributes)
-        | Some ({ elt = Sig_new_effect_for_free(ne) }, l) -> Some (l, ne.cattributes)
-        | Some ({ elt = Sig_effect_abbrev(_,_,_,_,_,cattributes) }, l) -> Some (l, cattributes)
+        | Some ({ sigel = Sig_new_effect(ne) }, l) -> Some (l, ne.cattributes)
+        | Some ({ sigel = Sig_new_effect_for_free(ne) }, l) -> Some (l, ne.cattributes)
+        | Some ({ sigel = Sig_effect_abbrev(_,_,_,_,_,cattributes) }, l) -> Some (l, cattributes)
         | _ -> None
 let try_lookup_effect_defn env l =
     match try_lookup_effect_name' (not env.iface) env l with
-        | Some ({ elt = Sig_new_effect(ne) }, _) -> Some ne
-        | Some ({ elt = Sig_new_effect_for_free(ne) }, _) -> Some ne
+        | Some ({ sigel = Sig_new_effect(ne) }, _) -> Some ne
+        | Some ({ sigel = Sig_new_effect_for_free(ne) }, _) -> Some ne
         | _ -> None
 let is_effect_name env lid =
     match try_lookup_effect_name env lid with
@@ -524,12 +524,12 @@ abbrevs. TODO: once indexed effects are in, also track how indices and
 other arguments are instantiated. *)
 let try_lookup_root_effect_name env l =
     match try_lookup_effect_name' (not env.iface) env l with
-	| Some ({ elt = Sig_effect_abbrev (l', _, _, _, _, _) }, _) ->
+	| Some ({ sigel = Sig_effect_abbrev (l', _, _, _, _, _) }, _) ->
 	  let rec aux new_name =
 	      match BU.smap_try_find (sigmap env) new_name.str with
 	      | None -> None
 	      | Some (s, _) ->
-	        begin match s.elt with
+	        begin match s.sigel with
                 | Sig_new_effect_for_free (ne)
 		| Sig_new_effect(ne)
 		  -> Some (set_lid_range ne.mname (range_of_lid l))
@@ -544,7 +544,7 @@ let try_lookup_root_effect_name env l =
 
 let lookup_letbinding_quals env lid =
   let k_global_def lid = function
-      | ({elt = Sig_declare_typ(lid, _, _, quals) }, _) ->
+      | ({sigel = Sig_declare_typ(lid, _, _, quals) }, _) ->
           Some quals
       | _ ->
           None in
@@ -559,7 +559,7 @@ let try_lookup_module env path =
 
 let try_lookup_let env (lid:lident) =
   let k_global_def lid = function
-      | ({ elt = Sig_let((_, lbs), _, _, _) }, _) ->
+      | ({ sigel = Sig_let((_, lbs), _, _, _) }, _) ->
         let fv = lb_fv lbs lid in
         Some (fvar lid fv.fv_delta fv.fv_qual)
       | _ -> None in
@@ -567,7 +567,7 @@ let try_lookup_let env (lid:lident) =
 
 let try_lookup_definition env (lid:lident) =
     let k_global_def lid = function
-      | ({ elt = Sig_let(lbs, _, _, _) }, _) ->
+      | ({ sigel = Sig_let(lbs, _, _, _) }, _) ->
         BU.find_map (snd lbs) (fun lb ->
             match lb.lbname with
                 | Inr fv when S.fv_eq_lid fv lid ->
@@ -600,17 +600,17 @@ let try_lookup_lid_no_resolve (env: env) l =
 
 let try_lookup_datacon env (lid:lident) =
   let k_global_def lid = function
-      | ({ elt = Sig_declare_typ(_, _, _, quals) }, _) ->
+      | ({ sigel = Sig_declare_typ(_, _, _, quals) }, _) ->
         if quals |> BU.for_some (function Assumption -> true | _ -> false)
         then Some (lid_as_fv lid Delta_constant None)
         else None
-      | ({ elt = Sig_datacon _ }, _) -> Some (lid_as_fv lid Delta_constant (Some Data_ctor))
+      | ({ sigel = Sig_datacon _ }, _) -> Some (lid_as_fv lid Delta_constant (Some Data_ctor))
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
 let find_all_datacons env (lid:lident) =
   let k_global_def lid = function
-      | ({ elt = Sig_inductive_typ(_, _, _, _, _, datas, _) }, _) -> Some datas
+      | ({ sigel = Sig_inductive_typ(_, _, _, _, _, datas, _) }, _) -> Some datas
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
@@ -663,7 +663,7 @@ let commit_record_cache =
     let _, _, _, _, commit = record_cache_aux in
     commit
 
-let extract_record (e:env) (new_globs: ref<(list<scope_mod>)>) = fun se -> match se.elt with
+let extract_record (e:env) (new_globs: ref<(list<scope_mod>)>) = fun se -> match se.sigel with
   | Sig_bundle(sigs, _, _) ->
     let is_rec = BU.for_some (function
       | RecordType _
@@ -672,13 +672,13 @@ let extract_record (e:env) (new_globs: ref<(list<scope_mod>)>) = fun se -> match
 
     let find_dc dc =
       sigs |> BU.find_opt (function
-        | { elt = Sig_datacon(lid, _, _, _, _, _, _) } -> lid_equals dc lid
+        | { sigel = Sig_datacon(lid, _, _, _, _, _, _) } -> lid_equals dc lid
         | _ -> false) in
 
     sigs |> List.iter (function
-      | { elt = Sig_inductive_typ(typename, univs, parms, _, _, [dc], tags) } ->
+      | { sigel = Sig_inductive_typ(typename, univs, parms, _, _, [dc], tags) } ->
         begin match must <| find_dc dc with
-            | { elt = Sig_datacon(constrname, _, t, _, _, _, _) } ->
+            | { sigel = Sig_datacon(constrname, _, t, _, _, _, _) } ->
                 let formals, _ = U.arrow_formals t in
                 let is_rec = is_rec tags in
                 let formals' = formals |> List.collect (fun (x,q) ->
@@ -813,7 +813,7 @@ let push_sigelt env s =
     raise (Error (BU.format2 "Duplicate top-level names [%s]; previously declared at %s" (text_of_lid l) r, range_of_lid l)) in
   let globals = BU.mk_ref env.scope_mods in
   let env =
-      let any_val, exclude_if = match s.elt with
+      let any_val, exclude_if = match s.sigel with
         | Sig_let _ -> false, true
         | Sig_bundle _ -> true, true
         | _ -> false, false in
@@ -823,7 +823,7 @@ let push_sigelt env s =
         | _ -> extract_record env globals s; {env with sigaccum=s::env.sigaccum}
       end in
   let env = {env with scope_mods = !globals} in
-  let env, lss = match s.elt with
+  let env, lss = match s.sigel with
     | Sig_bundle(ses, _, _) -> env, List.map (fun se -> (lids_of_sigelt se, se)) ses
     | _ -> env, [lids_of_sigelt s, s] in
   lss |> List.iter (fun (lids, se) ->
@@ -905,23 +905,23 @@ let push_module_abbrev env x l =
   else raise (Error(BU.format1 "Module %s cannot be found" (Ident.text_of_lid l), Ident.range_of_lid l))
 
 let check_admits env =
-  env.sigaccum |> List.iter (fun se -> match se.elt with
+  env.sigaccum |> List.iter (fun se -> match se.sigel with
     | Sig_declare_typ(l, u, t, quals) ->
       begin match try_lookup_lid env l with
         | None ->
           if not (Options.interactive ()) then
             BU.print_string (BU.format2 "%s: Warning: Admitting %s without a definition\n" (Range.string_of_range (range_of_lid l)) (Print.lid_to_string l));
-          BU.smap_add (sigmap env) l.str ({ se with elt = Sig_declare_typ(l, u, t, Assumption::quals) }, false)
+          BU.smap_add (sigmap env) l.str ({ se with sigel = Sig_declare_typ(l, u, t, Assumption::quals) }, false)
         | Some _ -> ()
       end
     | _ -> ())
 
 let finish env modul =
-  modul.declarations |> List.iter (fun se -> match se.elt with
+  modul.declarations |> List.iter (fun se -> match se.sigel with
     | Sig_bundle(ses, quals, _) ->
       if List.contains Private quals
       || List.contains Abstract quals
-      then ses |> List.iter (fun se -> match se.elt with
+      then ses |> List.iter (fun se -> match se.sigel with
                 | Sig_datacon(lid, _, _, _, _, _, _) -> BU.smap_remove (sigmap env) lid.str
                 | _ -> ())
 
@@ -939,7 +939,7 @@ let finish env modul =
       && not (List.contains Private quals)
       then lbs |> List.iter (fun lb ->
            let lid = (right lb.lbname).fv_name.v in
-           let decl = { se with elt = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, Assumption::quals) } in
+           let decl = { se with sigel = Sig_declare_typ(lid, lb.lbunivs, lb.lbtyp, Assumption::quals) } in
            BU.smap_add (sigmap env) lid.str (decl, false))
 
     | _ -> ());
@@ -1005,8 +1005,8 @@ let export_interface (m:lident) env =
         | Some (se, true) when sigelt_in_m se ->
           BU.smap_remove sm' k;
 //          printfn "Exporting %s" k;
-          let se = match se.elt with
-            | Sig_declare_typ(l, u, t, q) -> { se with elt = Sig_declare_typ(l, u, t, Assumption::q) }
+          let se = match se.sigel with
+            | Sig_declare_typ(l, u, t, q) -> { se with sigel = Sig_declare_typ(l, u, t, Assumption::q) }
             | _ -> se in
           BU.smap_add sm' k (se, false)
         | _ -> ());

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1313,7 +1313,9 @@ let mk_data_discriminators quals env t tps k datas =
     in
     datas |> List.map (fun d ->
         let disc_name = U.mk_discriminator d in
-        Sig_declare_typ(disc_name, [], Syntax.tun, quals [(* S.Logic ; *) S.OnlyName ; S.Discriminator d], range_of_lid disc_name))
+        { elt = Sig_declare_typ(disc_name, [], Syntax.tun, quals [(* S.Logic ; *) S.OnlyName ; S.Discriminator d]);
+          sigrng = range_of_lid disc_name;
+          doc = None }) // FIXME: Doc
 
 let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
     let p = range_of_lid lid in
@@ -1339,7 +1341,9 @@ let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
             in
             quals (OnlyName :: S.Projector(lid, x.ppname) :: iquals)
         in
-        let decl = Sig_declare_typ(field_name, [], Syntax.tun, quals, range_of_lid field_name) in
+        let decl = { elt = Sig_declare_typ(field_name, [], Syntax.tun, quals);
+                     sigrng = range_of_lid field_name;
+                     doc = None } in // FIXME: Doc
         if only_decl
         then [decl] //only the signature
         else
@@ -1355,11 +1359,13 @@ let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
                 lbeff=C.effect_Tot_lid;
                 lbdef=tun
             } in
-            let impl = Sig_let((false, [lb]), p, [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []) in
+            let impl = { elt = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []);
+                         sigrng = p;
+                         doc = None } in // FIXME: Doc
             if no_decl then [impl] else [decl;impl]) |> List.flatten
 
-let mk_data_projector_names iquals env (inductive_tps, se) = match se with
-  | Sig_datacon(lid, _, t, _, n, quals, _, _) when (//(not env.iface || env.admitted_iface) &&
+let mk_data_projector_names iquals env (inductive_tps, se) = match se.elt with
+  | Sig_datacon(lid, _, t, _, n, quals, _) when (//(not env.iface || env.admitted_iface) &&
                                                 not (lid_equals lid C.lexcons_lid)) ->
     let formals, _ = U.arrow_formals t in
     begin match formals with
@@ -1384,7 +1390,7 @@ let mk_data_projector_names iquals env (inductive_tps, se) = match se with
 
   | _ -> []
 
-let mk_typ_abbrev lid uvs typars k t lids quals rng =
+let mk_typ_abbrev lid uvs typars k t lids quals rng doc =
     let dd = if quals |> List.contains S.Abstract
              then Delta_abstract (incr_delta_qualifier t)
              else incr_delta_qualifier t in
@@ -1395,9 +1401,12 @@ let mk_typ_abbrev lid uvs typars k t lids quals rng =
         lbtyp=U.arrow typars (S.mk_Total k);
         lbeff=C.effect_Tot_lid;
     } in
-    Sig_let((false, [lb]), rng, lids, quals, [])
+    { elt = Sig_let((false, [lb]), lids, quals, []);
+      sigrng = rng;
+      doc = doc }
 
-let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
+let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
+  let rng = d.drange in
   let tycon_id = function
     | TyconAbstract(id, _, _)
     | TyconAbbrev(id, _, _, _)
@@ -1437,7 +1446,8 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
       let qlid = qualify _env id in
       let typars = Subst.close_binders typars in
       let k = Subst.close typars k in
-      let se = Sig_inductive_typ(qlid, [], typars, k, mutuals, [], quals, rng) in
+      let se = { elt = Sig_inductive_typ(qlid, [], typars, k, mutuals, [], quals);
+                 sigrng = rng; doc = d.doc } in
       let _env = Env.push_top_level_rec_binding _env id S.Delta_constant in
       let _env2 = Env.push_top_level_rec_binding _env' id S.Delta_constant in
       _env, _env2, se, tconstr
@@ -1454,17 +1464,19 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
             | _ -> kopt in
         let tc = TyconAbstract(id, bs, kopt) in
         let _, _, se, _ = desugar_abstract_tc quals env [] tc in
-        let se = match se with
-           | Sig_inductive_typ(l, _, typars, k, [], [], quals, rng) ->
+        let se = match se.elt with
+           | Sig_inductive_typ(l, _, typars, k, [], [], quals) ->
              let quals = if quals |> List.contains S.Assumption
                          then quals
                          else (BU.print2 "%s (Warning): Adding an implicit 'assume new' qualifier on %s\n"
-                                                (Range.string_of_range rng) (Print.lid_to_string l);
+                                                (Range.string_of_range se.sigrng) (Print.lid_to_string l);
                                S.Assumption::S.New::quals) in
              let t = match typars with
                 | [] -> k
-                | _ -> mk (Tm_arrow(typars, mk_Total k)) None rng in
-             Sig_declare_typ(l, [], t, quals, rng)
+                | _ -> mk (Tm_arrow(typars, mk_Total k)) None se.sigrng in
+             { elt = Sig_declare_typ(l, [], t, quals);
+               sigrng = se.sigrng;
+               doc = None } // FIXME: Doc
            | _ -> se in
         let env = push_sigelt env se in
         (* let _ = pr "Pushed %s\n" (text_of_lid (qualify env (tycon_id tc))) in *)
@@ -1507,10 +1519,11 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
                  let c = desugar_comp t.range env' t in
                  let typars = Subst.close_binders typars in
                  let c = Subst.close_comp typars c in
-                 Sig_effect_abbrev(qualify env id, [], typars, c, quals |> List.filter (function S.Effect -> false | _ -> true), cattributes @ comp_flags c, rng)
+                 { elt = Sig_effect_abbrev(qualify env id, [], typars, c, quals |> List.filter (function S.Effect -> false | _ -> true), cattributes @ comp_flags c);
+                   sigrng = rng; doc = d.doc }
             else let t = desugar_typ env' t in
                  let nm = qualify env id in
-                 mk_typ_abbrev nm [] typars k t [nm] quals rng in
+                 mk_typ_abbrev nm [] typars k t [nm] quals rng d.doc in
 
         let env = push_sigelt env se in
         env, [se]
@@ -1518,7 +1531,7 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
     | [TyconRecord _] ->
       let trec = List.hd tcs in
       let t, fs = tycon_record_as_variant trec in
-      desugar_tycon env rng (RecordType (ids_of_lid (current_module env), fs)::quals) [t]
+      desugar_tycon env d (RecordType (ids_of_lid (current_module env), fs)::quals) [t]
 
     |  _::_ ->
       let env0 = env in
@@ -1540,7 +1553,7 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
       let env, tcs = List.fold_left (collect_tcs quals) (env, []) tcs in
       let tcs = List.rev tcs in
       let tps_sigelts = tcs |> List.collect (function
-        | Inr(Sig_inductive_typ(id, uvs, tpars, k, _, _, _, _), binders, t, quals) -> //type abbrevs in mutual type definitions
+        | Inr ({ elt = Sig_inductive_typ(id, uvs, tpars, k, _, _, _) }, binders, t, quals) -> //type abbrevs in mutual type definitions
 	      let t =
 	          let env, tpars = typars_of_binders env binders in
 	          let env_tps, tpars = push_tparams env tpars in
@@ -1548,9 +1561,9 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
 	          let tpars = Subst.close_binders tpars in
 	          Subst.close tpars t
           in
-          [[], mk_typ_abbrev id uvs tpars k t [id] quals rng]
+          [[], mk_typ_abbrev id uvs tpars k t [id] quals rng d.doc]
 
-        | Inl (Sig_inductive_typ(tname, univs, tpars, k, mutuals, _, tags, _), constrs, tconstr, quals) ->
+        | Inl ({ elt = Sig_inductive_typ(tname, univs, tpars, k, mutuals, _, tags) }, constrs, tconstr, quals) ->
           let mk_tot t =
             let tot = mk_term (Name FStar.Syntax.Const.effect_Tot_lid) t.range t.level in
             mk_term (App(tot, t, Nothing)) t.range t.level in
@@ -1574,20 +1587,24 @@ let rec desugar_tycon env rng quals tcs : (env_t * sigelts) =
                     | RecordType fns -> [RecordConstructor fns]
                     | _ -> []) in
                 let ntps = List.length data_tpars in
-                (name, (tps, Sig_datacon(name, univs, U.arrow data_tpars (mk_Total (t |> U.name_function_binders)),
-                                         tname, ntps, quals, mutuals, rng)))))
+                (name, (tps, { elt = Sig_datacon(name, univs, U.arrow data_tpars (mk_Total (t |> U.name_function_binders)),
+                                                 tname, ntps, quals, mutuals);
+                               sigrng = rng;
+                               doc = d.doc }))))
           in
-          ([], Sig_inductive_typ(tname, univs, tpars, k, mutuals, constrNames, tags, rng))::constrs
+          ([], { elt = Sig_inductive_typ(tname, univs, tpars, k, mutuals, constrNames, tags);
+                 sigrng = rng;
+                 doc = d.doc })::constrs
         | _ -> failwith "impossible")
       in
       let sigelts = tps_sigelts |> List.map snd in
-      let bundle, abbrevs = FStar.Syntax.MutRecTy.disentangle_abbrevs_from_bundle sigelts quals (List.collect U.lids_of_sigelt sigelts) rng in
+      let bundle, abbrevs = FStar.Syntax.MutRecTy.disentangle_abbrevs_from_bundle sigelts quals (List.collect U.lids_of_sigelt sigelts) rng d.doc in
       let env = push_sigelt env0 bundle in
       let env = List.fold_left push_sigelt env abbrevs in
       (* NOTE: derived operators such as projectors and discriminators are using the type names before unfolding. *)
       let data_ops = tps_sigelts |> List.collect (mk_data_projector_names quals env) in
-      let discs = sigelts |> List.collect (function
-        | Sig_inductive_typ(tname, _, tps, k, _, constrs, quals, _) when (List.length constrs > 1)->
+      let discs = sigelts |> List.collect (fun se -> match se.elt with
+        | Sig_inductive_typ(tname, _, tps, k, _, constrs, quals) when (List.length constrs > 1)->
           let quals = if List.contains S.Abstract quals
                       then S.Private::quals
                       else quals in
@@ -1690,53 +1707,55 @@ let rec desugar_effect env d (quals: qualifiers) eff_name eff_binders eff_typ ef
     let se =
       if for_free then
         let dummy_tscheme = [], mk Tm_unknown None Range.dummyRange in
-        Sig_new_effect_for_free ({
-          mname       = mname;
-          qualifiers  = qualifiers;
-          cattributes  = [];
-          univs       = [];
-          binders     = binders;
-          signature   = eff_t;
-          ret_wp      = dummy_tscheme;
-          bind_wp     = dummy_tscheme;
-          if_then_else= dummy_tscheme;
-          ite_wp      = dummy_tscheme;
-          stronger    = dummy_tscheme;
-          close_wp    = dummy_tscheme;
-          assert_p    = dummy_tscheme;
-          assume_p    = dummy_tscheme;
-          null_wp     = dummy_tscheme;
-          trivial     = dummy_tscheme;
-          repr        = snd (lookup "repr");
-          bind_repr   = lookup "bind";
-          return_repr = lookup "return";
-          actions     = actions;
-        }, d.drange)
+        AST.sigelt_of_decl d
+          (Sig_new_effect_for_free ({
+             mname       = mname;
+             qualifiers  = qualifiers;
+             cattributes  = [];
+             univs       = [];
+             binders     = binders;
+             signature   = eff_t;
+             ret_wp      = dummy_tscheme;
+             bind_wp     = dummy_tscheme;
+             if_then_else= dummy_tscheme;
+             ite_wp      = dummy_tscheme;
+             stronger    = dummy_tscheme;
+             close_wp    = dummy_tscheme;
+             assert_p    = dummy_tscheme;
+             assume_p    = dummy_tscheme;
+             null_wp     = dummy_tscheme;
+             trivial     = dummy_tscheme;
+             repr        = snd (lookup "repr");
+             bind_repr   = lookup "bind";
+             return_repr = lookup "return";
+             actions     = actions;
+           }))
       else
         let rr = BU.for_some (function S.Reifiable | S.Reflectable _ -> true | _ -> false) qualifiers in
         let un_ts = [], Syntax.tun in
-        Sig_new_effect({
-          mname       = mname;
-          qualifiers  = qualifiers;
-          cattributes  = [];
-          univs       = [];
-          binders     = binders;
-          signature   = eff_t;
-          ret_wp      = lookup "return_wp";
-          bind_wp     = lookup "bind_wp";
-          if_then_else= lookup "if_then_else";
-          ite_wp      = lookup "ite_wp";
-          stronger    = lookup "stronger";
-          close_wp    = lookup "close_wp";
-          assert_p    = lookup "assert_p";
-          assume_p    = lookup "assume_p";
-          null_wp     = lookup "null_wp";
-          trivial     = lookup "trivial";
-          repr        = (if rr then snd <| lookup "repr" else S.tun);
-          bind_repr   = (if rr then lookup "bind" else un_ts);
-          return_repr = (if rr then lookup "return" else un_ts);
-          actions     = actions;
-        }, d.drange)
+        AST.sigelt_of_decl d
+          (Sig_new_effect({
+             mname       = mname;
+             qualifiers  = qualifiers;
+             cattributes  = [];
+             univs       = [];
+             binders     = binders;
+             signature   = eff_t;
+             ret_wp      = lookup "return_wp";
+             bind_wp     = lookup "bind_wp";
+             if_then_else= lookup "if_then_else";
+             ite_wp      = lookup "ite_wp";
+             stronger    = lookup "stronger";
+             close_wp    = lookup "close_wp";
+             assert_p    = lookup "assert_p";
+             assume_p    = lookup "assume_p";
+             null_wp     = lookup "null_wp";
+             trivial     = lookup "trivial";
+             repr        = (if rr then snd <| lookup "repr" else S.tun);
+             bind_repr   = (if rr then lookup "bind" else un_ts);
+             return_repr = (if rr then lookup "return" else un_ts);
+             actions     = actions;
+           }))
     in
     let env = push_sigelt env0 se in
     let env = actions |> List.fold_left (fun env a ->
@@ -1746,7 +1765,8 @@ let rec desugar_effect env d (quals: qualifiers) eff_name eff_binders eff_typ ef
     let env =
       if quals |> List.contains Reflectable
       then let reflect_lid = Ident.id_of_text "reflect" |> Env.qualify monad_env in
-            let refl_decl = S.Sig_declare_typ(reflect_lid, [], S.tun, [S.Assumption; S.Reflectable mname], d.drange) in
+            let refl_decl = AST.sigelt_of_decl d
+                              (S.Sig_declare_typ(reflect_lid, [], S.tun, [S.Assumption; S.Reflectable mname])) in
             push_sigelt env refl_decl
       else env
     in
@@ -1816,7 +1836,7 @@ and desugar_redefine_effect env d trans_qual quals eff_name eff_binders defn =
     let se =
       (* An effect for free has a type of the shape "a:Type -> Effect" *)
       let for_free = List.length (fst (U.arrow_formals ed.signature)) = 1 in
-      if for_free then Sig_new_effect_for_free (ed, d.drange) else Sig_new_effect (ed, d.drange)
+      AST.sigelt_of_decl d (if for_free then Sig_new_effect_for_free (ed) else Sig_new_effect (ed))
     in
     let monad_env = env in
     let env = push_sigelt env0 se in
@@ -1826,7 +1846,8 @@ and desugar_redefine_effect env d trans_qual quals eff_name eff_binders defn =
     let env =
         if quals |> List.contains Reflectable
         then let reflect_lid = Ident.id_of_text "reflect" |> Env.qualify monad_env in
-             let refl_decl = S.Sig_declare_typ(reflect_lid, [], S.tun, [S.Assumption; S.Reflectable mname], d.drange) in
+             let refl_decl = AST.sigelt_of_decl d
+                               (S.Sig_declare_typ(reflect_lid, [], S.tun, [S.Assumption; S.Reflectable mname])) in
              push_sigelt env refl_decl
         else env in
     env, [se]
@@ -1835,7 +1856,7 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
   let trans_qual = trans_qual d.drange in
   match d.d with
   | Pragma p ->
-    let se = Sig_pragma(trans_pragma p, d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_pragma(trans_pragma p)) in
     if p = LightOff
     then Options.set_ml_ish();
     env, [se]
@@ -1858,7 +1879,7 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
   | Tycon(is_effect, tcs) ->
     let quals = if is_effect then Effect_qual :: d.quals else d.quals in
     let tcs = List.map (fun (x,_) -> x) tcs in
-    desugar_tycon env d.drange (List.map (trans_qual None) quals) tcs
+    desugar_tycon env d (List.map (trans_qual None) quals) tcs
 
   | TopLevelLet(isrec, lets) ->
     let quals = d.quals in
@@ -1898,7 +1919,7 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
                             let fv = right lb.lbname in
                             {lb with lbname=Inr ({fv with fv_delta=Delta_abstract fv.fv_delta})})
                     else lbs in
-          let s = Sig_let(lbs, d.drange, fvs |> List.map (fun fv -> fv.fv_name.v), quals, attrs) in
+          let s = AST.sigelt_of_decl d (Sig_let(lbs, fvs |> List.map (fun fv -> fv.fv_name.v), quals, attrs)) in
           let env = push_sigelt env s in
           env, [s]
         | _ -> failwith "Desugaring a let did not produce a let"
@@ -1944,27 +1965,27 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
 
   | Main t ->
     let e = desugar_term env t in
-    let se = Sig_main(e, d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_main(e)) in
     env, [se]
 
   | Assume(id, t) ->
     let f = desugar_formula env t in
-    env, [Sig_assume(qualify env id, f, [S.Assumption], d.drange)]
+    env, [AST.sigelt_of_decl d (Sig_assume(qualify env id, f, [S.Assumption]))]
 
 
   | Val(id, t) ->
     let quals = d.quals in
     let t = desugar_term env (close_fun env t) in
     let quals = if env.iface && env.admitted_iface then Assumption::quals else quals in
-    let se = Sig_declare_typ(qualify env id, [], t, List.map (trans_qual None) quals, d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_declare_typ(qualify env id, [], t, List.map (trans_qual None) quals)) in
     let env = push_sigelt env se in
     env, [se]
 
   | Exception(id, None) ->
     let t, _ = fail_or env (try_lookup_lid env) C.exn_lid in
     let l = qualify env id in
-    let se = Sig_datacon(l, [], t, C.exn_lid, 0, [ExceptionConstructor], [C.exn_lid], d.drange) in
-    let se' = Sig_bundle([se], [ExceptionConstructor], [l], d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_datacon(l, [], t, C.exn_lid, 0, [ExceptionConstructor], [C.exn_lid])) in
+    let se' = AST.sigelt_of_decl d (Sig_bundle([se], [ExceptionConstructor], [l])) in
     let env = push_sigelt env se' in
     let data_ops = mk_data_projector_names [] env ([], se) in
     let discs = mk_data_discriminators [] env C.exn_lid [] tun [l] in
@@ -1975,8 +1996,8 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
     let t = desugar_term env term in
     let t = U.arrow ([null_binder t]) (mk_Total <| fst (fail_or env (try_lookup_lid env) C.exn_lid)) in
     let l = qualify env id in
-    let se = Sig_datacon(l, [], t, C.exn_lid, 0, [ExceptionConstructor], [C.exn_lid], d.drange) in
-    let se' = Sig_bundle([se], [ExceptionConstructor], [l], d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_datacon(l, [], t, C.exn_lid, 0, [ExceptionConstructor], [C.exn_lid])) in
+    let se' = AST.sigelt_of_decl d (Sig_bundle([se], [ExceptionConstructor], [l])) in
     let env = push_sigelt env se' in
     let data_ops = mk_data_projector_names [] env ([], se) in
     let discs = mk_data_discriminators [] env C.exn_lid [] tun [l] in
@@ -2002,7 +2023,7 @@ and desugar_decl env (d:decl) : (env_t * sigelts) =
         | ReifiableLift (wp, t) -> Some ([],desugar_term env wp), Some([], desugar_term env t)
         | LiftForFree t -> None, Some ([],desugar_term env t)
     in
-    let se = Sig_sub_effect({source=src; target=dst; lift_wp=lift_wp; lift=lift}, d.drange) in
+    let se = AST.sigelt_of_decl d (Sig_sub_effect({source=src; target=dst; lift_wp=lift_wp; lift=lift})) in
     env, [se]
 
  let desugar_decls env decls =

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -326,13 +326,13 @@ let lookup_qname env (lid:lident) : option<(either<(universes * typ), (sigelt * 
       | None ->
         BU.find_map env.gamma (function
           | Binding_lid(l,t) -> if lid_equals lid l then Some (Inl (inst_tscheme t), Ident.range_of_lid l) else None
-          | Binding_sig (_, Sig_bundle(ses, _, _, _)) ->
+          | Binding_sig (_, { elt = Sig_bundle(ses, _, _) }) ->
               BU.find_map ses (fun se ->
                 if lids_of_sigelt se |> BU.for_some (lid_equals lid)
                 then cache (Inr (se, None), U.range_of_sigelt se)
                 else None)
           | Binding_sig (lids, s) ->
-            let maybe_cache t = match s with
+            let maybe_cache t = match s.elt with
               | Sig_declare_typ _ -> Some t
               | _ -> cache t
             in
@@ -357,13 +357,13 @@ let lookup_qname env (lid:lident) : option<(either<(universes * typ), (sigelt * 
         | None -> None
   else None
 
-let rec add_sigelt env se = match se with
-    | Sig_bundle(ses, _, _, _) -> add_sigelts env ses
+let rec add_sigelt env se = match se.elt with
+    | Sig_bundle(ses, _, _) -> add_sigelts env ses
     | _ ->
     let lids = lids_of_sigelt se in
     List.iter (fun l -> BU.smap_add (sigtab env) l.str se) lids;
-    match se with
-    | Sig_new_effect(ne, _) ->
+    match se.elt with
+    | Sig_new_effect(ne) ->
       ne.actions |> List.iter (fun a ->
           let se_let = U.action_as_lb ne.mname a in
           BU.smap_add (sigtab env) a.action_name.str se_let)
@@ -381,11 +381,11 @@ let try_lookup_bv env (bv:bv) =
       Some (id.sort, id.ppname.idRange)
     | _ -> None)
 
-let lookup_type_of_let se lid = match se with
-    | Sig_let((_, [lb]), _, _, _, _) ->
+let lookup_type_of_let se lid = match se.elt with
+    | Sig_let((_, [lb]), _, _, _) ->
       Some (inst_tscheme (lb.lbunivs, lb.lbtyp), S.range_of_lbname lb.lbname)
 
-    | Sig_let((_, lbs), _, _, _, _) ->
+    | Sig_let((_, lbs), _, _, _) ->
         BU.find_map lbs (fun lb -> match lb.lbname with
           | Inl _ -> failwith "impossible"
           | Inr fv ->
@@ -396,12 +396,12 @@ let lookup_type_of_let se lid = match se with
     | _ -> None
 
 let effect_signature se =
-    match se with
-    | Sig_new_effect(ne, r) ->
-        Some (inst_tscheme (ne.univs, U.arrow ne.binders (mk_Total ne.signature)), r)
+    match se.elt with
+    | Sig_new_effect(ne) ->
+        Some (inst_tscheme (ne.univs, U.arrow ne.binders (mk_Total ne.signature)), se.sigrng)
 
-    | Sig_effect_abbrev (lid, us, binders, _, _, _, r) ->
-        Some (inst_tscheme (us, U.arrow binders (mk_Total teff)), r)
+    | Sig_effect_abbrev (lid, us, binders, _, _, _) ->
+        Some (inst_tscheme (us, U.arrow binders (mk_Total teff)), se.sigrng)
 
     | _ -> None
 
@@ -411,23 +411,23 @@ let try_lookup_lid_aux env lid =
     | Inl t ->
       Some (t, rng)
 
-    | Inr (Sig_datacon(_, uvs, t, _, _, _, _, _), None) ->
+    | Inr ({elt = Sig_datacon(_, uvs, t, _, _, _, _) }, None) ->
       Some (inst_tscheme (uvs, t), rng)
 
-    | Inr (Sig_declare_typ (l, uvs, t, qs, _), None) ->
+    | Inr ({elt = Sig_declare_typ (l, uvs, t, qs) }, None) ->
       if in_cur_mod env l = Yes
       then if qs |> List.contains Assumption || env.is_iface
            then Some (inst_tscheme (uvs, t), rng)
            else None
       else Some (inst_tscheme (uvs, t), rng)
 
-    | Inr (Sig_inductive_typ (lid, uvs, tps, k, _, _, _, _), None) ->
+    | Inr ({elt = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, None) ->
       begin match tps with
         | [] -> Some (inst_tscheme (uvs, k), rng)
         | _ ->  Some (inst_tscheme (uvs, U.flat_arrow tps (mk_Total k)), rng)
       end
 
-    | Inr (Sig_inductive_typ (lid, uvs, tps, k, _, _, _, _), Some us) ->
+    | Inr ({elt = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, Some us) ->
       begin match tps with
         | [] -> Some (inst_tscheme_with (uvs, k) us, rng)
         | _ ->  Some (inst_tscheme_with (uvs, U.flat_arrow tps (mk_Total k)) us, rng)
@@ -435,7 +435,7 @@ let try_lookup_lid_aux env lid =
 
     | Inr se ->
       begin match se with
-        | Sig_let _, None -> lookup_type_of_let (fst se) lid
+        | { elt = Sig_let _ }, None -> lookup_type_of_let (fst se) lid
         | _ -> effect_signature (fst se)
       end
   in
@@ -509,30 +509,30 @@ let lookup_univ env x =
 let try_lookup_val_decl env lid =
   //QUESTION: Why does this not inst_tscheme?
   match lookup_qname env lid with
-    | Some (Inr (Sig_declare_typ(_, uvs, t, q, _), None), _) ->
+    | Some (Inr ({ elt = Sig_declare_typ(_, uvs, t, q) }, None), _) ->
       Some ((uvs, Subst.set_use_range (range_of_lid lid) t),q)
     | _ -> None
 
 let lookup_val_decl env lid =
   match lookup_qname env lid with
-    | Some (Inr (Sig_declare_typ(_, uvs, t, _, _), None), _) ->
+    | Some (Inr ({ elt = Sig_declare_typ(_, uvs, t, _) }, None), _) ->
       inst_tscheme_with_range (range_of_lid lid) (uvs, t)
     | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 let lookup_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr (Sig_datacon (_, uvs, t, _, _, _, _, _), None), _) ->
+    | Some (Inr ({ elt = Sig_datacon (_, uvs, t, _, _, _, _) }, None), _) ->
       inst_tscheme_with_range (range_of_lid lid) (uvs, t)
     | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 let datacons_of_typ env lid =
   match lookup_qname env lid with
-    | Some (Inr(Sig_inductive_typ(_, _, _, _, _, dcs, _, _), _), _) -> true, dcs
+    | Some (Inr ({ elt = Sig_inductive_typ(_, _, _, _, _, dcs, _) }, _), _) -> true, dcs
     | _ -> false, []
 
 let typ_of_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr (Sig_datacon (_, _, _, l, _, _, _, _), _), _) -> l
+    | Some (Inr ({ elt = Sig_datacon (_, _, _, l, _, _, _) }, _), _) -> l
     | _ -> failwith (BU.format1 "Not a datacon: %s" (Print.lid_to_string lid))
 
 let lookup_definition delta_levels env lid =
@@ -541,8 +541,8 @@ let lookup_definition delta_levels env lid =
   in
   match lookup_qname env lid with
   | Some (Inr (se, None), _) ->
-    begin match se with
-      | Sig_let((_, lbs), _, _, quals, _) when visible quals ->
+    begin match se.elt with
+      | Sig_let((_, lbs), _, quals, _) when visible quals ->
           BU.find_map lbs (fun lb ->
               let fv = right lb.lbname in
               if fv_eq_lid fv lid
@@ -568,7 +568,7 @@ let lookup_effect_lid env (ftv:lident) : typ =
 
 let lookup_effect_abbrev env (univ_insts:universes) lid0 =
   match lookup_qname env lid0 with
-    | Some (Inr (Sig_effect_abbrev (lid, univs, binders, c, quals, _, _), None), _) ->
+    | Some (Inr ({ elt = Sig_effect_abbrev (lid, univs, binders, c, quals, _) }, None), _) ->
       let lid = Ident.set_lid_range lid (Range.set_use_range (Ident.range_of_lid lid) (Ident.range_of_lid lid0)) in
       if quals |> BU.for_some (function Irreducible -> true | _ -> false)
       then None
@@ -620,7 +620,7 @@ let norm_eff_name =
 let lookup_effect_quals env l =
     let l = norm_eff_name env l in
     match lookup_qname env l with
-    | Some (Inr (Sig_new_effect(ne, _), _), _) ->
+    | Some (Inr ({ elt = Sig_new_effect(ne) }, _), _) ->
       ne.qualifiers
     | _ -> []
 
@@ -637,24 +637,24 @@ let lookup_projector env lid i =
 
 let is_projector env (l:lident) : bool =
     match lookup_qname env l with
-        | Some (Inr (Sig_declare_typ(_, _, _, quals, _), _), _) ->
+        | Some (Inr ({ elt = Sig_declare_typ(_, _, _, quals) }, _), _) ->
           BU.for_some (function Projector _ -> true | _ -> false) quals
         | _ -> false
 
 let is_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr (Sig_datacon (_, _, _, _, _, _, _, _), _), _) -> true
+    | Some (Inr ({ elt = Sig_datacon (_, _, _, _, _, _, _) }, _), _) -> true
     | _ -> false
 
 let is_record env lid =
   match lookup_qname env lid with
-    | Some (Inr (Sig_inductive_typ(_, _, _, _, _, _, tags, _), _), _) ->
+    | Some (Inr ({ elt = Sig_inductive_typ(_, _, _, _, _, _, tags) }, _), _) ->
         BU.for_some (function RecordType _ | RecordConstructor _ -> true | _ -> false) tags
     | _ -> false
 
 let is_action env lid =
     match lookup_qname env lid with
-        | Some (Inr (Sig_let(_, _, _, tags, _), _), _) ->
+        | Some (Inr ({ elt = Sig_let(_, _, tags, _) }, _), _) ->
             BU.for_some (function Action _ -> true | _ -> false) tags
         | _ -> false
 
@@ -687,8 +687,8 @@ let is_type_constructor env lid =
         match fst x with
         | Inl _ -> Some false
         | Inr (se, _) ->
-           begin match se with
-            | Sig_declare_typ (_, _, _, qs, _) ->
+           begin match se.elt with
+            | Sig_declare_typ (_, _, _, qs) ->
               Some (List.contains New qs)
             | Sig_inductive_typ _ ->
               Some true
@@ -700,7 +700,7 @@ let is_type_constructor env lid =
 
 let num_inductive_ty_params env lid =
   match lookup_qname env lid with
-  | Some (Inr (Sig_inductive_typ (_, _, tps, _, _, _, _, _), _), _) -> List.length tps
+  | Some (Inr ({ elt = Sig_inductive_typ (_, _, tps, _, _, _, _) }, _), _) -> List.length tps
   | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 ////////////////////////////////////////////////////////////
@@ -761,12 +761,12 @@ let null_wp_for_eff env eff_name (res_u:universe) (res_t:term) =
                           effect_args=[S.as_arg null_wp_res];
                           flags=[]})
 
-let build_lattice env se = match se with
-  | Sig_new_effect(ne, _) ->
+let build_lattice env se = match se.elt with
+  | Sig_new_effect(ne) ->
     let effects = {env.effects with decls=ne::env.effects.decls} in
     {env with effects=effects}
 
-  | Sig_sub_effect(sub, _) ->
+  | Sig_sub_effect(sub) ->
     let compose_edges e1 e2 : edge =
       let composed_lift =
         let mlift_wp r wp1 = e2.mlift.mlift_wp r (e1.mlift.mlift_wp r wp1) in

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -326,13 +326,13 @@ let lookup_qname env (lid:lident) : option<(either<(universes * typ), (sigelt * 
       | None ->
         BU.find_map env.gamma (function
           | Binding_lid(l,t) -> if lid_equals lid l then Some (Inl (inst_tscheme t), Ident.range_of_lid l) else None
-          | Binding_sig (_, { elt = Sig_bundle(ses, _, _) }) ->
+          | Binding_sig (_, { sigel = Sig_bundle(ses, _, _) }) ->
               BU.find_map ses (fun se ->
                 if lids_of_sigelt se |> BU.for_some (lid_equals lid)
                 then cache (Inr (se, None), U.range_of_sigelt se)
                 else None)
           | Binding_sig (lids, s) ->
-            let maybe_cache t = match s.elt with
+            let maybe_cache t = match s.sigel with
               | Sig_declare_typ _ -> Some t
               | _ -> cache t
             in
@@ -357,12 +357,12 @@ let lookup_qname env (lid:lident) : option<(either<(universes * typ), (sigelt * 
         | None -> None
   else None
 
-let rec add_sigelt env se = match se.elt with
+let rec add_sigelt env se = match se.sigel with
     | Sig_bundle(ses, _, _) -> add_sigelts env ses
     | _ ->
     let lids = lids_of_sigelt se in
     List.iter (fun l -> BU.smap_add (sigtab env) l.str se) lids;
-    match se.elt with
+    match se.sigel with
     | Sig_new_effect(ne) ->
       ne.actions |> List.iter (fun a ->
           let se_let = U.action_as_lb ne.mname a in
@@ -381,7 +381,7 @@ let try_lookup_bv env (bv:bv) =
       Some (id.sort, id.ppname.idRange)
     | _ -> None)
 
-let lookup_type_of_let se lid = match se.elt with
+let lookup_type_of_let se lid = match se.sigel with
     | Sig_let((_, [lb]), _, _, _) ->
       Some (inst_tscheme (lb.lbunivs, lb.lbtyp), S.range_of_lbname lb.lbname)
 
@@ -396,7 +396,7 @@ let lookup_type_of_let se lid = match se.elt with
     | _ -> None
 
 let effect_signature se =
-    match se.elt with
+    match se.sigel with
     | Sig_new_effect(ne) ->
         Some (inst_tscheme (ne.univs, U.arrow ne.binders (mk_Total ne.signature)), se.sigrng)
 
@@ -411,23 +411,23 @@ let try_lookup_lid_aux env lid =
     | Inl t ->
       Some (t, rng)
 
-    | Inr ({elt = Sig_datacon(_, uvs, t, _, _, _, _) }, None) ->
+    | Inr ({sigel = Sig_datacon(_, uvs, t, _, _, _, _) }, None) ->
       Some (inst_tscheme (uvs, t), rng)
 
-    | Inr ({elt = Sig_declare_typ (l, uvs, t, qs) }, None) ->
+    | Inr ({sigel = Sig_declare_typ (l, uvs, t, qs) }, None) ->
       if in_cur_mod env l = Yes
       then if qs |> List.contains Assumption || env.is_iface
            then Some (inst_tscheme (uvs, t), rng)
            else None
       else Some (inst_tscheme (uvs, t), rng)
 
-    | Inr ({elt = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, None) ->
+    | Inr ({sigel = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, None) ->
       begin match tps with
         | [] -> Some (inst_tscheme (uvs, k), rng)
         | _ ->  Some (inst_tscheme (uvs, U.flat_arrow tps (mk_Total k)), rng)
       end
 
-    | Inr ({elt = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, Some us) ->
+    | Inr ({sigel = Sig_inductive_typ (lid, uvs, tps, k, _, _, _) }, Some us) ->
       begin match tps with
         | [] -> Some (inst_tscheme_with (uvs, k) us, rng)
         | _ ->  Some (inst_tscheme_with (uvs, U.flat_arrow tps (mk_Total k)) us, rng)
@@ -435,7 +435,7 @@ let try_lookup_lid_aux env lid =
 
     | Inr se ->
       begin match se with
-        | { elt = Sig_let _ }, None -> lookup_type_of_let (fst se) lid
+        | { sigel = Sig_let _ }, None -> lookup_type_of_let (fst se) lid
         | _ -> effect_signature (fst se)
       end
   in
@@ -509,30 +509,30 @@ let lookup_univ env x =
 let try_lookup_val_decl env lid =
   //QUESTION: Why does this not inst_tscheme?
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_declare_typ(_, uvs, t, q) }, None), _) ->
+    | Some (Inr ({ sigel = Sig_declare_typ(_, uvs, t, q) }, None), _) ->
       Some ((uvs, Subst.set_use_range (range_of_lid lid) t),q)
     | _ -> None
 
 let lookup_val_decl env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_declare_typ(_, uvs, t, _) }, None), _) ->
+    | Some (Inr ({ sigel = Sig_declare_typ(_, uvs, t, _) }, None), _) ->
       inst_tscheme_with_range (range_of_lid lid) (uvs, t)
     | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 let lookup_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_datacon (_, uvs, t, _, _, _, _) }, None), _) ->
+    | Some (Inr ({ sigel = Sig_datacon (_, uvs, t, _, _, _, _) }, None), _) ->
       inst_tscheme_with_range (range_of_lid lid) (uvs, t)
     | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 let datacons_of_typ env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_inductive_typ(_, _, _, _, _, dcs, _) }, _), _) -> true, dcs
+    | Some (Inr ({ sigel = Sig_inductive_typ(_, _, _, _, _, dcs, _) }, _), _) -> true, dcs
     | _ -> false, []
 
 let typ_of_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_datacon (_, _, _, l, _, _, _) }, _), _) -> l
+    | Some (Inr ({ sigel = Sig_datacon (_, _, _, l, _, _, _) }, _), _) -> l
     | _ -> failwith (BU.format1 "Not a datacon: %s" (Print.lid_to_string lid))
 
 let lookup_definition delta_levels env lid =
@@ -541,7 +541,7 @@ let lookup_definition delta_levels env lid =
   in
   match lookup_qname env lid with
   | Some (Inr (se, None), _) ->
-    begin match se.elt with
+    begin match se.sigel with
       | Sig_let((_, lbs), _, quals, _) when visible quals ->
           BU.find_map lbs (fun lb ->
               let fv = right lb.lbname in
@@ -568,7 +568,7 @@ let lookup_effect_lid env (ftv:lident) : typ =
 
 let lookup_effect_abbrev env (univ_insts:universes) lid0 =
   match lookup_qname env lid0 with
-    | Some (Inr ({ elt = Sig_effect_abbrev (lid, univs, binders, c, quals, _) }, None), _) ->
+    | Some (Inr ({ sigel = Sig_effect_abbrev (lid, univs, binders, c, quals, _) }, None), _) ->
       let lid = Ident.set_lid_range lid (Range.set_use_range (Ident.range_of_lid lid) (Ident.range_of_lid lid0)) in
       if quals |> BU.for_some (function Irreducible -> true | _ -> false)
       then None
@@ -620,7 +620,7 @@ let norm_eff_name =
 let lookup_effect_quals env l =
     let l = norm_eff_name env l in
     match lookup_qname env l with
-    | Some (Inr ({ elt = Sig_new_effect(ne) }, _), _) ->
+    | Some (Inr ({ sigel = Sig_new_effect(ne) }, _), _) ->
       ne.qualifiers
     | _ -> []
 
@@ -637,24 +637,24 @@ let lookup_projector env lid i =
 
 let is_projector env (l:lident) : bool =
     match lookup_qname env l with
-        | Some (Inr ({ elt = Sig_declare_typ(_, _, _, quals) }, _), _) ->
+        | Some (Inr ({ sigel = Sig_declare_typ(_, _, _, quals) }, _), _) ->
           BU.for_some (function Projector _ -> true | _ -> false) quals
         | _ -> false
 
 let is_datacon env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_datacon (_, _, _, _, _, _, _) }, _), _) -> true
+    | Some (Inr ({ sigel = Sig_datacon (_, _, _, _, _, _, _) }, _), _) -> true
     | _ -> false
 
 let is_record env lid =
   match lookup_qname env lid with
-    | Some (Inr ({ elt = Sig_inductive_typ(_, _, _, _, _, _, tags) }, _), _) ->
+    | Some (Inr ({ sigel = Sig_inductive_typ(_, _, _, _, _, _, tags) }, _), _) ->
         BU.for_some (function RecordType _ | RecordConstructor _ -> true | _ -> false) tags
     | _ -> false
 
 let is_action env lid =
     match lookup_qname env lid with
-        | Some (Inr ({ elt = Sig_let(_, _, tags, _) }, _), _) ->
+        | Some (Inr ({ sigel = Sig_let(_, _, tags, _) }, _), _) ->
             BU.for_some (function Action _ -> true | _ -> false) tags
         | _ -> false
 
@@ -687,7 +687,7 @@ let is_type_constructor env lid =
         match fst x with
         | Inl _ -> Some false
         | Inr (se, _) ->
-           begin match se.elt with
+           begin match se.sigel with
             | Sig_declare_typ (_, _, _, qs) ->
               Some (List.contains New qs)
             | Sig_inductive_typ _ ->
@@ -700,7 +700,7 @@ let is_type_constructor env lid =
 
 let num_inductive_ty_params env lid =
   match lookup_qname env lid with
-  | Some (Inr ({ elt = Sig_inductive_typ (_, _, tps, _, _, _, _) }, _), _) -> List.length tps
+  | Some (Inr ({ sigel = Sig_inductive_typ (_, _, tps, _, _, _, _) }, _), _) -> List.length tps
   | _ -> raise (Error(name_not_found lid, range_of_lid lid))
 
 ////////////////////////////////////////////////////////////
@@ -761,7 +761,7 @@ let null_wp_for_eff env eff_name (res_u:universe) (res_t:term) =
                           effect_args=[S.as_arg null_wp_res];
                           flags=[]})
 
-let build_lattice env se = match se.elt with
+let build_lattice env se = match se.sigel with
   | Sig_new_effect(ne) ->
     let effects = {env.effects with decls=ne::env.effects.decls} in
     {env with effects=effects}

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -617,15 +617,15 @@ and cps_and_elaborate env ed =
 
   // we do not expect the return_elab to verify, since that may require internalizing monotonicity of WPs (i.e. continuation monad)
   let return_wp = register "return_wp" return_wp in
-  sigelts := Sig_pragma (SetOptions "--admit_smt_queries true", Range.dummyRange) :: !sigelts;
+  sigelts := mk_sigelt (Sig_pragma (SetOptions "--admit_smt_queries true")) :: !sigelts;
   let return_elab = register "return_elab" return_elab in
-  sigelts := Sig_pragma (SetOptions "--admit_smt_queries false", Range.dummyRange) :: !sigelts;
+  sigelts := mk_sigelt (Sig_pragma (SetOptions "--admit_smt_queries false")) :: !sigelts;
 
   // we do not expect the bind to verify, since that requires internalizing monotonicity of WPs
   let bind_wp = register "bind_wp" bind_wp in
-  sigelts := Sig_pragma (SetOptions "--admit_smt_queries true", Range.dummyRange) :: !sigelts;
+  sigelts := mk_sigelt (Sig_pragma (SetOptions "--admit_smt_queries true")) :: !sigelts;
   let bind_elab = register "bind_elab" bind_elab in
-  sigelts := Sig_pragma (SetOptions "--admit_smt_queries false", Range.dummyRange) :: !sigelts;
+  sigelts := mk_sigelt (Sig_pragma (SetOptions "--admit_smt_queries false")) :: !sigelts;
 
   let dmff_env, actions = List.fold_left (fun (dmff_env, actions) action ->
     // We need to reverse-engineer what tc_eff_decl wants here...
@@ -714,7 +714,7 @@ and cps_and_elaborate env ed =
           lift_wp = Some ([], apply_close lift_from_pure_wp) ;
           lift = None //Some ([], apply_close return_elab)
       } in
-      Some (Sig_sub_effect (lift_from_pure, Range.dummyRange))
+      Some (mk_sigelt (Sig_sub_effect (lift_from_pure)))
     end else None
   in
 
@@ -737,9 +737,9 @@ and tc_lex_t env ses quals lids =
         | _ -> assert false
     end;
     begin match ses with
-      | [Sig_inductive_typ(lex_t, [], [], t, _, _, [], r);
-         Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _, r1);
-         Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _, r2)]
+      | [{ elt = Sig_inductive_typ(lex_t, [], [], t, _, _, []); sigrng = r } as se ;
+         { elt = Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _); sigrng = r1 } as se1;
+         { elt = Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _); sigrng = r2 } as se2]
          when (lid_equals lex_t Const.lex_t_lid
             && lid_equals lex_top Const.lextop_lid
             && lid_equals lex_cons Const.lexcons_lid) ->
@@ -747,12 +747,12 @@ and tc_lex_t env ses quals lids =
         let u = S.new_univ_name (Some r) in
         let t = mk (Tm_type(U_name u)) None r in
         let t = Subst.close_univ_vars [u] t in
-        let tc = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], [], r) in
+        let tc = { se with elt = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], []) } in
 
         let utop = S.new_univ_name (Some r1) in
         let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r1) Delta_constant None, [U_name utop])) None r1 in
         let lex_top_t = Subst.close_univ_vars [utop] lex_top_t in
-        let dc_lextop = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], [], r1) in
+        let dc_lextop = { se1 with elt = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], []) } in
 
         let ucons1 = S.new_univ_name (Some r2) in
         let ucons2 = S.new_univ_name (Some r2) in
@@ -763,10 +763,10 @@ and tc_lex_t env ses quals lids =
             let res = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r2) Delta_constant None, [U_max [U_name ucons1; U_name ucons2]])) None r2 in
             U.arrow [(a, Some S.imp_tag); (hd, None); (tl, None)] (S.mk_Total res) in
         let lex_cons_t = Subst.close_univ_vars [ucons1;ucons2]  lex_cons_t in
-        let dc_lexcons = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], [], r2) in
-        Sig_bundle([tc; dc_lextop; dc_lexcons], [], lids, Env.get_range env)
+        let dc_lexcons = { se2 with elt = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], []) } in
+        { elt = Sig_bundle([tc; dc_lextop; dc_lexcons], [], lids); sigrng = Env.get_range env; doc = None } // FIXME: Doc
       | _ ->
-        failwith (BU.format1 "Unexpected lex_t: %s\n" (Print.sigelt_to_string (Sig_bundle(ses, [], lids, Range.dummyRange))))
+        failwith (BU.format1 "Unexpected lex_t: %s\n" (Print.sigelt_to_string (mk_sigelt (Sig_bundle(ses, [], lids)))))
     end
 
 and tc_assume (env:env) (lid:lident) (phi:formula) (quals:list<qualifier>) (r:Range.range) :sigelt =
@@ -774,7 +774,7 @@ and tc_assume (env:env) (lid:lident) (phi:formula) (quals:list<qualifier>) (r:Ra
     let k, _ = U.type_u() in
     let phi = tc_check_trivial_guard env phi k |> N.normalize [N.Beta; N.Eager_unfolding] env in
     TcUtil.check_uvars r phi;
-    Sig_assume(lid, phi, quals, r)
+    { elt = Sig_assume(lid, phi, quals); sigrng = r; doc = None } // FIXME: Doc
 
 and tc_inductive env ses quals lids =
     let env0 = env in
@@ -795,9 +795,9 @@ and tc_inductive env ses quals lids =
          let b = TcInductive.check_positivity ty env in
          if not b then
            let lid, r =
-             match ty with
-             | Sig_inductive_typ (lid, _, _, _, _, _, _, r) -> lid, r
-             | _                                            -> failwith "Impossible!"
+             match ty.elt with
+             | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid, ty.sigrng
+             | _                                         -> failwith "Impossible!"
            in
            Errors.report r ("Inductive type " ^ lid.str ^ " does not satisfy the positivity condition")
          else ()
@@ -809,9 +809,9 @@ and tc_inductive env ses quals lids =
     let skip_prims_type (_:unit) :bool =
         let lid =
             let ty = List.hd tcs in
-            match ty with
-                | Sig_inductive_typ (lid, _, _, _, _, _, _, _) -> lid
-                | _                                            -> failwith "Impossible"
+            match ty.elt with
+                | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid
+                | _                                         -> failwith "Impossible"
         in
         //these are the prims type we are skipping
         let types_to_skip = [ "c_False"; "c_True"; "equals"; "h_equals"; "c_and"; "c_or"; ] in
@@ -828,7 +828,7 @@ and tc_inductive env ses quals lids =
           if is_unopteq then TcInductive.unoptimized_haseq_scheme sig_bndle tcs datas env0 tc_assume
           else TcInductive.optimized_haseq_scheme sig_bndle tcs datas env0 tc_assume
         in
-        (Sig_bundle(tcs@datas, quals, lids, Env.get_range env0))::ses, data_ops_ses
+        { elt = Sig_bundle(tcs@datas, quals, lids); sigrng = Env.get_range env0; doc = None }::ses, data_ops_ses // FIXME: Doc
 
 
 (* [tc_decl env se] typechecks [se] in environment [env] and returns *)
@@ -837,12 +837,13 @@ and tc_inductive env ses quals lids =
 and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
   let env = set_hint_correlator env se in
   TcUtil.check_sigelt_quals env se;
-  match se with
+  let r = se.sigrng in
+  match se.elt with
   | Sig_inductive_typ _
   | Sig_datacon _ ->
     failwith "Impossible bare data-constructor"
 
-  | Sig_bundle(ses, quals, lids, r) when (lids |> BU.for_some (lid_equals Const.lex_t_lid)) ->
+  | Sig_bundle(ses, quals, lids) when (lids |> BU.for_some (lid_equals Const.lex_t_lid)) ->
     //lex_t is very special; it uses a more expressive form of universe polymorphism than is allowed elsewhere
     //Instead of this special treatment, we could make use of explicit lifts, but LexCons is used pervasively
     (*
@@ -854,13 +855,13 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
     let se = tc_lex_t env ses quals lids  in
     [se], Env.push_sigelt env se, []
 
-  | Sig_bundle(ses, quals, lids, r) ->
+  | Sig_bundle(ses, quals, lids) ->
     let env = Env.set_range env r in
     let ses,projectors_ses = tc_inductive env ses quals lids  in
     let env = List.fold_left (fun env' se -> Env.push_sigelt env' se) env ses in
     ses, env, projectors_ses
 
-  | Sig_pragma(p, r) ->
+  | Sig_pragma(p) ->
     let set_options t s = match Options.set_options t s with
       | Getopt.Success -> ()
       | Getopt.Help  -> raise (Error ("Failed to process pragma: use 'fstar --help' to see which options are available", r))
@@ -885,22 +886,22 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
     end
 
 
-  | Sig_new_effect_for_free (ne, r) ->
+  | Sig_new_effect_for_free (ne) ->
       (* This is only an elaboration rule not a typechecking one *)
 
       // Let the power of Dijkstra generate everything "for free", then defer
       // the rest of the job to [tc_decl].
       let ses, ne, lift_from_pure_opt = cps_and_elaborate env ne in
       let effect_and_lift_ses = match lift_from_pure_opt with
-          | Some lift -> [ Sig_new_effect (ne, r) ; lift ]
-          | None -> [ Sig_new_effect (ne, r) ]
+          | Some lift -> [ { se with elt = Sig_new_effect (ne) } ; lift ]
+          | None -> [ { se with elt = Sig_new_effect (ne) } ]
       in
 
       [], env, ses @ effect_and_lift_ses
 
-  | Sig_new_effect(ne, r) ->
+  | Sig_new_effect(ne) ->
     let ne = tc_eff_decl env ne in
-    let se = Sig_new_effect(ne, r) in
+    let se = { se with elt = Sig_new_effect(ne) } in
     let env = Env.push_sigelt env se in
     (* KM : What's the point of collecting actions sig_let if they are not returned ??*)
     let env, ses = ne.actions |> List.fold_left (fun (env, ses) a ->
@@ -908,7 +909,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
         Env.push_sigelt env se_let, se_let::ses) (env, [se]) in
     [se], env, []
 
-  | Sig_sub_effect(sub, r) ->
+  | Sig_sub_effect(sub) ->
     let ed_src = Env.get_effect_decl env sub.source in
     let ed_tgt = Env.get_effect_decl env sub.target in
     let a, wp_a_src = monad_signature env sub.source (Env.lookup_effect_lid env sub.source) in
@@ -975,11 +976,11 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
     // Restore the proper lax flag!
     let env = { env with lax = lax } in
     let sub = {sub with lift_wp=Some lift_wp; lift=lift} in
-    let se = Sig_sub_effect(sub, r) in
+    let se = { se with elt = Sig_sub_effect(sub) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
-  | Sig_effect_abbrev(lid, uvs, tps, c, tags, flags, r) ->
+  | Sig_effect_abbrev(lid, uvs, tps, c, tags, flags) ->
     assert (uvs = []);
     let env0 = env in
     let env = Env.set_range env r in
@@ -1001,17 +1002,17 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
                                   (Print.lid_to_string lid)
                                   (List.length uvs |> BU.string_of_int)
                                   (Print.term_to_string t), r)));
-    let se = Sig_effect_abbrev(lid, uvs, tps, c, tags, flags, r) in
+    let se = { se with elt = Sig_effect_abbrev(lid, uvs, tps, c, tags, flags) } in
     let env = Env.push_sigelt env0 se in
     [se], env, []
 
-  | Sig_declare_typ (_, _, _, quals, _)
-  | Sig_let (_, _, _, quals, _)
+  | Sig_declare_typ (_, _, _, quals)
+  | Sig_let (_, _, quals, _)
       when quals |> BU.for_some (function OnlyName -> true | _ -> false) ->
       (* Dummy declaration which must be erased since it has been elaborated somewhere else *)
       [], env, []
 
-  | Sig_declare_typ(lid, uvs, t, quals, r) -> //NS: No checks on the qualifiers?
+  | Sig_declare_typ(lid, uvs, t, quals) -> //NS: No checks on the qualifiers?
     let env = Env.set_range env r in
     //assert (uvs = []);
     let uvs, t =
@@ -1023,26 +1024,26 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
             let t = N.normalize [N.NoFullNorm; N.Beta] env t in
             uvs, SS.close_univ_vars uvs t
     in
-    let se = Sig_declare_typ(lid, uvs, t, quals, r) in
+    let se = { se with elt = Sig_declare_typ(lid, uvs, t, quals) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
-  | Sig_assume(lid, phi, quals, r) ->
+  | Sig_assume(lid, phi, quals) ->
     let se = tc_assume env lid phi quals r in
     let env = Env.push_sigelt env se in
     [se], env, []
 
-  | Sig_main(e, r) ->
+  | Sig_main(e) ->
     let env = Env.set_range env r in
     let env = Env.set_expected_typ env Common.t_unit in
     let e, c, g1 = tc_term env e in
     let e, _, g = check_expected_effect env (Some (U.ml_comp Common.t_unit r)) (e, c.comp()) in
     Rel.force_trivial_guard env (Rel.conj_guard g1 g);
-    let se = Sig_main(e, r) in
+    let se = { se with elt = Sig_main(e) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
-  | Sig_let(lbs, r, lids, quals, attrs) ->
+  | Sig_let(lbs, lids, quals, attrs) ->
     let env = Env.set_range env r in
     let check_quals_eq l qopt q = match qopt with
       | None -> Some q
@@ -1121,7 +1122,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
             | q ->
                 Some q
           ) quals in
-          Sig_let(lbs, r, lids, quals, attrs), lbs
+          { se with elt = Sig_let(lbs, lids, quals, attrs) }, lbs
       | _ -> failwith "impossible"
     in
 
@@ -1173,23 +1174,23 @@ let for_export hidden se : list<sigelt> * list<lident> =
       | Discriminator l -> hidden |> BU.for_some (lid_equals l)
       | _ -> false
    in
-   match se with
+   match se.elt with
   | Sig_pragma         _ -> [], hidden
 
   | Sig_inductive_typ _
   | Sig_datacon _ -> failwith "Impossible"
 
-  | Sig_bundle(ses, quals, _, r) ->
+  | Sig_bundle(ses, quals, _) ->
     if is_abstract quals
     then
-      let for_export_bundle se (out, hidden) = match se with
-        | Sig_inductive_typ(l, us, bs, t, _, _, quals, r) ->
-          let dec = Sig_declare_typ(l, us, U.arrow bs (S.mk_Total t), Assumption::New::quals, r) in
+      let for_export_bundle se (out, hidden) = match se.elt with
+        | Sig_inductive_typ(l, us, bs, t, _, _, quals) ->
+          let dec = { se with elt = Sig_declare_typ(l, us, U.arrow bs (S.mk_Total t), Assumption::New::quals) } in
           dec::out, hidden
 
         (* logically, each constructor just becomes an uninterpreted function *)
-        | Sig_datacon(l, us, t, _, _, _, _, r) ->
-          let dec = Sig_declare_typ(l, us, t, [Assumption], r) in
+        | Sig_datacon(l, us, t, _, _, _, _) ->
+          let dec = { se with elt = Sig_declare_typ(l, us, t, [Assumption]) } in
           dec::out, l::hidden
 
         | _ ->
@@ -1198,14 +1199,14 @@ let for_export hidden se : list<sigelt> * list<lident> =
       List.fold_right for_export_bundle ses ([], hidden)
     else [se], hidden
 
-  | Sig_assume(_, _, quals, _) ->
+  | Sig_assume(_, _, quals) ->
     if is_abstract quals
     then [], hidden
     else [se], hidden
 
-  | Sig_declare_typ(l, us, t, quals, r) ->
+  | Sig_declare_typ(l, us, t, quals) ->
     if quals |> BU.for_some is_hidden_proj_or_disc //hidden projectors/discriminators become uninterpreted
-    then [Sig_declare_typ(l, us, t, [Assumption], r)], l::hidden
+    then [{se with elt = Sig_declare_typ(l, us, t, [Assumption]) }], l::hidden
     else if quals |> BU.for_some (function
       | Assumption
       | Projector _
@@ -1222,18 +1223,21 @@ let for_export hidden se : list<sigelt> * list<lident> =
   | Sig_sub_effect     _
   | Sig_effect_abbrev  _ -> [se], hidden
 
-  | Sig_let((false, [lb]), _, _, quals, _) when (quals |> BU.for_some is_hidden_proj_or_disc) ->
+  | Sig_let((false, [lb]), _, quals, _) when (quals |> BU.for_some is_hidden_proj_or_disc) ->
     let fv = right lb.lbname in
     let lid = fv.fv_name.v in
     if hidden |> BU.for_some (S.fv_eq_lid fv)
     then [], hidden //this projector definition already has a declare_typ
-    else let dec = Sig_declare_typ(fv.fv_name.v, lb.lbunivs, lb.lbtyp, [Assumption], Ident.range_of_lid lid) in
+    else let dec = { elt = Sig_declare_typ(fv.fv_name.v, lb.lbunivs, lb.lbtyp, [Assumption]);
+                     sigrng = Ident.range_of_lid lid;
+                     doc = se.doc } in
           [dec], lid::hidden
 
-  | Sig_let(lbs, r, l, quals, _) ->
+  | Sig_let(lbs, l, quals, _) ->
     if is_abstract quals
-    then snd lbs |> List.map (fun lb ->
-          Sig_declare_typ((right lb.lbname).fv_name.v, lb.lbunivs, lb.lbtyp, Assumption::quals, r)), hidden
+    then (snd lbs |>  List.map (fun lb ->
+           { se with elt = Sig_declare_typ((right lb.lbname).fv_name.v, lb.lbunivs, lb.lbtyp, Assumption::quals) }),
+          hidden)
     else [se], hidden
 
 let tc_decls env ses =
@@ -1319,26 +1323,26 @@ let check_exports env (modul:modul) exports =
         check_term lid univs t;
         Errors.message_prefix.clear_prefix()
     in
-    let rec check_sigelt = function
-        | Sig_bundle(ses, quals, _, _) ->
+    let rec check_sigelt = fun se -> match se.elt with
+        | Sig_bundle(ses, quals, _) ->
           if not (quals |> List.contains Private)
           then ses |> List.iter check_sigelt
-        | Sig_inductive_typ (l, univs, binders, typ, _, _, _, r) ->
-          let t = S.mk (Tm_arrow(binders, S.mk_Total typ)) None r in
+        | Sig_inductive_typ (l, univs, binders, typ, _, _, _) ->
+          let t = S.mk (Tm_arrow(binders, S.mk_Total typ)) None se.sigrng in
           check_term l univs t
-        | Sig_datacon(l , univs, t, _, _, _, _, _) ->
+        | Sig_datacon(l , univs, t, _, _, _, _) ->
           check_term l univs t
-        | Sig_declare_typ(l, univs, t, quals, _) ->
+        | Sig_declare_typ(l, univs, t, quals) ->
           if not (quals |> List.contains Private)
           then check_term l univs t
-        | Sig_let((_, lbs), _, _, quals, _) ->
+        | Sig_let((_, lbs), _, quals, _) ->
           if not (quals |> List.contains Private)
           then lbs |> List.iter (fun lb ->
                let fv = right lb.lbname in
                check_term fv.fv_name.v lb.lbunivs lb.lbtyp)
-        | Sig_effect_abbrev(l, univs, binders, comp, quals, flags, r) ->
+        | Sig_effect_abbrev(l, univs, binders, comp, quals, flags) ->
           if not (quals |> List.contains Private)
-          then let arrow = S.mk (Tm_arrow(binders, comp)) None r in
+          then let arrow = S.mk (Tm_arrow(binders, comp)) None se.sigrng in
                check_term l univs arrow
         | Sig_main _
         | Sig_assume _
@@ -1380,15 +1384,15 @@ let check_module env m =
   then BU.print1 "%s\n" (Print.modul_to_string m);
   if Options.dump_module m.name.str && Options.debug_at_level m.name.str (Options.Other "Normalize")
   then begin
-    let normalize_toplevel_lets = function
-        | Sig_let ((b, lbs), r, ids, qs, attrs) ->
+    let normalize_toplevel_lets = fun se -> match se.elt with
+        | Sig_let ((b, lbs), ids, qs, attrs) ->
             let n = N.normalize [N.Beta ; N.Eager_unfolding; N.Reify ; N.Inlining ; N.Primops ; N.UnfoldUntil S.Delta_constant ; N.AllowUnboundUniverses ] in
             let update lb =
                 let univnames, e = SS.open_univ_vars lb.lbunivs lb.lbdef in
                 { lb with lbdef = n (Env.push_univ_vars env univnames) e }
             in
-            Sig_let ((b, List.map update lbs), r, ids, qs, attrs)
-        | se -> se
+            { se with elt = Sig_let ((b, List.map update lbs), ids, qs, attrs) }
+        | _ -> se
     in
     let normalized_module = { m with declarations = List.map normalize_toplevel_lets m.declarations } in
     BU.print1 "%s\n" (Print.modul_to_string normalized_module)

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -737,9 +737,9 @@ and tc_lex_t env ses quals lids =
         | _ -> assert false
     end;
     begin match ses with
-      | [{ elt = Sig_inductive_typ(lex_t, [], [], t, _, _, []); sigrng = r; doc = d };
-         { elt = Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _); sigrng = r1; doc = d1 };
-         { elt = Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _); sigrng = r2; doc = d2 }]
+      | [{ sigel = Sig_inductive_typ(lex_t, [], [], t, _, _, []); sigrng = r; sigdoc = d };
+         { sigel = Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _); sigrng = r1; sigdoc = d1 };
+         { sigel = Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _); sigrng = r2; sigdoc = d2 }]
          when (lid_equals lex_t Const.lex_t_lid
             && lid_equals lex_top Const.lextop_lid
             && lid_equals lex_cons Const.lexcons_lid) ->
@@ -747,14 +747,14 @@ and tc_lex_t env ses quals lids =
         let u = S.new_univ_name (Some r) in
         let t = mk (Tm_type(U_name u)) None r in
         let t = Subst.close_univ_vars [u] t in
-        let tc = { elt = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], []);
-                   sigrng = r; doc = d } in
+        let tc = { sigel = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], []);
+                   sigrng = r; sigdoc = d } in
 
         let utop = S.new_univ_name (Some r1) in
         let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r1) Delta_constant None, [U_name utop])) None r1 in
         let lex_top_t = Subst.close_univ_vars [utop] lex_top_t in
-        let dc_lextop = { elt = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], []);
-                          sigrng = r1; doc = d1 } in
+        let dc_lextop = { sigel = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], []);
+                          sigrng = r1; sigdoc = d1 } in
 
         let ucons1 = S.new_univ_name (Some r2) in
         let ucons2 = S.new_univ_name (Some r2) in
@@ -765,9 +765,9 @@ and tc_lex_t env ses quals lids =
             let res = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r2) Delta_constant None, [U_max [U_name ucons1; U_name ucons2]])) None r2 in
             U.arrow [(a, Some S.imp_tag); (hd, None); (tl, None)] (S.mk_Total res) in
         let lex_cons_t = Subst.close_univ_vars [ucons1;ucons2]  lex_cons_t in
-        let dc_lexcons = { elt = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], []);
-                           sigrng = r2; doc = d2 } in
-        { elt = Sig_bundle([tc; dc_lextop; dc_lexcons], [], lids); sigrng = Env.get_range env; doc = None } // FIXME: Doc
+        let dc_lexcons = { sigel = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], []);
+                           sigrng = r2; sigdoc = d2 } in
+        { sigel = Sig_bundle([tc; dc_lextop; dc_lexcons], [], lids); sigrng = Env.get_range env; sigdoc = None } // FIXME: Doc
       | _ ->
         failwith (BU.format1 "Unexpected lex_t: %s\n" (Print.sigelt_to_string (mk_sigelt (Sig_bundle(ses, [], lids)))))
     end
@@ -777,7 +777,7 @@ and tc_assume (env:env) (lid:lident) (phi:formula) (quals:list<qualifier>) (r:Ra
     let k, _ = U.type_u() in
     let phi = tc_check_trivial_guard env phi k |> N.normalize [N.Beta; N.Eager_unfolding] env in
     TcUtil.check_uvars r phi;
-    { elt = Sig_assume(lid, phi, quals); sigrng = r; doc = None } // FIXME: Doc
+    { sigel = Sig_assume(lid, phi, quals); sigrng = r; sigdoc = None } // FIXME: Doc
 
 and tc_inductive env ses quals lids =
     let env0 = env in
@@ -798,7 +798,7 @@ and tc_inductive env ses quals lids =
          let b = TcInductive.check_positivity ty env in
          if not b then
            let lid, r =
-             match ty.elt with
+             match ty.sigel with
              | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid, ty.sigrng
              | _                                         -> failwith "Impossible!"
            in
@@ -812,7 +812,7 @@ and tc_inductive env ses quals lids =
     let skip_prims_type (_:unit) :bool =
         let lid =
             let ty = List.hd tcs in
-            match ty.elt with
+            match ty.sigel with
                 | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid
                 | _                                         -> failwith "Impossible"
         in
@@ -831,7 +831,7 @@ and tc_inductive env ses quals lids =
           if is_unopteq then TcInductive.unoptimized_haseq_scheme sig_bndle tcs datas env0 tc_assume
           else TcInductive.optimized_haseq_scheme sig_bndle tcs datas env0 tc_assume
         in
-        { elt = Sig_bundle(tcs@datas, quals, lids); sigrng = Env.get_range env0; doc = None }::ses, data_ops_ses // FIXME: Doc
+        { sigel = Sig_bundle(tcs@datas, quals, lids); sigrng = Env.get_range env0; sigdoc = None }::ses, data_ops_ses // FIXME: Doc
 
 
 (* [tc_decl env se] typechecks [se] in environment [env] and returns *)
@@ -841,7 +841,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
   let env = set_hint_correlator env se in
   TcUtil.check_sigelt_quals env se;
   let r = se.sigrng in
-  match se.elt with
+  match se.sigel with
   | Sig_inductive_typ _
   | Sig_datacon _ ->
     failwith "Impossible bare data-constructor"
@@ -896,15 +896,15 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
       // the rest of the job to [tc_decl].
       let ses, ne, lift_from_pure_opt = cps_and_elaborate env ne in
       let effect_and_lift_ses = match lift_from_pure_opt with
-          | Some lift -> [ { se with elt = Sig_new_effect (ne) } ; lift ]
-          | None -> [ { se with elt = Sig_new_effect (ne) } ]
+          | Some lift -> [ { se with sigel = Sig_new_effect (ne) } ; lift ]
+          | None -> [ { se with sigel = Sig_new_effect (ne) } ]
       in
 
       [], env, ses @ effect_and_lift_ses
 
   | Sig_new_effect(ne) ->
     let ne = tc_eff_decl env ne in
-    let se = { se with elt = Sig_new_effect(ne) } in
+    let se = { se with sigel = Sig_new_effect(ne) } in
     let env = Env.push_sigelt env se in
     (* KM : What's the point of collecting actions sig_let if they are not returned ??*)
     let env, ses = ne.actions |> List.fold_left (fun (env, ses) a ->
@@ -979,7 +979,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
     // Restore the proper lax flag!
     let env = { env with lax = lax } in
     let sub = {sub with lift_wp=Some lift_wp; lift=lift} in
-    let se = { se with elt = Sig_sub_effect(sub) } in
+    let se = { se with sigel = Sig_sub_effect(sub) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
@@ -1005,7 +1005,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
                                   (Print.lid_to_string lid)
                                   (List.length uvs |> BU.string_of_int)
                                   (Print.term_to_string t), r)));
-    let se = { se with elt = Sig_effect_abbrev(lid, uvs, tps, c, tags, flags) } in
+    let se = { se with sigel = Sig_effect_abbrev(lid, uvs, tps, c, tags, flags) } in
     let env = Env.push_sigelt env0 se in
     [se], env, []
 
@@ -1027,7 +1027,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
             let t = N.normalize [N.NoFullNorm; N.Beta] env t in
             uvs, SS.close_univ_vars uvs t
     in
-    let se = { se with elt = Sig_declare_typ(lid, uvs, t, quals) } in
+    let se = { se with sigel = Sig_declare_typ(lid, uvs, t, quals) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
@@ -1042,7 +1042,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
     let e, c, g1 = tc_term env e in
     let e, _, g = check_expected_effect env (Some (U.ml_comp Common.t_unit r)) (e, c.comp()) in
     Rel.force_trivial_guard env (Rel.conj_guard g1 g);
-    let se = { se with elt = Sig_main(e) } in
+    let se = { se with sigel = Sig_main(e) } in
     let env = Env.push_sigelt env se in
     [se], env, []
 
@@ -1125,7 +1125,7 @@ and tc_decl env se: list<sigelt> * Env.env * list<sigelt> =
             | q ->
                 Some q
           ) quals in
-          { se with elt = Sig_let(lbs, lids, quals, attrs) }, lbs
+          { se with sigel = Sig_let(lbs, lids, quals, attrs) }, lbs
       | _ -> failwith "impossible"
     in
 
@@ -1177,7 +1177,7 @@ let for_export hidden se : list<sigelt> * list<lident> =
       | Discriminator l -> hidden |> BU.for_some (lid_equals l)
       | _ -> false
    in
-   match se.elt with
+   match se.sigel with
   | Sig_pragma         _ -> [], hidden
 
   | Sig_inductive_typ _
@@ -1186,14 +1186,14 @@ let for_export hidden se : list<sigelt> * list<lident> =
   | Sig_bundle(ses, quals, _) ->
     if is_abstract quals
     then
-      let for_export_bundle se (out, hidden) = match se.elt with
+      let for_export_bundle se (out, hidden) = match se.sigel with
         | Sig_inductive_typ(l, us, bs, t, _, _, quals) ->
-          let dec = { se with elt = Sig_declare_typ(l, us, U.arrow bs (S.mk_Total t), Assumption::New::quals) } in
+          let dec = { se with sigel = Sig_declare_typ(l, us, U.arrow bs (S.mk_Total t), Assumption::New::quals) } in
           dec::out, hidden
 
         (* logically, each constructor just becomes an uninterpreted function *)
         | Sig_datacon(l, us, t, _, _, _, _) ->
-          let dec = { se with elt = Sig_declare_typ(l, us, t, [Assumption]) } in
+          let dec = { se with sigel = Sig_declare_typ(l, us, t, [Assumption]) } in
           dec::out, l::hidden
 
         | _ ->
@@ -1209,7 +1209,7 @@ let for_export hidden se : list<sigelt> * list<lident> =
 
   | Sig_declare_typ(l, us, t, quals) ->
     if quals |> BU.for_some is_hidden_proj_or_disc //hidden projectors/discriminators become uninterpreted
-    then [{se with elt = Sig_declare_typ(l, us, t, [Assumption]) }], l::hidden
+    then [{se with sigel = Sig_declare_typ(l, us, t, [Assumption]) }], l::hidden
     else if quals |> BU.for_some (function
       | Assumption
       | Projector _
@@ -1231,15 +1231,15 @@ let for_export hidden se : list<sigelt> * list<lident> =
     let lid = fv.fv_name.v in
     if hidden |> BU.for_some (S.fv_eq_lid fv)
     then [], hidden //this projector definition already has a declare_typ
-    else let dec = { elt = Sig_declare_typ(fv.fv_name.v, lb.lbunivs, lb.lbtyp, [Assumption]);
+    else let dec = { sigel = Sig_declare_typ(fv.fv_name.v, lb.lbunivs, lb.lbtyp, [Assumption]);
                      sigrng = Ident.range_of_lid lid;
-                     doc = se.doc } in
+                     sigdoc = se.sigdoc } in
           [dec], lid::hidden
 
   | Sig_let(lbs, l, quals, _) ->
     if is_abstract quals
     then (snd lbs |>  List.map (fun lb ->
-           { se with elt = Sig_declare_typ((right lb.lbname).fv_name.v, lb.lbunivs, lb.lbtyp, Assumption::quals) }),
+           { se with sigel = Sig_declare_typ((right lb.lbname).fv_name.v, lb.lbunivs, lb.lbtyp, Assumption::quals) }),
           hidden)
     else [se], hidden
 
@@ -1326,7 +1326,7 @@ let check_exports env (modul:modul) exports =
         check_term lid univs t;
         Errors.message_prefix.clear_prefix()
     in
-    let rec check_sigelt = fun se -> match se.elt with
+    let rec check_sigelt = fun se -> match se.sigel with
         | Sig_bundle(ses, quals, _) ->
           if not (quals |> List.contains Private)
           then ses |> List.iter check_sigelt
@@ -1387,14 +1387,14 @@ let check_module env m =
   then BU.print1 "%s\n" (Print.modul_to_string m);
   if Options.dump_module m.name.str && Options.debug_at_level m.name.str (Options.Other "Normalize")
   then begin
-    let normalize_toplevel_lets = fun se -> match se.elt with
+    let normalize_toplevel_lets = fun se -> match se.sigel with
         | Sig_let ((b, lbs), ids, qs, attrs) ->
             let n = N.normalize [N.Beta ; N.Eager_unfolding; N.Reify ; N.Inlining ; N.Primops ; N.UnfoldUntil S.Delta_constant ; N.AllowUnboundUniverses ] in
             let update lb =
                 let univnames, e = SS.open_univ_vars lb.lbunivs lb.lbdef in
                 { lb with lbdef = n (Env.push_univ_vars env univnames) e }
             in
-            { se with elt = Sig_let ((b, List.map update lbs), ids, qs, attrs) }
+            { se with sigel = Sig_let ((b, List.map update lbs), ids, qs, attrs) }
         | _ -> se
     in
     let normalized_module = { m with declarations = List.map normalize_toplevel_lets m.declarations } in

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -737,9 +737,9 @@ and tc_lex_t env ses quals lids =
         | _ -> assert false
     end;
     begin match ses with
-      | [{ elt = Sig_inductive_typ(lex_t, [], [], t, _, _, []); sigrng = r } as se ;
-         { elt = Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _); sigrng = r1 } as se1;
-         { elt = Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _); sigrng = r2 } as se2]
+      | [{ elt = Sig_inductive_typ(lex_t, [], [], t, _, _, []); sigrng = r; doc = d };
+         { elt = Sig_datacon(lex_top, [], _t_top, _lex_t_top, 0, [], _); sigrng = r1; doc = d1 };
+         { elt = Sig_datacon(lex_cons, [], _t_cons, _lex_t_cons, 0, [], _); sigrng = r2; doc = d2 }]
          when (lid_equals lex_t Const.lex_t_lid
             && lid_equals lex_top Const.lextop_lid
             && lid_equals lex_cons Const.lexcons_lid) ->
@@ -747,12 +747,14 @@ and tc_lex_t env ses quals lids =
         let u = S.new_univ_name (Some r) in
         let t = mk (Tm_type(U_name u)) None r in
         let t = Subst.close_univ_vars [u] t in
-        let tc = { se with elt = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], []) } in
+        let tc = { elt = Sig_inductive_typ(lex_t, [u], [], t, [], [Const.lextop_lid; Const.lexcons_lid], []);
+                   sigrng = r; doc = d } in
 
         let utop = S.new_univ_name (Some r1) in
         let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r1) Delta_constant None, [U_name utop])) None r1 in
         let lex_top_t = Subst.close_univ_vars [utop] lex_top_t in
-        let dc_lextop = { se1 with elt = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], []) } in
+        let dc_lextop = { elt = Sig_datacon(lex_top, [utop], lex_top_t, Const.lex_t_lid, 0, [], []);
+                          sigrng = r1; doc = d1 } in
 
         let ucons1 = S.new_univ_name (Some r2) in
         let ucons2 = S.new_univ_name (Some r2) in
@@ -763,7 +765,8 @@ and tc_lex_t env ses quals lids =
             let res = mk (Tm_uinst(S.fvar (Ident.set_lid_range Const.lex_t_lid r2) Delta_constant None, [U_max [U_name ucons1; U_name ucons2]])) None r2 in
             U.arrow [(a, Some S.imp_tag); (hd, None); (tl, None)] (S.mk_Total res) in
         let lex_cons_t = Subst.close_univ_vars [ucons1;ucons2]  lex_cons_t in
-        let dc_lexcons = { se2 with elt = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], []) } in
+        let dc_lexcons = { elt = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, Const.lex_t_lid, 0, [], []);
+                           sigrng = r2; doc = d2 } in
         { elt = Sig_bundle([tc; dc_lextop; dc_lexcons], [], lids); sigrng = Env.get_range env; doc = None } // FIXME: Doc
       | _ ->
         failwith (BU.format1 "Unexpected lex_t: %s\n" (Print.sigelt_to_string (mk_sigelt (Sig_bundle(ses, [], lids)))))

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -47,7 +47,7 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
        * sigelt         (* the typed version of s, with universe variables still TBD *)
        * universe       (* universe of the constructed type *)
        * guard_t        (* constraints on implicit variables *)
- = match s.elt with
+ = match s.sigel with
    | Sig_inductive_typ (tc, uvs, tps, k, mutuals, data, quals) -> //the only valid qual is Private
          assert (uvs = []);
  (*open*)let tps, k = SS.open_term tps k in
@@ -66,7 +66,7 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
          let k = SS.close tps k in
          let fv_tc = S.lid_as_fv tc Delta_constant None in
          Env.push_let_binding env (Inr fv_tc) ([], t_tc),
-         { s with elt = Sig_inductive_typ(tc, [], tps, k, mutuals, data, quals) },
+         { s with sigel = Sig_inductive_typ(tc, [], tps, k, mutuals, data, quals) },
          u,
          guard
 
@@ -76,14 +76,14 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
 (* 2. Checking each datacon *)
 let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
   : sigelt -> sigelt * guard_t =
-    fun se -> match se.elt with
+    fun se -> match se.sigel with
     | Sig_datacon(c, _uvs, t, tc_lid, ntps, quals, _mutual_tcs) ->
          assert (_uvs = []);
 
          let (env, tps, u_tc) = //u_tc is the universe of the inductive that c constructs
             let tps_u_opt = BU.find_map tcs (fun (se, u_tc) ->
                 if lid_equals tc_lid (must (U.lid_of_sigelt se))
-                then match se.elt with
+                then match se.sigel with
                      | Sig_inductive_typ(_, _, tps, _, _, _, _) ->
                         let tps = tps |> List.map (fun (x, _) -> (x, Some S.imp_tag)) in
                         let tps = Subst.open_binders tps in
@@ -136,7 +136,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
 
 (*close*)let t = U.arrow ((tps |> List.map (fun (x, _) -> (x, Some (Implicit true))))@arguments) (S.mk_Total result) in
                         //NB: the tps are tagged as Implicit inaccessbile arguments of the data constructor
-         { se with elt = Sig_datacon(c, [], t, tc_lid, ntps, quals, []) },
+         { se with sigel = Sig_datacon(c, [], t, tc_lid, ntps, quals, []) },
          g
 
    | _ -> failwith "impossible"
@@ -158,10 +158,10 @@ let generalize_and_inst_within (env:env_t) (g:guard_t) (tcs:list<(sigelt * unive
         //and each data constructor type dt_i
         //and generalize their universes together
         let binders = tcs |> List.map (fun (se, _) ->
-            match se.elt with
+            match se.sigel with
             | Sig_inductive_typ(_, _, tps, k, _, _, _) -> S.null_binder (U.arrow tps <| mk_Total k)
             | _ -> failwith "Impossible")  in
-        let binders' = datas |> List.map (fun se -> match se.elt with
+        let binders' = datas |> List.map (fun se -> match se.sigel with
             | Sig_datacon(_, _, t, _, _, _, _) -> S.null_binder t
             | _ -> failwith "Impossible") in
         let t = U.arrow (binders@binders') (S.mk_Total Common.t_unit) in
@@ -179,7 +179,7 @@ let generalize_and_inst_within (env:env_t) (g:guard_t) (tcs:list<(sigelt * unive
         let uvs, t = SS.open_univ_vars uvs t in
         let args, _ = U.arrow_formals t in
         let tc_types, data_types = BU.first_N (List.length binders) args in
-        let tcs = List.map2 (fun (x, _) (se, _) -> match se.elt with
+        let tcs = List.map2 (fun (x, _) (se, _) -> match se.sigel with
             | Sig_inductive_typ(tc, _, tps, _, mutuals, datas, quals) ->
               let ty = SS.close_univ_vars uvs x.sort in
               let tps, t = match (SS.compress ty).n with
@@ -192,7 +192,7 @@ let generalize_and_inst_within (env:env_t) (g:guard_t) (tcs:list<(sigelt * unive
                   tps, t
                 | _ -> [], ty
               in
-              { se with elt = Sig_inductive_typ(tc, uvs, tps, t, mutuals, datas, quals) }
+              { se with sigel = Sig_inductive_typ(tc, uvs, tps, t, mutuals, datas, quals) }
             | _ -> failwith "Impossible")
             tc_types tcs
         in
@@ -202,12 +202,12 @@ let generalize_and_inst_within (env:env_t) (g:guard_t) (tcs:list<(sigelt * unive
             | [] -> datas
             | _ ->
              let uvs_universes = uvs |> List.map U_name in
-             let tc_insts = tcs |> List.map (function { elt = Sig_inductive_typ(tc, _, _, _, _, _, _) } -> (tc, uvs_universes) | _ -> failwith "Impossible") in
+             let tc_insts = tcs |> List.map (function { sigel = Sig_inductive_typ(tc, _, _, _, _, _, _) } -> (tc, uvs_universes) | _ -> failwith "Impossible") in
              List.map2 (fun (t, _) d ->
-                match d.elt with
+                match d.sigel with
                     | Sig_datacon(l, _, _, tc, ntps, quals, mutuals) ->
                         let ty = InstFV.instantiate tc_insts t.sort |> SS.close_univ_vars uvs in
-                        { d with elt = Sig_datacon(l, uvs, ty, tc, ntps, quals, mutuals) }
+                        { d with sigel = Sig_datacon(l, uvs, ty, tc, ntps, quals, mutuals) }
                     | _ -> failwith "Impossible")
              data_types datas
         in
@@ -430,7 +430,7 @@ let check_positivity (ty:sigelt) (env:env_t) :bool =
   
   //ty_bs are the parameters of ty, it does not include the indexes (also indexes are not parameters of data constructor types, inductive type parameters are)
   let ty_lid, ty_us, ty_bs =
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (lid, us, bs, _, _, _, _) -> lid, us, bs
     | _                                           -> failwith "Impossible!"
   in
@@ -449,7 +449,7 @@ let check_positivity (ty:sigelt) (env:env_t) :bool =
   List.for_all (fun d -> ty_positive_in_datacon ty_lid d ty_bs (List.map (fun s -> U_name s) ty_us) unfolded_inductives env) (snd (datacons_of_typ env ty_lid))
 
 let datacon_typ (data:sigelt) :term =
-  match data.elt with
+  match data.sigel with
   | Sig_datacon (_, _, t, _, _, _, _) -> t
   | _                                 -> failwith "Impossible!"
 
@@ -493,7 +493,7 @@ let optimized_haseq_soundness_for_data (ty_lid:lident) (data:sigelt) (usubst:lis
     //term is the soundness condition derived from all the data constructors of this type
 let optimized_haseq_ty (all_datas_in_the_bundle:sigelts) (usubst:list<subst_elt>) (us:list<univ_name>) acc ty =
   let lid, bs, t, d_lids =
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (lid, _, bs, t, _, d_lids, _) -> lid, bs, t, d_lids
     | _                                               -> failwith "Impossible!"
   in
@@ -559,7 +559,7 @@ let optimized_haseq_ty (all_datas_in_the_bundle:sigelts) (usubst:list<subst_elt>
   //now generate the soundness condition by iterating over the data constructors
   //get the data constructors for this type
   let t_datas = List.filter (fun s ->
-    match s.elt with
+    match s.sigel with
     | Sig_datacon (_, _, _, t_lid, _, _, _) -> t_lid = lid
     | _                                     -> failwith "Impossible"
   ) all_datas_in_the_bundle in
@@ -576,7 +576,7 @@ let optimized_haseq_ty (all_datas_in_the_bundle:sigelts) (usubst:list<subst_elt>
 let optimized_haseq_scheme (sig_bndle:sigelt) (tcs:list<sigelt>) (datas:list<sigelt>) (env0:env_t) (tc_assume:(env_t -> lident -> formula -> list<qualifier> -> Range.range -> sigelt)) :list<sigelt> =
   let us =
     let ty = List.hd tcs in
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (_, us, _, _, _, _, _) -> us
     | _                                        -> failwith "Impossible!"
   in
@@ -665,7 +665,7 @@ let unoptimized_haseq_data (usubst:list<subst_elt>) (bs:binders) (haseq_ind:term
 //the accumulator is the formula that we are building, for each type constructor, we add a conjunct to it
 let unoptimized_haseq_ty (all_datas_in_the_bundle:list<sigelt>) (mutuals:list<lident>) (usubst:list<subst_elt>) (us:list<univ_name>) (acc:term) (ty:sigelt) =
   let lid, bs, t, d_lids =
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (lid, _, bs, t, _, d_lids, _) -> lid, bs, t, d_lids
     | _                                               -> failwith "Impossible!"
   in
@@ -696,7 +696,7 @@ let unoptimized_haseq_ty (all_datas_in_the_bundle:list<sigelt>) (mutuals:list<li
 
   //filter out data constructors for this type constructor
   let t_datas = List.filter (fun s ->
-    match s.elt with
+    match s.sigel with
     | Sig_datacon (_, _, _, t_lid, _, _, _) -> t_lid = lid
     | _                                     -> failwith "Impossible"
   ) all_datas_in_the_bundle in
@@ -723,7 +723,7 @@ let unoptimized_haseq_ty (all_datas_in_the_bundle:list<sigelt>) (mutuals:list<li
 let unoptimized_haseq_scheme (sig_bndle:sigelt) (tcs:list<sigelt>) (datas:list<sigelt>) (env0:env_t) (tc_assume:(env_t -> lident -> formula -> list<qualifier> -> Range.range -> sigelt)) :list<sigelt> =
   //TODO: perhaps make it a map ?
   let mutuals = List.map (fun ty ->
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid
     | _                                         -> failwith "Impossible!") tcs
   in
@@ -731,7 +731,7 @@ let unoptimized_haseq_scheme (sig_bndle:sigelt) (tcs:list<sigelt>) (datas:list<s
 
   let lid, us =
     let ty = List.hd tcs in
-    match ty.elt with
+    match ty.sigel with
     | Sig_inductive_typ (lid, us, _, _, _, _, _) -> lid, us
     | _                                        -> failwith "Impossible!"
   in
@@ -814,8 +814,8 @@ let check_inductive_well_typedness (env:env_t) (ses:list<sigelt>) (quals:list<qu
                 | C1 : (ua, ub, uw) => a:Type(ua) -> y:Type(ub) -> T<ua,ub,uw> a y
                 | C2 : (ua, ub, uw) => a:Type(ua) -> z:Type(ub) -> w:Type(uw) -> T<ua,ub,uw> a z
     *)
-  let tys, datas = ses |> List.partition (function { elt = Sig_inductive_typ _ } -> true | _ -> false) in
-  if datas |> BU.for_some (function { elt = Sig_datacon _ } -> false | _ -> true)
+  let tys, datas = ses |> List.partition (function { sigel = Sig_inductive_typ _ } -> true | _ -> false) in
+  if datas |> BU.for_some (function { sigel = Sig_datacon _ } -> false | _ -> true)
   then raise (Error("Mutually defined type contains a non-inductive element", Env.get_range env));
   let env0 = env in
 
@@ -838,5 +838,5 @@ let check_inductive_well_typedness (env:env_t) (ses:list<sigelt>) (quals:list<qu
   (* Generalize their universes *)
   let tcs, datas = generalize_and_inst_within env0 g tcs datas in
 
-  let sig_bndle = { elt = Sig_bundle(tcs@datas, quals, lids); sigrng = Env.get_range env0; doc = None } in // FIXME: Doc
+  let sig_bndle = { sigel = Sig_bundle(tcs@datas, quals, lids); sigrng = Env.get_range env0; sigdoc = None } in // FIXME: Doc
   sig_bndle, tcs, datas

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -1363,7 +1363,7 @@ let mk_toplevel_definition (env: env_t) lident (def: term): sigelt * term =
      lbeff = Const.effect_Tot_lid; //this will be recomputed correctly
   }] in
   // [Inline] triggers a "Impossible: locally nameless" error
-  let sig_ctx = Sig_let (lb, Range.dummyRange, [ lident ], [ Unfold_for_unification_and_vcgen ], []) in
+  let sig_ctx = mk_sigelt (Sig_let (lb, [ lident ], [ Unfold_for_unification_and_vcgen ], [])) in
   sig_ctx, mk (Tm_fvar fv) None Range.dummyRange
 
 
@@ -1448,8 +1448,8 @@ let check_sigelt_quals (env:FStar.TypeChecker.Env.env) se =
       then err "duplicate qualifiers";
       if not (quals |> List.for_all (quals_combo_ok quals))
       then err "ill-formed combination";
-      match se with
-      | Sig_let((is_rec, _), _, _, _, _) -> //let rec
+      match se.elt with
+      | Sig_let((is_rec, _), _, _, _) -> //let rec
         if is_rec && quals |> List.contains Unfold_for_unification_and_vcgen
         then err "recursive definitions cannot be marked inline";
         if quals |> BU.for_some (fun x -> assumption x || has_eq x)
@@ -1560,7 +1560,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                 let bool_typ = (S.mk_Total (S.fv_to_tm (S.lid_as_fv C.bool_lid Delta_constant None))) in
                 SS.close_univ_vars uvs <| U.arrow binders bool_typ
             in
-            let decl = Sig_declare_typ(discriminator_name, uvs, t, quals, range_of_lid discriminator_name) in
+            let decl = { elt = Sig_declare_typ(discriminator_name, uvs, t, quals); sigrng = range_of_lid discriminator_name; doc = None }  in // FIXME: Doc
             if Env.debug env (Options.Other "LogTypes")
             then BU.print1 "Declaration of a discriminator %s\n"  (Print.sigelt_to_string decl);
 
@@ -1597,7 +1597,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                     lbeff=C.effect_Tot_lid;
                     lbdef=SS.close_univ_vars uvs imp
                 } in
-                let impl = Sig_let((false, [lb]), p, [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []) in
+                let impl = { elt = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; doc = None } in // FIXME: Doc
                 if Env.debug env (Options.Other "LogTypes")
                 then BU.print1 "Implementation of a discriminator %s\n"  (Print.sigelt_to_string impl);
                 (* TODO : Are there some cases where we don't want one of these ? *)
@@ -1642,7 +1642,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   | _ -> false)
               in
               quals (S.Projector(lid, x.ppname)::iquals) in
-          let decl = Sig_declare_typ(field_name, uvs, t, quals, range_of_lid field_name) in
+          let decl = { elt = Sig_declare_typ(field_name, uvs, t, quals); sigrng = range_of_lid field_name; doc = None } in // FIXME: Doc
           if Env.debug env (Options.Other "LogTypes")
           then BU.print1 "Declaration of a projector %s\n"  (Print.sigelt_to_string decl);
           if only_decl
@@ -1673,15 +1673,15 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   lbeff=C.effect_Tot_lid;
                   lbdef=SS.close_univ_vars uvs imp
               } in
-              let impl = Sig_let((false, [lb]), p, [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []) in
+              let impl = { elt = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; doc = None } in // FIXME: doc
               if Env.debug env (Options.Other "LogTypes")
               then BU.print1 "Implementation of a projector %s\n"  (Print.sigelt_to_string impl);
               if no_decl then [impl] else [decl;impl]) |> List.flatten
     in
     discriminator_ses @ projectors_ses
 
-let mk_data_operations iquals env tcs se = match se with
-  | Sig_datacon(constr_lid, uvs, t, typ_lid, n_typars, quals, _, r) when not (lid_equals constr_lid C.lexcons_lid) ->
+let mk_data_operations iquals env tcs se = match se.elt with
+  | Sig_datacon(constr_lid, uvs, t, typ_lid, n_typars, quals, _) when not (lid_equals constr_lid C.lexcons_lid) ->
 
     let univ_opening, uvs = SS.univ_var_opening uvs in
     let t = SS.subst univ_opening t in
@@ -1690,8 +1690,8 @@ let mk_data_operations iquals env tcs se = match se with
     let inductive_tps, typ0, should_refine =
         let tps_opt = BU.find_map tcs (fun se ->
             if lid_equals typ_lid (must (U.lid_of_sigelt se))
-            then match se with
-                  | Sig_inductive_typ(_, uvs', tps, typ0, _, constrs, _, _) ->
+            then match se.elt with
+                  | Sig_inductive_typ(_, uvs', tps, typ0, _, constrs, _) ->
                       assert (List.length uvs = List.length uvs') ;
                       Some (tps, typ0, List.length constrs > 1)
                   | _ -> failwith "Impossible"
@@ -1702,7 +1702,7 @@ let mk_data_operations iquals env tcs se = match se with
             | None ->
                 if lid_equals typ_lid Const.exn_lid
                 then [], U.ktype0, true
-                else raise (Error("Unexpected data constructor", r))
+                else raise (Error("Unexpected data constructor", se.sigrng))
     in
 
     let inductive_tps = SS.subst_binders univ_opening inductive_tps in

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -1448,7 +1448,7 @@ let check_sigelt_quals (env:FStar.TypeChecker.Env.env) se =
       then err "duplicate qualifiers";
       if not (quals |> List.for_all (quals_combo_ok quals))
       then err "ill-formed combination";
-      match se.elt with
+      match se.sigel with
       | Sig_let((is_rec, _), _, _, _) -> //let rec
         if is_rec && quals |> List.contains Unfold_for_unification_and_vcgen
         then err "recursive definitions cannot be marked inline";
@@ -1560,7 +1560,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                 let bool_typ = (S.mk_Total (S.fv_to_tm (S.lid_as_fv C.bool_lid Delta_constant None))) in
                 SS.close_univ_vars uvs <| U.arrow binders bool_typ
             in
-            let decl = { elt = Sig_declare_typ(discriminator_name, uvs, t, quals); sigrng = range_of_lid discriminator_name; doc = None }  in // FIXME: Doc
+            let decl = { sigel = Sig_declare_typ(discriminator_name, uvs, t, quals); sigrng = range_of_lid discriminator_name; sigdoc = None }  in // FIXME: Doc
             if Env.debug env (Options.Other "LogTypes")
             then BU.print1 "Declaration of a discriminator %s\n"  (Print.sigelt_to_string decl);
 
@@ -1597,7 +1597,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                     lbeff=C.effect_Tot_lid;
                     lbdef=SS.close_univ_vars uvs imp
                 } in
-                let impl = { elt = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; doc = None } in // FIXME: Doc
+                let impl = { sigel = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; sigdoc = None } in // FIXME: Doc
                 if Env.debug env (Options.Other "LogTypes")
                 then BU.print1 "Implementation of a discriminator %s\n"  (Print.sigelt_to_string impl);
                 (* TODO : Are there some cases where we don't want one of these ? *)
@@ -1642,7 +1642,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   | _ -> false)
               in
               quals (S.Projector(lid, x.ppname)::iquals) in
-          let decl = { elt = Sig_declare_typ(field_name, uvs, t, quals); sigrng = range_of_lid field_name; doc = None } in // FIXME: Doc
+          let decl = { sigel = Sig_declare_typ(field_name, uvs, t, quals); sigrng = range_of_lid field_name; sigdoc = None } in // FIXME: Doc
           if Env.debug env (Options.Other "LogTypes")
           then BU.print1 "Declaration of a projector %s\n"  (Print.sigelt_to_string decl);
           if only_decl
@@ -1673,14 +1673,14 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   lbeff=C.effect_Tot_lid;
                   lbdef=SS.close_univ_vars uvs imp
               } in
-              let impl = { elt = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; doc = None } in // FIXME: doc
+              let impl = { sigel = Sig_let((false, [lb]), [lb.lbname |> right |> (fun fv -> fv.fv_name.v)], quals, []); sigrng = p; sigdoc = None } in // FIXME: doc
               if Env.debug env (Options.Other "LogTypes")
               then BU.print1 "Implementation of a projector %s\n"  (Print.sigelt_to_string impl);
               if no_decl then [impl] else [decl;impl]) |> List.flatten
     in
     discriminator_ses @ projectors_ses
 
-let mk_data_operations iquals env tcs se = match se.elt with
+let mk_data_operations iquals env tcs se = match se.sigel with
   | Sig_datacon(constr_lid, uvs, t, typ_lid, n_typars, quals, _) when not (lid_equals constr_lid C.lexcons_lid) ->
 
     let univ_opening, uvs = SS.univ_var_opening uvs in
@@ -1690,7 +1690,7 @@ let mk_data_operations iquals env tcs se = match se.elt with
     let inductive_tps, typ0, should_refine =
         let tps_opt = BU.find_map tcs (fun se ->
             if lid_equals typ_lid (must (U.lid_of_sigelt se))
-            then match se.elt with
+            then match se.sigel with
                   | Sig_inductive_typ(_, uvs', tps, typ0, _, constrs, _) ->
                       assert (List.length uvs = List.length uvs') ;
                       Some (tps, typ0, List.length constrs > 1)


### PR DESCRIPTION
Part of #911.  This adds a `doc` field on sigelts (that's the easy part), which requires refactoring to change sigelt into a record (that's the painful part).

Assuming this is the right way to go, can we expose that docstring in the interactive protocol?