### PR TITLE
SMTPat fix in FStar.Monotonic.Heap

### DIFF
--- a/ulib/FStar.Monotonic.HyperStack.fst
+++ b/ulib/FStar.Monotonic.HyperStack.fst
@@ -258,7 +258,7 @@ let lemma_sel_same_addr' (#a:Type0) (#rel:preorder a) (h:mem) (r1:mreference a r
          (ensures  (h `contains` r2 /\ sel h r1 == sel h r2))
 	 [SMTPatOr [
            [SMTPat (sel h r1); SMTPat (sel h r2)];
-           [SMTPat (frameOf r1); SMTPat (frameOf r2); SMTPat (as_addr r1); SMTPat (as_addr r2)]
+           [SMTPat (frameOf r1); SMTPat (frameOf r2); SMTPat (as_addr r1); SMTPat (as_addr r2); SMTPat(h `contains` r1)]
          ]]
 = lemma_sel_same_addr h r1 r2
 


### PR DESCRIPTION
@markulf found a small example that triggered a complaint from Z3 because of variable not being mentioned in a quantifier patttern:

```
module M
open FStar.HyperStack
type a = 
  | A: nat -> a
```

I think this fix should be sound and safe in terms of performance, but at least one other person should take a look at it :)