### PR TITLE
Fix find usage for non-GNU find

### DIFF
--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -107,7 +107,7 @@ fstar.exe: $(GENERATED_FILES)
 
 install-compiler-lib: fstar.exe
 	mkdir -p ../../bin/fstar-compiler-lib/
-	$(FIND) -name "*.cmi" -exec cp {} ../../bin/fstar-compiler-lib/ \;
+	$(FIND) . -name "*.cmi" -exec cp {} ../../bin/fstar-compiler-lib/ \;
 
 FStar_Parser_Parse.ml: parse.mly
 	# We are opening the same module twice but we need these modules


### PR DESCRIPTION
On OSX `find` always requires a path. I guess `.` is the intended path as that's the default.