### PR TITLE
Tentative desugaring fix for #1043 (badly positioned type error for scrutinee of destructuring let)

### DIFF
--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1064,7 +1064,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term =
                 | None
                 | Some ({v=Pat_wild _}) -> body
                 | Some pat ->
-                  S.mk (Tm_match(S.bv_to_name x, [U.branch (pat, None, body)])) None body.pos in
+                  S.mk (Tm_match(S.bv_to_name x, [U.branch (pat, None, body)])) None top.range in
               mk <| Tm_let((false, [mk_lb (Inl x, x.sort, t1)]), Subst.close [S.mk_binder x] body)
           end in
         if is_mutable


### PR DESCRIPTION
This is trying to fix a badly positioned type error message for scrutinee of destructuring let (see #1043). With this change the examples from #1043 give non-braindead error message that matches what we would get if we wrote the match by hand: the whole match gets blamed. (This is of course not ideal, since the problem is in the scrutinee, not in the whole match, but that seems like a different problem that's not related to desugaring.)

Anyway, I don't know this desugaring code and how ranges work precisely, so someone who does should sign off on this.

