### PR TITLE
Preserve type applications in extraction

### DIFF
--- a/src/extraction/FStar.Extraction.Kremlin.fs
+++ b/src/extraction/FStar.Extraction.Kremlin.fs
@@ -31,6 +31,11 @@ open FStar.BaseTypes
 
 module BU = FStar.Util
 
+(** CHANGELOG
+- Added a single constructor to the expression type to reflect the addition
+  of type applications to the ML extraction language.
+*)
+
 (* COPY-PASTED ****************************************************************)
 
 type program =
@@ -72,6 +77,7 @@ and expr =
   | EConstant of constant
   | EUnit
   | EApp of expr * list<expr>
+  | ETypApp of expr * list<typ>
   | ELet of binder * expr * expr
   | EIfThenElse of expr * expr * expr
   | ESequence of list<expr>
@@ -160,7 +166,7 @@ and typ =
 (** Versioned binary writing/reading of ASTs *)
 
 type version = int
-let current_version: version = 23
+let current_version: version = 24
 
 type file = string * program
 type binary_format = version * list<file>
@@ -651,6 +657,9 @@ and translate_expr env e: expr =
 
   | MLE_App ({ expr = MLE_Var (name, _) }, args) ->
       EApp (EBound (find env name), List.map (translate_expr env) args)
+
+  | MLE_TApp (head, ty_args) ->
+      ETypApp (translate_expr env head, List.map (translate_type env) ty_args)
 
   | MLE_Coerce (e, t_from, t_to) ->
       ECast (translate_expr env e, translate_type env t_to)

--- a/src/extraction/FStar.Extraction.ML.Code.fs
+++ b/src/extraction/FStar.Extraction.ML.Code.fs
@@ -474,6 +474,10 @@ let rec doc_of_expr (currentModule : mlsymbol) (outer : level) (e : mlexpr) : do
             text "with";
             combine hardline (List.map (doc_of_branch currentModule) pats)
         ]
+    | MLE_TApp (head, ty_args) ->
+        // Type applications are only useful meta-data for backends without inference, for example Kremlin.
+        // We just skip them here.
+        doc_of_expr currentModule outer head
 and  doc_of_binop currentModule p e1 e2 : doc =
         let (_, prio, txt) = Option.get (as_bin_op p) in
         let e1  = doc_of_expr  currentModule (prio, Left ) e1 in

--- a/src/extraction/FStar.Extraction.ML.Syntax.fs
+++ b/src/extraction/FStar.Extraction.ML.Syntax.fs
@@ -144,6 +144,7 @@ type mlexpr' =
 | MLE_Name   of mlpath
 | MLE_Let    of mlletbinding * mlexpr //tyscheme for polymorphic recursion
 | MLE_App    of mlexpr * list<mlexpr> //why are function types curried, but the applications not curried
+| MLE_TApp   of mlexpr * list<mlty>
 | MLE_Fun    of list<(mlident * mlty)> * mlexpr
 | MLE_Match  of mlexpr * list<mlbranch>
 | MLE_Coerce of mlexpr * mlty * mlty

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -1039,7 +1039,7 @@ and term_as_mlexpr' (g:env) (top:term) : (mlexpr * e_tag * mlty) =
                                  | MLE_Name _
                                  | MLE_Var _ -> {head_ml with mlty=t ; expr=MLE_TApp (head_ml, prefixAsMLTypes) }
                                  | MLE_App(head, [{expr=MLE_Const MLC_Unit}]) ->
-                                    MLE_App({head with expr=MLE_TApp (head_ml, prefixAsMLTypes); mlty=MLTY_Fun(ml_unit_ty, E_PURE, t)}, [ml_unit]) |> with_ty t
+                                    MLE_App({head with expr=MLE_TApp (head, prefixAsMLTypes); mlty=MLTY_Fun(ml_unit_ty, E_PURE, t)}, [ml_unit]) |> with_ty t
                                  | _ -> failwith "Impossible: Unexpected head term" in
                                head, t, rest
                           else err_uninst g head (vars, t) top in

--- a/src/extraction/ml/FStar_Extraction_ML_PrintML_4.02.X.ml
+++ b/src/extraction/ml/FStar_Extraction_ML_PrintML_4.02.X.ml
@@ -228,6 +228,8 @@ let rec build_expr ?annot (e: mlexpr): expression =
       let args = map (fun x -> (no_label, build_expr x)) es in
       let f = build_expr e in
       resugar_app f args es
+   | MLE_TApp (e, ts) ->
+     build_expr e
    | MLE_Fun (l, e) -> build_fun l e
    | MLE_Match (e, branches) ->
       let ep = build_expr e in

--- a/src/extraction/ml/FStar_Extraction_ML_PrintML_4.04.X.ml
+++ b/src/extraction/ml/FStar_Extraction_ML_PrintML_4.04.X.ml
@@ -226,6 +226,8 @@ let rec build_expr ?annot (e: mlexpr): expression =
       let args = map (fun x -> (Nolabel, build_expr x)) es in
       let f = build_expr e in
       resugar_app f args es
+   | MLE_TApp (e, ts) ->
+     build_expr e
    | MLE_Fun (l, e) -> build_fun l e
    | MLE_Match (e, branches) ->
       let ep = build_expr e in


### PR DESCRIPTION
I broke something in `FStar.Ident` in the snapshot, currently rebuilding it again.