### PR TITLE
Add support for extracting mutual recursive types via Kremlin

### DIFF
--- a/src/extraction/FStar.Extraction.Kremlin.fs
+++ b/src/extraction/FStar.Extraction.Kremlin.fs
@@ -48,6 +48,7 @@ and decl =
   | DTypeFlat of lident * int * fields_t
   | DExternal of option<cc> * lident * typ
   | DTypeVariant of lident * list<flag> * int * branches_t
+  | DTypeMutual of list<decl>
 
 and cc =
   | StdCall
@@ -169,7 +170,7 @@ and typ =
 (** Versioned binary writing/reading of ASTs *)
 
 type version = int
-let current_version: version = 24
+let current_version: version = 25
 
 type file = string * program
 type binary_format = version * list<file>
@@ -429,7 +430,37 @@ and translate_decl env d: option<decl> =
   | MLM_Loc _ ->
       None
 
-  | MLM_Ty [ (assumed, name, _mangled_name, args, _, Some (MLTD_Abbrev t)) ] ->
+  | MLM_Ty [ ty_decl ] ->
+    translate_single_type_decl env ty_decl
+
+  | MLM_Ty (ty_decls) ->
+      // BU.print1 "Warning: not translating definition for %s (and possibly others)\n" name;
+      let rec traverse (#a #b:Type) (f : a -> option b) (xs : list a) : option (list b) =
+        match xs with
+        | [] -> Some []
+        | (o :: os) ->
+            match traverse f os with
+            | None -> None
+            | Some os' -> match f o with
+                | None -> None
+                | Some o' -> Some (o' :: os')
+       in (match traverse (translate_single_type_decl env) ty_decls with
+       | None -> None
+       | Some decls -> Some (DTypeMutual decls))
+
+  | MLM_Ty [] ->
+      BU.print_string "Impossible!! Empty block of mutually recursive type declarations";
+      None
+
+  | MLM_Top _ ->
+      failwith "todo: translate_decl [MLM_Top]"
+
+  | MLM_Exn _ ->
+      failwith "todo: translate_decl [MLM_Exn]"
+
+and translate_single_type_decl env (ty_decl : one_mltydecl) =
+    match ty_decl with
+    | (assumed, name, _mangled_name, args, _, Some (MLTD_Abbrev t)) ->
       let name = env.module_name, name in
       let env = List.fold_left (fun env name -> extend_t env name) env args in
       if assumed then
@@ -437,13 +468,13 @@ and translate_decl env d: option<decl> =
       else
         Some (DTypeAlias (name, List.length args, translate_type env t))
 
-  | MLM_Ty [ (_, name, _mangled_name, args, _, Some (MLTD_Record fields)) ] ->
+  | (_, name, _mangled_name, args, _, Some (MLTD_Record fields)) ->
       let name = env.module_name, name in
       let env = List.fold_left (fun env name -> extend_t env name) env args in
       Some (DTypeFlat (name, List.length args, List.map (fun (f, t) ->
         f, (translate_type env t, false)) fields))
 
-  | MLM_Ty [ (_, name, _mangled_name, args, attrs, Some (MLTD_DType branches)) ] ->
+  | (_, name, _mangled_name, args, attrs, Some (MLTD_DType branches)) ->
       let name = env.module_name, name in
       let flags = translate_flags attrs in
       let env = List.fold_left extend_t env args in
@@ -452,20 +483,6 @@ and translate_decl env d: option<decl> =
           name, (translate_type env t, false)
         ) ts
       ) branches))
-
-  | MLM_Ty ((_, name, _mangled_name, _, _, _) :: _) ->
-      BU.print1_warning "Not translating definition for %s (and possibly others)\n" name;
-      None
-
-  | MLM_Ty [] ->
-      BU.print_string "Impossible!! Empty block of mutually recursive type declarations\n";
-      None
-
-  | MLM_Top _ ->
-      failwith "todo: translate_decl [MLM_Top]"
-
-  | MLM_Exn _ ->
-      failwith "todo: translate_decl [MLM_Exn]"
 
 and translate_type env t: typ =
   match t with

--- a/src/extraction/FStar.Extraction.Kremlin.fs
+++ b/src/extraction/FStar.Extraction.Kremlin.fs
@@ -170,7 +170,7 @@ and typ =
 (** Versioned binary writing/reading of ASTs *)
 
 type version = int
-let current_version: version = 25
+let current_version: version = 26
 
 type file = string * program
 type binary_format = version * list<file>
@@ -349,18 +349,18 @@ and translate_flags flags =
     | _ -> None // is this all of them?
   ) flags
 
-and translate_decl env d: option<decl> =
-  match d with
-  | MLM_Let (flavor, flags, [ {
+and translate_single_let env flavor flags binding =
+match (flavor, flags, binding) with
+| (flavor, flags, {
       mllb_name = name;
       mllb_tysc = Some (tvars, t0);
       mllb_def = { expr = MLE_Fun (args, body) }
-    } ])
-  | MLM_Let (flavor, flags, [ {
+    })
+| (flavor, flags, {
       mllb_name = name;
       mllb_tysc = Some (tvars, t0);
       mllb_def = { expr = MLE_Coerce ({ expr = MLE_Fun (args, body) }, _, _) }
-    } ]) ->
+    }) ->
       let assumed = BU.for_some (function Syntax.Assumed -> true | _ -> false) flags in
       let env = if flavor = Rec then extend env name false else env in
       let env = List.fold_left (fun env name -> extend_t env name) env tvars in
@@ -392,12 +392,11 @@ and translate_decl env d: option<decl> =
           let msg = "This function was not extracted:\n" ^ msg in
           Some (DFunction (None, flags, List.length tvars, t, name, binders, EAbortS msg))
       end
-
-  | MLM_Let (flavor, flags, [ {
+| (flavor, flags, {
       mllb_name = name;
       mllb_tysc = Some ([], t);
       mllb_def = expr
-    } ]) ->
+    }) ->
       let flags = translate_flags flags in
       let t = translate_type env t in
       let name = env.module_name, name in
@@ -409,7 +408,7 @@ and translate_decl env d: option<decl> =
         Some (DGlobal (flags, name, t, EAny))
       end
 
-  | MLM_Let (_, _, { mllb_name = name; mllb_tysc = ts } :: _) ->
+| (_, _, { mllb_name = name; mllb_tysc = ts }) ->
       (* Things we currently do not translate:
        * - polymorphic functions (lemmas do count, sadly)
        *)
@@ -423,9 +422,12 @@ and translate_decl env d: option<decl> =
           ()
       end;
       None
+| _ -> failwith "impossible"
 
-  | MLM_Let _ ->
-      failwith "impossible"
+and translate_decl env d: option<decl> =
+  match d with
+  | MLM_Let (flavor, flags, [ letbinding ]) ->
+    translate_single_let env flavor flags letbinding
 
   | MLM_Loc _ ->
       None

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -29,7 +29,12 @@ type decl =
                                             FStar_Pervasives_Native.tuple2
                                             Prims.list)
                               FStar_Pervasives_Native.tuple2 Prims.list)
+<<<<<<< HEAD
   FStar_Pervasives_Native.tuple4[@@deriving show]
+=======
+  FStar_Pervasives_Native.tuple4 
+  | DTypeMutual of decl Prims.list 
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
 and cc =
   | StdCall
   | CDecl
@@ -150,8 +155,14 @@ and typ =
   | TTuple of typ Prims.list[@@deriving show]
 let uu___is_DGlobal: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DGlobal _0 -> true | uu____523 -> false
 let __proj__DGlobal__item___0:
+=======
+    match projectee with | DGlobal _0 -> true | uu____526 -> false
+  
+let __proj__DGlobal__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (flag Prims.list,(Prims.string Prims.list,Prims.string)
                        FStar_Pervasives_Native.tuple2,typ,expr)
@@ -159,8 +170,14 @@ let __proj__DGlobal__item___0:
   = fun projectee  -> match projectee with | DGlobal _0 -> _0
 let uu___is_DFunction: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DFunction _0 -> true | uu____609 -> false
 let __proj__DFunction__item___0:
+=======
+    match projectee with | DFunction _0 -> true | uu____614 -> false
+  
+let __proj__DFunction__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (cc FStar_Pervasives_Native.option,flag Prims.list,Prims.int,typ,
       (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
@@ -168,16 +185,28 @@ let __proj__DFunction__item___0:
   = fun projectee  -> match projectee with | DFunction _0 -> _0
 let uu___is_DTypeAlias: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DTypeAlias _0 -> true | uu____711 -> false
 let __proj__DTypeAlias__item___0:
+=======
+    match projectee with | DTypeAlias _0 -> true | uu____718 -> false
+  
+let __proj__DTypeAlias__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       Prims.int,typ) FStar_Pervasives_Native.tuple3
   = fun projectee  -> match projectee with | DTypeAlias _0 -> _0
 let uu___is_DTypeFlat: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DTypeFlat _0 -> true | uu____781 -> false
 let __proj__DTypeFlat__item___0:
+=======
+    match projectee with | DTypeFlat _0 -> true | uu____790 -> false
+  
+let __proj__DTypeFlat__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       Prims.int,(Prims.string,(typ,Prims.bool) FStar_Pervasives_Native.tuple2)
@@ -186,8 +215,14 @@ let __proj__DTypeFlat__item___0:
   = fun projectee  -> match projectee with | DTypeFlat _0 -> _0
 let uu___is_DExternal: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DExternal _0 -> true | uu____873 -> false
 let __proj__DExternal__item___0:
+=======
+    match projectee with | DExternal _0 -> true | uu____884 -> false
+  
+let __proj__DExternal__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (cc FStar_Pervasives_Native.option,(Prims.string Prims.list,Prims.string)
                                          FStar_Pervasives_Native.tuple2,
@@ -195,8 +230,14 @@ let __proj__DExternal__item___0:
   = fun projectee  -> match projectee with | DExternal _0 -> _0
 let uu___is_DTypeVariant: decl -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | DTypeVariant _0 -> true | uu____959 -> false
 let __proj__DTypeVariant__item___0:
+=======
+    match projectee with | DTypeVariant _0 -> true | uu____972 -> false
+  
+let __proj__DTypeVariant__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       flag Prims.list,Prims.int,(Prims.string,(Prims.string,(typ,Prims.bool)
@@ -205,6 +246,7 @@ let __proj__DTypeVariant__item___0:
                                                 Prims.list)
                                   FStar_Pervasives_Native.tuple2 Prims.list)
       FStar_Pervasives_Native.tuple4
+<<<<<<< HEAD
   = fun projectee  -> match projectee with | DTypeVariant _0 -> _0
 let uu___is_StdCall: cc -> Prims.bool =
   fun projectee  ->
@@ -250,38 +292,127 @@ let uu___is_EQualified: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EQualified _0 -> true | uu____1137 -> false
 let __proj__EQualified__item___0:
+=======
+  = fun projectee  -> match projectee with | DTypeVariant _0 -> _0 
+let uu___is_DTypeMutual : decl -> Prims.bool =
+  fun projectee  ->
+    match projectee with | DTypeMutual _0 -> true | uu____1084 -> false
+  
+let __proj__DTypeMutual__item___0 : decl -> decl Prims.list =
+  fun projectee  -> match projectee with | DTypeMutual _0 -> _0 
+let uu___is_StdCall : cc -> Prims.bool =
+  fun projectee  ->
+    match projectee with | StdCall  -> true | uu____1103 -> false
+  
+let uu___is_CDecl : cc -> Prims.bool =
+  fun projectee  ->
+    match projectee with | CDecl  -> true | uu____1108 -> false
+  
+let uu___is_FastCall : cc -> Prims.bool =
+  fun projectee  ->
+    match projectee with | FastCall  -> true | uu____1113 -> false
+  
+let uu___is_Private : flag -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Private  -> true | uu____1118 -> false
+  
+let uu___is_NoExtract : flag -> Prims.bool =
+  fun projectee  ->
+    match projectee with | NoExtract  -> true | uu____1123 -> false
+  
+let uu___is_CInline : flag -> Prims.bool =
+  fun projectee  ->
+    match projectee with | CInline  -> true | uu____1128 -> false
+  
+let uu___is_Substitute : flag -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Substitute  -> true | uu____1133 -> false
+  
+let uu___is_GCType : flag -> Prims.bool =
+  fun projectee  ->
+    match projectee with | GCType  -> true | uu____1138 -> false
+  
+let uu___is_Eternal : lifetime -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Eternal  -> true | uu____1143 -> false
+  
+let uu___is_Stack : lifetime -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Stack  -> true | uu____1148 -> false
+  
+let uu___is_EBound : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EBound _0 -> true | uu____1154 -> false
+  
+let __proj__EBound__item___0 : expr -> Prims.int =
+  fun projectee  -> match projectee with | EBound _0 -> _0 
+let uu___is_EQualified : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EQualified _0 -> true | uu____1174 -> false
+  
+let __proj__EQualified__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr ->
     (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | EQualified _0 -> _0
 let uu___is_EConstant: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EConstant _0 -> true | uu____1171 -> false
 let __proj__EConstant__item___0:
+=======
+    match projectee with | EConstant _0 -> true | uu____1210 -> false
+  
+let __proj__EConstant__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (width,Prims.string) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EConstant _0 -> _0
 let uu___is_EUnit: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EUnit  -> true | uu____1194 -> false
 let uu___is_EApp: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EApp _0 -> true | uu____1205 -> false
 let __proj__EApp__item___0:
+=======
+    match projectee with | EUnit  -> true | uu____1235 -> false
+  
+let uu___is_EApp : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EApp _0 -> true | uu____1247 -> false
+  
+let __proj__EApp__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr Prims.list) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EApp _0 -> _0
 let uu___is_ETypApp: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | ETypApp _0 -> true | uu____1241 -> false
 let __proj__ETypApp__item___0:
+=======
+    match projectee with | ETypApp _0 -> true | uu____1285 -> false
+  
+let __proj__ETypApp__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,typ Prims.list) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | ETypApp _0 -> _0
 let uu___is_ELet: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | ELet _0 -> true | uu____1277 -> false
 let __proj__ELet__item___0:
+=======
+    match projectee with | ELet _0 -> true | uu____1323 -> false
+  
+let __proj__ELet__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (binder,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | ELet _0 -> _0
 let uu___is_EIfThenElse: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EIfThenElse _0 -> true | uu____1313 -> false
 let __proj__EIfThenElse__item___0:
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
@@ -295,40 +426,89 @@ let uu___is_EAssign: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EAssign _0 -> true | uu____1367 -> false
 let __proj__EAssign__item___0:
+=======
+    match projectee with | EIfThenElse _0 -> true | uu____1361 -> false
+  
+let __proj__EIfThenElse__item___0 :
+  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EIfThenElse _0 -> _0 
+let uu___is_ESequence : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | ESequence _0 -> true | uu____1395 -> false
+  
+let __proj__ESequence__item___0 : expr -> expr Prims.list =
+  fun projectee  -> match projectee with | ESequence _0 -> _0 
+let uu___is_EAssign : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EAssign _0 -> true | uu____1419 -> false
+  
+let __proj__EAssign__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EAssign _0 -> _0
 let uu___is_EBufCreate: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufCreate _0 -> true | uu____1397 -> false
 let __proj__EBufCreate__item___0:
+=======
+    match projectee with | EBufCreate _0 -> true | uu____1451 -> false
+  
+let __proj__EBufCreate__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (lifetime,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EBufCreate _0 -> _0
 let uu___is_EBufRead: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufRead _0 -> true | uu____1431 -> false
 let __proj__EBufRead__item___0:
+=======
+    match projectee with | EBufRead _0 -> true | uu____1487 -> false
+  
+let __proj__EBufRead__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EBufRead _0 -> _0
 let uu___is_EBufWrite: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufWrite _0 -> true | uu____1461 -> false
 let __proj__EBufWrite__item___0:
+=======
+    match projectee with | EBufWrite _0 -> true | uu____1519 -> false
+  
+let __proj__EBufWrite__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EBufWrite _0 -> _0
 let uu___is_EBufSub: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufSub _0 -> true | uu____1495 -> false
 let __proj__EBufSub__item___0:
+=======
+    match projectee with | EBufSub _0 -> true | uu____1555 -> false
+  
+let __proj__EBufSub__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EBufSub _0 -> _0
 let uu___is_EBufBlit: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufBlit _0 -> true | uu____1529 -> false
 let __proj__EBufBlit__item___0:
+=======
+    match projectee with | EBufBlit _0 -> true | uu____1591 -> false
+  
+let __proj__EBufBlit__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5 =
   fun projectee  -> match projectee with | EBufBlit _0 -> _0
 let uu___is_EMatch: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EMatch _0 -> true | uu____1581 -> false
 let __proj__EMatch__item___0:
   expr ->
@@ -372,24 +552,92 @@ let uu___is_EFlat: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EFlat _0 -> true | uu____1729 -> false
 let __proj__EFlat__item___0:
+=======
+    match projectee with | EMatch _0 -> true | uu____1645 -> false
+  
+let __proj__EMatch__item___0 :
+  expr ->
+    (expr,(pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EMatch _0 -> _0 
+let uu___is_EOp : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EOp _0 -> true | uu____1693 -> false
+  
+let __proj__EOp__item___0 : expr -> (op,width) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EOp _0 -> _0 
+let uu___is_ECast : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | ECast _0 -> true | uu____1723 -> false
+  
+let __proj__ECast__item___0 :
+  expr -> (expr,typ) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | ECast _0 -> _0 
+let uu___is_EPushFrame : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EPushFrame  -> true | uu____1748 -> false
+  
+let uu___is_EPopFrame : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EPopFrame  -> true | uu____1753 -> false
+  
+let uu___is_EBool : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EBool _0 -> true | uu____1759 -> false
+  
+let __proj__EBool__item___0 : expr -> Prims.bool =
+  fun projectee  -> match projectee with | EBool _0 -> _0 
+let uu___is_EAny : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EAny  -> true | uu____1772 -> false
+  
+let uu___is_EAbort : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EAbort  -> true | uu____1777 -> false
+  
+let uu___is_EReturn : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EReturn _0 -> true | uu____1783 -> false
+  
+let __proj__EReturn__item___0 : expr -> expr =
+  fun projectee  -> match projectee with | EReturn _0 -> _0 
+let uu___is_EFlat : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EFlat _0 -> true | uu____1807 -> false
+  
+let __proj__EFlat__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr ->
     (typ,(Prims.string,expr) FStar_Pervasives_Native.tuple2 Prims.list)
       FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | EFlat _0 -> _0
 let uu___is_EField: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EField _0 -> true | uu____1777 -> false
 let __proj__EField__item___0:
+=======
+    match projectee with | EField _0 -> true | uu____1857 -> false
+  
+let __proj__EField__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EField _0 -> _0
 let uu___is_EWhile: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EWhile _0 -> true | uu____1811 -> false
 let __proj__EWhile__item___0:
+=======
+    match projectee with | EWhile _0 -> true | uu____1893 -> false
+  
+let __proj__EWhile__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EWhile _0 -> _0
 let uu___is_EBufCreateL: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufCreateL _0 -> true | uu____1841 -> false
 let __proj__EBufCreateL__item___0:
   expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2 =
@@ -403,10 +651,29 @@ let uu___is_ECons: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ECons _0 -> true | uu____1899 -> false
 let __proj__ECons__item___0:
+=======
+    match projectee with | EBufCreateL _0 -> true | uu____1925 -> false
+  
+let __proj__EBufCreateL__item___0 :
+  expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EBufCreateL _0 -> _0 
+let uu___is_ETuple : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | ETuple _0 -> true | uu____1959 -> false
+  
+let __proj__ETuple__item___0 : expr -> expr Prims.list =
+  fun projectee  -> match projectee with | ETuple _0 -> _0 
+let uu___is_ECons : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | ECons _0 -> true | uu____1987 -> false
+  
+let __proj__ECons__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (typ,Prims.string,expr Prims.list) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | ECons _0 -> _0
 let uu___is_EBufFill: expr -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | EBufFill _0 -> true | uu____1941 -> false
 let __proj__EBufFill__item___0:
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
@@ -515,10 +782,141 @@ let uu___is_PRecord: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PRecord _0 -> true | uu____2229 -> false
 let __proj__PRecord__item___0:
+=======
+    match projectee with | EBufFill _0 -> true | uu____2031 -> false
+  
+let __proj__EBufFill__item___0 :
+  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EBufFill _0 -> _0 
+let uu___is_EString : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EString _0 -> true | uu____2063 -> false
+  
+let __proj__EString__item___0 : expr -> Prims.string =
+  fun projectee  -> match projectee with | EString _0 -> _0 
+let uu___is_EFun : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EFun _0 -> true | uu____2085 -> false
+  
+let __proj__EFun__item___0 :
+  expr -> (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EFun _0 -> _0 
+let uu___is_EAbortS : expr -> Prims.bool =
+  fun projectee  ->
+    match projectee with | EAbortS _0 -> true | uu____2123 -> false
+  
+let __proj__EAbortS__item___0 : expr -> Prims.string =
+  fun projectee  -> match projectee with | EAbortS _0 -> _0 
+let uu___is_Add : op -> Prims.bool =
+  fun projectee  -> match projectee with | Add  -> true | uu____2136 -> false 
+let uu___is_AddW : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | AddW  -> true | uu____2141 -> false
+  
+let uu___is_Sub : op -> Prims.bool =
+  fun projectee  -> match projectee with | Sub  -> true | uu____2146 -> false 
+let uu___is_SubW : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | SubW  -> true | uu____2151 -> false
+  
+let uu___is_Div : op -> Prims.bool =
+  fun projectee  -> match projectee with | Div  -> true | uu____2156 -> false 
+let uu___is_DivW : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | DivW  -> true | uu____2161 -> false
+  
+let uu___is_Mult : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Mult  -> true | uu____2166 -> false
+  
+let uu___is_MultW : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | MultW  -> true | uu____2171 -> false
+  
+let uu___is_Mod : op -> Prims.bool =
+  fun projectee  -> match projectee with | Mod  -> true | uu____2176 -> false 
+let uu___is_BOr : op -> Prims.bool =
+  fun projectee  -> match projectee with | BOr  -> true | uu____2181 -> false 
+let uu___is_BAnd : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | BAnd  -> true | uu____2186 -> false
+  
+let uu___is_BXor : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | BXor  -> true | uu____2191 -> false
+  
+let uu___is_BShiftL : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | BShiftL  -> true | uu____2196 -> false
+  
+let uu___is_BShiftR : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | BShiftR  -> true | uu____2201 -> false
+  
+let uu___is_BNot : op -> Prims.bool =
+  fun projectee  ->
+    match projectee with | BNot  -> true | uu____2206 -> false
+  
+let uu___is_Eq : op -> Prims.bool =
+  fun projectee  -> match projectee with | Eq  -> true | uu____2211 -> false 
+let uu___is_Neq : op -> Prims.bool =
+  fun projectee  -> match projectee with | Neq  -> true | uu____2216 -> false 
+let uu___is_Lt : op -> Prims.bool =
+  fun projectee  -> match projectee with | Lt  -> true | uu____2221 -> false 
+let uu___is_Lte : op -> Prims.bool =
+  fun projectee  -> match projectee with | Lte  -> true | uu____2226 -> false 
+let uu___is_Gt : op -> Prims.bool =
+  fun projectee  -> match projectee with | Gt  -> true | uu____2231 -> false 
+let uu___is_Gte : op -> Prims.bool =
+  fun projectee  -> match projectee with | Gte  -> true | uu____2236 -> false 
+let uu___is_And : op -> Prims.bool =
+  fun projectee  -> match projectee with | And  -> true | uu____2241 -> false 
+let uu___is_Or : op -> Prims.bool =
+  fun projectee  -> match projectee with | Or  -> true | uu____2246 -> false 
+let uu___is_Xor : op -> Prims.bool =
+  fun projectee  -> match projectee with | Xor  -> true | uu____2251 -> false 
+let uu___is_Not : op -> Prims.bool =
+  fun projectee  -> match projectee with | Not  -> true | uu____2256 -> false 
+let uu___is_PUnit : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PUnit  -> true | uu____2261 -> false
+  
+let uu___is_PBool : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PBool _0 -> true | uu____2267 -> false
+  
+let __proj__PBool__item___0 : pattern -> Prims.bool =
+  fun projectee  -> match projectee with | PBool _0 -> _0 
+let uu___is_PVar : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PVar _0 -> true | uu____2281 -> false
+  
+let __proj__PVar__item___0 : pattern -> binder =
+  fun projectee  -> match projectee with | PVar _0 -> _0 
+let uu___is_PCons : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PCons _0 -> true | uu____2301 -> false
+  
+let __proj__PCons__item___0 :
+  pattern -> (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PCons _0 -> _0 
+let uu___is_PTuple : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PTuple _0 -> true | uu____2335 -> false
+  
+let __proj__PTuple__item___0 : pattern -> pattern Prims.list =
+  fun projectee  -> match projectee with | PTuple _0 -> _0 
+let uu___is_PRecord : pattern -> Prims.bool =
+  fun projectee  ->
+    match projectee with | PRecord _0 -> true | uu____2361 -> false
+  
+let __proj__PRecord__item___0 :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   pattern -> (Prims.string,pattern) FStar_Pervasives_Native.tuple2 Prims.list
   = fun projectee  -> match projectee with | PRecord _0 -> _0
 let uu___is_UInt8: width -> Prims.bool =
   fun projectee  ->
+<<<<<<< HEAD
     match projectee with | UInt8  -> true | uu____2258 -> false
 let uu___is_UInt16: width -> Prims.bool =
   fun projectee  ->
@@ -548,6 +946,47 @@ let uu___is_CInt: width -> Prims.bool =
   fun projectee  ->
     match projectee with | CInt  -> true | uu____2294 -> false
 let __proj__Mkbinder__item__name: binder -> Prims.string =
+=======
+    match projectee with | UInt8  -> true | uu____2392 -> false
+  
+let uu___is_UInt16 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | UInt16  -> true | uu____2397 -> false
+  
+let uu___is_UInt32 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | UInt32  -> true | uu____2402 -> false
+  
+let uu___is_UInt64 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | UInt64  -> true | uu____2407 -> false
+  
+let uu___is_Int8 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Int8  -> true | uu____2412 -> false
+  
+let uu___is_Int16 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Int16  -> true | uu____2417 -> false
+  
+let uu___is_Int32 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Int32  -> true | uu____2422 -> false
+  
+let uu___is_Int64 : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Int64  -> true | uu____2427 -> false
+  
+let uu___is_Bool : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | Bool  -> true | uu____2432 -> false
+  
+let uu___is_CInt : width -> Prims.bool =
+  fun projectee  ->
+    match projectee with | CInt  -> true | uu____2437 -> false
+  
+let __proj__Mkbinder__item__name : binder -> Prims.string =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun projectee  ->
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
@@ -562,6 +1001,7 @@ let __proj__Mkbinder__item__mut: binder -> Prims.bool =
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
         __fname__mut
+<<<<<<< HEAD
 let uu___is_TInt: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TInt _0 -> true | uu____2317 -> false
@@ -613,6 +1053,71 @@ let __proj__TTuple__item___0: typ -> typ Prims.list =
   fun projectee  -> match projectee with | TTuple _0 -> _0
 type program = decl Prims.list[@@deriving show]
 type ident = Prims.string[@@deriving show]
+=======
+  
+let uu___is_TInt : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TInt _0 -> true | uu____2464 -> false
+  
+let __proj__TInt__item___0 : typ -> width =
+  fun projectee  -> match projectee with | TInt _0 -> _0 
+let uu___is_TBuf : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TBuf _0 -> true | uu____2478 -> false
+  
+let __proj__TBuf__item___0 : typ -> typ =
+  fun projectee  -> match projectee with | TBuf _0 -> _0 
+let uu___is_TUnit : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TUnit  -> true | uu____2491 -> false
+  
+let uu___is_TQualified : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TQualified _0 -> true | uu____2503 -> false
+  
+let __proj__TQualified__item___0 :
+  typ ->
+    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TQualified _0 -> _0 
+let uu___is_TBool : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TBool  -> true | uu____2534 -> false
+  
+let uu___is_TAny : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TAny  -> true | uu____2539 -> false
+  
+let uu___is_TArrow : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TArrow _0 -> true | uu____2549 -> false
+  
+let __proj__TArrow__item___0 :
+  typ -> (typ,typ) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | TArrow _0 -> _0 
+let uu___is_TBound : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TBound _0 -> true | uu____2575 -> false
+  
+let __proj__TBound__item___0 : typ -> Prims.int =
+  fun projectee  -> match projectee with | TBound _0 -> _0 
+let uu___is_TApp : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TApp _0 -> true | uu____2601 -> false
+  
+let __proj__TApp__item___0 :
+  typ ->
+    ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
+      typ Prims.list) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TApp _0 -> _0 
+let uu___is_TTuple : typ -> Prims.bool =
+  fun projectee  ->
+    match projectee with | TTuple _0 -> true | uu____2653 -> false
+  
+let __proj__TTuple__item___0 : typ -> typ Prims.list =
+  fun projectee  -> match projectee with | TTuple _0 -> _0 
+type program = decl Prims.list
+type ident = Prims.string
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
 type fields_t =
   (Prims.string,(typ,Prims.bool) FStar_Pervasives_Native.tuple2)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
@@ -629,6 +1134,7 @@ type constant = (width,Prims.string) FStar_Pervasives_Native.tuple2[@@deriving
 type var = Prims.int[@@deriving show]
 type lident =
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
+<<<<<<< HEAD
 [@@deriving show]
 type version = Prims.int[@@deriving show]
 let current_version: version = Prims.parse_int "24"
@@ -654,6 +1160,30 @@ let thd3:
 let mk_width: Prims.string -> width FStar_Pervasives_Native.option =
   fun uu___401_2645  ->
     match uu___401_2645 with
+=======
+type version = Prims.int
+let current_version : version = (Prims.parse_int "25") 
+type file = (Prims.string,program) FStar_Pervasives_Native.tuple2
+type binary_format = (version,file Prims.list) FStar_Pervasives_Native.tuple2
+let fst3 :
+  'Auu____2734 'Auu____2735 'Auu____2736 .
+    ('Auu____2736,'Auu____2735,'Auu____2734) FStar_Pervasives_Native.tuple3
+      -> 'Auu____2736
+  = fun uu____2746  -> match uu____2746 with | (x,uu____2754,uu____2755) -> x 
+let snd3 :
+  'Auu____2764 'Auu____2765 'Auu____2766 .
+    ('Auu____2766,'Auu____2765,'Auu____2764) FStar_Pervasives_Native.tuple3
+      -> 'Auu____2765
+  = fun uu____2776  -> match uu____2776 with | (uu____2783,x,uu____2785) -> x 
+let thd3 :
+  'Auu____2794 'Auu____2795 'Auu____2796 .
+    ('Auu____2796,'Auu____2795,'Auu____2794) FStar_Pervasives_Native.tuple3
+      -> 'Auu____2794
+  = fun uu____2806  -> match uu____2806 with | (uu____2813,uu____2814,x) -> x 
+let mk_width : Prims.string -> width FStar_Pervasives_Native.option =
+  fun uu___123_2821  ->
+    match uu___123_2821 with
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
     | "UInt8" -> FStar_Pervasives_Native.Some UInt8
     | "UInt16" -> FStar_Pervasives_Native.Some UInt16
     | "UInt32" -> FStar_Pervasives_Native.Some UInt32
@@ -662,21 +1192,39 @@ let mk_width: Prims.string -> width FStar_Pervasives_Native.option =
     | "Int16" -> FStar_Pervasives_Native.Some Int16
     | "Int32" -> FStar_Pervasives_Native.Some Int32
     | "Int64" -> FStar_Pervasives_Native.Some Int64
+<<<<<<< HEAD
     | uu____2648 -> FStar_Pervasives_Native.None
 let mk_bool_op: Prims.string -> op FStar_Pervasives_Native.option =
   fun uu___402_2653  ->
     match uu___402_2653 with
+=======
+    | uu____2824 -> FStar_Pervasives_Native.None
+  
+let mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option =
+  fun uu___124_2830  ->
+    match uu___124_2830 with
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
     | "op_Negation" -> FStar_Pervasives_Native.Some Not
     | "op_AmpAmp" -> FStar_Pervasives_Native.Some And
     | "op_BarBar" -> FStar_Pervasives_Native.Some Or
     | "op_Equality" -> FStar_Pervasives_Native.Some Eq
     | "op_disEquality" -> FStar_Pervasives_Native.Some Neq
+<<<<<<< HEAD
     | uu____2656 -> FStar_Pervasives_Native.None
 let is_bool_op: Prims.string -> Prims.bool =
   fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None
 let mk_op: Prims.string -> op FStar_Pervasives_Native.option =
   fun uu___403_2666  ->
     match uu___403_2666 with
+=======
+    | uu____2833 -> FStar_Pervasives_Native.None
+  
+let is_bool_op : Prims.string -> Prims.bool =
+  fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None 
+let mk_op : Prims.string -> op FStar_Pervasives_Native.option =
+  fun uu___125_2845  ->
+    match uu___125_2845 with
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
     | "add" -> FStar_Pervasives_Native.Some Add
     | "op_Plus_Hat" -> FStar_Pervasives_Native.Some Add
     | "add_mod" -> FStar_Pervasives_Native.Some AddW
@@ -716,11 +1264,20 @@ let mk_op: Prims.string -> op FStar_Pervasives_Native.option =
     | "lt" -> FStar_Pervasives_Native.Some Lt
     | "op_Less_Equals_Hat" -> FStar_Pervasives_Native.Some Lte
     | "lte" -> FStar_Pervasives_Native.Some Lte
+<<<<<<< HEAD
     | uu____2669 -> FStar_Pervasives_Native.None
 let is_op: Prims.string -> Prims.bool =
   fun op  -> (mk_op op) <> FStar_Pervasives_Native.None
 let is_machine_int: Prims.string -> Prims.bool =
   fun m  -> (mk_width m) <> FStar_Pervasives_Native.None
+=======
+    | uu____2848 -> FStar_Pervasives_Native.None
+  
+let is_op : Prims.string -> Prims.bool =
+  fun op  -> (mk_op op) <> FStar_Pervasives_Native.None 
+let is_machine_int : Prims.string -> Prims.bool =
+  fun m  -> (mk_width m) <> FStar_Pervasives_Native.None 
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
 type env =
   {
   names: name Prims.list;
@@ -758,24 +1315,41 @@ let extend: env -> Prims.string -> Prims.bool -> env =
   fun env  ->
     fun x  ->
       fun is_mut  ->
+<<<<<<< HEAD
         let uu___408_2780 = env in
         {
           names = ({ pretty = x; mut = is_mut } :: (env.names));
           names_t = (uu___408_2780.names_t);
           module_name = (uu___408_2780.module_name)
+=======
+        let uu___130_2970 = env  in
+        {
+          names = ({ pretty = x; mut = is_mut } :: (env.names));
+          names_t = (uu___130_2970.names_t);
+          module_name = (uu___130_2970.module_name)
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
         }
 let extend_t: env -> Prims.string -> env =
   fun env  ->
     fun x  ->
+<<<<<<< HEAD
       let uu___409_2787 = env in
       {
         names = (uu___409_2787.names);
         names_t = (x :: (env.names_t));
         module_name = (uu___409_2787.module_name)
+=======
+      let uu___131_2979 = env  in
+      {
+        names = (uu___131_2979.names);
+        names_t = (x :: (env.names_t));
+        module_name = (uu___131_2979.module_name)
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       }
 let find_name: env -> Prims.string -> name =
   fun env  ->
     fun x  ->
+<<<<<<< HEAD
       let uu____2794 =
         FStar_List.tryFind (fun name  -> name.pretty = x) env.names in
       match uu____2794 with
@@ -785,19 +1359,41 @@ let find_name: env -> Prims.string -> name =
 let is_mutable: env -> Prims.string -> Prims.bool =
   fun env  -> fun x  -> let uu____2806 = find_name env x in uu____2806.mut
 let find: env -> Prims.string -> Prims.int =
+=======
+      let uu____2988 =
+        FStar_List.tryFind (fun name  -> name.pretty = x) env.names  in
+      match uu____2988 with
+      | FStar_Pervasives_Native.Some name -> name
+      | FStar_Pervasives_Native.None  ->
+          failwith "internal error: name not found"
+  
+let is_mutable : env -> Prims.string -> Prims.bool =
+  fun env  -> fun x  -> let uu____3002 = find_name env x  in uu____3002.mut 
+let find : env -> Prims.string -> Prims.int =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name.pretty = x) env.names
       with
+<<<<<<< HEAD
       | uu____2821 ->
           let uu____2822 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
           failwith uu____2822
 let find_t: env -> Prims.string -> Prims.int =
+=======
+      | uu____3019 ->
+          let uu____3020 =
+            FStar_Util.format1 "Internal error: name not found %s\n" x  in
+          failwith uu____3020
+  
+let find_t : env -> Prims.string -> Prims.int =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name = x) env.names_t
       with
+<<<<<<< HEAD
       | uu____2837 ->
           let uu____2838 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
@@ -807,28 +1403,58 @@ let add_binders:
     env ->
       (Prims.string,'Auu____2842) FStar_Pervasives_Native.tuple2 Prims.list
         -> env
+=======
+      | uu____3037 ->
+          let uu____3038 =
+            FStar_Util.format1 "Internal error: name not found %s\n" x  in
+          failwith uu____3038
+  
+let add_binders :
+  'Auu____3047 'Auu____3048 .
+    env ->
+      ((Prims.string,'Auu____3048) FStar_Pervasives_Native.tuple2,'Auu____3047)
+        FStar_Pervasives_Native.tuple2 Prims.list -> env
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   =
   fun env  ->
     fun binders  ->
       FStar_List.fold_left
         (fun env1  ->
+<<<<<<< HEAD
            fun uu____2872  ->
              match uu____2872 with
              | (name,uu____2878) -> extend env1 name false) env binders
 let rec translate: FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
   fun uu____3003  ->
     match uu____3003 with
+=======
+           fun uu____3091  ->
+             match uu____3091 with
+             | ((name,uu____3101),uu____3102) -> extend env1 name false) env
+        binders
+  
+let rec translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
+  fun uu____3237  ->
+    match uu____3237 with
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
     | FStar_Extraction_ML_Syntax.MLLib modules1 ->
         FStar_List.filter_map
           (fun m  ->
              let m_name =
+<<<<<<< HEAD
                let uu____3063 = m in
                match uu____3063 with
                | ((prefix1,final),uu____3084,uu____3085) ->
+=======
+               let uu____3297 = m  in
+               match uu____3297 with
+               | ((prefix1,final),uu____3318,uu____3319) ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                    FStar_String.concat "."
                      (FStar_List.append prefix1 [final]) in
              try
                FStar_Util.print1 "Attempting to translate module %s\n" m_name;
+<<<<<<< HEAD
                (let uu____3117 = translate_module m in
                 FStar_Pervasives_Native.Some uu____3117)
              with
@@ -837,6 +1463,16 @@ let rec translate: FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
                    FStar_Util.print2
                      "Unable to translate module: %s because:\n  %s\n" m_name
                      uu____3126);
+=======
+               (let uu____3351 = translate_module m  in
+                FStar_Pervasives_Native.Some uu____3351)
+             with
+             | e ->
+                 ((let uu____3360 = FStar_Util.print_exn e  in
+                   FStar_Util.print2
+                     "Unable to translate module: %s because:\n  %s\n" m_name
+                     uu____3360);
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                   FStar_Pervasives_Native.None)) modules1
 and translate_module:
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
@@ -844,9 +1480,15 @@ and translate_module:
       FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option,FStar_Extraction_ML_Syntax.mllib)
     FStar_Pervasives_Native.tuple3 -> file
   =
+<<<<<<< HEAD
   fun uu____3127  ->
     match uu____3127 with
     | (module_name,modul,uu____3148) ->
+=======
+  fun uu____3361  ->
+    match uu____3361 with
+    | (module_name,modul,uu____3382) ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
         let module_name1 =
           FStar_List.append (FStar_Pervasives_Native.fst module_name)
             [FStar_Pervasives_Native.snd module_name] in
@@ -855,15 +1497,26 @@ and translate_module:
           | FStar_Pervasives_Native.Some (_signature,decls) ->
               FStar_List.filter_map (translate_decl (empty module_name1))
                 decls
+<<<<<<< HEAD
           | uu____3191 ->
               failwith "Unexpected standalone interface or nested modules" in
+=======
+          | uu____3425 ->
+              failwith "Unexpected standalone interface or nested modules"
+           in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
         ((FStar_String.concat "_" module_name1), program)
 and translate_flags:
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list =
   fun flags  ->
     FStar_List.choose
+<<<<<<< HEAD
       (fun uu___404_3206  ->
          match uu___404_3206 with
+=======
+      (fun uu___126_3440  ->
+         match uu___126_3440 with
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
          | FStar_Extraction_ML_Syntax.Private  ->
              FStar_Pervasives_Native.Some Private
          | FStar_Extraction_ML_Syntax.NoExtract  ->
@@ -874,10 +1527,16 @@ and translate_flags:
              FStar_Pervasives_Native.Some Substitute
          | FStar_Extraction_ML_Syntax.GCType  ->
              FStar_Pervasives_Native.Some GCType
+<<<<<<< HEAD
          | FStar_Extraction_ML_Syntax.Comment s ->
              FStar_Pervasives_Native.Some (Comment s)
          | uu____3210 -> FStar_Pervasives_Native.None) flags
 and translate_decl:
+=======
+         | uu____3443 -> FStar_Pervasives_Native.None) flags
+
+and translate_decl :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     FStar_Extraction_ML_Syntax.mlmodule1 ->
       decl FStar_Pervasives_Native.option
@@ -886,16 +1545,27 @@ and translate_decl:
     fun d  ->
       match d with
       | FStar_Extraction_ML_Syntax.MLM_Let
+<<<<<<< HEAD
           (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
                           FStar_Extraction_ML_Syntax.mllb_tysc =
                             FStar_Pervasives_Native.Some (tvars,t0);
                           FStar_Extraction_ML_Syntax.mllb_add_unit =
                             uu____3220;
+=======
+          (flavor,flags,{
+                          FStar_Extraction_ML_Syntax.mllb_name =
+                            (name,uu____3451);
+                          FStar_Extraction_ML_Syntax.mllb_tysc =
+                            FStar_Pervasives_Native.Some (tvars,t0);
+                          FStar_Extraction_ML_Syntax.mllb_add_unit =
+                            uu____3454;
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                           FStar_Extraction_ML_Syntax.mllb_def =
                             {
                               FStar_Extraction_ML_Syntax.expr =
                                 FStar_Extraction_ML_Syntax.MLE_Fun
                                 (args,body);
+<<<<<<< HEAD
                               FStar_Extraction_ML_Syntax.mlty = uu____3223;
                               FStar_Extraction_ML_Syntax.loc = uu____3224;_};
                           FStar_Extraction_ML_Syntax.print_typ = uu____3225;_}::[])
@@ -906,20 +1576,45 @@ and translate_decl:
                  match uu___405_3246 with
                  | FStar_Extraction_ML_Syntax.Assumed  -> true
                  | uu____3247 -> false) flags in
+=======
+                              FStar_Extraction_ML_Syntax.mlty = uu____3457;
+                              FStar_Extraction_ML_Syntax.loc = uu____3458;_};
+                          FStar_Extraction_ML_Syntax.print_typ = uu____3459;_}::[])
+          ->
+          let assumed =
+            FStar_Util.for_some
+              (fun uu___127_3480  ->
+                 match uu___127_3480 with
+                 | FStar_Extraction_ML_Syntax.Assumed  -> true
+                 | uu____3481 -> false) flags
+             in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           let env1 =
             if flavor = FStar_Extraction_ML_Syntax.Rec
             then extend env name false
             else env in
           let env2 =
             FStar_List.fold_left
+<<<<<<< HEAD
               (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
           let rec find_return_type i uu___406_3261 =
             match uu___406_3261 with
             | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3262,uu____3263,t)
+=======
+              (fun env2  ->
+                 fun uu____3494  ->
+                   match uu____3494 with
+                   | (name1,uu____3500) -> extend_t env2 name1) env1 tvars
+             in
+          let rec find_return_type i uu___128_3507 =
+            match uu___128_3507 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3508,uu____3509,t)
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                 when i > (Prims.parse_int "0") ->
                 find_return_type (i - (Prims.parse_int "1")) t
             | t -> t in
           let t =
+<<<<<<< HEAD
             let uu____3267 = find_return_type (FStar_List.length args) t0 in
             translate_type env2 uu____3267 in
           let binders = translate_binders env2 args in
@@ -933,16 +1628,40 @@ and translate_decl:
                 let uu____3292 = translate_flags flags in NoExtract ::
                   uu____3292
             | uu____3295 -> translate_flags flags in
+=======
+            let uu____3513 = find_return_type (FStar_List.length args) t0  in
+            translate_type env2 uu____3513  in
+          let binders = translate_binders env2 args  in
+          let env3 = add_binders env2 args  in
+          let name1 = ((env3.module_name), name)  in
+          let flags1 =
+            match t0 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun
+                (uu____3536,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3537)
+                ->
+                let uu____3538 = translate_flags flags  in NoExtract ::
+                  uu____3538
+            | uu____3541 -> translate_flags flags  in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           if assumed
           then
             (if (FStar_List.length tvars) = (Prims.parse_int "0")
              then
+<<<<<<< HEAD
                let uu____3300 =
                  let uu____3301 =
                    let uu____3316 = translate_type env3 t0 in
                    (FStar_Pervasives_Native.None, name1, uu____3316) in
                  DExternal uu____3301 in
                FStar_Pervasives_Native.Some uu____3300
+=======
+               let uu____3546 =
+                 let uu____3547 =
+                   let uu____3562 = translate_type env3 t0  in
+                   (FStar_Pervasives_Native.None, name1, uu____3562)  in
+                 DExternal uu____3547  in
+               FStar_Pervasives_Native.Some uu____3546
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
              else FStar_Pervasives_Native.None)
           else
             (try
@@ -964,11 +1683,21 @@ and translate_decl:
                           (FStar_List.length tvars), t, name1, binders,
                           (EAbortS msg1))))))
       | FStar_Extraction_ML_Syntax.MLM_Let
+<<<<<<< HEAD
           (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
                           FStar_Extraction_ML_Syntax.mllb_tysc =
                             FStar_Pervasives_Native.Some (tvars,t0);
                           FStar_Extraction_ML_Syntax.mllb_add_unit =
                             uu____3378;
+=======
+          (flavor,flags,{
+                          FStar_Extraction_ML_Syntax.mllb_name =
+                            (name,uu____3622);
+                          FStar_Extraction_ML_Syntax.mllb_tysc =
+                            FStar_Pervasives_Native.Some (tvars,t0);
+                          FStar_Extraction_ML_Syntax.mllb_add_unit =
+                            uu____3625;
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                           FStar_Extraction_ML_Syntax.mllb_def =
                             {
                               FStar_Extraction_ML_Syntax.expr =
@@ -978,6 +1707,7 @@ and translate_decl:
                                      FStar_Extraction_ML_Syntax.MLE_Fun
                                      (args,body);
                                    FStar_Extraction_ML_Syntax.mlty =
+<<<<<<< HEAD
                                      uu____3381;
                                    FStar_Extraction_ML_Syntax.loc =
                                      uu____3382;_},uu____3383,uu____3384);
@@ -991,20 +1721,48 @@ and translate_decl:
                  match uu___405_3408 with
                  | FStar_Extraction_ML_Syntax.Assumed  -> true
                  | uu____3409 -> false) flags in
+=======
+                                     uu____3628;
+                                   FStar_Extraction_ML_Syntax.loc =
+                                     uu____3629;_},uu____3630,uu____3631);
+                              FStar_Extraction_ML_Syntax.mlty = uu____3632;
+                              FStar_Extraction_ML_Syntax.loc = uu____3633;_};
+                          FStar_Extraction_ML_Syntax.print_typ = uu____3634;_}::[])
+          ->
+          let assumed =
+            FStar_Util.for_some
+              (fun uu___127_3655  ->
+                 match uu___127_3655 with
+                 | FStar_Extraction_ML_Syntax.Assumed  -> true
+                 | uu____3656 -> false) flags
+             in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           let env1 =
             if flavor = FStar_Extraction_ML_Syntax.Rec
             then extend env name false
             else env in
           let env2 =
             FStar_List.fold_left
+<<<<<<< HEAD
               (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
           let rec find_return_type i uu___406_3423 =
             match uu___406_3423 with
             | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3424,uu____3425,t)
+=======
+              (fun env2  ->
+                 fun uu____3669  ->
+                   match uu____3669 with
+                   | (name1,uu____3675) -> extend_t env2 name1) env1 tvars
+             in
+          let rec find_return_type i uu___128_3682 =
+            match uu___128_3682 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3683,uu____3684,t)
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                 when i > (Prims.parse_int "0") ->
                 find_return_type (i - (Prims.parse_int "1")) t
             | t -> t in
           let t =
+<<<<<<< HEAD
             let uu____3429 = find_return_type (FStar_List.length args) t0 in
             translate_type env2 uu____3429 in
           let binders = translate_binders env2 args in
@@ -1018,16 +1776,40 @@ and translate_decl:
                 let uu____3454 = translate_flags flags in NoExtract ::
                   uu____3454
             | uu____3457 -> translate_flags flags in
+=======
+            let uu____3688 = find_return_type (FStar_List.length args) t0  in
+            translate_type env2 uu____3688  in
+          let binders = translate_binders env2 args  in
+          let env3 = add_binders env2 args  in
+          let name1 = ((env3.module_name), name)  in
+          let flags1 =
+            match t0 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun
+                (uu____3711,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3712)
+                ->
+                let uu____3713 = translate_flags flags  in NoExtract ::
+                  uu____3713
+            | uu____3716 -> translate_flags flags  in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           if assumed
           then
             (if (FStar_List.length tvars) = (Prims.parse_int "0")
              then
+<<<<<<< HEAD
                let uu____3462 =
                  let uu____3463 =
                    let uu____3478 = translate_type env3 t0 in
                    (FStar_Pervasives_Native.None, name1, uu____3478) in
                  DExternal uu____3463 in
                FStar_Pervasives_Native.Some uu____3462
+=======
+               let uu____3721 =
+                 let uu____3722 =
+                   let uu____3737 = translate_type env3 t0  in
+                   (FStar_Pervasives_Native.None, name1, uu____3737)  in
+                 DExternal uu____3722  in
+               FStar_Pervasives_Native.Some uu____3721
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
              else FStar_Pervasives_Native.None)
           else
             (try
@@ -1049,6 +1831,7 @@ and translate_decl:
                           (FStar_List.length tvars), t, name1, binders,
                           (EAbortS msg1))))))
       | FStar_Extraction_ML_Syntax.MLM_Let
+<<<<<<< HEAD
           (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
                           FStar_Extraction_ML_Syntax.mllb_tysc =
                             FStar_Pervasives_Native.Some ([],t);
@@ -1056,6 +1839,17 @@ and translate_decl:
                             uu____3539;
                           FStar_Extraction_ML_Syntax.mllb_def = expr;
                           FStar_Extraction_ML_Syntax.print_typ = uu____3541;_}::[])
+=======
+          (flavor,flags,{
+                          FStar_Extraction_ML_Syntax.mllb_name =
+                            (name,uu____3797);
+                          FStar_Extraction_ML_Syntax.mllb_tysc =
+                            FStar_Pervasives_Native.Some ([],t);
+                          FStar_Extraction_ML_Syntax.mllb_add_unit =
+                            uu____3799;
+                          FStar_Extraction_ML_Syntax.mllb_def = expr;
+                          FStar_Extraction_ML_Syntax.print_typ = uu____3801;_}::[])
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           ->
           let flags1 = translate_flags flags in
           let t1 = translate_type env t in
@@ -1066,6 +1860,7 @@ and translate_decl:
                (DGlobal (flags1, name1, t1, expr1))
            with
            | e ->
+<<<<<<< HEAD
                ((let uu____3589 = FStar_Util.print_exn e in
                  FStar_Util.print2_warning
                    "Not translating definition for %s (%s)\n"
@@ -1083,11 +1878,31 @@ and translate_decl:
                                      uu____3605;
                                    FStar_Extraction_ML_Syntax.print_typ =
                                      uu____3606;_}::uu____3607)
+=======
+               ((let uu____3849 = FStar_Util.print_exn e  in
+                 FStar_Util.print2
+                   "Warning: not translating definition for %s (%s)\n"
+                   (FStar_Pervasives_Native.snd name1) uu____3849);
+                FStar_Pervasives_Native.Some
+                  (DGlobal (flags1, name1, t1, EAny))))
+      | FStar_Extraction_ML_Syntax.MLM_Let
+          (uu____3860,uu____3861,{
+                                   FStar_Extraction_ML_Syntax.mllb_name =
+                                     (name,uu____3863);
+                                   FStar_Extraction_ML_Syntax.mllb_tysc = ts;
+                                   FStar_Extraction_ML_Syntax.mllb_add_unit =
+                                     uu____3865;
+                                   FStar_Extraction_ML_Syntax.mllb_def =
+                                     uu____3866;
+                                   FStar_Extraction_ML_Syntax.print_typ =
+                                     uu____3867;_}::uu____3868)
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           ->
           (FStar_Util.print1_warning
              "Not translating definition for %s (and possibly others)\n" name;
            (match ts with
             | FStar_Pervasives_Native.Some (idents,t) ->
+<<<<<<< HEAD
                 let uu____3622 =
                   FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
                 FStar_Util.print2 "Type scheme is: forall %s. %s\n"
@@ -1179,11 +1994,150 @@ and translate_decl:
       | FStar_Extraction_ML_Syntax.MLM_Exn uu____4194 ->
           failwith "todo: translate_decl [MLM_Exn]"
 and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
+=======
+                let uu____3883 =
+                  let uu____3884 =
+                    FStar_List.map FStar_Pervasives_Native.fst idents  in
+                  FStar_String.concat ", " uu____3884  in
+                let uu____3891 =
+                  FStar_Extraction_ML_Code.string_of_mlty ([], "") t  in
+                FStar_Util.print2 "Type scheme is: forall %s. %s\n"
+                  uu____3883 uu____3891
+            | FStar_Pervasives_Native.None  -> ());
+           FStar_Pervasives_Native.None)
+      | FStar_Extraction_ML_Syntax.MLM_Let uu____3894 ->
+          failwith "impossible"
+      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3897 ->
+          FStar_Pervasives_Native.None
+      | FStar_Extraction_ML_Syntax.MLM_Ty (ty_decl::[]) ->
+          translate_single_type_decl env ty_decl
+      | FStar_Extraction_ML_Syntax.MLM_Ty ty_decls ->
+          let rec traverse f xs =
+            match xs with
+            | [] -> FStar_Pervasives_Native.Some []
+            | o::os ->
+                let uu____3938 = traverse f os  in
+                (match uu____3938 with
+                 | FStar_Pervasives_Native.None  ->
+                     FStar_Pervasives_Native.None
+                 | FStar_Pervasives_Native.Some os' ->
+                     let uu____3956 = f o  in
+                     (match uu____3956 with
+                      | FStar_Pervasives_Native.None  ->
+                          FStar_Pervasives_Native.None
+                      | FStar_Pervasives_Native.Some o' ->
+                          FStar_Pervasives_Native.Some (o' :: os')))
+             in
+          let uu____3968 = traverse (translate_single_type_decl env) ty_decls
+             in
+          (match uu____3968 with
+           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some decls ->
+               FStar_Pervasives_Native.Some (DTypeMutual decls))
+      | FStar_Extraction_ML_Syntax.MLM_Ty [] ->
+          (FStar_Util.print_string
+             "Impossible!! Empty block of mutually recursive type declarations";
+           FStar_Pervasives_Native.None)
+      | FStar_Extraction_ML_Syntax.MLM_Top uu____3983 ->
+          failwith "todo: translate_decl [MLM_Top]"
+      | FStar_Extraction_ML_Syntax.MLM_Exn uu____3986 ->
+          failwith "todo: translate_decl [MLM_Exn]"
+
+and translate_single_type_decl :
+  env ->
+    FStar_Extraction_ML_Syntax.one_mltydecl ->
+      decl FStar_Pervasives_Native.option
+  =
+  fun env  ->
+    fun ty_decl  ->
+      match ty_decl with
+      | (assumed,name,_mangled_name,args,uu____4007,FStar_Pervasives_Native.Some
+         (FStar_Extraction_ML_Syntax.MLTD_Abbrev t)) ->
+          let name1 = ((env.module_name), name)  in
+          let env1 =
+            FStar_List.fold_left
+              (fun env1  ->
+                 fun uu____4034  ->
+                   match uu____4034 with
+                   | (name2,uu____4040) -> extend_t env1 name2) env args
+             in
+          if assumed
+          then FStar_Pervasives_Native.None
+          else
+            (let uu____4044 =
+               let uu____4045 =
+                 let uu____4058 = translate_type env1 t  in
+                 (name1, (FStar_List.length args), uu____4058)  in
+               DTypeAlias uu____4045  in
+             FStar_Pervasives_Native.Some uu____4044)
+      | (uu____4065,name,_mangled_name,args,uu____4069,FStar_Pervasives_Native.Some
+         (FStar_Extraction_ML_Syntax.MLTD_Record fields)) ->
+          let name1 = ((env.module_name), name)  in
+          let env1 =
+            FStar_List.fold_left
+              (fun env1  ->
+                 fun uu____4102  ->
+                   match uu____4102 with
+                   | (name2,uu____4108) -> extend_t env1 name2) env args
+             in
+          let uu____4109 =
+            let uu____4110 =
+              let uu____4133 =
+                FStar_List.map
+                  (fun uu____4160  ->
+                     match uu____4160 with
+                     | (f,t) ->
+                         let uu____4175 =
+                           let uu____4180 = translate_type env1 t  in
+                           (uu____4180, false)  in
+                         (f, uu____4175)) fields
+                 in
+              (name1, (FStar_List.length args), uu____4133)  in
+            DTypeFlat uu____4110  in
+          FStar_Pervasives_Native.Some uu____4109
+      | (uu____4201,name,_mangled_name,args,attrs,FStar_Pervasives_Native.Some
+         (FStar_Extraction_ML_Syntax.MLTD_DType branches)) ->
+          let name1 = ((env.module_name), name)  in
+          let flags = translate_flags attrs  in
+          let env1 =
+            FStar_List.fold_left
+              (fun env1  ->
+                 fun uu____4247  ->
+                   match uu____4247 with
+                   | (name2,uu____4253) -> extend_t env1 name2) env args
+             in
+          let uu____4254 =
+            let uu____4255 =
+              let uu____4288 =
+                FStar_List.map
+                  (fun uu____4333  ->
+                     match uu____4333 with
+                     | (cons1,ts) ->
+                         let uu____4372 =
+                           FStar_List.map
+                             (fun uu____4399  ->
+                                match uu____4399 with
+                                | (name2,t) ->
+                                    let uu____4414 =
+                                      let uu____4419 = translate_type env1 t
+                                         in
+                                      (uu____4419, false)  in
+                                    (name2, uu____4414)) ts
+                            in
+                         (cons1, uu____4372)) branches
+                 in
+              (name1, flags, (FStar_List.length args), uu____4288)  in
+            DTypeVariant uu____4255  in
+          FStar_Pervasives_Native.Some uu____4254
+
+and translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun t  ->
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Tuple [] -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Top  -> TAny
+<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLTY_Var name ->
           let uu____4210 = find_t env name in TBound uu____4210
       | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4212,t2) ->
@@ -1214,12 +2168,45 @@ and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
       | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4264::[],p) when
           let uu____4268 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4268 = "FStar.Ghost.erased" -> TAny
+=======
+      | FStar_Extraction_ML_Syntax.MLTY_Var (name,uu____4461) ->
+          let uu____4462 = find_t env name  in TBound uu____4462
+      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4464,t2) ->
+          let uu____4466 =
+            let uu____4471 = translate_type env t1  in
+            let uu____4472 = translate_type env t2  in
+            (uu____4471, uu____4472)  in
+          TArrow uu____4466
+      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
+          let uu____4476 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4476 = "Prims.unit" -> TUnit
+      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
+          let uu____4480 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4480 = "Prims.bool" -> TBool
+      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
+          is_machine_int m ->
+          let uu____4492 = FStar_Util.must (mk_width m)  in TInt uu____4492
+      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
+          is_machine_int m ->
+          let uu____4504 = FStar_Util.must (mk_width m)  in TInt uu____4504
+      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
+          let uu____4509 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4509 = "FStar.Monotonic.HyperStack.mem" -> TUnit
+      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
+          let uu____4514 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4514 = "FStar.Buffer.buffer" ->
+          let uu____4515 = translate_type env arg  in TBuf uu____4515
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4516::[],p) when
+          let uu____4520 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4520 = "FStar.Ghost.erased" -> TAny
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],(path,type_name)) ->
           TQualified (path, type_name)
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,(ns,t1)) when
           ((ns = ["Prims"]) || (ns = ["FStar"; "Pervasives"; "Native"])) &&
             (FStar_Util.starts_with t1 "tuple")
           ->
+<<<<<<< HEAD
           let uu____4306 = FStar_List.map (translate_type env) args in
           TTuple uu____4306
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
@@ -1234,6 +2221,23 @@ and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
           let uu____4337 = FStar_List.map (translate_type env) ts in
           TTuple uu____4337
 and translate_binders:
+=======
+          let uu____4558 = FStar_List.map (translate_type env) args  in
+          TTuple uu____4558
+      | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
+          if (FStar_List.length args) > (Prims.parse_int "0")
+          then
+            let uu____4567 =
+              let uu____4580 = FStar_List.map (translate_type env) args  in
+              (lid, uu____4580)  in
+            TApp uu____4567
+          else TQualified lid
+      | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
+          let uu____4589 = FStar_List.map (translate_type env) ts  in
+          TTuple uu____4589
+
+and translate_binders :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     (FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
       FStar_Pervasives_Native.tuple2 Prims.list -> binder Prims.list
@@ -1244,17 +2248,28 @@ and translate_binder:
       FStar_Pervasives_Native.tuple2 -> binder
   =
   fun env  ->
+<<<<<<< HEAD
     fun uu____4353  ->
       match uu____4353 with
       | (name,typ) ->
           let uu____4360 = translate_type env typ in
           { name; typ = uu____4360; mut = false }
 and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
+=======
+    fun uu____4605  ->
+      match uu____4605 with
+      | ((name,uu____4611),typ) ->
+          let uu____4617 = translate_type env typ  in
+          { name; typ = uu____4617; mut = false }
+
+and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun e  ->
       match e.FStar_Extraction_ML_Syntax.expr with
       | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
+<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLE_Var name ->
           let uu____4365 = find env name in EBound uu____4365
       | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
@@ -1273,6 +2288,28 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
       | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
       | FStar_Extraction_ML_Syntax.MLE_Let
           ((flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
+=======
+      | FStar_Extraction_ML_Syntax.MLE_Var (name,uu____4622) ->
+          let uu____4623 = find env name  in EBound uu____4623
+      | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
+          (is_machine_int m) && (is_op op) ->
+          let uu____4628 =
+            let uu____4633 = FStar_Util.must (mk_op op)  in
+            let uu____4634 = FStar_Util.must (mk_width m)  in
+            (uu____4633, uu____4634)  in
+          EOp uu____4628
+      | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
+          is_bool_op op ->
+          let uu____4638 =
+            let uu____4643 = FStar_Util.must (mk_bool_op op)  in
+            (uu____4643, Bool)  in
+          EOp uu____4638
+      | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
+      | FStar_Extraction_ML_Syntax.MLE_Let
+          ((flavor,flags,{
+                           FStar_Extraction_ML_Syntax.mllb_name =
+                             (name,uu____4648);
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                            FStar_Extraction_ML_Syntax.mllb_tysc =
                              FStar_Pervasives_Native.Some ([],typ);
                            FStar_Extraction_ML_Syntax.mllb_add_unit =
@@ -1282,6 +2319,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           ->
           let is_mut =
             FStar_Util.for_some
+<<<<<<< HEAD
               (fun uu___407_4415  ->
                  match uu___407_4415 with
                  | FStar_Extraction_ML_Syntax.Mutable  -> true
@@ -1304,10 +2342,39 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                         uu____4434 in
                     failwith uu____4433 in
               let uu____4437 =
+=======
+              (fun uu___129_4674  ->
+                 match uu___129_4674 with
+                 | FStar_Extraction_ML_Syntax.Mutable  -> true
+                 | uu____4675 -> false) flags
+             in
+          let uu____4676 =
+            if is_mut
+            then
+              let uu____4685 =
+                match typ with
+                | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
+                    let uu____4690 =
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                    uu____4690 = "FStar.ST.stackref" -> t
+                | uu____4691 ->
+                    let uu____4692 =
+                      let uu____4693 =
+                        FStar_Extraction_ML_Code.string_of_mlty ([], "") typ
+                         in
+                      FStar_Util.format1
+                        "unexpected: bad desugaring of Mutable (typ is %s)"
+                        uu____4693
+                       in
+                    failwith uu____4692
+                 in
+              let uu____4696 =
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                 match body with
                 | {
                     FStar_Extraction_ML_Syntax.expr =
                       FStar_Extraction_ML_Syntax.MLE_App
+<<<<<<< HEAD
                       (uu____4438,body1::[]);
                     FStar_Extraction_ML_Syntax.mlty = uu____4440;
                     FStar_Extraction_ML_Syntax.loc = uu____4441;_} -> body1
@@ -1330,10 +2397,36 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4487 = translate_branches env branches in
             (uu____4486, uu____4487) in
           EMatch uu____4475
+=======
+                      (uu____4697,body1::[]);
+                    FStar_Extraction_ML_Syntax.mlty = uu____4699;
+                    FStar_Extraction_ML_Syntax.loc = uu____4700;_} -> body1
+                | uu____4703 ->
+                    failwith "unexpected: bad desugaring of Mutable"
+                 in
+              (uu____4685, uu____4696)
+            else (typ, body)  in
+          (match uu____4676 with
+           | (typ1,body1) ->
+               let binder =
+                 let uu____4708 = translate_type env typ1  in
+                 { name; typ = uu____4708; mut = is_mut }  in
+               let body2 = translate_expr env body1  in
+               let env1 = extend env name is_mut  in
+               let continuation1 = translate_expr env1 continuation  in
+               ELet (binder, body2, continuation1))
+      | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
+          let uu____4734 =
+            let uu____4745 = translate_expr env expr  in
+            let uu____4746 = translate_branches env branches  in
+            (uu____4745, uu____4746)  in
+          EMatch uu____4734
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4501;
              FStar_Extraction_ML_Syntax.loc = uu____4502;_},{
                                                               FStar_Extraction_ML_Syntax.expr
@@ -1348,10 +2441,27 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           (let uu____4510 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____4510 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
           -> let uu____4511 = find env v1 in EBound uu____4511
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____4760;
+             FStar_Extraction_ML_Syntax.loc = uu____4761;_},{
+                                                              FStar_Extraction_ML_Syntax.expr
+                                                                =
+                                                                FStar_Extraction_ML_Syntax.MLE_Var
+                                                                (v1,uu____4763);
+                                                              FStar_Extraction_ML_Syntax.mlty
+                                                                = uu____4764;
+                                                              FStar_Extraction_ML_Syntax.loc
+                                                                = uu____4765;_}::[])
+          when
+          (let uu____4770 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4770 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
+          -> let uu____4771 = find env v1  in EBound uu____4771
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4513;
              FStar_Extraction_ML_Syntax.loc = uu____4514;_},{
                                                               FStar_Extraction_ML_Syntax.expr
@@ -1373,6 +2483,29 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4531 = translate_expr env e1 in
             (uu____4529, uu____4531) in
           EAssign uu____4524
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____4773;
+             FStar_Extraction_ML_Syntax.loc = uu____4774;_},{
+                                                              FStar_Extraction_ML_Syntax.expr
+                                                                =
+                                                                FStar_Extraction_ML_Syntax.MLE_Var
+                                                                (v1,uu____4776);
+                                                              FStar_Extraction_ML_Syntax.mlty
+                                                                = uu____4777;
+                                                              FStar_Extraction_ML_Syntax.loc
+                                                                = uu____4778;_}::e1::[])
+          when
+          (let uu____4784 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4784 = "FStar.HyperStack.ST.op_Colon_Equals") &&
+            (is_mutable env v1)
+          ->
+          let uu____4785 =
+            let uu____4790 =
+              let uu____4791 = find env v1  in EBound uu____4791  in
+            let uu____4792 = translate_expr env e1  in
+            (uu____4790, uu____4792)  in
+          EAssign uu____4785
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1380,6 +2513,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4533;
                   FStar_Extraction_ML_Syntax.loc = uu____4534;_},uu____4535);
              FStar_Extraction_ML_Syntax.mlty = uu____4536;
@@ -1395,6 +2529,24 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4557 = translate_expr env e2 in
             (uu____4556, uu____4557) in
           EBufRead uu____4551
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4794;
+                  FStar_Extraction_ML_Syntax.loc = uu____4795;_},uu____4796);
+             FStar_Extraction_ML_Syntax.mlty = uu____4797;
+             FStar_Extraction_ML_Syntax.loc = uu____4798;_},e1::e2::[])
+          when
+          (let uu____4809 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4809 = "FStar.Buffer.index") ||
+            (let uu____4811 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+                in
+             uu____4811 = "FStar.Buffer.op_Array_Access")
+          ->
+          let uu____4812 =
+            let uu____4817 = translate_expr env e1  in
+            let uu____4818 = translate_expr env e2  in
+            (uu____4817, uu____4818)  in
+          EBufRead uu____4812
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1402,6 +2554,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4559;
                   FStar_Extraction_ML_Syntax.loc = uu____4560;_},uu____4561);
              FStar_Extraction_ML_Syntax.mlty = uu____4562;
@@ -1414,6 +2567,20 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4581 = translate_expr env e2 in
             (Stack, uu____4580, uu____4581) in
           EBufCreate uu____4573
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4820;
+                  FStar_Extraction_ML_Syntax.loc = uu____4821;_},uu____4822);
+             FStar_Extraction_ML_Syntax.mlty = uu____4823;
+             FStar_Extraction_ML_Syntax.loc = uu____4824;_},e1::e2::[])
+          when
+          let uu____4833 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4833 = "FStar.Buffer.create" ->
+          let uu____4834 =
+            let uu____4841 = translate_expr env e1  in
+            let uu____4842 = translate_expr env e2  in
+            (Stack, uu____4841, uu____4842)  in
+          EBufCreate uu____4834
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1421,6 +2588,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4583;
                   FStar_Extraction_ML_Syntax.loc = uu____4584;_},uu____4585);
              FStar_Extraction_ML_Syntax.mlty = uu____4586;
@@ -1433,6 +2601,20 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4606 = translate_expr env e2 in
             (Eternal, uu____4605, uu____4606) in
           EBufCreate uu____4598
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4844;
+                  FStar_Extraction_ML_Syntax.loc = uu____4845;_},uu____4846);
+             FStar_Extraction_ML_Syntax.mlty = uu____4847;
+             FStar_Extraction_ML_Syntax.loc = uu____4848;_},_e0::e1::e2::[])
+          when
+          let uu____4858 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4858 = "FStar.Buffer.rcreate" ->
+          let uu____4859 =
+            let uu____4866 = translate_expr env e1  in
+            let uu____4867 = translate_expr env e2  in
+            (Eternal, uu____4866, uu____4867)  in
+          EBufCreate uu____4859
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1440,6 +2622,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4608;
                   FStar_Extraction_ML_Syntax.loc = uu____4609;_},uu____4610);
              FStar_Extraction_ML_Syntax.mlty = uu____4611;
@@ -1447,6 +2630,15 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           when
           let uu____4620 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4620 = "FStar.Buffer.createL" ->
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4869;
+                  FStar_Extraction_ML_Syntax.loc = uu____4870;_},uu____4871);
+             FStar_Extraction_ML_Syntax.mlty = uu____4872;
+             FStar_Extraction_ML_Syntax.loc = uu____4873;_},e2::[])
+          when
+          let uu____4881 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4881 = "FStar.Buffer.createL" ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           let rec list_elements1 acc e21 =
             match e21.FStar_Extraction_ML_Syntax.expr with
             | FStar_Extraction_ML_Syntax.MLE_CTor
@@ -1454,6 +2646,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                 list_elements1 (hd1 :: acc) tl1
             | FStar_Extraction_ML_Syntax.MLE_CTor (("Prims"::[],"Nil"),[]) ->
                 FStar_List.rev acc
+<<<<<<< HEAD
             | uu____4658 ->
                 failwith
                   "Argument of FStar.Buffer.createL is not a string literal!" in
@@ -1464,6 +2657,19 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
               FStar_List.map (translate_expr env) uu____4676 in
             (Stack, uu____4673) in
           EBufCreateL uu____4666
+=======
+            | uu____4919 ->
+                failwith
+                  "Argument of FStar.Buffer.createL is not a string literal!"
+             in
+          let list_elements2 = list_elements1 []  in
+          let uu____4927 =
+            let uu____4934 =
+              let uu____4937 = list_elements2 e2  in
+              FStar_List.map (translate_expr env) uu____4937  in
+            (Stack, uu____4934)  in
+          EBufCreateL uu____4927
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1471,6 +2677,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4682;
                   FStar_Extraction_ML_Syntax.loc = uu____4683;_},uu____4684);
              FStar_Extraction_ML_Syntax.mlty = uu____4685;
@@ -1483,6 +2690,20 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4703 = translate_expr env e2 in
             (uu____4702, uu____4703) in
           EBufSub uu____4697
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4943;
+                  FStar_Extraction_ML_Syntax.loc = uu____4944;_},uu____4945);
+             FStar_Extraction_ML_Syntax.mlty = uu____4946;
+             FStar_Extraction_ML_Syntax.loc = uu____4947;_},e1::e2::_e3::[])
+          when
+          let uu____4957 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4957 = "FStar.Buffer.sub" ->
+          let uu____4958 =
+            let uu____4963 = translate_expr env e1  in
+            let uu____4964 = translate_expr env e2  in
+            (uu____4963, uu____4964)  in
+          EBufSub uu____4958
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1490,6 +2711,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4705;
                   FStar_Extraction_ML_Syntax.loc = uu____4706;_},uu____4707);
              FStar_Extraction_ML_Syntax.mlty = uu____4708;
@@ -1497,6 +2719,15 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           when
           let uu____4718 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4718 = "FStar.Buffer.join" -> translate_expr env e1
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4966;
+                  FStar_Extraction_ML_Syntax.loc = uu____4967;_},uu____4968);
+             FStar_Extraction_ML_Syntax.mlty = uu____4969;
+             FStar_Extraction_ML_Syntax.loc = uu____4970;_},e1::e2::[])
+          when
+          let uu____4979 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4979 = "FStar.Buffer.join" -> translate_expr env e1
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1504,6 +2735,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4720;
                   FStar_Extraction_ML_Syntax.loc = uu____4721;_},uu____4722);
              FStar_Extraction_ML_Syntax.mlty = uu____4723;
@@ -1516,6 +2748,20 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4740 = translate_expr env e2 in
             (uu____4739, uu____4740) in
           EBufSub uu____4734
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____4981;
+                  FStar_Extraction_ML_Syntax.loc = uu____4982;_},uu____4983);
+             FStar_Extraction_ML_Syntax.mlty = uu____4984;
+             FStar_Extraction_ML_Syntax.loc = uu____4985;_},e1::e2::[])
+          when
+          let uu____4994 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4994 = "FStar.Buffer.offset" ->
+          let uu____4995 =
+            let uu____5000 = translate_expr env e1  in
+            let uu____5001 = translate_expr env e2  in
+            (uu____5000, uu____5001)  in
+          EBufSub uu____4995
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1523,6 +2769,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4742;
                   FStar_Extraction_ML_Syntax.loc = uu____4743;_},uu____4744);
              FStar_Extraction_ML_Syntax.mlty = uu____4745;
@@ -1539,24 +2786,59 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4770 = translate_expr env e3 in
             (uu____4768, uu____4769, uu____4770) in
           EBufWrite uu____4761
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____5003;
+                  FStar_Extraction_ML_Syntax.loc = uu____5004;_},uu____5005);
+             FStar_Extraction_ML_Syntax.mlty = uu____5006;
+             FStar_Extraction_ML_Syntax.loc = uu____5007;_},e1::e2::e3::[])
+          when
+          (let uu____5019 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____5019 = "FStar.Buffer.upd") ||
+            (let uu____5021 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+                in
+             uu____5021 = "FStar.Buffer.op_Array_Assignment")
+          ->
+          let uu____5022 =
+            let uu____5029 = translate_expr env e1  in
+            let uu____5030 = translate_expr env e2  in
+            let uu____5031 = translate_expr env e3  in
+            (uu____5029, uu____5030, uu____5031)  in
+          EBufWrite uu____5022
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4772;
              FStar_Extraction_ML_Syntax.loc = uu____4773;_},uu____4774::[])
           when
           let uu____4777 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4777 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5033;
+             FStar_Extraction_ML_Syntax.loc = uu____5034;_},uu____5035::[])
+          when
+          let uu____5038 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5038 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4779;
              FStar_Extraction_ML_Syntax.loc = uu____4780;_},uu____4781::[])
           when
           let uu____4784 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4784 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5040;
+             FStar_Extraction_ML_Syntax.loc = uu____5041;_},uu____5042::[])
+          when
+          let uu____5045 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5045 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1564,6 +2846,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4786;
                   FStar_Extraction_ML_Syntax.loc = uu____4787;_},uu____4788);
              FStar_Extraction_ML_Syntax.mlty = uu____4789;
@@ -1579,6 +2862,23 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4818 = translate_expr env e5 in
             (uu____4814, uu____4815, uu____4816, uu____4817, uu____4818) in
           EBufBlit uu____4803
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____5047;
+                  FStar_Extraction_ML_Syntax.loc = uu____5048;_},uu____5049);
+             FStar_Extraction_ML_Syntax.mlty = uu____5050;
+             FStar_Extraction_ML_Syntax.loc = uu____5051;_},e1::e2::e3::e4::e5::[])
+          when
+          let uu____5063 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5063 = "FStar.Buffer.blit" ->
+          let uu____5064 =
+            let uu____5075 = translate_expr env e1  in
+            let uu____5076 = translate_expr env e2  in
+            let uu____5077 = translate_expr env e3  in
+            let uu____5078 = translate_expr env e4  in
+            let uu____5079 = translate_expr env e5  in
+            (uu____5075, uu____5076, uu____5077, uu____5078, uu____5079)  in
+          EBufBlit uu____5064
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1586,6 +2886,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
                   FStar_Extraction_ML_Syntax.mlty = uu____4820;
                   FStar_Extraction_ML_Syntax.loc = uu____4821;_},uu____4822);
              FStar_Extraction_ML_Syntax.mlty = uu____4823;
@@ -1599,19 +2900,43 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
             let uu____4844 = translate_expr env e3 in
             (uu____4842, uu____4843, uu____4844) in
           EBufFill uu____4835
+=======
+                  FStar_Extraction_ML_Syntax.mlty = uu____5081;
+                  FStar_Extraction_ML_Syntax.loc = uu____5082;_},uu____5083);
+             FStar_Extraction_ML_Syntax.mlty = uu____5084;
+             FStar_Extraction_ML_Syntax.loc = uu____5085;_},e1::e2::e3::[])
+          when
+          let uu____5095 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5095 = "FStar.Buffer.fill" ->
+          let uu____5096 =
+            let uu____5103 = translate_expr env e1  in
+            let uu____5104 = translate_expr env e2  in
+            let uu____5105 = translate_expr env e3  in
+            (uu____5103, uu____5104, uu____5105)  in
+          EBufFill uu____5096
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4846;
              FStar_Extraction_ML_Syntax.loc = uu____4847;_},uu____4848::[])
           when
           let uu____4851 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4851 = "FStar.HyperStack.ST.get" -> EUnit
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5107;
+             FStar_Extraction_ML_Syntax.loc = uu____5108;_},uu____5109::[])
+          when
+          let uu____5112 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5112 = "FStar.HyperStack.ST.get" -> EUnit
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4853;
              FStar_Extraction_ML_Syntax.loc = uu____4854;_},e1::[])
           when
@@ -1620,32 +2945,64 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           let uu____4859 =
             let uu____4864 = translate_expr env e1 in (uu____4864, TAny) in
           ECast uu____4859
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5114;
+             FStar_Extraction_ML_Syntax.loc = uu____5115;_},e1::[])
+          when
+          let uu____5119 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5119 = "Obj.repr" ->
+          let uu____5120 =
+            let uu____5125 = translate_expr env e1  in (uu____5125, TAny)  in
+          ECast uu____5120
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op);
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4867;
              FStar_Extraction_ML_Syntax.loc = uu____4868;_},args)
           when (is_machine_int m) && (is_op op) ->
           let uu____4876 = FStar_Util.must (mk_width m) in
           let uu____4877 = FStar_Util.must (mk_op op) in
           mk_op_app env uu____4876 uu____4877 args
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5128;
+             FStar_Extraction_ML_Syntax.loc = uu____5129;_},args)
+          when (is_machine_int m) && (is_op op) ->
+          let uu____5137 = FStar_Util.must (mk_width m)  in
+          let uu____5138 = FStar_Util.must (mk_op op)  in
+          mk_op_app env uu____5137 uu____5138 args
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op);
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4879;
              FStar_Extraction_ML_Syntax.loc = uu____4880;_},args)
           when is_bool_op op ->
           let uu____4888 = FStar_Util.must (mk_bool_op op) in
           mk_op_app env Bool uu____4888 args
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5140;
+             FStar_Extraction_ML_Syntax.loc = uu____5141;_},args)
+          when is_bool_op op ->
+          let uu____5149 = FStar_Util.must (mk_bool_op op)  in
+          mk_op_app env Bool uu____5149 args
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"int_to_t");
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4890;
              FStar_Extraction_ML_Syntax.loc = uu____4891;_},{
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5151;
+             FStar_Extraction_ML_Syntax.loc = uu____5152;_},{
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -1653,6 +3010,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
+<<<<<<< HEAD
                                                                 = uu____4893;
                                                               FStar_Extraction_ML_Syntax.loc
                                                                 = uu____4894;_}::[])
@@ -1660,13 +3018,28 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           let uu____4909 =
             let uu____4914 = FStar_Util.must (mk_width m) in (uu____4914, c) in
           EConstant uu____4909
+=======
+                                                                = uu____5154;
+                                                              FStar_Extraction_ML_Syntax.loc
+                                                                = uu____5155;_}::[])
+          when is_machine_int m ->
+          let uu____5170 =
+            let uu____5175 = FStar_Util.must (mk_width m)  in (uu____5175, c)
+             in
+          EConstant uu____5170
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"uint_to_t");
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4916;
              FStar_Extraction_ML_Syntax.loc = uu____4917;_},{
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5177;
+             FStar_Extraction_ML_Syntax.loc = uu____5178;_},{
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -1674,6 +3047,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
+<<<<<<< HEAD
                                                                 = uu____4919;
                                                               FStar_Extraction_ML_Syntax.loc
                                                                 = uu____4920;_}::[])
@@ -1681,11 +3055,22 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           let uu____4935 =
             let uu____4940 = FStar_Util.must (mk_width m) in (uu____4940, c) in
           EConstant uu____4935
+=======
+                                                                = uu____5180;
+                                                              FStar_Extraction_ML_Syntax.loc
+                                                                = uu____5181;_}::[])
+          when is_machine_int m ->
+          let uu____5196 =
+            let uu____5201 = FStar_Util.must (mk_width m)  in (uu____5201, c)
+             in
+          EConstant uu____5196
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::[],"string_of_literal");
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4941;
              FStar_Extraction_ML_Syntax.loc = uu____4942;_},{
                                                               FStar_Extraction_ML_Syntax.expr
@@ -1714,11 +3099,25 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                                                                 = uu____4955;
                                                               FStar_Extraction_ML_Syntax.loc
                                                                 = uu____4956;_}::[])
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5202;
+             FStar_Extraction_ML_Syntax.loc = uu____5203;_},{
+                                                              FStar_Extraction_ML_Syntax.expr
+                                                                = e1;
+                                                              FStar_Extraction_ML_Syntax.mlty
+                                                                = uu____5205;
+                                                              FStar_Extraction_ML_Syntax.loc
+                                                                = uu____5206;_}::[])
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
+<<<<<<< HEAD
            | uu____4962 ->
+=======
+           | uu____5212 ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -1726,8 +3125,13 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::"Int"::"Cast"::[],c);
+<<<<<<< HEAD
              FStar_Extraction_ML_Syntax.mlty = uu____4964;
              FStar_Extraction_ML_Syntax.loc = uu____4965;_},arg::[])
+=======
+             FStar_Extraction_ML_Syntax.mlty = uu____5214;
+             FStar_Extraction_ML_Syntax.loc = uu____5215;_},arg::[])
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           ->
           let is_known_type =
             (((((((FStar_Util.starts_with c "uint8") ||
@@ -1740,6 +3144,7 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
               || (FStar_Util.starts_with c "int64") in
           if (FStar_Util.ends_with c "uint64") && is_known_type
           then
+<<<<<<< HEAD
             let uu____4972 =
               let uu____4977 = translate_expr env arg in
               (uu____4977, (TInt UInt64)) in
@@ -1883,6 +3288,157 @@ and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
       | FStar_Extraction_ML_Syntax.MLE_Try uu____5294 ->
           failwith "todo: translate_expr [MLE_Try]"
       | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5309 ->
+=======
+            let uu____5222 =
+              let uu____5227 = translate_expr env arg  in
+              (uu____5227, (TInt UInt64))  in
+            ECast uu____5222
+          else
+            if (FStar_Util.ends_with c "uint32") && is_known_type
+            then
+              (let uu____5229 =
+                 let uu____5234 = translate_expr env arg  in
+                 (uu____5234, (TInt UInt32))  in
+               ECast uu____5229)
+            else
+              if (FStar_Util.ends_with c "uint16") && is_known_type
+              then
+                (let uu____5236 =
+                   let uu____5241 = translate_expr env arg  in
+                   (uu____5241, (TInt UInt16))  in
+                 ECast uu____5236)
+              else
+                if (FStar_Util.ends_with c "uint8") && is_known_type
+                then
+                  (let uu____5243 =
+                     let uu____5248 = translate_expr env arg  in
+                     (uu____5248, (TInt UInt8))  in
+                   ECast uu____5243)
+                else
+                  if (FStar_Util.ends_with c "int64") && is_known_type
+                  then
+                    (let uu____5250 =
+                       let uu____5255 = translate_expr env arg  in
+                       (uu____5255, (TInt Int64))  in
+                     ECast uu____5250)
+                  else
+                    if (FStar_Util.ends_with c "int32") && is_known_type
+                    then
+                      (let uu____5257 =
+                         let uu____5262 = translate_expr env arg  in
+                         (uu____5262, (TInt Int32))  in
+                       ECast uu____5257)
+                    else
+                      if (FStar_Util.ends_with c "int16") && is_known_type
+                      then
+                        (let uu____5264 =
+                           let uu____5269 = translate_expr env arg  in
+                           (uu____5269, (TInt Int16))  in
+                         ECast uu____5264)
+                      else
+                        if (FStar_Util.ends_with c "int8") && is_known_type
+                        then
+                          (let uu____5271 =
+                             let uu____5276 = translate_expr env arg  in
+                             (uu____5276, (TInt Int8))  in
+                           ECast uu____5271)
+                        else
+                          (let uu____5278 =
+                             let uu____5285 =
+                               let uu____5288 = translate_expr env arg  in
+                               [uu____5288]  in
+                             ((EQualified (["FStar"; "Int"; "Cast"], c)),
+                               uu____5285)
+                              in
+                           EApp uu____5278)
+      | FStar_Extraction_ML_Syntax.MLE_App (head1,args) ->
+          let uu____5299 =
+            let uu____5306 = translate_expr env head1  in
+            let uu____5307 = FStar_List.map (translate_expr env) args  in
+            (uu____5306, uu____5307)  in
+          EApp uu____5299
+      | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
+          let uu____5318 =
+            let uu____5325 = translate_expr env head1  in
+            let uu____5326 = FStar_List.map (translate_type env) ty_args  in
+            (uu____5325, uu____5326)  in
+          ETypApp uu____5318
+      | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
+          let uu____5334 =
+            let uu____5339 = translate_expr env e1  in
+            let uu____5340 = translate_type env t_to  in
+            (uu____5339, uu____5340)  in
+          ECast uu____5334
+      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5341,fields) ->
+          let uu____5359 =
+            let uu____5370 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
+               in
+            let uu____5371 =
+              FStar_List.map
+                (fun uu____5390  ->
+                   match uu____5390 with
+                   | (field,expr) ->
+                       let uu____5401 = translate_expr env expr  in
+                       (field, uu____5401)) fields
+               in
+            (uu____5370, uu____5371)  in
+          EFlat uu____5359
+      | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
+          let uu____5410 =
+            let uu____5417 =
+              assert_lid env e1.FStar_Extraction_ML_Syntax.mlty  in
+            let uu____5418 = translate_expr env e1  in
+            (uu____5417, uu____5418, (FStar_Pervasives_Native.snd path))  in
+          EField uu____5410
+      | FStar_Extraction_ML_Syntax.MLE_Let uu____5421 ->
+          failwith "todo: translate_expr [MLE_Let]"
+      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5435) ->
+          let uu____5440 =
+            let uu____5441 =
+              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1  in
+            FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
+              uu____5441
+             in
+          failwith uu____5440
+      | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
+          let uu____5447 = FStar_List.map (translate_expr env) seqs  in
+          ESequence uu____5447
+      | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
+          let uu____5453 = FStar_List.map (translate_expr env) es  in
+          ETuple uu____5453
+      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5456,cons1),es) ->
+          let uu____5473 =
+            let uu____5482 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
+               in
+            let uu____5483 = FStar_List.map (translate_expr env) es  in
+            (uu____5482, cons1, uu____5483)  in
+          ECons uu____5473
+      | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
+          let binders = translate_binders env args  in
+          let env1 = add_binders env args  in
+          let uu____5506 =
+            let uu____5515 = translate_expr env1 body  in
+            let uu____5516 =
+              translate_type env1 body.FStar_Extraction_ML_Syntax.mlty  in
+            (binders, uu____5515, uu____5516)  in
+          EFun uu____5506
+      | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
+          let uu____5526 =
+            let uu____5533 = translate_expr env e1  in
+            let uu____5534 = translate_expr env e2  in
+            let uu____5535 =
+              match e3 with
+              | FStar_Pervasives_Native.None  -> EUnit
+              | FStar_Pervasives_Native.Some e31 -> translate_expr env e31
+               in
+            (uu____5533, uu____5534, uu____5535)  in
+          EIfThenElse uu____5526
+      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5537 ->
+          failwith "todo: translate_expr [MLE_Raise]"
+      | FStar_Extraction_ML_Syntax.MLE_Try uu____5544 ->
+          failwith "todo: translate_expr [MLE_Try]"
+      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5559 ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           failwith "todo: translate_expr [MLE_Coerce]"
 and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
   fun env  ->
@@ -1891,6 +3447,7 @@ and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
       | FStar_Extraction_ML_Syntax.MLTY_Named (ts,lid) ->
           if (FStar_List.length ts) > (Prims.parse_int "0")
           then
+<<<<<<< HEAD
             let uu____5324 =
               let uu____5337 = FStar_List.map (translate_type env) ts in
               (lid, uu____5337) in
@@ -1898,6 +3455,16 @@ and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
           else TQualified lid
       | uu____5343 -> failwith "invalid argument: assert_lid"
 and translate_branches:
+=======
+            let uu____5574 =
+              let uu____5587 = FStar_List.map (translate_type env) ts  in
+              (lid, uu____5587)  in
+            TApp uu____5574
+          else TQualified lid
+      | uu____5593 -> failwith "invalid argument: assert_lid"
+
+and translate_branches :
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern,FStar_Extraction_ML_Syntax.mlexpr
                                             FStar_Pervasives_Native.option,
@@ -1913,6 +3480,7 @@ and translate_branch:
       (pattern,expr) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
+<<<<<<< HEAD
     fun uu____5369  ->
       match uu____5369 with
       | (pat,guard,expr) ->
@@ -1923,6 +3491,18 @@ and translate_branch:
              | (env1,pat1) ->
                  let uu____5406 = translate_expr env1 expr in
                  (pat1, uu____5406))
+=======
+    fun uu____5619  ->
+      match uu____5619 with
+      | (pat,guard,expr) ->
+          if guard = FStar_Pervasives_Native.None
+          then
+            let uu____5645 = translate_pat env pat  in
+            (match uu____5645 with
+             | (env1,pat1) ->
+                 let uu____5656 = translate_expr env1 expr  in
+                 (pat1, uu____5656))
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           else failwith "todo: translate_branch"
 and translate_pat:
   env ->
@@ -1936,12 +3516,18 @@ and translate_pat:
           (FStar_Extraction_ML_Syntax.MLC_Unit ) -> (env, PUnit)
       | FStar_Extraction_ML_Syntax.MLP_Const
           (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env, (PBool b))
+<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLP_Var name ->
           let env1 = extend env name false in
+=======
+      | FStar_Extraction_ML_Syntax.MLP_Var (name,uu____5670) ->
+          let env1 = extend env name false  in
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           (env1, (PVar { name; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild  ->
           let env1 = extend env "_" false in
           (env1, (PVar { name = "_"; typ = TAny; mut = false }))
+<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5422,cons1),ps) ->
           let uu____5439 =
             FStar_List.fold_left
@@ -1982,6 +3568,51 @@ and translate_pat:
       | FStar_Extraction_ML_Syntax.MLP_Const uu____5759 ->
           failwith "todo: translate_pat [MLP_Const]"
       | FStar_Extraction_ML_Syntax.MLP_Branch uu____5764 ->
+=======
+      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5673,cons1),ps) ->
+          let uu____5690 =
+            FStar_List.fold_left
+              (fun uu____5710  ->
+                 fun p1  ->
+                   match uu____5710 with
+                   | (env1,acc) ->
+                       let uu____5730 = translate_pat env1 p1  in
+                       (match uu____5730 with
+                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
+             in
+          (match uu____5690 with
+           | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
+      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5759,ps) ->
+          let uu____5777 =
+            FStar_List.fold_left
+              (fun uu____5811  ->
+                 fun uu____5812  ->
+                   match (uu____5811, uu____5812) with
+                   | ((env1,acc),(field,p1)) ->
+                       let uu____5881 = translate_pat env1 p1  in
+                       (match uu____5881 with
+                        | (env2,p2) -> (env2, ((field, p2) :: acc))))
+              (env, []) ps
+             in
+          (match uu____5777 with
+           | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
+      | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
+          let uu____5943 =
+            FStar_List.fold_left
+              (fun uu____5963  ->
+                 fun p1  ->
+                   match uu____5963 with
+                   | (env1,acc) ->
+                       let uu____5983 = translate_pat env1 p1  in
+                       (match uu____5983 with
+                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
+             in
+          (match uu____5943 with
+           | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
+      | FStar_Extraction_ML_Syntax.MLP_Const uu____6010 ->
+          failwith "todo: translate_pat [MLP_Const]"
+      | FStar_Extraction_ML_Syntax.MLP_Branch uu____6015 ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           failwith "todo: translate_pat [MLP_Branch]"
 and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
   fun c  ->
@@ -1989,6 +3620,7 @@ and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_Int
+<<<<<<< HEAD
         (s,FStar_Pervasives_Native.Some uu____5774) ->
         failwith
           "impossible: machine integer not desugared to a function call"
@@ -1999,6 +3631,18 @@ and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
     | FStar_Extraction_ML_Syntax.MLC_String uu____5791 ->
         failwith "todo: translate_expr [MLC_String]"
     | FStar_Extraction_ML_Syntax.MLC_Bytes uu____5792 ->
+=======
+        (s,FStar_Pervasives_Native.Some uu____6025) ->
+        failwith
+          "impossible: machine integer not desugared to a function call"
+    | FStar_Extraction_ML_Syntax.MLC_Float uu____6040 ->
+        failwith "todo: translate_expr [MLC_Float]"
+    | FStar_Extraction_ML_Syntax.MLC_Char uu____6041 ->
+        failwith "todo: translate_expr [MLC_Char]"
+    | FStar_Extraction_ML_Syntax.MLC_String uu____6042 ->
+        failwith "todo: translate_expr [MLC_String]"
+    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____6043 ->
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s,FStar_Pervasives_Native.None ) ->
         EConstant (CInt, s)
@@ -2009,7 +3653,14 @@ and mk_op_app:
     fun w  ->
       fun op  ->
         fun args  ->
+<<<<<<< HEAD
           let uu____5812 =
             let uu____5819 = FStar_List.map (translate_expr env) args in
             ((EOp (op, w)), uu____5819) in
           EApp uu____5812
+=======
+          let uu____6063 =
+            let uu____6070 = FStar_List.map (translate_expr env) args  in
+            ((EOp (op, w)), uu____6070)  in
+          EApp uu____6063
+>>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -29,12 +29,8 @@ type decl =
                                             FStar_Pervasives_Native.tuple2
                                             Prims.list)
                               FStar_Pervasives_Native.tuple2 Prims.list)
-<<<<<<< HEAD
-  FStar_Pervasives_Native.tuple4[@@deriving show]
-=======
-  FStar_Pervasives_Native.tuple4 
-  | DTypeMutual of decl Prims.list 
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  FStar_Pervasives_Native.tuple4
+  | DTypeMutual of decl Prims.list[@@deriving show]
 and cc =
   | StdCall
   | CDecl
@@ -155,14 +151,8 @@ and typ =
   | TTuple of typ Prims.list[@@deriving show]
 let uu___is_DGlobal: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DGlobal _0 -> true | uu____523 -> false
+    match projectee with | DGlobal _0 -> true | uu____529 -> false
 let __proj__DGlobal__item___0:
-=======
-    match projectee with | DGlobal _0 -> true | uu____526 -> false
-  
-let __proj__DGlobal__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (flag Prims.list,(Prims.string Prims.list,Prims.string)
                        FStar_Pervasives_Native.tuple2,typ,expr)
@@ -170,14 +160,8 @@ let __proj__DGlobal__item___0 :
   = fun projectee  -> match projectee with | DGlobal _0 -> _0
 let uu___is_DFunction: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DFunction _0 -> true | uu____609 -> false
+    match projectee with | DFunction _0 -> true | uu____615 -> false
 let __proj__DFunction__item___0:
-=======
-    match projectee with | DFunction _0 -> true | uu____614 -> false
-  
-let __proj__DFunction__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (cc FStar_Pervasives_Native.option,flag Prims.list,Prims.int,typ,
       (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
@@ -185,28 +169,16 @@ let __proj__DFunction__item___0 :
   = fun projectee  -> match projectee with | DFunction _0 -> _0
 let uu___is_DTypeAlias: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DTypeAlias _0 -> true | uu____711 -> false
+    match projectee with | DTypeAlias _0 -> true | uu____717 -> false
 let __proj__DTypeAlias__item___0:
-=======
-    match projectee with | DTypeAlias _0 -> true | uu____718 -> false
-  
-let __proj__DTypeAlias__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       Prims.int,typ) FStar_Pervasives_Native.tuple3
   = fun projectee  -> match projectee with | DTypeAlias _0 -> _0
 let uu___is_DTypeFlat: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DTypeFlat _0 -> true | uu____781 -> false
+    match projectee with | DTypeFlat _0 -> true | uu____787 -> false
 let __proj__DTypeFlat__item___0:
-=======
-    match projectee with | DTypeFlat _0 -> true | uu____790 -> false
-  
-let __proj__DTypeFlat__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       Prims.int,(Prims.string,(typ,Prims.bool) FStar_Pervasives_Native.tuple2)
@@ -215,14 +187,8 @@ let __proj__DTypeFlat__item___0 :
   = fun projectee  -> match projectee with | DTypeFlat _0 -> _0
 let uu___is_DExternal: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DExternal _0 -> true | uu____873 -> false
+    match projectee with | DExternal _0 -> true | uu____879 -> false
 let __proj__DExternal__item___0:
-=======
-    match projectee with | DExternal _0 -> true | uu____884 -> false
-  
-let __proj__DExternal__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     (cc FStar_Pervasives_Native.option,(Prims.string Prims.list,Prims.string)
                                          FStar_Pervasives_Native.tuple2,
@@ -230,14 +196,8 @@ let __proj__DExternal__item___0 :
   = fun projectee  -> match projectee with | DExternal _0 -> _0
 let uu___is_DTypeVariant: decl -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | DTypeVariant _0 -> true | uu____959 -> false
+    match projectee with | DTypeVariant _0 -> true | uu____965 -> false
 let __proj__DTypeVariant__item___0:
-=======
-    match projectee with | DTypeVariant _0 -> true | uu____972 -> false
-  
-let __proj__DTypeVariant__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       flag Prims.list,Prims.int,(Prims.string,(Prims.string,(typ,Prims.bool)
@@ -246,270 +206,136 @@ let __proj__DTypeVariant__item___0 :
                                                 Prims.list)
                                   FStar_Pervasives_Native.tuple2 Prims.list)
       FStar_Pervasives_Native.tuple4
-<<<<<<< HEAD
   = fun projectee  -> match projectee with | DTypeVariant _0 -> _0
+let uu___is_DTypeMutual: decl -> Prims.bool =
+  fun projectee  ->
+    match projectee with | DTypeMutual _0 -> true | uu____1075 -> false
+let __proj__DTypeMutual__item___0: decl -> decl Prims.list =
+  fun projectee  -> match projectee with | DTypeMutual _0 -> _0
 let uu___is_StdCall: cc -> Prims.bool =
   fun projectee  ->
-    match projectee with | StdCall  -> true | uu____1066 -> false
+    match projectee with | StdCall  -> true | uu____1092 -> false
 let uu___is_CDecl: cc -> Prims.bool =
   fun projectee  ->
-    match projectee with | CDecl  -> true | uu____1070 -> false
+    match projectee with | CDecl  -> true | uu____1096 -> false
 let uu___is_FastCall: cc -> Prims.bool =
   fun projectee  ->
-    match projectee with | FastCall  -> true | uu____1074 -> false
+    match projectee with | FastCall  -> true | uu____1100 -> false
 let uu___is_Private: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | Private  -> true | uu____1078 -> false
+    match projectee with | Private  -> true | uu____1104 -> false
 let uu___is_NoExtract: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____1082 -> false
+    match projectee with | NoExtract  -> true | uu____1108 -> false
 let uu___is_CInline: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | CInline  -> true | uu____1086 -> false
+    match projectee with | CInline  -> true | uu____1112 -> false
 let uu___is_Substitute: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | Substitute  -> true | uu____1090 -> false
+    match projectee with | Substitute  -> true | uu____1116 -> false
 let uu___is_GCType: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | GCType  -> true | uu____1094 -> false
+    match projectee with | GCType  -> true | uu____1120 -> false
 let uu___is_Comment: flag -> Prims.bool =
   fun projectee  ->
-    match projectee with | Comment _0 -> true | uu____1099 -> false
+    match projectee with | Comment _0 -> true | uu____1125 -> false
 let __proj__Comment__item___0: flag -> Prims.string =
   fun projectee  -> match projectee with | Comment _0 -> _0
 let uu___is_Eternal: lifetime -> Prims.bool =
   fun projectee  ->
-    match projectee with | Eternal  -> true | uu____1110 -> false
+    match projectee with | Eternal  -> true | uu____1136 -> false
 let uu___is_Stack: lifetime -> Prims.bool =
   fun projectee  ->
-    match projectee with | Stack  -> true | uu____1114 -> false
+    match projectee with | Stack  -> true | uu____1140 -> false
 let uu___is_EBound: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EBound _0 -> true | uu____1119 -> false
+    match projectee with | EBound _0 -> true | uu____1145 -> false
 let __proj__EBound__item___0: expr -> Prims.int =
   fun projectee  -> match projectee with | EBound _0 -> _0
 let uu___is_EQualified: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EQualified _0 -> true | uu____1137 -> false
+    match projectee with | EQualified _0 -> true | uu____1163 -> false
 let __proj__EQualified__item___0:
-=======
-  = fun projectee  -> match projectee with | DTypeVariant _0 -> _0 
-let uu___is_DTypeMutual : decl -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DTypeMutual _0 -> true | uu____1084 -> false
-  
-let __proj__DTypeMutual__item___0 : decl -> decl Prims.list =
-  fun projectee  -> match projectee with | DTypeMutual _0 -> _0 
-let uu___is_StdCall : cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | StdCall  -> true | uu____1103 -> false
-  
-let uu___is_CDecl : cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CDecl  -> true | uu____1108 -> false
-  
-let uu___is_FastCall : cc -> Prims.bool =
-  fun projectee  ->
-    match projectee with | FastCall  -> true | uu____1113 -> false
-  
-let uu___is_Private : flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Private  -> true | uu____1118 -> false
-  
-let uu___is_NoExtract : flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____1123 -> false
-  
-let uu___is_CInline : flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CInline  -> true | uu____1128 -> false
-  
-let uu___is_Substitute : flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Substitute  -> true | uu____1133 -> false
-  
-let uu___is_GCType : flag -> Prims.bool =
-  fun projectee  ->
-    match projectee with | GCType  -> true | uu____1138 -> false
-  
-let uu___is_Eternal : lifetime -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Eternal  -> true | uu____1143 -> false
-  
-let uu___is_Stack : lifetime -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Stack  -> true | uu____1148 -> false
-  
-let uu___is_EBound : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBound _0 -> true | uu____1154 -> false
-  
-let __proj__EBound__item___0 : expr -> Prims.int =
-  fun projectee  -> match projectee with | EBound _0 -> _0 
-let uu___is_EQualified : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EQualified _0 -> true | uu____1174 -> false
-  
-let __proj__EQualified__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr ->
     (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | EQualified _0 -> _0
 let uu___is_EConstant: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EConstant _0 -> true | uu____1171 -> false
+    match projectee with | EConstant _0 -> true | uu____1197 -> false
 let __proj__EConstant__item___0:
-=======
-    match projectee with | EConstant _0 -> true | uu____1210 -> false
-  
-let __proj__EConstant__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (width,Prims.string) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EConstant _0 -> _0
 let uu___is_EUnit: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EUnit  -> true | uu____1194 -> false
+    match projectee with | EUnit  -> true | uu____1220 -> false
 let uu___is_EApp: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EApp _0 -> true | uu____1205 -> false
+    match projectee with | EApp _0 -> true | uu____1231 -> false
 let __proj__EApp__item___0:
-=======
-    match projectee with | EUnit  -> true | uu____1235 -> false
-  
-let uu___is_EApp : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EApp _0 -> true | uu____1247 -> false
-  
-let __proj__EApp__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr Prims.list) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EApp _0 -> _0
 let uu___is_ETypApp: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | ETypApp _0 -> true | uu____1241 -> false
+    match projectee with | ETypApp _0 -> true | uu____1267 -> false
 let __proj__ETypApp__item___0:
-=======
-    match projectee with | ETypApp _0 -> true | uu____1285 -> false
-  
-let __proj__ETypApp__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,typ Prims.list) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | ETypApp _0 -> _0
 let uu___is_ELet: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | ELet _0 -> true | uu____1277 -> false
+    match projectee with | ELet _0 -> true | uu____1303 -> false
 let __proj__ELet__item___0:
-=======
-    match projectee with | ELet _0 -> true | uu____1323 -> false
-  
-let __proj__ELet__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (binder,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | ELet _0 -> _0
 let uu___is_EIfThenElse: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EIfThenElse _0 -> true | uu____1313 -> false
+    match projectee with | EIfThenElse _0 -> true | uu____1339 -> false
 let __proj__EIfThenElse__item___0:
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EIfThenElse _0 -> _0
 let uu___is_ESequence: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | ESequence _0 -> true | uu____1345 -> false
+    match projectee with | ESequence _0 -> true | uu____1371 -> false
 let __proj__ESequence__item___0: expr -> expr Prims.list =
   fun projectee  -> match projectee with | ESequence _0 -> _0
 let uu___is_EAssign: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EAssign _0 -> true | uu____1367 -> false
+    match projectee with | EAssign _0 -> true | uu____1393 -> false
 let __proj__EAssign__item___0:
-=======
-    match projectee with | EIfThenElse _0 -> true | uu____1361 -> false
-  
-let __proj__EIfThenElse__item___0 :
-  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
-  fun projectee  -> match projectee with | EIfThenElse _0 -> _0 
-let uu___is_ESequence : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ESequence _0 -> true | uu____1395 -> false
-  
-let __proj__ESequence__item___0 : expr -> expr Prims.list =
-  fun projectee  -> match projectee with | ESequence _0 -> _0 
-let uu___is_EAssign : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAssign _0 -> true | uu____1419 -> false
-  
-let __proj__EAssign__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EAssign _0 -> _0
 let uu___is_EBufCreate: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufCreate _0 -> true | uu____1397 -> false
+    match projectee with | EBufCreate _0 -> true | uu____1423 -> false
 let __proj__EBufCreate__item___0:
-=======
-    match projectee with | EBufCreate _0 -> true | uu____1451 -> false
-  
-let __proj__EBufCreate__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (lifetime,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EBufCreate _0 -> _0
 let uu___is_EBufRead: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufRead _0 -> true | uu____1431 -> false
+    match projectee with | EBufRead _0 -> true | uu____1457 -> false
 let __proj__EBufRead__item___0:
-=======
-    match projectee with | EBufRead _0 -> true | uu____1487 -> false
-  
-let __proj__EBufRead__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EBufRead _0 -> _0
 let uu___is_EBufWrite: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufWrite _0 -> true | uu____1461 -> false
+    match projectee with | EBufWrite _0 -> true | uu____1487 -> false
 let __proj__EBufWrite__item___0:
-=======
-    match projectee with | EBufWrite _0 -> true | uu____1519 -> false
-  
-let __proj__EBufWrite__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EBufWrite _0 -> _0
 let uu___is_EBufSub: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufSub _0 -> true | uu____1495 -> false
+    match projectee with | EBufSub _0 -> true | uu____1521 -> false
 let __proj__EBufSub__item___0:
-=======
-    match projectee with | EBufSub _0 -> true | uu____1555 -> false
-  
-let __proj__EBufSub__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EBufSub _0 -> _0
 let uu___is_EBufBlit: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufBlit _0 -> true | uu____1529 -> false
+    match projectee with | EBufBlit _0 -> true | uu____1555 -> false
 let __proj__EBufBlit__item___0:
-=======
-    match projectee with | EBufBlit _0 -> true | uu____1591 -> false
-  
-let __proj__EBufBlit__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5 =
   fun projectee  -> match projectee with | EBufBlit _0 -> _0
 let uu___is_EMatch: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EMatch _0 -> true | uu____1581 -> false
+    match projectee with | EMatch _0 -> true | uu____1607 -> false
 let __proj__EMatch__item___0:
   expr ->
     (expr,(pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
@@ -517,476 +343,217 @@ let __proj__EMatch__item___0:
   = fun projectee  -> match projectee with | EMatch _0 -> _0
 let uu___is_EOp: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EOp _0 -> true | uu____1627 -> false
+    match projectee with | EOp _0 -> true | uu____1653 -> false
 let __proj__EOp__item___0: expr -> (op,width) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | EOp _0 -> _0
 let uu___is_ECast: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | ECast _0 -> true | uu____1655 -> false
+    match projectee with | ECast _0 -> true | uu____1681 -> false
 let __proj__ECast__item___0:
   expr -> (expr,typ) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | ECast _0 -> _0
 let uu___is_EPushFrame: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EPushFrame  -> true | uu____1678 -> false
+    match projectee with | EPushFrame  -> true | uu____1704 -> false
 let uu___is_EPopFrame: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EPopFrame  -> true | uu____1682 -> false
+    match projectee with | EPopFrame  -> true | uu____1708 -> false
 let uu___is_EBool: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EBool _0 -> true | uu____1687 -> false
+    match projectee with | EBool _0 -> true | uu____1713 -> false
 let __proj__EBool__item___0: expr -> Prims.bool =
   fun projectee  -> match projectee with | EBool _0 -> _0
 let uu___is_EAny: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EAny  -> true | uu____1698 -> false
+    match projectee with | EAny  -> true | uu____1724 -> false
 let uu___is_EAbort: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EAbort  -> true | uu____1702 -> false
+    match projectee with | EAbort  -> true | uu____1728 -> false
 let uu___is_EReturn: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EReturn _0 -> true | uu____1707 -> false
+    match projectee with | EReturn _0 -> true | uu____1733 -> false
 let __proj__EReturn__item___0: expr -> expr =
   fun projectee  -> match projectee with | EReturn _0 -> _0
 let uu___is_EFlat: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EFlat _0 -> true | uu____1729 -> false
+    match projectee with | EFlat _0 -> true | uu____1755 -> false
 let __proj__EFlat__item___0:
-=======
-    match projectee with | EMatch _0 -> true | uu____1645 -> false
-  
-let __proj__EMatch__item___0 :
-  expr ->
-    (expr,(pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | EMatch _0 -> _0 
-let uu___is_EOp : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EOp _0 -> true | uu____1693 -> false
-  
-let __proj__EOp__item___0 : expr -> (op,width) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | EOp _0 -> _0 
-let uu___is_ECast : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ECast _0 -> true | uu____1723 -> false
-  
-let __proj__ECast__item___0 :
-  expr -> (expr,typ) FStar_Pervasives_Native.tuple2 =
-  fun projectee  -> match projectee with | ECast _0 -> _0 
-let uu___is_EPushFrame : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EPushFrame  -> true | uu____1748 -> false
-  
-let uu___is_EPopFrame : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EPopFrame  -> true | uu____1753 -> false
-  
-let uu___is_EBool : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EBool _0 -> true | uu____1759 -> false
-  
-let __proj__EBool__item___0 : expr -> Prims.bool =
-  fun projectee  -> match projectee with | EBool _0 -> _0 
-let uu___is_EAny : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAny  -> true | uu____1772 -> false
-  
-let uu___is_EAbort : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAbort  -> true | uu____1777 -> false
-  
-let uu___is_EReturn : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EReturn _0 -> true | uu____1783 -> false
-  
-let __proj__EReturn__item___0 : expr -> expr =
-  fun projectee  -> match projectee with | EReturn _0 -> _0 
-let uu___is_EFlat : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EFlat _0 -> true | uu____1807 -> false
-  
-let __proj__EFlat__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr ->
     (typ,(Prims.string,expr) FStar_Pervasives_Native.tuple2 Prims.list)
       FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | EFlat _0 -> _0
 let uu___is_EField: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EField _0 -> true | uu____1777 -> false
+    match projectee with | EField _0 -> true | uu____1803 -> false
 let __proj__EField__item___0:
-=======
-    match projectee with | EField _0 -> true | uu____1857 -> false
-  
-let __proj__EField__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EField _0 -> _0
 let uu___is_EWhile: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EWhile _0 -> true | uu____1811 -> false
+    match projectee with | EWhile _0 -> true | uu____1837 -> false
 let __proj__EWhile__item___0:
-=======
-    match projectee with | EWhile _0 -> true | uu____1893 -> false
-  
-let __proj__EWhile__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EWhile _0 -> _0
 let uu___is_EBufCreateL: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufCreateL _0 -> true | uu____1841 -> false
+    match projectee with | EBufCreateL _0 -> true | uu____1867 -> false
 let __proj__EBufCreateL__item___0:
   expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2 =
   fun projectee  -> match projectee with | EBufCreateL _0 -> _0
 let uu___is_ETuple: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | ETuple _0 -> true | uu____1873 -> false
+    match projectee with | ETuple _0 -> true | uu____1899 -> false
 let __proj__ETuple__item___0: expr -> expr Prims.list =
   fun projectee  -> match projectee with | ETuple _0 -> _0
 let uu___is_ECons: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | ECons _0 -> true | uu____1899 -> false
+    match projectee with | ECons _0 -> true | uu____1925 -> false
 let __proj__ECons__item___0:
-=======
-    match projectee with | EBufCreateL _0 -> true | uu____1925 -> false
-  
-let __proj__EBufCreateL__item___0 :
-  expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2 =
-  fun projectee  -> match projectee with | EBufCreateL _0 -> _0 
-let uu___is_ETuple : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ETuple _0 -> true | uu____1959 -> false
-  
-let __proj__ETuple__item___0 : expr -> expr Prims.list =
-  fun projectee  -> match projectee with | ETuple _0 -> _0 
-let uu___is_ECons : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | ECons _0 -> true | uu____1987 -> false
-  
-let __proj__ECons__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   expr -> (typ,Prims.string,expr Prims.list) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | ECons _0 -> _0
 let uu___is_EBufFill: expr -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | EBufFill _0 -> true | uu____1941 -> false
+    match projectee with | EBufFill _0 -> true | uu____1967 -> false
 let __proj__EBufFill__item___0:
   expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EBufFill _0 -> _0
 let uu___is_EString: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EString _0 -> true | uu____1971 -> false
+    match projectee with | EString _0 -> true | uu____1997 -> false
 let __proj__EString__item___0: expr -> Prims.string =
   fun projectee  -> match projectee with | EString _0 -> _0
 let uu___is_EFun: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EFun _0 -> true | uu____1991 -> false
+    match projectee with | EFun _0 -> true | uu____2017 -> false
 let __proj__EFun__item___0:
   expr -> (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3 =
   fun projectee  -> match projectee with | EFun _0 -> _0
 let uu___is_EAbortS: expr -> Prims.bool =
   fun projectee  ->
-    match projectee with | EAbortS _0 -> true | uu____2027 -> false
+    match projectee with | EAbortS _0 -> true | uu____2053 -> false
 let __proj__EAbortS__item___0: expr -> Prims.string =
   fun projectee  -> match projectee with | EAbortS _0 -> _0
 let uu___is_Add: op -> Prims.bool =
-  fun projectee  -> match projectee with | Add  -> true | uu____2038 -> false
+  fun projectee  -> match projectee with | Add  -> true | uu____2064 -> false
 let uu___is_AddW: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | AddW  -> true | uu____2042 -> false
+    match projectee with | AddW  -> true | uu____2068 -> false
 let uu___is_Sub: op -> Prims.bool =
-  fun projectee  -> match projectee with | Sub  -> true | uu____2046 -> false
+  fun projectee  -> match projectee with | Sub  -> true | uu____2072 -> false
 let uu___is_SubW: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | SubW  -> true | uu____2050 -> false
+    match projectee with | SubW  -> true | uu____2076 -> false
 let uu___is_Div: op -> Prims.bool =
-  fun projectee  -> match projectee with | Div  -> true | uu____2054 -> false
+  fun projectee  -> match projectee with | Div  -> true | uu____2080 -> false
 let uu___is_DivW: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | DivW  -> true | uu____2058 -> false
+    match projectee with | DivW  -> true | uu____2084 -> false
 let uu___is_Mult: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | Mult  -> true | uu____2062 -> false
+    match projectee with | Mult  -> true | uu____2088 -> false
 let uu___is_MultW: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | MultW  -> true | uu____2066 -> false
+    match projectee with | MultW  -> true | uu____2092 -> false
 let uu___is_Mod: op -> Prims.bool =
-  fun projectee  -> match projectee with | Mod  -> true | uu____2070 -> false
+  fun projectee  -> match projectee with | Mod  -> true | uu____2096 -> false
 let uu___is_BOr: op -> Prims.bool =
-  fun projectee  -> match projectee with | BOr  -> true | uu____2074 -> false
+  fun projectee  -> match projectee with | BOr  -> true | uu____2100 -> false
 let uu___is_BAnd: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | BAnd  -> true | uu____2078 -> false
+    match projectee with | BAnd  -> true | uu____2104 -> false
 let uu___is_BXor: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | BXor  -> true | uu____2082 -> false
+    match projectee with | BXor  -> true | uu____2108 -> false
 let uu___is_BShiftL: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | BShiftL  -> true | uu____2086 -> false
+    match projectee with | BShiftL  -> true | uu____2112 -> false
 let uu___is_BShiftR: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | BShiftR  -> true | uu____2090 -> false
+    match projectee with | BShiftR  -> true | uu____2116 -> false
 let uu___is_BNot: op -> Prims.bool =
   fun projectee  ->
-    match projectee with | BNot  -> true | uu____2094 -> false
+    match projectee with | BNot  -> true | uu____2120 -> false
 let uu___is_Eq: op -> Prims.bool =
-  fun projectee  -> match projectee with | Eq  -> true | uu____2098 -> false
+  fun projectee  -> match projectee with | Eq  -> true | uu____2124 -> false
 let uu___is_Neq: op -> Prims.bool =
-  fun projectee  -> match projectee with | Neq  -> true | uu____2102 -> false
+  fun projectee  -> match projectee with | Neq  -> true | uu____2128 -> false
 let uu___is_Lt: op -> Prims.bool =
-  fun projectee  -> match projectee with | Lt  -> true | uu____2106 -> false
+  fun projectee  -> match projectee with | Lt  -> true | uu____2132 -> false
 let uu___is_Lte: op -> Prims.bool =
-  fun projectee  -> match projectee with | Lte  -> true | uu____2110 -> false
+  fun projectee  -> match projectee with | Lte  -> true | uu____2136 -> false
 let uu___is_Gt: op -> Prims.bool =
-  fun projectee  -> match projectee with | Gt  -> true | uu____2114 -> false
+  fun projectee  -> match projectee with | Gt  -> true | uu____2140 -> false
 let uu___is_Gte: op -> Prims.bool =
-  fun projectee  -> match projectee with | Gte  -> true | uu____2118 -> false
+  fun projectee  -> match projectee with | Gte  -> true | uu____2144 -> false
 let uu___is_And: op -> Prims.bool =
-  fun projectee  -> match projectee with | And  -> true | uu____2122 -> false
+  fun projectee  -> match projectee with | And  -> true | uu____2148 -> false
 let uu___is_Or: op -> Prims.bool =
-  fun projectee  -> match projectee with | Or  -> true | uu____2126 -> false
+  fun projectee  -> match projectee with | Or  -> true | uu____2152 -> false
 let uu___is_Xor: op -> Prims.bool =
-  fun projectee  -> match projectee with | Xor  -> true | uu____2130 -> false
+  fun projectee  -> match projectee with | Xor  -> true | uu____2156 -> false
 let uu___is_Not: op -> Prims.bool =
-  fun projectee  -> match projectee with | Not  -> true | uu____2134 -> false
+  fun projectee  -> match projectee with | Not  -> true | uu____2160 -> false
 let uu___is_PUnit: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PUnit  -> true | uu____2138 -> false
+    match projectee with | PUnit  -> true | uu____2164 -> false
 let uu___is_PBool: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PBool _0 -> true | uu____2143 -> false
+    match projectee with | PBool _0 -> true | uu____2169 -> false
 let __proj__PBool__item___0: pattern -> Prims.bool =
   fun projectee  -> match projectee with | PBool _0 -> _0
 let uu___is_PVar: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PVar _0 -> true | uu____2155 -> false
+    match projectee with | PVar _0 -> true | uu____2181 -> false
 let __proj__PVar__item___0: pattern -> binder =
   fun projectee  -> match projectee with | PVar _0 -> _0
 let uu___is_PCons: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PCons _0 -> true | uu____2173 -> false
+    match projectee with | PCons _0 -> true | uu____2199 -> false
 let __proj__PCons__item___0:
   pattern -> (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | PCons _0 -> _0
 let uu___is_PTuple: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PTuple _0 -> true | uu____2205 -> false
+    match projectee with | PTuple _0 -> true | uu____2231 -> false
 let __proj__PTuple__item___0: pattern -> pattern Prims.list =
   fun projectee  -> match projectee with | PTuple _0 -> _0
 let uu___is_PRecord: pattern -> Prims.bool =
   fun projectee  ->
-    match projectee with | PRecord _0 -> true | uu____2229 -> false
+    match projectee with | PRecord _0 -> true | uu____2255 -> false
 let __proj__PRecord__item___0:
-=======
-    match projectee with | EBufFill _0 -> true | uu____2031 -> false
-  
-let __proj__EBufFill__item___0 :
-  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
-  fun projectee  -> match projectee with | EBufFill _0 -> _0 
-let uu___is_EString : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EString _0 -> true | uu____2063 -> false
-  
-let __proj__EString__item___0 : expr -> Prims.string =
-  fun projectee  -> match projectee with | EString _0 -> _0 
-let uu___is_EFun : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EFun _0 -> true | uu____2085 -> false
-  
-let __proj__EFun__item___0 :
-  expr -> (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3 =
-  fun projectee  -> match projectee with | EFun _0 -> _0 
-let uu___is_EAbortS : expr -> Prims.bool =
-  fun projectee  ->
-    match projectee with | EAbortS _0 -> true | uu____2123 -> false
-  
-let __proj__EAbortS__item___0 : expr -> Prims.string =
-  fun projectee  -> match projectee with | EAbortS _0 -> _0 
-let uu___is_Add : op -> Prims.bool =
-  fun projectee  -> match projectee with | Add  -> true | uu____2136 -> false 
-let uu___is_AddW : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | AddW  -> true | uu____2141 -> false
-  
-let uu___is_Sub : op -> Prims.bool =
-  fun projectee  -> match projectee with | Sub  -> true | uu____2146 -> false 
-let uu___is_SubW : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | SubW  -> true | uu____2151 -> false
-  
-let uu___is_Div : op -> Prims.bool =
-  fun projectee  -> match projectee with | Div  -> true | uu____2156 -> false 
-let uu___is_DivW : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | DivW  -> true | uu____2161 -> false
-  
-let uu___is_Mult : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Mult  -> true | uu____2166 -> false
-  
-let uu___is_MultW : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | MultW  -> true | uu____2171 -> false
-  
-let uu___is_Mod : op -> Prims.bool =
-  fun projectee  -> match projectee with | Mod  -> true | uu____2176 -> false 
-let uu___is_BOr : op -> Prims.bool =
-  fun projectee  -> match projectee with | BOr  -> true | uu____2181 -> false 
-let uu___is_BAnd : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BAnd  -> true | uu____2186 -> false
-  
-let uu___is_BXor : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BXor  -> true | uu____2191 -> false
-  
-let uu___is_BShiftL : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BShiftL  -> true | uu____2196 -> false
-  
-let uu___is_BShiftR : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BShiftR  -> true | uu____2201 -> false
-  
-let uu___is_BNot : op -> Prims.bool =
-  fun projectee  ->
-    match projectee with | BNot  -> true | uu____2206 -> false
-  
-let uu___is_Eq : op -> Prims.bool =
-  fun projectee  -> match projectee with | Eq  -> true | uu____2211 -> false 
-let uu___is_Neq : op -> Prims.bool =
-  fun projectee  -> match projectee with | Neq  -> true | uu____2216 -> false 
-let uu___is_Lt : op -> Prims.bool =
-  fun projectee  -> match projectee with | Lt  -> true | uu____2221 -> false 
-let uu___is_Lte : op -> Prims.bool =
-  fun projectee  -> match projectee with | Lte  -> true | uu____2226 -> false 
-let uu___is_Gt : op -> Prims.bool =
-  fun projectee  -> match projectee with | Gt  -> true | uu____2231 -> false 
-let uu___is_Gte : op -> Prims.bool =
-  fun projectee  -> match projectee with | Gte  -> true | uu____2236 -> false 
-let uu___is_And : op -> Prims.bool =
-  fun projectee  -> match projectee with | And  -> true | uu____2241 -> false 
-let uu___is_Or : op -> Prims.bool =
-  fun projectee  -> match projectee with | Or  -> true | uu____2246 -> false 
-let uu___is_Xor : op -> Prims.bool =
-  fun projectee  -> match projectee with | Xor  -> true | uu____2251 -> false 
-let uu___is_Not : op -> Prims.bool =
-  fun projectee  -> match projectee with | Not  -> true | uu____2256 -> false 
-let uu___is_PUnit : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PUnit  -> true | uu____2261 -> false
-  
-let uu___is_PBool : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PBool _0 -> true | uu____2267 -> false
-  
-let __proj__PBool__item___0 : pattern -> Prims.bool =
-  fun projectee  -> match projectee with | PBool _0 -> _0 
-let uu___is_PVar : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PVar _0 -> true | uu____2281 -> false
-  
-let __proj__PVar__item___0 : pattern -> binder =
-  fun projectee  -> match projectee with | PVar _0 -> _0 
-let uu___is_PCons : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PCons _0 -> true | uu____2301 -> false
-  
-let __proj__PCons__item___0 :
-  pattern -> (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | PCons _0 -> _0 
-let uu___is_PTuple : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PTuple _0 -> true | uu____2335 -> false
-  
-let __proj__PTuple__item___0 : pattern -> pattern Prims.list =
-  fun projectee  -> match projectee with | PTuple _0 -> _0 
-let uu___is_PRecord : pattern -> Prims.bool =
-  fun projectee  ->
-    match projectee with | PRecord _0 -> true | uu____2361 -> false
-  
-let __proj__PRecord__item___0 :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   pattern -> (Prims.string,pattern) FStar_Pervasives_Native.tuple2 Prims.list
   = fun projectee  -> match projectee with | PRecord _0 -> _0
 let uu___is_UInt8: width -> Prims.bool =
   fun projectee  ->
-<<<<<<< HEAD
-    match projectee with | UInt8  -> true | uu____2258 -> false
+    match projectee with | UInt8  -> true | uu____2284 -> false
 let uu___is_UInt16: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | UInt16  -> true | uu____2262 -> false
+    match projectee with | UInt16  -> true | uu____2288 -> false
 let uu___is_UInt32: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | UInt32  -> true | uu____2266 -> false
+    match projectee with | UInt32  -> true | uu____2292 -> false
 let uu___is_UInt64: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | UInt64  -> true | uu____2270 -> false
+    match projectee with | UInt64  -> true | uu____2296 -> false
 let uu___is_Int8: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | Int8  -> true | uu____2274 -> false
+    match projectee with | Int8  -> true | uu____2300 -> false
 let uu___is_Int16: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | Int16  -> true | uu____2278 -> false
+    match projectee with | Int16  -> true | uu____2304 -> false
 let uu___is_Int32: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | Int32  -> true | uu____2282 -> false
+    match projectee with | Int32  -> true | uu____2308 -> false
 let uu___is_Int64: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | Int64  -> true | uu____2286 -> false
+    match projectee with | Int64  -> true | uu____2312 -> false
 let uu___is_Bool: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | Bool  -> true | uu____2290 -> false
+    match projectee with | Bool  -> true | uu____2316 -> false
 let uu___is_CInt: width -> Prims.bool =
   fun projectee  ->
-    match projectee with | CInt  -> true | uu____2294 -> false
+    match projectee with | CInt  -> true | uu____2320 -> false
 let __proj__Mkbinder__item__name: binder -> Prims.string =
-=======
-    match projectee with | UInt8  -> true | uu____2392 -> false
-  
-let uu___is_UInt16 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt16  -> true | uu____2397 -> false
-  
-let uu___is_UInt32 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt32  -> true | uu____2402 -> false
-  
-let uu___is_UInt64 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | UInt64  -> true | uu____2407 -> false
-  
-let uu___is_Int8 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int8  -> true | uu____2412 -> false
-  
-let uu___is_Int16 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int16  -> true | uu____2417 -> false
-  
-let uu___is_Int32 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int32  -> true | uu____2422 -> false
-  
-let uu___is_Int64 : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Int64  -> true | uu____2427 -> false
-  
-let uu___is_Bool : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | Bool  -> true | uu____2432 -> false
-  
-let uu___is_CInt : width -> Prims.bool =
-  fun projectee  ->
-    match projectee with | CInt  -> true | uu____2437 -> false
-  
-let __proj__Mkbinder__item__name : binder -> Prims.string =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun projectee  ->
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
@@ -1001,46 +568,45 @@ let __proj__Mkbinder__item__mut: binder -> Prims.bool =
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
         __fname__mut
-<<<<<<< HEAD
 let uu___is_TInt: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TInt _0 -> true | uu____2317 -> false
+    match projectee with | TInt _0 -> true | uu____2343 -> false
 let __proj__TInt__item___0: typ -> width =
   fun projectee  -> match projectee with | TInt _0 -> _0
 let uu___is_TBuf: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TBuf _0 -> true | uu____2329 -> false
+    match projectee with | TBuf _0 -> true | uu____2355 -> false
 let __proj__TBuf__item___0: typ -> typ =
   fun projectee  -> match projectee with | TBuf _0 -> _0
 let uu___is_TUnit: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TUnit  -> true | uu____2340 -> false
+    match projectee with | TUnit  -> true | uu____2366 -> false
 let uu___is_TQualified: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TQualified _0 -> true | uu____2351 -> false
+    match projectee with | TQualified _0 -> true | uu____2377 -> false
 let __proj__TQualified__item___0:
   typ ->
     (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | TQualified _0 -> _0
 let uu___is_TBool: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TBool  -> true | uu____2380 -> false
+    match projectee with | TBool  -> true | uu____2406 -> false
 let uu___is_TAny: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TAny  -> true | uu____2384 -> false
+    match projectee with | TAny  -> true | uu____2410 -> false
 let uu___is_TArrow: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TArrow _0 -> true | uu____2393 -> false
+    match projectee with | TArrow _0 -> true | uu____2419 -> false
 let __proj__TArrow__item___0: typ -> (typ,typ) FStar_Pervasives_Native.tuple2
   = fun projectee  -> match projectee with | TArrow _0 -> _0
 let uu___is_TBound: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TBound _0 -> true | uu____2417 -> false
+    match projectee with | TBound _0 -> true | uu____2443 -> false
 let __proj__TBound__item___0: typ -> Prims.int =
   fun projectee  -> match projectee with | TBound _0 -> _0
 let uu___is_TApp: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TApp _0 -> true | uu____2441 -> false
+    match projectee with | TApp _0 -> true | uu____2467 -> false
 let __proj__TApp__item___0:
   typ ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
@@ -1048,76 +614,11 @@ let __proj__TApp__item___0:
   = fun projectee  -> match projectee with | TApp _0 -> _0
 let uu___is_TTuple: typ -> Prims.bool =
   fun projectee  ->
-    match projectee with | TTuple _0 -> true | uu____2491 -> false
+    match projectee with | TTuple _0 -> true | uu____2517 -> false
 let __proj__TTuple__item___0: typ -> typ Prims.list =
   fun projectee  -> match projectee with | TTuple _0 -> _0
 type program = decl Prims.list[@@deriving show]
 type ident = Prims.string[@@deriving show]
-=======
-  
-let uu___is_TInt : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TInt _0 -> true | uu____2464 -> false
-  
-let __proj__TInt__item___0 : typ -> width =
-  fun projectee  -> match projectee with | TInt _0 -> _0 
-let uu___is_TBuf : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBuf _0 -> true | uu____2478 -> false
-  
-let __proj__TBuf__item___0 : typ -> typ =
-  fun projectee  -> match projectee with | TBuf _0 -> _0 
-let uu___is_TUnit : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TUnit  -> true | uu____2491 -> false
-  
-let uu___is_TQualified : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TQualified _0 -> true | uu____2503 -> false
-  
-let __proj__TQualified__item___0 :
-  typ ->
-    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | TQualified _0 -> _0 
-let uu___is_TBool : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBool  -> true | uu____2534 -> false
-  
-let uu___is_TAny : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TAny  -> true | uu____2539 -> false
-  
-let uu___is_TArrow : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TArrow _0 -> true | uu____2549 -> false
-  
-let __proj__TArrow__item___0 :
-  typ -> (typ,typ) FStar_Pervasives_Native.tuple2 =
-  fun projectee  -> match projectee with | TArrow _0 -> _0 
-let uu___is_TBound : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TBound _0 -> true | uu____2575 -> false
-  
-let __proj__TBound__item___0 : typ -> Prims.int =
-  fun projectee  -> match projectee with | TBound _0 -> _0 
-let uu___is_TApp : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TApp _0 -> true | uu____2601 -> false
-  
-let __proj__TApp__item___0 :
-  typ ->
-    ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-      typ Prims.list) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | TApp _0 -> _0 
-let uu___is_TTuple : typ -> Prims.bool =
-  fun projectee  ->
-    match projectee with | TTuple _0 -> true | uu____2653 -> false
-  
-let __proj__TTuple__item___0 : typ -> typ Prims.list =
-  fun projectee  -> match projectee with | TTuple _0 -> _0 
-type program = decl Prims.list
-type ident = Prims.string
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
 type fields_t =
   (Prims.string,(typ,Prims.bool) FStar_Pervasives_Native.tuple2)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
@@ -1134,56 +635,31 @@ type constant = (width,Prims.string) FStar_Pervasives_Native.tuple2[@@deriving
 type var = Prims.int[@@deriving show]
 type lident =
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
-<<<<<<< HEAD
 [@@deriving show]
 type version = Prims.int[@@deriving show]
-let current_version: version = Prims.parse_int "24"
+let current_version: version = Prims.parse_int "26"
 type file = (Prims.string,program) FStar_Pervasives_Native.tuple2[@@deriving
                                                                    show]
 type binary_format = (version,file Prims.list) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 let fst3:
-  'Auu____2567 'Auu____2568 'Auu____2569 .
-    ('Auu____2569,'Auu____2568,'Auu____2567) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2569
-  = fun uu____2579  -> match uu____2579 with | (x,uu____2587,uu____2588) -> x
-let snd3:
   'Auu____2593 'Auu____2594 'Auu____2595 .
     ('Auu____2595,'Auu____2594,'Auu____2593) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2594
-  = fun uu____2605  -> match uu____2605 with | (uu____2612,x,uu____2614) -> x
-let thd3:
+      -> 'Auu____2595
+  = fun uu____2605  -> match uu____2605 with | (x,uu____2613,uu____2614) -> x
+let snd3:
   'Auu____2619 'Auu____2620 'Auu____2621 .
     ('Auu____2621,'Auu____2620,'Auu____2619) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2619
-  = fun uu____2631  -> match uu____2631 with | (uu____2638,uu____2639,x) -> x
+      -> 'Auu____2620
+  = fun uu____2631  -> match uu____2631 with | (uu____2638,x,uu____2640) -> x
+let thd3:
+  'Auu____2645 'Auu____2646 'Auu____2647 .
+    ('Auu____2647,'Auu____2646,'Auu____2645) FStar_Pervasives_Native.tuple3
+      -> 'Auu____2645
+  = fun uu____2657  -> match uu____2657 with | (uu____2664,uu____2665,x) -> x
 let mk_width: Prims.string -> width FStar_Pervasives_Native.option =
-  fun uu___401_2645  ->
-    match uu___401_2645 with
-=======
-type version = Prims.int
-let current_version : version = (Prims.parse_int "25") 
-type file = (Prims.string,program) FStar_Pervasives_Native.tuple2
-type binary_format = (version,file Prims.list) FStar_Pervasives_Native.tuple2
-let fst3 :
-  'Auu____2734 'Auu____2735 'Auu____2736 .
-    ('Auu____2736,'Auu____2735,'Auu____2734) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2736
-  = fun uu____2746  -> match uu____2746 with | (x,uu____2754,uu____2755) -> x 
-let snd3 :
-  'Auu____2764 'Auu____2765 'Auu____2766 .
-    ('Auu____2766,'Auu____2765,'Auu____2764) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2765
-  = fun uu____2776  -> match uu____2776 with | (uu____2783,x,uu____2785) -> x 
-let thd3 :
-  'Auu____2794 'Auu____2795 'Auu____2796 .
-    ('Auu____2796,'Auu____2795,'Auu____2794) FStar_Pervasives_Native.tuple3
-      -> 'Auu____2794
-  = fun uu____2806  -> match uu____2806 with | (uu____2813,uu____2814,x) -> x 
-let mk_width : Prims.string -> width FStar_Pervasives_Native.option =
-  fun uu___123_2821  ->
-    match uu___123_2821 with
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  fun uu___401_2671  ->
+    match uu___401_2671 with
     | "UInt8" -> FStar_Pervasives_Native.Some UInt8
     | "UInt16" -> FStar_Pervasives_Native.Some UInt16
     | "UInt32" -> FStar_Pervasives_Native.Some UInt32
@@ -1192,39 +668,21 @@ let mk_width : Prims.string -> width FStar_Pervasives_Native.option =
     | "Int16" -> FStar_Pervasives_Native.Some Int16
     | "Int32" -> FStar_Pervasives_Native.Some Int32
     | "Int64" -> FStar_Pervasives_Native.Some Int64
-<<<<<<< HEAD
-    | uu____2648 -> FStar_Pervasives_Native.None
+    | uu____2674 -> FStar_Pervasives_Native.None
 let mk_bool_op: Prims.string -> op FStar_Pervasives_Native.option =
-  fun uu___402_2653  ->
-    match uu___402_2653 with
-=======
-    | uu____2824 -> FStar_Pervasives_Native.None
-  
-let mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option =
-  fun uu___124_2830  ->
-    match uu___124_2830 with
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  fun uu___402_2679  ->
+    match uu___402_2679 with
     | "op_Negation" -> FStar_Pervasives_Native.Some Not
     | "op_AmpAmp" -> FStar_Pervasives_Native.Some And
     | "op_BarBar" -> FStar_Pervasives_Native.Some Or
     | "op_Equality" -> FStar_Pervasives_Native.Some Eq
     | "op_disEquality" -> FStar_Pervasives_Native.Some Neq
-<<<<<<< HEAD
-    | uu____2656 -> FStar_Pervasives_Native.None
+    | uu____2682 -> FStar_Pervasives_Native.None
 let is_bool_op: Prims.string -> Prims.bool =
   fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None
 let mk_op: Prims.string -> op FStar_Pervasives_Native.option =
-  fun uu___403_2666  ->
-    match uu___403_2666 with
-=======
-    | uu____2833 -> FStar_Pervasives_Native.None
-  
-let is_bool_op : Prims.string -> Prims.bool =
-  fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None 
-let mk_op : Prims.string -> op FStar_Pervasives_Native.option =
-  fun uu___125_2845  ->
-    match uu___125_2845 with
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  fun uu___403_2692  ->
+    match uu___403_2692 with
     | "add" -> FStar_Pervasives_Native.Some Add
     | "op_Plus_Hat" -> FStar_Pervasives_Native.Some Add
     | "add_mod" -> FStar_Pervasives_Native.Some AddW
@@ -1264,20 +722,11 @@ let mk_op : Prims.string -> op FStar_Pervasives_Native.option =
     | "lt" -> FStar_Pervasives_Native.Some Lt
     | "op_Less_Equals_Hat" -> FStar_Pervasives_Native.Some Lte
     | "lte" -> FStar_Pervasives_Native.Some Lte
-<<<<<<< HEAD
-    | uu____2669 -> FStar_Pervasives_Native.None
+    | uu____2695 -> FStar_Pervasives_Native.None
 let is_op: Prims.string -> Prims.bool =
   fun op  -> (mk_op op) <> FStar_Pervasives_Native.None
 let is_machine_int: Prims.string -> Prims.bool =
   fun m  -> (mk_width m) <> FStar_Pervasives_Native.None
-=======
-    | uu____2848 -> FStar_Pervasives_Native.None
-  
-let is_op : Prims.string -> Prims.bool =
-  fun op  -> (mk_op op) <> FStar_Pervasives_Native.None 
-let is_machine_int : Prims.string -> Prims.bool =
-  fun m  -> (mk_width m) <> FStar_Pervasives_Native.None 
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
 type env =
   {
   names: name Prims.list;
@@ -1315,164 +764,85 @@ let extend: env -> Prims.string -> Prims.bool -> env =
   fun env  ->
     fun x  ->
       fun is_mut  ->
-<<<<<<< HEAD
-        let uu___408_2780 = env in
+        let uu___408_2806 = env in
         {
           names = ({ pretty = x; mut = is_mut } :: (env.names));
-          names_t = (uu___408_2780.names_t);
-          module_name = (uu___408_2780.module_name)
-=======
-        let uu___130_2970 = env  in
-        {
-          names = ({ pretty = x; mut = is_mut } :: (env.names));
-          names_t = (uu___130_2970.names_t);
-          module_name = (uu___130_2970.module_name)
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          names_t = (uu___408_2806.names_t);
+          module_name = (uu___408_2806.module_name)
         }
 let extend_t: env -> Prims.string -> env =
   fun env  ->
     fun x  ->
-<<<<<<< HEAD
-      let uu___409_2787 = env in
+      let uu___409_2813 = env in
       {
-        names = (uu___409_2787.names);
+        names = (uu___409_2813.names);
         names_t = (x :: (env.names_t));
-        module_name = (uu___409_2787.module_name)
-=======
-      let uu___131_2979 = env  in
-      {
-        names = (uu___131_2979.names);
-        names_t = (x :: (env.names_t));
-        module_name = (uu___131_2979.module_name)
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+        module_name = (uu___409_2813.module_name)
       }
 let find_name: env -> Prims.string -> name =
   fun env  ->
     fun x  ->
-<<<<<<< HEAD
-      let uu____2794 =
+      let uu____2820 =
         FStar_List.tryFind (fun name  -> name.pretty = x) env.names in
-      match uu____2794 with
+      match uu____2820 with
       | FStar_Pervasives_Native.Some name -> name
       | FStar_Pervasives_Native.None  ->
           failwith "internal error: name not found"
 let is_mutable: env -> Prims.string -> Prims.bool =
-  fun env  -> fun x  -> let uu____2806 = find_name env x in uu____2806.mut
+  fun env  -> fun x  -> let uu____2832 = find_name env x in uu____2832.mut
 let find: env -> Prims.string -> Prims.int =
-=======
-      let uu____2988 =
-        FStar_List.tryFind (fun name  -> name.pretty = x) env.names  in
-      match uu____2988 with
-      | FStar_Pervasives_Native.Some name -> name
-      | FStar_Pervasives_Native.None  ->
-          failwith "internal error: name not found"
-  
-let is_mutable : env -> Prims.string -> Prims.bool =
-  fun env  -> fun x  -> let uu____3002 = find_name env x  in uu____3002.mut 
-let find : env -> Prims.string -> Prims.int =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name.pretty = x) env.names
       with
-<<<<<<< HEAD
-      | uu____2821 ->
-          let uu____2822 =
+      | uu____2847 ->
+          let uu____2848 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____2822
+          failwith uu____2848
 let find_t: env -> Prims.string -> Prims.int =
-=======
-      | uu____3019 ->
-          let uu____3020 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x  in
-          failwith uu____3020
-  
-let find_t : env -> Prims.string -> Prims.int =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name = x) env.names_t
       with
-<<<<<<< HEAD
-      | uu____2837 ->
-          let uu____2838 =
+      | uu____2863 ->
+          let uu____2864 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____2838
+          failwith uu____2864
 let add_binders:
-  'Auu____2842 .
+  'Auu____2868 .
     env ->
-      (Prims.string,'Auu____2842) FStar_Pervasives_Native.tuple2 Prims.list
+      (Prims.string,'Auu____2868) FStar_Pervasives_Native.tuple2 Prims.list
         -> env
-=======
-      | uu____3037 ->
-          let uu____3038 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x  in
-          failwith uu____3038
-  
-let add_binders :
-  'Auu____3047 'Auu____3048 .
-    env ->
-      ((Prims.string,'Auu____3048) FStar_Pervasives_Native.tuple2,'Auu____3047)
-        FStar_Pervasives_Native.tuple2 Prims.list -> env
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   =
   fun env  ->
     fun binders  ->
       FStar_List.fold_left
         (fun env1  ->
-<<<<<<< HEAD
-           fun uu____2872  ->
-             match uu____2872 with
-             | (name,uu____2878) -> extend env1 name false) env binders
+           fun uu____2898  ->
+             match uu____2898 with
+             | (name,uu____2904) -> extend env1 name false) env binders
 let rec translate: FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
-  fun uu____3003  ->
-    match uu____3003 with
-=======
-           fun uu____3091  ->
-             match uu____3091 with
-             | ((name,uu____3101),uu____3102) -> extend env1 name false) env
-        binders
-  
-let rec translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
-  fun uu____3237  ->
-    match uu____3237 with
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  fun uu____3047  ->
+    match uu____3047 with
     | FStar_Extraction_ML_Syntax.MLLib modules1 ->
         FStar_List.filter_map
           (fun m  ->
              let m_name =
-<<<<<<< HEAD
-               let uu____3063 = m in
-               match uu____3063 with
-               | ((prefix1,final),uu____3084,uu____3085) ->
-=======
-               let uu____3297 = m  in
-               match uu____3297 with
-               | ((prefix1,final),uu____3318,uu____3319) ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+               let uu____3107 = m in
+               match uu____3107 with
+               | ((prefix1,final),uu____3128,uu____3129) ->
                    FStar_String.concat "."
                      (FStar_List.append prefix1 [final]) in
              try
                FStar_Util.print1 "Attempting to translate module %s\n" m_name;
-<<<<<<< HEAD
-               (let uu____3117 = translate_module m in
-                FStar_Pervasives_Native.Some uu____3117)
+               (let uu____3161 = translate_module m in
+                FStar_Pervasives_Native.Some uu____3161)
              with
              | e ->
-                 ((let uu____3126 = FStar_Util.print_exn e in
+                 ((let uu____3170 = FStar_Util.print_exn e in
                    FStar_Util.print2
                      "Unable to translate module: %s because:\n  %s\n" m_name
-                     uu____3126);
-=======
-               (let uu____3351 = translate_module m  in
-                FStar_Pervasives_Native.Some uu____3351)
-             with
-             | e ->
-                 ((let uu____3360 = FStar_Util.print_exn e  in
-                   FStar_Util.print2
-                     "Unable to translate module: %s because:\n  %s\n" m_name
-                     uu____3360);
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+                     uu____3170);
                   FStar_Pervasives_Native.None)) modules1
 and translate_module:
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
@@ -1480,15 +850,9 @@ and translate_module:
       FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option,FStar_Extraction_ML_Syntax.mllib)
     FStar_Pervasives_Native.tuple3 -> file
   =
-<<<<<<< HEAD
-  fun uu____3127  ->
-    match uu____3127 with
-    | (module_name,modul,uu____3148) ->
-=======
-  fun uu____3361  ->
-    match uu____3361 with
-    | (module_name,modul,uu____3382) ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+  fun uu____3171  ->
+    match uu____3171 with
+    | (module_name,modul,uu____3192) ->
         let module_name1 =
           FStar_List.append (FStar_Pervasives_Native.fst module_name)
             [FStar_Pervasives_Native.snd module_name] in
@@ -1497,26 +861,15 @@ and translate_module:
           | FStar_Pervasives_Native.Some (_signature,decls) ->
               FStar_List.filter_map (translate_decl (empty module_name1))
                 decls
-<<<<<<< HEAD
-          | uu____3191 ->
+          | uu____3235 ->
               failwith "Unexpected standalone interface or nested modules" in
-=======
-          | uu____3425 ->
-              failwith "Unexpected standalone interface or nested modules"
-           in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
         ((FStar_String.concat "_" module_name1), program)
 and translate_flags:
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list =
   fun flags  ->
     FStar_List.choose
-<<<<<<< HEAD
-      (fun uu___404_3206  ->
-         match uu___404_3206 with
-=======
-      (fun uu___126_3440  ->
-         match uu___126_3440 with
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+      (fun uu___404_3250  ->
+         match uu___404_3250 with
          | FStar_Extraction_ML_Syntax.Private  ->
              FStar_Pervasives_Native.Some Private
          | FStar_Extraction_ML_Syntax.NoExtract  ->
@@ -1527,16 +880,243 @@ and translate_flags:
              FStar_Pervasives_Native.Some Substitute
          | FStar_Extraction_ML_Syntax.GCType  ->
              FStar_Pervasives_Native.Some GCType
-<<<<<<< HEAD
          | FStar_Extraction_ML_Syntax.Comment s ->
              FStar_Pervasives_Native.Some (Comment s)
-         | uu____3210 -> FStar_Pervasives_Native.None) flags
+         | uu____3254 -> FStar_Pervasives_Native.None) flags
+and translate_single_let:
+  env ->
+    FStar_Extraction_ML_Syntax.mlletflavor ->
+      FStar_Extraction_ML_Syntax.meta Prims.list ->
+        FStar_Extraction_ML_Syntax.mllb ->
+          decl FStar_Pervasives_Native.option
+  =
+  fun env  ->
+    fun flavor  ->
+      fun flags  ->
+        fun binding  ->
+          match (flavor, flags, binding) with
+          | (flavor1,flags1,{ FStar_Extraction_ML_Syntax.mllb_name = name;
+                              FStar_Extraction_ML_Syntax.mllb_tysc =
+                                FStar_Pervasives_Native.Some (tvars,t0);
+                              FStar_Extraction_ML_Syntax.mllb_add_unit =
+                                uu____3270;
+                              FStar_Extraction_ML_Syntax.mllb_def =
+                                {
+                                  FStar_Extraction_ML_Syntax.expr =
+                                    FStar_Extraction_ML_Syntax.MLE_Fun
+                                    (args,body);
+                                  FStar_Extraction_ML_Syntax.mlty =
+                                    uu____3273;
+                                  FStar_Extraction_ML_Syntax.loc = uu____3274;_};
+                              FStar_Extraction_ML_Syntax.print_typ =
+                                uu____3275;_})
+              ->
+              let assumed =
+                FStar_Util.for_some
+                  (fun uu___405_3298  ->
+                     match uu___405_3298 with
+                     | FStar_Extraction_ML_Syntax.Assumed  -> true
+                     | uu____3299 -> false) flags1 in
+              let env1 =
+                if flavor1 = FStar_Extraction_ML_Syntax.Rec
+                then extend env name false
+                else env in
+              let env2 =
+                FStar_List.fold_left
+                  (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
+              let rec find_return_type i uu___406_3313 =
+                match uu___406_3313 with
+                | FStar_Extraction_ML_Syntax.MLTY_Fun
+                    (uu____3314,uu____3315,t) when i > (Prims.parse_int "0")
+                    -> find_return_type (i - (Prims.parse_int "1")) t
+                | t -> t in
+              let t =
+                let uu____3319 = find_return_type (FStar_List.length args) t0 in
+                translate_type env2 uu____3319 in
+              let binders = translate_binders env2 args in
+              let env3 = add_binders env2 args in
+              let name1 = ((env3.module_name), name) in
+              let flags2 =
+                match t0 with
+                | FStar_Extraction_ML_Syntax.MLTY_Fun
+                    (uu____3342,FStar_Extraction_ML_Syntax.E_GHOST
+                     ,uu____3343)
+                    ->
+                    let uu____3344 = translate_flags flags1 in NoExtract ::
+                      uu____3344
+                | uu____3347 -> translate_flags flags1 in
+              if assumed
+              then
+                (if (FStar_List.length tvars) = (Prims.parse_int "0")
+                 then
+                   let uu____3352 =
+                     let uu____3353 =
+                       let uu____3368 = translate_type env3 t0 in
+                       (FStar_Pervasives_Native.None, name1, uu____3368) in
+                     DExternal uu____3353 in
+                   FStar_Pervasives_Native.Some uu____3352
+                 else FStar_Pervasives_Native.None)
+              else
+                (try
+                   let body1 = translate_expr env3 body in
+                   FStar_Pervasives_Native.Some
+                     (DFunction
+                        (FStar_Pervasives_Native.None, flags2,
+                          (FStar_List.length tvars), t, name1, binders,
+                          body1))
+                 with
+                 | e ->
+                     let msg = FStar_Util.print_exn e in
+                     (FStar_Util.print2_warning
+                        "Writing a stub for %s (%s)\n"
+                        (FStar_Pervasives_Native.snd name1) msg;
+                      (let msg1 =
+                         Prims.strcat "This function was not extracted:\n"
+                           msg in
+                       FStar_Pervasives_Native.Some
+                         (DFunction
+                            (FStar_Pervasives_Native.None, flags2,
+                              (FStar_List.length tvars), t, name1, binders,
+                              (EAbortS msg1))))))
+          | (flavor1,flags1,{ FStar_Extraction_ML_Syntax.mllb_name = name;
+                              FStar_Extraction_ML_Syntax.mllb_tysc =
+                                FStar_Pervasives_Native.Some (tvars,t0);
+                              FStar_Extraction_ML_Syntax.mllb_add_unit =
+                                uu____3430;
+                              FStar_Extraction_ML_Syntax.mllb_def =
+                                {
+                                  FStar_Extraction_ML_Syntax.expr =
+                                    FStar_Extraction_ML_Syntax.MLE_Coerce
+                                    ({
+                                       FStar_Extraction_ML_Syntax.expr =
+                                         FStar_Extraction_ML_Syntax.MLE_Fun
+                                         (args,body);
+                                       FStar_Extraction_ML_Syntax.mlty =
+                                         uu____3433;
+                                       FStar_Extraction_ML_Syntax.loc =
+                                         uu____3434;_},uu____3435,uu____3436);
+                                  FStar_Extraction_ML_Syntax.mlty =
+                                    uu____3437;
+                                  FStar_Extraction_ML_Syntax.loc = uu____3438;_};
+                              FStar_Extraction_ML_Syntax.print_typ =
+                                uu____3439;_})
+              ->
+              let assumed =
+                FStar_Util.for_some
+                  (fun uu___405_3462  ->
+                     match uu___405_3462 with
+                     | FStar_Extraction_ML_Syntax.Assumed  -> true
+                     | uu____3463 -> false) flags1 in
+              let env1 =
+                if flavor1 = FStar_Extraction_ML_Syntax.Rec
+                then extend env name false
+                else env in
+              let env2 =
+                FStar_List.fold_left
+                  (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
+              let rec find_return_type i uu___406_3477 =
+                match uu___406_3477 with
+                | FStar_Extraction_ML_Syntax.MLTY_Fun
+                    (uu____3478,uu____3479,t) when i > (Prims.parse_int "0")
+                    -> find_return_type (i - (Prims.parse_int "1")) t
+                | t -> t in
+              let t =
+                let uu____3483 = find_return_type (FStar_List.length args) t0 in
+                translate_type env2 uu____3483 in
+              let binders = translate_binders env2 args in
+              let env3 = add_binders env2 args in
+              let name1 = ((env3.module_name), name) in
+              let flags2 =
+                match t0 with
+                | FStar_Extraction_ML_Syntax.MLTY_Fun
+                    (uu____3506,FStar_Extraction_ML_Syntax.E_GHOST
+                     ,uu____3507)
+                    ->
+                    let uu____3508 = translate_flags flags1 in NoExtract ::
+                      uu____3508
+                | uu____3511 -> translate_flags flags1 in
+              if assumed
+              then
+                (if (FStar_List.length tvars) = (Prims.parse_int "0")
+                 then
+                   let uu____3516 =
+                     let uu____3517 =
+                       let uu____3532 = translate_type env3 t0 in
+                       (FStar_Pervasives_Native.None, name1, uu____3532) in
+                     DExternal uu____3517 in
+                   FStar_Pervasives_Native.Some uu____3516
+                 else FStar_Pervasives_Native.None)
+              else
+                (try
+                   let body1 = translate_expr env3 body in
+                   FStar_Pervasives_Native.Some
+                     (DFunction
+                        (FStar_Pervasives_Native.None, flags2,
+                          (FStar_List.length tvars), t, name1, binders,
+                          body1))
+                 with
+                 | e ->
+                     let msg = FStar_Util.print_exn e in
+                     (FStar_Util.print2_warning
+                        "Writing a stub for %s (%s)\n"
+                        (FStar_Pervasives_Native.snd name1) msg;
+                      (let msg1 =
+                         Prims.strcat "This function was not extracted:\n"
+                           msg in
+                       FStar_Pervasives_Native.Some
+                         (DFunction
+                            (FStar_Pervasives_Native.None, flags2,
+                              (FStar_List.length tvars), t, name1, binders,
+                              (EAbortS msg1))))))
+          | (flavor1,flags1,{ FStar_Extraction_ML_Syntax.mllb_name = name;
+                              FStar_Extraction_ML_Syntax.mllb_tysc =
+                                FStar_Pervasives_Native.Some ([],t);
+                              FStar_Extraction_ML_Syntax.mllb_add_unit =
+                                uu____3593;
+                              FStar_Extraction_ML_Syntax.mllb_def = expr;
+                              FStar_Extraction_ML_Syntax.print_typ =
+                                uu____3595;_})
+              ->
+              let flags2 = translate_flags flags1 in
+              let t1 = translate_type env t in
+              let name1 = ((env.module_name), name) in
+              (try
+                 let expr1 = translate_expr env expr in
+                 FStar_Pervasives_Native.Some
+                   (DGlobal (flags2, name1, t1, expr1))
+               with
+               | e ->
+                   ((let uu____3645 = FStar_Util.print_exn e in
+                     FStar_Util.print2_warning
+                       "Not translating definition for %s (%s)\n"
+                       (FStar_Pervasives_Native.snd name1) uu____3645);
+                    FStar_Pervasives_Native.Some
+                      (DGlobal (flags2, name1, t1, EAny))))
+          | (uu____3656,uu____3657,{
+                                     FStar_Extraction_ML_Syntax.mllb_name =
+                                       name;
+                                     FStar_Extraction_ML_Syntax.mllb_tysc =
+                                       ts;
+                                     FStar_Extraction_ML_Syntax.mllb_add_unit
+                                       = uu____3660;
+                                     FStar_Extraction_ML_Syntax.mllb_def =
+                                       uu____3661;
+                                     FStar_Extraction_ML_Syntax.print_typ =
+                                       uu____3662;_})
+              ->
+              (FStar_Util.print1_warning
+                 "Not translating definition for %s (and possibly others)\n"
+                 name;
+               (match ts with
+                | FStar_Pervasives_Native.Some (idents,t) ->
+                    let uu____3677 =
+                      FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
+                    FStar_Util.print2 "Type scheme is: forall %s. %s\n"
+                      (FStar_String.concat ", " idents) uu____3677
+                | FStar_Pervasives_Native.None  -> ());
+               FStar_Pervasives_Native.None)
+          | uu____3680 -> failwith "impossible"
 and translate_decl:
-=======
-         | uu____3443 -> FStar_Pervasives_Native.None) flags
-
-and translate_decl :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     FStar_Extraction_ML_Syntax.mlmodule1 ->
       decl FStar_Pervasives_Native.option
@@ -1544,470 +1124,9 @@ and translate_decl :
   fun env  ->
     fun d  ->
       match d with
-      | FStar_Extraction_ML_Syntax.MLM_Let
-<<<<<<< HEAD
-          (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some (tvars,t0);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3220;
-=======
-          (flavor,flags,{
-                          FStar_Extraction_ML_Syntax.mllb_name =
-                            (name,uu____3451);
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some (tvars,t0);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3454;
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-                          FStar_Extraction_ML_Syntax.mllb_def =
-                            {
-                              FStar_Extraction_ML_Syntax.expr =
-                                FStar_Extraction_ML_Syntax.MLE_Fun
-                                (args,body);
-<<<<<<< HEAD
-                              FStar_Extraction_ML_Syntax.mlty = uu____3223;
-                              FStar_Extraction_ML_Syntax.loc = uu____3224;_};
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3225;_}::[])
-          ->
-          let assumed =
-            FStar_Util.for_some
-              (fun uu___405_3246  ->
-                 match uu___405_3246 with
-                 | FStar_Extraction_ML_Syntax.Assumed  -> true
-                 | uu____3247 -> false) flags in
-=======
-                              FStar_Extraction_ML_Syntax.mlty = uu____3457;
-                              FStar_Extraction_ML_Syntax.loc = uu____3458;_};
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3459;_}::[])
-          ->
-          let assumed =
-            FStar_Util.for_some
-              (fun uu___127_3480  ->
-                 match uu___127_3480 with
-                 | FStar_Extraction_ML_Syntax.Assumed  -> true
-                 | uu____3481 -> false) flags
-             in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          let env1 =
-            if flavor = FStar_Extraction_ML_Syntax.Rec
-            then extend env name false
-            else env in
-          let env2 =
-            FStar_List.fold_left
-<<<<<<< HEAD
-              (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
-          let rec find_return_type i uu___406_3261 =
-            match uu___406_3261 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3262,uu____3263,t)
-=======
-              (fun env2  ->
-                 fun uu____3494  ->
-                   match uu____3494 with
-                   | (name1,uu____3500) -> extend_t env2 name1) env1 tvars
-             in
-          let rec find_return_type i uu___128_3507 =
-            match uu___128_3507 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3508,uu____3509,t)
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-                when i > (Prims.parse_int "0") ->
-                find_return_type (i - (Prims.parse_int "1")) t
-            | t -> t in
-          let t =
-<<<<<<< HEAD
-            let uu____3267 = find_return_type (FStar_List.length args) t0 in
-            translate_type env2 uu____3267 in
-          let binders = translate_binders env2 args in
-          let env3 = add_binders env2 args in
-          let name1 = ((env3.module_name), name) in
-          let flags1 =
-            match t0 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun
-                (uu____3290,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3291)
-                ->
-                let uu____3292 = translate_flags flags in NoExtract ::
-                  uu____3292
-            | uu____3295 -> translate_flags flags in
-=======
-            let uu____3513 = find_return_type (FStar_List.length args) t0  in
-            translate_type env2 uu____3513  in
-          let binders = translate_binders env2 args  in
-          let env3 = add_binders env2 args  in
-          let name1 = ((env3.module_name), name)  in
-          let flags1 =
-            match t0 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun
-                (uu____3536,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3537)
-                ->
-                let uu____3538 = translate_flags flags  in NoExtract ::
-                  uu____3538
-            | uu____3541 -> translate_flags flags  in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          if assumed
-          then
-            (if (FStar_List.length tvars) = (Prims.parse_int "0")
-             then
-<<<<<<< HEAD
-               let uu____3300 =
-                 let uu____3301 =
-                   let uu____3316 = translate_type env3 t0 in
-                   (FStar_Pervasives_Native.None, name1, uu____3316) in
-                 DExternal uu____3301 in
-               FStar_Pervasives_Native.Some uu____3300
-=======
-               let uu____3546 =
-                 let uu____3547 =
-                   let uu____3562 = translate_type env3 t0  in
-                   (FStar_Pervasives_Native.None, name1, uu____3562)  in
-                 DExternal uu____3547  in
-               FStar_Pervasives_Native.Some uu____3546
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-             else FStar_Pervasives_Native.None)
-          else
-            (try
-               let body1 = translate_expr env3 body in
-               FStar_Pervasives_Native.Some
-                 (DFunction
-                    (FStar_Pervasives_Native.None, flags1,
-                      (FStar_List.length tvars), t, name1, binders, body1))
-             with
-             | e ->
-                 let msg = FStar_Util.print_exn e in
-                 (FStar_Util.print2_warning "Writing a stub for %s (%s)\n"
-                    (FStar_Pervasives_Native.snd name1) msg;
-                  (let msg1 =
-                     Prims.strcat "This function was not extracted:\n" msg in
-                   FStar_Pervasives_Native.Some
-                     (DFunction
-                        (FStar_Pervasives_Native.None, flags1,
-                          (FStar_List.length tvars), t, name1, binders,
-                          (EAbortS msg1))))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-<<<<<<< HEAD
-          (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some (tvars,t0);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3378;
-=======
-          (flavor,flags,{
-                          FStar_Extraction_ML_Syntax.mllb_name =
-                            (name,uu____3622);
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some (tvars,t0);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3625;
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-                          FStar_Extraction_ML_Syntax.mllb_def =
-                            {
-                              FStar_Extraction_ML_Syntax.expr =
-                                FStar_Extraction_ML_Syntax.MLE_Coerce
-                                ({
-                                   FStar_Extraction_ML_Syntax.expr =
-                                     FStar_Extraction_ML_Syntax.MLE_Fun
-                                     (args,body);
-                                   FStar_Extraction_ML_Syntax.mlty =
-<<<<<<< HEAD
-                                     uu____3381;
-                                   FStar_Extraction_ML_Syntax.loc =
-                                     uu____3382;_},uu____3383,uu____3384);
-                              FStar_Extraction_ML_Syntax.mlty = uu____3385;
-                              FStar_Extraction_ML_Syntax.loc = uu____3386;_};
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3387;_}::[])
-          ->
-          let assumed =
-            FStar_Util.for_some
-              (fun uu___405_3408  ->
-                 match uu___405_3408 with
-                 | FStar_Extraction_ML_Syntax.Assumed  -> true
-                 | uu____3409 -> false) flags in
-=======
-                                     uu____3628;
-                                   FStar_Extraction_ML_Syntax.loc =
-                                     uu____3629;_},uu____3630,uu____3631);
-                              FStar_Extraction_ML_Syntax.mlty = uu____3632;
-                              FStar_Extraction_ML_Syntax.loc = uu____3633;_};
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3634;_}::[])
-          ->
-          let assumed =
-            FStar_Util.for_some
-              (fun uu___127_3655  ->
-                 match uu___127_3655 with
-                 | FStar_Extraction_ML_Syntax.Assumed  -> true
-                 | uu____3656 -> false) flags
-             in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          let env1 =
-            if flavor = FStar_Extraction_ML_Syntax.Rec
-            then extend env name false
-            else env in
-          let env2 =
-            FStar_List.fold_left
-<<<<<<< HEAD
-              (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
-          let rec find_return_type i uu___406_3423 =
-            match uu___406_3423 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3424,uu____3425,t)
-=======
-              (fun env2  ->
-                 fun uu____3669  ->
-                   match uu____3669 with
-                   | (name1,uu____3675) -> extend_t env2 name1) env1 tvars
-             in
-          let rec find_return_type i uu___128_3682 =
-            match uu___128_3682 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3683,uu____3684,t)
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-                when i > (Prims.parse_int "0") ->
-                find_return_type (i - (Prims.parse_int "1")) t
-            | t -> t in
-          let t =
-<<<<<<< HEAD
-            let uu____3429 = find_return_type (FStar_List.length args) t0 in
-            translate_type env2 uu____3429 in
-          let binders = translate_binders env2 args in
-          let env3 = add_binders env2 args in
-          let name1 = ((env3.module_name), name) in
-          let flags1 =
-            match t0 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun
-                (uu____3452,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3453)
-                ->
-                let uu____3454 = translate_flags flags in NoExtract ::
-                  uu____3454
-            | uu____3457 -> translate_flags flags in
-=======
-            let uu____3688 = find_return_type (FStar_List.length args) t0  in
-            translate_type env2 uu____3688  in
-          let binders = translate_binders env2 args  in
-          let env3 = add_binders env2 args  in
-          let name1 = ((env3.module_name), name)  in
-          let flags1 =
-            match t0 with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun
-                (uu____3711,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3712)
-                ->
-                let uu____3713 = translate_flags flags  in NoExtract ::
-                  uu____3713
-            | uu____3716 -> translate_flags flags  in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          if assumed
-          then
-            (if (FStar_List.length tvars) = (Prims.parse_int "0")
-             then
-<<<<<<< HEAD
-               let uu____3462 =
-                 let uu____3463 =
-                   let uu____3478 = translate_type env3 t0 in
-                   (FStar_Pervasives_Native.None, name1, uu____3478) in
-                 DExternal uu____3463 in
-               FStar_Pervasives_Native.Some uu____3462
-=======
-               let uu____3721 =
-                 let uu____3722 =
-                   let uu____3737 = translate_type env3 t0  in
-                   (FStar_Pervasives_Native.None, name1, uu____3737)  in
-                 DExternal uu____3722  in
-               FStar_Pervasives_Native.Some uu____3721
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-             else FStar_Pervasives_Native.None)
-          else
-            (try
-               let body1 = translate_expr env3 body in
-               FStar_Pervasives_Native.Some
-                 (DFunction
-                    (FStar_Pervasives_Native.None, flags1,
-                      (FStar_List.length tvars), t, name1, binders, body1))
-             with
-             | e ->
-                 let msg = FStar_Util.print_exn e in
-                 (FStar_Util.print2_warning "Writing a stub for %s (%s)\n"
-                    (FStar_Pervasives_Native.snd name1) msg;
-                  (let msg1 =
-                     Prims.strcat "This function was not extracted:\n" msg in
-                   FStar_Pervasives_Native.Some
-                     (DFunction
-                        (FStar_Pervasives_Native.None, flags1,
-                          (FStar_List.length tvars), t, name1, binders,
-                          (EAbortS msg1))))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-<<<<<<< HEAD
-          (flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some ([],t);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3539;
-                          FStar_Extraction_ML_Syntax.mllb_def = expr;
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3541;_}::[])
-=======
-          (flavor,flags,{
-                          FStar_Extraction_ML_Syntax.mllb_name =
-                            (name,uu____3797);
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.Some ([],t);
-                          FStar_Extraction_ML_Syntax.mllb_add_unit =
-                            uu____3799;
-                          FStar_Extraction_ML_Syntax.mllb_def = expr;
-                          FStar_Extraction_ML_Syntax.print_typ = uu____3801;_}::[])
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          ->
-          let flags1 = translate_flags flags in
-          let t1 = translate_type env t in
-          let name1 = ((env.module_name), name) in
-          (try
-             let expr1 = translate_expr env expr in
-             FStar_Pervasives_Native.Some
-               (DGlobal (flags1, name1, t1, expr1))
-           with
-           | e ->
-<<<<<<< HEAD
-               ((let uu____3589 = FStar_Util.print_exn e in
-                 FStar_Util.print2_warning
-                   "Not translating definition for %s (%s)\n"
-                   (FStar_Pervasives_Native.snd name1) uu____3589);
-                FStar_Pervasives_Native.Some
-                  (DGlobal (flags1, name1, t1, EAny))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-          (uu____3600,uu____3601,{
-                                   FStar_Extraction_ML_Syntax.mllb_name =
-                                     name;
-                                   FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-                                   FStar_Extraction_ML_Syntax.mllb_add_unit =
-                                     uu____3604;
-                                   FStar_Extraction_ML_Syntax.mllb_def =
-                                     uu____3605;
-                                   FStar_Extraction_ML_Syntax.print_typ =
-                                     uu____3606;_}::uu____3607)
-=======
-               ((let uu____3849 = FStar_Util.print_exn e  in
-                 FStar_Util.print2
-                   "Warning: not translating definition for %s (%s)\n"
-                   (FStar_Pervasives_Native.snd name1) uu____3849);
-                FStar_Pervasives_Native.Some
-                  (DGlobal (flags1, name1, t1, EAny))))
-      | FStar_Extraction_ML_Syntax.MLM_Let
-          (uu____3860,uu____3861,{
-                                   FStar_Extraction_ML_Syntax.mllb_name =
-                                     (name,uu____3863);
-                                   FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-                                   FStar_Extraction_ML_Syntax.mllb_add_unit =
-                                     uu____3865;
-                                   FStar_Extraction_ML_Syntax.mllb_def =
-                                     uu____3866;
-                                   FStar_Extraction_ML_Syntax.print_typ =
-                                     uu____3867;_}::uu____3868)
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-          ->
-          (FStar_Util.print1_warning
-             "Not translating definition for %s (and possibly others)\n" name;
-           (match ts with
-            | FStar_Pervasives_Native.Some (idents,t) ->
-<<<<<<< HEAD
-                let uu____3622 =
-                  FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
-                FStar_Util.print2 "Type scheme is: forall %s. %s\n"
-                  (FStar_String.concat ", " idents) uu____3622
-            | FStar_Pervasives_Native.None  -> ());
-           FStar_Pervasives_Native.None)
-      | FStar_Extraction_ML_Syntax.MLM_Let uu____3625 ->
-          failwith "impossible"
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3628 ->
-          FStar_Pervasives_Native.None
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((assumed,name,_mangled_name,args,uu____3633,FStar_Pervasives_Native.Some
-            (FStar_Extraction_ML_Syntax.MLTD_Abbrev t))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
-          if assumed
-          then FStar_Pervasives_Native.None
-          else
-            (let uu____3690 =
-               let uu____3691 =
-                 let uu____3704 = translate_type env1 t in
-                 (name1, (FStar_List.length args), uu____3704) in
-               DTypeAlias uu____3691 in
-             FStar_Pervasives_Native.Some uu____3690)
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____3711,name,_mangled_name,args,uu____3715,FStar_Pervasives_Native.Some
-            (FStar_Extraction_ML_Syntax.MLTD_Record fields))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
-          let uu____3775 =
-            let uu____3776 =
-              let uu____3799 =
-                FStar_List.map
-                  (fun uu____3826  ->
-                     match uu____3826 with
-                     | (f,t) ->
-                         let uu____3841 =
-                           let uu____3846 = translate_type env1 t in
-                           (uu____3846, false) in
-                         (f, uu____3841)) fields in
-              (name1, (FStar_List.length args), uu____3799) in
-            DTypeFlat uu____3776 in
-          FStar_Pervasives_Native.Some uu____3775
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____3867,name,_mangled_name,args,attrs,FStar_Pervasives_Native.Some
-            (FStar_Extraction_ML_Syntax.MLTD_DType branches))::[])
-          ->
-          let name1 = ((env.module_name), name) in
-          let flags = translate_flags attrs in
-          let env1 = FStar_List.fold_left extend_t env args in
-          let uu____3936 =
-            let uu____3937 =
-              let uu____3970 =
-                FStar_List.map
-                  (fun uu____4015  ->
-                     match uu____4015 with
-                     | (cons1,ts) ->
-                         let uu____4054 =
-                           FStar_List.map
-                             (fun uu____4081  ->
-                                match uu____4081 with
-                                | (name2,t) ->
-                                    let uu____4096 =
-                                      let uu____4101 = translate_type env1 t in
-                                      (uu____4101, false) in
-                                    (name2, uu____4096)) ts in
-                         (cons1, uu____4054)) branches in
-              (name1, flags, (FStar_List.length args), uu____3970) in
-            DTypeVariant uu____3937 in
-          FStar_Pervasives_Native.Some uu____3936
-      | FStar_Extraction_ML_Syntax.MLM_Ty
-          ((uu____4140,name,_mangled_name,uu____4143,uu____4144,uu____4145)::uu____4146)
-          ->
-          (FStar_Util.print1_warning
-             "Not translating definition for %s (and possibly others)\n" name;
-           FStar_Pervasives_Native.None)
-      | FStar_Extraction_ML_Syntax.MLM_Ty [] ->
-          (FStar_Util.print_string
-             "Impossible!! Empty block of mutually recursive type declarations\n";
-           FStar_Pervasives_Native.None)
-      | FStar_Extraction_ML_Syntax.MLM_Top uu____4191 ->
-          failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn uu____4194 ->
-          failwith "todo: translate_decl [MLM_Exn]"
-and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
-=======
-                let uu____3883 =
-                  let uu____3884 =
-                    FStar_List.map FStar_Pervasives_Native.fst idents  in
-                  FStar_String.concat ", " uu____3884  in
-                let uu____3891 =
-                  FStar_Extraction_ML_Code.string_of_mlty ([], "") t  in
-                FStar_Util.print2 "Type scheme is: forall %s. %s\n"
-                  uu____3883 uu____3891
-            | FStar_Pervasives_Native.None  -> ());
-           FStar_Pervasives_Native.None)
-      | FStar_Extraction_ML_Syntax.MLM_Let uu____3894 ->
-          failwith "impossible"
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3897 ->
+      | FStar_Extraction_ML_Syntax.MLM_Let (flavor,flags,letbinding::[]) ->
+          translate_single_let env flavor flags letbinding
+      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3700 ->
           FStar_Pervasives_Native.None
       | FStar_Extraction_ML_Syntax.MLM_Ty (ty_decl::[]) ->
           translate_single_type_decl env ty_decl
@@ -2016,21 +1135,19 @@ and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
             match xs with
             | [] -> FStar_Pervasives_Native.Some []
             | o::os ->
-                let uu____3938 = traverse f os  in
-                (match uu____3938 with
+                let uu____3741 = traverse f os in
+                (match uu____3741 with
                  | FStar_Pervasives_Native.None  ->
                      FStar_Pervasives_Native.None
                  | FStar_Pervasives_Native.Some os' ->
-                     let uu____3956 = f o  in
-                     (match uu____3956 with
+                     let uu____3759 = f o in
+                     (match uu____3759 with
                       | FStar_Pervasives_Native.None  ->
                           FStar_Pervasives_Native.None
                       | FStar_Pervasives_Native.Some o' ->
-                          FStar_Pervasives_Native.Some (o' :: os')))
-             in
-          let uu____3968 = traverse (translate_single_type_decl env) ty_decls
-             in
-          (match uu____3968 with
+                          FStar_Pervasives_Native.Some (o' :: os'))) in
+          let uu____3771 = traverse (translate_single_type_decl env) ty_decls in
+          (match uu____3771 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some decls ->
                FStar_Pervasives_Native.Some (DTypeMutual decls))
@@ -2038,12 +1155,11 @@ and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
           (FStar_Util.print_string
              "Impossible!! Empty block of mutually recursive type declarations";
            FStar_Pervasives_Native.None)
-      | FStar_Extraction_ML_Syntax.MLM_Top uu____3983 ->
+      | FStar_Extraction_ML_Syntax.MLM_Top uu____3786 ->
           failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn uu____3986 ->
+      | FStar_Extraction_ML_Syntax.MLM_Exn uu____3789 ->
           failwith "todo: translate_decl [MLM_Exn]"
-
-and translate_single_type_decl :
+and translate_single_type_decl:
   env ->
     FStar_Extraction_ML_Syntax.one_mltydecl ->
       decl FStar_Pervasives_Native.option
@@ -2051,193 +1167,122 @@ and translate_single_type_decl :
   fun env  ->
     fun ty_decl  ->
       match ty_decl with
-      | (assumed,name,_mangled_name,args,uu____4007,FStar_Pervasives_Native.Some
+      | (assumed,name,_mangled_name,args,uu____3810,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_Abbrev t)) ->
-          let name1 = ((env.module_name), name)  in
+          let name1 = ((env.module_name), name) in
           let env1 =
             FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____4034  ->
-                   match uu____4034 with
-                   | (name2,uu____4040) -> extend_t env1 name2) env args
-             in
+              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
           if assumed
           then FStar_Pervasives_Native.None
           else
-            (let uu____4044 =
-               let uu____4045 =
-                 let uu____4058 = translate_type env1 t  in
-                 (name1, (FStar_List.length args), uu____4058)  in
-               DTypeAlias uu____4045  in
-             FStar_Pervasives_Native.Some uu____4044)
-      | (uu____4065,name,_mangled_name,args,uu____4069,FStar_Pervasives_Native.Some
+            (let uu____3835 =
+               let uu____3836 =
+                 let uu____3849 = translate_type env1 t in
+                 (name1, (FStar_List.length args), uu____3849) in
+               DTypeAlias uu____3836 in
+             FStar_Pervasives_Native.Some uu____3835)
+      | (uu____3856,name,_mangled_name,args,uu____3860,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_Record fields)) ->
-          let name1 = ((env.module_name), name)  in
+          let name1 = ((env.module_name), name) in
           let env1 =
             FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____4102  ->
-                   match uu____4102 with
-                   | (name2,uu____4108) -> extend_t env1 name2) env args
-             in
-          let uu____4109 =
-            let uu____4110 =
-              let uu____4133 =
+              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
+          let uu____3888 =
+            let uu____3889 =
+              let uu____3912 =
                 FStar_List.map
-                  (fun uu____4160  ->
-                     match uu____4160 with
+                  (fun uu____3939  ->
+                     match uu____3939 with
                      | (f,t) ->
-                         let uu____4175 =
-                           let uu____4180 = translate_type env1 t  in
-                           (uu____4180, false)  in
-                         (f, uu____4175)) fields
-                 in
-              (name1, (FStar_List.length args), uu____4133)  in
-            DTypeFlat uu____4110  in
-          FStar_Pervasives_Native.Some uu____4109
-      | (uu____4201,name,_mangled_name,args,attrs,FStar_Pervasives_Native.Some
+                         let uu____3954 =
+                           let uu____3959 = translate_type env1 t in
+                           (uu____3959, false) in
+                         (f, uu____3954)) fields in
+              (name1, (FStar_List.length args), uu____3912) in
+            DTypeFlat uu____3889 in
+          FStar_Pervasives_Native.Some uu____3888
+      | (uu____3980,name,_mangled_name,args,attrs,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_DType branches)) ->
-          let name1 = ((env.module_name), name)  in
-          let flags = translate_flags attrs  in
-          let env1 =
-            FStar_List.fold_left
-              (fun env1  ->
-                 fun uu____4247  ->
-                   match uu____4247 with
-                   | (name2,uu____4253) -> extend_t env1 name2) env args
-             in
-          let uu____4254 =
-            let uu____4255 =
-              let uu____4288 =
+          let name1 = ((env.module_name), name) in
+          let flags = translate_flags attrs in
+          let env1 = FStar_List.fold_left extend_t env args in
+          let uu____4017 =
+            let uu____4018 =
+              let uu____4051 =
                 FStar_List.map
-                  (fun uu____4333  ->
-                     match uu____4333 with
+                  (fun uu____4096  ->
+                     match uu____4096 with
                      | (cons1,ts) ->
-                         let uu____4372 =
+                         let uu____4135 =
                            FStar_List.map
-                             (fun uu____4399  ->
-                                match uu____4399 with
+                             (fun uu____4162  ->
+                                match uu____4162 with
                                 | (name2,t) ->
-                                    let uu____4414 =
-                                      let uu____4419 = translate_type env1 t
-                                         in
-                                      (uu____4419, false)  in
-                                    (name2, uu____4414)) ts
-                            in
-                         (cons1, uu____4372)) branches
-                 in
-              (name1, flags, (FStar_List.length args), uu____4288)  in
-            DTypeVariant uu____4255  in
-          FStar_Pervasives_Native.Some uu____4254
-
-and translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+                                    let uu____4177 =
+                                      let uu____4182 = translate_type env1 t in
+                                      (uu____4182, false) in
+                                    (name2, uu____4177)) ts in
+                         (cons1, uu____4135)) branches in
+              (name1, flags, (FStar_List.length args), uu____4051) in
+            DTypeVariant uu____4018 in
+          FStar_Pervasives_Native.Some uu____4017
+and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
   fun env  ->
     fun t  ->
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Tuple [] -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Top  -> TAny
-<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLTY_Var name ->
-          let uu____4210 = find_t env name in TBound uu____4210
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4212,t2) ->
-          let uu____4214 =
-            let uu____4219 = translate_type env t1 in
-            let uu____4220 = translate_type env t2 in
-            (uu____4219, uu____4220) in
-          TArrow uu____4214
+          let uu____4224 = find_t env name in TBound uu____4224
+      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4226,t2) ->
+          let uu____4228 =
+            let uu____4233 = translate_type env t1 in
+            let uu____4234 = translate_type env t2 in
+            (uu____4233, uu____4234) in
+          TArrow uu____4228
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4224 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4224 = "Prims.unit" -> TUnit
+          let uu____4238 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4238 = "Prims.unit" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4228 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4228 = "Prims.bool" -> TBool
+          let uu____4242 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4242 = "Prims.bool" -> TBool
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
           is_machine_int m ->
-          let uu____4240 = FStar_Util.must (mk_width m) in TInt uu____4240
+          let uu____4254 = FStar_Util.must (mk_width m) in TInt uu____4254
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
           is_machine_int m ->
-          let uu____4252 = FStar_Util.must (mk_width m) in TInt uu____4252
+          let uu____4266 = FStar_Util.must (mk_width m) in TInt uu____4266
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4257 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4257 = "FStar.Monotonic.HyperStack.mem" -> TUnit
+          let uu____4271 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4271 = "FStar.Monotonic.HyperStack.mem" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4262 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4262 = "FStar.Buffer.buffer" ->
-          let uu____4263 = translate_type env arg in TBuf uu____4263
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4264::[],p) when
-          let uu____4268 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4268 = "FStar.Ghost.erased" -> TAny
-=======
-      | FStar_Extraction_ML_Syntax.MLTY_Var (name,uu____4461) ->
-          let uu____4462 = find_t env name  in TBound uu____4462
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4464,t2) ->
-          let uu____4466 =
-            let uu____4471 = translate_type env t1  in
-            let uu____4472 = translate_type env t2  in
-            (uu____4471, uu____4472)  in
-          TArrow uu____4466
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4476 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4476 = "Prims.unit" -> TUnit
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4480 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4480 = "Prims.bool" -> TBool
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
-          is_machine_int m ->
-          let uu____4492 = FStar_Util.must (mk_width m)  in TInt uu____4492
-      | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
-          is_machine_int m ->
-          let uu____4504 = FStar_Util.must (mk_width m)  in TInt uu____4504
-      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4509 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4509 = "FStar.Monotonic.HyperStack.mem" -> TUnit
-      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4514 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4514 = "FStar.Buffer.buffer" ->
-          let uu____4515 = translate_type env arg  in TBuf uu____4515
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4516::[],p) when
-          let uu____4520 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4520 = "FStar.Ghost.erased" -> TAny
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4276 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4276 = "FStar.Buffer.buffer" ->
+          let uu____4277 = translate_type env arg in TBuf uu____4277
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4278::[],p) when
+          let uu____4282 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4282 = "FStar.Ghost.erased" -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],(path,type_name)) ->
           TQualified (path, type_name)
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,(ns,t1)) when
           ((ns = ["Prims"]) || (ns = ["FStar"; "Pervasives"; "Native"])) &&
             (FStar_Util.starts_with t1 "tuple")
           ->
-<<<<<<< HEAD
-          let uu____4306 = FStar_List.map (translate_type env) args in
-          TTuple uu____4306
+          let uu____4320 = FStar_List.map (translate_type env) args in
+          TTuple uu____4320
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
           if (FStar_List.length args) > (Prims.parse_int "0")
           then
-            let uu____4315 =
-              let uu____4328 = FStar_List.map (translate_type env) args in
-              (lid, uu____4328) in
-            TApp uu____4315
+            let uu____4329 =
+              let uu____4342 = FStar_List.map (translate_type env) args in
+              (lid, uu____4342) in
+            TApp uu____4329
           else TQualified lid
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____4337 = FStar_List.map (translate_type env) ts in
-          TTuple uu____4337
+          let uu____4351 = FStar_List.map (translate_type env) ts in
+          TTuple uu____4351
 and translate_binders:
-=======
-          let uu____4558 = FStar_List.map (translate_type env) args  in
-          TTuple uu____4558
-      | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
-          if (FStar_List.length args) > (Prims.parse_int "0")
-          then
-            let uu____4567 =
-              let uu____4580 = FStar_List.map (translate_type env) args  in
-              (lid, uu____4580)  in
-            TApp uu____4567
-          else TQualified lid
-      | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____4589 = FStar_List.map (translate_type env) ts  in
-          TTuple uu____4589
-
-and translate_binders :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     (FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
       FStar_Pervasives_Native.tuple2 Prims.list -> binder Prims.list
@@ -2248,68 +1293,35 @@ and translate_binder:
       FStar_Pervasives_Native.tuple2 -> binder
   =
   fun env  ->
-<<<<<<< HEAD
-    fun uu____4353  ->
-      match uu____4353 with
+    fun uu____4367  ->
+      match uu____4367 with
       | (name,typ) ->
-          let uu____4360 = translate_type env typ in
-          { name; typ = uu____4360; mut = false }
+          let uu____4374 = translate_type env typ in
+          { name; typ = uu____4374; mut = false }
 and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
-=======
-    fun uu____4605  ->
-      match uu____4605 with
-      | ((name,uu____4611),typ) ->
-          let uu____4617 = translate_type env typ  in
-          { name; typ = uu____4617; mut = false }
-
-and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   fun env  ->
     fun e  ->
       match e.FStar_Extraction_ML_Syntax.expr with
       | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
-<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLE_Var name ->
-          let uu____4365 = find env name in EBound uu____4365
+          let uu____4379 = find env name in EBound uu____4379
       | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
           (is_machine_int m) && (is_op op) ->
-          let uu____4370 =
-            let uu____4375 = FStar_Util.must (mk_op op) in
-            let uu____4376 = FStar_Util.must (mk_width m) in
-            (uu____4375, uu____4376) in
-          EOp uu____4370
+          let uu____4384 =
+            let uu____4389 = FStar_Util.must (mk_op op) in
+            let uu____4390 = FStar_Util.must (mk_width m) in
+            (uu____4389, uu____4390) in
+          EOp uu____4384
       | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
           is_bool_op op ->
-          let uu____4380 =
-            let uu____4385 = FStar_Util.must (mk_bool_op op) in
-            (uu____4385, Bool) in
-          EOp uu____4380
+          let uu____4394 =
+            let uu____4399 = FStar_Util.must (mk_bool_op op) in
+            (uu____4399, Bool) in
+          EOp uu____4394
       | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
       | FStar_Extraction_ML_Syntax.MLE_Let
           ((flavor,flags,{ FStar_Extraction_ML_Syntax.mllb_name = name;
-=======
-      | FStar_Extraction_ML_Syntax.MLE_Var (name,uu____4622) ->
-          let uu____4623 = find env name  in EBound uu____4623
-      | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
-          (is_machine_int m) && (is_op op) ->
-          let uu____4628 =
-            let uu____4633 = FStar_Util.must (mk_op op)  in
-            let uu____4634 = FStar_Util.must (mk_width m)  in
-            (uu____4633, uu____4634)  in
-          EOp uu____4628
-      | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
-          is_bool_op op ->
-          let uu____4638 =
-            let uu____4643 = FStar_Util.must (mk_bool_op op)  in
-            (uu____4643, Bool)  in
-          EOp uu____4638
-      | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
-      | FStar_Extraction_ML_Syntax.MLE_Let
-          ((flavor,flags,{
-                           FStar_Extraction_ML_Syntax.mllb_name =
-                             (name,uu____4648);
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
                            FStar_Extraction_ML_Syntax.mllb_tysc =
                              FStar_Pervasives_Native.Some ([],typ);
                            FStar_Extraction_ML_Syntax.mllb_add_unit =
@@ -2319,193 +1331,119 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
           ->
           let is_mut =
             FStar_Util.for_some
-<<<<<<< HEAD
-              (fun uu___407_4415  ->
-                 match uu___407_4415 with
+              (fun uu___407_4429  ->
+                 match uu___407_4429 with
                  | FStar_Extraction_ML_Syntax.Mutable  -> true
-                 | uu____4416 -> false) flags in
-          let uu____4417 =
+                 | uu____4430 -> false) flags in
+          let uu____4431 =
             if is_mut
             then
-              let uu____4426 =
+              let uu____4440 =
                 match typ with
                 | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
-                    let uu____4431 =
+                    let uu____4445 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                    uu____4431 = "FStar.ST.stackref" -> t
-                | uu____4432 ->
-                    let uu____4433 =
-                      let uu____4434 =
+                    uu____4445 = "FStar.ST.stackref" -> t
+                | uu____4446 ->
+                    let uu____4447 =
+                      let uu____4448 =
                         FStar_Extraction_ML_Code.string_of_mlty ([], "") typ in
                       FStar_Util.format1
                         "unexpected: bad desugaring of Mutable (typ is %s)"
-                        uu____4434 in
-                    failwith uu____4433 in
-              let uu____4437 =
-=======
-              (fun uu___129_4674  ->
-                 match uu___129_4674 with
-                 | FStar_Extraction_ML_Syntax.Mutable  -> true
-                 | uu____4675 -> false) flags
-             in
-          let uu____4676 =
-            if is_mut
-            then
-              let uu____4685 =
-                match typ with
-                | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
-                    let uu____4690 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4690 = "FStar.ST.stackref" -> t
-                | uu____4691 ->
-                    let uu____4692 =
-                      let uu____4693 =
-                        FStar_Extraction_ML_Code.string_of_mlty ([], "") typ
-                         in
-                      FStar_Util.format1
-                        "unexpected: bad desugaring of Mutable (typ is %s)"
-                        uu____4693
-                       in
-                    failwith uu____4692
-                 in
-              let uu____4696 =
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+                        uu____4448 in
+                    failwith uu____4447 in
+              let uu____4451 =
                 match body with
                 | {
                     FStar_Extraction_ML_Syntax.expr =
                       FStar_Extraction_ML_Syntax.MLE_App
-<<<<<<< HEAD
-                      (uu____4438,body1::[]);
-                    FStar_Extraction_ML_Syntax.mlty = uu____4440;
-                    FStar_Extraction_ML_Syntax.loc = uu____4441;_} -> body1
-                | uu____4444 ->
+                      (uu____4452,body1::[]);
+                    FStar_Extraction_ML_Syntax.mlty = uu____4454;
+                    FStar_Extraction_ML_Syntax.loc = uu____4455;_} -> body1
+                | uu____4458 ->
                     failwith "unexpected: bad desugaring of Mutable" in
-              (uu____4426, uu____4437)
+              (uu____4440, uu____4451)
             else (typ, body) in
-          (match uu____4417 with
+          (match uu____4431 with
            | (typ1,body1) ->
                let binder =
-                 let uu____4449 = translate_type env typ1 in
-                 { name; typ = uu____4449; mut = is_mut } in
+                 let uu____4463 = translate_type env typ1 in
+                 { name; typ = uu____4463; mut = is_mut } in
                let body2 = translate_expr env body1 in
                let env1 = extend env name is_mut in
                let continuation1 = translate_expr env1 continuation in
                ELet (binder, body2, continuation1))
       | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
-          let uu____4475 =
-            let uu____4486 = translate_expr env expr in
-            let uu____4487 = translate_branches env branches in
-            (uu____4486, uu____4487) in
-          EMatch uu____4475
-=======
-                      (uu____4697,body1::[]);
-                    FStar_Extraction_ML_Syntax.mlty = uu____4699;
-                    FStar_Extraction_ML_Syntax.loc = uu____4700;_} -> body1
-                | uu____4703 ->
-                    failwith "unexpected: bad desugaring of Mutable"
-                 in
-              (uu____4685, uu____4696)
-            else (typ, body)  in
-          (match uu____4676 with
-           | (typ1,body1) ->
-               let binder =
-                 let uu____4708 = translate_type env typ1  in
-                 { name; typ = uu____4708; mut = is_mut }  in
-               let body2 = translate_expr env body1  in
-               let env1 = extend env name is_mut  in
-               let continuation1 = translate_expr env1 continuation  in
-               ELet (binder, body2, continuation1))
-      | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
-          let uu____4734 =
-            let uu____4745 = translate_expr env expr  in
-            let uu____4746 = translate_branches env branches  in
-            (uu____4745, uu____4746)  in
-          EMatch uu____4734
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4489 =
+            let uu____4500 = translate_expr env expr in
+            let uu____4501 = translate_branches env branches in
+            (uu____4500, uu____4501) in
+          EMatch uu____4489
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4501;
-             FStar_Extraction_ML_Syntax.loc = uu____4502;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4515;
+             FStar_Extraction_ML_Syntax.loc = uu____4516;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Var
                                                                 v1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4504;
+                                                                = uu____4518;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4505;_}::[])
+                                                                = uu____4519;_}::[])
           when
-          (let uu____4510 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____4510 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
-          -> let uu____4511 = find env v1 in EBound uu____4511
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____4760;
-             FStar_Extraction_ML_Syntax.loc = uu____4761;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                =
-                                                                FStar_Extraction_ML_Syntax.MLE_Var
-                                                                (v1,uu____4763);
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4764;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4765;_}::[])
-          when
-          (let uu____4770 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4770 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
-          -> let uu____4771 = find env v1  in EBound uu____4771
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          (let uu____4524 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu____4524 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
+          -> let uu____4525 = find env v1 in EBound uu____4525
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4513;
-             FStar_Extraction_ML_Syntax.loc = uu____4514;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4527;
+             FStar_Extraction_ML_Syntax.loc = uu____4528;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Var
                                                                 v1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4516;
+                                                                = uu____4530;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4517;_}::e1::[])
+                                                                = uu____4531;_}::e1::[])
           when
-          (let uu____4523 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____4523 = "FStar.HyperStack.ST.op_Colon_Equals") &&
+          (let uu____4537 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu____4537 = "FStar.HyperStack.ST.op_Colon_Equals") &&
             (is_mutable env v1)
           ->
-          let uu____4524 =
-            let uu____4529 =
-              let uu____4530 = find env v1 in EBound uu____4530 in
-            let uu____4531 = translate_expr env e1 in
-            (uu____4529, uu____4531) in
-          EAssign uu____4524
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____4773;
-             FStar_Extraction_ML_Syntax.loc = uu____4774;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                =
-                                                                FStar_Extraction_ML_Syntax.MLE_Var
-                                                                (v1,uu____4776);
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4777;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4778;_}::e1::[])
+          let uu____4538 =
+            let uu____4543 =
+              let uu____4544 = find env v1 in EBound uu____4544 in
+            let uu____4545 = translate_expr env e1 in
+            (uu____4543, uu____4545) in
+          EAssign uu____4538
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu____4547;
+                  FStar_Extraction_ML_Syntax.loc = uu____4548;_},uu____4549);
+             FStar_Extraction_ML_Syntax.mlty = uu____4550;
+             FStar_Extraction_ML_Syntax.loc = uu____4551;_},e1::e2::[])
           when
-          (let uu____4784 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4784 = "FStar.HyperStack.ST.op_Colon_Equals") &&
-            (is_mutable env v1)
+          (let uu____4562 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu____4562 = "FStar.Buffer.index") ||
+            (let uu____4564 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu____4564 = "FStar.Buffer.op_Array_Access")
           ->
-          let uu____4785 =
-            let uu____4790 =
-              let uu____4791 = find env v1  in EBound uu____4791  in
-            let uu____4792 = translate_expr env e1  in
-            (uu____4790, uu____4792)  in
-          EAssign uu____4785
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4565 =
+            let uu____4570 = translate_expr env e1 in
+            let uu____4571 = translate_expr env e2 in
+            (uu____4570, uu____4571) in
+          EBufRead uu____4565
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2513,40 +1451,18 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4533;
-                  FStar_Extraction_ML_Syntax.loc = uu____4534;_},uu____4535);
-             FStar_Extraction_ML_Syntax.mlty = uu____4536;
-             FStar_Extraction_ML_Syntax.loc = uu____4537;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4573;
+                  FStar_Extraction_ML_Syntax.loc = uu____4574;_},uu____4575);
+             FStar_Extraction_ML_Syntax.mlty = uu____4576;
+             FStar_Extraction_ML_Syntax.loc = uu____4577;_},e1::e2::[])
           when
-          (let uu____4548 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____4548 = "FStar.Buffer.index") ||
-            (let uu____4550 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____4550 = "FStar.Buffer.op_Array_Access")
-          ->
-          let uu____4551 =
-            let uu____4556 = translate_expr env e1 in
-            let uu____4557 = translate_expr env e2 in
-            (uu____4556, uu____4557) in
-          EBufRead uu____4551
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4794;
-                  FStar_Extraction_ML_Syntax.loc = uu____4795;_},uu____4796);
-             FStar_Extraction_ML_Syntax.mlty = uu____4797;
-             FStar_Extraction_ML_Syntax.loc = uu____4798;_},e1::e2::[])
-          when
-          (let uu____4809 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4809 = "FStar.Buffer.index") ||
-            (let uu____4811 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
-             uu____4811 = "FStar.Buffer.op_Array_Access")
-          ->
-          let uu____4812 =
-            let uu____4817 = translate_expr env e1  in
-            let uu____4818 = translate_expr env e2  in
-            (uu____4817, uu____4818)  in
-          EBufRead uu____4812
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4586 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4586 = "FStar.Buffer.create" ->
+          let uu____4587 =
+            let uu____4594 = translate_expr env e1 in
+            let uu____4595 = translate_expr env e2 in
+            (Stack, uu____4594, uu____4595) in
+          EBufCreate uu____4587
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2554,33 +1470,18 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4559;
-                  FStar_Extraction_ML_Syntax.loc = uu____4560;_},uu____4561);
-             FStar_Extraction_ML_Syntax.mlty = uu____4562;
-             FStar_Extraction_ML_Syntax.loc = uu____4563;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4597;
+                  FStar_Extraction_ML_Syntax.loc = uu____4598;_},uu____4599);
+             FStar_Extraction_ML_Syntax.mlty = uu____4600;
+             FStar_Extraction_ML_Syntax.loc = uu____4601;_},_e0::e1::e2::[])
           when
-          let uu____4572 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4572 = "FStar.Buffer.create" ->
-          let uu____4573 =
-            let uu____4580 = translate_expr env e1 in
-            let uu____4581 = translate_expr env e2 in
-            (Stack, uu____4580, uu____4581) in
-          EBufCreate uu____4573
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4820;
-                  FStar_Extraction_ML_Syntax.loc = uu____4821;_},uu____4822);
-             FStar_Extraction_ML_Syntax.mlty = uu____4823;
-             FStar_Extraction_ML_Syntax.loc = uu____4824;_},e1::e2::[])
-          when
-          let uu____4833 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4833 = "FStar.Buffer.create" ->
-          let uu____4834 =
-            let uu____4841 = translate_expr env e1  in
-            let uu____4842 = translate_expr env e2  in
-            (Stack, uu____4841, uu____4842)  in
-          EBufCreate uu____4834
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4611 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4611 = "FStar.Buffer.rcreate" ->
+          let uu____4612 =
+            let uu____4619 = translate_expr env e1 in
+            let uu____4620 = translate_expr env e2 in
+            (Eternal, uu____4619, uu____4620) in
+          EBufCreate uu____4612
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2588,57 +1489,13 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4583;
-                  FStar_Extraction_ML_Syntax.loc = uu____4584;_},uu____4585);
-             FStar_Extraction_ML_Syntax.mlty = uu____4586;
-             FStar_Extraction_ML_Syntax.loc = uu____4587;_},_e0::e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4622;
+                  FStar_Extraction_ML_Syntax.loc = uu____4623;_},uu____4624);
+             FStar_Extraction_ML_Syntax.mlty = uu____4625;
+             FStar_Extraction_ML_Syntax.loc = uu____4626;_},e2::[])
           when
-          let uu____4597 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4597 = "FStar.Buffer.rcreate" ->
-          let uu____4598 =
-            let uu____4605 = translate_expr env e1 in
-            let uu____4606 = translate_expr env e2 in
-            (Eternal, uu____4605, uu____4606) in
-          EBufCreate uu____4598
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4844;
-                  FStar_Extraction_ML_Syntax.loc = uu____4845;_},uu____4846);
-             FStar_Extraction_ML_Syntax.mlty = uu____4847;
-             FStar_Extraction_ML_Syntax.loc = uu____4848;_},_e0::e1::e2::[])
-          when
-          let uu____4858 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4858 = "FStar.Buffer.rcreate" ->
-          let uu____4859 =
-            let uu____4866 = translate_expr env e1  in
-            let uu____4867 = translate_expr env e2  in
-            (Eternal, uu____4866, uu____4867)  in
-          EBufCreate uu____4859
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_TApp
-               ({
-                  FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4608;
-                  FStar_Extraction_ML_Syntax.loc = uu____4609;_},uu____4610);
-             FStar_Extraction_ML_Syntax.mlty = uu____4611;
-             FStar_Extraction_ML_Syntax.loc = uu____4612;_},e2::[])
-          when
-          let uu____4620 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4620 = "FStar.Buffer.createL" ->
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4869;
-                  FStar_Extraction_ML_Syntax.loc = uu____4870;_},uu____4871);
-             FStar_Extraction_ML_Syntax.mlty = uu____4872;
-             FStar_Extraction_ML_Syntax.loc = uu____4873;_},e2::[])
-          when
-          let uu____4881 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4881 = "FStar.Buffer.createL" ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4634 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4634 = "FStar.Buffer.createL" ->
           let rec list_elements1 acc e21 =
             match e21.FStar_Extraction_ML_Syntax.expr with
             | FStar_Extraction_ML_Syntax.MLE_CTor
@@ -2646,30 +1503,16 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                 list_elements1 (hd1 :: acc) tl1
             | FStar_Extraction_ML_Syntax.MLE_CTor (("Prims"::[],"Nil"),[]) ->
                 FStar_List.rev acc
-<<<<<<< HEAD
-            | uu____4658 ->
+            | uu____4672 ->
                 failwith
                   "Argument of FStar.Buffer.createL is not a string literal!" in
           let list_elements2 = list_elements1 [] in
-          let uu____4666 =
-            let uu____4673 =
-              let uu____4676 = list_elements2 e2 in
-              FStar_List.map (translate_expr env) uu____4676 in
-            (Stack, uu____4673) in
-          EBufCreateL uu____4666
-=======
-            | uu____4919 ->
-                failwith
-                  "Argument of FStar.Buffer.createL is not a string literal!"
-             in
-          let list_elements2 = list_elements1 []  in
-          let uu____4927 =
-            let uu____4934 =
-              let uu____4937 = list_elements2 e2  in
-              FStar_List.map (translate_expr env) uu____4937  in
-            (Stack, uu____4934)  in
-          EBufCreateL uu____4927
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4680 =
+            let uu____4687 =
+              let uu____4690 = list_elements2 e2 in
+              FStar_List.map (translate_expr env) uu____4690 in
+            (Stack, uu____4687) in
+          EBufCreateL uu____4680
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2677,33 +1520,18 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4682;
-                  FStar_Extraction_ML_Syntax.loc = uu____4683;_},uu____4684);
-             FStar_Extraction_ML_Syntax.mlty = uu____4685;
-             FStar_Extraction_ML_Syntax.loc = uu____4686;_},e1::e2::_e3::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4696;
+                  FStar_Extraction_ML_Syntax.loc = uu____4697;_},uu____4698);
+             FStar_Extraction_ML_Syntax.mlty = uu____4699;
+             FStar_Extraction_ML_Syntax.loc = uu____4700;_},e1::e2::_e3::[])
           when
-          let uu____4696 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4696 = "FStar.Buffer.sub" ->
-          let uu____4697 =
-            let uu____4702 = translate_expr env e1 in
-            let uu____4703 = translate_expr env e2 in
-            (uu____4702, uu____4703) in
-          EBufSub uu____4697
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4943;
-                  FStar_Extraction_ML_Syntax.loc = uu____4944;_},uu____4945);
-             FStar_Extraction_ML_Syntax.mlty = uu____4946;
-             FStar_Extraction_ML_Syntax.loc = uu____4947;_},e1::e2::_e3::[])
-          when
-          let uu____4957 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4957 = "FStar.Buffer.sub" ->
-          let uu____4958 =
-            let uu____4963 = translate_expr env e1  in
-            let uu____4964 = translate_expr env e2  in
-            (uu____4963, uu____4964)  in
-          EBufSub uu____4958
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4710 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4710 = "FStar.Buffer.sub" ->
+          let uu____4711 =
+            let uu____4716 = translate_expr env e1 in
+            let uu____4717 = translate_expr env e2 in
+            (uu____4716, uu____4717) in
+          EBufSub uu____4711
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2711,23 +1539,13 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4705;
-                  FStar_Extraction_ML_Syntax.loc = uu____4706;_},uu____4707);
-             FStar_Extraction_ML_Syntax.mlty = uu____4708;
-             FStar_Extraction_ML_Syntax.loc = uu____4709;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4719;
+                  FStar_Extraction_ML_Syntax.loc = uu____4720;_},uu____4721);
+             FStar_Extraction_ML_Syntax.mlty = uu____4722;
+             FStar_Extraction_ML_Syntax.loc = uu____4723;_},e1::e2::[])
           when
-          let uu____4718 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4718 = "FStar.Buffer.join" -> translate_expr env e1
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4966;
-                  FStar_Extraction_ML_Syntax.loc = uu____4967;_},uu____4968);
-             FStar_Extraction_ML_Syntax.mlty = uu____4969;
-             FStar_Extraction_ML_Syntax.loc = uu____4970;_},e1::e2::[])
-          when
-          let uu____4979 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4979 = "FStar.Buffer.join" -> translate_expr env e1
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4732 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4732 = "FStar.Buffer.join" -> translate_expr env e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2735,33 +1553,18 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4720;
-                  FStar_Extraction_ML_Syntax.loc = uu____4721;_},uu____4722);
-             FStar_Extraction_ML_Syntax.mlty = uu____4723;
-             FStar_Extraction_ML_Syntax.loc = uu____4724;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4734;
+                  FStar_Extraction_ML_Syntax.loc = uu____4735;_},uu____4736);
+             FStar_Extraction_ML_Syntax.mlty = uu____4737;
+             FStar_Extraction_ML_Syntax.loc = uu____4738;_},e1::e2::[])
           when
-          let uu____4733 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4733 = "FStar.Buffer.offset" ->
-          let uu____4734 =
-            let uu____4739 = translate_expr env e1 in
-            let uu____4740 = translate_expr env e2 in
-            (uu____4739, uu____4740) in
-          EBufSub uu____4734
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____4981;
-                  FStar_Extraction_ML_Syntax.loc = uu____4982;_},uu____4983);
-             FStar_Extraction_ML_Syntax.mlty = uu____4984;
-             FStar_Extraction_ML_Syntax.loc = uu____4985;_},e1::e2::[])
-          when
-          let uu____4994 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4994 = "FStar.Buffer.offset" ->
-          let uu____4995 =
-            let uu____5000 = translate_expr env e1  in
-            let uu____5001 = translate_expr env e2  in
-            (uu____5000, uu____5001)  in
-          EBufSub uu____4995
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4747 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4747 = "FStar.Buffer.offset" ->
+          let uu____4748 =
+            let uu____4753 = translate_expr env e1 in
+            let uu____4754 = translate_expr env e2 in
+            (uu____4753, uu____4754) in
+          EBufSub uu____4748
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2769,76 +1572,40 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4742;
-                  FStar_Extraction_ML_Syntax.loc = uu____4743;_},uu____4744);
-             FStar_Extraction_ML_Syntax.mlty = uu____4745;
-             FStar_Extraction_ML_Syntax.loc = uu____4746;_},e1::e2::e3::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4756;
+                  FStar_Extraction_ML_Syntax.loc = uu____4757;_},uu____4758);
+             FStar_Extraction_ML_Syntax.mlty = uu____4759;
+             FStar_Extraction_ML_Syntax.loc = uu____4760;_},e1::e2::e3::[])
           when
-          (let uu____4758 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____4758 = "FStar.Buffer.upd") ||
-            (let uu____4760 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____4760 = "FStar.Buffer.op_Array_Assignment")
+          (let uu____4772 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu____4772 = "FStar.Buffer.upd") ||
+            (let uu____4774 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu____4774 = "FStar.Buffer.op_Array_Assignment")
           ->
-          let uu____4761 =
-            let uu____4768 = translate_expr env e1 in
-            let uu____4769 = translate_expr env e2 in
-            let uu____4770 = translate_expr env e3 in
-            (uu____4768, uu____4769, uu____4770) in
-          EBufWrite uu____4761
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____5003;
-                  FStar_Extraction_ML_Syntax.loc = uu____5004;_},uu____5005);
-             FStar_Extraction_ML_Syntax.mlty = uu____5006;
-             FStar_Extraction_ML_Syntax.loc = uu____5007;_},e1::e2::e3::[])
-          when
-          (let uu____5019 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____5019 = "FStar.Buffer.upd") ||
-            (let uu____5021 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
-             uu____5021 = "FStar.Buffer.op_Array_Assignment")
-          ->
-          let uu____5022 =
-            let uu____5029 = translate_expr env e1  in
-            let uu____5030 = translate_expr env e2  in
-            let uu____5031 = translate_expr env e3  in
-            (uu____5029, uu____5030, uu____5031)  in
-          EBufWrite uu____5022
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4775 =
+            let uu____4782 = translate_expr env e1 in
+            let uu____4783 = translate_expr env e2 in
+            let uu____4784 = translate_expr env e3 in
+            (uu____4782, uu____4783, uu____4784) in
+          EBufWrite uu____4775
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4772;
-             FStar_Extraction_ML_Syntax.loc = uu____4773;_},uu____4774::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____4786;
+             FStar_Extraction_ML_Syntax.loc = uu____4787;_},uu____4788::[])
           when
-          let uu____4777 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4777 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5033;
-             FStar_Extraction_ML_Syntax.loc = uu____5034;_},uu____5035::[])
-          when
-          let uu____5038 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5038 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4791 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4791 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4779;
-             FStar_Extraction_ML_Syntax.loc = uu____4780;_},uu____4781::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____4793;
+             FStar_Extraction_ML_Syntax.loc = uu____4794;_},uu____4795::[])
           when
-          let uu____4784 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4784 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5040;
-             FStar_Extraction_ML_Syntax.loc = uu____5041;_},uu____5042::[])
-          when
-          let uu____5045 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5045 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4798 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4798 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2846,39 +1613,21 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4786;
-                  FStar_Extraction_ML_Syntax.loc = uu____4787;_},uu____4788);
-             FStar_Extraction_ML_Syntax.mlty = uu____4789;
-             FStar_Extraction_ML_Syntax.loc = uu____4790;_},e1::e2::e3::e4::e5::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4800;
+                  FStar_Extraction_ML_Syntax.loc = uu____4801;_},uu____4802);
+             FStar_Extraction_ML_Syntax.mlty = uu____4803;
+             FStar_Extraction_ML_Syntax.loc = uu____4804;_},e1::e2::e3::e4::e5::[])
           when
-          let uu____4802 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4802 = "FStar.Buffer.blit" ->
-          let uu____4803 =
-            let uu____4814 = translate_expr env e1 in
-            let uu____4815 = translate_expr env e2 in
-            let uu____4816 = translate_expr env e3 in
-            let uu____4817 = translate_expr env e4 in
-            let uu____4818 = translate_expr env e5 in
-            (uu____4814, uu____4815, uu____4816, uu____4817, uu____4818) in
-          EBufBlit uu____4803
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____5047;
-                  FStar_Extraction_ML_Syntax.loc = uu____5048;_},uu____5049);
-             FStar_Extraction_ML_Syntax.mlty = uu____5050;
-             FStar_Extraction_ML_Syntax.loc = uu____5051;_},e1::e2::e3::e4::e5::[])
-          when
-          let uu____5063 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5063 = "FStar.Buffer.blit" ->
-          let uu____5064 =
-            let uu____5075 = translate_expr env e1  in
-            let uu____5076 = translate_expr env e2  in
-            let uu____5077 = translate_expr env e3  in
-            let uu____5078 = translate_expr env e4  in
-            let uu____5079 = translate_expr env e5  in
-            (uu____5075, uu____5076, uu____5077, uu____5078, uu____5079)  in
-          EBufBlit uu____5064
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4816 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4816 = "FStar.Buffer.blit" ->
+          let uu____4817 =
+            let uu____4828 = translate_expr env e1 in
+            let uu____4829 = translate_expr env e2 in
+            let uu____4830 = translate_expr env e3 in
+            let uu____4831 = translate_expr env e4 in
+            let uu____4832 = translate_expr env e5 in
+            (uu____4828, uu____4829, uu____4830, uu____4831, uu____4832) in
+          EBufBlit uu____4817
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2886,123 +1635,66 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-                  FStar_Extraction_ML_Syntax.mlty = uu____4820;
-                  FStar_Extraction_ML_Syntax.loc = uu____4821;_},uu____4822);
-             FStar_Extraction_ML_Syntax.mlty = uu____4823;
-             FStar_Extraction_ML_Syntax.loc = uu____4824;_},e1::e2::e3::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4834;
+                  FStar_Extraction_ML_Syntax.loc = uu____4835;_},uu____4836);
+             FStar_Extraction_ML_Syntax.mlty = uu____4837;
+             FStar_Extraction_ML_Syntax.loc = uu____4838;_},e1::e2::e3::[])
           when
-          let uu____4834 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4834 = "FStar.Buffer.fill" ->
-          let uu____4835 =
-            let uu____4842 = translate_expr env e1 in
-            let uu____4843 = translate_expr env e2 in
-            let uu____4844 = translate_expr env e3 in
-            (uu____4842, uu____4843, uu____4844) in
-          EBufFill uu____4835
-=======
-                  FStar_Extraction_ML_Syntax.mlty = uu____5081;
-                  FStar_Extraction_ML_Syntax.loc = uu____5082;_},uu____5083);
-             FStar_Extraction_ML_Syntax.mlty = uu____5084;
-             FStar_Extraction_ML_Syntax.loc = uu____5085;_},e1::e2::e3::[])
-          when
-          let uu____5095 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5095 = "FStar.Buffer.fill" ->
-          let uu____5096 =
-            let uu____5103 = translate_expr env e1  in
-            let uu____5104 = translate_expr env e2  in
-            let uu____5105 = translate_expr env e3  in
-            (uu____5103, uu____5104, uu____5105)  in
-          EBufFill uu____5096
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4848 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4848 = "FStar.Buffer.fill" ->
+          let uu____4849 =
+            let uu____4856 = translate_expr env e1 in
+            let uu____4857 = translate_expr env e2 in
+            let uu____4858 = translate_expr env e3 in
+            (uu____4856, uu____4857, uu____4858) in
+          EBufFill uu____4849
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4846;
-             FStar_Extraction_ML_Syntax.loc = uu____4847;_},uu____4848::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____4860;
+             FStar_Extraction_ML_Syntax.loc = uu____4861;_},uu____4862::[])
           when
-          let uu____4851 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4851 = "FStar.HyperStack.ST.get" -> EUnit
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5107;
-             FStar_Extraction_ML_Syntax.loc = uu____5108;_},uu____5109::[])
-          when
-          let uu____5112 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5112 = "FStar.HyperStack.ST.get" -> EUnit
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4865 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4865 = "FStar.HyperStack.ST.get" -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4853;
-             FStar_Extraction_ML_Syntax.loc = uu____4854;_},e1::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____4867;
+             FStar_Extraction_ML_Syntax.loc = uu____4868;_},e1::[])
           when
-          let uu____4858 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4858 = "Obj.repr" ->
-          let uu____4859 =
-            let uu____4864 = translate_expr env e1 in (uu____4864, TAny) in
-          ECast uu____4859
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5114;
-             FStar_Extraction_ML_Syntax.loc = uu____5115;_},e1::[])
-          when
-          let uu____5119 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5119 = "Obj.repr" ->
-          let uu____5120 =
-            let uu____5125 = translate_expr env e1  in (uu____5125, TAny)  in
-          ECast uu____5120
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4872 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu____4872 = "Obj.repr" ->
+          let uu____4873 =
+            let uu____4878 = translate_expr env e1 in (uu____4878, TAny) in
+          ECast uu____4873
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op);
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4867;
-             FStar_Extraction_ML_Syntax.loc = uu____4868;_},args)
+             FStar_Extraction_ML_Syntax.mlty = uu____4881;
+             FStar_Extraction_ML_Syntax.loc = uu____4882;_},args)
           when (is_machine_int m) && (is_op op) ->
-          let uu____4876 = FStar_Util.must (mk_width m) in
-          let uu____4877 = FStar_Util.must (mk_op op) in
-          mk_op_app env uu____4876 uu____4877 args
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5128;
-             FStar_Extraction_ML_Syntax.loc = uu____5129;_},args)
-          when (is_machine_int m) && (is_op op) ->
-          let uu____5137 = FStar_Util.must (mk_width m)  in
-          let uu____5138 = FStar_Util.must (mk_op op)  in
-          mk_op_app env uu____5137 uu____5138 args
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4890 = FStar_Util.must (mk_width m) in
+          let uu____4891 = FStar_Util.must (mk_op op) in
+          mk_op_app env uu____4890 uu____4891 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op);
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4879;
-             FStar_Extraction_ML_Syntax.loc = uu____4880;_},args)
+             FStar_Extraction_ML_Syntax.mlty = uu____4893;
+             FStar_Extraction_ML_Syntax.loc = uu____4894;_},args)
           when is_bool_op op ->
-          let uu____4888 = FStar_Util.must (mk_bool_op op) in
-          mk_op_app env Bool uu____4888 args
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5140;
-             FStar_Extraction_ML_Syntax.loc = uu____5141;_},args)
-          when is_bool_op op ->
-          let uu____5149 = FStar_Util.must (mk_bool_op op)  in
-          mk_op_app env Bool uu____5149 args
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4902 = FStar_Util.must (mk_bool_op op) in
+          mk_op_app env Bool uu____4902 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"int_to_t");
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4890;
-             FStar_Extraction_ML_Syntax.loc = uu____4891;_},{
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5151;
-             FStar_Extraction_ML_Syntax.loc = uu____5152;_},{
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+             FStar_Extraction_ML_Syntax.mlty = uu____4904;
+             FStar_Extraction_ML_Syntax.loc = uu____4905;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -3010,36 +1702,20 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
-<<<<<<< HEAD
-                                                                = uu____4893;
+                                                                = uu____4907;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4894;_}::[])
+                                                                = uu____4908;_}::[])
           when is_machine_int m ->
-          let uu____4909 =
-            let uu____4914 = FStar_Util.must (mk_width m) in (uu____4914, c) in
-          EConstant uu____4909
-=======
-                                                                = uu____5154;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5155;_}::[])
-          when is_machine_int m ->
-          let uu____5170 =
-            let uu____5175 = FStar_Util.must (mk_width m)  in (uu____5175, c)
-             in
-          EConstant uu____5170
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4923 =
+            let uu____4928 = FStar_Util.must (mk_width m) in (uu____4928, c) in
+          EConstant uu____4923
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"uint_to_t");
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4916;
-             FStar_Extraction_ML_Syntax.loc = uu____4917;_},{
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5177;
-             FStar_Extraction_ML_Syntax.loc = uu____5178;_},{
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+             FStar_Extraction_ML_Syntax.mlty = uu____4930;
+             FStar_Extraction_ML_Syntax.loc = uu____4931;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -3047,43 +1723,31 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
-<<<<<<< HEAD
-                                                                = uu____4919;
+                                                                = uu____4933;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4920;_}::[])
+                                                                = uu____4934;_}::[])
           when is_machine_int m ->
-          let uu____4935 =
-            let uu____4940 = FStar_Util.must (mk_width m) in (uu____4940, c) in
-          EConstant uu____4935
-=======
-                                                                = uu____5180;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5181;_}::[])
-          when is_machine_int m ->
-          let uu____5196 =
-            let uu____5201 = FStar_Util.must (mk_width m)  in (uu____5201, c)
-             in
-          EConstant uu____5196
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____4949 =
+            let uu____4954 = FStar_Util.must (mk_width m) in (uu____4954, c) in
+          EConstant uu____4949
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::[],"string_of_literal");
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4941;
-             FStar_Extraction_ML_Syntax.loc = uu____4942;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4955;
+             FStar_Extraction_ML_Syntax.loc = uu____4956;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 = e1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4944;
+                                                                = uu____4958;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4945;_}::[])
+                                                                = uu____4959;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____4951 ->
+           | uu____4965 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -3091,33 +1755,19 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::"String"::[],"of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____4952;
-             FStar_Extraction_ML_Syntax.loc = uu____4953;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4966;
+             FStar_Extraction_ML_Syntax.loc = uu____4967;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 = e1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4955;
+                                                                = uu____4969;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4956;_}::[])
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5202;
-             FStar_Extraction_ML_Syntax.loc = uu____5203;_},{
-                                                              FStar_Extraction_ML_Syntax.expr
-                                                                = e1;
-                                                              FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____5205;
-                                                              FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5206;_}::[])
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+                                                                = uu____4970;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-<<<<<<< HEAD
-           | uu____4962 ->
-=======
-           | uu____5212 ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+           | uu____4976 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -3125,13 +1775,8 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::"Int"::"Cast"::[],c);
-<<<<<<< HEAD
-             FStar_Extraction_ML_Syntax.mlty = uu____4964;
-             FStar_Extraction_ML_Syntax.loc = uu____4965;_},arg::[])
-=======
-             FStar_Extraction_ML_Syntax.mlty = uu____5214;
-             FStar_Extraction_ML_Syntax.loc = uu____5215;_},arg::[])
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+             FStar_Extraction_ML_Syntax.mlty = uu____4978;
+             FStar_Extraction_ML_Syntax.loc = uu____4979;_},arg::[])
           ->
           let is_known_type =
             (((((((FStar_Util.starts_with c "uint8") ||
@@ -3144,301 +1789,149 @@ and translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
               || (FStar_Util.starts_with c "int64") in
           if (FStar_Util.ends_with c "uint64") && is_known_type
           then
-<<<<<<< HEAD
-            let uu____4972 =
-              let uu____4977 = translate_expr env arg in
-              (uu____4977, (TInt UInt64)) in
-            ECast uu____4972
+            let uu____4986 =
+              let uu____4991 = translate_expr env arg in
+              (uu____4991, (TInt UInt64)) in
+            ECast uu____4986
           else
             if (FStar_Util.ends_with c "uint32") && is_known_type
             then
-              (let uu____4979 =
-                 let uu____4984 = translate_expr env arg in
-                 (uu____4984, (TInt UInt32)) in
-               ECast uu____4979)
+              (let uu____4993 =
+                 let uu____4998 = translate_expr env arg in
+                 (uu____4998, (TInt UInt32)) in
+               ECast uu____4993)
             else
               if (FStar_Util.ends_with c "uint16") && is_known_type
               then
-                (let uu____4986 =
-                   let uu____4991 = translate_expr env arg in
-                   (uu____4991, (TInt UInt16)) in
-                 ECast uu____4986)
+                (let uu____5000 =
+                   let uu____5005 = translate_expr env arg in
+                   (uu____5005, (TInt UInt16)) in
+                 ECast uu____5000)
               else
                 if (FStar_Util.ends_with c "uint8") && is_known_type
                 then
-                  (let uu____4993 =
-                     let uu____4998 = translate_expr env arg in
-                     (uu____4998, (TInt UInt8)) in
-                   ECast uu____4993)
+                  (let uu____5007 =
+                     let uu____5012 = translate_expr env arg in
+                     (uu____5012, (TInt UInt8)) in
+                   ECast uu____5007)
                 else
                   if (FStar_Util.ends_with c "int64") && is_known_type
                   then
-                    (let uu____5000 =
-                       let uu____5005 = translate_expr env arg in
-                       (uu____5005, (TInt Int64)) in
-                     ECast uu____5000)
+                    (let uu____5014 =
+                       let uu____5019 = translate_expr env arg in
+                       (uu____5019, (TInt Int64)) in
+                     ECast uu____5014)
                   else
                     if (FStar_Util.ends_with c "int32") && is_known_type
                     then
-                      (let uu____5007 =
-                         let uu____5012 = translate_expr env arg in
-                         (uu____5012, (TInt Int32)) in
-                       ECast uu____5007)
+                      (let uu____5021 =
+                         let uu____5026 = translate_expr env arg in
+                         (uu____5026, (TInt Int32)) in
+                       ECast uu____5021)
                     else
                       if (FStar_Util.ends_with c "int16") && is_known_type
                       then
-                        (let uu____5014 =
-                           let uu____5019 = translate_expr env arg in
-                           (uu____5019, (TInt Int16)) in
-                         ECast uu____5014)
+                        (let uu____5028 =
+                           let uu____5033 = translate_expr env arg in
+                           (uu____5033, (TInt Int16)) in
+                         ECast uu____5028)
                       else
                         if (FStar_Util.ends_with c "int8") && is_known_type
                         then
-                          (let uu____5021 =
-                             let uu____5026 = translate_expr env arg in
-                             (uu____5026, (TInt Int8)) in
-                           ECast uu____5021)
+                          (let uu____5035 =
+                             let uu____5040 = translate_expr env arg in
+                             (uu____5040, (TInt Int8)) in
+                           ECast uu____5035)
                         else
-                          (let uu____5028 =
-                             let uu____5035 =
-                               let uu____5038 = translate_expr env arg in
-                               [uu____5038] in
+                          (let uu____5042 =
+                             let uu____5049 =
+                               let uu____5052 = translate_expr env arg in
+                               [uu____5052] in
                              ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____5035) in
-                           EApp uu____5028)
+                               uu____5049) in
+                           EApp uu____5042)
       | FStar_Extraction_ML_Syntax.MLE_App (head1,args) ->
-          let uu____5049 =
-            let uu____5056 = translate_expr env head1 in
-            let uu____5057 = FStar_List.map (translate_expr env) args in
-            (uu____5056, uu____5057) in
-          EApp uu____5049
+          let uu____5063 =
+            let uu____5070 = translate_expr env head1 in
+            let uu____5071 = FStar_List.map (translate_expr env) args in
+            (uu____5070, uu____5071) in
+          EApp uu____5063
       | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
-          let uu____5068 =
-            let uu____5075 = translate_expr env head1 in
-            let uu____5076 = FStar_List.map (translate_type env) ty_args in
-            (uu____5075, uu____5076) in
-          ETypApp uu____5068
-      | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
-          let uu____5084 =
-            let uu____5089 = translate_expr env e1 in
-            let uu____5090 = translate_type env t_to in
+          let uu____5082 =
+            let uu____5089 = translate_expr env head1 in
+            let uu____5090 = FStar_List.map (translate_type env) ty_args in
             (uu____5089, uu____5090) in
-          ECast uu____5084
-      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5091,fields) ->
-          let uu____5109 =
-            let uu____5120 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____5121 =
+          ETypApp uu____5082
+      | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
+          let uu____5098 =
+            let uu____5103 = translate_expr env e1 in
+            let uu____5104 = translate_type env t_to in
+            (uu____5103, uu____5104) in
+          ECast uu____5098
+      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5105,fields) ->
+          let uu____5123 =
+            let uu____5134 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
+            let uu____5135 =
               FStar_List.map
-                (fun uu____5140  ->
-                   match uu____5140 with
+                (fun uu____5154  ->
+                   match uu____5154 with
                    | (field,expr) ->
-                       let uu____5151 = translate_expr env expr in
-                       (field, uu____5151)) fields in
-            (uu____5120, uu____5121) in
-          EFlat uu____5109
+                       let uu____5165 = translate_expr env expr in
+                       (field, uu____5165)) fields in
+            (uu____5134, uu____5135) in
+          EFlat uu____5123
       | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
-          let uu____5160 =
-            let uu____5167 =
+          let uu____5174 =
+            let uu____5181 =
               assert_lid env e1.FStar_Extraction_ML_Syntax.mlty in
-            let uu____5168 = translate_expr env e1 in
-            (uu____5167, uu____5168, (FStar_Pervasives_Native.snd path)) in
-          EField uu____5160
-      | FStar_Extraction_ML_Syntax.MLE_Let uu____5171 ->
+            let uu____5182 = translate_expr env e1 in
+            (uu____5181, uu____5182, (FStar_Pervasives_Native.snd path)) in
+          EField uu____5174
+      | FStar_Extraction_ML_Syntax.MLE_Let uu____5185 ->
           failwith "todo: translate_expr [MLE_Let]"
-      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5185) ->
-          let uu____5190 =
-            let uu____5191 =
+      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5199) ->
+          let uu____5204 =
+            let uu____5205 =
               FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1 in
             FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____5191 in
-          failwith uu____5190
+              uu____5205 in
+          failwith uu____5204
       | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____5197 = FStar_List.map (translate_expr env) seqs in
-          ESequence uu____5197
+          let uu____5211 = FStar_List.map (translate_expr env) seqs in
+          ESequence uu____5211
       | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____5203 = FStar_List.map (translate_expr env) es in
-          ETuple uu____5203
-      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5206,cons1),es) ->
-          let uu____5223 =
-            let uu____5232 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____5233 = FStar_List.map (translate_expr env) es in
-            (uu____5232, cons1, uu____5233) in
-          ECons uu____5223
+          let uu____5217 = FStar_List.map (translate_expr env) es in
+          ETuple uu____5217
+      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5220,cons1),es) ->
+          let uu____5237 =
+            let uu____5246 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
+            let uu____5247 = FStar_List.map (translate_expr env) es in
+            (uu____5246, cons1, uu____5247) in
+          ECons uu____5237
       | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
           let binders = translate_binders env args in
           let env1 = add_binders env args in
-          let uu____5256 =
-            let uu____5265 = translate_expr env1 body in
-            let uu____5266 =
+          let uu____5270 =
+            let uu____5279 = translate_expr env1 body in
+            let uu____5280 =
               translate_type env1 body.FStar_Extraction_ML_Syntax.mlty in
-            (binders, uu____5265, uu____5266) in
-          EFun uu____5256
+            (binders, uu____5279, uu____5280) in
+          EFun uu____5270
       | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
-          let uu____5276 =
-            let uu____5283 = translate_expr env e1 in
-            let uu____5284 = translate_expr env e2 in
-            let uu____5285 =
+          let uu____5290 =
+            let uu____5297 = translate_expr env e1 in
+            let uu____5298 = translate_expr env e2 in
+            let uu____5299 =
               match e3 with
               | FStar_Pervasives_Native.None  -> EUnit
               | FStar_Pervasives_Native.Some e31 -> translate_expr env e31 in
-            (uu____5283, uu____5284, uu____5285) in
-          EIfThenElse uu____5276
-      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5287 ->
+            (uu____5297, uu____5298, uu____5299) in
+          EIfThenElse uu____5290
+      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5301 ->
           failwith "todo: translate_expr [MLE_Raise]"
-      | FStar_Extraction_ML_Syntax.MLE_Try uu____5294 ->
+      | FStar_Extraction_ML_Syntax.MLE_Try uu____5308 ->
           failwith "todo: translate_expr [MLE_Try]"
-      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5309 ->
-=======
-            let uu____5222 =
-              let uu____5227 = translate_expr env arg  in
-              (uu____5227, (TInt UInt64))  in
-            ECast uu____5222
-          else
-            if (FStar_Util.ends_with c "uint32") && is_known_type
-            then
-              (let uu____5229 =
-                 let uu____5234 = translate_expr env arg  in
-                 (uu____5234, (TInt UInt32))  in
-               ECast uu____5229)
-            else
-              if (FStar_Util.ends_with c "uint16") && is_known_type
-              then
-                (let uu____5236 =
-                   let uu____5241 = translate_expr env arg  in
-                   (uu____5241, (TInt UInt16))  in
-                 ECast uu____5236)
-              else
-                if (FStar_Util.ends_with c "uint8") && is_known_type
-                then
-                  (let uu____5243 =
-                     let uu____5248 = translate_expr env arg  in
-                     (uu____5248, (TInt UInt8))  in
-                   ECast uu____5243)
-                else
-                  if (FStar_Util.ends_with c "int64") && is_known_type
-                  then
-                    (let uu____5250 =
-                       let uu____5255 = translate_expr env arg  in
-                       (uu____5255, (TInt Int64))  in
-                     ECast uu____5250)
-                  else
-                    if (FStar_Util.ends_with c "int32") && is_known_type
-                    then
-                      (let uu____5257 =
-                         let uu____5262 = translate_expr env arg  in
-                         (uu____5262, (TInt Int32))  in
-                       ECast uu____5257)
-                    else
-                      if (FStar_Util.ends_with c "int16") && is_known_type
-                      then
-                        (let uu____5264 =
-                           let uu____5269 = translate_expr env arg  in
-                           (uu____5269, (TInt Int16))  in
-                         ECast uu____5264)
-                      else
-                        if (FStar_Util.ends_with c "int8") && is_known_type
-                        then
-                          (let uu____5271 =
-                             let uu____5276 = translate_expr env arg  in
-                             (uu____5276, (TInt Int8))  in
-                           ECast uu____5271)
-                        else
-                          (let uu____5278 =
-                             let uu____5285 =
-                               let uu____5288 = translate_expr env arg  in
-                               [uu____5288]  in
-                             ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____5285)
-                              in
-                           EApp uu____5278)
-      | FStar_Extraction_ML_Syntax.MLE_App (head1,args) ->
-          let uu____5299 =
-            let uu____5306 = translate_expr env head1  in
-            let uu____5307 = FStar_List.map (translate_expr env) args  in
-            (uu____5306, uu____5307)  in
-          EApp uu____5299
-      | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
-          let uu____5318 =
-            let uu____5325 = translate_expr env head1  in
-            let uu____5326 = FStar_List.map (translate_type env) ty_args  in
-            (uu____5325, uu____5326)  in
-          ETypApp uu____5318
-      | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
-          let uu____5334 =
-            let uu____5339 = translate_expr env e1  in
-            let uu____5340 = translate_type env t_to  in
-            (uu____5339, uu____5340)  in
-          ECast uu____5334
-      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5341,fields) ->
-          let uu____5359 =
-            let uu____5370 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
-               in
-            let uu____5371 =
-              FStar_List.map
-                (fun uu____5390  ->
-                   match uu____5390 with
-                   | (field,expr) ->
-                       let uu____5401 = translate_expr env expr  in
-                       (field, uu____5401)) fields
-               in
-            (uu____5370, uu____5371)  in
-          EFlat uu____5359
-      | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
-          let uu____5410 =
-            let uu____5417 =
-              assert_lid env e1.FStar_Extraction_ML_Syntax.mlty  in
-            let uu____5418 = translate_expr env e1  in
-            (uu____5417, uu____5418, (FStar_Pervasives_Native.snd path))  in
-          EField uu____5410
-      | FStar_Extraction_ML_Syntax.MLE_Let uu____5421 ->
-          failwith "todo: translate_expr [MLE_Let]"
-      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5435) ->
-          let uu____5440 =
-            let uu____5441 =
-              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1  in
-            FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____5441
-             in
-          failwith uu____5440
-      | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____5447 = FStar_List.map (translate_expr env) seqs  in
-          ESequence uu____5447
-      | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____5453 = FStar_List.map (translate_expr env) es  in
-          ETuple uu____5453
-      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5456,cons1),es) ->
-          let uu____5473 =
-            let uu____5482 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
-               in
-            let uu____5483 = FStar_List.map (translate_expr env) es  in
-            (uu____5482, cons1, uu____5483)  in
-          ECons uu____5473
-      | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
-          let binders = translate_binders env args  in
-          let env1 = add_binders env args  in
-          let uu____5506 =
-            let uu____5515 = translate_expr env1 body  in
-            let uu____5516 =
-              translate_type env1 body.FStar_Extraction_ML_Syntax.mlty  in
-            (binders, uu____5515, uu____5516)  in
-          EFun uu____5506
-      | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
-          let uu____5526 =
-            let uu____5533 = translate_expr env e1  in
-            let uu____5534 = translate_expr env e2  in
-            let uu____5535 =
-              match e3 with
-              | FStar_Pervasives_Native.None  -> EUnit
-              | FStar_Pervasives_Native.Some e31 -> translate_expr env e31
-               in
-            (uu____5533, uu____5534, uu____5535)  in
-          EIfThenElse uu____5526
-      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5537 ->
-          failwith "todo: translate_expr [MLE_Raise]"
-      | FStar_Extraction_ML_Syntax.MLE_Try uu____5544 ->
-          failwith "todo: translate_expr [MLE_Try]"
-      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5559 ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5323 ->
           failwith "todo: translate_expr [MLE_Coerce]"
 and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
   fun env  ->
@@ -3447,24 +1940,13 @@ and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
       | FStar_Extraction_ML_Syntax.MLTY_Named (ts,lid) ->
           if (FStar_List.length ts) > (Prims.parse_int "0")
           then
-<<<<<<< HEAD
-            let uu____5324 =
-              let uu____5337 = FStar_List.map (translate_type env) ts in
-              (lid, uu____5337) in
-            TApp uu____5324
+            let uu____5338 =
+              let uu____5351 = FStar_List.map (translate_type env) ts in
+              (lid, uu____5351) in
+            TApp uu____5338
           else TQualified lid
-      | uu____5343 -> failwith "invalid argument: assert_lid"
+      | uu____5357 -> failwith "invalid argument: assert_lid"
 and translate_branches:
-=======
-            let uu____5574 =
-              let uu____5587 = FStar_List.map (translate_type env) ts  in
-              (lid, uu____5587)  in
-            TApp uu____5574
-          else TQualified lid
-      | uu____5593 -> failwith "invalid argument: assert_lid"
-
-and translate_branches :
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern,FStar_Extraction_ML_Syntax.mlexpr
                                             FStar_Pervasives_Native.option,
@@ -3480,29 +1962,16 @@ and translate_branch:
       (pattern,expr) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
-<<<<<<< HEAD
-    fun uu____5369  ->
-      match uu____5369 with
+    fun uu____5383  ->
+      match uu____5383 with
       | (pat,guard,expr) ->
           if guard = FStar_Pervasives_Native.None
           then
-            let uu____5395 = translate_pat env pat in
-            (match uu____5395 with
+            let uu____5409 = translate_pat env pat in
+            (match uu____5409 with
              | (env1,pat1) ->
-                 let uu____5406 = translate_expr env1 expr in
-                 (pat1, uu____5406))
-=======
-    fun uu____5619  ->
-      match uu____5619 with
-      | (pat,guard,expr) ->
-          if guard = FStar_Pervasives_Native.None
-          then
-            let uu____5645 = translate_pat env pat  in
-            (match uu____5645 with
-             | (env1,pat1) ->
-                 let uu____5656 = translate_expr env1 expr  in
-                 (pat1, uu____5656))
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+                 let uu____5420 = translate_expr env1 expr in
+                 (pat1, uu____5420))
           else failwith "todo: translate_branch"
 and translate_pat:
   env ->
@@ -3516,103 +1985,52 @@ and translate_pat:
           (FStar_Extraction_ML_Syntax.MLC_Unit ) -> (env, PUnit)
       | FStar_Extraction_ML_Syntax.MLP_Const
           (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env, (PBool b))
-<<<<<<< HEAD
       | FStar_Extraction_ML_Syntax.MLP_Var name ->
           let env1 = extend env name false in
-=======
-      | FStar_Extraction_ML_Syntax.MLP_Var (name,uu____5670) ->
-          let env1 = extend env name false  in
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
           (env1, (PVar { name; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild  ->
           let env1 = extend env "_" false in
           (env1, (PVar { name = "_"; typ = TAny; mut = false }))
-<<<<<<< HEAD
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5422,cons1),ps) ->
-          let uu____5439 =
+      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5436,cons1),ps) ->
+          let uu____5453 =
             FStar_List.fold_left
-              (fun uu____5459  ->
+              (fun uu____5473  ->
                  fun p1  ->
-                   match uu____5459 with
+                   match uu____5473 with
                    | (env1,acc) ->
-                       let uu____5479 = translate_pat env1 p1 in
-                       (match uu____5479 with
+                       let uu____5493 = translate_pat env1 p1 in
+                       (match uu____5493 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
-          (match uu____5439 with
+          (match uu____5453 with
            | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5508,ps) ->
-          let uu____5526 =
+      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5522,ps) ->
+          let uu____5540 =
             FStar_List.fold_left
-              (fun uu____5560  ->
-                 fun uu____5561  ->
-                   match (uu____5560, uu____5561) with
+              (fun uu____5574  ->
+                 fun uu____5575  ->
+                   match (uu____5574, uu____5575) with
                    | ((env1,acc),(field,p1)) ->
-                       let uu____5630 = translate_pat env1 p1 in
-                       (match uu____5630 with
+                       let uu____5644 = translate_pat env1 p1 in
+                       (match uu____5644 with
                         | (env2,p2) -> (env2, ((field, p2) :: acc))))
               (env, []) ps in
-          (match uu____5526 with
+          (match uu____5540 with
            | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____5692 =
+          let uu____5706 =
             FStar_List.fold_left
-              (fun uu____5712  ->
+              (fun uu____5726  ->
                  fun p1  ->
-                   match uu____5712 with
+                   match uu____5726 with
                    | (env1,acc) ->
-                       let uu____5732 = translate_pat env1 p1 in
-                       (match uu____5732 with
+                       let uu____5746 = translate_pat env1 p1 in
+                       (match uu____5746 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
-          (match uu____5692 with
+          (match uu____5706 with
            | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____5759 ->
+      | FStar_Extraction_ML_Syntax.MLP_Const uu____5773 ->
           failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____5764 ->
-=======
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5673,cons1),ps) ->
-          let uu____5690 =
-            FStar_List.fold_left
-              (fun uu____5710  ->
-                 fun p1  ->
-                   match uu____5710 with
-                   | (env1,acc) ->
-                       let uu____5730 = translate_pat env1 p1  in
-                       (match uu____5730 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
-             in
-          (match uu____5690 with
-           | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5759,ps) ->
-          let uu____5777 =
-            FStar_List.fold_left
-              (fun uu____5811  ->
-                 fun uu____5812  ->
-                   match (uu____5811, uu____5812) with
-                   | ((env1,acc),(field,p1)) ->
-                       let uu____5881 = translate_pat env1 p1  in
-                       (match uu____5881 with
-                        | (env2,p2) -> (env2, ((field, p2) :: acc))))
-              (env, []) ps
-             in
-          (match uu____5777 with
-           | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____5943 =
-            FStar_List.fold_left
-              (fun uu____5963  ->
-                 fun p1  ->
-                   match uu____5963 with
-                   | (env1,acc) ->
-                       let uu____5983 = translate_pat env1 p1  in
-                       (match uu____5983 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
-             in
-          (match uu____5943 with
-           | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____6010 ->
-          failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____6015 ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+      | FStar_Extraction_ML_Syntax.MLP_Branch uu____5778 ->
           failwith "todo: translate_pat [MLP_Branch]"
 and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
   fun c  ->
@@ -3620,29 +2038,16 @@ and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_Int
-<<<<<<< HEAD
-        (s,FStar_Pervasives_Native.Some uu____5774) ->
+        (s,FStar_Pervasives_Native.Some uu____5788) ->
         failwith
           "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____5789 ->
+    | FStar_Extraction_ML_Syntax.MLC_Float uu____5803 ->
         failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Char uu____5790 ->
+    | FStar_Extraction_ML_Syntax.MLC_Char uu____5804 ->
         failwith "todo: translate_expr [MLC_Char]"
-    | FStar_Extraction_ML_Syntax.MLC_String uu____5791 ->
+    | FStar_Extraction_ML_Syntax.MLC_String uu____5805 ->
         failwith "todo: translate_expr [MLC_String]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____5792 ->
-=======
-        (s,FStar_Pervasives_Native.Some uu____6025) ->
-        failwith
-          "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____6040 ->
-        failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Char uu____6041 ->
-        failwith "todo: translate_expr [MLC_Char]"
-    | FStar_Extraction_ML_Syntax.MLC_String uu____6042 ->
-        failwith "todo: translate_expr [MLC_String]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____6043 ->
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____5806 ->
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s,FStar_Pervasives_Native.None ) ->
         EConstant (CInt, s)
@@ -3653,14 +2058,7 @@ and mk_op_app:
     fun w  ->
       fun op  ->
         fun args  ->
-<<<<<<< HEAD
-          let uu____5812 =
-            let uu____5819 = FStar_List.map (translate_expr env) args in
-            ((EOp (op, w)), uu____5819) in
-          EApp uu____5812
-=======
-          let uu____6063 =
-            let uu____6070 = FStar_List.map (translate_expr env) args  in
-            ((EOp (op, w)), uu____6070)  in
-          EApp uu____6063
->>>>>>> e808de684... Add support for extracting mutually recursive data types via Kremlin
+          let uu____5826 =
+            let uu____5833 = FStar_List.map (translate_expr env) args in
+            ((EOp (op, w)), uu____5833) in
+          EApp uu____5826


### PR DESCRIPTION
@nikswamy @protz My first stab at extracting the mutual recursive datatypes changes doen on `c_mitls2c`.

I just cherry-picked the changes from my old branch but am happy to rebase/rewrite into a better form.

I will follow up with a Kremlin PR here shortly.