### PR TITLE
Consistently escape asterisk in F* in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,17 +6,17 @@
     * [OPAM package](#opam-package)
     * [Homebrew formula for Mac OS X](#homebrew-formula-for-mac-os-x)
     * [Chocolatey Package on Windows](#chocolatey-package-on-windows)
-    * [Running F* from a docker image](#running-f-from-a-docker-image)
-  * [Building F* from sources](#building-f-from-sources)
-    * [Step 1. Building F* from sources using the F# compiler](#step-1-building-f-from-sources-using-the-f-compiler)
+    * [Running F\* from a docker image](#running-f-from-a-docker-image)
+  * [Building F\* from sources](#building-f-from-sources)
+    * [Step 1. Building F\* from sources using the F# compiler](#step-1-building-f-from-sources-using-the-f-compiler)
       * [On Windows 7/8/10](#on-windows-7810)
       * [On Linux or Mac OS X using Mono](#on-linux-or-mac-os-x-using-mono)
     * [Prerequisite for steps 2 and 3: Working OCaml setup](#prerequisite-for-steps-2-and-3-working-ocaml-setup)
       * [Instructions for Windows](#instructions-for-windows)
       * [Instructions for Linux and Mac OS X](#instructions-for-linux-and-mac-os-x)
       * [Instructions for all OSes](#instructions-for-all-oses)
-    * [Step 2. Extracting the sources of F* itself to OCaml](#step-2-extracting-the-sources-of-f-itself-to-ocaml)
-    * [Step 3. Building F* from the OCaml snapshot](#step-3-building-f-from-the-ocaml-snapshot)
+    * [Step 2. Extracting the sources of F\* itself to OCaml](#step-2-extracting-the-sources-of-f-itself-to-ocaml)
+    * [Step 3. Building F\* from the OCaml snapshot](#step-3-building-f-from-the-ocaml-snapshot)
   * [Runtime dependency: Z3 SMT solver](#runtime-dependency-z3-smt-solver)
 
 
@@ -65,11 +65,11 @@ following commands. (On Windows this requires Cygwin and `make`)
 
         $ make -C examples/micro-benchmarks
 
-3. If you have OCaml installed the following command should print "Hello F*!"
+3. If you have OCaml installed the following command should print "Hello F\*!"
 
         $ make -C examples/hello ocaml
 
-4. If you have F# installed the following command should print "Hello F*!"
+4. If you have F# installed the following command should print "Hello F\*!"
 
         $ make -C examples/hello fs
 
@@ -88,7 +88,7 @@ Z3) using the opam package:
 
         $ opam install fstar
 
-Right now, the opam package is version 0.9.3-beta1. You can easily get the latest development version of F* with some opam magic:
+Right now, the opam package is version 0.9.3-beta1. You can easily get the latest development version of F\* with some opam magic:
 
         $ opam pin add fstar --dev-repo
 
@@ -116,7 +116,7 @@ or
     
 you can find the package description [here](https://chocolatey.org/packages/FStar)
 
-### Running F* from a docker image ###
+### Running F\* from a docker image ###
 
 An alternative to installing binaries is to install a docker image.
 We currently provide the following two on docker hub: `fstarlang/fstar-emacs`
@@ -124,31 +124,31 @@ with emacs support and `fstarlang/fstar` for purists.
 The image is automatically kept up to date through a cloud build.
 
 You only have to install docker and an X server for your platform and you are good to go.
-See [Running F* from a docker image] (https://github.com/FStarLang/FStar/wiki/Running-F%2A-from-a-docker-image) for the details on how to use docker.
+See [Running F\* from a docker image] (https://github.com/FStarLang/FStar/wiki/Running-F%2A-from-a-docker-image) for the details on how to use docker.
 
 
 
-## Building F* from sources ##
+## Building F\* from sources ##
 
 If you have a serious interest in F\* or want to report bugs then we
 recommend that you build F\* from the sources on GitHub (the `master` branch).
 
 F\* is written in a subset of F# that F\* itself can also parse with a
-special flag. Therefore, the standard build process of F* involves the following
+special flag. Therefore, the standard build process of F\* involves the following
 three steps:
 
-  **Step 1.** build F* from sources using the F# compiler
+  **Step 1.** build F\* from sources using the F# compiler
      (obtaining a .NET binary for F\*);
 
-  **Step 2.** extract the sources of F* itself to OCaml
-     using the F* binary produced at step 1 (or even a previous step 3) —
+  **Step 2.** extract the sources of F\* itself to OCaml
+     using the F\* binary produced at step 1 (or even a previous step 3) —
      **Note:** this no longer works reliably with the .NET binary, please
      consider doing 3-2-3 instead of 1-2-3;
 
-  **Step 3.** re-build F* using the OCaml compiler from the code
+  **Step 3.** re-build F\* using the OCaml compiler from the code
      generated at step 2 (obtaining a faster native binary for F\*).
 
-**Note:** If you build F* from sources you will also need to get a Z3
+**Note:** If you build F\* from sources you will also need to get a Z3
 binary. This is further explained towards the end of this document.
 
 **Easier alternative:**  If you don't care about efficiency, about the .NET
@@ -159,7 +159,7 @@ you can stop already after step 1.
 also build F\* directly from the generated OCaml sources.  Therefore, for
 convenience, we keep a (possibly a bit outdated) snapshot of the F\* sources
 extracted to OCaml (the result of step 2) in the repo.  This allows
-you to skip directly to step 3 and build F* with just an OCaml compiler.
+you to skip directly to step 3 and build F\* with just an OCaml compiler.
 
 Some convenience Makefile targets are available for steps 2 and 3:
 
@@ -167,10 +167,10 @@ Some convenience Makefile targets are available for steps 2 and 3:
 - To run steps 3, 2 and 3 again, do: `make -j 6 ocaml-fstar-ocaml`.
 
 The latter step is not always guaranteed to work but almost always does,
-and is a tiny bit faster than extracting F* using the F# version.
+and is a tiny bit faster than extracting F\* using the F# version.
 
 
-### Step 1. Building F* from sources using the F# compiler ###
+### Step 1. Building F\* from sources using the F# compiler ###
 
 #### On Windows 7/8/10 ####
 
@@ -189,9 +189,9 @@ clicking the "Build" button within Visual Studio.
 
 Read on for the more complete solution involving Visual Studio itself.
 
-  - Run the `src/VS/nuget-restore.bat` script _from the top-level F* directory_
+  - Run the `src/VS/nuget-restore.bat` script _from the top-level F\* directory_
     before opening the solution for the first time.
-    F* depends upon NuGet packages that are incompatible with
+    F\* depends upon NuGet packages that are incompatible with
     Visual Studio's internal invocation of NuGet's restore feature.
 
         C:\Users\xxx\Desktop\FStar>src\VS\nuget-restore.bat
@@ -210,7 +210,7 @@ Read on for the more complete solution involving Visual Studio itself.
   problem is likely that the NuGet package cache hasn't been
   restored. You must either exit Visual Studio to restore the cache
   (using the `src/VS/nuget-restore.bat` script), or restart Visual
-  Studio after having restored the cache. Otherwise, F* may not
+  Studio after having restored the cache. Otherwise, F\* may not
   successfully build (or correctly build).
 
 #### On Linux or Mac OS X using Mono ####
@@ -239,7 +239,7 @@ Read on for the more complete solution involving Visual Studio itself.
 
           $ mozroots --import --sync
 
-  - Compile F* from sources
+  - Compile F\* from sources
 
           $ git clone https://github.com/FStarLang/FStar.git
           $ cd FStar
@@ -270,7 +270,7 @@ Steps 2 and 3 below require a working OCaml setup. Any version of OCaml from 4.0
 
 Please use the  [OCaml Installer for Windows](http://protz.github.io/ocaml-installer/).
 Follow the [installation guide](https://github.com/protz/ocaml-installer/wiki)
-that's over there (it's optimized for F*). This will install both OCaml and OPAM.
+that's over there (it's optimized for F\*). This will install both OCaml and OPAM.
 
 #### Instructions for Linux and Mac OS X ####
 
@@ -300,10 +300,10 @@ that's over there (it's optimized for F*). This will install both OCaml and OPAM
 
    - Type `opam switch list`. The current OCaml version used by opam
      is identified by the letter C. If it is not within the version
-     range required by F* (see above), type `opam switch ` and then
+     range required by F\* (see above), type `opam switch ` and then
      the version number you wish to switch opam to.
 
-4. F* depends on a bunch of external OCaml packages which you should install using OPAM:
+4. F\* depends on a bunch of external OCaml packages which you should install using OPAM:
 
   ```sh
   $ opam install ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint
@@ -311,9 +311,9 @@ that's over there (it's optimized for F*). This will install both OCaml and OPAM
   Some of the examples also require the `sqlite3` opam package, which depends
   on SQLite itself that you can install with `opam depext sqlite3` (at least on Linux)
 
-### Step 2. Extracting the sources of F* itself to OCaml ###
+### Step 2. Extracting the sources of F\* itself to OCaml ###
 
-0. Get an F* binary, either using the F#/.NET build process (step 1
+0. Get an F\* binary, either using the F#/.NET build process (step 1
    above; remember to build a Release version, else you'll get a
    `StackOverflowException` in `make ocaml -C src` below),
    or the OCaml build process (step 3 above).
@@ -324,11 +324,11 @@ that's over there (it's optimized for F*). This will install both OCaml and OPAM
    and `find`. These can be installed using `brew install gnu-sed coreutils`.
 
 2. Once you satisfy the prerequisites for your platform,
-   translate the F* sources from F# to OCaml using F* by running:
+   translate the F\* sources from F# to OCaml using F\* by running:
 
         $ make ocaml -C src
 
-### Step 3. Building F* from the OCaml snapshot ###
+### Step 3. Building F\* from the OCaml snapshot ###
 
 Once you have a working OCaml setup (see above)
 just run the following command:
@@ -337,7 +337,7 @@ just run the following command:
 
 The option `-j 6` controls the number of cores to be used in parallel build. This is a relatively standard unix feature.
 
-**Note:** On Windows this generates a native F* binary, that is, a binary that
+**Note:** On Windows this generates a native F\* binary, that is, a binary that
 does *not* depend on `cygwin1.dll`, since the installer above uses a
 *native* Windows port of OCaml.  Cygwin is just there to provide `make` and
 other utilities required for the build.
@@ -348,8 +348,8 @@ special `flexlink` technology for this. See `contrib/CoreCrypto/ml` and
 
 ## Runtime dependency: Z3 SMT solver ##
 
-To use F* for verification you need a Z3 4.5.0 binary.
+To use F\* for verification you need a Z3 4.5.0 binary.
 Our binary packages include that already in `bin`, but if you compile
-F* from sources you need to get a Z3 binary yourself and add it to
+F\* from sources you need to get a Z3 binary yourself and add it to
 your `PATH`. We recommend you use the 4.5.0 binaries here:
 https://github.com/Z3Prover/z3/releases/tag/z3-4.5.0


### PR DESCRIPTION
This is not always needed, but the exact rules are unintuitive (when there are no other asterisks on the line, the Markdown parser might recognize that the asterisk should be treated as an ordinary character rather than a marker for emphasis) and in any case might depend on the Markdown parser. Better to just always escape F\*.