### PR TITLE
Refactor FStar.Errors: route all messages through a single interface

### DIFF
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -13,20 +13,106 @@ exception Empty_frag
 
 module BU = FStar.Util
 
-let diag r msg =
-  if Options.debug_any()
-  then BU.print_string (format2 "%s : (Diagnostic) %s\n" (Range.string_of_range r) msg)
+type issue_level =
+| ENotImplemented
+| EInfo
+| EWarning
+| EError
 
-let warn r msg =
-  BU.print2_error "%s: (Warning) %s\n" (Range.string_of_range r) msg
+type issue = {
+    issue_message: string;
+    issue_level: issue_level;
+    issue_range: option<Range.range>
+}
 
-let num_errs = BU.mk_ref 0
-let verification_errs : ref<list<(Range.range * string)>> = BU.mk_ref []
+type error_handler = {
+    eh_add_one: issue -> unit;
+    eh_count_errors: unit -> int;
+    eh_report: unit -> list<issue>;
+    eh_clear: unit -> unit
+}
+
+let format_issue issue =
+    let level_header =
+        match issue.issue_level with
+        | EInfo -> "(Info) "
+        | EWarning -> "(Warning) "
+        | EError -> "(Error) "
+        | ENotImplemented -> "Feature not yet implemented: " in
+    let range_str, see_also_str =
+        match issue.issue_range with
+        | None -> "", ""
+        | Some r ->
+          (BU.format1 "%s: " (Range.string_of_use_range r),
+           (if r.use_range = r.def_range then ""
+            else BU.format1 " (see also %s)" (Range.string_of_range r))) in
+    BU.format4 "%s%s%s%s\n" range_str level_header issue.issue_message see_also_str
+
+let print_issue issue =
+    BU.print_error (format_issue issue)
+
+let compare_issues i1 i2 =
+    match i1.issue_range, i2.issue_range with
+    | None, None -> 0
+    | None, Some _ -> -1
+    | Some _, None -> 1
+    | Some r1, Some r2 -> Range.compare_use_range r1 r2
+
+let default_handler =
+    let errs : ref<list<issue>> = BU.mk_ref [] in
+    let add_one (e: issue) =
+        match e.issue_level with
+        | EError -> errs := e :: !errs
+        | _ -> print_issue e in
+    let count_errors () =
+        List.length !errs in
+    let report () =
+        let sorted = List.sortWith compare_issues !errs in
+        List.iter print_issue sorted;
+        sorted in
+    let clear () =
+        errs := [] in
+    { eh_add_one = add_one;
+      eh_count_errors = count_errors;
+      eh_report = report;
+      eh_clear = clear }
+
+let current_handler =
+    BU.mk_ref default_handler
+
+let mk_issue level range msg =
+    { issue_level = level; issue_range = range; issue_message = msg }
+
+let get_err_count () = (!current_handler).eh_count_errors ()
+
+let add_one issue =
+    atomically (fun () -> (!current_handler).eh_add_one issue)
+
+let add_many issues =
+    atomically (fun () -> List.iter (!current_handler).eh_add_one issues)
+
+let report_all () =
+    (!current_handler).eh_report ()
+
+let clear () =
+    (!current_handler).eh_clear ()
+
+let set_handler handler =
+    let issues = report_all () in
+    clear (); current_handler := handler; add_many issues
+
+let diag r msg = if Options.debug_any() then add_one (mk_issue EInfo (Some r) msg)
+
+let warn r msg = add_one (mk_issue EWarning (Some r) msg)
+
+let err r msg = add_one (mk_issue EError (Some r) msg)
+
 type error_message_prefix = {
     set_prefix: string -> unit;
     append_prefix: string -> string;
     clear_prefix: unit -> unit;
 }
+
 let message_prefix =
     let pfx = BU.mk_ref None in
     let set_prefix s = pfx := Some s in
@@ -39,45 +125,24 @@ let message_prefix =
      append_prefix=append_prefix}
 
 let add_errors errs =
-    let errs =
-        errs |> List.map (fun (msg, r) -> r, message_prefix.append_prefix msg) in
-    let n_errs = List.length errs in
-    atomically (fun () -> verification_errs := errs @ (!verification_errs);
-                          num_errs := !num_errs + n_errs)
+    atomically (fun () -> List.iter (fun (msg, r) -> err r (message_prefix.append_prefix msg)) errs)
 
-let mk_error msg r =
-    if r.use_range <> r.def_range
-    then BU.format3 "%s: (Error) %s (see %s)\n" (Range.string_of_use_range r) msg (Range.string_of_range r)
-    else BU.format2 "%s: (Error) %s\n" (Range.string_of_range r) msg
-
-let report_all () =
-    let all_errs = atomically (fun () -> let x = !verification_errs in verification_errs := []; x) in
-    let all_errs = List.sortWith (fun (r1, _) (r2, _) -> Range.compare_use_range r1 r2) all_errs in
-    all_errs |> List.iter (fun (r, msg) -> BU.print_error (mk_error msg r));
-    List.length all_errs
-
-let handle_err warning e =
-  match e with
+let issue_of_exn = function
     | Error(msg, r) ->
-        let msg = message_prefix.append_prefix msg in
-        BU.print3_error "%s : %s %s\n" (Range.string_of_range r) (if warning then "(Warning)" else "(Error)") msg
+      Some (mk_issue EError (Some r) (message_prefix.append_prefix msg))
     | NYI msg ->
-        let msg = message_prefix.append_prefix msg in
-        BU.print1_error "Feature not yet implemented: %s" msg
+      Some (mk_issue ENotImplemented None (message_prefix.append_prefix msg))
     | Err msg ->
-        let msg = message_prefix.append_prefix msg in
-        BU.print1_error "Error: %s" msg
-    | _ -> raise e
+      Some (mk_issue EError None (message_prefix.append_prefix msg))
+    | _ -> None
+
+let err_exn exn =
+    match issue_of_exn exn with
+    | Some issue -> add_one issue
+    | None -> raise exn
 
 let handleable = function
   | Error _
   | NYI _
   | Err _ -> true
   | _ -> false
-
-let report r msg =
-  incr num_errs;
-  let msg = message_prefix.append_prefix msg in
-  BU.print_error (mk_error msg r)
-
-let get_err_count () = !num_errs

--- a/src/basic/util.fs
+++ b/src/basic/util.fs
@@ -300,12 +300,49 @@ let imap_copy (m:imap<'value>) =
     imap_fold m (fun k v () -> imap_add n k v) ();
     n
 
+let format (fmt:string) (args:list<string>) =
+    let frags = fmt.Split([|"%s"|], System.StringSplitOptions.None) in
+    if frags.Length <> List.length args + 1
+    then failwith ("Not enough arguments to format string " ^fmt^ " : expected " ^ (string frags.Length) ^ " got [" ^ (String.concat ", " args) ^ "] frags are [" ^ (String.concat ", " (List.ofArray frags)) ^ "]")
+    else let args = Array.ofList (args@[""]) in
+         Array.fold2 (fun out frag arg -> out ^ frag ^ arg) "" frags args
+
+let format1 f a = format f [a]
+let format2 f a b = format f [a;b]
+let format3 f a b c = format f [a;b;c]
+let format4 f a b c d = format f [a;b;c;d]
+let format5 f a b c d e = format f [a;b;c;d;e]
+let format6 f a b c d e g = format f [a;b;c;d;e;g]
+
+let stdout_isatty () = None:option<bool>
+
+// These functions have no effect in F#
+let colorize (s:string) (colors:(string * string)) = s
+let colorize_bold (s:string) = s
+let colorize_red (s:string) = s
+let colorize_cyan (s:string) = s
+// END
+
 let pr  = Printf.printf
 let spr = Printf.sprintf
 let fpr = Printf.fprintf
 
-let print_string s = pr "%s" s
-let print_any s = pr "%A" s
+type printer = {
+  printer_prinfo: string -> unit;
+  printer_prwarning: string -> unit;
+  printer_prerror: string -> unit;
+}
+
+let default_printer =
+  { printer_prinfo = fun s -> pr "%s" s;
+    printer_prwarning = fun s -> fpr stderr "%s" (colorize_cyan s);
+    printer_prerror = fun s -> fpr stderr "%s" (colorize_red s); }
+
+let current_printer = ref default_printer
+let set_printer printer = current_printer := printer
+
+let print_string s = (!current_printer).printer_prinfo s
+let print_any s = print_string (spr "%A" s)
 let strcat s1 s2 = s1 ^ s2
 let concat_l sep (l:list<string>) = String.concat sep l
 
@@ -358,21 +395,6 @@ let split (s1:string) (s2:string) = Array.toList (s1.Split([|s2|], StringSplitOp
 let iof = int_of_float
 let foi = float_of_int
 
-let format (fmt:string) (args:list<string>) =
-    let frags = fmt.Split([|"%s"|], System.StringSplitOptions.None) in
-    if frags.Length <> List.length args + 1
-    then failwith ("Not enough arguments to format string " ^fmt^ " : expected " ^ (string frags.Length) ^ " got [" ^ (String.concat ", " args) ^ "] frags are [" ^ (String.concat ", " (List.ofArray frags)) ^ "]")
-    else let args = Array.ofList (args@[""]) in
-         Array.fold2 (fun out frag arg -> out ^ frag ^ arg) "" frags args
-
-let format1 f a = format f [a]
-let format2 f a b = format f [a;b]
-let format3 f a b c = format f [a;b;c]
-let format4 f a b c d = format f [a;b;c;d]
-let format5 f a b c d e = format f [a;b;c;d;e]
-let format6 f a b c d e g = format f [a;b;c;d;e;g]
-
-
 let print1 a b = print_string <| format1 a b
 let print2 a b c = print_string <| format2 a b c
 let print3 a b c d = print_string <| format3 a b c d
@@ -382,21 +404,12 @@ let print6 a b c d e f g = print_string <| format6 a b c d e f g
 
 let print s args = print_string <| format s args
 
-let stdout_isatty () = None:option<bool>
-
-// These functions have no effect in F#
-let colorize (s:string) (colors:(string * string)) = s
-let colorize_bold (s:string) = s
-let colorize_red (s:string) = s
-let colorize_cyan (s:string) = s
-// END
-
-let print_error s = fpr stderr "%s" (colorize_red s)
+let print_error s = (!current_printer).printer_prerror s
 let print1_error a b = print_error <| format1 a b
 let print2_error a b c = print_error <| format2 a b c
 let print3_error a b c d = print_error <| format3 a b c d
 
-let print_warning s = fpr stderr "%s" (colorize_cyan s)
+let print_warning s = (!current_printer).printer_prwarning s
 let print1_warning a b = print_warning <| format1 a b
 let print2_warning a b c = print_warning <| format2 a b c
 let print3_warning a b c d = print_warning <| format3 a b c d

--- a/src/basic/util.fsi
+++ b/src/basic/util.fsi
@@ -130,6 +130,15 @@ val stderr: out_channel
 val stdout: out_channel
 val fprint: out_channel -> string -> list<string> -> unit
 
+type printer = {
+  printer_prinfo: string -> unit;
+  printer_prwarning: string -> unit;
+  printer_prerror: string -> unit;
+}
+
+val default_printer : printer
+val set_printer : printer -> unit
+
 val print_string : string -> unit
 val print_any : 'a -> unit
 val strcat : string -> string -> string

--- a/src/fstar/FStar.Interactive.fs
+++ b/src/fstar/FStar.Interactive.fs
@@ -110,7 +110,7 @@ let check_frag (dsenv, (env:TcEnv.env)) curmod frag =
 
 let report_fail () =
     FStar.Errors.report_all() |> ignore;
-    FStar.Errors.num_errs := 0
+    FStar.Errors.clear ()
 
 (******************************************************************************************)
 (* The interface expected to be provided by a type-checker to run in the interactive loop *)

--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -178,9 +178,9 @@ let lowercase_join_longident (l: lident) (last: bool) =
 let check_module_declaration_against_filename (lid: lident) (filename: string): unit =
   let k' = lowercase_join_longident lid true in
   if String.lowercase (must (check_and_strip_suffix (basename filename))) <> k' then
-    Util.fprint stderr "Warning: the module declaration \"module %s\" \
+    Util.print2_warning "Warning: the module declaration \"module %s\" \
       found in file %s does not match its filename. Dependencies will be \
-      incorrect.\n" [string_of_lid lid true; filename]
+      incorrect.\n" (string_of_lid lid true) filename
 
 exception Exit
 
@@ -211,8 +211,8 @@ let collect_one
           if let_open then
             raise (Err ("let-open only supported for modules, not namespaces"))
           else
-            Util.fprint stderr "Warning: no modules in namespace %s and no file with \
-              that name either\n" [string_of_lid lid true]
+            Util.print1_warning "Warning: no modules in namespace %s and no file with \
+              that name either\n" (string_of_lid lid true)
         end
     end
   in
@@ -236,7 +236,7 @@ let collect_one
             List.iter (fun f -> add_dep (lowercase_module_name f)) (list_of_pair pair)
         | None ->
             if List.length lid.ns > 0 && Options.debug_any() then
-              Util.fprint stderr "Warning: unbound module reference %s\n" [string_of_lid lid false]
+              Util.print1_warning "Warning: unbound module reference %s\n" (string_of_lid lid false)
         end
       in
       // Option.Some x
@@ -267,7 +267,7 @@ let collect_one
     | [ modul ] ->
         collect_module modul
     | modules ->
-        Util.fprint stderr "Warning: file %s does not respect the one module per file convention\n" [ filename ];
+        Util.print1_warning "Warning: file %s does not respect the one module per file convention\n" filename;
         List.iter collect_module modules
 
   and collect_module = function

--- a/src/smtencoding/FStar.SMTEncoding.ErrorReporting.fs
+++ b/src/smtencoding/FStar.SMTEncoding.ErrorReporting.fs
@@ -271,7 +271,7 @@ let detail_errors env
     let print_result ((_, msg, r), success) =
         if success
         then BU.print1_error "OK: proof obligation at %s was proven\n" (Range.string_of_range r)
-        else FStar.Errors.report r msg
+        else FStar.Errors.err r msg
     in
 
     let elim labs = //assumes that all the labs are true, effectively removing them from the query

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -2479,7 +2479,7 @@ let try_subtype' env t1 t2 smt_ok =
 let try_subtype env t1 t2 = try_subtype' env t1 t2 true
 
 let subtype_fail env e t1 t2 =
-    Errors.report (Env.get_range env) (Err.basic_type_error env (Some e) t2 t1)
+    Errors.err (Env.get_range env) (Err.basic_type_error env (Some e) t2 t1)
 
 
 let sub_comp env c1 c2 =
@@ -2653,10 +2653,10 @@ let force_trivial_guard env g =
     match g.implicits with
         | [] -> ignore <| discharge_guard env g
         | (reason,_,_,e,t,r)::_ ->
-           Errors.report r (BU.format3 "Failed to resolve implicit argument of type '%s' introduced in %s because %s"
-                                       (Print.term_to_string t)
-                                       (Print.term_to_string e)
-                                       reason)
+           Errors.err r (BU.format3 "Failed to resolve implicit argument of type '%s' introduced in %s because %s"
+                                    (Print.term_to_string t)
+                                    (Print.term_to_string e)
+                                    reason)
 
 let universe_inequality (u1:universe) (u2:universe) : guard_t =
     //Printf.printf "Universe inequality %s <= %s\n" (Print.univ_to_string u1) (Print.univ_to_string u2);

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -837,7 +837,7 @@ and tc_inductive env ses quals lids =
              | Sig_inductive_typ (lid, _, _, _, _, _, _) -> lid, ty.sigrng
              | _                                         -> failwith "Impossible!"
            in
-           Errors.report r ("Inductive type " ^ lid.str ^ " does not satisfy the positivity condition")
+           Errors.err r ("Inductive type " ^ lid.str ^ " does not satisfy the positivity condition")
          else ()
        ) tcs in
        ());

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -44,8 +44,8 @@ module C = FStar.Syntax.Const
 
 //Reporting errors
 let report env errs =
-    Errors.report (Env.get_range env)
-                  (Err.failed_to_prove_specification errs)
+    Errors.err (Env.get_range env)
+               (Err.failed_to_prove_specification errs)
 
 (************************************************************************)
 (* Unification variables *)
@@ -91,7 +91,7 @@ let check_uvars r t =
     Options.push();
     Options.set_option "hide_uvar_nums" (Options.Bool false);
     Options.set_option "print_implicits" (Options.Bool true);
-    Errors.report r
+    Errors.err r
       (BU.format2 "Unconstrained unification variables %s in type signature %s; \
        please add an annotation" us (Print.term_to_string t));
     Options.pop()


### PR DESCRIPTION
The current behavior was a mix of immediate printing (using `report*`) and collecting for future printing (using `add_errors`).  Warnings and diagnostics were always printed straight away, though.

The new design stores all errors silently until `report_all` is called, but still prints warnings and diagnostics immediately.  The hope is to

* Make printing more consistent.  This change also opens the door for a richer error type, instead of calling formatting functions from Tc.Err.
* Simplify the logic (all errors, warnings and diagnostics flow through one a single interface instead of being immediately printed)
* Make it possible to install a different printer (that's the `error_handler` field).

The last one is crucial if we want to move to a better interactive protocol at some point, because then we'll want to print all errors in a structured format.  The first one is important for that goal too because having a richer error type would allow us to e.g. clearly tell which parts of an error message are code, and which are data (think of unification errors, for example; the UI could highlight code in those, for example, if it knew where it was).

This is my first patch to a core-ish part of F*, so thorough review and criticism is of course very welcome :)