### PR TITLE
Revert identifier info table when backtracking

### DIFF
--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((fstar-mode
+  (fstar-subp-prover-args . fstar-subp-prover-args-for-compiler-hacking)))

--- a/src/Makefile
+++ b/src/Makefile
@@ -119,6 +119,8 @@ boot_fstis/FStar.util.fsti: basic/util.fsi
 	$(SED) -i 's/type time.*/assume new type time/g'  $@
 	$(SED) -i 's/type smap.*/assume new type smap : Type0 -> Type0/g'  $@
 	$(SED) -i 's/type imap.*/assume new type imap : Type0 -> Type0/g'  $@
+	$(SED) -i 's/type psmap.*/assume new type psmap : Type0 -> Type0/g'  $@
+	$(SED) -i 's/type pimap.*/assume new type pimap : Type0 -> Type0/g'  $@
 	$(SED) -i 's/type out_channel.*/assume new type out_channel/g'  $@
 	$(SED) -i 's/type file_handle.*/assume new type file_handle/g'  $@
 	$(SED) -i 's/type stream_reader.*/assume new type stream_reader/g'  $@

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -293,7 +293,7 @@ let smap_copy (m:'value smap) = BatHashtbl.copy m
 let smap_size (m:'value smap) = BatHashtbl.length m
 
 type 'value psmap = (string, 'value) BatMap.t
-let psmap_empty : 'value psmap = BatMap.empty
+let psmap_empty (_: unit) : 'value psmap = BatMap.empty
 let psmap_add (map: 'value psmap) (key: string) (value: 'value) = BatMap.add key value map
 let psmap_find_default (map: 'value psmap) (key: string) (dflt: 'value) =
   try BatMap.find key map with Not_found -> dflt
@@ -315,7 +315,7 @@ let imap_keys (m:'value imap) = imap_fold m (fun k _ acc -> k::acc) []
 let imap_copy (m:'value imap) = BatHashtbl.copy m
 
 type 'value pimap = (int, 'value) BatMap.t
-let pimap_empty : 'value pimap = BatMap.empty
+let pimap_empty (_: unit) : 'value pimap = BatMap.empty
 let pimap_add (map: 'value pimap) (key: int) (value: 'value) = BatMap.add key value map
 let pimap_find_default (map: 'value pimap) (key: int) (dflt: 'value) =
   try BatMap.find key map with Not_found -> dflt

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -292,6 +292,14 @@ let smap_keys (m:'value smap) = smap_fold m (fun k _ acc -> k::acc) []
 let smap_copy (m:'value smap) = BatHashtbl.copy m
 let smap_size (m:'value smap) = BatHashtbl.length m
 
+type 'value psmap = (string, 'value) BatMap.t
+let psmap_empty : 'value psmap = BatMap.empty
+let psmap_add (map: 'value psmap) (key: string) (value: 'value) = BatMap.add key value map
+let psmap_find_default (map: 'value psmap) (key: string) (dflt: 'value) =
+  try BatMap.find key map with Not_found -> dflt
+let psmap_try_find (map: 'value psmap) (key: string) =
+  try Some (BatMap.find key map) with Not_found -> None
+
 type 'value imap = (Z.t, 'value) BatHashtbl.t
 let imap_create (i:Z.t) : 'value imap = BatHashtbl.create (Z.to_int i)
 let imap_clear (s:('value imap)) = BatHashtbl.clear s
@@ -305,6 +313,14 @@ let imap_fold (m:'value imap) f a = BatHashtbl.fold f m a
 let imap_remove (m:'value imap) k = BatHashtbl.remove m k
 let imap_keys (m:'value imap) = imap_fold m (fun k _ acc -> k::acc) []
 let imap_copy (m:'value imap) = BatHashtbl.copy m
+
+type 'value pimap = (int, 'value) BatMap.t
+let pimap_empty : 'value pimap = BatMap.empty
+let pimap_add (map: 'value pimap) (key: int) (value: 'value) = BatMap.add key value map
+let pimap_find_default (map: 'value pimap) (key: int) (dflt: 'value) =
+  try BatMap.find key map with Not_found -> dflt
+let pimap_try_find (map: 'value pimap) (key: int) =
+  try Some (BatMap.find key map) with Not_found -> None
 
 let format (fmt:string) (args:string list) =
   let frags = BatString.nsplit fmt "%s" in

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -314,12 +314,12 @@ let imap_remove (m:'value imap) k = BatHashtbl.remove m k
 let imap_keys (m:'value imap) = imap_fold m (fun k _ acc -> k::acc) []
 let imap_copy (m:'value imap) = BatHashtbl.copy m
 
-type 'value pimap = (int, 'value) BatMap.t
+type 'value pimap = (Z.t, 'value) BatMap.t
 let pimap_empty (_: unit) : 'value pimap = BatMap.empty
-let pimap_add (map: 'value pimap) (key: int) (value: 'value) = BatMap.add key value map
-let pimap_find_default (map: 'value pimap) (key: int) (dflt: 'value) =
+let pimap_add (map: 'value pimap) (key: Z.t) (value: 'value) = BatMap.add key value map
+let pimap_find_default (map: 'value pimap) (key: Z.t) (dflt: 'value) =
   try BatMap.find key map with Not_found -> dflt
-let pimap_try_find (map: 'value pimap) (key: int) =
+let pimap_try_find (map: 'value pimap) (key: Z.t) =
   try Some (BatMap.find key map) with Not_found -> None
 
 let format (fmt:string) (args:string list) =

--- a/src/basic/util.fs
+++ b/src/basic/util.fs
@@ -279,6 +279,14 @@ let smap_copy (m:smap<'value>) =
     n
 let smap_size (m:smap<'value>) = m.Count
 
+type psmap<'value> = Collections.Map<string,'value>
+let psmap_empty : psmap<'value> = Collections.Map.empty
+let psmap_add (map: psmap<'value>) (key: string) (value: 'value) = Collections.Map.add key value map
+let psmap_find_default (map: psmap<'value>) (key: string) (dflt: 'value) =
+  match Collections.Map.tryFind key map with | Some v -> v | None -> dflt
+let psmap_try_find (map: psmap<'value>) (key: string) =
+  Collections.Map.tryFind key map
+
 type imap<'value>=System.Collections.Generic.Dictionary<int,'value>
 let imap_create<'value> (i:int) = new Dictionary<int,'value>(i)
 let imap_clear<'value> (s:imap<'value>) = s.Clear()
@@ -299,6 +307,14 @@ let imap_copy (m:imap<'value>) =
     let n = imap_create (m.Count) in
     imap_fold m (fun k v () -> imap_add n k v) ();
     n
+
+type pimap<'value> = Collections.Map<int,'value>
+let pimap_empty : pimap<'value> = Collections.Map.empty
+let pimap_add (map: pimap<'value>) (key: int) (value: 'value) = Collections.Map.add key value map
+let pimap_find_default (map: pimap<'value>) (key: int) (dflt: 'value) =
+  match Collections.Map.tryFind key map with | Some v -> v | None -> dflt
+let pimap_try_find (map: pimap<'value>) (key: int) =
+  Collections.Map.tryFind key map
 
 let format (fmt:string) (args:list<string>) =
     let frags = fmt.Split([|"%s"|], System.StringSplitOptions.None) in

--- a/src/basic/util.fs
+++ b/src/basic/util.fs
@@ -280,7 +280,7 @@ let smap_copy (m:smap<'value>) =
 let smap_size (m:smap<'value>) = m.Count
 
 type psmap<'value> = Collections.Map<string,'value>
-let psmap_empty : psmap<'value> = Collections.Map.empty
+let psmap_empty (_: unit) : psmap<'value> = Collections.Map.empty
 let psmap_add (map: psmap<'value>) (key: string) (value: 'value) = Collections.Map.add key value map
 let psmap_find_default (map: psmap<'value>) (key: string) (dflt: 'value) =
   match Collections.Map.tryFind key map with | Some v -> v | None -> dflt
@@ -309,7 +309,7 @@ let imap_copy (m:imap<'value>) =
     n
 
 type pimap<'value> = Collections.Map<int,'value>
-let pimap_empty : pimap<'value> = Collections.Map.empty
+let pimap_empty (_: unit) : pimap<'value> = Collections.Map.empty
 let pimap_add (map: pimap<'value>) (key: int) (value: 'value) = Collections.Map.add key value map
 let pimap_find_default (map: pimap<'value>) (key: int) (dflt: 'value) =
   match Collections.Map.tryFind key map with | Some v -> v | None -> dflt

--- a/src/basic/util.fsi
+++ b/src/basic/util.fsi
@@ -79,6 +79,12 @@ val smap_keys: smap<'value> -> list<string>
 val smap_copy: smap<'value> -> smap<'value>
 val smap_size: smap<'value> -> int
 
+type psmap<'value> = Collections.Map<string,'value> (* pure version *)
+val psmap_empty: psmap<'value>
+val psmap_add: psmap<'value> -> string -> 'value -> psmap<'value>
+val psmap_find_default: psmap<'value> -> string -> 'value -> 'value
+val psmap_try_find: psmap<'value> -> string -> option<'value>
+
 type imap<'value> = System.Collections.Generic.Dictionary<int,'value> (* not relying on representation *)
 val imap_create: int -> imap<'value>
 val imap_clear:imap<'value> -> unit
@@ -90,6 +96,12 @@ val imap_remove: imap<'value> -> int -> unit
 (* The list may contain duplicates. *)
 val imap_keys: imap<'value> -> list<int>
 val imap_copy: imap<'value> -> imap<'value>
+
+type pimap<'value> = Collections.Map<int,'value> (* pure version *)
+val pimap_empty: pimap<'value>
+val pimap_add: pimap<'value> -> int -> 'value -> pimap<'value>
+val pimap_find_default: pimap<'value> -> int -> 'value -> 'value
+val pimap_try_find: pimap<'value> -> int -> option<'value>
 
 val format: string -> list<string> -> string
 val format1: string -> string -> string

--- a/src/basic/util.fsi
+++ b/src/basic/util.fsi
@@ -80,7 +80,7 @@ val smap_copy: smap<'value> -> smap<'value>
 val smap_size: smap<'value> -> int
 
 type psmap<'value> = Collections.Map<string,'value> (* pure version *)
-val psmap_empty: psmap<'value>
+val psmap_empty: unit -> psmap<'value> // GH-1161
 val psmap_add: psmap<'value> -> string -> 'value -> psmap<'value>
 val psmap_find_default: psmap<'value> -> string -> 'value -> 'value
 val psmap_try_find: psmap<'value> -> string -> option<'value>
@@ -98,7 +98,7 @@ val imap_keys: imap<'value> -> list<int>
 val imap_copy: imap<'value> -> imap<'value>
 
 type pimap<'value> = Collections.Map<int,'value> (* pure version *)
-val pimap_empty: pimap<'value>
+val pimap_empty: unit -> pimap<'value> // GH-1161
 val pimap_add: pimap<'value> -> int -> 'value -> pimap<'value>
 val pimap_find_default: pimap<'value> -> int -> 'value -> 'value
 val pimap_try_find: pimap<'value> -> int -> option<'value>

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -197,7 +197,8 @@ let needs_interleaving intf impl =
   let m1 = Parser.Dep.lowercase_module_name intf in
   let m2 = Parser.Dep.lowercase_module_name impl in
   m1 = m2 &&
-  FStar.Util.get_file_extension intf = "fsti" && FStar.Util.get_file_extension impl = "fst"
+  List.mem (FStar.Util.get_file_extension intf) ["fsti"; "fsi"] &&
+  List.mem (FStar.Util.get_file_extension impl) ["fst"; "fs"]
 
 let pop_context env msg =
     DsEnv.pop () |> ignore;

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -203,7 +203,6 @@ let needs_interleaving intf impl =
 let pop_context env msg =
     DsEnv.pop () |> ignore;
     TcEnv.pop env msg |> ignore;
-    FStar.TypeChecker.Common.insert_id_info.clear();
     env.solver.refresh()
 
 let push_context (dsenv, env) msg =

--- a/src/parser/ml/FStar_Parser_ParseIt.ml
+++ b/src/parser/ml/FStar_Parser_ParseIt.ml
@@ -40,6 +40,7 @@ let read_file (filename:string) =
 
 let fs_extensions = [".fs"; ".fsi"]
 let fst_extensions = [".fst"; ".fsti"]
+let interface_extensions = [".fsti"; ".fsi"]
 
 let valid_extensions () =
   fst_extensions @ if FStar_Options.ml_ish () then fs_extensions else []
@@ -75,7 +76,7 @@ let parse fn =
       let fileOrFragment = FStar_Parser_Parse.inputFragment lexer lexbuf in
       let frags = match fileOrFragment with
           | U.Inl mods ->
-             if FStar_Util.ends_with filename ".fsti"
+             if has_extension filename interface_extensions
              then U.Inl (mods |> FStar_List.map (function
                   | FStar_Parser_AST.Module(l,d) ->
                     FStar_Parser_AST.Interface(l, d, true)

--- a/src/parser/parseit.fs
+++ b/src/parser/parseit.fs
@@ -59,6 +59,7 @@ let read_file (filename:string) =
 
 let fs_extensions = [".fs"; ".fsi"]
 let fst_extensions = [".fst"; ".fsti"]
+let interface_extensions = [".fsti"; ".fsi"]
 
 let valid_extensions () =
   fst_extensions @ if Options.ml_ish () then fs_extensions else []
@@ -114,7 +115,7 @@ let parse fn =
       let fileOrFragment = Parse.inputFragment lexer lexbuf in
       let frags = match fileOrFragment with
         | Inl mods ->
-           if Util.ends_with filename ".fsti"
+           if has_extension filename interface_extensions
            then Inl (mods |> List.map (function
                 | AST.Module(l,d) ->
                   AST.Interface(l, d, true)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -2389,7 +2389,7 @@ let as_interface (m:AST.modul) : AST.modul =
 let desugar_partial_modul curmod (env:env_t) (m:AST.modul) : env_t * Syntax.modul =
   let m =
     if Options.interactive () &&
-      get_file_extension (List.hd (Options.file_list ())) = "fsti"
+      List.mem (get_file_extension (List.hd (Options.file_list ()))) ["fsti"; "fsi"]
     then as_interface m
     else m
   in

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -141,7 +141,7 @@ type id_info_table = {
 
 let id_info_table_empty =
     { id_info_enabled = false;
-      id_info_db = BU.psmap_empty;
+      id_info_db = BU.psmap_empty ();
       id_info_buffer = [] }
 
 open FStar.Range
@@ -156,7 +156,7 @@ let id_info__insert ty_map db info =
     let start = start_of_range use_range in
     let row, col = line_of_pos start, col_of_pos start in
 
-    let rows = BU.psmap_find_default db fn BU.pimap_empty in
+    let rows = BU.psmap_find_default db fn (BU.pimap_empty ()) in
     let cols = BU.pimap_find_default rows row [] in
 
     insert_col_info col info cols
@@ -185,7 +185,7 @@ let id_info_promote table ty_map =
                      table.id_info_db table.id_info_buffer }
 
 let id_info_at_pos (table: id_info_table) (fn:string) (row:int) (col:int) : option<identifier_info> =
-    let rows = BU.psmap_find_default table.id_info_db fn BU.pimap_empty in
+    let rows = BU.psmap_find_default table.id_info_db fn (BU.pimap_empty ()) in
     let cols = BU.pimap_find_default rows row [] in
 
     match find_nearest_preceding_col_info col cols with

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -101,6 +101,7 @@ type identifier_info = {
     identifier_ty:typ;
     identifier_range:Range.range;
 }
+
 let insert_col_info col info col_infos =
     // Tail recursive helper
     let rec __insert aux rest =
@@ -122,73 +123,73 @@ let find_nearest_preceding_col_info col col_infos =
           else aux (Some i) rest
     in
     aux None col_infos
-type col_info = //sorted in ascending order of columns
+
+type id_info_by_col = //sorted in ascending order of columns
     list<(int * identifier_info)>
-type row_info =
-    BU.imap<ref<col_info>>
-type file_info =
-    BU.smap<row_info>
-let mk_info id ty range = {
-    identifier=id;
-    identifier_ty=ty;
-    identifier_range=range
+
+type col_info_by_row =
+    BU.pimap<id_info_by_col>
+
+type row_info_by_file =
+    BU.psmap<col_info_by_row>
+
+type id_info_table = {
+    id_info_enabled: bool;
+    id_info_db: row_info_by_file;
+    id_info_buffer: list<identifier_info>;
 }
-let file_info_table : file_info = BU.smap_create 50 //50 files
+
+let id_info_table_empty =
+    { id_info_enabled = false;
+      id_info_db = BU.psmap_empty;
+      id_info_buffer = [] }
+
 open FStar.Range
-let insert_identifier_info id ty range =
-    let use_range = {range with def_range=range.use_range} in //key the lookup table from the use range
-    let info = mk_info id ty use_range in
-    let fn = Range.file_of_range use_range in
-    let start = Range.start_of_range use_range in
-    let row, col = Range.line_of_pos start, Range.col_of_pos start in
-    begin match BU.smap_try_find file_info_table fn with
-    | None ->
-      let col_info = BU.mk_ref (insert_col_info col info []) in
-      let rows = BU.imap_create 1000 in //1000 rows per file
-      BU.imap_add rows row col_info;
-      BU.smap_add file_info_table fn rows
-    | Some file_rows -> begin
-      match BU.imap_try_find file_rows row with
-      | None ->
-        let col_info = BU.mk_ref (insert_col_info col info []) in
-        BU.imap_add file_rows row col_info
-      | Some col_infos ->
-        col_infos := insert_col_info col info !col_infos
-      end
-    end;
-    fn, row, col
-let info_at_pos (fn:string) (row:int) (col:int) : option<identifier_info> =
-    match BU.smap_try_find file_info_table fn with
+
+let id_info__insert ty_map db info =
+    let range = info.identifier_range in
+    let use_range = { range with def_range = range.use_range } in
+    let info = { info with identifier_range = use_range;
+                           identifier_ty = ty_map info.identifier_ty } in
+
+    let fn = file_of_range use_range in
+    let start = start_of_range use_range in
+    let row, col = line_of_pos start, col_of_pos start in
+
+    let rows = BU.psmap_find_default db fn BU.pimap_empty in
+    let cols = BU.pimap_find_default rows row [] in
+
+    insert_col_info col info cols
+    |> BU.pimap_add rows row
+    |> BU.psmap_add db fn
+
+let id_info_insert table id ty range =
+    let info = { identifier = id; identifier_ty = ty; identifier_range = range} in
+    { table with id_info_buffer = info :: table.id_info_buffer }
+
+let id_info_insert_bv table bv ty =
+    if table.id_info_enabled then id_info_insert table (Inl bv) ty (range_of_bv bv)
+    else table
+
+let id_info_insert_fv table fv ty =
+    if table.id_info_enabled then id_info_insert table (Inr fv) ty (range_of_fv fv)
+    else table
+
+let id_info_toggle table enabled =
+    { table with id_info_enabled = enabled && FStar.Options.ide () }
+
+let id_info_promote table ty_map =
+    { table with
+      id_info_buffer = [];
+      id_info_db = List.fold_left (id_info__insert ty_map)
+                     table.id_info_db table.id_info_buffer }
+
+let id_info_at_pos (table: id_info_table) (fn:string) (row:int) (col:int) : option<identifier_info> =
+    let rows = BU.psmap_find_default table.id_info_db fn BU.pimap_empty in
+    let cols = BU.pimap_find_default rows row [] in
+
+    match find_nearest_preceding_col_info col cols with
     | None -> None
-    | Some rows ->
-      match BU.imap_try_find rows row with
-      | None -> None
-      | Some cols ->
-        match find_nearest_preceding_col_info col !cols with
-        | None -> None
-        | Some ci ->
-          // Check that `col` is in `ci.identifier_range`
-          let last_col = Range.col_of_pos (Range.end_of_range ci.identifier_range) in
-          if col <= last_col then Some ci else None
-type insert_id_info_ops = {
-    enable:bool -> unit;
-    bv:bv -> typ -> unit;
-    fv:fv -> typ -> unit;
-    promote:(typ -> typ) -> unit;
-    clear: unit -> unit;
-}
-let insert_id_info =
-    let enabled = BU.mk_ref false in
-    let id_info_buffer : ref<(list<(either<bv,fv>*typ*Range.range)>)> = BU.mk_ref [] in
-    let enable b = enabled := FStar.Options.ide() && b in
-    let bv x t = if !enabled then id_info_buffer := (Inl x, t, range_of_bv x)::!id_info_buffer in
-    let fv x t = if !enabled then id_info_buffer := (Inr x, t, range_of_fv x)::!id_info_buffer in
-    let promote cb =
-        !id_info_buffer |> List.iter (fun (i, t, r) -> ignore <| insert_identifier_info i (cb t) r);
-        id_info_buffer := [] in
-    let clear () = id_info_buffer := [] in
-    {enable=enable;
-     bv=bv;
-     fv=fv;
-     promote=promote;
-     clear=clear}
+    | Some info ->
+      let last_col = col_of_pos (end_of_range info.identifier_range) in
+      if col <= last_col then Some info else None

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -107,7 +107,8 @@ type env = {
   qname_and_index:option<(lident*int)>;              (* the top-level term we're currently processing and the nth query for it *)
   proof_ns       :proof_namespace;                   (* the current names that will be encoded to SMT *)
   synth          :env -> typ -> term -> term;        (* hook for synthesizing terms via tactics, third arg is tactic term *)
-  is_native_tactic: lid -> bool                      (* callback into the native tactics engine *)
+  is_native_tactic: lid -> bool;                      (* callback into the native tactics engine *)
+  identifier_info: ref<FStar.TypeChecker.Common.id_info_table> (* information on identifiers *)
 }
 and solver_t = {
     init         :env -> unit;
@@ -182,6 +183,7 @@ let initial_env type_of universe_of solver module_lid =
                | None -> [[]]);
     synth = (fun e g tau -> failwith "no synthesizer available");
     is_native_tactic = (fun _ -> false);
+    identifier_info=BU.mk_ref FStar.TypeChecker.Common.id_info_table_empty
   }
 
 (* Marking and resetting the environment, for the interactive mode *)
@@ -210,7 +212,8 @@ let stack: ref<(list<env>)> = BU.mk_ref []
 let push_stack env =
     stack := env::!stack;
     {env with sigtab=BU.smap_copy (sigtab env);
-              gamma_cache=BU.smap_copy (gamma_cache env)}
+              gamma_cache=BU.smap_copy (gamma_cache env);
+              identifier_info=BU.mk_ref !env.identifier_info}
 
 let pop_stack () =
     match !stack with
@@ -269,6 +272,19 @@ let debug env (l:Options.debug_level_t) =
     Options.debug_at_level env.curmodule.str l
 let set_range e r = if r=dummyRange then e else {e with range=r}
 let get_range e = e.range
+
+let toggle_id_info env enabled =
+  env.identifier_info :=
+    FStar.TypeChecker.Common.id_info_toggle !env.identifier_info enabled
+let insert_bv_info env bv ty =
+  env.identifier_info :=
+    FStar.TypeChecker.Common.id_info_insert_bv !env.identifier_info bv ty
+let insert_fv_info env fv ty =
+  env.identifier_info :=
+    FStar.TypeChecker.Common.id_info_insert_fv !env.identifier_info fv ty
+let promote_id_info env ty_map =
+  env.identifier_info :=
+    FStar.TypeChecker.Common.id_info_promote !env.identifier_info ty_map
 
 ////////////////////////////////////////////////////////////
 // Private utilities                                      //

--- a/src/typechecker/FStar.TypeChecker.Env.fsi
+++ b/src/typechecker/FStar.TypeChecker.Env.fsi
@@ -105,7 +105,8 @@ type env = {
   qname_and_index:option<(lident*int)>;           (* the top-level term we're currently processing and the nth query for it *)
   proof_ns       :proof_namespace;                (* the current names that will be encoded to SMT (a.k.a. hint db) *)
   synth          :env -> typ -> term -> term;     (* hook for synthesizing terms via tactics, third arg is tactic term *)
-  is_native_tactic: lid -> bool                   (* callback into the native tactics engine *)
+  is_native_tactic: lid -> bool;                   (* callback into the native tactics engine *)
+  identifier_info: ref<FStar.TypeChecker.Common.id_info_table> (* information on identifiers *)
 }
 and solver_t = {
     init         :env -> unit;
@@ -150,6 +151,10 @@ val debug          : env -> Options.debug_level_t -> bool
 val current_module : env -> lident
 val set_range      : env -> Range.range -> env
 val get_range      : env -> Range.range
+val insert_bv_info : env -> bv -> typ -> unit
+val insert_fv_info : env -> fv -> typ -> unit
+val toggle_id_info : env -> bool -> unit
+val promote_id_info : env -> (typ -> typ) -> unit
 
 (* Querying identifiers *)
 val lid_exists             : env -> lident -> bool

--- a/src/typechecker/FStar.TypeChecker.Err.fs
+++ b/src/typechecker/FStar.TypeChecker.Err.fs
@@ -34,7 +34,7 @@ module Env = FStar.TypeChecker.Env
 open FStar.TypeChecker.Common
 
 let info_at_pos env file row col =
-    match TypeChecker.Common.info_at_pos file row col with
+    match TypeChecker.Common.id_info_at_pos !env.identifier_info file row col with
     | None -> None
     | Some info ->
       match info.identifier with

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -1246,7 +1246,7 @@ let tc_decl env se: list<sigelt> * list<sigelt> =
     (* 4. Record the type of top-level lets, and log if requested *)
     snd lbs |> List.iter (fun lb ->
         let fv = right lb.lbname in
-        Common.insert_id_info.fv fv lb.lbtyp);
+        Env.insert_fv_info env fv lb.lbtyp);
 
     if log env
     then BU.print1 "%s\n" (snd lbs |> List.map (fun lb ->
@@ -1493,7 +1493,7 @@ let tc_decls env ses =
         (* then printfn "About to elim vars from %s" (Print.sigelt_to_string se); *)
         N.elim_uvars env se) in
 
-    Common.insert_id_info.promote (fun t ->
+    Env.promote_id_info env (fun t ->
         N.normalize
                [N.AllowUnboundUniverses; //this is allowed, since we're reducing types that appear deep within some arbitrary context
                 N.CheckNoUvars;

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -678,7 +678,7 @@ and tc_value env (e:term) : term
         then x.sort, S.range_of_bv x
         else Env.lookup_bv env x in
     let x = S.set_range_of_bv ({x with sort=t}) rng in
-    FStar.TypeChecker.Common.insert_id_info.bv x t;
+    Env.insert_bv_info env x t;
     let e = S.bv_to_name x in
     let e, t, implicits = TcUtil.maybe_instantiate env e t in
     let tc = if Env.should_verify env then Inl t else Inr (U.lcomp_of_comp <| mk_Total t) in
@@ -700,7 +700,7 @@ and tc_value env (e:term) : term
             | U_unif u'' -> UF.univ_change u'' u
             | _ -> failwith "Impossible") us' us;
     let fv' = S.set_range_of_fv fv range in
-    FStar.TypeChecker.Common.insert_id_info.fv fv' t;
+    Env.insert_fv_info env fv' t;
     let e = S.mk_Tm_uinst (mk (Tm_fvar fv') None e.pos) us in
     check_instantiated_fvar env fv'.fv_name fv'.fv_qual e t
 
@@ -714,7 +714,7 @@ and tc_value env (e:term) : term
             (Range.string_of_use_range range)
             (Print.term_to_string t);
     let fv' = S.set_range_of_fv fv range in
-    FStar.TypeChecker.Common.insert_id_info.fv fv' t;
+    Env.insert_fv_info env fv' t;
     let e = S.mk_Tm_uinst (mk (Tm_fvar fv') None e.pos) us in
     check_instantiated_fvar env fv'.fv_name fv'.fv_qual e t
 


### PR DESCRIPTION
Fixes #949.

I'm not super happy with that reference.  It'd be nicer to just construct a new environment when changing the identifier info table, but `insert_fv` and `insert_bv` are called from places that don't return an environment.