### PR TITLE
Propagate parameter names into the types of top-level let bindings

### DIFF
--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -1112,6 +1112,35 @@ and tc_decl env se: list<sigelt> * list<sigelt> =
                               (Print.quals_to_string q'), r))
     in
 
+    let rename_parameters lb =
+      let rename_in_typ def typ =
+        let typ = Subst.compress typ in
+        let def_bs = match (Subst.compress def).n with
+                     | Tm_abs (binders, _, _) -> binders
+                     | _ -> [] in
+        match typ with
+        | { n = Tm_arrow(val_bs, c); pos = r } -> begin
+          let has_auto_name bv =
+            BU.starts_with bv.ppname.idText Ident.reserved_prefix in
+          let rec rename_binders def_bs val_bs =
+            match def_bs, val_bs with
+            | [], _ | _, [] -> val_bs
+            | (body_bv, _) :: bt, (val_bv, aqual) :: vt ->
+              (match has_auto_name body_bv, has_auto_name val_bv with
+               | true, _ -> (val_bv, aqual)
+               | false, true -> ({ val_bv with
+                                   ppname = { val_bv.ppname with
+                                              idText = body_bv.ppname.idText } }, aqual)
+               | false, false ->
+                 if body_bv.ppname.idText <> val_bv.ppname.idText then
+                   Errors.warn body_bv.ppname.idRange
+                     (BU.format2 "Parameter name %s doesn't match name %s used in val declaration"
+                                  body_bv.ppname.idText val_bv.ppname.idText);
+                 (val_bv, aqual)) :: rename_binders bt vt in
+          Syntax.mk (Tm_arrow(rename_binders def_bs val_bs, c)) None r end
+        | _ -> typ in
+      { lb with lbtyp = rename_in_typ lb.lbdef lb.lbtyp } in
+
     (* 1. (a) Annotate each lb in lbs with a type from the corresponding val decl, if there is one
           (b) Generalize the type of lb only if none of the lbs have val decls nor explicit universes
       *)
@@ -1156,6 +1185,9 @@ and tc_decl env se: list<sigelt> * list<sigelt> =
     (* 3. Type-check the Tm_let and then convert it back to a Sig_let *)
     let se, lbs = match tc_maybe_toplevel_term ({env with top_level=true; generalize=should_generalize}) e with
         | {n=Tm_let(lbs, e)}, _, g when Rel.is_trivial g ->
+          // Propagate binder names into signature
+          let lbs = (fst lbs, (snd lbs) |> List.map rename_parameters) in
+
           //propagate the MaskedEffect tag to the qualifiers
           let quals = match e.n with
               | Tm_meta(_, Meta_desugared Masked_effect) -> HasMaskedEffect::quals

--- a/ulib/FStar.List.Tot.Base.fst
+++ b/ulib/FStar.List.Tot.Base.fst
@@ -153,7 +153,7 @@ let rec concatMap f = function
 ... yn). Requires, at type-checking time, [f] to be a pure total
 function. Named as in: OCaml, Coq. *)
 val fold_left: ('a -> 'b -> Tot 'a) -> 'a -> l:list 'b -> Tot 'a (decreases l)
-let rec fold_left f x y = match y with
+let rec fold_left f x l = match l with
   | [] -> x
   | hd::tl -> fold_left f (f x hd) tl
 


### PR DESCRIPTION
This is useful when the type of a top-level let is given separately.
As an example,

    val substr: string -> int -> int
    let substr str start len = ...

now has signature `str:string -> start:int -> len:int` instead of just `string -> int -> int`.  Inconsistencies between let and val trigger a warning.

Fixes #929.

(I realize this touches a tricky bit of F* for cosmetics/usability reasons, so it's low priority)