### PR TITLE
Autodeps fix

### DIFF
--- a/examples/incl/shadow2.pos/Squash.fst
+++ b/examples/incl/shadow2.pos/Squash.fst
@@ -1,0 +1,3 @@
+module Squash
+
+let x = 2

--- a/examples/incl/shadow2.pos/Test.fst
+++ b/examples/incl/shadow2.pos/Test.fst
@@ -1,0 +1,7 @@
+module Test
+
+open Squash
+
+(* Testing that our standard library doesn't shadow local modules *)
+
+let z : int = x

--- a/src/parser/FStar.Parser.Dep.fsi
+++ b/src/parser/FStar.Parser.Dep.fsi
@@ -26,7 +26,7 @@ type verify_mode =
   | VerifyUserList
   | VerifyFigureItOut
 
-type map = smap<(option<string> * option<string>)>
+type map = smap<(int * (option<string> * option<string>))>
 
 type color = | White | Gray | Black
 


### PR DESCRIPTION
This introduces a depth argument for in-scope modules, using it to shadow
selectively.

Fixes that a local `Squash` (or any name) module is shadowed by ulib's `FStar.Squash`, since the `FStar` namespace is always open, and adds a regression test for it. The main reason for this is that I need to introduce a `FStar.Range` module, and miTLS already has a `Range`. Nevertheless, I believe this is the desired behaviour for any end user too.

I am not sure the "depth" is actually needed to be something other than a boolean, but this seemed more generic. I can refactor as needed, of course.