### PR TITLE
Forbid references to current module when desugaring (fixes #451)

### DIFF
--- a/src/tosyntax/FStar.ToSyntax.Env.fsi
+++ b/src/tosyntax/FStar.ToSyntax.Env.fsi
@@ -127,6 +127,7 @@ val is_effect_name: env -> lident -> bool
 val find_all_datacons: env -> lident -> option<list<lident>>
 val lookup_letbinding_quals: env -> lident -> list<qualifier>
 val resolve_module_name: env:env -> lid:lident -> honor_ns:bool -> option<lident>
+val fail_if_qualified_by_curmodule: env -> lident -> unit
 val resolve_to_fully_qualified_name : env:env -> l:lident -> option<lident>
 
 val push_bv: env -> ident -> env * bv


### PR DESCRIPTION
This pull request allows the desugaring phase to catch unwanted references to the current module. It may be useful in at least two situations: when in interactive mode; or when using `--explicit_deps`
