### PR TITLE
update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,6 +173,9 @@ Some convenience Makefile targets are available for steps 2 and 3:
 - To run steps 2 and 3, do `make -j 6 fstar-ocaml`.
 - To run steps 3, 2 and 3 again, do: `make -j 6 ocaml-fstar-ocaml`.
 
+The option `-j 6` controls the number of cores to be used in parallel build.
+Using more cores results in greater RAM usage. This can make builds slow if you do not have enough RAM to support all parallel builds. Consider monitoring RAM usage when building, and use less cores if you are using 100% of your RAM. 
+
 The latter step is not always guaranteed to work but almost always does,
 and is a tiny bit faster than extracting F\* using the F# version.
 
@@ -348,7 +351,6 @@ just run the following command:
         $ make -C src/ocaml-output -j 6
 
 The option `-j 6` controls the number of cores to be used in parallel build. This is a relatively standard unix feature.
-Using more cores resuls in greater RAM usage. This can make builds slow if your system does not have enough RAM to support all parralel builds. Consider monitoring RAM usage when building, and use less cores if you are using 100% of your RAM. 
 
 **Note:** On Windows this generates a native F\* binary, that is, a binary that
 does *not* depend on `cygwin1.dll`, since the installer above uses a

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,7 +174,7 @@ Some convenience Makefile targets are available for steps 2 and 3:
 - To run steps 3, 2 and 3 again, do: `make -j 6 ocaml-fstar-ocaml`.
 
 The option `-j 6` controls the number of cores to be used in parallel build.
-Using more cores results in greater RAM usage. This can make builds slow if you do not have enough RAM to support all parallel builds. Consider monitoring RAM usage when building, and use less cores if you are using 100% of your RAM. 
+Using more cores results in greater RAM usage. This can make builds slow if you do not have enough RAM to support all parallel builds. Consider monitoring RAM usage when building, and use fewer cores if you are using 100% of your RAM. 
 
 The latter step is not always guaranteed to work but almost always does,
 and is a tiny bit faster than extracting F\* using the F# version.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -348,6 +348,7 @@ just run the following command:
         $ make -C src/ocaml-output -j 6
 
 The option `-j 6` controls the number of cores to be used in parallel build. This is a relatively standard unix feature.
+Using more cores resuls in greater RAM usage. This can make builds slow if your system does not have enough RAM to support all parralel builds. Consider monitoring RAM usage when building, and use less cores if you are using 100% of your RAM. 
 
 **Note:** On Windows this generates a native F\* binary, that is, a binary that
 does *not* depend on `cygwin1.dll`, since the installer above uses a


### PR DESCRIPTION
Building F* was taking >30 minutes for me with `make -C src/ocaml-output -j 6`, on a system with an i7 4700 @ 2.4 GHz (8 threads) and 12GB of RAM.
Profiling showed that building F* was maxing out my RAM. `make -C src/ocaml-output -j 4` is much faster for me.

Adding a note about this so that others can do faster builds.